### PR TITLE
Tighten mixed-provider guards in the LLM inspector

### DIFF
--- a/assistant/src/__tests__/llm-context-normalization.test.ts
+++ b/assistant/src/__tests__/llm-context-normalization.test.ts
@@ -553,6 +553,67 @@ describe("normalizeLlmContextPayloads", () => {
     ]);
   });
 
+  test("rejects ambiguous request payloads that match OpenAI and Anthropic", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_010,
+      requestPayload: {
+        model: "gpt-4.1",
+        tool_choice: { type: "auto" },
+        parallel_tool_calls: true,
+        messages: [{ role: "user", content: "Hello there." }],
+      },
+      responsePayload: {
+        model: "gpt-4.1-2026-03-01",
+        choices: [
+          {
+            finish_reason: "stop",
+            message: {
+              role: "assistant",
+              content: "Hello back.",
+            },
+          },
+        ],
+        usage: {
+          prompt_tokens: 12,
+          completion_tokens: 4,
+        },
+      },
+    });
+
+    expect(normalized).toEqual({});
+  });
+
+  test("rejects ambiguous response payloads that match OpenAI and Anthropic", () => {
+    const normalized = normalizeLlmContextPayloads({
+      createdAt: 1_742_400_000_011,
+      requestPayload: {
+        model: "gpt-4.1",
+        parallel_tool_calls: true,
+        messages: [{ role: "user", content: "Hello there." }],
+      },
+      responsePayload: {
+        model: "gpt-4.1-2026-03-01",
+        choices: [
+          {
+            finish_reason: "stop",
+            message: {
+              role: "assistant",
+              content: "Hello back.",
+            },
+          },
+        ],
+        content: [{ type: "text", text: "Hello back." }],
+        stop_reason: "end_turn",
+        usage: {
+          prompt_tokens: 12,
+          completion_tokens: 4,
+        },
+      },
+    });
+
+    expect(normalized).toEqual({});
+  });
+
   test("normalizes Anthropic document attachments in request prompt sections", () => {
     const normalized = normalizeLlmContextPayloads({
       createdAt: 1_742_400_000_009,

--- a/assistant/src/runtime/routes/llm-context-normalization.ts
+++ b/assistant/src/runtime/routes/llm-context-normalization.ts
@@ -70,41 +70,37 @@ export function normalizeLlmContextPayloads(
     Boolean(candidate),
   );
 
-  const requestProviders = new Set(
-    requestCandidates.map((candidate) => candidate.provider),
-  );
-  const responseProviders = new Set(
-    responseCandidates.map((candidate) => candidate.provider),
-  );
-  const sharedProviders = [...requestProviders].filter((provider) =>
-    responseProviders.has(provider),
-  );
-
-  if (sharedProviders.length > 1) {
+  if (requestCandidates.length > 1 || responseCandidates.length > 1) {
     return {};
   }
 
-  if (sharedProviders.length === 1) {
-    const provider = sharedProviders[0] as LlmContextSummary["provider"];
-    return mergeNormalizedCandidates(
-      requestCandidates.find((candidate) => candidate.provider === provider) ??
-        undefined,
-      responseCandidates.find((candidate) => candidate.provider === provider) ??
-        undefined,
-    );
+  const requestCandidate = requestCandidates[0];
+  const responseCandidate = responseCandidates[0];
+
+  if (requestCandidate && responseCandidate) {
+    if (requestCandidate.provider !== responseCandidate.provider) {
+      return {};
+    }
+
+    return mergeNormalizedCandidates(requestCandidate, responseCandidate);
   }
 
-  if (requestCandidates.length === 1 && responseCandidates.length === 0) {
-    return requestCandidates[0] as LlmContextNormalizationResult;
+  if (requestCandidate) {
+    return requestCandidate as LlmContextNormalizationResult;
   }
 
-  if (responseCandidates.length === 1 && requestCandidates.length === 0) {
-    const responseCandidate =
-      responseCandidates[0] as NormalizedPayloadCandidate;
+  if (responseCandidate) {
     const requestCandidate = normalizeCompatibleRequestPayload(
       input.requestPayload,
       responseCandidate.provider,
     );
+    if (
+      requestCandidate &&
+      requestCandidate.provider !== responseCandidate.provider
+    ) {
+      return {};
+    }
+
     return mergeNormalizedCandidates(requestCandidate, responseCandidate);
   }
 


### PR DESCRIPTION
## Summary
- reject ambiguous hybrid payloads instead of normalizing a guessed provider
- preserve the existing single-provider and partial-normalization paths
- add assistant coverage for mixed-provider ambiguity cases

Part of plan: llm-context-inspector-redesign.md (remediation round 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
