### PR TITLE
fix: move VDiffView colors to semantic design tokens

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/VDiffView.swift
+++ b/clients/shared/DesignSystem/Components/Display/VDiffView.swift
@@ -29,24 +29,11 @@ public struct VDiffView: View {
 
     // MARK: - Colors
 
-    private static let addedBg = adaptiveColor(
-        light: Forest._100,     // #EDF2EB — very light green
-        dark: Emerald._950      // #073D2E — dark green
-    )
-    private static let removedBg = adaptiveColor(
-        light: Danger._100,     // #FFF3EE — very light red
-        dark: Danger._950       // #4E281D — dark red
-    )
-    private static let hunkBg = adaptiveColor(
-        light: Color(hex: 0xDDE4EE),  // subtle blue-gray
-        dark: Color(hex: 0x1E2A38)    // subtle dark blue
-    )
-
     private static func lineBackground(_ kind: LineKind) -> Color {
         switch kind {
-        case .added: return addedBg
-        case .removed: return removedBg
-        case .hunk: return hunkBg
+        case .added: return VColor.diffAddedBg
+        case .removed: return VColor.diffRemovedBg
+        case .hunk: return VColor.diffHunkBg
         case .context: return .clear
         }
     }

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -340,6 +340,11 @@ public enum VColor {
     public static let systemMidStrong = adaptiveColor(light: FigmaRawColor.systemLightMidStrong, dark: FigmaRawColor.systemDarkMidStrong)
     public static let systemMidWeak = adaptiveColor(light: FigmaRawColor.systemLightMidWeak, dark: FigmaRawColor.systemDarkMidWeak)
 
+    // Diff view — adaptive background tints for unified-diff line highlighting.
+    public static let diffAddedBg  = adaptiveColor(light: Forest._100, dark: Emerald._950)
+    public static let diffRemovedBg = adaptiveColor(light: Danger._100, dark: Danger._950)
+    public static let diffHunkBg   = adaptiveColor(light: Color(hex: 0xDDE4EE), dark: Color(hex: 0x1E2A38))
+
     // Syntax highlighting — adaptive tokens shared by SyntaxTheme and HighlightedTextView.
     // Light values are high-contrast for light surfaces; dark values are softer pastels.
     public static let syntaxString = adaptiveColor(


### PR DESCRIPTION
## Summary
- Added `VColor.diffAddedBg`, `VColor.diffRemovedBg`, and `VColor.diffHunkBg` semantic tokens to `ColorTokens.swift`
- Updated `VDiffView.swift` to use the new tokens instead of raw palette enums, `adaptiveColor()`, and `Color(hex:)` — all of which are forbidden outside token files by the design token guard

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23290130378/job/67723313702
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
