### PR TITLE
fix: use actual failover provider in usage accounting

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -760,6 +760,81 @@ describe("session-agent-loop", () => {
     });
   });
 
+  describe("usage accounting", () => {
+    test("records the actual provider for failover-served usage", async () => {
+      const events: ServerMessage[] = [];
+
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
+        onEvent({
+          type: "message_complete",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "Hi there." }],
+          },
+        });
+        onEvent({
+          type: "usage",
+          inputTokens: 12,
+          outputTokens: 3,
+          model: "gpt-4.1-2026-03-01",
+          actualProvider: "fireworks",
+          providerDurationMs: 45,
+          rawRequest: {
+            model: "gpt-4.1",
+            messages: [{ role: "user", content: "Hello" }],
+          },
+          rawResponse: {
+            model: "gpt-4.1-2026-03-01",
+            choices: [
+              {
+                finish_reason: "stop",
+                message: {
+                  role: "assistant",
+                  content: "Hi there.",
+                },
+              },
+            ],
+          },
+        });
+        return [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [{ type: "text", text: "Hi there." }] as ContentBlock[],
+          },
+        ];
+      };
+
+      const ctx = makeCtx({
+        agentLoopRun,
+        provider: {
+          name: "openrouter",
+          sendMessage: async () => ({
+            content: [{ type: "text", text: "title" }],
+            model: "mock",
+            usage: { inputTokens: 0, outputTokens: 0 },
+            stopReason: "end_turn",
+          }),
+        } as unknown as AgentLoopConversationContext["provider"],
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+
+      const mainAgentCall = recordUsageMock.mock.calls.find(
+        (call) => (call as unknown[])[5] === "main_agent",
+      ) as unknown[] | undefined;
+
+      expect(mainAgentCall).toBeDefined();
+      expect(mainAgentCall?.[0]).toMatchObject({
+        conversationId: "test-conv",
+        providerName: "fireworks",
+      });
+      expect(mainAgentCall?.[1]).toBe(12);
+      expect(mainAgentCall?.[2]).toBe(3);
+      expect(mainAgentCall?.[3]).toBe("gpt-4.1-2026-03-01");
+    });
+  });
+
   describe("context window exhaustion (context-too-large recovery)", () => {
     test("forwards cache-aware compaction usage to recordUsage", async () => {
       const events: ServerMessage[] = [];

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -53,6 +53,8 @@ export interface EventHandlerState {
   llmCallStartedEmitted: boolean;
   pendingDirectiveDisplayBuffer: string;
   firstAssistantText: string;
+  /** Most recent resolved provider for the current exchange's usage accounting. */
+  exchangeProviderName: string | undefined;
   exchangeInputTokens: number;
   exchangeCacheCreationInputTokens: number;
   exchangeCacheReadInputTokens: number;
@@ -119,6 +121,7 @@ export function createEventHandlerState(): EventHandlerState {
     llmCallStartedEmitted: false,
     pendingDirectiveDisplayBuffer: "",
     firstAssistantText: "",
+    exchangeProviderName: undefined,
     exchangeInputTokens: 0,
     exchangeCacheCreationInputTokens: 0,
     exchangeCacheReadInputTokens: 0,
@@ -761,6 +764,7 @@ export function handleUsage(
   event: Extract<AgentEvent, { type: "usage" }>,
 ): void {
   const providerName = event.actualProvider ?? deps.ctx.provider.name;
+  state.exchangeProviderName = providerName;
   state.exchangeInputTokens += event.inputTokens;
   state.exchangeCacheCreationInputTokens += event.cacheCreationInputTokens ?? 0;
   state.exchangeCacheReadInputTokens += event.cacheReadInputTokens ?? 0;

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1536,6 +1536,7 @@ export async function runAgentLoopImpl(
       state.exchangeCacheCreationInputTokens,
       state.exchangeCacheReadInputTokens,
       collapseRawResponses(state.exchangeRawResponses),
+      state.exchangeProviderName,
     );
 
     void getHookManager().trigger("post-message", {
@@ -1802,11 +1803,12 @@ function emitUsage(
   cacheCreationInputTokens = 0,
   cacheReadInputTokens = 0,
   rawResponse?: unknown,
+  providerName?: string,
 ): void {
   recordUsage(
     {
       conversationId: ctx.conversationId,
-      providerName: ctx.provider.name,
+      providerName: providerName ?? ctx.provider.name,
       usageStats: ctx.usageStats,
     },
     inputTokens,


### PR DESCRIPTION
## Summary
- carry the resolved provider from usage events into the end-of-turn usage ledger
- keep failover-served turns consistent between request logs, usage accounting, and downstream exports
- add a focused agent-loop regression for actual-provider usage persistence

## Original prompt
The fix for Gap 1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
