### PR TITLE
feat: add chat bottom-pin coordinator

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBottomPinCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBottomPinCoordinator.swift
@@ -1,0 +1,311 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "ChatBottomPinCoordinator")
+
+// MARK: - Request Reasons & User Actions
+
+/// Reasons the system may request a scroll-to-bottom pin.
+enum BottomPinRequestReason: String, Sendable {
+    /// Initial conversation load / restore from disk.
+    case initialRestore
+    /// Streaming tokens are arriving on the last message.
+    case streaming
+    /// A new message was appended to the conversation.
+    case messageCount
+    /// An inline element (progress card, tool output) expanded its height.
+    case expansion
+    /// The chat container was resized (sidebar toggle, window drag).
+    case resize
+}
+
+/// User-initiated actions that affect the follow/detach state machine.
+enum BottomPinUserAction: Sendable {
+    /// Physical scroll-wheel / trackpad upward movement.
+    case scrollUp
+    /// User explicitly scrolled to the bottom (wheel hit bottom, or clicked "Scroll to latest").
+    case scrollToBottom
+    /// User clicked "Jump to latest" or equivalent explicit re-tether action.
+    case jumpToLatest
+}
+
+// MARK: - Pin Session
+
+/// Represents a single bounded scroll-to-bottom retry session.
+/// Sessions coalesce duplicate requests and cap total retry attempts.
+struct BottomPinSession: Sendable {
+    /// The conversation this session targets.
+    let conversationId: UUID
+    /// The reason that initiated this session.
+    let reason: BottomPinRequestReason
+    /// Number of retry attempts executed so far.
+    private(set) var attemptCount: Int = 0
+    /// Wall-clock time the session was created.
+    let startTime: CFAbsoluteTime
+
+    /// Maximum retries before the session self-terminates.
+    /// Prevents an unbounded series of pin attempts from a single trigger.
+    static let maxRetries: Int = 5
+
+    /// Whether the session has exhausted its retry budget.
+    var isExhausted: Bool { attemptCount >= Self.maxRetries }
+
+    /// Records a retry attempt. Returns false if the budget is exhausted.
+    @discardableResult
+    mutating func recordAttempt() -> Bool {
+        guard !isExhausted else { return false }
+        attemptCount += 1
+        return true
+    }
+
+    /// Whether this session can coalesce a new request with the given reason
+    /// and conversation. Coalescing merges duplicates into the existing session
+    /// instead of creating a new retry loop.
+    func canCoalesce(reason: BottomPinRequestReason, conversationId: UUID) -> Bool {
+        guard self.conversationId == conversationId else { return false }
+        guard !isExhausted else { return false }
+        // Expansion and streaming requests coalesce freely within the same conversation.
+        // Different reasons (e.g. resize vs expansion) start a fresh session.
+        switch (self.reason, reason) {
+        case (.expansion, .expansion),
+             (.streaming, .streaming),
+             (.messageCount, .messageCount),
+             (.resize, .resize):
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+// MARK: - Cancellation Triggers
+
+/// Events that cancel the active pin session.
+enum BottomPinCancellationTrigger: String, Sendable {
+    /// User scrolled up away from the bottom.
+    case userScrollUp
+    /// A deep-link anchor was set, handing off scroll control.
+    case deepLinkAnchorHandoff
+    /// Pagination scroll-position restore is in progress.
+    case paginationRestore
+    /// The active conversation changed.
+    case conversationSwitch
+}
+
+// MARK: - Coordinator
+
+/// Centralizes the transcript follow-vs-detached state and coordinates bounded
+/// scroll-to-bottom retry sessions.
+///
+/// The coordinator is decision-complete: while the user is detached from the
+/// bottom, background requests from streaming, message growth, and progress
+/// expansion are suppressed. Once the user explicitly returns to the bottom,
+/// requests may schedule a bounded retry sequence again.
+///
+/// Only one pin session is active at a time. Duplicate requests for the same
+/// conversation inside the active window merge into the existing session
+/// instead of creating a fresh loop.
+@MainActor
+final class ChatBottomPinCoordinator {
+
+    // MARK: - State
+
+    /// Whether the viewport is logically following the bottom of the transcript.
+    /// When false (detached), background pin requests are suppressed.
+    private(set) var isFollowingBottom: Bool = true
+
+    /// The currently active pin session, if any.
+    private(set) var activeSession: BottomPinSession?
+
+    /// The in-flight async task driving the active session's retry loop.
+    private var sessionTask: Task<Void, Never>?
+
+    /// Callback invoked when the coordinator decides a scroll-to-bottom should
+    /// be executed. The caller (typically MessageListView) performs the actual
+    /// `proxy.scrollTo` call. The Bool return indicates whether the pin was
+    /// successful (anchor is within viewport).
+    var onPinRequested: ((_ reason: BottomPinRequestReason, _ animated: Bool) -> Bool)?
+
+    /// Callback invoked when the follow/detach state changes, allowing the
+    /// view to update `isNearBottom` and related reactive state.
+    var onFollowStateChanged: ((_ isFollowing: Bool) -> Void)?
+
+    // MARK: - Configuration
+
+    /// Delay between retry attempts in a pin session.
+    static let retryInterval: UInt64 = 50_000_000 // 50ms
+
+    /// Maximum elapsed time for a single pin session before it self-terminates,
+    /// even if retries remain. Prevents stale sessions from lingering.
+    static let sessionTimeout: TimeInterval = 0.5
+
+    // MARK: - Follow/Detach State Machine
+
+    /// Transitions to the detached state, suppressing all background pin requests.
+    func detach(trigger: BottomPinCancellationTrigger) {
+        let wasFollowing = isFollowingBottom
+        isFollowingBottom = false
+        cancelActiveSession(reason: trigger)
+
+        if wasFollowing {
+            log.debug("Detached from bottom (trigger: \(trigger.rawValue))")
+            onFollowStateChanged?(false)
+        }
+    }
+
+    /// Transitions to the following state, allowing pin requests to proceed.
+    func reattach() {
+        let wasDetached = !isFollowingBottom
+        isFollowingBottom = true
+
+        if wasDetached {
+            log.debug("Re-attached to bottom")
+            onFollowStateChanged?(true)
+        }
+    }
+
+    // MARK: - User Actions
+
+    /// Processes a user-initiated action that affects follow/detach state.
+    func handleUserAction(_ action: BottomPinUserAction) {
+        switch action {
+        case .scrollUp:
+            detach(trigger: .userScrollUp)
+
+        case .scrollToBottom, .jumpToLatest:
+            reattach()
+        }
+    }
+
+    // MARK: - Pin Requests
+
+    /// Requests a scroll-to-bottom pin for the given reason.
+    ///
+    /// When the user is detached, the request is silently suppressed (decision-
+    /// complete suppression). When following, the request either coalesces into
+    /// the active session or starts a new bounded session.
+    ///
+    /// - Parameters:
+    ///   - reason: Why the pin is being requested.
+    ///   - conversationId: The conversation the request targets.
+    ///   - animated: Whether the scroll should be animated.
+    func requestPin(
+        reason: BottomPinRequestReason,
+        conversationId: UUID,
+        animated: Bool = false
+    ) {
+        // Decision-complete suppression: detached users are not yanked to bottom.
+        guard isFollowingBottom else {
+            log.debug("Pin request suppressed (detached) — reason: \(reason.rawValue)")
+            return
+        }
+
+        // Coalesce into active session if possible.
+        if let session = activeSession, session.canCoalesce(reason: reason, conversationId: conversationId) {
+            log.debug("Coalescing \(reason.rawValue) into active session (attempt \(session.attemptCount)/\(BottomPinSession.maxRetries))")
+            // The existing session task continues; no new task needed.
+            // Just record that a new request arrived (the retry loop will
+            // pick it up on its next iteration).
+            return
+        }
+
+        // Cancel any stale session before starting a new one.
+        cancelActiveSession(reason: .conversationSwitch)
+
+        // Start a new bounded session.
+        let session = BottomPinSession(
+            conversationId: conversationId,
+            reason: reason,
+            startTime: CFAbsoluteTimeGetCurrent()
+        )
+        activeSession = session
+        startSessionTask(animated: animated)
+    }
+
+    /// Cancels the active pin session and its associated task.
+    func cancelActiveSession(reason: BottomPinCancellationTrigger) {
+        guard activeSession != nil else { return }
+        log.debug("Cancelling active pin session (reason: \(reason.rawValue))")
+        sessionTask?.cancel()
+        sessionTask = nil
+        activeSession = nil
+    }
+
+    /// Resets all state, typically called on conversation switch.
+    func reset(newConversationId: UUID? = nil) {
+        cancelActiveSession(reason: .conversationSwitch)
+        isFollowingBottom = true
+        onFollowStateChanged?(true)
+    }
+
+    // MARK: - Session Task
+
+    private func startSessionTask(animated: Bool) {
+        sessionTask?.cancel()
+
+        sessionTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            // Immediate first attempt.
+            guard var session = self.activeSession else { return }
+            session.recordAttempt()
+            self.activeSession = session
+            let pinned = self.onPinRequested?(session.reason, animated) ?? false
+
+            if pinned {
+                self.completeSession()
+                return
+            }
+
+            // Bounded retry loop.
+            while !Task.isCancelled {
+                guard var currentSession = self.activeSession else { break }
+                guard !currentSession.isExhausted else {
+                    log.debug("Pin session exhausted after \(currentSession.attemptCount) attempts")
+                    break
+                }
+
+                // Check session timeout.
+                let elapsed = CFAbsoluteTimeGetCurrent() - currentSession.startTime
+                if elapsed > Self.sessionTimeout {
+                    log.debug("Pin session timed out after \(String(format: "%.0f", elapsed * 1000))ms")
+                    break
+                }
+
+                do {
+                    try await Task.sleep(nanoseconds: Self.retryInterval)
+                } catch {
+                    break
+                }
+                guard !Task.isCancelled else { break }
+
+                // Re-check follow state after sleep — user may have scrolled up.
+                guard self.isFollowingBottom else {
+                    log.debug("Pin retry aborted — user detached during sleep")
+                    break
+                }
+
+                currentSession.recordAttempt()
+                self.activeSession = currentSession
+                let succeeded = self.onPinRequested?(currentSession.reason, animated) ?? false
+
+                if succeeded {
+                    self.completeSession()
+                    return
+                }
+            }
+
+            // Clean up if we fell through without completing.
+            self.completeSession()
+        }
+    }
+
+    private func completeSession() {
+        sessionTask = nil
+        activeSession = nil
+    }
+
+    deinit {
+        sessionTask?.cancel()
+    }
+}

--- a/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
@@ -1,0 +1,386 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class ChatBottomPinCoordinatorTests: XCTestCase {
+    private var coordinator: ChatBottomPinCoordinator!
+    private var pinRequestCount: Int = 0
+    private var lastPinReason: BottomPinRequestReason?
+    private var lastPinAnimated: Bool?
+    private var pinShouldSucceed: Bool = true
+    private var followStateChanges: [Bool] = []
+
+    override func setUp() {
+        super.setUp()
+        coordinator = ChatBottomPinCoordinator()
+        pinRequestCount = 0
+        lastPinReason = nil
+        lastPinAnimated = nil
+        pinShouldSucceed = true
+        followStateChanges = []
+
+        coordinator.onPinRequested = { [weak self] reason, animated in
+            self?.pinRequestCount += 1
+            self?.lastPinReason = reason
+            self?.lastPinAnimated = animated
+            return self?.pinShouldSucceed ?? false
+        }
+        coordinator.onFollowStateChanged = { [weak self] isFollowing in
+            self?.followStateChanges.append(isFollowing)
+        }
+    }
+
+    override func tearDown() {
+        coordinator = nil
+        super.tearDown()
+    }
+
+    // MARK: - Initial State
+
+    func testInitialStateIsFollowingBottom() {
+        XCTAssertTrue(coordinator.isFollowingBottom)
+        XCTAssertNil(coordinator.activeSession)
+    }
+
+    // MARK: - Detach on Upward Scroll
+
+    func testScrollUpDetachesFromBottom() {
+        coordinator.handleUserAction(.scrollUp)
+
+        XCTAssertFalse(coordinator.isFollowingBottom)
+        XCTAssertEqual(followStateChanges, [false])
+    }
+
+    func testScrollUpCancelsActiveSession() {
+        let convId = UUID()
+        coordinator.requestPin(reason: .streaming, conversationId: convId)
+        XCTAssertNotNil(coordinator.activeSession)
+
+        coordinator.handleUserAction(.scrollUp)
+
+        XCTAssertFalse(coordinator.isFollowingBottom)
+        XCTAssertNil(coordinator.activeSession)
+    }
+
+    func testRepeatedScrollUpDoesNotDuplicateStateChange() {
+        coordinator.handleUserAction(.scrollUp)
+        coordinator.handleUserAction(.scrollUp)
+
+        XCTAssertFalse(coordinator.isFollowingBottom)
+        // Only one state change callback should fire.
+        XCTAssertEqual(followStateChanges, [false])
+    }
+
+    // MARK: - Re-arm After Explicit Return to Bottom
+
+    func testScrollToBottomReattaches() {
+        coordinator.handleUserAction(.scrollUp)
+        XCTAssertFalse(coordinator.isFollowingBottom)
+
+        coordinator.handleUserAction(.scrollToBottom)
+
+        XCTAssertTrue(coordinator.isFollowingBottom)
+        XCTAssertEqual(followStateChanges, [false, true])
+    }
+
+    func testJumpToLatestReattaches() {
+        coordinator.handleUserAction(.scrollUp)
+        coordinator.handleUserAction(.jumpToLatest)
+
+        XCTAssertTrue(coordinator.isFollowingBottom)
+        XCTAssertEqual(followStateChanges, [false, true])
+    }
+
+    func testReattachWhenAlreadyFollowingDoesNotFireCallback() {
+        coordinator.handleUserAction(.scrollToBottom)
+
+        // Should not fire since we were already following.
+        XCTAssertEqual(followStateChanges, [])
+    }
+
+    // MARK: - Suppression While Detached
+
+    func testPinRequestSuppressedWhileDetached() {
+        let convId = UUID()
+        coordinator.handleUserAction(.scrollUp)
+
+        coordinator.requestPin(reason: .streaming, conversationId: convId)
+
+        XCTAssertEqual(pinRequestCount, 0)
+        XCTAssertNil(coordinator.activeSession)
+    }
+
+    func testPinRequestSuppressedForMessageCountWhileDetached() {
+        let convId = UUID()
+        coordinator.handleUserAction(.scrollUp)
+
+        coordinator.requestPin(reason: .messageCount, conversationId: convId)
+
+        XCTAssertEqual(pinRequestCount, 0)
+    }
+
+    func testPinRequestSuppressedForExpansionWhileDetached() {
+        let convId = UUID()
+        coordinator.handleUserAction(.scrollUp)
+
+        coordinator.requestPin(reason: .expansion, conversationId: convId)
+
+        XCTAssertEqual(pinRequestCount, 0)
+    }
+
+    func testPinRequestAllowedAfterReattach() {
+        let convId = UUID()
+        coordinator.handleUserAction(.scrollUp)
+        coordinator.requestPin(reason: .streaming, conversationId: convId)
+        XCTAssertEqual(pinRequestCount, 0)
+
+        coordinator.handleUserAction(.scrollToBottom)
+        coordinator.requestPin(reason: .streaming, conversationId: convId)
+
+        XCTAssertEqual(pinRequestCount, 1)
+    }
+
+    // MARK: - Coalescing Duplicate Requests
+
+    func testDuplicateExpansionRequestsCoalesce() {
+        let convId = UUID()
+        pinShouldSucceed = false
+
+        coordinator.requestPin(reason: .expansion, conversationId: convId)
+        let firstSessionStartTime = coordinator.activeSession?.startTime
+
+        // Second expansion request should coalesce.
+        coordinator.requestPin(reason: .expansion, conversationId: convId)
+
+        // Should still be the same session (same start time).
+        XCTAssertEqual(coordinator.activeSession?.startTime, firstSessionStartTime)
+        // Only one pin call from the initial session start.
+        XCTAssertEqual(pinRequestCount, 1)
+    }
+
+    func testDuplicateStreamingRequestsCoalesce() {
+        let convId = UUID()
+        pinShouldSucceed = false
+
+        coordinator.requestPin(reason: .streaming, conversationId: convId)
+        let firstStartTime = coordinator.activeSession?.startTime
+
+        coordinator.requestPin(reason: .streaming, conversationId: convId)
+
+        XCTAssertEqual(coordinator.activeSession?.startTime, firstStartTime)
+        XCTAssertEqual(pinRequestCount, 1)
+    }
+
+    func testDifferentReasonsDoNotCoalesce() {
+        let convId = UUID()
+        pinShouldSucceed = false
+
+        coordinator.requestPin(reason: .expansion, conversationId: convId)
+        let firstStartTime = coordinator.activeSession?.startTime
+
+        coordinator.requestPin(reason: .resize, conversationId: convId)
+
+        // Should be a new session with a new start time.
+        XCTAssertNotEqual(coordinator.activeSession?.startTime, firstStartTime)
+    }
+
+    func testDifferentConversationsDoNotCoalesce() {
+        let conv1 = UUID()
+        let conv2 = UUID()
+        pinShouldSucceed = false
+
+        coordinator.requestPin(reason: .expansion, conversationId: conv1)
+        let firstConvSession = coordinator.activeSession
+
+        coordinator.requestPin(reason: .expansion, conversationId: conv2)
+
+        // New session for the different conversation.
+        XCTAssertNotEqual(coordinator.activeSession?.conversationId, firstConvSession?.conversationId)
+        XCTAssertEqual(coordinator.activeSession?.conversationId, conv2)
+    }
+
+    // MARK: - Bounded Retry Sessions
+
+    func testSessionCapsRetries() {
+        var session = BottomPinSession(
+            conversationId: UUID(),
+            reason: .expansion,
+            startTime: CFAbsoluteTimeGetCurrent()
+        )
+
+        for _ in 0..<BottomPinSession.maxRetries {
+            XCTAssertFalse(session.isExhausted)
+            let recorded = session.recordAttempt()
+            XCTAssertTrue(recorded)
+        }
+
+        XCTAssertTrue(session.isExhausted)
+        let overBudget = session.recordAttempt()
+        XCTAssertFalse(overBudget)
+        XCTAssertEqual(session.attemptCount, BottomPinSession.maxRetries)
+    }
+
+    func testExhaustedSessionDoesNotCoalesce() {
+        var session = BottomPinSession(
+            conversationId: UUID(),
+            reason: .expansion,
+            startTime: CFAbsoluteTimeGetCurrent()
+        )
+
+        for _ in 0..<BottomPinSession.maxRetries {
+            session.recordAttempt()
+        }
+
+        XCTAssertFalse(session.canCoalesce(reason: .expansion, conversationId: session.conversationId))
+    }
+
+    func testSuccessfulPinCompletesSession() {
+        let convId = UUID()
+        pinShouldSucceed = true
+
+        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
+
+        // Successful pin on first attempt should clear the session.
+        XCTAssertEqual(pinRequestCount, 1)
+        XCTAssertNil(coordinator.activeSession)
+    }
+
+    // MARK: - Cancellation Triggers
+
+    func testDeepLinkAnchorCancelsSession() {
+        let convId = UUID()
+        pinShouldSucceed = false
+
+        coordinator.requestPin(reason: .streaming, conversationId: convId)
+        XCTAssertNotNil(coordinator.activeSession)
+
+        coordinator.cancelActiveSession(reason: .deepLinkAnchorHandoff)
+
+        XCTAssertNil(coordinator.activeSession)
+    }
+
+    func testPaginationRestoreCancelsSession() {
+        let convId = UUID()
+        pinShouldSucceed = false
+
+        coordinator.requestPin(reason: .messageCount, conversationId: convId)
+        XCTAssertNotNil(coordinator.activeSession)
+
+        coordinator.cancelActiveSession(reason: .paginationRestore)
+
+        XCTAssertNil(coordinator.activeSession)
+    }
+
+    func testConversationSwitchCancelsSession() {
+        let convId = UUID()
+        pinShouldSucceed = false
+
+        coordinator.requestPin(reason: .streaming, conversationId: convId)
+        XCTAssertNotNil(coordinator.activeSession)
+
+        coordinator.cancelActiveSession(reason: .conversationSwitch)
+
+        XCTAssertNil(coordinator.activeSession)
+    }
+
+    // MARK: - Reset
+
+    func testResetClearsAllStateAndReattaches() {
+        let convId = UUID()
+        pinShouldSucceed = false
+
+        coordinator.handleUserAction(.scrollUp)
+        coordinator.requestPin(reason: .expansion, conversationId: convId)
+        XCTAssertFalse(coordinator.isFollowingBottom)
+
+        let newConvId = UUID()
+        coordinator.reset(newConversationId: newConvId)
+
+        XCTAssertTrue(coordinator.isFollowingBottom)
+        XCTAssertNil(coordinator.activeSession)
+    }
+
+    // MARK: - Pin Session Struct
+
+    func testSessionCoalesceRequiresSameConversation() {
+        let convA = UUID()
+        let convB = UUID()
+        let session = BottomPinSession(
+            conversationId: convA,
+            reason: .expansion,
+            startTime: CFAbsoluteTimeGetCurrent()
+        )
+
+        XCTAssertTrue(session.canCoalesce(reason: .expansion, conversationId: convA))
+        XCTAssertFalse(session.canCoalesce(reason: .expansion, conversationId: convB))
+    }
+
+    func testSessionCoalesceRequiresSameReason() {
+        let convId = UUID()
+        let session = BottomPinSession(
+            conversationId: convId,
+            reason: .streaming,
+            startTime: CFAbsoluteTimeGetCurrent()
+        )
+
+        XCTAssertTrue(session.canCoalesce(reason: .streaming, conversationId: convId))
+        XCTAssertFalse(session.canCoalesce(reason: .expansion, conversationId: convId))
+        XCTAssertFalse(session.canCoalesce(reason: .resize, conversationId: convId))
+        XCTAssertFalse(session.canCoalesce(reason: .messageCount, conversationId: convId))
+        XCTAssertFalse(session.canCoalesce(reason: .initialRestore, conversationId: convId))
+    }
+
+    // MARK: - Async Retry Behavior
+
+    func testRetryLoopStopsOnSuccess() async throws {
+        let convId = UUID()
+        var callCount = 0
+        pinShouldSucceed = false
+
+        coordinator.onPinRequested = { [weak self] reason, animated in
+            callCount += 1
+            self?.pinRequestCount = callCount
+            // Succeed on the third attempt.
+            if callCount >= 3 {
+                return true
+            }
+            return false
+        }
+
+        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
+
+        // Allow the retry loop to run.
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        // Should have stopped after success (3 attempts), not continued to maxRetries.
+        XCTAssertGreaterThanOrEqual(callCount, 3)
+        XCTAssertLessThanOrEqual(callCount, BottomPinSession.maxRetries)
+        XCTAssertNil(coordinator.activeSession)
+    }
+
+    func testRetryLoopAbortsOnDetach() async throws {
+        let convId = UUID()
+        var callCount = 0
+        pinShouldSucceed = false
+
+        coordinator.onPinRequested = { reason, animated in
+            callCount += 1
+            return false
+        }
+
+        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
+
+        // Let one retry fire.
+        try await Task.sleep(nanoseconds: 80_000_000)
+
+        // User scrolls up mid-session.
+        coordinator.handleUserAction(.scrollUp)
+
+        let countAfterDetach = callCount
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        // No more attempts after detach.
+        XCTAssertEqual(callCount, countAfterDetach)
+        XCTAssertNil(coordinator.activeSession)
+    }
+}


### PR DESCRIPTION
## Summary
- Add ChatBottomPinCoordinator as a pure helper centralizing follow-vs-detached state
- Model explicit request reasons and user actions with decision-complete suppression logic
- Implement bounded retry sessions with coalescing and cancellation triggers

Part of plan: desktop-chat-freeze-logging.md (PR 7 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
