### PR TITLE
feat: add GET/PUT /v1/config/embeddings API endpoints

### DIFF
--- a/assistant/src/config/raw-config-utils.ts
+++ b/assistant/src/config/raw-config-utils.ts
@@ -28,3 +28,33 @@ export function setServiceField(
   services[service] = svc;
   raw.services = services;
 }
+
+/**
+ * Safely set a nested field on a raw config object's `memory.embeddings` map.
+ *
+ * Ensures the `memory` and `embeddings` objects exist before writing,
+ * so callers don't need to guard against undefined intermediate keys.
+ *
+ * Example: `setMemoryEmbeddingField(raw, "provider", "openai")`
+ * produces `raw.memory.embeddings.provider = "openai"`.
+ */
+export function setMemoryEmbeddingField(
+  raw: Record<string, unknown>,
+  field: string,
+  value: unknown,
+): void {
+  const memory: Record<string, unknown> =
+    raw.memory != null &&
+    typeof raw.memory === "object" &&
+    !Array.isArray(raw.memory)
+      ? (raw.memory as Record<string, unknown>)
+      : {};
+  const existing = memory.embeddings;
+  const embeddings: Record<string, unknown> =
+    existing != null && typeof existing === "object" && !Array.isArray(existing)
+      ? (existing as Record<string, unknown>)
+      : {};
+  embeddings[field] = value;
+  memory.embeddings = embeddings;
+  raw.memory = memory;
+}

--- a/assistant/src/config/schemas/memory-storage.ts
+++ b/assistant/src/config/schemas/memory-storage.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-const VALID_MEMORY_EMBEDDING_PROVIDERS = [
+export const VALID_MEMORY_EMBEDDING_PROVIDERS = [
   "auto",
   "local",
   "openai",

--- a/assistant/src/daemon/handlers/config-embeddings.ts
+++ b/assistant/src/daemon/handlers/config-embeddings.ts
@@ -1,0 +1,148 @@
+import {
+  getConfig,
+  loadRawConfig,
+  saveRawConfig,
+} from "../../config/loader.js";
+import { setMemoryEmbeddingField } from "../../config/raw-config-utils.js";
+import { VALID_MEMORY_EMBEDDING_PROVIDERS } from "../../config/schemas/memory-storage.js";
+import {
+  clearEmbeddingBackendCache,
+  getMemoryBackendStatus,
+} from "../../memory/embedding-backend.js";
+import type { ModelSetContext } from "./config-model.js";
+import { CONFIG_RELOAD_DEBOUNCE_MS, log } from "./shared.js";
+
+// ---------------------------------------------------------------------------
+// Embedding provider catalog
+// ---------------------------------------------------------------------------
+
+const EMBEDDING_PROVIDER_CATALOG = [
+  {
+    id: "auto",
+    displayName: "Auto (Best Available)",
+    defaultModel: "",
+    requiresKey: false,
+  },
+  {
+    id: "local",
+    displayName: "Local (In-Process)",
+    defaultModel: "Xenova/bge-small-en-v1.5",
+    requiresKey: false,
+  },
+  {
+    id: "openai",
+    displayName: "OpenAI",
+    defaultModel: "text-embedding-3-small",
+    requiresKey: true,
+  },
+  {
+    id: "gemini",
+    displayName: "Gemini",
+    defaultModel: "gemini-embedding-2-preview",
+    requiresKey: true,
+  },
+  {
+    id: "ollama",
+    displayName: "Ollama",
+    defaultModel: "nomic-embed-text",
+    requiresKey: false,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Provider-specific model field names
+// ---------------------------------------------------------------------------
+
+const PROVIDER_MODEL_FIELD: Record<string, string> = {
+  local: "localModel",
+  openai: "openaiModel",
+  gemini: "geminiModel",
+  ollama: "ollamaModel",
+};
+
+// ---------------------------------------------------------------------------
+// GET — return current embedding config + resolved status
+// ---------------------------------------------------------------------------
+
+export async function getEmbeddingConfigInfo(): Promise<{
+  provider: string;
+  model: string | null;
+  activeProvider: string | null;
+  activeModel: string | null;
+  availableProviders: typeof EMBEDDING_PROVIDER_CATALOG;
+  status: { enabled: boolean; degraded: boolean; reason: string | null };
+}> {
+  const config = getConfig();
+  const embeddingConfig = config.memory.embeddings;
+  const backendStatus = await getMemoryBackendStatus(config);
+
+  // Derive the provider-specific model from config
+  const fieldName = PROVIDER_MODEL_FIELD[embeddingConfig.provider];
+  const model = fieldName
+    ? (embeddingConfig as Record<string, unknown>)[fieldName]
+    : null;
+
+  return {
+    provider: embeddingConfig.provider,
+    model: typeof model === "string" ? model : null,
+    activeProvider: backendStatus.provider,
+    activeModel: backendStatus.model,
+    availableProviders: EMBEDDING_PROVIDER_CATALOG,
+    status: {
+      enabled: backendStatus.enabled,
+      degraded: backendStatus.degraded,
+      reason: backendStatus.reason,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PUT — persist embedding provider/model to config
+// ---------------------------------------------------------------------------
+
+export async function setEmbeddingConfig(
+  provider: string,
+  model: string | undefined,
+  ctx: ModelSetContext,
+): Promise<ReturnType<typeof getEmbeddingConfigInfo>> {
+  const validProviders = new Set<string>(VALID_MEMORY_EMBEDDING_PROVIDERS);
+  if (!validProviders.has(provider)) {
+    throw new Error(
+      `Invalid embedding provider "${provider}". Valid providers: ${[...validProviders].join(", ")}`,
+    );
+  }
+
+  const raw = loadRawConfig();
+  setMemoryEmbeddingField(raw, "provider", provider);
+
+  if (model !== undefined) {
+    const fieldName = PROVIDER_MODEL_FIELD[provider];
+    if (fieldName) {
+      setMemoryEmbeddingField(raw, fieldName, model);
+    }
+  }
+
+  // Suppress the file watcher callback — we handle the reload ourselves.
+  const wasSuppressed = ctx.suppressConfigReload;
+  ctx.setSuppressConfigReload(true);
+  try {
+    saveRawConfig(raw);
+  } catch (err) {
+    ctx.setSuppressConfigReload(wasSuppressed);
+    throw err;
+  }
+  ctx.debounceTimers.schedule(
+    "__suppress_reset__",
+    () => {
+      ctx.setSuppressConfigReload(false);
+    },
+    CONFIG_RELOAD_DEBOUNCE_MS,
+  );
+
+  clearEmbeddingBackendCache();
+  ctx.updateConfigFingerprint();
+
+  log.info({ provider, model }, "Embedding config updated");
+
+  return getEmbeddingConfigInfo();
+}

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1,19 +1,27 @@
 /**
- * HTTP route definitions for model configuration, conversation search,
- * message content, LLM context inspection, and queued message deletion.
+ * HTTP route definitions for model configuration, embedding configuration,
+ * conversation search, message content, LLM context inspection, and queued
+ * message deletion.
  *
  * These routes expose conversation query functionality over the HTTP API.
  *
  * GET    /v1/model                      — current model info
  * PUT    /v1/model                      — set model
  * PUT    /v1/model/image-gen            — set image-gen model
+ * GET    /v1/config/embeddings          — current embedding config
+ * PUT    /v1/config/embeddings          — set embedding provider/model
  * GET    /v1/conversations/search       — search conversations
  * GET    /v1/messages/:id/content       — full message content
  * GET    /v1/messages/:id/llm-context   — LLM request logs for a message
  * DELETE /v1/messages/queued/:id        — delete queued message
  */
 
+import { VALID_MEMORY_EMBEDDING_PROVIDERS } from "../../config/schemas/memory-storage.js";
 import { VALID_INFERENCE_PROVIDERS } from "../../config/schemas/services.js";
+import {
+  getEmbeddingConfigInfo,
+  setEmbeddingConfig,
+} from "../../daemon/handlers/config-embeddings.js";
 import {
   getModelInfo,
   type ModelSetContext,
@@ -31,6 +39,9 @@ import type { RouteDefinition } from "../http-router.js";
 import { normalizeLlmContextPayloads } from "./llm-context-normalization.js";
 
 const validProviderSet = new Set<string>(VALID_INFERENCE_PROVIDERS);
+const validEmbeddingProviderSet = new Set<string>(
+  VALID_MEMORY_EMBEDDING_PROVIDERS,
+);
 
 type LlmContextNormalizationResult = ReturnType<
   typeof normalizeLlmContextPayloads
@@ -168,6 +179,64 @@ export function conversationQueryRouteDefinitions(
           return httpError(
             "INTERNAL_ERROR",
             `Failed to set image gen model: ${message}`,
+            500,
+          );
+        }
+      },
+    },
+
+    // ── Embedding config ─────────────────────────────────────────────
+    {
+      endpoint: "config/embeddings",
+      method: "GET",
+      policyKey: "config/embeddings",
+      handler: async () => {
+        const info = await getEmbeddingConfigInfo();
+        return Response.json(info);
+      },
+    },
+    {
+      endpoint: "config/embeddings",
+      method: "PUT",
+      policyKey: "config/embeddings",
+      handler: async ({ req }) => {
+        if (!deps.getModelSetContext) {
+          return httpError(
+            "INTERNAL_ERROR",
+            "Embedding config not available",
+            500,
+          );
+        }
+        const body = (await req.json()) as {
+          provider?: string;
+          model?: string;
+        };
+        if (!body.provider || typeof body.provider !== "string") {
+          return httpError(
+            "BAD_REQUEST",
+            "Missing required field: provider",
+            400,
+          );
+        }
+        if (!validEmbeddingProviderSet.has(body.provider)) {
+          return httpError(
+            "BAD_REQUEST",
+            `Invalid provider "${body.provider}". Valid providers: ${[...validEmbeddingProviderSet].join(", ")}`,
+            400,
+          );
+        }
+        try {
+          const info = await setEmbeddingConfig(
+            body.provider,
+            body.model,
+            deps.getModelSetContext(),
+          );
+          return Response.json(info);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return httpError(
+            "INTERNAL_ERROR",
+            `Failed to set embedding config: ${message}`,
             500,
           );
         }


### PR DESCRIPTION
## Summary
- Add embedding config handler with GET/PUT endpoints for provider and model configuration
- Add `setMemoryEmbeddingField` raw config helper analogous to `setServiceField`
- Wire routes into conversation-query-routes
- Export `VALID_MEMORY_EMBEDDING_PROVIDERS` from memory-storage schema for route-level validation

Part of plan: embed-config-desktop-settings.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
