### PR TITLE
fix: persist actual failover provider

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -607,7 +607,7 @@ describe("session-agent-loop", () => {
   });
 
   describe("LLM request log persistence", () => {
-    test("record request log forwards the runtime provider", async () => {
+    test("record request log prefers the actual provider from failover", async () => {
       const events: ServerMessage[] = [];
       const rawRequest = {
         model: "gpt-4.1",
@@ -643,6 +643,7 @@ describe("session-agent-loop", () => {
           inputTokens: 12,
           outputTokens: 3,
           model: "gpt-4.1-2026-03-01",
+          actualProvider: "fireworks",
           providerDurationMs: 45,
           rawRequest,
           rawResponse,
@@ -684,8 +685,78 @@ describe("session-agent-loop", () => {
         JSON.stringify(rawRequest),
         JSON.stringify(rawResponse),
         undefined,
-        "openrouter",
+        "fireworks",
       ]);
+    });
+
+    test("record request log falls back to the runtime provider when no actual provider is supplied", async () => {
+      const rawRequest = {
+        model: "gpt-4.1",
+        messages: [{ role: "user", content: "Hello" }],
+      };
+      const rawResponse = {
+        model: "gpt-4.1-2026-03-01",
+        choices: [
+          {
+            finish_reason: "stop",
+            message: {
+              role: "assistant",
+              content: "Hi there.",
+            },
+          },
+        ],
+      };
+
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
+        onEvent({
+          type: "message_complete",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "Hi there." }],
+          },
+        });
+        onEvent({
+          type: "usage",
+          inputTokens: 12,
+          outputTokens: 3,
+          model: "gpt-4.1-2026-03-01",
+          providerDurationMs: 45,
+          rawRequest,
+          rawResponse,
+        });
+        return [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [{ type: "text", text: "Hi there." }] as ContentBlock[],
+          },
+        ];
+      };
+
+      const ctx = makeCtx({
+        agentLoopRun,
+        provider: {
+          name: "openrouter",
+          sendMessage: async () => ({
+            content: [{ type: "text", text: "title" }],
+            model: "mock",
+            usage: { inputTokens: 0, outputTokens: 0 },
+            stopReason: "end_turn",
+          }),
+        } as unknown as AgentLoopConversationContext["provider"],
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      expect(recordRequestLogMock).toHaveBeenCalledTimes(1);
+      const call = recordRequestLogMock.mock.calls[0] as unknown as [
+        string,
+        string,
+        string,
+        undefined,
+        string,
+      ];
+      expect(call[4]).toBe("openrouter");
     });
   });
 

--- a/assistant/src/__tests__/provider-failover-actual-provider.test.ts
+++ b/assistant/src/__tests__/provider-failover-actual-provider.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+import { FailoverProvider } from "../providers/failover.js";
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+} from "../providers/types.js";
+import { ProviderError } from "../util/errors.js";
+
+const MESSAGES: Message[] = [
+  { role: "user", content: [{ type: "text", text: "Hello" }] },
+];
+
+function successResponse(
+  overrides?: Partial<ProviderResponse>,
+): ProviderResponse {
+  return {
+    content: [{ type: "text", text: "ok" }],
+    model: "test-model",
+    usage: { inputTokens: 10, outputTokens: 5 },
+    stopReason: "end_turn",
+    ...overrides,
+  };
+}
+
+describe("FailoverProvider actual provider propagation", () => {
+  test("stamps the winning provider when failover uses a fallback", async () => {
+    const primary: Provider = {
+      name: "openrouter",
+      async sendMessage() {
+        throw new ProviderError("down", "openrouter", 500);
+      },
+    };
+    const secondary: Provider = {
+      name: "fireworks",
+      async sendMessage() {
+        return successResponse();
+      },
+    };
+
+    const provider = new FailoverProvider([primary, secondary]);
+    const response = await provider.sendMessage(MESSAGES);
+
+    expect(response.actualProvider).toBe("fireworks");
+  });
+
+  test("preserves an inner provider's actual provider when already set", async () => {
+    const inner: Provider = {
+      name: "retry-wrapper",
+      async sendMessage() {
+        return successResponse({ actualProvider: "anthropic" });
+      },
+    };
+
+    const provider = new FailoverProvider([inner]);
+    const response = await provider.sendMessage(MESSAGES);
+
+    expect(response.actualProvider).toBe("anthropic");
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -88,6 +88,7 @@ export type AgentEvent =
       cacheCreationInputTokens?: number;
       cacheReadInputTokens?: number;
       model: string;
+      actualProvider?: string;
       providerDurationMs: number;
       rawRequest?: unknown;
       rawResponse?: unknown;
@@ -352,6 +353,7 @@ export class AgentLoop {
           cacheCreationInputTokens: response.usage.cacheCreationInputTokens,
           cacheReadInputTokens: response.usage.cacheReadInputTokens,
           model: response.model,
+          actualProvider: response.actualProvider ?? this.provider.name,
           providerDurationMs,
           rawRequest: response.rawRequest,
           rawResponse: response.rawResponse,

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -760,6 +760,7 @@ export function handleUsage(
   deps: EventHandlerDeps,
   event: Extract<AgentEvent, { type: "usage" }>,
 ): void {
+  const providerName = event.actualProvider ?? deps.ctx.provider.name;
   state.exchangeInputTokens += event.inputTokens;
   state.exchangeCacheCreationInputTokens += event.cacheCreationInputTokens ?? 0;
   state.exchangeCacheReadInputTokens += event.cacheReadInputTokens ?? 0;
@@ -776,7 +777,7 @@ export function handleUsage(
         JSON.stringify(event.rawRequest),
         JSON.stringify(event.rawResponse),
         undefined,
-        deps.ctx.provider.name,
+        providerName,
       );
     } catch (err) {
       deps.rlog.warn({ err }, "Failed to persist LLM request log (non-fatal)");
@@ -787,12 +788,12 @@ export function handleUsage(
 
   deps.ctx.traceEmitter.emit(
     "llm_call_finished",
-    `LLM call to ${deps.ctx.provider.name} finished`,
+    `LLM call to ${providerName} finished`,
     {
       requestId: deps.reqId,
       status: "success",
       attributes: {
-        provider: deps.ctx.provider.name,
+        provider: providerName,
         model: event.model,
         inputTokens: event.inputTokens,
         outputTokens: event.outputTokens,

--- a/assistant/src/providers/failover.ts
+++ b/assistant/src/providers/failover.ts
@@ -133,7 +133,10 @@ export class FailoverProvider implements Provider {
           );
           health.unhealthySince = null;
         }
-        return response;
+        return {
+          ...response,
+          actualProvider: response.actualProvider ?? provider.name,
+        };
       } catch (error) {
         lastError = error;
 

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -93,6 +93,8 @@ export type ModelIntent =
 export interface ProviderResponse {
   content: ContentBlock[];
   model: string;
+  /** Provider that actually produced this response, which may differ from a wrapper provider name. */
+  actualProvider?: string;
   usage: {
     /** Total input tokens (input_tokens + cache_creation + cache_read). */
     inputTokens: number;


### PR DESCRIPTION
## Summary
- propagate the actual winning provider through failover and usage/request-log persistence
- keep llm-context provider reporting accurate when failover serves a request
- add focused regressions for failover provider recording

Fixes gap identified during plan review for llm-log-provider-persistence.md.

**Gap:** Persisted provider is wrong when failover serves the request
**What was expected:** Stored provider identity should match the provider that actually handled the request.
**What was found:** The current code persisted the wrapper provider name, which can be wrong under failover.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19385" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
