### PR TITLE
refactor: update display names and workspace context for app_refresh

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -179,7 +179,7 @@ export function emitLlmCallStartedIfNeeded(
 // tool_input_delta streams accumulated JSON as tools run. For non-app
 // tools the client discards it (extractCodePreview only handles app tools),
 // so we skip forwarding entirely to avoid transport/decode overhead.
-const APP_TOOL_NAMES = new Set(["app_create", "app_update"]);
+const APP_TOOL_NAMES = new Set(["app_create"]);
 
 // ── Friendly Tool Names ──────────────────────────────────────────────
 
@@ -197,11 +197,9 @@ const TOOL_FRIENDLY_NAMES: Record<string, string> = {
   browser_scroll: "browser",
   browser_wait: "browser",
   app_create: "app",
-  app_update: "app",
+  app_refresh: "app refresh",
   skill_load: "skill",
   skill_execute: "skill",
-  app_file_edit: "app file",
-  app_file_write: "app file",
 };
 
 function friendlyToolName(name: string): string {

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -32,7 +32,7 @@ import {
   setSentryConversationContext,
 } from "../instrument.js";
 import { commitAppTurnChanges } from "../memory/app-git-service.js";
-import { getApp, listAppFiles } from "../memory/app-store.js";
+import { getApp, listAppFiles, resolveAppDir } from "../memory/app-store.js";
 import {
   addMessage,
   deleteMessageById,
@@ -176,11 +176,9 @@ const TOOL_FRIENDLY_LABEL: Record<string, string> = {
   browser_scroll: "Browser",
   browser_wait: "Browser",
   app_create: "Create App",
-  app_update: "Update App",
+  app_refresh: "Refresh App",
   skill_load: "Load Skill",
   skill_execute: "Run Skill Tool",
-  app_file_edit: "Edit App File",
-  app_file_write: "Write App File",
 };
 
 type GitServiceInitializer = {
@@ -607,6 +605,7 @@ export async function runAgentLoopImpl(
           if (app) {
             activeSurface.appId = app.id;
             activeSurface.appName = app.name;
+            activeSurface.appDirName = resolveAppDir(app.id).dirName;
             activeSurface.appSchemaJson = app.schemaJson;
             activeSurface.appFiles = listAppFiles(app.id);
             if (app.pages && Object.keys(app.pages).length > 0) {

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -266,6 +266,8 @@ export interface ActiveSurfaceContext {
   /** When set, the surface is backed by a persisted app. */
   appId?: string;
   appName?: string;
+  /** Filesystem directory/slug for the app (used to construct file paths). */
+  appDirName?: string;
   appSchemaJson?: string;
   /** Additional pages keyed by filename (e.g. "settings.html" → HTML content). */
   appPages?: Record<string, string>;
@@ -297,19 +299,18 @@ export function injectActiveSurfaceContext(
 
   if (ctx.appId) {
     // ── App-backed surface ──
+    const slug = ctx.appDirName ?? ctx.appId;
     lines.push(
-      `The user is viewing app "${ctx.appName ?? "Untitled"}" (app_id: "${ctx.appId}") in workspace mode.`,
+      `The user is viewing app "${ctx.appName ?? "Untitled"}" (app_id: "${ctx.appId}", slug: "${slug}") in workspace mode.`,
       "",
-      'PREREQUISITE: If `app_*` tools (e.g. `app_file_edit`, `app_file_write`) are not yet available, call `skill_load` with `id: "app-builder"` first to load them.',
+      'PREREQUISITE: If `app_refresh` is not yet available, call `skill_load` with `id: "app-builder"` first to load it.',
       "",
       "RULES FOR WORKSPACE MODIFICATION:",
-      `1. Use \`app_file_edit\` with app_id "${ctx.appId}" for surgical changes.`,
-      "   Provide old_string (exact match) and new_string (replacement).",
-      '   Include a short `status` message describing what you\'re doing (e.g. "adding dark mode styles").',
-      "2. Use `app_file_write` to create new files or fully rewrite files. Include `status`.",
-      "3. Use `app_file_read` to read any file with line numbers before editing.",
-      "4. Use `app_file_list` to see all files in the app.",
-      "5. The surface refreshes automatically after file edits — do NOT call app_update, ui_show, or ui_update.",
+      `1. Use \`file_edit\` to make surgical changes to app files. The file path is \`~/.vellum/workspace/data/apps/${slug}/<path>\`.`,
+      "2. Use `file_write` to create new files or rewrite files.",
+      "3. Use `file_read` to read any file with line numbers before editing.",
+      "4. Use `bash ls` to see all files in the app directory.",
+      `5. Call \`app_refresh\` with app_id "${ctx.appId}" ONCE after all changes are complete.`,
       "6. NEVER respond with only text — the user expects a visual update.",
       "7. Make ONLY the changes the user requested. Preserve existing content/styling.",
       "8. Keep your text response to 1 brief sentence confirming what you changed.",


### PR DESCRIPTION
## Summary
- Update TOOL_FRIENDLY_NAMES and TOOL_FRIENDLY_LABEL to replace removed app tool entries with app_refresh
- Rewrite workspace context instructions to use generic file tools + app_refresh
- Inject dirName/slug so the assistant can construct file paths

Part of plan: simplify-app-builder-tools.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
