### PR TITLE
fix: include provider in diagnostics export

### DIFF
--- a/assistant/src/__tests__/diagnostics-export.test.ts
+++ b/assistant/src/__tests__/diagnostics-export.test.ts
@@ -5,10 +5,12 @@
  * (specific ID → most recent assistant → any message → empty conversation).
  */
 
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import JSZip from "jszip";
 
 const testDir = mkdtempSync(join(tmpdir(), "diagnostics-export-test-"));
 
@@ -90,6 +92,27 @@ function seedMessage(
   );
 }
 
+function seedLlmRequestLog(
+  id: string,
+  conversationId: string,
+  provider: string | null,
+  requestPayload: unknown,
+  responsePayload: unknown,
+  createdAt: number,
+): void {
+  db().run(
+    "INSERT INTO llm_request_logs (id, conversation_id, provider, request_payload, response_payload, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+    [
+      id,
+      conversationId,
+      provider,
+      JSON.stringify(requestPayload),
+      JSON.stringify(responsePayload),
+      createdAt,
+    ],
+  );
+}
+
 function seedConversationKey(
   conversationKey: string,
   conversationId: string,
@@ -102,6 +125,7 @@ function seedConversationKey(
 
 function cleanDb(): void {
   db().run("DELETE FROM messages");
+  db().run("DELETE FROM llm_request_logs");
   db().run("DELETE FROM conversation_keys");
   db().run("DELETE FROM conversations");
 }
@@ -215,5 +239,50 @@ describe("diagnostics export", () => {
     expect(res.status).toBe(200);
     const json = (await res.json()) as { success: boolean };
     expect(json.success).toBe(true);
+  });
+
+  test("preserves llm request provider identity in the exported JSONL", async () => {
+    const convId = "conv-7";
+    const now = Date.now();
+
+    seedConversation(convId);
+    seedMessage("msg-user-7", convId, "user", "hello", now - 1000);
+    seedMessage("msg-assistant-7", convId, "assistant", "world", now);
+    seedLlmRequestLog(
+      "log-7",
+      convId,
+      "openrouter",
+      { model: "openai/gpt-4.1-mini", input: "hello" },
+      { output: "world" },
+      now,
+    );
+
+    const res = await callExport({ conversationId: convId });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { success: boolean; filePath: string };
+    expect(json.success).toBe(true);
+
+    const zip = await JSZip.loadAsync(readFileSync(json.filePath));
+    const llmRequests = zip.file("llm_requests.jsonl");
+    expect(llmRequests).not.toBeNull();
+
+    const lines = (await llmRequests!.async("string")).trim().split("\n");
+    expect(lines).toHaveLength(1);
+
+    const row = JSON.parse(lines[0]) as {
+      id: string;
+      conversationId: string;
+      provider?: string | null;
+      request: unknown;
+      response: unknown;
+    };
+
+    expect(row).toMatchObject({
+      id: "log-7",
+      conversationId: convId,
+      provider: "openrouter",
+    });
+
+    rmSync(json.filePath, { force: true });
   });
 });

--- a/assistant/src/runtime/routes/diagnostics-routes.ts
+++ b/assistant/src/runtime/routes/diagnostics-routes.ts
@@ -410,6 +410,7 @@ async function handleDiagnosticsExport(body: {
         return JSON.stringify({
           id: r.id,
           conversationId: r.conversationId,
+          provider: r.provider,
           request: redactDeep(request),
           response: redactDeep(response),
           createdAt: r.createdAt,


### PR DESCRIPTION
## Summary
- include llm request-log provider identity in diagnostics JSONL exports
- keep downstream debugging exports aligned with the new persisted schema

Fixes gap identified during plan review for llm-log-provider-persistence.md.

**Gap:** Diagnostics export still strips the new provider field
**What was expected:** Diagnostics exports should preserve persisted llm request-log provider identity.
**What was found:** The diagnostics serializer rebuilt llm request rows without the provider field.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
