### PR TITLE
fix: include accumulated state in relay_prompt reactive actions

### DIFF
--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -758,6 +758,11 @@ export function handleSurfaceAction(
       );
     }
   }
+  // When prompt is truthy, fallbackContent (which includes accumulated state)
+  // is discarded. Re-append accumulated state so the LLM sees it.
+  if (prompt && accumulatedState && Object.keys(accumulatedState).length > 0) {
+    content += `\n\nAccumulated surface state: ${JSON.stringify(accumulatedState)}`;
+  }
   // Show the user plain-text instead of raw JSON action data.
   const displayContent = prompt
     ? undefined


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for app-interaction-hooks.md.

**Gap:** relay_prompt actions discard accumulated state
**What was expected:** All reactive actions include accumulated surface state
**What was found:** `content = prompt || fallbackContent` discards fallbackContent (with accumulated state) when prompt is truthy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
