### PR TITLE
Fix Anthropic document normalization in the LLM inspector

### DIFF
--- a/assistant/src/__tests__/llm-context-normalization.test.ts
+++ b/assistant/src/__tests__/llm-context-normalization.test.ts
@@ -553,6 +553,56 @@ describe("normalizeLlmContextPayloads", () => {
     ]);
   });
 
+  test("normalizes Anthropic document attachments in request prompt sections", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_009,
+      requestPayload: {
+        model: "claude-sonnet",
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "document",
+                title: "agenda.pdf",
+                source: {
+                  type: "base64",
+                  media_type: "application/pdf",
+                  data: "JVBERi0xLjQK",
+                },
+              },
+            ],
+          },
+        ],
+      },
+      responsePayload: undefined,
+    });
+
+    expect(normalized.summary).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet",
+      inputTokens: undefined,
+      outputTokens: undefined,
+      cacheCreationInputTokens: undefined,
+      cacheReadInputTokens: undefined,
+      stopReason: undefined,
+      requestMessageCount: 1,
+      requestToolCount: 0,
+      responseMessageCount: undefined,
+      responseToolCallCount: undefined,
+      responsePreview: undefined,
+      toolCallNames: undefined,
+    });
+    expect(normalized.requestSections).toEqual([
+      {
+        kind: "message",
+        label: "User message 1",
+        role: "user",
+        text: "[document: agenda.pdf]",
+      },
+    ]);
+  });
+
   test("normalizes Anthropic web_search_tool_result blocks", () => {
     const normalized = normalizeLlmContextPayloads({
       createdAt: 1_742_400_000_004,

--- a/assistant/src/runtime/routes/llm-context-normalization.ts
+++ b/assistant/src/runtime/routes/llm-context-normalization.ts
@@ -284,6 +284,7 @@ function normalizeAnthropicRequestPayload(
     (asRecordArray(message.content) ?? []).some((block) => {
       const type = asString(block.type);
       return (
+        type === "document" ||
         type === "tool_use" ||
         type === "server_tool_use" ||
         type === "tool_result" ||
@@ -848,17 +849,9 @@ function collectAnthropicText(content: unknown): string | undefined {
 
   const textParts: string[] = [];
   for (const block of blocks) {
-    const type = asString(block.type);
-    if (type === "text") {
-      const text = asString(block.text);
-      if (text) {
-        textParts.push(text);
-      }
-      continue;
-    }
-
-    if (type === "image") {
-      textParts.push("[image]");
+    const text = collectAnthropicBlockText(block);
+    if (text) {
+      textParts.push(text);
     }
   }
 
@@ -877,17 +870,9 @@ function collectAnthropicMessageText(content: unknown): string | undefined {
 
   const textParts: string[] = [];
   for (const block of blocks) {
-    const type = asString(block.type);
-    if (type === "text") {
-      const text = asString(block.text);
-      if (text) {
-        textParts.push(text);
-      }
-      continue;
-    }
-
-    if (type === "image") {
-      textParts.push("[image]");
+    const text = collectAnthropicBlockText(block);
+    if (text) {
+      textParts.push(text);
     }
   }
 
@@ -917,6 +902,27 @@ function collectAnthropicPreviewText(content: unknown): string | undefined {
   }
 
   return joinTextParts(textParts);
+}
+
+function collectAnthropicBlockText(
+  block: Record<string, unknown>,
+): string | undefined {
+  const type = asString(block.type);
+  if (type === "text") {
+    const text = asString(block.text);
+    return text ? text : undefined;
+  }
+
+  if (type === "image") {
+    return "[image]";
+  }
+
+  if (type === "document") {
+    const title = asString(block.title);
+    return title ? `[document: ${title}]` : "[document]";
+  }
+
+  return undefined;
 }
 
 function collectAnthropicReasoningText(


### PR DESCRIPTION
## Summary
- surface Anthropic document attachments in normalized prompt sections
- keep attachment-driven prompts from falling through to the empty prompt fallback
- add assistant coverage for Anthropic document normalization

Part of plan: llm-context-inspector-redesign.md (remediation round 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
