### PR TITLE
fix: update tool-preview-lifecycle test for removed app_update tool

### DIFF
--- a/assistant/src/__tests__/tool-preview-lifecycle.test.ts
+++ b/assistant/src/__tests__/tool-preview-lifecycle.test.ts
@@ -382,7 +382,7 @@ describe("tool preview lifecycle", () => {
 
       const toolUseId = "toolu_full_lifecycle";
       // Use an app tool so input_json_delta is forwarded to the client
-      const toolName = "app_update";
+      const toolName = "app_create";
 
       // 1. Preview start
       handleToolUsePreviewStart(state, deps, {


### PR DESCRIPTION
## Summary
- The `app_update` tool was removed in #19419 but `tool-preview-lifecycle.test.ts` still used it in the full lifecycle test
- Changed the test to use `app_create` (the remaining app tool that forwards `input_json_delta` events)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23289565992/job/67721382598
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
