### PR TITLE
fix: fix failing test and remove dead interface methods

### DIFF
--- a/assistant/src/__tests__/app-builder-tool-scripts.test.ts
+++ b/assistant/src/__tests__/app-builder-tool-scripts.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, mock, test } from "bun:test";
 
 import type { AppDefinition } from "../memory/app-store.js";
 import type { AppStore } from "../tools/apps/executors.js";
-import type { EditEngineResult } from "../tools/shared/filesystem/edit-engine.js";
 import type { ToolContext } from "../tools/types.js";
 
 // ---------------------------------------------------------------------------
@@ -26,24 +25,11 @@ function makeMockStore(overrides: Partial<AppStore> = {}): AppStore {
   return {
     getApp: () => makeApp(),
     listApps: () => [makeApp()],
-    queryAppRecords: () => [],
-    listAppFiles: () => ["index.html"],
-    readAppFile: () => "<h1>Hi</h1>",
     createApp: (params) =>
       makeApp({ name: params.name, description: params.description }),
     updateApp: (id, updates) => makeApp({ id, ...updates }),
     deleteApp: () => {},
     writeAppFile: () => {},
-    editAppFile: () =>
-      ({
-        ok: true,
-        updatedContent: "new",
-        matchCount: 1,
-        matchMethod: "exact",
-        similarity: 1,
-        actualOld: "old",
-        actualNew: "new",
-      }) as EditEngineResult,
     ...overrides,
   };
 }

--- a/assistant/src/__tests__/app-executors.test.ts
+++ b/assistant/src/__tests__/app-executors.test.ts
@@ -53,41 +53,11 @@ function mockStore(
   return {
     getApp: (id: string) => (id === app.id ? app : null),
     listApps: () => [app],
-    queryAppRecords: () => [],
-    listAppFiles: () => Object.keys(files).sort(),
-    readAppFile: (_appId: string, path: string) => {
-      if (!(path in files)) throw new Error(`File not found: ${path}`);
-      return files[path];
-    },
     createApp: () => app,
     updateApp: () => app,
     deleteApp: () => {},
     writeAppFile: (_appId: string, path: string, content: string) => {
       files[path] = content;
-    },
-    editAppFile: (
-      _appId: string,
-      path: string,
-      oldStr: string,
-      newStr: string,
-      _replaceAll?: boolean,
-    ) => {
-      if (!(path in files)) throw new Error(`File not found: ${path}`);
-      const content = files[path];
-      if (!content.includes(oldStr)) {
-        return { ok: false as const, reason: "not_found" as const };
-      }
-      const updated = content.replace(oldStr, newStr);
-      files[path] = updated;
-      return {
-        ok: true as const,
-        updatedContent: updated,
-        matchCount: 1,
-        matchMethod: "exact" as const,
-        similarity: 1,
-        actualOld: oldStr,
-        actualNew: newStr,
-      };
     },
   };
 }

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -10,10 +10,7 @@
 
 import { compileApp } from "../../bundler/app-compiler.js";
 import { generateAppIcon } from "../../media/app-icon-generator.js";
-import type {
-  AppDefinition,
-  EditEngineResult,
-} from "../../memory/app-store.js";
+import type { AppDefinition } from "../../memory/app-store.js";
 import { getAppDirPath } from "../../memory/app-store.js";
 
 // ---------------------------------------------------------------------------
@@ -35,9 +32,6 @@ export interface ExecutorResult {
 export interface AppStoreReader {
   getApp(id: string): AppDefinition | null;
   listApps(): AppDefinition[];
-  queryAppRecords(appId: string): unknown[];
-  listAppFiles(appId: string): string[];
-  readAppFile(appId: string, path: string): string;
 }
 
 export interface AppStoreWriter {
@@ -61,13 +55,6 @@ export interface AppStoreWriter {
   ): AppDefinition;
   deleteApp(id: string): void;
   writeAppFile(appId: string, path: string, content: string): void;
-  editAppFile(
-    appId: string,
-    path: string,
-    oldString: string,
-    newString: string,
-    replaceAll?: boolean,
-  ): EditEngineResult;
 }
 
 export type AppStore = AppStoreReader & AppStoreWriter;


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for simplify-app-builder-tools.md.

**Gap 1:** tool-preview-lifecycle.test.ts `app_update` → `app_create` change already landed in main.
**Gap 2:** Dead interface methods in AppStoreReader/AppStoreWriter — removed unused declarations (`queryAppRecords`, `listAppFiles`, `readAppFile`, `editAppFile`) and cleaned up test mocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
