### PR TITLE
feat: add chat scroll loop guard helper

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatScrollLoopGuard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatScrollLoopGuard.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+// MARK: - ChatScrollLoopGuard
+
+/// Detects runaway scroll-loop patterns in the chat transcript by tracking
+/// rolling counters of scroll-related events per conversation.
+///
+/// This is a pure helper with no SwiftUI or AppKit dependencies. It accepts
+/// monotonic timestamps and event kinds, maintains short rolling counters,
+/// and returns a structured aggregate snapshot when thresholds are exceeded.
+/// Callers (e.g. `MessageListView`) can forward the snapshot to both
+/// `os.Logger` and `ChatDiagnosticsStore`.
+///
+/// **Thresholds:**
+/// - More than 40 `anchorPreferenceChange` events in 2 seconds
+/// - More than 15 `scrollToRequested` events in 2 seconds
+///
+/// Once tripped, the guard emits at most one aggregate warning per cooldown
+/// window (the same 2-second duration), then re-arms after a quiet window
+/// elapses with no events.
+final class ChatScrollLoopGuard {
+
+    // MARK: - Event Kinds
+
+    enum EventKind: String, CaseIterable {
+        case anchorPreferenceChange
+        case scrollToRequested
+        case repinAttempt
+        case suppressionFlip
+    }
+
+    // MARK: - Aggregate Snapshot
+
+    /// Structured warning payload emitted when the guard trips.
+    /// Contains the event counts observed during the detection window
+    /// so callers can log or store the same data without re-querying.
+    struct AggregateSnapshot: Equatable {
+        let conversationId: String
+        let windowDuration: TimeInterval
+        let counts: [EventKind: Int]
+        let trippedBy: EventKind
+        let timestamp: TimeInterval
+    }
+
+    // MARK: - Thresholds (explicit constants)
+
+    /// Maximum anchor preference change events allowed in the detection window.
+    static let anchorThreshold: Int = 40
+
+    /// Maximum scrollTo requests allowed in the detection window.
+    static let scrollToThreshold: Int = 15
+
+    /// Rolling window duration in seconds for event counting.
+    static let windowDuration: TimeInterval = 2.0
+
+    /// After tripping, the guard suppresses further warnings for this duration.
+    /// The guard re-arms only after a full quiet window elapses with no events.
+    static let cooldownDuration: TimeInterval = 2.0
+
+    // MARK: - Internal State
+
+    private struct ConversationState {
+        /// Rolling timestamps per event kind within the current window.
+        var events: [EventKind: [TimeInterval]] = [:]
+
+        /// Timestamp when the guard last tripped (nil if never tripped or reset).
+        var lastTripTime: TimeInterval?
+
+        /// Whether the guard is currently in cooldown (suppressing warnings).
+        var inCooldown: Bool = false
+    }
+
+    private var states: [String: ConversationState] = [:]
+
+    // MARK: - Public API
+
+    /// Records an event and returns an aggregate snapshot if the guard trips.
+    ///
+    /// - Parameters:
+    ///   - kind: The type of scroll-related event.
+    ///   - conversationId: The conversation this event belongs to.
+    ///   - timestamp: Monotonic timestamp (e.g. `ProcessInfo.processInfo.systemUptime`).
+    /// - Returns: An `AggregateSnapshot` if thresholds are exceeded and the guard
+    ///   is not in cooldown; `nil` otherwise.
+    @discardableResult
+    func record(
+        _ kind: EventKind,
+        conversationId: String,
+        timestamp: TimeInterval
+    ) -> AggregateSnapshot? {
+        var state = states[conversationId] ?? ConversationState()
+
+        // Prune events outside the rolling window.
+        let windowStart = timestamp - Self.windowDuration
+        for eventKind in EventKind.allCases {
+            state.events[eventKind] = (state.events[eventKind] ?? []).filter { $0 > windowStart }
+        }
+
+        // Append the new event.
+        state.events[kind, default: []].append(timestamp)
+
+        // Check if cooldown has expired (quiet window elapsed).
+        if state.inCooldown, let lastTrip = state.lastTripTime {
+            // Re-arm if cooldown duration has passed.
+            if timestamp - lastTrip >= Self.cooldownDuration {
+                state.inCooldown = false
+            }
+        }
+
+        // Check thresholds.
+        let anchorCount = state.events[.anchorPreferenceChange]?.count ?? 0
+        let scrollToCount = state.events[.scrollToRequested]?.count ?? 0
+
+        var trippedBy: EventKind?
+        if anchorCount > Self.anchorThreshold {
+            trippedBy = .anchorPreferenceChange
+        } else if scrollToCount > Self.scrollToThreshold {
+            trippedBy = .scrollToRequested
+        }
+
+        var snapshot: AggregateSnapshot?
+
+        if let trippedKind = trippedBy, !state.inCooldown {
+            // Build the aggregate counts for all event kinds.
+            var counts: [EventKind: Int] = [:]
+            for eventKind in EventKind.allCases {
+                let count = state.events[eventKind]?.count ?? 0
+                if count > 0 {
+                    counts[eventKind] = count
+                }
+            }
+
+            snapshot = AggregateSnapshot(
+                conversationId: conversationId,
+                windowDuration: Self.windowDuration,
+                counts: counts,
+                trippedBy: trippedKind,
+                timestamp: timestamp
+            )
+
+            state.lastTripTime = timestamp
+            state.inCooldown = true
+        }
+
+        states[conversationId] = state
+        return snapshot
+    }
+
+    /// Resets all tracking state for a conversation.
+    func reset(conversationId: String) {
+        states.removeValue(forKey: conversationId)
+    }
+
+    /// Resets all tracking state for all conversations.
+    func resetAll() {
+        states.removeAll()
+    }
+}
+
+// MARK: - Hashable conformance for EventKind (dictionary key)
+
+extension ChatScrollLoopGuard.EventKind: Hashable {}

--- a/clients/macos/vellum-assistantTests/ChatScrollLoopGuardTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatScrollLoopGuardTests.swift
@@ -1,0 +1,322 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class ChatScrollLoopGuardTests: XCTestCase {
+
+    private var guard_: ChatScrollLoopGuard!
+    private let conversationId = "test-conversation"
+
+    override func setUp() {
+        super.setUp()
+        guard_ = ChatScrollLoopGuard()
+    }
+
+    override func tearDown() {
+        guard_ = nil
+        super.tearDown()
+    }
+
+    // MARK: - Normal Streaming Does Not Trip
+
+    func testNormalStreamingDoesNotTrip() {
+        // Simulate a normal streaming session: anchor updates arrive at a
+        // reasonable rate (~10 per second) and scrollTo requests are sparse.
+        var timestamp: TimeInterval = 1000.0
+        let interval: TimeInterval = 0.1  // 10 events/sec
+
+        for _ in 0..<20 {
+            let result = guard_.record(
+                .anchorPreferenceChange,
+                conversationId: conversationId,
+                timestamp: timestamp
+            )
+            XCTAssertNil(result, "Normal-rate anchor updates should not trip the guard")
+            timestamp += interval
+        }
+
+        // A few scrollTo requests mixed in.
+        for _ in 0..<5 {
+            let result = guard_.record(
+                .scrollToRequested,
+                conversationId: conversationId,
+                timestamp: timestamp
+            )
+            XCTAssertNil(result, "Sparse scrollTo requests should not trip the guard")
+            timestamp += 0.3
+        }
+    }
+
+    func testMixedEventsWithinThresholdsDoNotTrip() {
+        var timestamp: TimeInterval = 1000.0
+
+        // 30 anchor changes in 2 seconds (under 40 threshold)
+        for _ in 0..<30 {
+            let result = guard_.record(
+                .anchorPreferenceChange,
+                conversationId: conversationId,
+                timestamp: timestamp
+            )
+            XCTAssertNil(result)
+            timestamp += 2.0 / 30.0
+        }
+
+        // 10 scrollTo requests in 2 seconds (under 15 threshold)
+        timestamp = 1000.0
+        for _ in 0..<10 {
+            let result = guard_.record(
+                .scrollToRequested,
+                conversationId: conversationId,
+                timestamp: timestamp
+            )
+            XCTAssertNil(result)
+            timestamp += 0.2
+        }
+    }
+
+    // MARK: - Loop-Like Bursts Trip Once
+
+    func testAnchorBurstTripsGuard() {
+        var timestamp: TimeInterval = 1000.0
+        var tripped = false
+
+        // Fire 41 anchor updates in under 2 seconds (exceeds threshold of 40).
+        for _ in 0..<45 {
+            let result = guard_.record(
+                .anchorPreferenceChange,
+                conversationId: conversationId,
+                timestamp: timestamp
+            )
+            if let snapshot = result {
+                XCTAssertFalse(tripped, "Guard should trip exactly once per cooldown window")
+                tripped = true
+                XCTAssertEqual(snapshot.conversationId, conversationId)
+                XCTAssertEqual(snapshot.trippedBy, .anchorPreferenceChange)
+                XCTAssertEqual(snapshot.windowDuration, ChatScrollLoopGuard.windowDuration)
+                XCTAssertGreaterThan(snapshot.counts[.anchorPreferenceChange] ?? 0, ChatScrollLoopGuard.anchorThreshold)
+            }
+            // ~22 events/sec = 45 events in ~2 seconds
+            timestamp += 0.045
+        }
+
+        XCTAssertTrue(tripped, "Guard should have tripped for anchor burst")
+    }
+
+    func testScrollToBurstTripsGuard() {
+        var timestamp: TimeInterval = 1000.0
+        var tripped = false
+
+        // Fire 16 scrollTo requests in under 2 seconds (exceeds threshold of 15).
+        for _ in 0..<20 {
+            let result = guard_.record(
+                .scrollToRequested,
+                conversationId: conversationId,
+                timestamp: timestamp
+            )
+            if let snapshot = result {
+                XCTAssertFalse(tripped, "Guard should trip exactly once per cooldown window")
+                tripped = true
+                XCTAssertEqual(snapshot.trippedBy, .scrollToRequested)
+                XCTAssertGreaterThan(snapshot.counts[.scrollToRequested] ?? 0, ChatScrollLoopGuard.scrollToThreshold)
+            }
+            timestamp += 0.1
+        }
+
+        XCTAssertTrue(tripped, "Guard should have tripped for scrollTo burst")
+    }
+
+    func testOnlyOneWarningPerCooldownWindow() {
+        var timestamp: TimeInterval = 1000.0
+        var tripCount = 0
+
+        // Rapidly fire anchor events well above threshold.
+        for _ in 0..<100 {
+            let result = guard_.record(
+                .anchorPreferenceChange,
+                conversationId: conversationId,
+                timestamp: timestamp
+            )
+            if result != nil {
+                tripCount += 1
+            }
+            // All within a 2-second window.
+            timestamp += 0.02
+        }
+
+        XCTAssertEqual(tripCount, 1, "Should emit exactly one warning per cooldown window")
+    }
+
+    // MARK: - Cooldown and Re-arming
+
+    func testGuardRearmsAfterQuietWindow() {
+        var timestamp: TimeInterval = 1000.0
+        var tripCount = 0
+
+        // First burst: trip the guard.
+        for _ in 0..<50 {
+            if guard_.record(.anchorPreferenceChange, conversationId: conversationId, timestamp: timestamp) != nil {
+                tripCount += 1
+            }
+            timestamp += 0.03
+        }
+        XCTAssertEqual(tripCount, 1, "First burst should trip once")
+
+        // Wait for cooldown to expire (2 seconds of quiet).
+        timestamp += ChatScrollLoopGuard.cooldownDuration + 0.1
+
+        // Second burst: guard should re-arm and trip again.
+        for _ in 0..<50 {
+            if guard_.record(.anchorPreferenceChange, conversationId: conversationId, timestamp: timestamp) != nil {
+                tripCount += 1
+            }
+            timestamp += 0.03
+        }
+        XCTAssertEqual(tripCount, 2, "Guard should re-arm and trip again after quiet window")
+    }
+
+    func testGuardDoesNotRearmDuringCooldown() {
+        var timestamp: TimeInterval = 1000.0
+        var tripCount = 0
+
+        // Trip the guard.
+        for _ in 0..<50 {
+            if guard_.record(.anchorPreferenceChange, conversationId: conversationId, timestamp: timestamp) != nil {
+                tripCount += 1
+            }
+            timestamp += 0.03
+        }
+        XCTAssertEqual(tripCount, 1)
+
+        // Advance by less than cooldown duration and fire another burst.
+        timestamp += ChatScrollLoopGuard.cooldownDuration * 0.5
+
+        for _ in 0..<50 {
+            if guard_.record(.anchorPreferenceChange, conversationId: conversationId, timestamp: timestamp) != nil {
+                tripCount += 1
+            }
+            timestamp += 0.03
+        }
+        XCTAssertEqual(tripCount, 1, "Should not trip again during cooldown window")
+    }
+
+    // MARK: - Conversation Isolation
+
+    func testSeparateConversationsAreIsolated() {
+        var timestamp: TimeInterval = 1000.0
+        let convA = "conversation-a"
+        let convB = "conversation-b"
+
+        // Trip guard for conversation A.
+        for _ in 0..<50 {
+            guard_.record(.anchorPreferenceChange, conversationId: convA, timestamp: timestamp)
+            timestamp += 0.03
+        }
+
+        // Conversation B should not be affected — send a few events.
+        let resultB = guard_.record(.anchorPreferenceChange, conversationId: convB, timestamp: timestamp)
+        XCTAssertNil(resultB, "Conversation B should not trip from conversation A's events")
+    }
+
+    // MARK: - Reset
+
+    func testResetClearsState() {
+        var timestamp: TimeInterval = 1000.0
+
+        // Trip the guard.
+        for _ in 0..<50 {
+            guard_.record(.anchorPreferenceChange, conversationId: conversationId, timestamp: timestamp)
+            timestamp += 0.03
+        }
+
+        // Reset and immediately fire another burst — should trip again
+        // because cooldown state was cleared.
+        guard_.reset(conversationId: conversationId)
+
+        var tripped = false
+        for _ in 0..<50 {
+            if guard_.record(.anchorPreferenceChange, conversationId: conversationId, timestamp: timestamp) != nil {
+                tripped = true
+            }
+            timestamp += 0.03
+        }
+        XCTAssertTrue(tripped, "Guard should trip again after reset")
+    }
+
+    // MARK: - Repinning and Suppression Events
+
+    func testRepinAndSuppressionEventsAreTracked() {
+        var timestamp: TimeInterval = 1000.0
+
+        // These event kinds don't have their own thresholds but should appear
+        // in the aggregate snapshot when the guard trips.
+        for _ in 0..<10 {
+            guard_.record(.repinAttempt, conversationId: conversationId, timestamp: timestamp)
+            timestamp += 0.02
+        }
+        for _ in 0..<5 {
+            guard_.record(.suppressionFlip, conversationId: conversationId, timestamp: timestamp)
+            timestamp += 0.02
+        }
+
+        // Now trip via anchor threshold.
+        var snapshot: ChatScrollLoopGuard.AggregateSnapshot?
+        for _ in 0..<50 {
+            if let result = guard_.record(.anchorPreferenceChange, conversationId: conversationId, timestamp: timestamp) {
+                snapshot = result
+            }
+            timestamp += 0.03
+        }
+
+        XCTAssertNotNil(snapshot, "Guard should trip")
+        if let snapshot = snapshot {
+            XCTAssertEqual(snapshot.counts[.repinAttempt], 10)
+            XCTAssertEqual(snapshot.counts[.suppressionFlip], 5)
+        }
+    }
+
+    // MARK: - Window Rolling Behavior
+
+    func testEventsOutsideWindowAreExpired() {
+        var timestamp: TimeInterval = 1000.0
+
+        // Fire 30 anchor events.
+        for _ in 0..<30 {
+            guard_.record(.anchorPreferenceChange, conversationId: conversationId, timestamp: timestamp)
+            timestamp += 0.05
+        }
+
+        // Advance past the window so those 30 events expire.
+        timestamp += ChatScrollLoopGuard.windowDuration + 0.1
+
+        // Fire 20 more — total in window is only 20 (under threshold).
+        var tripped = false
+        for _ in 0..<20 {
+            if guard_.record(.anchorPreferenceChange, conversationId: conversationId, timestamp: timestamp) != nil {
+                tripped = true
+            }
+            timestamp += 0.05
+        }
+        XCTAssertFalse(tripped, "Events outside the rolling window should not count")
+    }
+
+    // MARK: - Snapshot Fields
+
+    func testSnapshotContainsCorrectFields() {
+        var timestamp: TimeInterval = 42.0
+        var snapshot: ChatScrollLoopGuard.AggregateSnapshot?
+
+        for _ in 0..<50 {
+            if let result = guard_.record(.anchorPreferenceChange, conversationId: "conv-123", timestamp: timestamp) {
+                snapshot = result
+            }
+            timestamp += 0.03
+        }
+
+        XCTAssertNotNil(snapshot)
+        if let s = snapshot {
+            XCTAssertEqual(s.conversationId, "conv-123")
+            XCTAssertEqual(s.windowDuration, ChatScrollLoopGuard.windowDuration)
+            XCTAssertEqual(s.trippedBy, .anchorPreferenceChange)
+            XCTAssertGreaterThanOrEqual(s.timestamp, 42.0)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add ChatScrollLoopGuard as a pure helper with no SwiftUI dependencies
- Define explicit thresholds (40 anchor updates or 15 scrollTo requests in 2s) with cooldown window
- Return structured aggregate snapshot for unified logging to os.Logger and ChatDiagnosticsStore
- Tests cover normal streaming, burst detection, cooldown/reset, conversation isolation, and window rolling

Part of plan: desktop-chat-freeze-logging.md (PR 2 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
