### PR TITLE
Fix response mode labels in the LLM inspector

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorResponseTab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorResponseTab.swift
@@ -239,15 +239,26 @@ struct MessageInspectorResponseTabModel: Equatable {
         summary: LLMCallSummary?,
         sections: [MessageInspectorResponseSectionModel]
     ) -> String? {
-        if let responseToolCallCount = summary?.responseToolCallCount {
-            return responseToolCallCount > 0 ? "Tool-calling response" : "Text-only response"
+        if let responseToolCallCount = summary?.responseToolCallCount, responseToolCallCount > 0 {
+            return "Tool-calling response"
         }
 
         if sections.contains(where: { $0.isToolCallSection }) {
             return "Tool-calling response"
         }
 
-        return sections.isEmpty ? nil : "Text-only response"
+        let hasAssistantText = sections.contains(where: { $0.presentationKind == .assistantText })
+        let hasResultSection = sections.contains(where: { $0.isResultSection })
+
+        if hasAssistantText && !hasResultSection {
+            return "Text-only response"
+        }
+
+        if hasResultSection && !hasAssistantText {
+            return "Result-only response"
+        }
+
+        return nil
     }
 
     private static func deriveStopReasonLabel(summary: LLMCallSummary?) -> String? {
@@ -275,6 +286,7 @@ struct MessageInspectorResponseSectionModel: Identifiable, Equatable {
     let copyText: String
     let presentationKind: PresentationKind
     let isToolCallSection: Bool
+    let isResultSection: Bool
 
     var showsRawPayloadHint: Bool {
         presentationKind == .toolCall
@@ -292,6 +304,7 @@ struct MessageInspectorResponseSectionModel: Identifiable, Equatable {
         case .tool, .toolUse, .functionCall:
             presentationKind = .toolCall
             isToolCallSection = true
+            isResultSection = false
             kindLabel = "Tool call"
             let preview = Self.previewText(for: section.data) ?? section.text
             bodyText = preview
@@ -300,6 +313,7 @@ struct MessageInspectorResponseSectionModel: Identifiable, Equatable {
         case .toolResult, .functionResponse:
             presentationKind = .other
             isToolCallSection = false
+            isResultSection = true
             kindLabel = section.kind == .functionResponse ? "Function response" : "Tool result"
             let preview = Self.previewText(for: section.data) ?? section.text
             bodyText = preview
@@ -307,6 +321,7 @@ struct MessageInspectorResponseSectionModel: Identifiable, Equatable {
         case .assistant, .message, .text, .output, .completion, .reasoning, .markdown, .code, .json:
             presentationKind = .assistantText
             isToolCallSection = false
+            isResultSection = false
             kindLabel = "Assistant text"
             bodyText = section.text ?? Self.previewText(for: section.data)
             copyText = bodyText ?? title
@@ -314,6 +329,7 @@ struct MessageInspectorResponseSectionModel: Identifiable, Equatable {
             let preview = section.text ?? Self.previewText(for: section.data)
             presentationKind = preview == nil ? .other : .assistantText
             isToolCallSection = false
+            isResultSection = false
             kindLabel = section.kind.rawValue
             bodyText = preview
             copyText = bodyText ?? title

--- a/clients/macos/vellum-assistantTests/MessageInspectorResponseTabTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorResponseTabTests.swift
@@ -106,7 +106,7 @@ final class MessageInspectorResponseTabTests: XCTestCase {
         XCTAssertEqual(model.sections[2].copyText, model.sections[2].bodyText)
     }
 
-    func testResponseTabModelDerivesTextOnlyMetadataForNormalizedSections() {
+    func testResponseTabModelDerivesTextOnlyMetadataForAssistantTextOnlySections() {
         let model = MessageInspectorResponseTabModel(
             entry: makeEntry(
                 responsePayload: AnyCodable([
@@ -132,7 +132,7 @@ final class MessageInspectorResponseTabTests: XCTestCase {
         XCTAssertEqual(model.sections.count, 1)
     }
 
-    func testResponseTabModelDoesNotTreatResultOnlySectionsAsToolCalling() {
+    func testResponseTabModelLabelsResultOnlySectionsAsResultOnlyResponse() {
         let model = MessageInspectorResponseTabModel(
             entry: makeEntry(
                 responsePayload: AnyCodable([
@@ -170,10 +170,45 @@ final class MessageInspectorResponseTabTests: XCTestCase {
 
         XCTAssertTrue(model.hasNormalizedSections)
         XCTAssertEqual(model.responseStopReason, "function_response")
-        XCTAssertEqual(model.responseModeLabel, "Text-only response")
+        XCTAssertEqual(model.responseModeLabel, "Result-only response")
         XCTAssertEqual(model.sections.count, 2)
         XCTAssertEqual(model.sections[0].presentationKind, .other)
         XCTAssertEqual(model.sections[1].presentationKind, .other)
+    }
+
+    func testResponseTabModelDoesNotCallMixedAssistantTextAndResultSectionsTextOnly() {
+        let model = MessageInspectorResponseTabModel(
+            entry: makeEntry(
+                responsePayload: AnyCodable([
+                    "stop_reason": "function_response"
+                ]),
+                summary: LLMCallSummary(
+                    stopReason: "function_response"
+                ),
+                responseSections: [
+                    LLMContextSection(
+                        kind: .assistant,
+                        label: "Assistant response",
+                        role: "assistant",
+                        text: "Normalized assistant text"
+                    ),
+                    LLMContextSection(
+                        kind: .functionResponse,
+                        label: "Function response 1",
+                        role: "assistant",
+                        text: "function response preview",
+                        toolName: "search_web",
+                        data: AnyCodable([
+                            "status": "ok"
+                        ])
+                    )
+                ]
+            )
+        )
+
+        XCTAssertTrue(model.hasNormalizedSections)
+        XCTAssertNil(model.responseModeLabel)
+        XCTAssertEqual(model.sections.count, 2)
     }
 
     func testResponseTabModelUsesExplicitSummaryToolCallCountForToolCalling() {


### PR DESCRIPTION
## Summary
- stop labeling result-only normalized responses as text-only
- preserve the existing tool-calling and true text-only response modes
- add response-tab coverage for the corrected metadata behavior

Part of plan: llm-context-inspector-redesign.md (remediation round 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
