### PR TITLE
feat: add shared visible-message filter for chat pagination

### DIFF
--- a/clients/shared/Features/Chat/ChatVisibleMessageFilter.swift
+++ b/clients/shared/Features/Chat/ChatVisibleMessageFilter.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Shared source of truth for which messages count toward chat pagination and anchors.
+/// Both `ChatViewModel` and the macOS `MessageListView` should use this to determine
+/// the visible message set, ensuring consistent filtering rules across platforms.
+public enum ChatVisibleMessageFilter {
+
+    /// Returns all messages that should be visible in the chat UI.
+    /// Excludes subagent notifications and hidden (automated) messages.
+    public static func visibleMessages(from messages: [ChatMessage]) -> [ChatMessage] {
+        messages.filter { !$0.isSubagentNotification && !$0.isHidden }
+    }
+
+    /// Returns the paginated suffix of visible messages for a given `displayedMessageCount`.
+    /// Filtering is applied first, then the suffix window is taken from the filtered set.
+    /// When `displayedMessageCount >= visibleCount` (including `.max`), all visible messages
+    /// are returned so new incoming messages don't collapse visible history.
+    public static func paginatedMessages(
+        from messages: [ChatMessage],
+        displayedMessageCount: Int
+    ) -> [ChatMessage] {
+        let visible = visibleMessages(from: messages)
+        guard displayedMessageCount < visible.count else { return visible }
+        return Array(visible.suffix(displayedMessageCount))
+    }
+}

--- a/clients/shared/Tests/ChatVisibleMessageFilterTests.swift
+++ b/clients/shared/Tests/ChatVisibleMessageFilterTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import VellumAssistantShared
+
+final class ChatVisibleMessageFilterTests: XCTestCase {
+
+    // MARK: - visibleMessages
+
+    func testHiddenAutomatedMessagesAreFilteredOut() {
+        var hidden = ChatMessage(role: .user, text: "bootstrap")
+        hidden.isHidden = true
+        let visible = ChatMessage(role: .user, text: "Hello")
+
+        let result = ChatVisibleMessageFilter.visibleMessages(from: [hidden, visible])
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].text, "Hello")
+    }
+
+    func testSubagentNotificationsAreFilteredOut() {
+        var notification = ChatMessage(role: .assistant, text: "Subagent completed")
+        notification.isSubagentNotification = true
+        let visible = ChatMessage(role: .assistant, text: "Here is the result")
+
+        let result = ChatVisibleMessageFilter.visibleMessages(from: [notification, visible])
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].text, "Here is the result")
+    }
+
+    func testNormalVisibleMessagesArePreserved() {
+        let user = ChatMessage(role: .user, text: "What is the weather?")
+        let assistant = ChatMessage(role: .assistant, text: "It is sunny today.")
+
+        let result = ChatVisibleMessageFilter.visibleMessages(from: [user, assistant])
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].text, "What is the weather?")
+        XCTAssertEqual(result[1].text, "It is sunny today.")
+    }
+
+    func testMixedArrayFiltersCorrectly() {
+        var hidden = ChatMessage(role: .user, text: "auto-wake")
+        hidden.isHidden = true
+        let user = ChatMessage(role: .user, text: "Tell me a joke")
+        var notification = ChatMessage(role: .assistant, text: "Subagent done")
+        notification.isSubagentNotification = true
+        let assistant = ChatMessage(role: .assistant, text: "Why did the chicken cross the road?")
+        var bothFlags = ChatMessage(role: .assistant, text: "ghost message")
+        bothFlags.isHidden = true
+        bothFlags.isSubagentNotification = true
+
+        let result = ChatVisibleMessageFilter.visibleMessages(
+            from: [hidden, user, notification, assistant, bothFlags]
+        )
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].text, "Tell me a joke")
+        XCTAssertEqual(result[1].text, "Why did the chicken cross the road?")
+    }
+
+    func testEmptyArrayReturnsEmpty() {
+        let result = ChatVisibleMessageFilter.visibleMessages(from: [])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - paginatedMessages
+
+    func testSuffixWindowReturnsAllWhenDisplayedMessageCountIsMax() {
+        let messages = (0..<10).map { i in
+            ChatMessage(role: .user, text: "Message \(i)")
+        }
+
+        let result = ChatVisibleMessageFilter.paginatedMessages(
+            from: messages,
+            displayedMessageCount: .max
+        )
+
+        XCTAssertEqual(result.count, 10)
+    }
+
+    func testSuffixWindowUsesFilteredVisibleSetNotRawCount() {
+        // 5 raw messages, but 2 are hidden/notification, so 3 visible.
+        var hidden1 = ChatMessage(role: .user, text: "hidden-1")
+        hidden1.isHidden = true
+        var notif1 = ChatMessage(role: .assistant, text: "notif-1")
+        notif1.isSubagentNotification = true
+        let visible1 = ChatMessage(role: .user, text: "A")
+        let visible2 = ChatMessage(role: .assistant, text: "B")
+        let visible3 = ChatMessage(role: .user, text: "C")
+
+        // Request last 2 visible messages — should get B and C, not based on raw array.
+        let result = ChatVisibleMessageFilter.paginatedMessages(
+            from: [hidden1, visible1, notif1, visible2, visible3],
+            displayedMessageCount: 2
+        )
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].text, "B")
+        XCTAssertEqual(result[1].text, "C")
+    }
+
+    func testSuffixWindowReturnsAllWhenCountExceedsVisible() {
+        let messages = [
+            ChatMessage(role: .user, text: "First"),
+            ChatMessage(role: .assistant, text: "Second"),
+        ]
+
+        let result = ChatVisibleMessageFilter.paginatedMessages(
+            from: messages,
+            displayedMessageCount: 100
+        )
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].text, "First")
+        XCTAssertEqual(result[1].text, "Second")
+    }
+
+    func testSuffixWindowReturnsCorrectSlice() {
+        let messages = (0..<5).map { i in
+            ChatMessage(role: .user, text: "Msg \(i)")
+        }
+
+        let result = ChatVisibleMessageFilter.paginatedMessages(
+            from: messages,
+            displayedMessageCount: 3
+        )
+
+        XCTAssertEqual(result.count, 3)
+        XCTAssertEqual(result[0].text, "Msg 2")
+        XCTAssertEqual(result[1].text, "Msg 3")
+        XCTAssertEqual(result[2].text, "Msg 4")
+    }
+}


### PR DESCRIPTION
## Summary
- Add ChatVisibleMessageFilter as a shared source of truth for which messages count toward pagination and anchors
- Excludes isSubagentNotification and isHidden messages
- Add comprehensive tests covering filtering, suffix windowing, and edge cases

Part of plan: desktop-scroll-jump-fix.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
