### PR TITLE
fix: swap model/provider argument order in macOS test

### DIFF
--- a/clients/macos/vellum-assistantTests/MessageInspectorOverviewTabTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorOverviewTabTests.swift
@@ -210,7 +210,7 @@ final class MessageInspectorOverviewTabTests: XCTestCase {
         )
         XCTAssertFalse(
             MessageInspectorSummaryFormatters.isProviderOnlySummary(
-                .init(provider: "openrouter", model: "gpt-4.1")
+                .init(model: "gpt-4.1", provider: "openrouter")
             )
         )
     }


### PR DESCRIPTION
## Summary
- Fix Swift compile error in `MessageInspectorOverviewTabTests` where `model` and `provider` arguments were passed in the wrong order to `LLMCallSummary.init`
- The struct declares `model` before `provider`, so Swift's memberwise init requires `model` first

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23290065178/job/67723107375
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
