### PR TITLE
feat: improve llm inspector provider labels

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorSummaryFormatters.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorSummaryFormatters.swift
@@ -88,8 +88,14 @@ enum MessageInspectorSummaryFormatters {
             return "Anthropic"
         case "gemini":
             return "Gemini"
+        case "openrouter":
+            return "OpenRouter"
+        case "fireworks":
+            return "Fireworks"
+        case "ollama":
+            return "Ollama"
         default:
-            return provider
+            return titleCasedProviderLabel(provider)
         }
     }
 
@@ -137,6 +143,23 @@ enum MessageInspectorSummaryFormatters {
     static func formattedCreatedAt(_ epochMs: Int) -> String {
         Date(timeIntervalSince1970: TimeInterval(epochMs) / 1000.0)
             .formatted(date: .abbreviated, time: .shortened)
+    }
+
+    private static func titleCasedProviderLabel(_ provider: String) -> String {
+        let separators = CharacterSet(charactersIn: "-_")
+        let parts = provider
+            .lowercased()
+            .components(separatedBy: separators)
+            .filter { !$0.isEmpty }
+
+        guard !parts.isEmpty else {
+            return provider.capitalized
+        }
+
+        return parts.map { part in
+            part.prefix(1).uppercased() + part.dropFirst()
+        }
+        .joined(separator: " ")
     }
 
     private static let numberFormatter: NumberFormatter = {

--- a/clients/macos/vellum-assistantTests/MessageInspectorOverviewTabTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorOverviewTabTests.swift
@@ -128,6 +128,20 @@ final class MessageInspectorOverviewTabTests: XCTestCase {
         XCTAssertNil(content.fallbackMessage)
     }
 
+    func testProviderLabelsStayReadableForKnownRuntimeProviders() throws {
+        XCTAssertEqual(providerLabel(for: "openai"), "OpenAI")
+        XCTAssertEqual(providerLabel(for: "anthropic"), "Anthropic")
+        XCTAssertEqual(providerLabel(for: "gemini"), "Gemini")
+        XCTAssertEqual(providerLabel(for: "openrouter"), "OpenRouter")
+        XCTAssertEqual(providerLabel(for: "fireworks"), "Fireworks")
+        XCTAssertEqual(providerLabel(for: "ollama"), "Ollama")
+    }
+
+    func testUnknownProviderSlugIsNormalizedIntoReadableText() throws {
+        XCTAssertEqual(providerLabel(for: "future-provider_name"), "Future Provider Name")
+        XCTAssertEqual(providerLabel(for: "custom"), "Custom")
+    }
+
     func testMissingSummaryFallsBackToRawPayloadHint() throws {
         let entry = try decodeEntry(
             #"""
@@ -167,5 +181,33 @@ final class MessageInspectorOverviewTabTests: XCTestCase {
 
     private func decodeEntry(_ json: String) throws -> LLMRequestLogEntry {
         try JSONDecoder().decode(LLMRequestLogEntry.self, from: Data(json.utf8))
+    }
+
+    private func providerLabel(for provider: String) -> String {
+        let entry = LLMRequestLogEntry(
+            id: "provider-\(provider)",
+            requestPayload: AnyCodable(["type": "request"]),
+            responsePayload: AnyCodable(["type": "response"]),
+            createdAt: 0,
+            summary: .init(
+                model: "gpt-4.1",
+                provider: provider,
+                inputTokens: nil,
+                outputTokens: nil,
+                cacheCreationInputTokens: nil,
+                cacheReadInputTokens: nil,
+                stopReason: nil,
+                requestMessageCount: nil,
+                requestToolCount: nil,
+                responseMessageCount: nil,
+                responseToolCallCount: nil,
+                responsePreview: nil,
+                toolCallNames: nil
+            ),
+            requestSections: nil,
+            responseSections: nil
+        )
+
+        return MessageInspectorOverviewContent(entry: entry).identityRows[0].value
     }
 }


### PR DESCRIPTION
## Summary
- add display labels for runtime providers beyond the original openai, anthropic, and gemini set
- cover explicit and fallback provider label formatting in focused overview-tab tests

Part of plan: llm-log-provider-persistence.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
