### PR TITLE
Include accumulated surface state in LLM context for reactive actions

### DIFF
--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -700,6 +700,10 @@ export function handleSurfaceAction(
       selectedIds,
     );
   }
+  const accumulatedState = ctx.accumulatedSurfaceState.get(surfaceId);
+  if (accumulatedState && Object.keys(accumulatedState).length > 0) {
+    fallbackContent += `\n\nAccumulated surface state: ${JSON.stringify(accumulatedState)}`;
+  }
   // When a relay_prompt button also carries selection data (e.g. list/table
   // surface with a canned prompt + user-selected rows), append the selection
   // context so the LLM sees both the prompt and the user's selections.


### PR DESCRIPTION
## Summary
- Injects accumulated `state_update` state into the fallback content when a reactive action fires
- The LLM sees `Accumulated surface state: {...}` alongside the action data
- No-op when no state has been accumulated

Part of plan: app-interaction-hooks.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
