### PR TITLE
feat: use persisted runtime providers in llm context

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -227,6 +227,7 @@ mock.module("../daemon/conversation-history.js", () => ({
 }));
 
 const recordUsageMock = mock(() => {});
+const recordRequestLogMock = mock(() => {});
 mock.module("../daemon/conversation-usage.js", () => ({
   recordUsage: recordUsageMock,
 }));
@@ -315,7 +316,7 @@ mock.module("../agent/message-types.js", () => ({
 }));
 
 mock.module("../memory/llm-request-log-store.js", () => ({
-  recordRequestLog: () => {},
+  recordRequestLog: recordRequestLogMock,
   backfillMessageIdOnLogs: () => {},
 }));
 
@@ -457,6 +458,7 @@ beforeEach(() => {
   mockOverflowAction = "fail_gracefully";
   mockApprovalResult = { approved: false };
   recordUsageMock.mockClear();
+  recordRequestLogMock.mockClear();
   syncMessageToDiskMock.mockClear();
   rebuildConversationDiskViewFromDbStateMock.mockClear();
   consolidateAssistantMessagesMock.mockReset();
@@ -601,6 +603,89 @@ describe("session-agent-loop", () => {
       expect(conversationError).toBeUndefined();
       const complete = events.find((e) => e.type === "message_complete");
       expect(complete).toBeDefined();
+    });
+  });
+
+  describe("LLM request log persistence", () => {
+    test("record request log forwards the runtime provider", async () => {
+      const events: ServerMessage[] = [];
+      const rawRequest = {
+        model: "gpt-4.1",
+        messages: [{ role: "user", content: "Hello" }],
+      };
+      const rawResponse = {
+        model: "gpt-4.1-2026-03-01",
+        choices: [
+          {
+            finish_reason: "stop",
+            message: {
+              role: "assistant",
+              content: "Hi there.",
+            },
+          },
+        ],
+        usage: {
+          prompt_tokens: 12,
+          completion_tokens: 3,
+        },
+      };
+
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
+        onEvent({
+          type: "message_complete",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "Hi there." }],
+          },
+        });
+        onEvent({
+          type: "usage",
+          inputTokens: 12,
+          outputTokens: 3,
+          model: "gpt-4.1-2026-03-01",
+          providerDurationMs: 45,
+          rawRequest,
+          rawResponse,
+        });
+        return [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [{ type: "text", text: "Hi there." }] as ContentBlock[],
+          },
+        ];
+      };
+
+      const ctx = makeCtx({
+        agentLoopRun,
+        provider: {
+          name: "openrouter",
+          sendMessage: async () => ({
+            content: [{ type: "text", text: "title" }],
+            model: "mock",
+            usage: { inputTokens: 0, outputTokens: 0 },
+            stopReason: "end_turn",
+          }),
+        } as unknown as AgentLoopConversationContext["provider"],
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+
+      expect(recordRequestLogMock).toHaveBeenCalledTimes(1);
+      const call = recordRequestLogMock.mock.calls[0] as unknown as [
+        string,
+        string,
+        string,
+        undefined,
+        string,
+      ];
+      expect(call).toEqual([
+        "test-conv",
+        JSON.stringify(rawRequest),
+        JSON.stringify(rawResponse),
+        undefined,
+        "openrouter",
+      ]);
     });
   });
 

--- a/assistant/src/__tests__/llm-context-route-provider.test.ts
+++ b/assistant/src/__tests__/llm-context-route-provider.test.ts
@@ -1,0 +1,217 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "llm-context-route-provider-"));
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { llmRequestLogs } from "../memory/schema.js";
+import { conversationQueryRouteDefinitions } from "../runtime/routes/conversation-query-routes.js";
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+const routes = conversationQueryRouteDefinitions();
+
+function dispatchLlmContext(messageId: string): Promise<Response> | Response {
+  const url = new URL(`http://localhost/v1/messages/${messageId}/llm-context`);
+  const route = routes.find(
+    (r) => r.method === "GET" && r.endpoint === "messages/:id/llm-context",
+  );
+  if (!route) {
+    throw new Error("No llm-context route found");
+  }
+
+  return route.handler({
+    req: new Request(url.toString(), { method: "GET" }),
+    url,
+    server: null as never,
+    authContext: {} as never,
+    params: { id: messageId },
+  });
+}
+
+function clearRequestLogs(): void {
+  getDb().delete(llmRequestLogs).run();
+}
+
+function seedRequestLog(overrides: {
+  id: string;
+  messageId: string;
+  provider: string | null;
+  requestPayload: string;
+  responsePayload: string;
+  createdAt?: number;
+}): void {
+  getDb()
+    .insert(llmRequestLogs)
+    .values({
+      id: overrides.id,
+      conversationId: "conv-1",
+      messageId: overrides.messageId,
+      provider: overrides.provider,
+      requestPayload: overrides.requestPayload,
+      responsePayload: overrides.responsePayload,
+      createdAt: overrides.createdAt ?? 1_700_000_000_000,
+    })
+    .run();
+}
+
+beforeEach(() => {
+  clearRequestLogs();
+});
+
+describe("GET /v1/messages/:id/llm-context provider preference", () => {
+  const openAiRequestPayload = JSON.stringify({
+    model: "gpt-4.1",
+    tool_choice: "auto",
+    messages: [
+      { role: "system", content: "Stay brief." },
+      { role: "user", content: "Hello there." },
+    ],
+  });
+
+  const openAiResponsePayload = JSON.stringify({
+    model: "gpt-4.1-2026-03-01",
+    choices: [
+      {
+        finish_reason: "stop",
+        message: {
+          role: "assistant",
+          content: "Hello back.",
+        },
+      },
+    ],
+    usage: {
+      prompt_tokens: 11,
+      completion_tokens: 4,
+    },
+  });
+
+  test("prefers a stored OpenRouter provider over OpenAI-shaped payload inference", async () => {
+    seedRequestLog({
+      id: "log-openrouter",
+      messageId: "msg-openrouter",
+      provider: "openrouter",
+      requestPayload: openAiRequestPayload,
+      responsePayload: openAiResponsePayload,
+    });
+
+    const response = await dispatchLlmContext("msg-openrouter");
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      logs: Array<{
+        summary?: { provider: string };
+      }>;
+    };
+
+    expect(body.logs).toHaveLength(1);
+    expect(body.logs[0]?.summary).toEqual(
+      expect.objectContaining({
+        provider: "openrouter",
+      }),
+    );
+  });
+
+  test("prefers a stored Fireworks provider over OpenAI-shaped payload inference", async () => {
+    seedRequestLog({
+      id: "log-fireworks",
+      messageId: "msg-fireworks",
+      provider: "fireworks",
+      requestPayload: openAiRequestPayload,
+      responsePayload: openAiResponsePayload,
+    });
+
+    const response = await dispatchLlmContext("msg-fireworks");
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      logs: Array<{
+        summary?: { provider: string };
+      }>;
+    };
+
+    expect(body.logs).toHaveLength(1);
+    expect(body.logs[0]?.summary).toEqual(
+      expect.objectContaining({
+        provider: "fireworks",
+      }),
+    );
+  });
+
+  test("keeps the legacy shape-inferred provider when no stored provider exists", async () => {
+    seedRequestLog({
+      id: "log-legacy",
+      messageId: "msg-legacy",
+      provider: null,
+      requestPayload: openAiRequestPayload,
+      responsePayload: openAiResponsePayload,
+    });
+
+    const response = await dispatchLlmContext("msg-legacy");
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      logs: Array<{
+        summary?: { provider: string };
+      }>;
+    };
+
+    expect(body.logs).toHaveLength(1);
+    expect(body.logs[0]?.summary).toEqual(
+      expect.objectContaining({
+        provider: "openai",
+      }),
+    );
+  });
+
+  test("keeps a stored provider label even when payload normalization fails", async () => {
+    seedRequestLog({
+      id: "log-raw-only",
+      messageId: "msg-raw-only",
+      provider: "ollama",
+      requestPayload: "not-json",
+      responsePayload: "still-not-json",
+    });
+
+    const response = await dispatchLlmContext("msg-raw-only");
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      logs: Array<{
+        summary?: { provider: string };
+      }>;
+    };
+
+    expect(body.logs).toHaveLength(1);
+    expect(body.logs[0]?.summary).toEqual({ provider: "ollama" });
+  });
+});

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -775,6 +775,8 @@ export function handleUsage(
         deps.ctx.conversationId,
         JSON.stringify(event.rawRequest),
         JSON.stringify(event.rawResponse),
+        undefined,
+        deps.ctx.provider.name,
       );
     } catch (err) {
       deps.rlog.warn({ err }, "Failed to persist LLM request log (non-fatal)");

--- a/assistant/src/memory/llm-request-log-store.ts
+++ b/assistant/src/memory/llm-request-log-store.ts
@@ -10,6 +10,7 @@ export function recordRequestLog(
   requestPayload: string,
   responsePayload: string,
   messageId?: string,
+  provider?: string,
 ): void {
   const db = getDb();
   db.insert(llmRequestLogs)
@@ -17,6 +18,7 @@ export function recordRequestLog(
       id: uuid(),
       conversationId,
       messageId: messageId ?? null,
+      provider: provider ?? null,
       requestPayload,
       responsePayload,
       createdAt: Date.now(),
@@ -70,6 +72,7 @@ export function getRequestLogsByMessageId(messageId: string): Array<{
   id: string;
   conversationId: string;
   messageId: string | null;
+  provider: string | null;
   requestPayload: string;
   responsePayload: string;
   createdAt: number;
@@ -81,6 +84,7 @@ export function getRequestLogsByMessageId(messageId: string): Array<{
         id: llmRequestLogs.id,
         conversationId: llmRequestLogs.conversationId,
         messageId: llmRequestLogs.messageId,
+        provider: llmRequestLogs.provider,
         requestPayload: llmRequestLogs.requestPayload,
         responsePayload: llmRequestLogs.responsePayload,
         createdAt: llmRequestLogs.createdAt,
@@ -101,7 +105,9 @@ export function getRequestLogsByMessageId(messageId: string): Array<{
   }
 
   try {
-    const parsed = messageMetadataSchema.safeParse(JSON.parse(message.metadata));
+    const parsed = messageMetadataSchema.safeParse(
+      JSON.parse(message.metadata),
+    );
     const sourceMessageId =
       parsed.success && typeof parsed.data.forkSourceMessageId === "string"
         ? parsed.data.forkSourceMessageId

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -32,6 +32,36 @@ import { normalizeLlmContextPayloads } from "./llm-context-normalization.js";
 
 const validProviderSet = new Set<string>(VALID_INFERENCE_PROVIDERS);
 
+type LlmContextNormalizationResult = ReturnType<
+  typeof normalizeLlmContextPayloads
+>;
+
+type LlmContextSummaryResponse = NonNullable<
+  Omit<NonNullable<LlmContextNormalizationResult["summary"]>, "provider">
+> & {
+  provider: string;
+};
+
+type LlmContextRouteResult = Omit<LlmContextNormalizationResult, "summary"> & {
+  summary?: LlmContextSummaryResponse;
+};
+
+function applyStoredProviderToLlmContextResult(
+  normalized: LlmContextNormalizationResult,
+  provider: string | null,
+): LlmContextRouteResult {
+  if (!provider) {
+    return normalized as LlmContextRouteResult;
+  }
+
+  return {
+    ...normalized,
+    summary: normalized.summary
+      ? { ...normalized.summary, provider }
+      : { provider },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Dependency interfaces
 // ---------------------------------------------------------------------------
@@ -222,12 +252,16 @@ export function conversationQueryRouteDefinitions(
               responsePayload,
               createdAt: log.createdAt,
             });
+            const result = applyStoredProviderToLlmContextResult(
+              normalized,
+              log.provider,
+            );
             return {
               id: log.id,
               requestPayload,
               responsePayload,
               createdAt: log.createdAt,
-              ...normalized,
+              ...result,
             };
           }),
         });


### PR DESCRIPTION
## Summary
- persist the runtime provider through request-log storage and agent-loop logging
- prefer stored providers over payload-shape inference in the llm context route while preserving legacy fallback
- add focused tests for route behavior and provider forwarding

Part of plan: llm-log-provider-persistence.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
