### PR TITLE
Fix Anthropic normalization fidelity in the LLM inspector

### DIFF
--- a/assistant/src/__tests__/llm-context-normalization.test.ts
+++ b/assistant/src/__tests__/llm-context-normalization.test.ts
@@ -191,8 +191,16 @@ describe("normalizeLlmContextPayloads", () => {
             content: [
               { type: "text", text: "Checking sources." },
               {
-                type: "tool_use",
-                id: "toolu_req_1",
+                type: "thinking",
+                thinking: "I should search the changelog.",
+              },
+              {
+                type: "redacted_thinking",
+                signature: "sig_req_1",
+              },
+              {
+                type: "server_tool_use",
+                id: "srvtoolu_req_1",
                 name: "web_search",
                 input: { query: "vellum changelog" },
               },
@@ -219,6 +227,20 @@ describe("normalizeLlmContextPayloads", () => {
         content: [
           { type: "text", text: "I found the changelog." },
           {
+            type: "thinking",
+            thinking: "I should fetch the page.",
+          },
+          {
+            type: "redacted_thinking",
+            signature: "sig_resp_1",
+          },
+          {
+            type: "server_tool_use",
+            id: "srvtoolu_resp_1",
+            name: "web_search",
+            input: { query: "vellum changelog" },
+          },
+          {
             type: "tool_use",
             id: "toolu_resp_1",
             name: "fetch_page",
@@ -239,9 +261,9 @@ describe("normalizeLlmContextPayloads", () => {
       requestMessageCount: 2,
       requestToolCount: 1,
       responseMessageCount: 1,
-      responseToolCallCount: 1,
+      responseToolCallCount: 2,
       responsePreview: "I found the changelog.",
-      toolCallNames: ["fetch_page"],
+      toolCallNames: ["web_search", "fetch_page"],
     });
     expect(normalized.requestSections).toEqual([
       {
@@ -261,6 +283,18 @@ describe("normalizeLlmContextPayloads", () => {
         label: "Assistant message 2",
         role: "assistant",
         text: "Checking sources.",
+      },
+      {
+        kind: "reasoning",
+        label: "Assistant message 2 reasoning",
+        role: "assistant",
+        text: "I should search the changelog.",
+      },
+      {
+        kind: "reasoning",
+        label: "Assistant message 2 reasoning",
+        role: "assistant",
+        text: "[redacted thinking]",
       },
       {
         kind: "tool_use",
@@ -304,12 +338,97 @@ describe("normalizeLlmContextPayloads", () => {
         text: "I found the changelog.",
       },
       {
+        kind: "reasoning",
+        label: "Assistant response reasoning",
+        role: "assistant",
+        text: "I should fetch the page.",
+      },
+      {
+        kind: "reasoning",
+        label: "Assistant response reasoning",
+        role: "assistant",
+        text: "[redacted thinking]",
+      },
+      {
+        kind: "tool_use",
+        label: "Assistant response tool use",
+        role: "assistant",
+        toolName: "web_search",
+        data: { query: "vellum changelog" },
+        text: '{"query":"vellum changelog"}',
+      },
+      {
         kind: "tool_use",
         label: "Assistant response tool use",
         role: "assistant",
         toolName: "fetch_page",
         data: { url: "https://example.com/changelog" },
         text: '{"url":"https://example.com/changelog"}',
+      },
+    ]);
+  });
+
+  test("keeps Anthropic reasoning separate from response preview text", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_008,
+      requestPayload: {
+        model: "claude-sonnet",
+        messages: [{ role: "user", content: "Give me the answer." }],
+      },
+      responsePayload: {
+        model: "claude-sonnet-4-6",
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 21,
+          output_tokens: 10,
+        },
+        content: [
+          {
+            type: "thinking",
+            thinking: "I have enough context now.",
+          },
+          {
+            type: "redacted_thinking",
+            signature: "sig_resp_2",
+          },
+          { type: "text", text: "The answer is 42." },
+        ],
+      },
+    });
+
+    expect(normalized.summary).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      inputTokens: 21,
+      outputTokens: 10,
+      cacheCreationInputTokens: undefined,
+      cacheReadInputTokens: undefined,
+      stopReason: "end_turn",
+      requestMessageCount: 1,
+      requestToolCount: 0,
+      responseMessageCount: 1,
+      responseToolCallCount: undefined,
+      responsePreview: "The answer is 42.",
+      toolCallNames: undefined,
+    });
+    expect(normalized.responseSections).toEqual([
+      {
+        kind: "message",
+        label: "Assistant response",
+        role: "assistant",
+        text: "The answer is 42.",
+      },
+      {
+        kind: "reasoning",
+        label: "Assistant response reasoning",
+        role: "assistant",
+        text: "I have enough context now.",
+      },
+      {
+        kind: "reasoning",
+        label: "Assistant response reasoning",
+        role: "assistant",
+        text: "[redacted thinking]",
       },
     ]);
   });

--- a/assistant/src/runtime/routes/llm-context-normalization.ts
+++ b/assistant/src/runtime/routes/llm-context-normalization.ts
@@ -24,6 +24,7 @@ export interface LlmContextSection {
   kind:
     | "system"
     | "message"
+    | "reasoning"
     | "settings"
     | "tool_definitions"
     | "tool_use"
@@ -284,6 +285,7 @@ function normalizeAnthropicRequestPayload(
       const type = asString(block.type);
       return (
         type === "tool_use" ||
+        type === "server_tool_use" ||
         type === "tool_result" ||
         type === "web_search_tool_result" ||
         type === "thinking" ||
@@ -373,12 +375,20 @@ function normalizeAnthropicResponsePayload(
     content,
     "Assistant response",
   );
-  const responseText = collectAnthropicText(content);
+  const responseText = collectAnthropicPreviewText(content);
   const responseToolNames = content
     .map((block) =>
-      asString(block.type) === "tool_use" ? asString(block.name) : undefined,
+      isAnthropicToolUseType(asString(block.type))
+        ? asString(block.name)
+        : undefined,
     )
     .filter((name): name is string => typeof name === "string");
+  const hasAnthropicResponseMessage = responseSections.some(
+    (section) =>
+      section.kind === "message" ||
+      section.kind === "tool_use" ||
+      section.kind === "reasoning",
+  );
 
   const usage = asRecord(response.usage);
   return {
@@ -393,10 +403,7 @@ function normalizeAnthropicResponsePayload(
       stopReason: asString(response.stop_reason),
       requestMessageCount: undefined,
       requestToolCount: undefined,
-      responseMessageCount:
-        responseText !== undefined || responseToolNames.length > 0
-          ? 1
-          : undefined,
+      responseMessageCount: hasAnthropicResponseMessage ? 1 : undefined,
       responseToolCallCount:
         responseToolNames.length > 0 ? responseToolNames.length : undefined,
       responsePreview: responseText ? truncateText(responseText) : undefined,
@@ -562,7 +569,7 @@ function anthropicMessageSections(
   const role = asString(message.role) ?? "unknown";
   const content = message.content;
   const sections: LlmContextSection[] = [];
-  const text = collectAnthropicText(content);
+  const text = collectAnthropicMessageText(content);
   if (text) {
     sections.push({
       kind: "message",
@@ -574,7 +581,17 @@ function anthropicMessageSections(
 
   for (const block of asRecordArray(content) ?? []) {
     const type = asString(block.type);
-    if (type === "tool_use") {
+    if (type === "thinking" || type === "redacted_thinking") {
+      sections.push({
+        kind: "reasoning",
+        label: `${label} reasoning`,
+        role,
+        text: collectAnthropicReasoningText(block),
+      });
+      continue;
+    }
+
+    if (isAnthropicToolUseType(type)) {
       sections.push({
         kind: "tool_use",
         label: `${label} tool use`,
@@ -840,16 +857,32 @@ function collectAnthropicText(content: unknown): string | undefined {
       continue;
     }
 
-    if (type === "thinking") {
-      const thinking = asString(block.thinking);
-      if (thinking) {
-        textParts.push(thinking);
-      }
-      continue;
+    if (type === "image") {
+      textParts.push("[image]");
     }
+  }
 
-    if (type === "redacted_thinking") {
-      textParts.push("[redacted thinking]");
+  return joinTextParts(textParts);
+}
+
+function collectAnthropicMessageText(content: unknown): string | undefined {
+  if (typeof content === "string") {
+    return hasMeaningfulText(content) ? content : undefined;
+  }
+
+  const blocks = asRecordArray(content);
+  if (!blocks) {
+    return undefined;
+  }
+
+  const textParts: string[] = [];
+  for (const block of blocks) {
+    const type = asString(block.type);
+    if (type === "text") {
+      const text = asString(block.text);
+      if (text) {
+        textParts.push(text);
+      }
       continue;
     }
 
@@ -859,6 +892,51 @@ function collectAnthropicText(content: unknown): string | undefined {
   }
 
   return joinTextParts(textParts);
+}
+
+function collectAnthropicPreviewText(content: unknown): string | undefined {
+  if (typeof content === "string") {
+    return hasMeaningfulText(content) ? content : undefined;
+  }
+
+  const blocks = asRecordArray(content);
+  if (!blocks) {
+    return undefined;
+  }
+
+  const textParts: string[] = [];
+  for (const block of blocks) {
+    if (asString(block.type) !== "text") {
+      continue;
+    }
+
+    const text = asString(block.text);
+    if (text) {
+      textParts.push(text);
+    }
+  }
+
+  return joinTextParts(textParts);
+}
+
+function collectAnthropicReasoningText(
+  block: Record<string, unknown>,
+): string | undefined {
+  const type = asString(block.type);
+  if (type === "thinking") {
+    const thinking = asString(block.thinking);
+    return thinking ? thinking : undefined;
+  }
+
+  if (type === "redacted_thinking") {
+    return "[redacted thinking]";
+  }
+
+  return undefined;
+}
+
+function isAnthropicToolUseType(type: string | undefined): boolean {
+  return type === "tool_use" || type === "server_tool_use";
 }
 
 function isAnthropicToolResultType(type: string | undefined): boolean {


### PR DESCRIPTION
## Summary
- normalize Anthropic native server-tool calls into the inspector response shape
- separate Anthropic reasoning from final response text and previews
- add assistant tests covering the updated Anthropic normalization behavior

Part of plan: llm-context-inspector-redesign.md (remediation round 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
