### PR TITLE
Fix compacted-history fork regression

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -248,7 +248,7 @@ describe("forkConversation", () => {
     expect(fork.forkParentMessageId).toBe(branchPoint.id);
   });
 
-  test("rejects forks from the compacted-away prefix", async () => {
+  test("forks from the compacted-away prefix without inheriting source compaction state", async () => {
     const source = createConversation("Compacted thread");
     const compactedBranchPoint = await addMessage(
       source.id,
@@ -274,14 +274,19 @@ describe("forkConversation", () => {
       .where(eq(conversations.id, source.id))
       .run();
 
-    expect(() =>
-      forkConversation({
-        conversationId: source.id,
-        throughMessageId: compactedBranchPoint.id,
-      }),
-    ).toThrow(
-      `Message ${compactedBranchPoint.id} falls inside the compacted-away prefix of conversation ${source.id}`,
-    );
+    const fork = forkConversation({
+      conversationId: source.id,
+      throughMessageId: compactedBranchPoint.id,
+    });
+
+    expect(fork.contextSummary).toBeNull();
+    expect(fork.contextCompactedMessageCount).toBe(0);
+    expect(fork.contextCompactedAt).toBeNull();
+    expect(fork.forkParentConversationId).toBe(source.id);
+    expect(fork.forkParentMessageId).toBe(compactedBranchPoint.id);
+    expect(getMessages(fork.id).map((message) => message.content)).toEqual([
+      "Message 1",
+    ]);
   });
 
   test("rejects forks when the source conversation has no persisted messages", () => {

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -361,13 +361,8 @@ export function forkConversation(params: {
       sourceMessages.length,
     ),
   );
-  const branchPointMessageId =
-    throughMessageId ?? sourceMessages.at(-1)?.id ?? null;
-  if (copyBoundaryIndex < visibleWindowStartIndex) {
-    throw new UserError(
-      `Message ${branchPointMessageId} falls inside the compacted-away prefix of conversation ${conversationId}`,
-    );
-  }
+  const preserveSourceCompactionState =
+    copyBoundaryIndex >= visibleWindowStartIndex;
 
   const messagesToCopy =
     copyBoundaryIndex >= 0
@@ -384,10 +379,15 @@ export function forkConversation(params: {
     .set({
       forkParentConversationId: sourceConversation.id,
       forkParentMessageId,
-      contextSummary: sourceConversation.contextSummary,
-      contextCompactedMessageCount:
-        sourceConversation.contextCompactedMessageCount,
-      contextCompactedAt: sourceConversation.contextCompactedAt,
+      contextSummary: preserveSourceCompactionState
+        ? sourceConversation.contextSummary
+        : null,
+      contextCompactedMessageCount: preserveSourceCompactionState
+        ? sourceConversation.contextCompactedMessageCount
+        : 0,
+      contextCompactedAt: preserveSourceCompactionState
+        ? sourceConversation.contextCompactedAt
+        : null,
     })
     .where(eq(conversations.id, forkedConversation.id))
     .run();


### PR DESCRIPTION
## Summary
- preserve compaction state only when the fork branch point still matches the visible window
- allow forks from earlier persisted messages in compacted conversations without carrying an incorrect summary
- cover both behaviors with focused fork tests

Part of plan: conversation-forking.md remediation round 5
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
