### PR TITLE
fix: add @MainActor to shouldShowCurrentTipForkAction

### DIFF
--- a/clients/ios/Views/ConversationListView.swift
+++ b/clients/ios/Views/ConversationListView.swift
@@ -42,6 +42,7 @@ func applyConversationSelectionRequest(
     }
 }
 
+@MainActor
 func shouldShowCurrentTipForkAction(
     store: IOSConversationStore,
     for conversation: IOSConversation


### PR DESCRIPTION
## Summary
- Add `@MainActor` annotation to `shouldShowCurrentTipForkAction` in `ConversationListView.swift` to fix iOS build failure
- The function calls `store.latestPersistedTipDaemonMessageId(for:)` which is main-actor-isolated, but was being called from a synchronous nonisolated context

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23288059424/job/67716317406
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
