### PR TITLE
test: add top-pagination trigger policy for macOS chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListPaginationTriggerPolicy.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListPaginationTriggerPolicy.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Pure helper that decides when the top-pagination sentinel should fire.
+///
+/// The sentinel is a zero-height view placed at the top of the `LazyVStack`
+/// in `MessageListView`. SwiftUI materialises it when it enters the prefetch
+/// zone — which can be **several screens above** the visible viewport — so a
+/// naive `onAppear` fires long before the user has actually scrolled to the
+/// top of the conversation.
+///
+/// This policy adds a geometric check: the sentinel's `minY` (in the scroll
+/// view's coordinate space) must fall within a *trigger band* near the top of
+/// the viewport. It also enforces one-shot semantics — pagination fires only
+/// on the **transition** from out-of-band to in-band, preventing repeated
+/// loads while the sentinel remains visible.
+///
+/// The type is deliberately free of SwiftUI imports so it can be exercised
+/// entirely through unit tests.
+enum MessageListPaginationTriggerPolicy {
+    /// How far above the visible top edge (negative minY) the sentinel can be
+    /// and still count as "in range". Accounts for the padding/spacing applied
+    /// to the LazyVStack content.
+    static let topTolerance: CGFloat = 50
+
+    /// How far below the visible top edge the sentinel can be and still count
+    /// as "in range". Covers the case where the sentinel is slightly below the
+    /// top of the viewport (e.g. the user overscrolled).
+    static let bottomTolerance: CGFloat = 200
+
+    /// Returns `true` when the sentinel's `minY` falls inside the trigger band
+    /// around the top of the scroll viewport.
+    ///
+    /// - Parameters:
+    ///   - sentinelMinY: The sentinel's `minY` in the scroll view's coordinate
+    ///     space. Negative values mean the sentinel is above the viewport.
+    ///   - viewportHeight: The scroll view's visible height.
+    /// - Returns: `true` when the sentinel is geometrically near the top.
+    static func isInTriggerBand(
+        sentinelMinY: CGFloat,
+        viewportHeight: CGFloat
+    ) -> Bool {
+        guard sentinelMinY.isFinite, viewportHeight.isFinite else { return false }
+        // The trigger band runs from `topTolerance` pixels above the viewport
+        // top (minY = 0) to `bottomTolerance` pixels below it.
+        return sentinelMinY >= -topTolerance && sentinelMinY <= bottomTolerance
+    }
+
+    /// One-shot trigger: returns `true` only on the transition from
+    /// out-of-band to in-band.
+    ///
+    /// Callers must persist `wasInRange` across updates so the policy can
+    /// detect the edge transition.
+    ///
+    /// - Parameters:
+    ///   - sentinelMinY: The sentinel's `minY` in the scroll view's coordinate
+    ///     space.
+    ///   - viewportHeight: The scroll view's visible height.
+    ///   - wasInRange: Whether the sentinel was inside the trigger band on the
+    ///     previous geometry update.
+    /// - Returns: `true` exactly once when the sentinel enters the band.
+    static func shouldTrigger(
+        sentinelMinY: CGFloat,
+        viewportHeight: CGFloat,
+        wasInRange: Bool
+    ) -> Bool {
+        let inRange = isInTriggerBand(sentinelMinY: sentinelMinY, viewportHeight: viewportHeight)
+        // Fire only on the rising edge: was outside, now inside.
+        return inRange && !wasInRange
+    }
+}

--- a/clients/macos/vellum-assistantTests/MessageListPaginationTriggerPolicyTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListPaginationTriggerPolicyTests.swift
@@ -1,0 +1,205 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class MessageListPaginationTriggerPolicyTests: XCTestCase {
+
+    // MARK: - Prefetch-zone regression
+
+    /// Regression: LazyVStack materialises the sentinel in its prefetch zone,
+    /// which can be hundreds of points above the visible viewport. The sentinel
+    /// reports a large negative minY (e.g. -800) in that case. The policy must
+    /// NOT trigger pagination for positions well outside the trigger band.
+    func testSentinelWellAboveViewportDoesNotTrigger() {
+        // Sentinel is 800pt above the top of a 600pt viewport —
+        // deep in the prefetch zone, not near the visible top.
+        let triggered = MessageListPaginationTriggerPolicy.shouldTrigger(
+            sentinelMinY: -800,
+            viewportHeight: 600,
+            wasInRange: false
+        )
+        XCTAssertFalse(triggered, "Sentinel deep in the prefetch zone should not trigger pagination")
+    }
+
+    /// A sentinel just barely outside the tolerance should not trigger.
+    func testSentinelJustOutsideToleranceDoesNotTrigger() {
+        let tolerance = MessageListPaginationTriggerPolicy.topTolerance
+        let triggered = MessageListPaginationTriggerPolicy.shouldTrigger(
+            sentinelMinY: -(tolerance + 1),
+            viewportHeight: 600,
+            wasInRange: false
+        )
+        XCTAssertFalse(triggered)
+    }
+
+    // MARK: - Trigger band entry
+
+    /// When the sentinel scrolls into the trigger band for the first time,
+    /// pagination should fire.
+    func testSentinelEnteringTriggerBandTriggersOnce() {
+        let triggered = MessageListPaginationTriggerPolicy.shouldTrigger(
+            sentinelMinY: 10,
+            viewportHeight: 600,
+            wasInRange: false
+        )
+        XCTAssertTrue(triggered, "Sentinel entering the trigger band should fire pagination")
+    }
+
+    /// The sentinel sitting right at the top edge (minY = 0) is in-band.
+    func testSentinelAtExactTopEdgeTriggersOnce() {
+        let triggered = MessageListPaginationTriggerPolicy.shouldTrigger(
+            sentinelMinY: 0,
+            viewportHeight: 600,
+            wasInRange: false
+        )
+        XCTAssertTrue(triggered)
+    }
+
+    /// The sentinel at a small negative minY (within topTolerance) triggers.
+    func testSentinelSlightlyAboveViewportTriggersOnce() {
+        let triggered = MessageListPaginationTriggerPolicy.shouldTrigger(
+            sentinelMinY: -20,
+            viewportHeight: 600,
+            wasInRange: false
+        )
+        XCTAssertTrue(triggered)
+    }
+
+    // MARK: - One-shot / no repeated triggers
+
+    /// Once the sentinel is in-band and wasInRange is true, subsequent updates
+    /// must NOT re-trigger pagination.
+    func testSentinelRemainingInBandDoesNotRepeatTrigger() {
+        // First entry triggers.
+        let first = MessageListPaginationTriggerPolicy.shouldTrigger(
+            sentinelMinY: 10,
+            viewportHeight: 600,
+            wasInRange: false
+        )
+        XCTAssertTrue(first)
+
+        // Sentinel stays in-band (wasInRange now true) — should not fire again.
+        let second = MessageListPaginationTriggerPolicy.shouldTrigger(
+            sentinelMinY: 10,
+            viewportHeight: 600,
+            wasInRange: true
+        )
+        XCTAssertFalse(second, "Pagination must not repeatedly fire while sentinel stays in-band")
+
+        // Sentinel moves within the band — still no re-trigger.
+        let third = MessageListPaginationTriggerPolicy.shouldTrigger(
+            sentinelMinY: 30,
+            viewportHeight: 600,
+            wasInRange: true
+        )
+        XCTAssertFalse(third)
+    }
+
+    // MARK: - Re-arming after exit and re-entry
+
+    /// When the sentinel leaves the trigger band and then re-enters,
+    /// pagination should fire again (re-arm).
+    func testSentinelLeavingAndReenteringRearmsCorrectly() {
+        // 1. Enter band — triggers.
+        let entry = MessageListPaginationTriggerPolicy.shouldTrigger(
+            sentinelMinY: 10,
+            viewportHeight: 600,
+            wasInRange: false
+        )
+        XCTAssertTrue(entry)
+
+        // 2. Leave band (sentinel scrolled back down, out of range).
+        let exitIsInBand = MessageListPaginationTriggerPolicy.isInTriggerBand(
+            sentinelMinY: 400,
+            viewportHeight: 600
+        )
+        // 400 is above bottomTolerance (200), so it's out of band.
+        XCTAssertFalse(exitIsInBand, "Sentinel at minY 400 should be outside the trigger band")
+
+        let duringExit = MessageListPaginationTriggerPolicy.shouldTrigger(
+            sentinelMinY: 400,
+            viewportHeight: 600,
+            wasInRange: true
+        )
+        XCTAssertFalse(duringExit)
+
+        // 3. Re-enter band — should trigger again.
+        let reentry = MessageListPaginationTriggerPolicy.shouldTrigger(
+            sentinelMinY: 10,
+            viewportHeight: 600,
+            wasInRange: false  // was out of band after step 2
+        )
+        XCTAssertTrue(reentry, "Re-entering the trigger band after leaving should re-arm pagination")
+    }
+
+    // MARK: - Edge cases
+
+    /// Non-finite geometry should never trigger.
+    func testNonFiniteGeometryDoesNotTrigger() {
+        XCTAssertFalse(
+            MessageListPaginationTriggerPolicy.shouldTrigger(
+                sentinelMinY: .infinity,
+                viewportHeight: 600,
+                wasInRange: false
+            )
+        )
+        XCTAssertFalse(
+            MessageListPaginationTriggerPolicy.shouldTrigger(
+                sentinelMinY: 10,
+                viewportHeight: .infinity,
+                wasInRange: false
+            )
+        )
+        XCTAssertFalse(
+            MessageListPaginationTriggerPolicy.shouldTrigger(
+                sentinelMinY: .nan,
+                viewportHeight: 600,
+                wasInRange: false
+            )
+        )
+    }
+
+    // MARK: - isInTriggerBand unit tests
+
+    func testIsInTriggerBandAtBoundaries() {
+        let top = MessageListPaginationTriggerPolicy.topTolerance
+        let bottom = MessageListPaginationTriggerPolicy.bottomTolerance
+
+        // Exactly at top tolerance boundary — in band.
+        XCTAssertTrue(
+            MessageListPaginationTriggerPolicy.isInTriggerBand(sentinelMinY: -top, viewportHeight: 600)
+        )
+        // Just inside top boundary.
+        XCTAssertTrue(
+            MessageListPaginationTriggerPolicy.isInTriggerBand(sentinelMinY: -(top - 1), viewportHeight: 600)
+        )
+        // Just outside top boundary.
+        XCTAssertFalse(
+            MessageListPaginationTriggerPolicy.isInTriggerBand(sentinelMinY: -(top + 1), viewportHeight: 600)
+        )
+
+        // Exactly at bottom tolerance boundary — in band.
+        XCTAssertTrue(
+            MessageListPaginationTriggerPolicy.isInTriggerBand(sentinelMinY: bottom, viewportHeight: 600)
+        )
+        // Just inside bottom boundary.
+        XCTAssertTrue(
+            MessageListPaginationTriggerPolicy.isInTriggerBand(sentinelMinY: bottom - 1, viewportHeight: 600)
+        )
+        // Just outside bottom boundary.
+        XCTAssertFalse(
+            MessageListPaginationTriggerPolicy.isInTriggerBand(sentinelMinY: bottom + 1, viewportHeight: 600)
+        )
+    }
+
+    /// The trigger band should work with various viewport heights since it is
+    /// anchored to the top of the viewport (minY = 0), not relative to height.
+    func testTriggerBandIsViewportHeightIndependent() {
+        // Sentinel at minY = 10 should be in-band regardless of viewport size.
+        XCTAssertTrue(
+            MessageListPaginationTriggerPolicy.isInTriggerBand(sentinelMinY: 10, viewportHeight: 300)
+        )
+        XCTAssertTrue(
+            MessageListPaginationTriggerPolicy.isInTriggerBand(sentinelMinY: 10, viewportHeight: 1200)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add pure MessageListPaginationTriggerPolicy helper for deciding when the top pagination sentinel should fire
- Add comprehensive unit tests covering prefetch-zone filtering, one-shot triggering, and re-arming

Part of plan: desktop-scroll-jump-fix.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
