### PR TITLE
fix: recognize fork-source messages as in-context for memory filtering

### DIFF
--- a/assistant/src/memory/retriever.test.ts
+++ b/assistant/src/memory/retriever.test.ts
@@ -145,6 +145,7 @@ function insertMessage(
   role: string,
   text: string,
   createdAt: number,
+  opts?: { metadata?: string | null },
 ) {
   db.insert(messages)
     .values({
@@ -153,6 +154,7 @@ function insertMessage(
       role,
       content: JSON.stringify([{ type: "text", text }]),
       createdAt,
+      metadata: opts?.metadata ?? null,
     })
     .run();
 }
@@ -857,5 +859,358 @@ describe("Memory Retriever Pipeline", () => {
     expect(result.recencyHits).toBeGreaterThan(0);
     // Current-conversation segments are filtered out of merged results
     expect(result.mergedCount).toBe(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // Step 5b: fork-aware filtering
+  // -----------------------------------------------------------------------
+
+  describe("step 5b: fork-aware filtering", () => {
+    test("filters segments sourced from fork-parent messages", async () => {
+      const db = getDb();
+      const now = Date.now();
+
+      // Parent conversation with messages
+      const parentConv = "conv-parent";
+      insertConversation(db, parentConv, now - 120_000);
+      insertMessage(
+        db,
+        "parent-msg-1",
+        parentConv,
+        "user",
+        "discuss fork patterns",
+        now - 110_000,
+      );
+      insertMessage(
+        db,
+        "parent-msg-2",
+        parentConv,
+        "assistant",
+        "fork patterns are useful",
+        now - 100_000,
+      );
+
+      // Fork conversation — messages are copies with forkSourceMessageId metadata
+      const forkConv = "conv-fork";
+      insertConversation(db, forkConv, now - 50_000);
+      insertMessage(
+        db,
+        "fork-msg-1",
+        forkConv,
+        "user",
+        "discuss fork patterns",
+        now - 50_000,
+        {
+          metadata: JSON.stringify({
+            forkSourceMessageId: "parent-msg-1",
+          }),
+        },
+      );
+      insertMessage(
+        db,
+        "fork-msg-2",
+        forkConv,
+        "assistant",
+        "fork patterns are useful",
+        now - 49_000,
+        {
+          metadata: JSON.stringify({
+            forkSourceMessageId: "parent-msg-2",
+          }),
+        },
+      );
+
+      // Segment sourced from a parent message — should be filtered when
+      // recalling for the fork conversation since the fork copy is in context.
+      insertSegment(
+        db,
+        "seg-parent-1",
+        "parent-msg-1",
+        parentConv,
+        "user",
+        "discuss fork patterns detail",
+        now - 110_000,
+      );
+
+      const result = await buildMemoryRecall(
+        "fork patterns",
+        forkConv,
+        TEST_CONFIG,
+      );
+
+      expect(result.enabled).toBe(true);
+      // Recency finds segments from this conversation, but the parent-sourced
+      // segment (via forkSourceMessageId) and the fork's own segments should
+      // all be filtered as in-context.
+      expect(result.mergedCount).toBe(0);
+    });
+
+    test("keeps segments from compacted fork messages' parents", async () => {
+      const db = getDb();
+      const now = Date.now();
+
+      // Parent conversation
+      const parentConv = "conv-parent-compact";
+      insertConversation(db, parentConv, now - 200_000);
+      insertMessage(
+        db,
+        "parent-compact-msg-1",
+        parentConv,
+        "user",
+        "compacted parent topic",
+        now - 190_000,
+      );
+      insertMessage(
+        db,
+        "parent-compact-msg-2",
+        parentConv,
+        "assistant",
+        "compacted parent response",
+        now - 180_000,
+      );
+
+      // Fork conversation with compaction — first 2 messages are compacted
+      const forkConv = "conv-fork-compact";
+      insertConversation(db, forkConv, now - 100_000, {
+        contextCompactedMessageCount: 2,
+      });
+
+      // These two messages are compacted (offset=2 means first 2 are compacted)
+      insertMessage(
+        db,
+        "fork-compact-msg-1",
+        forkConv,
+        "user",
+        "compacted parent topic",
+        now - 100_000,
+        {
+          metadata: JSON.stringify({
+            forkSourceMessageId: "parent-compact-msg-1",
+          }),
+        },
+      );
+      insertMessage(
+        db,
+        "fork-compact-msg-2",
+        forkConv,
+        "assistant",
+        "compacted parent response",
+        now - 99_000,
+        {
+          metadata: JSON.stringify({
+            forkSourceMessageId: "parent-compact-msg-2",
+          }),
+        },
+      );
+
+      // A newer message still in context
+      insertMessage(
+        db,
+        "fork-compact-msg-3",
+        forkConv,
+        "user",
+        "recent fork topic",
+        now - 50_000,
+      );
+
+      // Segment in the fork conversation sourced from a compacted fork
+      // message. Since the fork message is compacted, its forkSourceMessageId
+      // is NOT added to the in-context set, so the segment should survive.
+      insertSegment(
+        db,
+        "seg-compact-fork",
+        "fork-compact-msg-1",
+        forkConv,
+        "user",
+        "compacted parent topic detail",
+        now - 100_000,
+      );
+
+      // Also insert a segment from an in-context message for contrast —
+      // this one SHOULD be filtered.
+      insertSegment(
+        db,
+        "seg-in-context-fork",
+        "fork-compact-msg-3",
+        forkConv,
+        "user",
+        "recent fork topic detail",
+        now - 50_000,
+      );
+
+      const result = await buildMemoryRecall(
+        "compacted parent topic",
+        forkConv,
+        TEST_CONFIG,
+      );
+
+      expect(result.enabled).toBe(true);
+      // The segment from the compacted fork message survives filtering
+      // (its source message is no longer in context). The in-context segment
+      // is filtered out. Recency search returns both, but only the compacted
+      // one survives step 5b.
+      expect(result.mergedCount).toBeGreaterThan(0);
+    });
+
+    test("handles multi-level forks", async () => {
+      const db = getDb();
+      const now = Date.now();
+
+      // Grandparent conversation
+      const grandparentConv = "conv-grandparent";
+      insertConversation(db, grandparentConv, now - 300_000);
+      insertMessage(
+        db,
+        "gp-msg-1",
+        grandparentConv,
+        "user",
+        "grandparent topic",
+        now - 290_000,
+      );
+
+      // Parent conversation (fork of grandparent)
+      // The fork metadata preserves the original grandparent message ID
+      const parentConv = "conv-parent-multi";
+      insertConversation(db, parentConv, now - 200_000);
+      insertMessage(
+        db,
+        "parent-multi-msg-1",
+        parentConv,
+        "user",
+        "grandparent topic",
+        now - 200_000,
+        {
+          metadata: JSON.stringify({
+            forkSourceMessageId: "gp-msg-1",
+          }),
+        },
+      );
+
+      // Child conversation (fork of parent)
+      // forkSourceMessageId still points to the original grandparent message
+      const childConv = "conv-child-multi";
+      insertConversation(db, childConv, now - 100_000);
+      insertMessage(
+        db,
+        "child-multi-msg-1",
+        childConv,
+        "user",
+        "grandparent topic",
+        now - 100_000,
+        {
+          metadata: JSON.stringify({
+            forkSourceMessageId: "gp-msg-1",
+          }),
+        },
+      );
+
+      // Segment sourced from the grandparent message
+      insertSegment(
+        db,
+        "seg-gp",
+        "gp-msg-1",
+        grandparentConv,
+        "user",
+        "grandparent topic detail",
+        now - 290_000,
+      );
+
+      const result = await buildMemoryRecall(
+        "grandparent topic",
+        childConv,
+        TEST_CONFIG,
+      );
+
+      expect(result.enabled).toBe(true);
+      // The segment from the grandparent message should be filtered because
+      // the child's fork message metadata traces back to gp-msg-1.
+      expect(result.mergedCount).toBe(0);
+    });
+
+    test("handles missing or invalid metadata gracefully", async () => {
+      const db = getDb();
+      const now = Date.now();
+
+      const forkConv = "conv-fork-bad-meta";
+      insertConversation(db, forkConv, now - 50_000);
+
+      // Message with null metadata (no forkSourceMessageId)
+      insertMessage(
+        db,
+        "fork-null-meta",
+        forkConv,
+        "user",
+        "null metadata topic",
+        now - 50_000,
+      );
+
+      // Message with malformed JSON metadata
+      insertMessage(
+        db,
+        "fork-bad-json",
+        forkConv,
+        "assistant",
+        "bad json topic",
+        now - 49_000,
+        { metadata: "not valid json {{{" },
+      );
+
+      // Message with metadata that is a JSON array (not an object)
+      insertMessage(
+        db,
+        "fork-array-meta",
+        forkConv,
+        "user",
+        "array metadata topic",
+        now - 48_000,
+        { metadata: JSON.stringify([1, 2, 3]) },
+      );
+
+      // Message with metadata object but no forkSourceMessageId field
+      insertMessage(
+        db,
+        "fork-no-field",
+        forkConv,
+        "assistant",
+        "no field topic",
+        now - 47_000,
+        { metadata: JSON.stringify({ someOtherField: "value" }) },
+      );
+
+      // Message with forkSourceMessageId that is not a string
+      insertMessage(
+        db,
+        "fork-non-string",
+        forkConv,
+        "user",
+        "non-string fork id",
+        now - 46_000,
+        { metadata: JSON.stringify({ forkSourceMessageId: 12345 }) },
+      );
+
+      // Insert a segment from this conversation — should be filtered normally
+      // (it's an in-context segment from the active conversation)
+      insertSegment(
+        db,
+        "seg-bad-meta",
+        "fork-null-meta",
+        forkConv,
+        "user",
+        "null metadata topic detail",
+        now - 50_000,
+      );
+
+      // This should not crash despite various malformed metadata
+      const result = await buildMemoryRecall(
+        "metadata topic",
+        forkConv,
+        TEST_CONFIG,
+      );
+
+      expect(result.enabled).toBe(true);
+      // No crash — the pipeline completes successfully
+      // The in-context segment is still filtered normally
+      expect(result.mergedCount).toBe(0);
+    });
   });
 });

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -373,7 +373,7 @@ export async function buildMemoryRecall(
   // those messages are no longer in the conversation history and memory is
   // the only way they can influence the response.
   if (conversationId) {
-    const inContextMessageIds = getInContextMessageIds(conversationId);
+    const inContextMessageIds = getEffectiveInContextMessageIds(conversationId);
     if (inContextMessageIds) {
       for (const [key, c] of candidateMap) {
         if (c.type === "segment") {
@@ -574,14 +574,22 @@ export async function buildMemoryRecall(
 }
 
 /**
- * Get the set of message IDs that are still in the conversation's context
- * window (i.e., not compacted away). Uses `contextCompactedMessageCount` to
- * determine the offset: messages ordered by createdAt after that count are
- * still visible to the model.
+ * Get the set of message IDs that are effectively in the conversation's
+ * context window. This includes:
+ *   1. Messages still visible (not compacted) in the conversation history.
+ *   2. Fork-source message IDs — when a conversation is forked, messages are
+ *      copied with new IDs but their metadata stores the original parent
+ *      message ID as `forkSourceMessageId`. Segments sourced from those parent
+ *      messages are redundant because the fork already contains their content.
+ *
+ * Uses `contextCompactedMessageCount` to determine the compaction offset:
+ * messages ordered by createdAt after that count are still visible to the model.
  *
  * Returns `null` if the conversation is not found (deleted, or no DB row).
  */
-function getInContextMessageIds(conversationId: string): Set<string> | null {
+function getEffectiveInContextMessageIds(
+  conversationId: string,
+): Set<string> | null {
   try {
     const db = getDb();
 
@@ -599,9 +607,9 @@ function getInContextMessageIds(conversationId: string): Set<string> | null {
 
     const offset = conv.contextCompactedMessageCount;
 
-    // Fetch message IDs ordered by creation time, skipping compacted ones
+    // Fetch message IDs and metadata ordered by creation time
     const rows = db
-      .select({ id: messages.id })
+      .select({ id: messages.id, metadata: messages.metadata })
       .from(messages)
       .where(eq(messages.conversationId, conversationId))
       .orderBy(asc(messages.createdAt))
@@ -609,7 +617,30 @@ function getInContextMessageIds(conversationId: string): Set<string> | null {
 
     // Messages up to `offset` have been compacted out of context
     const inContextRows = rows.slice(offset);
-    return new Set(inContextRows.map((r) => r.id));
+    const idSet = new Set(inContextRows.map((r) => r.id));
+
+    // Also include fork-source message IDs from in-context messages.
+    // When a conversation is forked, each copied message's metadata contains
+    // `forkSourceMessageId` pointing to the original (parent or grandparent)
+    // message ID. Segments sourced from those original messages are redundant.
+    for (const row of inContextRows) {
+      if (!row.metadata) continue;
+      try {
+        const parsed = JSON.parse(row.metadata);
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          !Array.isArray(parsed) &&
+          typeof parsed.forkSourceMessageId === "string"
+        ) {
+          idSet.add(parsed.forkSourceMessageId);
+        }
+      } catch {
+        // Invalid metadata JSON — skip, don't break filtering.
+      }
+    }
+
+    return idSet;
   } catch (err) {
     log.warn(
       { err },


### PR DESCRIPTION
## Summary
- Rename `getInContextMessageIds` to `getEffectiveInContextMessageIds` to reflect expanded scope
- Parse `forkSourceMessageId` from message metadata and include parent message IDs in the in-context set
- Handles compaction correctly (compacted fork messages don't contribute source IDs)
- Handles multi-level forks (metadata preserves original source ID through any depth)

Part of plan: fork-aware-memory-recall.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
