### PR TITLE
Fix shared defaults migration test isolation

### DIFF
--- a/clients/shared/Tests/SharedUserDefaultsTests.swift
+++ b/clients/shared/Tests/SharedUserDefaultsTests.swift
@@ -5,6 +5,8 @@ import XCTest
 final class SharedUserDefaultsTests: XCTestCase {
     private let key = "shared-defaults-regression-test"
     private let legacySuiteName = "com.vellum.vellum-assistant.swiftpackage"
+    private var legacySuiteSnapshot: [String: Any]?
+    private var standardValueSnapshot: Any?
 
     private var legacyDefaults: UserDefaults {
         guard let defaults = UserDefaults(suiteName: legacySuiteName) else {
@@ -15,14 +17,25 @@ final class SharedUserDefaultsTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        legacySuiteSnapshot = legacyDefaults.persistentDomain(forName: legacySuiteName)
+        standardValueSnapshot = UserDefaults.standard.object(forKey: key)
         SharedUserDefaults.resetLegacyMigrationStateForTests()
         UserDefaults.standard.removeObject(forKey: key)
         legacyDefaults.removeObject(forKey: key)
     }
 
     override func tearDown() {
-        UserDefaults.standard.removeObject(forKey: key)
-        legacyDefaults.removeObject(forKey: key)
+        if let legacySuiteSnapshot {
+            legacyDefaults.setPersistentDomain(legacySuiteSnapshot, forName: legacySuiteName)
+        } else {
+            legacyDefaults.removePersistentDomain(forName: legacySuiteName)
+        }
+
+        if let standardValueSnapshot {
+            UserDefaults.standard.set(standardValueSnapshot, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
         SharedUserDefaults.resetLegacyMigrationStateForTests()
         super.tearDown()
     }


### PR DESCRIPTION
## Summary
- keep shared defaults migration tests from mutating a machine’s real leftover legacy-suite state
- preserve the regression coverage for legacy-suite migration behavior

Part of plan: conversation-forking.md remediation round 6
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
