### PR TITLE
Fix overview inspector tests and review tracking

### DIFF
--- a/clients/macos/vellum-assistantTests/MessageInspectorOverviewTabTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorOverviewTabTests.swift
@@ -41,7 +41,7 @@ final class MessageInspectorOverviewTabTests: XCTestCase {
         XCTAssertEqual(content.identityRows.map(\.label), ["Provider", "Model", "Created"])
         XCTAssertEqual(content.identityRows.map(\.value)[0], "OpenAI")
         XCTAssertEqual(content.identityRows.map(\.value)[1], "gpt-4.1")
-        XCTAssertTrue(content.identityRows.map(\.value)[2].contains("1970"))
+        XCTAssertEqual(content.identityRows.map(\.value)[2], MessageInspectorSummaryFormatters.formattedCreatedAt(0))
 
         XCTAssertEqual(content.usageRows.map(\.label), ["Input tokens", "Output tokens", "Cache tokens", "Request messages", "Tool count"])
         XCTAssertEqual(content.usageRows.map(\.value), ["321", "54", "Unavailable", "2", "2"])
@@ -148,7 +148,7 @@ final class MessageInspectorOverviewTabTests: XCTestCase {
         XCTAssertNil(content.toolCallNames)
         XCTAssertNotNil(content.fallbackMessage)
         XCTAssertTrue(content.fallbackMessage?.contains("Raw tab") == true)
-        XCTAssertTrue(content.fallbackMessage?.contains("1970") == true)
+        XCTAssertTrue(content.fallbackMessage?.contains(MessageInspectorSummaryFormatters.formattedCreatedAt(0)) == true)
     }
 
     func testFormatterHelpersTruncateAndCompactValues() {
@@ -166,6 +166,6 @@ final class MessageInspectorOverviewTabTests: XCTestCase {
     }
 
     private func decodeEntry(_ json: String) throws -> LLMRequestLogEntry {
-        try JSONDecoder().decode(LLMContextResponse.self, from: Data(json.utf8)).logs[0]
+        try JSONDecoder().decode(LLMRequestLogEntry.self, from: Data(json.utf8))
     }
 }


### PR DESCRIPTION
## Summary
- fix the overview tab test helper so its fixtures decode correctly
- keep the overview coverage aligned with the merged inspector contract
- backfill PR #19360 in the unreviewed PR tracking file

Part of plan: llm-context-inspector-redesign.md (remediation round 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
