### PR TITLE
refactor: align macOS message-list pagination with shared visible rows

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -228,12 +228,13 @@ struct MessageListView: View {
     @State private var scrollTracking = ScrollTrackingState()
 
     /// The subset of messages actually shown, honoring the pagination window.
+    /// Uses the shared `ChatVisibleMessageFilter` so hidden automated messages
+    /// are excluded from rendered rows, pagination anchors, and all derived state.
     private var visibleMessages: [ChatMessage] {
-        let all = messages.filter { !$0.isSubagentNotification }
-        // When displayedMessageCount covers all messages (or is Int.max / show-all mode),
-        // return everything so new incoming messages don't collapse visible history.
-        guard displayedMessageCount < all.count else { return all }
-        return Array(all.suffix(displayedMessageCount))
+        ChatVisibleMessageFilter.paginatedMessages(
+            from: messages,
+            displayedMessageCount: displayedMessageCount
+        )
     }
 
     /// The active pending confirmation request ID, derived from the visible


### PR DESCRIPTION
## Summary
- Replace local visibleMessages filtering in MessageListView with shared ChatVisibleMessageFilter
- Hidden automated messages now properly excluded from pagination anchors and rendered rows
- Filtering-only change; scrolling behavior unchanged until PR 5

Part of plan: desktop-scroll-jump-fix.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
