### PR TITLE
fix: resolve type errors in suggestion-routes.test.ts

### DIFF
--- a/assistant/src/__tests__/suggestion-routes.test.ts
+++ b/assistant/src/__tests__/suggestion-routes.test.ts
@@ -221,7 +221,12 @@ describe("GET /v1/suggestion", () => {
         metadata: null,
       },
     ]);
-    mockGetConfiguredProvider.mockImplementation(async () => null);
+    mockGetConfiguredProvider.mockImplementation(
+      async () =>
+        null as unknown as Awaited<
+          ReturnType<typeof mockGetConfiguredProvider>
+        >,
+    );
 
     const url = makeUrl({ conversationKey: "test-key" });
     const deps = makeDeps();
@@ -429,10 +434,10 @@ describe("GET /v1/suggestion", () => {
     await handleGetSuggestion(url, deps);
 
     expect(provider.sendMessage).toHaveBeenCalledTimes(1);
-    const callArgs = provider.sendMessage.mock.calls[0];
-    const options = callArgs[3] as {
-      config?: { modelIntent?: string };
-    };
+    const callArgs = provider.sendMessage.mock.calls[0] as unknown[];
+    const options = callArgs[3] as
+      | { config?: { modelIntent?: string } }
+      | undefined;
     expect(options?.config?.modelIntent).toBe("latency-optimized");
   });
 });


### PR DESCRIPTION
## Summary
- Fix `Promise<null>` not assignable error by casting the null return in the provider-unavailable test case
- Fix tuple access errors by casting `mock.calls[0]` to `unknown[]` for runtime argument inspection in the modelIntent test

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23291048577/job/67726475305
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
