### PR TITLE
fix: add missing embedding config stubs to test StubSettingsClient

### DIFF
--- a/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
+++ b/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
@@ -19,6 +19,10 @@ final class ChatViewModelSlashCommandTests: XCTestCase {
 
         func setImageGenModel(modelId: String) async -> ModelInfoMessage? { nil }
 
+        func fetchEmbeddingConfig() async -> EmbeddingConfigMessage? { nil }
+
+        func setEmbeddingConfig(provider: String, model: String?) async -> EmbeddingConfigMessage? { nil }
+
         func fetchTelegramConfig() async -> TelegramConfigResponseMessage? { nil }
 
         func setTelegramConfig(


### PR DESCRIPTION
## Summary
- Add `fetchEmbeddingConfig()` and `setEmbeddingConfig(provider:model:)` stub methods to `StubSettingsClient` in `ChatViewModelSlashCommandTests.swift` to satisfy `SettingsClientProtocol` conformance
- Fixes macOS CI build failure introduced when the embedding config feature was added to the protocol

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23288527591/job/67717942507
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
