### PR TITLE
fix: guard inference-card state in saveInferenceAPIKey for embedding callers

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -832,8 +832,14 @@ public final class SettingsStore: ObservableObject {
     func saveInferenceAPIKey(_ raw: String, provider: String, onSuccess: (() -> Void)? = nil, onError: ((String) -> Void)? = nil) {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        apiKeySaveError = nil
-        apiKeySaving = true
+        // Only mutate inference-card state when called from the inference path
+        // (onError == nil). When called from the embedding path, these would
+        // briefly flash saving state on the inference card and clear any
+        // existing inference error.
+        if onError == nil {
+            apiKeySaveError = nil
+            apiKeySaving = true
+        }
 
         // Persist locally first
         APIKeyManager.setKey(trimmed, for: provider)
@@ -846,7 +852,9 @@ public final class SettingsStore: ObservableObject {
 
         Task {
             let result = await syncKeyToDaemonWithValidation(provider: provider, value: trimmed)
-            apiKeySaving = false
+            if onError == nil {
+                apiKeySaving = false
+            }
             if result.success {
                 scheduleRoutingSourceRefresh()
                 onSuccess?()


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for embed-config-desktop-settings.md.

**Gap:** saveInferenceAPIKey mutates inference-card state when called from embedding path
**What was expected:** Embedding key saves should not affect inference card state
**What was found:** apiKeySaving and apiKeySaveError are unconditionally mutated, causing cross-contamination

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
