### PR TITLE
fix: add missing embedding config methods to MockSettingsClient

### DIFF
--- a/clients/macos/vellum-assistantTests/MockSettingsClient.swift
+++ b/clients/macos/vellum-assistantTests/MockSettingsClient.swift
@@ -13,6 +13,8 @@ final class MockSettingsClient: SettingsClientProtocol {
     var fetchTelegramConfigCallCount = 0
     var setTelegramConfigCalls: [(action: String, botToken: String?, commands: [TelegramConfigRequestCommand]?)] = []
     var setSlackWebhookConfigCalls: [(action: String, webhookUrl: String?)] = []
+    var fetchEmbeddingConfigCallCount = 0
+    var setEmbeddingConfigCalls: [(provider: String, model: String?)] = []
     var fetchChannelVerificationStatusCalls: [String] = []
 
     // MARK: - Configurable Responses
@@ -21,6 +23,8 @@ final class MockSettingsClient: SettingsClientProtocol {
     var modelInfoResponse: ModelInfoMessage?
     var setModelResponse: ModelInfoMessage?
     var setImageGenModelResponse: ModelInfoMessage?
+    var embeddingConfigResponse: EmbeddingConfigMessage?
+    var setEmbeddingConfigResponse: EmbeddingConfigMessage?
     var telegramConfigResponse: TelegramConfigResponseMessage?
     var setTelegramConfigResponse: TelegramConfigResponseMessage?
     var setSlackWebhookConfigResponse: Bool = true
@@ -46,6 +50,16 @@ final class MockSettingsClient: SettingsClientProtocol {
     func setImageGenModel(modelId: String) async -> ModelInfoMessage? {
         setImageGenModelCalls.append(modelId)
         return setImageGenModelResponse
+    }
+
+    func fetchEmbeddingConfig() async -> EmbeddingConfigMessage? {
+        fetchEmbeddingConfigCallCount += 1
+        return embeddingConfigResponse
+    }
+
+    func setEmbeddingConfig(provider: String, model: String?) async -> EmbeddingConfigMessage? {
+        setEmbeddingConfigCalls.append((provider: provider, model: model))
+        return setEmbeddingConfigResponse
     }
 
     func fetchTelegramConfig() async -> TelegramConfigResponseMessage? {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for embed-config-desktop-settings.md.

**Gap:** MockSettingsClient missing new protocol methods — test compilation broken
**What was expected:** MockSettingsClient should implement fetchEmbeddingConfig() and setEmbeddingConfig()
**What was found:** The two new SettingsClientProtocol methods were not added to MockSettingsClient
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
