### PR TITLE
fix: clear accumulatedSurfaceState in abort and dispose paths

### DIFF
--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -125,6 +125,7 @@ export interface AbortContext {
     string,
     { surfaceType: SurfaceType; data: SurfaceData; title?: string }
   >;
+  accumulatedSurfaceState: Map<string, Record<string, unknown>>;
   readonly queue: MessageQueue;
 }
 
@@ -237,6 +238,7 @@ export function abortConversation(ctx: AbortContext): void {
     ctx.pendingSurfaceActions.clear();
     ctx.surfaceActionRequestIds.clear();
     ctx.surfaceState.clear();
+    ctx.accumulatedSurfaceState.clear();
     unregisterWatchNotifiers(ctx.conversationId);
     for (const queued of ctx.queue) {
       queued.onEvent({
@@ -268,6 +270,7 @@ export function disposeConversation(ctx: DisposeContext): void {
   ctx.pendingSurfaceActions.clear();
   ctx.surfaceActionRequestIds.clear();
   ctx.surfaceState.clear();
+  ctx.accumulatedSurfaceState.clear();
   ctx.lastSurfaceAction.clear();
   ctx.workspaceTopLevelContext = null;
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for app-interaction-hooks.md.

**Gap:** accumulatedSurfaceState not cleared in abort/dispose
**What was expected:** All surface-scoped maps cleared consistently
**What was found:** New map missing from AbortContext, DisposeContext interfaces and their cleanup blocks

[skip ci]
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
