### PR TITLE
feat: register post-execution side-effect hook for `app_refresh`

### DIFF
--- a/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
@@ -228,6 +228,124 @@ describe("session-tool-setup app refresh side effects", () => {
     });
   });
 
+  // ── app_refresh ─────────────────────────────────────────────────────
+
+  describe("app_refresh", () => {
+    test("triggers refreshSurfacesForApp when result is not an error", async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({
+        content: '{"id":"app-1"}',
+        isError: false,
+      });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+        noopLifecycleHandler,
+        broadcastSpy,
+      );
+
+      await toolFn("app_refresh", { app_id: "app-1" });
+
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect((refreshSpy.mock.calls as unknown[][])[0][0]).toBe(ctx);
+      expect((refreshSpy.mock.calls as unknown[][])[0][1]).toBe("app-1");
+    });
+
+    test("broadcasts app_files_changed with correct appId", async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: "{}", isError: false });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+        noopLifecycleHandler,
+        broadcastSpy,
+      );
+
+      await toolFn("app_refresh", { app_id: "app-42" });
+
+      expect(broadcastSpy).toHaveBeenCalledTimes(1);
+      expect((broadcastSpy.mock.calls as unknown[][])[0][0]).toEqual({
+        type: "app_files_changed",
+        appId: "app-42",
+      });
+    });
+
+    test("calls updatePublishedAppDeployment", async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: "{}", isError: false });
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+        noopLifecycleHandler,
+        mock(() => {}),
+      );
+
+      await toolFn("app_refresh", { app_id: "app-publish" });
+
+      // updatePublishedAppDeployment is called with void (fire-and-forget),
+      // so just verify it was invoked.
+      expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
+      expect((updatePublishedSpy.mock.calls as unknown[][])[0][0]).toBe(
+        "app-publish",
+      );
+    });
+
+    test("skips side effects when result is an error", async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({
+        content: "Error: not found",
+        isError: true,
+      });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+        noopLifecycleHandler,
+        broadcastSpy,
+      );
+
+      await toolFn("app_refresh", { app_id: "app-err" });
+
+      expect(refreshSpy).not.toHaveBeenCalled();
+      expect(broadcastSpy).not.toHaveBeenCalled();
+      expect(updatePublishedSpy).not.toHaveBeenCalled();
+    });
+
+    test("skips side effects when app_id is missing", async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: "{}", isError: false });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+        noopLifecycleHandler,
+        broadcastSpy,
+      );
+
+      await toolFn("app_refresh", {});
+
+      expect(refreshSpy).not.toHaveBeenCalled();
+      expect(broadcastSpy).not.toHaveBeenCalled();
+    });
+  });
+
   // ── app_file_edit ───────────────────────────────────────────────────
 
   describe("app_file_edit", () => {

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -168,6 +168,17 @@ registerHook(
   },
 );
 
+// Trigger compilation + surface refresh + broadcast when an app is refreshed.
+registerHook(
+  "app_refresh",
+  (_name, input, _result, { ctx, broadcastToAllClients }) => {
+    const appId = input.app_id as string | undefined;
+    if (appId) {
+      handleAppChange(ctx, appId, broadcastToAllClients);
+    }
+  },
+);
+
 // Broadcast tasks_changed so connected clients (e.g. macOS Tasks window)
 // auto-refresh when the LLM mutates the task queue via tools
 registerHook(


### PR DESCRIPTION
## Summary
- Register side-effect hook for `app_refresh` that calls `handleAppChange` for compilation + surface refresh + broadcast
- Add comprehensive test coverage following the `app_update` hook test pattern

Part of plan: simplify-app-builder-tools.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
