### PR TITLE
fix: wire embeddingKeySaveError for API key validation feedback

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -829,7 +829,7 @@ public final class SettingsStore: ObservableObject {
         refreshModelInfo()
     }
 
-    func saveInferenceAPIKey(_ raw: String, provider: String, onSuccess: (() -> Void)? = nil) {
+    func saveInferenceAPIKey(_ raw: String, provider: String, onSuccess: (() -> Void)? = nil, onError: ((String) -> Void)? = nil) {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         apiKeySaveError = nil
@@ -852,7 +852,11 @@ public final class SettingsStore: ObservableObject {
                 onSuccess?()
                 refreshModelInfo()
             } else if let error = result.error {
-                apiKeySaveError = error
+                if let onError {
+                    onError(error)
+                } else {
+                    apiKeySaveError = error
+                }
                 if !result.isTransient {
                     // Definitive validation failure — revert optimistic local state
                     APIKeyManager.deleteKey(for: provider)
@@ -1055,9 +1059,12 @@ public final class SettingsStore: ObservableObject {
     }
 
     func saveEmbeddingAPIKey(_ raw: String, provider: String) {
+        embeddingKeySaveError = nil
         // Delegate to saveInferenceAPIKey — same keychain store, same daemon validation
         saveInferenceAPIKey(raw, provider: provider, onSuccess: {
             self.refreshEmbeddingConfig()
+        }, onError: { error in
+            self.embeddingKeySaveError = error
         })
     }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for embed-config-desktop-settings.md.

**Gap:** embeddingKeySaveError is declared but never set — API key validation errors silently lost
**What was expected:** API key save errors should display in the embedding card
**What was found:** saveEmbeddingAPIKey delegates to saveInferenceAPIKey which sets apiKeySaveError instead of embeddingKeySaveError

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
