### PR TITLE
refactor: centralize ChatViewModel visible-message filtering

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -622,8 +622,12 @@ public final class ChatViewModel: ObservableObject {
 
     /// Recompute and cache the displayedMessages from the current messages array.
     /// Call this after any mutation to messages.
+    ///
+    /// Uses the shared `ChatVisibleMessageFilter` so that `displayedMessages` and the
+    /// macOS message list apply identical visibility rules — this keeps scroll-anchor
+    /// math stable across pagination boundaries.
     private func updateDisplayedMessages() {
-        displayedMessages = messages.filter { !$0.isSubagentNotification && !$0.isHidden }
+        displayedMessages = ChatVisibleMessageFilter.visibleMessages(from: messages)
     }
 
     // MARK: - Daemon History Pagination
@@ -942,7 +946,7 @@ public final class ChatViewModel: ObservableObject {
         messageManager.$messages
             .throttle(for: .milliseconds(100), scheduler: RunLoop.main, latest: true)
             .sink { [weak self] newMessages in
-                self?.displayedMessages = newMessages.filter { !$0.isSubagentNotification && !$0.isHidden }
+                self?.displayedMessages = ChatVisibleMessageFilter.visibleMessages(from: newMessages)
             }
             .store(in: &cancellables)
 


### PR DESCRIPTION
## Summary
- Replace inline message visibility filtering in ChatViewModel with the shared ChatVisibleMessageFilter helper
- Eliminates duplicate filter logic between updateDisplayedMessages() and the throttled $messages sink
- No pagination semantics changed

Part of plan: desktop-scroll-jump-fix.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
