### PR TITLE
feat: add pulsing glow to avatar while assistant is generating

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -494,6 +494,7 @@ struct MessageListView: View {
                                    entryAnimationEnabled: shouldPlayTailEntryAnimation)
                     .frame(width: ConversationAvatarFollower.avatarSize,
                            height: ConversationAvatarFollower.avatarSize)
+                    .modifier(AvatarGlowModifier(isActive: isSending))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, VSpacing.xl)
                     .frame(maxWidth: VSpacing.chatColumnMaxWidth)
@@ -508,6 +509,7 @@ struct MessageListView: View {
             } else {
                 HStack {
                     VAvatarImage(image: appearance.chatAvatarImage, size: ConversationAvatarFollower.avatarSize)
+                        .modifier(AvatarGlowModifier(isActive: isSending))
                     Spacer()
                 }
                 .padding(.horizontal, VSpacing.xl)
@@ -1772,6 +1774,43 @@ enum MessageListBottomAnchorPolicy {
     ) -> Bool {
         guard anchorMinY.isFinite, viewportHeight.isFinite else { return true }
         return anchorMinY > viewportHeight + tolerance
+    }
+}
+
+// MARK: - Avatar Glow
+
+/// Pulsing glow effect applied to the conversation tail avatar while the
+/// assistant is generating a response, making the "still working" state
+/// visible near the content area.
+private struct AvatarGlowModifier: ViewModifier {
+    let isActive: Bool
+
+    @State private var glowIntensity: CGFloat = 0
+
+    func body(content: Content) -> some View {
+        content
+            .shadow(color: VColor.primaryActive.opacity(glowIntensity), radius: 6 + glowIntensity * 16, x: 0, y: 0)
+            .shadow(color: VColor.primaryActive.opacity(glowIntensity * 0.5), radius: 2 + glowIntensity * 6, x: 0, y: 0)
+            .onChange(of: isActive) {
+                if isActive {
+                    withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
+                        glowIntensity = 0.5
+                    }
+                } else {
+                    withAnimation(.easeOut(duration: 0.4)) {
+                        glowIntensity = 0
+                    }
+                }
+            }
+            .onAppear {
+                if isActive {
+                    DispatchQueue.main.async {
+                        withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
+                            glowIntensity = 0.5
+                        }
+                    }
+                }
+            }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `AvatarGlowModifier` ViewModifier that applies a pulsing green glow (`VColor.primaryActive`) around the conversation tail avatar while `isSending` is true
- Double shadow (outer diffuse + inner tight) animated via a single `glowIntensity` property with 1.5s easeInOut cycle
- Applied to both the character avatar (AnimatedAvatarView) and static image avatar (VAvatarImage) paths in `conversationTailAvatar`

## Original prompt
Implement the pulsing avatar glow during response generation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
