### PR TITLE
ci: add cancel-if-superseded to iOS CI main build

### DIFF
--- a/.github/workflows/ci-main-ios.yaml
+++ b/.github/workflows/ci-main-ios.yaml
@@ -16,6 +16,35 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 25
     steps:
+      - name: Cancel if superseded by a newer run
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.ref.replace('refs/heads/', '');
+            for (const status of ['queued', 'waiting', 'in_progress']) {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'ci-main-ios.yaml',
+                branch,
+                status,
+                per_page: 10,
+              });
+              const newer = data.workflow_runs.filter(r => r.run_number > context.runNumber);
+              if (newer.length > 0) {
+                core.info(`Superseded by newer ${status} run(s): ${newer.map(r => '#' + r.run_number).join(', ')}`);
+                await github.rest.actions.cancelWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: context.runId,
+                });
+                await new Promise(r => setTimeout(r, 5000));
+                core.setFailed('Superseded by a newer run');
+                return;
+              }
+            }
+            core.info('This is the newest run — proceeding.');
+
       - name: Checkout
         uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- Add "Cancel if superseded by a newer run" step to the iOS CI main build job, matching the existing macOS CI workflow behavior
- When multiple commits land on main in quick succession, older runs self-cancel instead of wasting macOS runner minutes

## Original prompt
Make the iOS build GHA have the same cancel behavior as the macOS build GHA
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
