### PR TITLE
feat: add assistant progress transition diagnostics

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -1,4 +1,3 @@
-import os
 import SwiftUI
 import VellumAssistantShared
 
@@ -202,6 +201,11 @@ struct AssistantProgressView: View {
         .background(VColor.surfaceOverlay)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .onChange(of: phase) { _, newPhase in
+            ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
+                kind: .progressCardTransition,
+                reason: "phase_change:\(newPhase) denied=\(deniedCount) pending_confirm=\(hasPendingConfirmation) rehydrate=\(onRehydrate != nil)",
+                toolCallCount: toolCalls.count
+            ))
             if newPhase == .processing {
                 processingStartDate = Date()
                 startDate = Date()
@@ -211,6 +215,11 @@ struct AssistantProgressView: View {
                !isExpanded,
                MacOSClientFeatureFlagManager.shared.isEnabled("expand_completed_steps")
             {
+                ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
+                    kind: .progressCardTransition,
+                    reason: "auto_expand:completed_steps_flag",
+                    toolCallCount: toolCalls.count
+                ))
                 withAnimation(VAnimation.fast) {
                     isExpanded = true
                 }
@@ -234,6 +243,11 @@ struct AssistantProgressView: View {
         }
         .onChange(of: hasPendingConfirmation) { _, pending in
             if pending && !isExpanded {
+                ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
+                    kind: .progressCardTransition,
+                    reason: "auto_expand:pending_confirmation",
+                    toolCallCount: toolCalls.count
+                ))
                 withAnimation(VAnimation.fast) {
                     isExpanded = true
                 }
@@ -255,11 +269,21 @@ struct AssistantProgressView: View {
                (phase == .complete || phase == .denied),
                MacOSClientFeatureFlagManager.shared.isEnabled("expand_completed_steps")
             {
+                ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
+                    kind: .progressCardTransition,
+                    reason: "auto_expand:completed_steps_flag_on_appear",
+                    toolCallCount: toolCalls.count
+                ))
                 isExpanded = true
                 // Rehydration is handled by onChange(of: isExpanded) above.
             }
             // Auto-expand when a pending confirmation exists on appear
             if hasPendingConfirmation && !isExpanded {
+                ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
+                    kind: .progressCardTransition,
+                    reason: "auto_expand:pending_confirmation_on_appear",
+                    toolCallCount: toolCalls.count
+                ))
                 withAnimation(VAnimation.fast) {
                     isExpanded = true
                 }
@@ -279,6 +303,11 @@ struct AssistantProgressView: View {
             // Prevent collapsing while a confirmation is pending — the inline
             // bubble is the only visible approval UI when the standalone is suppressed.
             if isExpanded && hasPendingConfirmation { return }
+            ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
+                kind: .progressCardTransition,
+                reason: "manual_toggle:\(isExpanded ? "collapse" : "expand")",
+                toolCallCount: toolCalls.count
+            ))
             suppressAutoScroll?()
             withAnimation(VAnimation.fast) {
                 isExpanded.toggle()
@@ -427,8 +456,6 @@ struct AssistantProgressView: View {
 
     @ViewBuilder
     private var expandedContent: some View {
-        let _ = os_signpost(.event, log: PerfSignposts.log, name: "assistantProgressExpandedContent",
-                            "toolCallCount=%d", toolCalls.count)
         VStack(alignment: .leading, spacing: 0) {
             ForEach(toolCalls) { toolCall in
                 if !toolCall.isComplete && toolCall.toolName == "claude_code"


### PR DESCRIPTION
## Summary
- Remove render-time `assistantProgressExpandedContent` signpost that fired on every SwiftUI re-render of the expanded content subtree
- Add transition-only diagnostics at state change seams: phase changes, manual header toggles, auto-expansion on pending confirmations, and auto-expansion for completed groups
- Record content-safe progress events through `ChatDiagnosticsStore` with phase, tool-call count, denied count, pending-confirmation flag, expansion source, and rehydrate availability

Part of plan: desktop-chat-freeze-logging.md (PR 4 of 9)

## Test plan
- [ ] Build the app and trigger tool calls; verify a single `progressCardTransition` diagnostic is recorded per state transition (not per render)
- [ ] Manually expand/collapse a progress card; verify `manual_toggle:expand` / `manual_toggle:collapse` events are recorded and `suppressAutoScroll` is still called exactly once
- [ ] Trigger a pending confirmation; verify the group auto-expands and a `auto_expand:pending_confirmation` event is recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
