### PR TITLE
fix: remove overclaim about user-message injection from SKILL.md

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -553,7 +553,7 @@ window.vellum.sendAction('level_complete', { level: 5, score: 2400 });
 
 ### Silent hooks
 
-Silent hooks accumulate state without interrupting the user. The state is automatically included as context when the next reactive hook fires or the user sends a message.
+Silent hooks accumulate state without interrupting the user. The state is automatically included as context when the next reactive hook fires.
 
 ```javascript
 // User navigates to a new tab — no response needed, but assistant should know


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for app-interaction-hooks.md.

**Gap:** SKILL.md overclaims user-message injection
**What was expected:** Documentation matches implementation
**What was found:** SKILL.md claimed accumulated state is injected on user messages, but only reactive hooks inject it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
