### PR TITLE
feat: add `app_refresh` tool for compile + surface refresh

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/TOOLS.json
+++ b/assistant/src/config/bundled-skills/app-builder/TOOLS.json
@@ -192,6 +192,28 @@
       "execution_target": "host"
     },
     {
+      "name": "app_refresh",
+      "description": "Trigger recompilation and surface refresh for an app after making file changes. Call this once after you finish editing app files with generic file tools.",
+      "category": "apps",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "app_id": {
+            "type": "string",
+            "description": "The ID of the app to refresh"
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["app_id"]
+      },
+      "executor": "tools/app-refresh.ts",
+      "execution_target": "host"
+    },
+    {
       "name": "app_file_list",
       "description": "List all files in an app. Returns a JSON array of file paths.",
       "category": "apps",

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-refresh.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-refresh.ts
@@ -1,0 +1,13 @@
+import * as appStore from "../../../../memory/app-store.js";
+import { executeAppRefresh } from "../../../../tools/apps/executors.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeAppRefresh({ app_id: input.app_id as string }, appStore);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -27,6 +27,7 @@ import * as appFileWrite from "./bundled-skills/app-builder/tools/app-file-write
 import * as appGenerateIcon from "./bundled-skills/app-builder/tools/app-generate-icon.js";
 import * as appList from "./bundled-skills/app-builder/tools/app-list.js";
 import * as appQuery from "./bundled-skills/app-builder/tools/app-query.js";
+import * as appRefresh from "./bundled-skills/app-builder/tools/app-refresh.js";
 import * as appUpdate from "./bundled-skills/app-builder/tools/app-update.js";
 // ── browser ────────────────────────────────────────────────────────────────────
 import * as browserClick from "./bundled-skills/browser/tools/browser-click.js";
@@ -197,6 +198,7 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["app-builder:tools/app-query.ts", appQuery],
   ["app-builder:tools/app-update.ts", appUpdate],
   ["app-builder:tools/app-delete.ts", appDelete],
+  ["app-builder:tools/app-refresh.ts", appRefresh],
   ["app-builder:tools/app-file-list.ts", appFileList],
   ["app-builder:tools/app-file-read.ts", appFileRead],
   ["app-builder:tools/app-file-edit.ts", appFileEdit],

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -371,6 +371,39 @@ export function executeAppDelete(
 }
 
 // ---------------------------------------------------------------------------
+// app_refresh
+// ---------------------------------------------------------------------------
+
+export interface AppRefreshInput {
+  app_id: string;
+}
+
+export function executeAppRefresh(
+  input: AppRefreshInput,
+  store: AppStore,
+): ExecutorResult {
+  const app = store.getApp(input.app_id);
+  if (!app) {
+    return {
+      content: JSON.stringify({ error: `App '${input.app_id}' not found` }),
+      isError: true,
+    };
+  }
+
+  // Empty update bumps updatedAt timestamp, triggering recompilation and
+  // surface refresh on the client side.
+  const updated = store.updateApp(input.app_id, {});
+  return {
+    content: JSON.stringify({
+      refreshed: true,
+      appId: updated.id,
+      name: updated.name,
+    }),
+    isError: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // app_file_list
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add `app_refresh` tool that validates an app exists, bumps `updatedAt`, and returns metadata
- New executor function `executeAppRefresh` in executors.ts
- Skill script, TOOLS.json entry, and bundled registry registration

Part of plan: simplify-app-builder-tools.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
