### PR TITLE
Fix shared defaults upgrade migration

### DIFF
--- a/clients/shared/Tests/SharedUserDefaultsTests.swift
+++ b/clients/shared/Tests/SharedUserDefaultsTests.swift
@@ -4,10 +4,26 @@ import XCTest
 
 final class SharedUserDefaultsTests: XCTestCase {
     private let key = "shared-defaults-regression-test"
+    private let legacySuiteName = "com.vellum.vellum-assistant.swiftpackage"
+
+    private var legacyDefaults: UserDefaults {
+        guard let defaults = UserDefaults(suiteName: legacySuiteName) else {
+            fatalError("Expected legacy suite to be available in tests")
+        }
+        return defaults
+    }
+
+    override func setUp() {
+        super.setUp()
+        SharedUserDefaults.resetLegacyMigrationStateForTests()
+        UserDefaults.standard.removeObject(forKey: key)
+        legacyDefaults.removeObject(forKey: key)
+    }
 
     override func tearDown() {
         UserDefaults.standard.removeObject(forKey: key)
-        SharedUserDefaults.standard.removeObject(forKey: key)
+        legacyDefaults.removeObject(forKey: key)
+        SharedUserDefaults.resetLegacyMigrationStateForTests()
         super.tearDown()
     }
 
@@ -17,5 +33,27 @@ final class SharedUserDefaultsTests: XCTestCase {
         UserDefaults.standard.set(expectedValue, forKey: key)
 
         XCTAssertEqual(SharedUserDefaults.standard.string(forKey: key), expectedValue)
+    }
+
+    func testSharedUserDefaultsMigratesValuesFromLegacySwiftPackageSuite() {
+        let expectedValue = "migrated-from-legacy-suite"
+
+        legacyDefaults.set(expectedValue, forKey: key)
+
+        XCTAssertNil(UserDefaults.standard.object(forKey: key))
+        XCTAssertEqual(SharedUserDefaults.standard.string(forKey: key), expectedValue)
+        XCTAssertEqual(UserDefaults.standard.string(forKey: key), expectedValue)
+        XCTAssertNil(legacyDefaults.object(forKey: key))
+    }
+
+    func testSharedUserDefaultsKeepsNewerStandardValueWhenLegacySuiteHasStaleValue() {
+        let expectedValue = "newer-standard-value"
+
+        UserDefaults.standard.set(expectedValue, forKey: key)
+        legacyDefaults.set("stale-legacy-value", forKey: key)
+
+        XCTAssertEqual(SharedUserDefaults.standard.string(forKey: key), expectedValue)
+        XCTAssertEqual(UserDefaults.standard.string(forKey: key), expectedValue)
+        XCTAssertNil(legacyDefaults.object(forKey: key))
     }
 }

--- a/clients/shared/Utilities/SharedUserDefaults.swift
+++ b/clients/shared/Utilities/SharedUserDefaults.swift
@@ -1,7 +1,38 @@
 import Foundation
 
 enum SharedUserDefaults {
+    private static let legacySuiteName = "com.vellum.vellum-assistant.swiftpackage"
+    private static let lock = NSLock()
+    private static var didMigrateLegacySuite = false
+
     static var standard: UserDefaults {
+        migrateLegacySuiteIfNeeded()
         return .standard
+    }
+
+    static func resetLegacyMigrationStateForTests() {
+        lock.lock()
+        defer { lock.unlock() }
+        didMigrateLegacySuite = false
+    }
+
+    private static func migrateLegacySuiteIfNeeded() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard !didMigrateLegacySuite else { return }
+        didMigrateLegacySuite = true
+
+        guard let legacyDefaults = UserDefaults(suiteName: legacySuiteName) else { return }
+        let legacyValues = legacyDefaults.dictionaryRepresentation()
+        guard !legacyValues.isEmpty else { return }
+
+        let standardDefaults = UserDefaults.standard
+        for (key, value) in legacyValues {
+            if standardDefaults.object(forKey: key) == nil {
+                standardDefaults.set(value, forKey: key)
+            }
+            legacyDefaults.removeObject(forKey: key)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- keep standard defaults as the canonical shared runtime store
- migrate values written to the temporary Swift-package suite back into standard defaults without overwriting newer standard values
- add regression coverage for the upgrade path

Part of plan: conversation-forking.md remediation round 5
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
