### PR TITLE
feat: show all LLM calls per turn in context inspector

### DIFF
--- a/assistant/src/__tests__/llm-request-log-turn-query.test.ts
+++ b/assistant/src/__tests__/llm-request-log-turn-query.test.ts
@@ -1,0 +1,270 @@
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = realpathSync(
+  mkdtempSync(join(tmpdir(), "llm-request-log-turn-query-test-")),
+);
+const workspaceDir = join(testDir, ".vellum", "workspace");
+const conversationsDir = join(workspaceDir, "conversations");
+
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => join(testDir, ".vellum"),
+  getDataDir: () => join(workspaceDir, "data"),
+  getWorkspaceDir: () => workspaceDir,
+  getConversationsDir: () => conversationsDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+  }),
+}));
+
+import {
+  addMessage,
+  createConversation,
+  forkConversation,
+} from "../memory/conversation-crud.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import {
+  backfillMessageIdOnLogs,
+  getRequestLogsByMessageId,
+  recordRequestLog,
+} from "../memory/llm-request-log-store.js";
+import { llmRequestLogs, toolInvocations } from "../memory/schema.js";
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.delete(llmRequestLogs).run();
+  db.delete(toolInvocations).run();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+function toolResultContent(toolUseIds: string[]): string {
+  return JSON.stringify(
+    toolUseIds.map((id) => ({
+      type: "tool_result",
+      tool_use_id: id,
+      content: "ok",
+      is_error: false,
+    })),
+  );
+}
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe("getRequestLogsByMessageId — turn-aware query", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("single message, single log: backward compat — returns 1 log", async () => {
+    const conv = createConversation("single-msg");
+    await addMessage(conv.id, "user", "Hello", undefined, {
+      skipIndexing: true,
+    });
+    const a1 = await addMessage(conv.id, "assistant", "Hi!", undefined, {
+      skipIndexing: true,
+    });
+
+    // Record a log without messageId, then backfill
+    recordRequestLog(conv.id, '{"prompt":"hi"}', '{"result":"hello"}');
+    backfillMessageIdOnLogs(conv.id, a1.id);
+
+    const logs = getRequestLogsByMessageId(a1.id);
+    expect(logs).toHaveLength(1);
+    expect(logs[0]?.messageId).toBe(a1.id);
+    expect(logs[0]?.conversationId).toBe(conv.id);
+  });
+
+  test("multi-step turn: returns logs from all assistant messages in the turn", async () => {
+    const conv = createConversation("multi-step");
+
+    // user → A1 (+ log1) → tool_result → A2 (+ log2)
+    await addMessage(conv.id, "user", "Do the task", undefined, {
+      skipIndexing: true,
+    });
+
+    // First LLM call → A1
+    recordRequestLog(conv.id, '{"step":1}', '{"tool_use":"bash"}');
+    const a1 = await addMessage(
+      conv.id,
+      "assistant",
+      "Using tool...",
+      undefined,
+      { skipIndexing: true },
+    );
+    backfillMessageIdOnLogs(conv.id, a1.id);
+
+    // tool_result user message
+    await addMessage(
+      conv.id,
+      "user",
+      toolResultContent(["tool-1"]),
+      undefined,
+      { skipIndexing: true },
+    );
+
+    // Second LLM call → A2
+    recordRequestLog(conv.id, '{"step":2}', '{"result":"done"}');
+    const a2 = await addMessage(conv.id, "assistant", "All done!", undefined, {
+      skipIndexing: true,
+    });
+    backfillMessageIdOnLogs(conv.id, a2.id);
+
+    // Query from A2 (the last message in the turn) → should return both logs
+    const logs = getRequestLogsByMessageId(a2.id);
+    expect(logs).toHaveLength(2);
+    expect(logs[0]?.messageId).toBe(a1.id);
+    expect(logs[1]?.messageId).toBe(a2.id);
+    // Verify ordering is by createdAt ASC
+    expect(logs[0]!.createdAt).toBeLessThanOrEqual(logs[1]!.createdAt);
+  });
+
+  test("fork fallback still works: forked message with no logs, source has turn logs", async () => {
+    const source = createConversation("source-conv");
+
+    // Build a multi-step turn in the source conversation
+    await addMessage(source.id, "user", "Original task", undefined, {
+      skipIndexing: true,
+    });
+
+    recordRequestLog(source.id, '{"step":1}', '{"tool":"bash"}');
+    const a1 = await addMessage(
+      source.id,
+      "assistant",
+      "Using tool...",
+      undefined,
+      { skipIndexing: true },
+    );
+    backfillMessageIdOnLogs(source.id, a1.id);
+
+    await addMessage(
+      source.id,
+      "user",
+      toolResultContent(["tool-1"]),
+      undefined,
+      { skipIndexing: true },
+    );
+
+    recordRequestLog(source.id, '{"step":2}', '{"result":"ok"}');
+    const a2 = await addMessage(
+      source.id,
+      "assistant",
+      "Done with source!",
+      undefined,
+      { skipIndexing: true },
+    );
+    backfillMessageIdOnLogs(source.id, a2.id);
+
+    // Fork the conversation
+    const fork = forkConversation({ conversationId: source.id });
+    const forkMessages = (
+      await import("../memory/conversation-crud.js")
+    ).getMessages(fork.id);
+    const forkLastAssistant = forkMessages
+      .filter((m) => m.role === "assistant")
+      .at(-1);
+    expect(forkLastAssistant).toBeDefined();
+
+    // The fork has no LLM logs of its own — should fall back to source turn's logs
+    const logs = getRequestLogsByMessageId(forkLastAssistant!.id);
+    expect(logs).toHaveLength(2);
+    expect(logs[0]?.conversationId).toBe(source.id);
+    expect(logs[1]?.conversationId).toBe(source.id);
+  });
+
+  test("logs from different turns don't bleed", async () => {
+    const conv = createConversation("two-turns");
+
+    // First turn: user → A1 (+ log1)
+    await addMessage(conv.id, "user", "First question", undefined, {
+      skipIndexing: true,
+    });
+    recordRequestLog(conv.id, '{"turn":1}', '{"answer":"first"}');
+    const a1 = await addMessage(
+      conv.id,
+      "assistant",
+      "First answer",
+      undefined,
+      { skipIndexing: true },
+    );
+    backfillMessageIdOnLogs(conv.id, a1.id);
+
+    // Second turn: user → A2 (+ log2) → tool_result → A3 (+ log3)
+    await addMessage(conv.id, "user", "Second question", undefined, {
+      skipIndexing: true,
+    });
+    recordRequestLog(conv.id, '{"turn":2,"step":1}', '{"tool":"bash"}');
+    const a2 = await addMessage(
+      conv.id,
+      "assistant",
+      "Using tool...",
+      undefined,
+      { skipIndexing: true },
+    );
+    backfillMessageIdOnLogs(conv.id, a2.id);
+
+    await addMessage(
+      conv.id,
+      "user",
+      toolResultContent(["tool-2"]),
+      undefined,
+      { skipIndexing: true },
+    );
+
+    recordRequestLog(conv.id, '{"turn":2,"step":2}', '{"result":"done"}');
+    const a3 = await addMessage(
+      conv.id,
+      "assistant",
+      "Second done!",
+      undefined,
+      { skipIndexing: true },
+    );
+    backfillMessageIdOnLogs(conv.id, a3.id);
+
+    // Query second turn → should only return logs for A2 and A3, NOT A1
+    const secondTurnLogs = getRequestLogsByMessageId(a3.id);
+    expect(secondTurnLogs).toHaveLength(2);
+    expect(secondTurnLogs[0]?.messageId).toBe(a2.id);
+    expect(secondTurnLogs[1]?.messageId).toBe(a3.id);
+
+    // Query first turn → should only return log for A1
+    const firstTurnLogs = getRequestLogsByMessageId(a1.id);
+    expect(firstTurnLogs).toHaveLength(1);
+    expect(firstTurnLogs[0]?.messageId).toBe(a1.id);
+  });
+});

--- a/assistant/src/memory/llm-request-log-store.ts
+++ b/assistant/src/memory/llm-request-log-store.ts
@@ -1,7 +1,11 @@
-import { and, eq, gte, isNull, lte } from "drizzle-orm";
+import { and, eq, gte, inArray, isNull, lte } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getMessageById, messageMetadataSchema } from "./conversation-crud.js";
+import {
+  getAssistantMessageIdsInTurn,
+  getMessageById,
+  messageMetadataSchema,
+} from "./conversation-crud.js";
 import { getDb } from "./db.js";
 import { llmRequestLogs } from "./schema.js";
 
@@ -68,6 +72,38 @@ export function backfillMessageIdOnLogs(
     .run();
 }
 
+/**
+ * Internal helper: query `llm_request_logs` for rows matching any of the
+ * given message IDs, ordered by `createdAt ASC`. Uses the existing
+ * `idx_llm_request_logs_message_id` index via `inArray`.
+ */
+function selectLogsByMessageIds(messageIds: string[]): Array<{
+  id: string;
+  conversationId: string;
+  messageId: string | null;
+  provider: string | null;
+  requestPayload: string;
+  responsePayload: string;
+  createdAt: number;
+}> {
+  if (messageIds.length === 0) return [];
+  const db = getDb();
+  return db
+    .select({
+      id: llmRequestLogs.id,
+      conversationId: llmRequestLogs.conversationId,
+      messageId: llmRequestLogs.messageId,
+      provider: llmRequestLogs.provider,
+      requestPayload: llmRequestLogs.requestPayload,
+      responsePayload: llmRequestLogs.responsePayload,
+      createdAt: llmRequestLogs.createdAt,
+    })
+    .from(llmRequestLogs)
+    .where(inArray(llmRequestLogs.messageId, messageIds))
+    .orderBy(llmRequestLogs.createdAt)
+    .all();
+}
+
 export function getRequestLogsByMessageId(messageId: string): Array<{
   id: string;
   conversationId: string;
@@ -77,31 +113,19 @@ export function getRequestLogsByMessageId(messageId: string): Array<{
   responsePayload: string;
   createdAt: number;
 }> {
-  const db = getDb();
-  const selectLogs = (targetMessageId: string) =>
-    db
-      .select({
-        id: llmRequestLogs.id,
-        conversationId: llmRequestLogs.conversationId,
-        messageId: llmRequestLogs.messageId,
-        provider: llmRequestLogs.provider,
-        requestPayload: llmRequestLogs.requestPayload,
-        responsePayload: llmRequestLogs.responsePayload,
-        createdAt: llmRequestLogs.createdAt,
-      })
-      .from(llmRequestLogs)
-      .where(eq(llmRequestLogs.messageId, targetMessageId))
-      .orderBy(llmRequestLogs.createdAt)
-      .all();
-
-  const exactLogs = selectLogs(messageId);
-  if (exactLogs.length > 0) {
-    return exactLogs;
+  // Resolve all assistant message IDs in the same turn so the inspector
+  // shows every LLM call from the entire agent turn, not just the queried message.
+  const turnMessageIds = getAssistantMessageIdsInTurn(messageId);
+  const turnLogs = selectLogsByMessageIds(turnMessageIds);
+  if (turnLogs.length > 0) {
+    return turnLogs;
   }
 
+  // Fork-source fallback: if no logs found for the turn, check whether
+  // the queried message was forked from a source and resolve that source's turn.
   const message = getMessageById(messageId);
   if (!message?.metadata) {
-    return exactLogs;
+    return [];
   }
 
   try {
@@ -113,10 +137,11 @@ export function getRequestLogsByMessageId(messageId: string): Array<{
         ? parsed.data.forkSourceMessageId
         : null;
     if (!sourceMessageId || sourceMessageId === messageId) {
-      return exactLogs;
+      return [];
     }
-    return selectLogs(sourceMessageId);
+    const sourceTurnIds = getAssistantMessageIdsInTurn(sourceMessageId);
+    return selectLogsByMessageIds(sourceTurnIds);
   } catch {
-    return exactLogs;
+    return [];
   }
 }


### PR DESCRIPTION
## Summary
- Modify `getRequestLogsByMessageId()` to resolve the full turn and return LLM logs from all assistant messages in the turn, not just the queried message
- Add `selectLogsByMessageIds()` internal helper using `inArray` for efficient multi-message log queries
- Add integration tests covering single-message, multi-step turn, fork fallback, and turn isolation

Part of plan: llm-inspector-turn-logs.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
