### PR TITLE
fix: update macOS client tool labels for app_refresh

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolHelpers.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolHelpers.swift
@@ -85,7 +85,7 @@ extension ChatBubble {
     static func friendlyRunningLabel(_ toolName: String, inputSummary: String? = nil, buildingStatus: String? = nil) -> String {
         // For app file tools, prefer the descriptive building status from tool input
         if let status = buildingStatus {
-            if toolName == "app_file_edit" || toolName == "app_file_write" || toolName == "app_create" || toolName == "app_update" {
+            if toolName == "app_create" || toolName == "app_refresh" {
                 return status
             }
         }
@@ -102,9 +102,7 @@ extension ChatBubble {
         case "browser_click":                   return "Clicking on the page"
         case "browser_screenshot":              return "Taking a screenshot"
         case "app_create":                      return "Building your app"
-        case "app_update":                      return "Updating your app"
-        case "app_file_edit":                   return "Editing app files"
-        case "app_file_write":                  return "Writing app files"
+        case "app_refresh":                     return "Refreshing your app"
         case "skill_load":
             if let name = inputSummary, !name.isEmpty {
                 // App-builder skill gets a more contextual label
@@ -129,9 +127,7 @@ extension ChatBubble {
         if let status = buildingStatus { return status }
         switch toolName {
         case "app_create":                              return "Building your app"
-        case "app_update":                              return "Updating your app"
-        case "app_file_edit":                           return "Styling UI"
-        case "app_file_write":                          return "Writing interface code"
+        case "app_refresh":                             return "Refreshing your app"
         case "skill_load":                              return "Loading skill"
         case "web_search":                              return "Researching"
         case "web_fetch":                               return "Gathering information"
@@ -156,11 +152,11 @@ extension ChatBubble {
                 "Polishing the details",
                 "Almost there",
             ]
-        case "app_update":
+        case "app_refresh":
             return [
                 "Reviewing your app",
                 "Applying changes",
-                "Updating the interface",
+                "Refreshing the interface",
                 "Polishing the details",
             ]
         default:

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -937,7 +937,7 @@ public struct ToolCallData: Identifiable, Equatable {
         case "browser_click":                      return "Click Element"
         case "browser_type":                       return "Type Text"
         case "app_create":                         return "Create App"
-        case "app_update":                         return "Update App"
+        case "app_refresh":                        return "Refresh App"
         case "request_system_permission":          return "Request Permission"
         default:
             return toolName
@@ -962,7 +962,7 @@ public struct ToolCallData: Identifiable, Equatable {
         case "browser_screenshot":                 return .scan
         case "browser_click":                      return .mousePointerClick
         case "browser_type":                       return .keyboard
-        case "app_create", "app_update":           return .smartphone
+        case "app_create", "app_refresh":           return .smartphone
         case "request_system_permission":          return .shield
         default:                                   return .puzzle
         }
@@ -998,8 +998,8 @@ public struct ToolCallData: Identifiable, Equatable {
             return "Typed in a field"
         case "app_create":
             return "Created an app"
-        case "app_update":
-            return "Updated the app"
+        case "app_refresh":
+            return "Refreshed the app"
         case "app_open":
             return inputSummary.isEmpty ? "Opened an app" : "Opened \(inputSummary)"
         case "request_system_permission":

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -265,10 +265,10 @@ extension ChatViewModel {
     }
 
     /// Extract a code preview from accumulated tool input JSON.
-    /// Shows the HTML code as it streams during app_create/app_update.
+    /// Shows the HTML code as it streams during app_create/app_refresh.
     static func extractCodePreview(from accumulatedJson: String, toolName: String) -> String? {
         guard !accumulatedJson.isEmpty else { return nil }
-        let isAppTool = toolName == "app_create" || toolName == "app_update"
+        let isAppTool = toolName == "app_create" || toolName == "app_refresh"
         guard isAppTool else { return nil }
 
         // Find the html JSON string value by locating the opening quote
@@ -1309,18 +1309,13 @@ extension ChatViewModel {
             isThinking = false
             // Extract building status for app tools
             let buildingStatus: String? = {
-                let appTools: Set<String> = ["app_create", "app_update", "app_file_edit", "app_file_write"]
+                let appTools: Set<String> = ["app_create", "app_refresh"]
                 guard appTools.contains(msg.toolName) else { return nil }
                 if let status = msg.input["status"]?.value as? String, !status.isEmpty {
                     return status
                 }
-                // Fallback status for file tools only; app_create/app_update
-                // rely on friendlyRunningLabel + progressive label cycling
-                switch msg.toolName {
-                case "app_file_edit": return "Editing app files"
-                case "app_file_write": return "Writing app files"
-                default: return nil
-                }
+                // app_create/app_refresh rely on friendlyRunningLabel + progressive label cycling
+                return nil
             }()
             // Upsert by toolUseId: if a preview chip already exists for this tool, update it
             // instead of creating a duplicate.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for simplify-app-builder-tools.md.

**Gap:** macOS client has stale tool name references (`app_update`, `app_file_edit`, `app_file_write`) and missing `app_refresh` handling in display labels, icons, and progressive labels.

- **ChatMessage.swift**: `app_update` -> `app_refresh` in `friendlyName` ("Refresh App"), `toolIcon` (`.smartphone`), `actionDescription` ("Refreshed the app")
- **ChatBubbleToolHelpers.swift**: Removed `app_update`/`app_file_edit`/`app_file_write` entries, added `app_refresh` in running labels, capability labels, and progressive labels
- **ChatViewModel+MessageHandling.swift**: Updated `extractCodePreview` and `buildingStatus` tool sets from `app_update`/`app_file_edit`/`app_file_write` to `app_refresh`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
