### PR TITLE
Fix equal-timestamp fork ordering

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -174,6 +174,34 @@ describe("forkConversation", () => {
     ).toBe(true);
   });
 
+  test("preserves source order when source messages share a timestamp", () => {
+    const source = createConversation("Equal timestamp thread");
+    const db = getDb();
+    const createdAt = Date.now();
+
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('z-source-message', '${source.id}', 'user', 'first', ${createdAt})`,
+    );
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('a-source-message', '${source.id}', 'assistant', 'second', ${createdAt})`,
+    );
+
+    const sourceMessages = getMessages(source.id);
+    const fork = forkConversation({ conversationId: source.id });
+    const forkMessages = getMessages(fork.id);
+
+    expect(sourceMessages.map((message) => message.content)).toEqual([
+      "first",
+      "second",
+    ]);
+    expect(forkMessages.map((message) => message.content)).toEqual(
+      sourceMessages.map((message) => message.content),
+    );
+    expect(forkMessages.map((message) => message.role)).toEqual(
+      sourceMessages.map((message) => message.role),
+    );
+  });
+
   test("forks only through the requested branch point", async () => {
     const source = createConversation("Branchable thread");
     await addMessage(source.id, "user", "Message 1", undefined, {

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -329,13 +329,7 @@ export function forkConversation(params: {
     throw new UserError(PRIVATE_CONVERSATION_FORK_ERROR);
   }
 
-  const sourceMessages = db
-    .select()
-    .from(messages)
-    .where(eq(messages.conversationId, conversationId))
-    .orderBy(asc(messages.createdAt), asc(messages.id))
-    .all()
-    .map(parseMessage);
+  const sourceMessages = getMessages(conversationId);
 
   if (sourceMessages.length === 0) {
     throw new UserError(


### PR DESCRIPTION
## Summary
- preserve the source conversation’s existing message order when forking equal-timestamp history
- add regression coverage for equal-timestamp fork cloning

Part of plan: conversation-forking.md remediation round 6
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
