### PR TITLE
fix: pass fileChange flag in app_refresh hook and update stale comments

### DIFF
--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -873,7 +873,7 @@ export function handleSurfaceAction(
 }
 
 /**
- * After an app_update, refresh any active surface that displays the updated app.
+ * After an app_refresh, refresh any active surface that displays the updated app.
  */
 export function refreshSurfacesForApp(
   ctx: SurfaceConversationContext,
@@ -922,7 +922,7 @@ export function refreshSurfacesForApp(
     refreshed = true;
     log.info(
       { conversationId: ctx.conversationId, surfaceId, appId },
-      "Auto-refreshed surface after app_update",
+      "Auto-refreshed surface after app_refresh",
     );
   }
   return refreshed;

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -163,7 +163,7 @@ registerHook(
   (_name, input, _result, { ctx, broadcastToAllClients }) => {
     const appId = input.app_id as string | undefined;
     if (appId) {
-      handleAppChange(ctx, appId, broadcastToAllClients);
+      handleAppChange(ctx, appId, broadcastToAllClients, { fileChange: true });
     }
   },
 );


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for simplify-app-builder-tools.md.

**Gap 1:** app_refresh hook missing `{ fileChange: true }` — WebView wouldn't reload after refresh
**Gap 2:** Stale `app_update` references in conversation-surfaces.ts docstring and log message
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
