### PR TITLE
fix: add route policy for config/embeddings endpoints

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -343,6 +343,10 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "model:PUT", scopes: ["settings.write"] },
   { endpoint: "model/image-gen", scopes: ["settings.write"] },
 
+  // Embedding config
+  { endpoint: "config/embeddings:GET", scopes: ["settings.read"] },
+  { endpoint: "config/embeddings:PUT", scopes: ["settings.write"] },
+
   // Conversation management
   { endpoint: "conversations/wipe", scopes: ["chat.write"] },
   { endpoint: "conversations/reorder", scopes: ["chat.write"] },


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for embed-config-desktop-settings.md.

**Gap:** Missing route policy for config/embeddings — endpoints are unauthenticated
**What was expected:** Endpoints should require authentication like all other routes
**What was found:** No ACTOR_ENDPOINTS entry for config/embeddings, so enforcePolicy allows unauthenticated access

## Test plan
- [x] Verified route policy key format matches what the HTTP router looks up (`config/embeddings:GET`, `config/embeddings:PUT`)
- [x] Scopes follow the same pattern as existing model config endpoints (`settings.read` for GET, `settings.write` for PUT)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
