### PR TITLE
fix: add structured logging for suggestion generation diagnostics

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1209,6 +1209,7 @@ async function generateLlmSuggestion(
   provider: Provider,
   assistantText: string,
 ): Promise<string | null> {
+  const log = (await import("../../util/logger.js")).getLogger("runtime-http");
   const truncated =
     assistantText.length > 2000 ? assistantText.slice(-2000) : assistantText;
 
@@ -1224,11 +1225,20 @@ async function generateLlmSuggestion(
   const raw = textBlock && "text" in textBlock ? textBlock.text.trim() : "";
   const stripped = raw.replace(/^["']+|["']+$/g, "");
 
-  if (!stripped) return null;
+  if (!stripped) {
+    log.debug("Suggestion rejected: empty LLM response");
+    return null;
+  }
 
   // Take first line only, then enforce the length cap
   const firstLine = stripped.split("\n")[0].trim();
-  if (!firstLine) return null;
+  if (!firstLine) {
+    log.debug(
+      { rawLength: stripped.length },
+      "Suggestion rejected: empty after first-line extraction",
+    );
+    return null;
+  }
   if (firstLine.length <= 50) return firstLine;
   // Truncate at last word boundary within 50 chars
   const wordTruncated = firstLine
@@ -1362,8 +1372,16 @@ export async function handleGetSuggestion(
         }
       } catch (err) {
         suggestionInFlight.delete(msg.id);
-        log.warn({ err }, "LLM suggestion failed");
+        log.warn(
+          { err, conversationKey, messageId: msg.id },
+          "LLM suggestion failed",
+        );
       }
+    } else {
+      log.debug(
+        { conversationKey, messageId: msg.id },
+        "Suggestion skipped: no provider available",
+      );
     }
 
     return Response.json({


### PR DESCRIPTION
## Summary
- Add debug log when `getConfiguredProvider()` returns null in suggestion handler
- Enrich the LLM failure catch log with `conversationKey` and `messageId` context
- Add debug logs in `generateLlmSuggestion` for empty response and validation rejection paths

Part of plan: fix-suggestion-ghost.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
