### PR TITLE
fix: dispatch null suggestion response on all client error paths

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient+Settings.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Settings.swift
@@ -308,11 +308,30 @@ extension HTTPTransport {
         return components.url ?? url
     }
 
+    /// Dispatch a synthetic null `suggestion_response` so the view model clears
+    /// `pendingSuggestionRequestId` even when the HTTP request fails.
+    private func dispatchNullSuggestion(requestId: String) {
+        let syntheticJSON: [String: Any] = [
+            "type": "suggestion_response",
+            "requestId": requestId,
+            "suggestion": NSNull(),
+            "source": "error",
+        ]
+        do {
+            let data = try JSONSerialization.data(withJSONObject: syntheticJSON)
+            let serverMessage = try decoder.decode(ServerMessage.self, from: data)
+            onMessage?(serverMessage)
+        } catch {
+            log.error("dispatchNullSuggestion: failed to decode synthetic message: \(error.localizedDescription)")
+        }
+    }
+
     /// Fetch a follow-up suggestion via GET and dispatch the response through
     /// the message handler chain so `suggestionResponse` fires in the view model.
     private func sendSuggestionGetAndDispatch(conversationId: String, requestId: String) async {
         guard var url = buildURL(for: .suggestion) else {
             log.error("Failed to build URL for suggestion_request")
+            dispatchNullSuggestion(requestId: requestId)
             return
         }
         if var components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
@@ -331,15 +350,20 @@ extension HTTPTransport {
 
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
-            guard let http = response as? HTTPURLResponse else { return }
+            guard let http = response as? HTTPURLResponse else {
+                dispatchNullSuggestion(requestId: requestId)
+                return
+            }
 
             if !(200...299).contains(http.statusCode) {
                 log.error("suggestion_request failed: \(http.statusCode)")
+                dispatchNullSuggestion(requestId: requestId)
                 return
             }
 
             guard var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                 log.error("suggestion_request: failed to parse response JSON")
+                dispatchNullSuggestion(requestId: requestId)
                 return
             }
             json["type"] = "suggestion_response"
@@ -349,6 +373,7 @@ extension HTTPTransport {
             onMessage?(serverMessage)
         } catch {
             log.error("suggestion_request error: \(error.localizedDescription)")
+            dispatchNullSuggestion(requestId: requestId)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `dispatchNullSuggestion(requestId:)` helper that constructs a synthetic null `suggestion_response` and dispatches it through `onMessage`
- Call the helper on every error/early-return path in `sendSuggestionGetAndDispatch` (URL build failure, non-2xx status, JSON parse failure, network error)
- This ensures `pendingSuggestionRequestId` is always cleared, preventing a single transient error from permanently breaking suggestions for the session

Part of plan: fix-suggestion-ghost.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
