### PR TITLE
fix: resolve iOS conversation fork test races

### DIFF
--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -920,19 +920,20 @@ class IOSConversationStore: ObservableObject {
                 messages.last(where: { $0.daemonMessageId != nil && !$0.isStreaming && !$0.isHidden })?.daemonMessageId
             }
             .removeDuplicates()
-            .sink { [weak self, weak vm] _ in
+            .sink { [weak self, weak vm] latestTipId in
                 guard let self, let vm else { return }
-                self.updateForkCommandHandler(vm: vm, conversationLocalId: conversationLocalId)
+                self.updateForkCommandHandler(vm: vm, conversationLocalId: conversationLocalId, knownTipId: latestTipId)
             }
             .store(in: &cancellables)
     }
 
-    private func updateForkCommandHandler(vm: ChatViewModel, conversationLocalId: UUID) {
+    private func updateForkCommandHandler(vm: ChatViewModel, conversationLocalId: UUID, knownTipId: String? = nil) {
+        let hasTip = knownTipId != nil || latestPersistedTipDaemonMessageId(for: conversationLocalId) != nil
         guard isConnectedMode,
               let conversation = conversations.first(where: { $0.id == conversationLocalId }),
               !conversation.isPrivate,
               conversation.conversationId != nil,
-              latestPersistedTipDaemonMessageId(for: conversationLocalId) != nil else {
+              hasTip else {
             vm.onFork = nil
             return
         }

--- a/clients/ios/Tests/ConversationForkIOSTests.swift
+++ b/clients/ios/Tests/ConversationForkIOSTests.swift
@@ -167,7 +167,7 @@ final class ConversationForkIOSTests: XCTestCase {
         persistedTip.daemonMessageId = "msg-tip"
         viewModel.messages = [persistedTip]
 
-        waitUntil(timeout: 1.0) { viewModel.onFork != nil }
+        await waitUntil(timeout: 1.0) { viewModel.onFork != nil }
 
         viewModel.inputText = "/fork"
         viewModel.sendMessage()
@@ -176,7 +176,7 @@ final class ConversationForkIOSTests: XCTestCase {
         XCTAssertEqual(viewModel.messages.first?.text, "Persisted assistant reply")
         XCTAssertEqual(viewModel.inputText, "")
 
-        waitUntil(timeout: 1.0) { store.selectionRequest != nil }
+        await waitUntil(timeout: 1.0) { store.selectionRequest != nil }
 
         XCTAssertEqual(forkClient.requests.count, 1)
         XCTAssertEqual(forkClient.requests.first?.conversationId, "conv-parent")
@@ -226,23 +226,12 @@ final class ConversationForkIOSTests: XCTestCase {
         timeout: TimeInterval,
         file: StaticString = #filePath,
         line: UInt = #line,
-        condition: @escaping () -> Bool
-    ) {
-        let expectation = expectation(description: "Condition met")
-        let deadline = Date().addingTimeInterval(timeout)
-
-        func poll() {
-            if condition() {
-                expectation.fulfill()
-            } else if Date() < deadline {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
-                    poll()
-                }
-            }
+        condition: @escaping @Sendable () -> Bool
+    ) async {
+        let deadline = ContinuousClock.now + .seconds(timeout)
+        while !condition() && ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
         }
-
-        poll()
-        wait(for: [expectation], timeout: timeout + 0.2)
         XCTAssertTrue(condition(), file: file, line: line)
     }
 

--- a/clients/ios/Tests/ConversationForkMessageActionIOSTests.swift
+++ b/clients/ios/Tests/ConversationForkMessageActionIOSTests.swift
@@ -96,7 +96,7 @@ final class ConversationForkMessageActionIOSTests: XCTestCase {
 
         action("msg-branch")
 
-        waitUntil(timeout: 1.0) { store.selectionRequest != nil }
+        await waitUntil(timeout: 1.0) { store.selectionRequest != nil }
 
         XCTAssertEqual(forkClient.requests.count, 1)
         XCTAssertEqual(forkClient.requests.first?.conversationId, "conv-parent")
@@ -140,23 +140,12 @@ final class ConversationForkMessageActionIOSTests: XCTestCase {
         timeout: TimeInterval,
         file: StaticString = #filePath,
         line: UInt = #line,
-        condition: @escaping () -> Bool
-    ) {
-        let expectation = expectation(description: "Condition met")
-        let deadline = Date().addingTimeInterval(timeout)
-
-        func poll() {
-            if condition() {
-                expectation.fulfill()
-            } else if Date() < deadline {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
-                    poll()
-                }
-            }
+        condition: @escaping @Sendable () -> Bool
+    ) async {
+        let deadline = ContinuousClock.now + .seconds(timeout)
+        while !condition() && ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
         }
-
-        poll()
-        wait(for: [expectation], timeout: timeout + 0.2)
         XCTAssertTrue(condition(), file: file, line: line)
     }
 

--- a/clients/ios/Tests/ConversationForkNavigationIOSTests.swift
+++ b/clients/ios/Tests/ConversationForkNavigationIOSTests.swift
@@ -178,7 +178,7 @@ final class ConversationForkNavigationIOSTests: XCTestCase {
         )
         action()
 
-        waitUntil(timeout: 1.0) { store.selectionRequest != nil }
+        await waitUntil(timeout: 1.0) { store.selectionRequest != nil }
 
         XCTAssertEqual(forkClient.requests.count, 1)
         XCTAssertEqual(forkClient.requests.first?.conversationId, "conv-parent")
@@ -233,23 +233,12 @@ final class ConversationForkNavigationIOSTests: XCTestCase {
         timeout: TimeInterval,
         file: StaticString = #filePath,
         line: UInt = #line,
-        condition: @escaping () -> Bool
-    ) {
-        let expectation = expectation(description: "Condition met")
-        let deadline = Date().addingTimeInterval(timeout)
-
-        func poll() {
-            if condition() {
-                expectation.fulfill()
-            } else if Date() < deadline {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
-                    poll()
-                }
-            }
+        condition: @escaping @Sendable () -> Bool
+    ) async {
+        let deadline = ContinuousClock.now + .seconds(timeout)
+        while !condition() && ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
         }
-
-        poll()
-        wait(for: [expectation], timeout: timeout + 0.2)
         XCTAssertTrue(condition(), file: file, line: line)
     }
 


### PR DESCRIPTION
## Summary
- Fix `@Published` willSet race in `observeForForkAvailability` — pass the Combine pipeline's mapped value directly into `updateForkCommandHandler` via a `knownTipId` parameter instead of re-reading the stale property
- Replace synchronous `waitUntil` (which blocks the main actor via `wait(for:timeout:)`) with an async version using `Task.sleep` that cooperatively yields the main actor, allowing fire-and-forget Tasks to execute

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23288771250/job/67718728484
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
