### PR TITLE
fix: use dirName for vellumapp:// scheme URLs to resolve app files

### DIFF
--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1,6 +1,11 @@
 import { v4 as uuid } from "uuid";
 
-import { getApp, getAppPreview, updateApp } from "../memory/app-store.js";
+import {
+  getApp,
+  getAppPreview,
+  resolveAppDir,
+  updateApp,
+} from "../memory/app-store.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { getLogger } from "../util/logger.js";
 import { isPlainObject } from "../util/object.js";
@@ -1219,9 +1224,11 @@ export async function surfaceProxyResolver(
     const defaultPreview = { title: app.name, subtitle: app.description };
 
     const storedPreview = getAppPreview(app.id);
+    const { dirName } = resolveAppDir(app.id);
     const surfaceData: DynamicPageSurfaceData = {
       html: app.htmlDefinition,
       appId: app.id,
+      dirName,
       preview: {
         ...defaultPreview,
         ...preview,

--- a/assistant/src/daemon/message-types/surfaces.ts
+++ b/assistant/src/daemon/message-types/surfaces.ts
@@ -100,6 +100,8 @@ export interface DynamicPageSurfaceData {
   width?: number;
   height?: number;
   appId?: string;
+  /** Filesystem directory name for this app (may differ from `appId`). */
+  dirName?: string;
   reloadGeneration?: number;
   status?: string;
   preview?: DynamicPagePreview;

--- a/assistant/src/runtime/routes/app-management-routes.ts
+++ b/assistant/src/runtime/routes/app-management-routes.ts
@@ -39,6 +39,7 @@ import {
   isMultifileApp,
   listApps,
   queryAppRecords,
+  resolveAppDir,
   updateApp,
   updateAppRecord,
 } from "../../memory/app-store.js";
@@ -689,8 +690,10 @@ export function appManagementRouteDefinitions(): RouteDefinition[] {
             }
           }
 
+          const { dirName } = resolveAppDir(app.id);
           return Response.json({
             appId: app.id,
+            dirName,
             name: app.name,
             html,
           });

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -437,9 +437,11 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         // isolated per app. Non-app surfaces get a shared fallback origin.
         if let appId = appId {
             // App-backed surface — serve from disk via scheme handler.
+            // Use dirName for filesystem paths (may differ from appId/UUID).
+            let localDir = data.dirName ?? appId
             // Multifile apps have a compiled dist/ directory; prefer it over root index.html.
             let appsDirectory = userAppsDirectory ?? VellumAppSchemeHandler.userAppsDirectory
-            let appDir = appsDirectory.appendingPathComponent(appId)
+            let appDir = appsDirectory.appendingPathComponent(localDir)
             let distIndex = appDir.appendingPathComponent("dist/index.html")
             let hasSrcDir = FileManager.default.fileExists(atPath: appDir.appendingPathComponent("src").path)
 
@@ -447,8 +449,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                 // Multifile app whose dist/ hasn't been compiled yet — show a
                 // "building" placeholder that auto-retries by navigating to the
                 // scheme URL (not reload, which would just re-render this inline HTML).
-                let distSchemeURL = "vellumapp://\(appId)/dist/index.html"
-                let origin = "vellumapp://\(appId)/"
+                let distSchemeURL = "vellumapp://\(localDir)/dist/index.html"
+                let origin = "vellumapp://\(localDir)/"
                 let buildingHTML = """
                 <!DOCTYPE html><html><head><meta charset="UTF-8">
                 <style>body{display:flex;align-items:center;justify-content:center;height:100vh;margin:0;
@@ -466,7 +468,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                 let entryPath = FileManager.default.fileExists(atPath: distIndex.path)
                     ? "dist/index.html"
                     : "index.html"
-                let schemeURL = URL(string: "vellumapp://\(appId)/\(entryPath)")!
+                let schemeURL = URL(string: "vellumapp://\(localDir)/\(entryPath)")!
                 webView.load(URLRequest(url: schemeURL))
             }
         } else {

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -314,16 +314,19 @@ public struct DynamicPageSurfaceData: Sendable, Equatable {
     public let width: Int?
     public let height: Int?
     public let appId: String?
+    /// Filesystem directory name for this app (may differ from `appId`).
+    public let dirName: String?
     public let appType: String?
     public var preview: DynamicPagePreview?
     public let reloadGeneration: Int?
     public let status: String?
 
-    public init(html: String, width: Int? = nil, height: Int? = nil, appId: String? = nil, appType: String? = nil, preview: DynamicPagePreview? = nil, reloadGeneration: Int? = nil, status: String? = nil) {
+    public init(html: String, width: Int? = nil, height: Int? = nil, appId: String? = nil, dirName: String? = nil, appType: String? = nil, preview: DynamicPagePreview? = nil, reloadGeneration: Int? = nil, status: String? = nil) {
         self.html = html
         self.width = width
         self.height = height
         self.appId = appId
+        self.dirName = dirName
         self.appType = appType
         self.preview = preview
         self.reloadGeneration = reloadGeneration
@@ -756,13 +759,14 @@ public extension Surface {
         let width: Int? = update.keys.contains("width") ? (update["width"] as? Int) : existing.width
         let height: Int? = update.keys.contains("height") ? (update["height"] as? Int) : existing.height
         let appId: String? = update.keys.contains("appId") ? (update["appId"] as? String) : existing.appId
+        let dirName: String? = update.keys.contains("dirName") ? (update["dirName"] as? String) : existing.dirName
         let appType: String? = update.keys.contains("appType") ? (update["appType"] as? String) : existing.appType
         let preview: DynamicPagePreview? = update.keys.contains("preview")
             ? parseDynamicPagePreview(update["preview"] as? [String: Any?])
             : existing.preview
         let reloadGeneration: Int? = update.keys.contains("reloadGeneration") ? (update["reloadGeneration"] as? Int) : existing.reloadGeneration
         let status: String? = update.keys.contains("status") ? (update["status"] as? String) : existing.status
-        return DynamicPageSurfaceData(html: html, width: width, height: height, appId: appId, appType: appType, preview: preview, reloadGeneration: reloadGeneration, status: status)
+        return DynamicPageSurfaceData(html: html, width: width, height: height, appId: appId, dirName: dirName, appType: appType, preview: preview, reloadGeneration: reloadGeneration, status: status)
     }
     // MARK: - Field Parsing Helpers
 
@@ -928,6 +932,7 @@ public extension Surface {
             width: dict["width"] as? Int,
             height: dict["height"] as? Int,
             appId: dict["appId"] as? String,
+            dirName: dict["dirName"] as? String,
             appType: dict["appType"] as? String,
             preview: parseDynamicPagePreview(dict["preview"] as? [String: Any?]),
             reloadGeneration: dict["reloadGeneration"] as? Int,

--- a/clients/shared/Network/AppsClient.swift
+++ b/clients/shared/Network/AppsClient.swift
@@ -29,6 +29,8 @@ public protocol AppsClientProtocol {
 /// REST shape returned by `/v1/apps/:id/open`.
 public struct AppOpenResult: Sendable {
     public let appId: String
+    /// Filesystem directory name for this app (may differ from `appId`).
+    public let dirName: String
     public let name: String
     public let html: String
 }
@@ -77,6 +79,7 @@ public struct AppsClient: AppsClientProtocol {
 
     private struct HTTPAppOpenResponse: Decodable {
         let appId: String
+        let dirName: String?
         let name: String
         let html: String
     }
@@ -134,7 +137,7 @@ public struct AppsClient: AppsClientProtocol {
                 return nil
             }
             let decoded = try JSONDecoder().decode(HTTPAppOpenResponse.self, from: response.data)
-            return AppOpenResult(appId: decoded.appId, name: decoded.name, html: decoded.html)
+            return AppOpenResult(appId: decoded.appId, dirName: decoded.dirName ?? decoded.appId, name: decoded.name, html: decoded.html)
         } catch {
             log.error("openApp error: \(error.localizedDescription)")
             return nil
@@ -151,7 +154,7 @@ public struct AppsClient: AppsClientProtocol {
             surfaceId: "app-open-\(result.appId)",
             surfaceType: "dynamic_page",
             title: result.name,
-            data: AnyCodable(["html": result.html, "appId": result.appId]),
+            data: AnyCodable(["html": result.html, "appId": result.appId, "dirName": result.dirName]),
             actions: nil,
             display: "panel",
             messageId: nil


### PR DESCRIPTION
## Summary
- Apps with slug-based `dirName` (introduced with the dirName migration) showed "File not found: index.html" because the client used the UUID as the `vellumapp://` scheme host, but the scheme handler looked for a directory with that exact name
- Added `dirName` to the daemon's open response and surface data so the client can resolve the correct filesystem path
- Client now uses `data.dirName ?? appId` for scheme URLs, falling back to UUID for pre-migration apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
