### PR TITLE
fix: restore inspector fallback for provider-only summaries

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorSummaryFormatters.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorSummaryFormatters.swift
@@ -27,6 +27,18 @@ struct MessageInspectorOverviewContent: Equatable {
             return
         }
 
+        if MessageInspectorSummaryFormatters.isProviderOnlySummary(summary) {
+            identityRows = []
+            usageRows = []
+            responsePreview = nil
+            toolCallNames = nil
+            fallbackMessage = MessageInspectorSummaryFormatters.summaryFallbackMessage(
+                recordedAt: MessageInspectorSummaryFormatters.formattedCreatedAt(entry.createdAt),
+                provider: MessageInspectorSummaryFormatters.displayProvider(summary.provider)
+            )
+            return
+        }
+
         identityRows = [
             .init(label: "Provider", value: MessageInspectorSummaryFormatters.displayProvider(summary.provider)),
             .init(label: "Model", value: MessageInspectorSummaryFormatters.displayText(summary.model)),
@@ -106,8 +118,12 @@ enum MessageInspectorSummaryFormatters {
         return value
     }
 
-    static func summaryFallbackMessage(recordedAt: String) -> String {
-        "Normalized summary unavailable. Recorded at \(recordedAt). Raw request and response payloads are still available in the Raw tab."
+    static func summaryFallbackMessage(recordedAt: String, provider: String? = nil) -> String {
+        if let provider, provider != missingValue {
+            return "Normalized summary unavailable for \(provider). Recorded at \(recordedAt). Raw request and response payloads are still available in the Raw tab."
+        }
+
+        return "Normalized summary unavailable. Recorded at \(recordedAt). Raw request and response payloads are still available in the Raw tab."
     }
 
     static func truncatedResponsePreview(_ text: String?, limit: Int = 160) -> String? {
@@ -143,6 +159,25 @@ enum MessageInspectorSummaryFormatters {
     static func formattedCreatedAt(_ epochMs: Int) -> String {
         Date(timeIntervalSince1970: TimeInterval(epochMs) / 1000.0)
             .formatted(date: .abbreviated, time: .shortened)
+    }
+
+    static func isProviderOnlySummary(_ summary: LLMCallSummary) -> Bool {
+        let hasProvider = displayProvider(summary.provider) != missingValue
+        guard hasProvider else { return false }
+
+        return summary.model == nil
+            && summary.status == nil
+            && summary.inputTokens == nil
+            && summary.outputTokens == nil
+            && summary.cacheCreationInputTokens == nil
+            && summary.cacheReadInputTokens == nil
+            && summary.stopReason == nil
+            && summary.requestMessageCount == nil
+            && summary.requestToolCount == nil
+            && summary.responseMessageCount == nil
+            && summary.responseToolCallCount == nil
+            && summary.responsePreview == nil
+            && (summary.toolCallNames?.isEmpty != false)
     }
 
     private static func titleCasedProviderLabel(_ provider: String) -> String {

--- a/clients/macos/vellum-assistantTests/MessageInspectorOverviewTabTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorOverviewTabTests.swift
@@ -165,6 +165,32 @@ final class MessageInspectorOverviewTabTests: XCTestCase {
         XCTAssertTrue(content.fallbackMessage?.contains(MessageInspectorSummaryFormatters.formattedCreatedAt(0)) == true)
     }
 
+    func testProviderOnlySummaryStillUsesRawPayloadFallback() throws {
+        let entry = try decodeEntry(
+            #"""
+            {
+              "id": "raw-only-provider",
+              "requestPayload": "not-json",
+              "responsePayload": "still-not-json",
+              "createdAt": 0,
+              "summary": {
+                "provider": "ollama"
+              }
+            }
+            """#
+        )
+
+        let content = MessageInspectorOverviewContent(entry: entry)
+
+        XCTAssertTrue(content.identityRows.isEmpty)
+        XCTAssertTrue(content.usageRows.isEmpty)
+        XCTAssertNil(content.responsePreview)
+        XCTAssertNil(content.toolCallNames)
+        XCTAssertNotNil(content.fallbackMessage)
+        XCTAssertTrue(content.fallbackMessage?.contains("Ollama") == true)
+        XCTAssertTrue(content.fallbackMessage?.contains("Raw tab") == true)
+    }
+
     func testFormatterHelpersTruncateAndCompactValues() {
         let preview = String(repeating: "a", count: 200)
         let truncated = MessageInspectorSummaryFormatters.truncatedResponsePreview(preview, limit: 40)
@@ -177,6 +203,16 @@ final class MessageInspectorOverviewTabTests: XCTestCase {
         )
         XCTAssertNil(MessageInspectorSummaryFormatters.compactToolNames([], maxVisible: 3))
         XCTAssertEqual(MessageInspectorSummaryFormatters.formatCacheTokens(created: nil, read: nil), "Unavailable")
+        XCTAssertTrue(
+            MessageInspectorSummaryFormatters.isProviderOnlySummary(
+                .init(provider: "openrouter")
+            )
+        )
+        XCTAssertFalse(
+            MessageInspectorSummaryFormatters.isProviderOnlySummary(
+                .init(provider: "openrouter", model: "gpt-4.1")
+            )
+        )
     }
 
     private func decodeEntry(_ json: String) throws -> LLMRequestLogEntry {


### PR DESCRIPTION
## Summary
- treat provider-only LLM context summaries as raw-payload fallback cases in the macOS overview tab
- include the recorded provider label in the fallback message instead of rendering mostly unavailable metadata
- add focused overview formatter tests for provider-only summaries

## Original prompt
The fix for Gap 2 afterwards
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
