### PR TITLE
test: update tests for simplified app builder tool surface

### DIFF
--- a/assistant/src/__tests__/app-builder-tool-scripts.test.ts
+++ b/assistant/src/__tests__/app-builder-tool-scripts.test.ts
@@ -90,6 +90,7 @@ mock.module("../bundler/app-compiler.js", () => ({
 
 import * as appCreateScript from "../config/bundled-skills/app-builder/tools/app-create.js";
 import * as appDeleteScript from "../config/bundled-skills/app-builder/tools/app-delete.js";
+import * as appRefreshScript from "../config/bundled-skills/app-builder/tools/app-refresh.js";
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -155,6 +156,25 @@ describe("app-builder skill tool scripts", () => {
       expect(result.isError).toBe(false);
       const parsed = JSON.parse(result.content);
       expect(parsed.deleted).toBe(true);
+      expect(parsed.appId).toBe("app-1");
+    });
+  });
+
+  // ---- app-refresh -------------------------------------------------------
+
+  describe("app-refresh", () => {
+    test("exports a run function", () => {
+      expect(typeof appRefreshScript.run).toBe("function");
+    });
+
+    test("delegates to executeAppRefresh and returns result", async () => {
+      const result = await appRefreshScript.run(
+        { app_id: "app-1" },
+        makeContext(),
+      );
+      expect(result.isError).toBe(false);
+      const parsed = JSON.parse(result.content);
+      expect(parsed.refreshed).toBe(true);
       expect(parsed.appId).toBe("app-1");
     });
   });

--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -1779,14 +1779,9 @@ describe("bundled skill: claude-code", () => {
 
 const APP_BUILDER_TOOL_NAMES = [
   "app_create",
-  "app_list",
-  "app_query",
-  "app_update",
   "app_delete",
-  "app_file_list",
-  "app_file_read",
-  "app_file_edit",
-  "app_file_write",
+  "app_generate_icon",
+  "app_refresh",
 ] as const;
 
 describe("bundled skill: app-builder", () => {
@@ -1803,7 +1798,7 @@ describe("bundled skill: app-builder", () => {
     sessionState = new Map<string, string>();
   });
 
-  test("app-builder skill activation registers all 9 canonical non-proxy tools in allowedToolNames", () => {
+  test("app-builder skill activation registers all 4 canonical non-proxy tools in allowedToolNames", () => {
     mockCatalog = [
       makeSkill("app-builder", "/path/to/bundled-skills/app-builder"),
     ];
@@ -1862,7 +1857,7 @@ describe("bundled skill: app-builder", () => {
 
     const tools = mockRegisteredTools.get("app-builder");
     expect(tools).toBeDefined();
-    expect(tools!.length).toBe(9);
+    expect(tools!.length).toBe(4);
 
     // All tools should have skill origin metadata
     for (const tool of tools!) {

--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -187,14 +187,9 @@ describe("baseline characterization: core app tool surface", () => {
 
     const nonProxyAppTools = [
       "app_create",
-      "app_list",
-      "app_query",
-      "app_update",
       "app_delete",
-      "app_file_list",
-      "app_file_read",
-      "app_file_edit",
-      "app_file_write",
+      "app_generate_icon",
+      "app_refresh",
     ];
 
     for (const name of nonProxyAppTools) {


### PR DESCRIPTION
## Summary
- Update APP_BUILDER_TOOL_NAMES to reflect the new 4-tool surface
- Update registry test assertions for the new tool list
- Add test for app_refresh tool script
- Verify system-prompt tests still pass with updated workspace context

Part of plan: simplify-app-builder-tools.md (PR 7 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
