### PR TITLE
feat: add line-level diff highlighting with red/green backgrounds

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/VDiffView.swift
+++ b/clients/shared/DesignSystem/Components/Display/VDiffView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+/// Renders a unified diff string with per-line colored backgrounds.
+/// Added lines (+) get a green tint, removed lines (-) get a red tint,
+/// and hunk headers (@@) get a subtle accent.
+public struct VDiffView: View {
+    let text: String
+    let maxHeight: CGFloat?
+
+    public init(_ text: String, maxHeight: CGFloat? = nil) {
+        self.text = text
+        self.maxHeight = maxHeight
+    }
+
+    // MARK: - Line Classification
+
+    private enum LineKind {
+        case added, removed, hunk, context
+    }
+
+    private static func classify(_ line: Substring) -> LineKind {
+        // Unified diff file headers ("--- a/..." and "+++ b/...") are metadata, not changes.
+        if line.hasPrefix("--- ") || line.hasPrefix("+++ ") { return .context }
+        if line.hasPrefix("@@") { return .hunk }
+        if line.hasPrefix("+") { return .added }
+        if line.hasPrefix("-") { return .removed }
+        return .context
+    }
+
+    // MARK: - Colors
+
+    private static let addedBg = adaptiveColor(
+        light: Forest._100,     // #EDF2EB — very light green
+        dark: Emerald._950      // #073D2E — dark green
+    )
+    private static let removedBg = adaptiveColor(
+        light: Danger._100,     // #FFF3EE — very light red
+        dark: Danger._950       // #4E281D — dark red
+    )
+    private static let hunkBg = adaptiveColor(
+        light: Color(hex: 0xDDE4EE),  // subtle blue-gray
+        dark: Color(hex: 0x1E2A38)    // subtle dark blue
+    )
+
+    private static func lineBackground(_ kind: LineKind) -> Color {
+        switch kind {
+        case .added: return addedBg
+        case .removed: return removedBg
+        case .hunk: return hunkBg
+        case .context: return .clear
+        }
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+        if let maxHeight {
+            diffScrollView(lines: lines, axes: [.horizontal, .vertical])
+                .frame(maxHeight: maxHeight)
+        } else {
+            diffScrollView(lines: lines, axes: .horizontal)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func diffScrollView(lines: [Substring], axes: Axis.Set) -> some View {
+        ScrollView(axes, showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
+                    diffLine(line)
+                }
+            }
+            .fixedSize(horizontal: true, vertical: true)
+        }
+        .textSelection(.enabled)
+    }
+
+    private func diffLine(_ line: Substring) -> some View {
+        let kind = Self.classify(line)
+        return HStack(spacing: 0) {
+            Text(line.isEmpty ? " " : String(line))
+                .font(VFont.monoSmall)
+                .foregroundColor(VColor.contentSecondary)
+                .fixedSize(horizontal: true, vertical: true)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, VSpacing.xs)
+        .padding(.vertical, 1)
+        .background(Self.lineBackground(kind))
+    }
+}

--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -44,6 +44,14 @@ public struct ToolCallChip: View {
         return count
     }
 
+    /// Whether the tool produces diff-formatted output that benefits from line-level highlighting.
+    static func isFileEditTool(_ name: String) -> Bool {
+        switch name {
+        case "file_edit", "host_file_edit", "app_file_edit": return true
+        default: return false
+        }
+    }
+
     /// Human-readable explanation for common exit codes.
     static func exitCodeExplanation(_ code: Int) -> String? {
         switch code {
@@ -219,7 +227,9 @@ public struct ToolCallChip: View {
                                 }
                             } else {
                                 let lineCount = cachedResultLineCount ?? Self.countLines(in: result)
-                                if lineCount > 500 {
+                                if Self.isFileEditTool(toolCall.toolName) {
+                                    VDiffView(result, maxHeight: lineCount > 500 ? 400 : nil)
+                                } else if lineCount > 500 {
                                     ScrollView {
                                         Text(result)
                                             .font(VFont.monoSmall)

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -371,7 +371,13 @@ public struct ToolConfirmationBubble: View {
                         .font(VFont.monoSmall)
                         .foregroundColor(VColor.contentTertiary)
 
-                    codePreviewBlock(diffBody, maxHeight: 260)
+                    VDiffView(diffBody, maxHeight: 260)
+                        .padding(VSpacing.sm)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(
+                            RoundedRectangle(cornerRadius: VRadius.sm)
+                                .fill(VColor.surfaceOverlay)
+                        )
                 }
                 .textSelection(.enabled)
                 .transition(.opacity.combined(with: .move(edge: .top)))


### PR DESCRIPTION
## Summary
- Add `VDiffView` component that renders unified diff text with per-line colored backgrounds (green for `+` additions, red for `-` removals, blue for `@@` hunk headers)
- Integrate into `ToolCallChip` output section for file edit tools (`file_edit`, `host_file_edit`, `app_file_edit`)
- Integrate into `ToolConfirmationBubble` diff preview section

## Design choices
- Uses existing palette colors: `Emerald._950`/`Forest._100` (added), `Danger._950`/`Danger._100` (removed) — adaptive for light/dark modes
- Full-width line backgrounds via `HStack + Spacer` pattern
- Horizontal scrolling for long diff lines (diff text should not wrap)
- Unified diff file headers (`--- a/...`, `+++ b/...`) treated as context, not changes

## Test plan
- [ ] Open a conversation where the assistant edits a file
- [ ] Expand the tool call chip and verify the OUTPUT section shows diff lines with green/red backgrounds
- [ ] Trigger a file edit confirmation and verify the "View diff" section shows highlighted lines
- [ ] Verify light mode and dark mode both look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
