### PR TITLE
Add accumulatedSurfaceState field to surface context interface

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
@@ -34,6 +34,7 @@ function makeContext(
       { surfaceType: SurfaceType; data: SurfaceData; title?: string }
     >(),
     surfaceUndoStacks: new Map<string, string[]>(),
+    accumulatedSurfaceState: new Map<string, Record<string, unknown>>(),
     surfaceActionRequestIds: new Set<string>(),
     currentTurnSurfaces: [],
     isProcessing: () => false,

--- a/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
@@ -69,6 +69,7 @@ function makeCtx(overrides: Partial<ToolSetupContext> = {}): ToolSetupContext {
       { surfaceType: SurfaceType; data: SurfaceData; title?: string }
     >(),
     surfaceUndoStacks: new Map(),
+    accumulatedSurfaceState: new Map(),
     surfaceActionRequestIds: new Set<string>(),
     currentTurnSurfaces: [],
     isProcessing: () => false,

--- a/assistant/src/__tests__/conversation-tool-setup-memory-scope.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-memory-scope.test.ts
@@ -56,6 +56,7 @@ function makeCtx(overrides: Partial<ToolSetupContext> = {}): ToolSetupContext {
       { surfaceType: SurfaceType; data: SurfaceData; title?: string }
     >(),
     surfaceUndoStacks: new Map(),
+    accumulatedSurfaceState: new Map(),
     surfaceActionRequestIds: new Set<string>(),
     currentTurnSurfaces: [],
     isProcessing: () => false,

--- a/assistant/src/__tests__/conversation-tool-setup-side-effect-flag.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-side-effect-flag.test.ts
@@ -56,6 +56,7 @@ function makeCtx(overrides: Partial<ToolSetupContext> = {}): ToolSetupContext {
       { surfaceType: SurfaceType; data: SurfaceData; title?: string }
     >(),
     surfaceUndoStacks: new Map(),
+    accumulatedSurfaceState: new Map(),
     surfaceActionRequestIds: new Set<string>(),
     currentTurnSurfaces: [],
     isProcessing: () => false,

--- a/assistant/src/__tests__/cu-unified-flow.test.ts
+++ b/assistant/src/__tests__/cu-unified-flow.test.ts
@@ -30,6 +30,7 @@ function buildMockContext(
     lastSurfaceAction: new Map(),
     surfaceState: new Map(),
     surfaceUndoStacks: new Map(),
+    accumulatedSurfaceState: new Map(),
     surfaceActionRequestIds: new Set(),
     currentTurnSurfaces: [],
     hostCuProxy,

--- a/assistant/src/__tests__/starter-task-flow.test.ts
+++ b/assistant/src/__tests__/starter-task-flow.test.ts
@@ -39,6 +39,7 @@ function makeContext(): SurfaceConversationContext {
     >(),
     surfaceState: new Map(),
     surfaceUndoStacks: new Map(),
+    accumulatedSurfaceState: new Map(),
     surfaceActionRequestIds: new Set<string>(),
     currentTurnSurfaces: [],
     isProcessing: () => false,

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -192,6 +192,7 @@ export interface SurfaceConversationContext {
     }
   >;
   surfaceUndoStacks: Map<string, string[]>;
+  accumulatedSurfaceState: Map<string, Record<string, unknown>>;
   /** Request IDs that originated from surface action button clicks (not regular user messages). */
   surfaceActionRequestIds: Set<string>;
   currentTurnSurfaces: Array<{

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -198,6 +198,10 @@ export class Conversation {
     { surfaceType: SurfaceType; data: SurfaceData; title?: string }
   >();
   /** @internal */ surfaceUndoStacks = new Map<string, string[]>();
+  /** @internal */ accumulatedSurfaceState = new Map<
+    string,
+    Record<string, unknown>
+  >();
   /** @internal */ withSurface = createSurfaceMutex();
   /** @internal */ currentTurnSurfaces: Array<{
     surfaceId: string;


### PR DESCRIPTION
## Summary
- Adds `accumulatedSurfaceState` map to `SurfaceConversationContext` interface
- Initializes the map in the `Conversation` class
- Updates test mocks to include the new field

Part of plan: app-interaction-hooks (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
