### PR TITLE
fix: update memory recall quality tests for item in-context filtering

### DIFF
--- a/assistant/src/__tests__/memory-recall-quality.test.ts
+++ b/assistant/src/__tests__/memory-recall-quality.test.ts
@@ -287,7 +287,7 @@ describe("Memory Recall Quality", () => {
     test("preferences are recalled when querying about user preferences", async () => {
       const db = getDb();
       const now = 1_700_000_000_000;
-      insertConversation(db, "conv-pref", now);
+      insertConversation(db, "conv-pref", now, 3);
       insertMessage(
         db,
         "msg-pref-1",
@@ -408,7 +408,7 @@ describe("Memory Recall Quality", () => {
     test("high-importance preferences outrank low-importance facts in recall", async () => {
       const db = getDb();
       const now = 1_700_000_100_000;
-      insertConversation(db, "conv-rank", now);
+      insertConversation(db, "conv-rank", now, 2);
 
       // High-importance preference
       insertMessage(
@@ -692,7 +692,7 @@ describe("Memory Recall Quality", () => {
       const db = getDb();
       const now = Date.now();
       const oneMonthAgo = now - 30 * 24 * 60 * 60 * 1000;
-      insertConversation(db, "conv-stale", now);
+      insertConversation(db, "conv-stale", now, 2);
 
       // Recent mention
       insertMessage(
@@ -774,7 +774,7 @@ describe("Memory Recall Quality", () => {
     test("frequently accessed items surface via recency search when seeded with segments", async () => {
       const db = getDb();
       const now = 1_700_000_400_000;
-      insertConversation(db, "conv-access", now);
+      insertConversation(db, "conv-access", now, 2);
 
       // Frequently accessed item with segment
       insertMessage(
@@ -885,7 +885,7 @@ describe("Memory Recall Quality", () => {
     test("recency search surfaces segments when hybrid search is unavailable", async () => {
       const db = getDb();
       const now = 1_700_000_500_000;
-      insertConversation(db, "conv-multi", now);
+      insertConversation(db, "conv-multi", now, 1);
 
       // Segment (recency source)
       insertMessage(


### PR DESCRIPTION
## Summary
- Set `contextCompactedMessageCount` in 5 failing test conversations so messages are treated as compacted (out of context window)
- This fixes test failures introduced by `dea21f09d` which added item-level in-context filtering but didn't update the recall quality fixture tests

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23288602698/job/67718169973
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
