### PR TITLE
Fix fork compaction fidelity and detail metadata

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -154,11 +154,16 @@ describe("forkConversation", () => {
     expect(forkMessages.map((message) => message.createdAt)).toEqual(
       sourceMessages.map((message) => message.createdAt),
     );
-    expect(forkMessages.map((message) => parseMetadata(message.metadata))).toEqual(
+    expect(
+      forkMessages.map((message) => parseMetadata(message.metadata)),
+    ).toEqual(
       sourceMessages.map((message) => {
         const metadata = parseMetadata(message.metadata);
         return metadata && typeof metadata === "object"
-          ? { ...(metadata as Record<string, unknown>), forkSourceMessageId: message.id }
+          ? {
+              ...(metadata as Record<string, unknown>),
+              forkSourceMessageId: message.id,
+            }
           : { forkSourceMessageId: message.id };
       }),
     );
@@ -199,6 +204,84 @@ describe("forkConversation", () => {
       "Message 1",
       "Message 2",
     ]);
+  });
+
+  test("preserves compacted context when forking from the visible window", async () => {
+    const source = createConversation("Compacted thread");
+    await addMessage(source.id, "user", "Message 1", undefined, {
+      skipIndexing: true,
+    });
+    await addMessage(source.id, "assistant", "Message 2", undefined, {
+      skipIndexing: true,
+    });
+    const branchPoint = await addMessage(
+      source.id,
+      "user",
+      "Message 3",
+      undefined,
+      { skipIndexing: true },
+    );
+    await addMessage(source.id, "assistant", "Message 4", undefined, {
+      skipIndexing: true,
+    });
+
+    const compactedAt = Date.now();
+    getDb()
+      .update(conversations)
+      .set({
+        contextSummary: "Compacted summary",
+        contextCompactedMessageCount: 2,
+        contextCompactedAt: compactedAt,
+      })
+      .where(eq(conversations.id, source.id))
+      .run();
+
+    const fork = forkConversation({
+      conversationId: source.id,
+      throughMessageId: branchPoint.id,
+    });
+
+    expect(fork.contextSummary).toBe("Compacted summary");
+    expect(fork.contextCompactedMessageCount).toBe(2);
+    expect(fork.contextCompactedAt).toBe(compactedAt);
+    expect(fork.forkParentConversationId).toBe(source.id);
+    expect(fork.forkParentMessageId).toBe(branchPoint.id);
+  });
+
+  test("rejects forks from the compacted-away prefix", async () => {
+    const source = createConversation("Compacted thread");
+    const compactedBranchPoint = await addMessage(
+      source.id,
+      "user",
+      "Message 1",
+      undefined,
+      { skipIndexing: true },
+    );
+    await addMessage(source.id, "assistant", "Message 2", undefined, {
+      skipIndexing: true,
+    });
+    await addMessage(source.id, "user", "Message 3", undefined, {
+      skipIndexing: true,
+    });
+
+    getDb()
+      .update(conversations)
+      .set({
+        contextSummary: "Compacted summary",
+        contextCompactedMessageCount: 2,
+        contextCompactedAt: Date.now(),
+      })
+      .where(eq(conversations.id, source.id))
+      .run();
+
+    expect(() =>
+      forkConversation({
+        conversationId: source.id,
+        throughMessageId: compactedBranchPoint.id,
+      }),
+    ).toThrow(
+      `Message ${compactedBranchPoint.id} falls inside the compacted-away prefix of conversation ${source.id}`,
+    );
   });
 
   test("rejects forks when the source conversation has no persisted messages", () => {
@@ -390,7 +473,9 @@ describe("forkConversation", () => {
     const forkRequestLogs = forkAssistant
       ? getRequestLogsByMessageId(forkAssistant.id)
       : [];
-    const forkState = getAttentionStateByConversationIds([fork.id]).get(fork.id);
+    const forkState = getAttentionStateByConversationIds([fork.id]).get(
+      fork.id,
+    );
     const forkRequestLogCount = db
       .select()
       .from(llmRequestLogs)
@@ -422,7 +507,9 @@ describe("forkConversation", () => {
     expect(forkState).toBeDefined();
     expect(forkState?.latestAssistantMessageId).toBe(forkAssistant?.id);
     expect(forkState?.lastSeenAssistantMessageId).toBe(forkAssistant?.id);
-    expect(forkState?.lastSeenAssistantMessageAt).toBe(forkAssistant?.createdAt);
+    expect(forkState?.lastSeenAssistantMessageAt).toBe(
+      forkAssistant?.createdAt,
+    );
     expect(forkRequestLogCount).toBe(0);
     expect(forkToolInvocationCount).toBe(0);
     expect(forkInboundEventCount).toBe(0);

--- a/assistant/src/__tests__/http-conversation-lineage.test.ts
+++ b/assistant/src/__tests__/http-conversation-lineage.test.ts
@@ -53,6 +53,7 @@ mock.module("../config/loader.js", () => ({
 }));
 
 import {
+  batchSetDisplayOrders,
   createConversation,
   updateConversationTitle,
 } from "../memory/conversation-crud.js";
@@ -64,6 +65,8 @@ initializeDb();
 type ConversationSummary = {
   id: string;
   title: string;
+  displayOrder?: number | null;
+  isPinned?: boolean;
   forkParent?: {
     conversationId: string;
     messageId: string;
@@ -137,6 +140,28 @@ describe("conversation lineage in HTTP reads", () => {
     });
   });
 
+  test("GET /v1/conversations/:id includes pin metadata when present", async () => {
+    const conversation = createConversation("Pinned conversation");
+    batchSetDisplayOrders([
+      { id: conversation.id, displayOrder: 7, isPinned: true },
+    ]);
+    await startServer();
+
+    const response = await fetch(url(`/conversations/${conversation.id}`));
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      conversation: ConversationSummary;
+    };
+
+    expect(body.conversation).toMatchObject({
+      id: conversation.id,
+      title: conversation.title ?? "Untitled",
+      displayOrder: 7,
+      isPinned: true,
+    });
+  });
+
   test("GET /v1/conversations/:id resolves the parent's current title at read time", async () => {
     const { child, parent } = seedForkedConversation({
       parentTitle: "Original parent title",
@@ -168,7 +193,9 @@ describe("conversation lineage in HTTP reads", () => {
     const listBody = (await listResponse.json()) as {
       conversations: ConversationSummary[];
     };
-    const listedChild = listBody.conversations.find((item) => item.id === child.id);
+    const listedChild = listBody.conversations.find(
+      (item) => item.id === child.id,
+    );
     expect(listedChild).toBeDefined();
     expect(listedChild?.forkParent).toBeUndefined();
 
@@ -190,7 +217,9 @@ describe("conversation lineage in HTTP reads", () => {
   }
 
   function seedForkedConversation(opts?: { parentTitle?: string }) {
-    const parent = createConversation(opts?.parentTitle ?? "Parent conversation");
+    const parent = createConversation(
+      opts?.parentTitle ?? "Parent conversation",
+    );
     const child = createConversation("Forked conversation");
 
     rawRun(
@@ -208,7 +237,10 @@ describe("conversation lineage in HTTP reads", () => {
   }
 
   async function startServer(): Promise<void> {
-    server = new RuntimeHttpServer({ port: 0, bearerToken: "test-bearer-token" });
+    server = new RuntimeHttpServer({
+      port: 0,
+      bearerToken: "test-bearer-token",
+    });
     await server.start();
   }
 

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -354,6 +354,21 @@ export function forkConversation(params: {
     );
   }
 
+  const visibleWindowStartIndex = Math.max(
+    0,
+    Math.min(
+      sourceConversation.contextCompactedMessageCount,
+      sourceMessages.length,
+    ),
+  );
+  const branchPointMessageId =
+    throughMessageId ?? sourceMessages.at(-1)?.id ?? null;
+  if (copyBoundaryIndex < visibleWindowStartIndex) {
+    throw new UserError(
+      `Message ${branchPointMessageId} falls inside the compacted-away prefix of conversation ${conversationId}`,
+    );
+  }
+
   const messagesToCopy =
     copyBoundaryIndex >= 0
       ? sourceMessages.slice(0, copyBoundaryIndex + 1)
@@ -369,14 +384,17 @@ export function forkConversation(params: {
     .set({
       forkParentConversationId: sourceConversation.id,
       forkParentMessageId,
+      contextSummary: sourceConversation.contextSummary,
+      contextCompactedMessageCount:
+        sourceConversation.contextCompactedMessageCount,
+      contextCompactedAt: sourceConversation.contextCompactedAt,
     })
     .where(eq(conversations.id, forkedConversation.id))
     .run();
 
   const forkedMessageIds = new Map<string, string>();
-  let latestForkedAssistant:
-    | { messageId: string; messageAt: number }
-    | null = null;
+  let latestForkedAssistant: { messageId: string; messageAt: number } | null =
+    null;
 
   for (const message of messagesToCopy) {
     const forkedMessageId = uuid();
@@ -417,8 +435,7 @@ export function forkConversation(params: {
     const uncachedAttachmentLinks = attachmentLinks.filter(
       (link) => !attachmentIdMap.has(link.attachmentId),
     );
-    const stagingMessageId =
-      uncachedAttachmentLinks.length > 0 ? uuid() : null;
+    const stagingMessageId = uncachedAttachmentLinks.length > 0 ? uuid() : null;
 
     if (stagingMessageId) {
       db.insert(messages)

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -721,9 +721,7 @@ export class RuntimeHttpServer {
     });
   }
 
-  private buildAssistantAttention(
-    attentionState: AttentionState | undefined,
-  ):
+  private buildAssistantAttention(attentionState: AttentionState | undefined):
     | {
         hasUnseenLatestAssistantMessage: boolean;
         latestAssistantMessageAt?: number;
@@ -848,7 +846,10 @@ export class RuntimeHttpServer {
     const bindings = externalConversationStore.getBindingsForConversations([
       conversation.id,
     ]);
-    const attentionStates = getAttentionStateByConversationIds([conversation.id]);
+    const attentionStates = getAttentionStateByConversationIds([
+      conversation.id,
+    ]);
+    const displayMeta = getDisplayMetaForConversations([conversation.id]);
     const parentCache = new Map<string, ConversationRow | null>();
 
     return {
@@ -856,14 +857,13 @@ export class RuntimeHttpServer {
         conversation,
         binding: bindings.get(conversation.id),
         attentionState: attentionStates.get(conversation.id),
+        displayMeta: displayMeta.get(conversation.id),
         parentCache,
       }),
     };
   }
 
-  private getConversationManagementRouteDeps():
-    | ConversationManagementDeps
-    | null {
+  private getConversationManagementRouteDeps(): ConversationManagementDeps | null {
     if (!this.conversationManagementDeps) {
       return null;
     }


### PR DESCRIPTION
## Summary
- preserve compacted conversation state when cloning forks
- reject forks from compacted-away branch points and cover the behavior with tests
- return display metadata from conversation detail responses

Part of conversation-forking.md remediation round 4
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
