### PR TITLE
feat: add helper to resolve all assistant messages in a turn

### DIFF
--- a/assistant/src/__tests__/turn-boundary-resolution.test.ts
+++ b/assistant/src/__tests__/turn-boundary-resolution.test.ts
@@ -1,0 +1,243 @@
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = realpathSync(
+  mkdtempSync(join(tmpdir(), "turn-boundary-resolution-test-")),
+);
+const workspaceDir = join(testDir, ".vellum", "workspace");
+const conversationsDir = join(workspaceDir, "conversations");
+
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => join(testDir, ".vellum"),
+  getDataDir: () => join(workspaceDir, "data"),
+  getWorkspaceDir: () => workspaceDir,
+  getConversationsDir: () => conversationsDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+  }),
+}));
+
+import {
+  addMessage,
+  createConversation,
+  getAssistantMessageIdsInTurn,
+} from "../memory/conversation-crud.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { llmRequestLogs, toolInvocations } from "../memory/schema.js";
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.delete(llmRequestLogs).run();
+  db.delete(toolInvocations).run();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+function toolResultContent(toolUseIds: string[]): string {
+  return JSON.stringify(
+    toolUseIds.map((id) => ({
+      type: "tool_result",
+      tool_use_id: id,
+      content: "ok",
+      is_error: false,
+    })),
+  );
+}
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe("getAssistantMessageIdsInTurn", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("single-step turn: returns only the one assistant message", async () => {
+    const conv = createConversation("single-step");
+    await addMessage(conv.id, "user", "Hello", undefined, {
+      skipIndexing: true,
+    });
+    const a1 = await addMessage(conv.id, "assistant", "Hi there!", undefined, {
+      skipIndexing: true,
+    });
+
+    const result = getAssistantMessageIdsInTurn(a1.id);
+    expect(result).toEqual([a1.id]);
+  });
+
+  test("multi-step turn: user → A1 → tool_result → A2 → query A2 → returns [A1, A2]", async () => {
+    const conv = createConversation("multi-step");
+    await addMessage(conv.id, "user", "Do the thing", undefined, {
+      skipIndexing: true,
+    });
+    const a1 = await addMessage(
+      conv.id,
+      "assistant",
+      "Using tool...",
+      undefined,
+      { skipIndexing: true },
+    );
+    await addMessage(
+      conv.id,
+      "user",
+      toolResultContent(["tool-1"]),
+      undefined,
+      { skipIndexing: true },
+    );
+    const a2 = await addMessage(conv.id, "assistant", "Done!", undefined, {
+      skipIndexing: true,
+    });
+
+    const result = getAssistantMessageIdsInTurn(a2.id);
+    expect(result).toEqual([a1.id, a2.id]);
+  });
+
+  test("3-step turn: user → A1 → tool_result → A2 → tool_result → A3 → query A3 → returns [A1, A2, A3]", async () => {
+    const conv = createConversation("three-step");
+    await addMessage(conv.id, "user", "Complex task", undefined, {
+      skipIndexing: true,
+    });
+    const a1 = await addMessage(conv.id, "assistant", "Step 1...", undefined, {
+      skipIndexing: true,
+    });
+    await addMessage(
+      conv.id,
+      "user",
+      toolResultContent(["tool-1"]),
+      undefined,
+      { skipIndexing: true },
+    );
+    const a2 = await addMessage(conv.id, "assistant", "Step 2...", undefined, {
+      skipIndexing: true,
+    });
+    await addMessage(
+      conv.id,
+      "user",
+      toolResultContent(["tool-2"]),
+      undefined,
+      { skipIndexing: true },
+    );
+    const a3 = await addMessage(conv.id, "assistant", "All done!", undefined, {
+      skipIndexing: true,
+    });
+
+    const result = getAssistantMessageIdsInTurn(a3.id);
+    expect(result).toEqual([a1.id, a2.id, a3.id]);
+  });
+
+  test("query intermediate message: query A1 in a 2-step turn → returns [A1, A2]", async () => {
+    const conv = createConversation("intermediate");
+    await addMessage(conv.id, "user", "Start task", undefined, {
+      skipIndexing: true,
+    });
+    const a1 = await addMessage(
+      conv.id,
+      "assistant",
+      "Using tool...",
+      undefined,
+      { skipIndexing: true },
+    );
+    await addMessage(
+      conv.id,
+      "user",
+      toolResultContent(["tool-1"]),
+      undefined,
+      { skipIndexing: true },
+    );
+    const a2 = await addMessage(conv.id, "assistant", "Done!", undefined, {
+      skipIndexing: true,
+    });
+
+    const result = getAssistantMessageIdsInTurn(a1.id);
+    expect(result).toEqual([a1.id, a2.id]);
+  });
+
+  test("message not found: returns [messageId]", () => {
+    const result = getAssistantMessageIdsInTurn("nonexistent-id");
+    expect(result).toEqual(["nonexistent-id"]);
+  });
+
+  test("consecutive turns: query message in second turn → returns only that turn's messages", async () => {
+    const conv = createConversation("consecutive");
+
+    // First turn
+    await addMessage(conv.id, "user", "First question", undefined, {
+      skipIndexing: true,
+    });
+    const a1 = await addMessage(
+      conv.id,
+      "assistant",
+      "First answer",
+      undefined,
+      { skipIndexing: true },
+    );
+
+    // Second turn
+    await addMessage(conv.id, "user", "Second question", undefined, {
+      skipIndexing: true,
+    });
+    const a2 = await addMessage(
+      conv.id,
+      "assistant",
+      "Using tool...",
+      undefined,
+      { skipIndexing: true },
+    );
+    await addMessage(
+      conv.id,
+      "user",
+      toolResultContent(["tool-1"]),
+      undefined,
+      { skipIndexing: true },
+    );
+    const a3 = await addMessage(
+      conv.id,
+      "assistant",
+      "Done with second",
+      undefined,
+      { skipIndexing: true },
+    );
+
+    // Query second turn → should NOT include a1
+    const result = getAssistantMessageIdsInTurn(a3.id);
+    expect(result).toEqual([a2.id, a3.id]);
+
+    // Query first turn → should only include a1
+    const firstTurnResult = getAssistantMessageIdsInTurn(a1.id);
+    expect(firstTurnResult).toEqual([a1.id]);
+  });
+});

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1,6 +1,17 @@
 import { mkdirSync, rmSync } from "node:fs";
 
-import { and, asc, count, eq, inArray, isNull, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  gt,
+  inArray,
+  isNull,
+  lte,
+  sql,
+} from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 import { z } from "zod";
 
@@ -1492,4 +1503,171 @@ export function getDisplayMetaForConversations(
     });
   }
   return result;
+}
+
+// ── Turn boundary resolution ─────────────────────────────────────────
+
+/**
+ * Returns `true` if a message is a tool-result user message — i.e. its
+ * role is "user" and its content is a JSON array where every block has
+ * `type === "tool_result"`. These synthetic user messages are injected
+ * between assistant messages within a single agent turn and should NOT
+ * be treated as turn boundaries.
+ */
+function isToolResultMessage(role: string, content: string): boolean {
+  if (role !== "user") return false;
+  try {
+    const parsed = JSON.parse(content);
+    if (!Array.isArray(parsed) || parsed.length === 0) return false;
+    return parsed.every(
+      (block: unknown) =>
+        block != null &&
+        typeof block === "object" &&
+        (block as Record<string, unknown>).type === "tool_result",
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve all assistant message IDs that belong to the same agent turn
+ * as the given `messageId`. A "turn" is bounded by:
+ *   - The start of the conversation, or
+ *   - A user message whose content is NOT a tool_result array.
+ *
+ * Within a multi-step agent loop, the pattern is:
+ *   user msg → assistant A1 → user (tool_result) → assistant A2 → ...
+ * All assistant messages from A1 through the queried message (and beyond,
+ * up to the next real user message) are part of the same turn.
+ *
+ * Returns `[messageId]` as a fallback if the message is not found,
+ * preserving backward compatibility for callers.
+ */
+export function getAssistantMessageIdsInTurn(messageId: string): string[] {
+  const db = getDb();
+
+  // Look up the target message to get its conversationId and createdAt.
+  const target = getMessageById(messageId);
+  if (!target) return [messageId];
+
+  // Walk backward from the target message to find the turn boundary.
+  // Limit to 50 rows — sufficient for even aggressive tool-use loops.
+  const backwardRows = db
+    .select({
+      id: messages.id,
+      role: messages.role,
+      content: messages.content,
+      createdAt: messages.createdAt,
+    })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, target.conversationId),
+        lte(messages.createdAt, target.createdAt),
+      ),
+    )
+    .orderBy(desc(messages.createdAt))
+    .limit(50)
+    .all();
+
+  const assistantIds: string[] = [];
+  let boundaryCreatedAt: number | null = null;
+
+  for (const row of backwardRows) {
+    if (row.role === "assistant") {
+      assistantIds.push(row.id);
+    } else if (row.role === "user") {
+      if (isToolResultMessage(row.role, row.content)) {
+        // Tool-result user message — still within the same turn, continue.
+        continue;
+      }
+      // Real user message — this is the turn boundary.
+      boundaryCreatedAt = row.createdAt;
+      break;
+    }
+  }
+
+  // Walk forward from the target to collect any later assistant messages
+  // still within the same turn (e.g. when querying an intermediate
+  // message like A1 in a multi-step turn A1 → tool_result → A2).
+  const forwardRows = db
+    .select({
+      id: messages.id,
+      role: messages.role,
+      content: messages.content,
+      createdAt: messages.createdAt,
+    })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, target.conversationId),
+        gt(messages.createdAt, target.createdAt),
+      ),
+    )
+    .orderBy(asc(messages.createdAt))
+    .limit(50)
+    .all();
+
+  for (const row of forwardRows) {
+    if (row.role === "assistant") {
+      if (!assistantIds.includes(row.id)) {
+        assistantIds.push(row.id);
+      }
+    } else if (row.role === "user") {
+      if (isToolResultMessage(row.role, row.content)) {
+        // Tool-result user message — still within the same turn.
+        continue;
+      }
+      // Real user message — end of the turn.
+      break;
+    }
+  }
+
+  // Also query forward from the backward-walk boundary to pick up any
+  // assistant messages between the boundary and the target that may have
+  // been missed (e.g. due to the 50-row limit in the backward walk).
+  if (boundaryCreatedAt != null) {
+    const gapRows = db
+      .select({
+        id: messages.id,
+        role: messages.role,
+        createdAt: messages.createdAt,
+      })
+      .from(messages)
+      .where(
+        and(
+          eq(messages.conversationId, target.conversationId),
+          gt(messages.createdAt, boundaryCreatedAt),
+          lte(messages.createdAt, target.createdAt),
+        ),
+      )
+      .orderBy(asc(messages.createdAt))
+      .all();
+
+    for (const row of gapRows) {
+      if (row.role === "assistant" && !assistantIds.includes(row.id)) {
+        assistantIds.push(row.id);
+      }
+    }
+  }
+
+  // Sort by createdAt to ensure stable ordering.
+  // Re-fetch createdAt for all collected IDs so the sort is accurate.
+  if (assistantIds.length <= 1) return assistantIds;
+
+  const idSet = new Set(assistantIds);
+  const sorted = db
+    .select({ id: messages.id, createdAt: messages.createdAt })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, target.conversationId),
+        inArray(messages.id, [...idSet]),
+      ),
+    )
+    .orderBy(asc(messages.createdAt))
+    .all();
+
+  return sorted.map((r) => r.id);
 }


### PR DESCRIPTION
## Summary
- Add `getAssistantMessageIdsInTurn()` to conversation-crud.ts that resolves all assistant messages in a turn by walking backward from a given message to find the turn boundary
- Add `isToolResultMessage()` internal helper to distinguish tool-result user messages from real user messages
- Add comprehensive tests covering single-step, multi-step, 3-step turns, intermediate message queries, consecutive turns, and fallback behavior

Part of plan: llm-inspector-turn-logs.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
