### PR TITLE
fix: defer accumulated state consumption until message is accepted

### DIFF
--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -744,8 +744,6 @@ export function handleSurfaceAction(
   const accumulatedState = ctx.accumulatedSurfaceState.get(surfaceId);
   if (accumulatedState && Object.keys(accumulatedState).length > 0) {
     fallbackContent += `\n\nAccumulated surface state: ${JSON.stringify(accumulatedState)}`;
-    // One-shot: clear accumulated state so it isn't re-injected on subsequent actions.
-    ctx.accumulatedSurfaceState.delete(surfaceId);
   }
   // When a relay_prompt button also carries selection data (e.g. list/table
   // surface with a canned prompt + user-selected rows), append the selection
@@ -799,6 +797,12 @@ export function handleSurfaceAction(
   if (result.rejected) {
     ctx.surfaceActionRequestIds.delete(requestId);
     return;
+  }
+
+  // One-shot: clear accumulated state now that the message has been accepted.
+  // Deferred until after rejection check so state is preserved for retry on rejection.
+  if (accumulatedState && Object.keys(accumulatedState).length > 0) {
+    ctx.accumulatedSurfaceState.delete(surfaceId);
   }
 
   // Echo the user's prompt to the client so it appears in the chat UI.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for app-interaction-hooks.md.

**Gap:** Accumulated state lost on rejected enqueue
**What was expected:** State preserved if message is rejected (queue full)
**What was found:** `accumulatedSurfaceState.delete()` fires before `enqueueMessage`, so rejection permanently loses the state

## Test plan
- [x] Existing `conversation-surfaces-state-update.test.ts` tests pass (11/11)
- [x] Type check passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
