### PR TITLE
fix: consume accumulated surface state after injection into reactive action

### DIFF
--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -744,6 +744,8 @@ export function handleSurfaceAction(
   const accumulatedState = ctx.accumulatedSurfaceState.get(surfaceId);
   if (accumulatedState && Object.keys(accumulatedState).length > 0) {
     fallbackContent += `\n\nAccumulated surface state: ${JSON.stringify(accumulatedState)}`;
+    // One-shot: clear accumulated state so it isn't re-injected on subsequent actions.
+    ctx.accumulatedSurfaceState.delete(surfaceId);
   }
   // When a relay_prompt button also carries selection data (e.g. list/table
   // surface with a canned prompt + user-selected rows), append the selection


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for app-interaction-hooks.md.

**Gap:** Accumulated state not consumed after injection
**What was expected:** State injected once then cleared (one-shot)
**What was found:** State persists and re-injects on every subsequent reactive action

## Test plan
- [x] Existing `conversation-surfaces-state-update.test.ts` tests pass (11/11)
- [x] Verified accumulated state is deleted from map after injection into `fallbackContent`
- [x] State is also cleared when relay_prompt path is taken (preventing stale state on future actions)


🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
