### PR TITLE
fix: remove @Sendable from iOS fork test waitUntil closures

### DIFF
--- a/clients/ios/Tests/ConversationForkIOSTests.swift
+++ b/clients/ios/Tests/ConversationForkIOSTests.swift
@@ -226,7 +226,7 @@ final class ConversationForkIOSTests: XCTestCase {
         timeout: TimeInterval,
         file: StaticString = #filePath,
         line: UInt = #line,
-        condition: @escaping @Sendable () -> Bool
+        condition: @escaping () -> Bool
     ) async {
         let deadline = ContinuousClock.now + .seconds(timeout)
         while !condition() && ContinuousClock.now < deadline {

--- a/clients/ios/Tests/ConversationForkMessageActionIOSTests.swift
+++ b/clients/ios/Tests/ConversationForkMessageActionIOSTests.swift
@@ -140,7 +140,7 @@ final class ConversationForkMessageActionIOSTests: XCTestCase {
         timeout: TimeInterval,
         file: StaticString = #filePath,
         line: UInt = #line,
-        condition: @escaping @Sendable () -> Bool
+        condition: @escaping () -> Bool
     ) async {
         let deadline = ContinuousClock.now + .seconds(timeout)
         while !condition() && ContinuousClock.now < deadline {

--- a/clients/ios/Tests/ConversationForkNavigationIOSTests.swift
+++ b/clients/ios/Tests/ConversationForkNavigationIOSTests.swift
@@ -233,7 +233,7 @@ final class ConversationForkNavigationIOSTests: XCTestCase {
         timeout: TimeInterval,
         file: StaticString = #filePath,
         line: UInt = #line,
-        condition: @escaping @Sendable () -> Bool
+        condition: @escaping () -> Bool
     ) async {
         let deadline = ContinuousClock.now + .seconds(timeout)
         while !condition() && ContinuousClock.now < deadline {


### PR DESCRIPTION
## Summary
- Remove `@Sendable` annotation from `waitUntil` condition closures in `ConversationForkIOSTests`, `ConversationForkMessageActionIOSTests`, and `ConversationForkNavigationIOSTests`
- These test classes are `@MainActor`, so the closures inherit main actor isolation and don't need `@Sendable` — which was causing build failures when accessing `@MainActor`-isolated properties like `onFork` and `selectionRequest`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23290297022/job/67723898949

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
