### PR TITLE
feat: add transcript diagnostics to debug-state snapshot

### DIFF
--- a/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
+++ b/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
@@ -116,6 +116,10 @@ struct ChatDiagnosticEvent: Codable, Sendable {
 
 /// A point-in-time snapshot of per-conversation transcript state.
 /// Used by the debug panel and exported with hang diagnostics.
+///
+/// **Privacy invariant**: contains only identifiers, flags, counts, timestamps,
+/// and numeric geometry. Never includes message text, tool input/output bodies,
+/// inline surface HTML, or attachment contents.
 struct ChatTranscriptSnapshot: Codable, Sendable {
     let conversationId: String
     let capturedAt: Date
@@ -126,6 +130,79 @@ struct ChatTranscriptSnapshot: Codable, Sendable {
     let scrollOffsetY: Double?
     let contentHeight: Double?
     let viewportHeight: Double?
+
+    // MARK: Extended diagnostics (populated by scroll instrumentation)
+
+    /// Whether the transcript scroll position is near the bottom.
+    let isNearBottom: Bool?
+    /// Whether any scroll event has been received since the last reset.
+    let hasReceivedScrollEvent: Bool?
+    /// Whether a pagination load is currently in flight.
+    let isPaginationInFlight: Bool?
+    /// Human-readable reason the bottom-scroll suppression flag is active, if any.
+    let suppressionReason: String?
+    /// The message ID the scroll view is anchored to, if any.
+    let anchorMessageId: String?
+    /// The message ID currently highlighted (e.g. from search), if any.
+    let highlightedMessageId: String?
+    /// The minY geometry value of the anchor message row, if measured.
+    let anchorMinY: Double?
+    /// The Y position of the tail anchor (bottom of visible content).
+    let tailAnchorY: Double?
+    /// The height of the scroll viewport.
+    let scrollViewportHeight: Double?
+    /// The width of the chat container.
+    let containerWidth: Double?
+    /// Human-readable reason for the last `scrollTo` call.
+    let lastScrollToReason: String?
+    /// Timestamp of the last scroll-loop warning from `ChatScrollLoopGuard`.
+    let lastLoopWarningTimestamp: Date?
+
+    init(
+        conversationId: String,
+        capturedAt: Date,
+        messageCount: Int,
+        toolCallCount: Int,
+        isPinnedToBottom: Bool,
+        isUserScrolling: Bool,
+        scrollOffsetY: Double? = nil,
+        contentHeight: Double? = nil,
+        viewportHeight: Double? = nil,
+        isNearBottom: Bool? = nil,
+        hasReceivedScrollEvent: Bool? = nil,
+        isPaginationInFlight: Bool? = nil,
+        suppressionReason: String? = nil,
+        anchorMessageId: String? = nil,
+        highlightedMessageId: String? = nil,
+        anchorMinY: Double? = nil,
+        tailAnchorY: Double? = nil,
+        scrollViewportHeight: Double? = nil,
+        containerWidth: Double? = nil,
+        lastScrollToReason: String? = nil,
+        lastLoopWarningTimestamp: Date? = nil
+    ) {
+        self.conversationId = conversationId
+        self.capturedAt = capturedAt
+        self.messageCount = messageCount
+        self.toolCallCount = toolCallCount
+        self.isPinnedToBottom = isPinnedToBottom
+        self.isUserScrolling = isUserScrolling
+        self.scrollOffsetY = scrollOffsetY
+        self.contentHeight = contentHeight
+        self.viewportHeight = viewportHeight
+        self.isNearBottom = isNearBottom
+        self.hasReceivedScrollEvent = hasReceivedScrollEvent
+        self.isPaginationInFlight = isPaginationInFlight
+        self.suppressionReason = suppressionReason
+        self.anchorMessageId = anchorMessageId
+        self.highlightedMessageId = highlightedMessageId
+        self.anchorMinY = anchorMinY
+        self.tailAnchorY = tailAnchorY
+        self.scrollViewportHeight = scrollViewportHeight
+        self.containerWidth = containerWidth
+        self.lastScrollToReason = lastScrollToReason
+        self.lastLoopWarningTimestamp = lastLoopWarningTimestamp
+    }
 }
 
 // MARK: - ChatDiagnosticsStore

--- a/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
+++ b/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
@@ -13,15 +13,23 @@ final class DebugStateWriter {
     private var timer: Timer?
     private weak var appDelegate: AppDelegate?
 
-    private let fileURL: URL
+    let fileURL: URL
     private let encoder: JSONEncoder
+    private let diagnosticsStore: ChatDiagnosticsStore
 
-    init() {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-            ?? FileManager.default.temporaryDirectory
-        let dir = appSupport.appendingPathComponent("vellum-assistant", isDirectory: true)
+    init(directory: URL? = nil, diagnosticsStore: ChatDiagnosticsStore? = nil) {
+        let dir: URL
+        if let directory {
+            dir = directory
+        } else {
+            let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+                ?? FileManager.default.temporaryDirectory
+            dir = appSupport.appendingPathComponent("vellum-assistant", isDirectory: true)
+        }
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         self.fileURL = dir.appendingPathComponent("debug-state.json")
+
+        self.diagnosticsStore = diagnosticsStore ?? ChatDiagnosticsStore.shared
 
         self.encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -56,7 +64,7 @@ final class DebugStateWriter {
 
     // MARK: - Snapshot Capture
 
-    private func captureSnapshot(from appDelegate: AppDelegate) -> DebugSnapshot {
+    func captureSnapshot(from appDelegate: AppDelegate) -> DebugSnapshot {
         let daemonClient = appDelegate.services.daemonClient
         let conversationManager = appDelegate.mainWindow?.conversationManager
 
@@ -94,6 +102,14 @@ final class DebugStateWriter {
 
         var activeChatState: DebugSnapshot.ActiveChatState?
         if let vm = conversationManager?.activeViewModel {
+            // Merge transcript diagnostics from the shared diagnostics store
+            // when a snapshot exists for the active conversation.
+            var transcriptDiagnostics: DebugSnapshot.TranscriptDiagnostics?
+            if let activeConvId = conversationManager?.activeConversationId,
+               let transcriptSnapshot = diagnosticsStore.snapshot(for: activeConvId.uuidString) {
+                transcriptDiagnostics = DebugSnapshot.TranscriptDiagnostics(from: transcriptSnapshot)
+            }
+
             activeChatState = DebugSnapshot.ActiveChatState(
                 conversationId: vm.conversationId,
                 isThinking: vm.isThinking,
@@ -107,7 +123,8 @@ final class DebugStateWriter {
                 pendingQueuedCount: vm.pendingQueuedCount,
                 pendingAttachmentCount: vm.pendingAttachments.count,
                 isRecording: vm.isRecording,
-                activeSubagentCount: vm.activeSubagents.count
+                activeSubagentCount: vm.activeSubagents.count,
+                transcriptDiagnostics: transcriptDiagnostics
             )
         }
 
@@ -176,6 +193,58 @@ struct DebugSnapshot: Codable {
         let pendingAttachmentCount: Int
         let isRecording: Bool
         let activeSubagentCount: Int
+        let transcriptDiagnostics: TranscriptDiagnostics?
+    }
+
+    /// Content-safe transcript diagnostics sourced from `ChatDiagnosticsStore`.
+    ///
+    /// Contains only identifiers, flags, counts, timestamps, and numeric geometry.
+    /// Never includes message text, tool input/output bodies, surface HTML,
+    /// or attachment data.
+    struct TranscriptDiagnostics: Codable {
+        let capturedAt: Date
+        let messageCount: Int
+        let toolCallCount: Int
+        let isPinnedToBottom: Bool
+        let isUserScrolling: Bool
+        let scrollOffsetY: Double?
+        let contentHeight: Double?
+        let viewportHeight: Double?
+        let isNearBottom: Bool?
+        let hasReceivedScrollEvent: Bool?
+        let isPaginationInFlight: Bool?
+        let suppressionReason: String?
+        let anchorMessageId: String?
+        let highlightedMessageId: String?
+        let anchorMinY: Double?
+        let tailAnchorY: Double?
+        let scrollViewportHeight: Double?
+        let containerWidth: Double?
+        let lastScrollToReason: String?
+        let lastLoopWarningTimestamp: Date?
+
+        init(from snapshot: ChatTranscriptSnapshot) {
+            self.capturedAt = snapshot.capturedAt
+            self.messageCount = snapshot.messageCount
+            self.toolCallCount = snapshot.toolCallCount
+            self.isPinnedToBottom = snapshot.isPinnedToBottom
+            self.isUserScrolling = snapshot.isUserScrolling
+            self.scrollOffsetY = snapshot.scrollOffsetY
+            self.contentHeight = snapshot.contentHeight
+            self.viewportHeight = snapshot.viewportHeight
+            self.isNearBottom = snapshot.isNearBottom
+            self.hasReceivedScrollEvent = snapshot.hasReceivedScrollEvent
+            self.isPaginationInFlight = snapshot.isPaginationInFlight
+            self.suppressionReason = snapshot.suppressionReason
+            self.anchorMessageId = snapshot.anchorMessageId
+            self.highlightedMessageId = snapshot.highlightedMessageId
+            self.anchorMinY = snapshot.anchorMinY
+            self.tailAnchorY = snapshot.tailAnchorY
+            self.scrollViewportHeight = snapshot.scrollViewportHeight
+            self.containerWidth = snapshot.containerWidth
+            self.lastScrollToReason = snapshot.lastScrollToReason
+            self.lastLoopWarningTimestamp = snapshot.lastLoopWarningTimestamp
+        }
     }
 
     struct ComputerUseState: Codable {

--- a/clients/macos/vellum-assistantTests/DebugStateWriterTests.swift
+++ b/clients/macos/vellum-assistantTests/DebugStateWriterTests.swift
@@ -1,0 +1,493 @@
+import Foundation
+import Testing
+@testable import VellumAssistantLib
+
+@Suite("DebugStateWriterTests")
+struct DebugStateWriterTests {
+
+    // MARK: - TranscriptDiagnostics Encoding
+
+    @Test @MainActor
+    func transcriptDiagnosticsIncludedInSnapshot() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("debug-state-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // Seed the diagnostics store with a transcript snapshot for an active conversation.
+        let store = ChatDiagnosticsStore()
+        let conversationId = UUID().uuidString
+        let loopWarningDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let capturedAt = Date(timeIntervalSince1970: 1_700_000_100)
+
+        store.updateSnapshot(ChatTranscriptSnapshot(
+            conversationId: conversationId,
+            capturedAt: capturedAt,
+            messageCount: 42,
+            toolCallCount: 7,
+            isPinnedToBottom: true,
+            isUserScrolling: false,
+            scrollOffsetY: 1234.5,
+            contentHeight: 5000.0,
+            viewportHeight: 800.0,
+            isNearBottom: true,
+            hasReceivedScrollEvent: true,
+            isPaginationInFlight: false,
+            suppressionReason: "pagination-restore",
+            anchorMessageId: "msg-anchor-123",
+            highlightedMessageId: "msg-highlight-456",
+            anchorMinY: 120.5,
+            tailAnchorY: 4800.0,
+            scrollViewportHeight: 790.0,
+            containerWidth: 600.0,
+            lastScrollToReason: "auto-scroll-bottom",
+            lastLoopWarningTimestamp: loopWarningDate
+        ))
+
+        // Build a DebugSnapshot with transcript diagnostics from the seeded store.
+        let transcriptSnapshot = store.snapshot(for: conversationId)!
+        let diagnostics = DebugSnapshot.TranscriptDiagnostics(from: transcriptSnapshot)
+
+        let snapshot = DebugSnapshot(
+            timestamp: Date(),
+            appVersion: "test",
+            daemon: DebugSnapshot.DaemonState(
+                isConnected: true,
+                isConnecting: false,
+                daemonVersion: "1.0.0",
+                transport: "http"
+            ),
+            conversations: DebugSnapshot.ConversationsState(
+                activeConversationId: conversationId,
+                count: 1,
+                conversations: []
+            ),
+            activeChat: DebugSnapshot.ActiveChatState(
+                conversationId: conversationId,
+                isThinking: false,
+                isSending: false,
+                isBootstrapping: false,
+                errorText: nil,
+                conversationErrorCategory: nil,
+                conversationErrorDebugDetails: nil,
+                selectedModel: "test-model",
+                messageCount: 42,
+                pendingQueuedCount: 0,
+                pendingAttachmentCount: 0,
+                isRecording: false,
+                activeSubagentCount: 0,
+                transcriptDiagnostics: diagnostics
+            ),
+            computerUse: DebugSnapshot.ComputerUseState(
+                isActive: false,
+                isStarting: false
+            )
+        )
+
+        // Write to the temp directory.
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(snapshot)
+        let fileURL = tempDir.appendingPathComponent("debug-state.json")
+        try data.write(to: fileURL, options: .atomic)
+
+        // Read back and parse as raw JSON.
+        let readData = try Data(contentsOf: fileURL)
+        let json = try JSONSerialization.jsonObject(with: readData) as! [String: Any]
+
+        // Verify the activeChat contains transcriptDiagnostics.
+        let activeChat = json["activeChat"] as! [String: Any]
+        let td = activeChat["transcriptDiagnostics"] as! [String: Any]
+
+        #expect(td["messageCount"] as? Int == 42)
+        #expect(td["toolCallCount"] as? Int == 7)
+        #expect(td["isPinnedToBottom"] as? Bool == true)
+        #expect(td["isUserScrolling"] as? Bool == false)
+        #expect(td["scrollOffsetY"] as? Double == 1234.5)
+        #expect(td["contentHeight"] as? Double == 5000.0)
+        #expect(td["viewportHeight"] as? Double == 800.0)
+        #expect(td["isNearBottom"] as? Bool == true)
+        #expect(td["hasReceivedScrollEvent"] as? Bool == true)
+        #expect(td["isPaginationInFlight"] as? Bool == false)
+        #expect(td["suppressionReason"] as? String == "pagination-restore")
+        #expect(td["anchorMessageId"] as? String == "msg-anchor-123")
+        #expect(td["highlightedMessageId"] as? String == "msg-highlight-456")
+        #expect(td["anchorMinY"] as? Double == 120.5)
+        #expect(td["tailAnchorY"] as? Double == 4800.0)
+        #expect(td["scrollViewportHeight"] as? Double == 790.0)
+        #expect(td["containerWidth"] as? Double == 600.0)
+        #expect(td["lastScrollToReason"] as? String == "auto-scroll-bottom")
+        #expect(td["capturedAt"] != nil)
+        #expect(td["lastLoopWarningTimestamp"] != nil)
+    }
+
+    @Test @MainActor
+    func transcriptDiagnosticsOmitsNilExtendedFields() throws {
+        // Create a minimal snapshot without extended fields.
+        let store = ChatDiagnosticsStore()
+        let conversationId = UUID().uuidString
+
+        store.updateSnapshot(ChatTranscriptSnapshot(
+            conversationId: conversationId,
+            capturedAt: Date(),
+            messageCount: 5,
+            toolCallCount: 1,
+            isPinnedToBottom: false,
+            isUserScrolling: true,
+            scrollOffsetY: nil,
+            contentHeight: nil,
+            viewportHeight: nil
+        ))
+
+        let transcriptSnapshot = store.snapshot(for: conversationId)!
+        let diagnostics = DebugSnapshot.TranscriptDiagnostics(from: transcriptSnapshot)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(diagnostics)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        // Core fields are present.
+        #expect(json["messageCount"] as? Int == 5)
+        #expect(json["isPinnedToBottom"] as? Bool == false)
+
+        // Extended fields that were nil should be absent or null.
+        let extendedKeys = [
+            "isNearBottom", "hasReceivedScrollEvent", "isPaginationInFlight",
+            "suppressionReason", "anchorMessageId", "highlightedMessageId",
+            "anchorMinY", "tailAnchorY", "scrollViewportHeight", "containerWidth",
+            "lastScrollToReason", "lastLoopWarningTimestamp"
+        ]
+        for key in extendedKeys {
+            let val = json[key]
+            let isAbsentOrNull = val == nil || val is NSNull
+            #expect(isAbsentOrNull, "Optional field '\(key)' should be absent or null when not set")
+        }
+    }
+
+    @Test @MainActor
+    func snapshotOmitsTranscriptDiagnosticsWhenNoMatchingConversation() throws {
+        // When no transcript snapshot exists for the active conversation,
+        // transcriptDiagnostics should be null in the JSON.
+        let snapshot = DebugSnapshot(
+            timestamp: Date(),
+            appVersion: "test",
+            daemon: DebugSnapshot.DaemonState(
+                isConnected: true,
+                isConnecting: false,
+                daemonVersion: "1.0.0",
+                transport: "http"
+            ),
+            conversations: DebugSnapshot.ConversationsState(
+                activeConversationId: UUID().uuidString,
+                count: 0,
+                conversations: []
+            ),
+            activeChat: DebugSnapshot.ActiveChatState(
+                conversationId: nil,
+                isThinking: false,
+                isSending: false,
+                isBootstrapping: false,
+                errorText: nil,
+                conversationErrorCategory: nil,
+                conversationErrorDebugDetails: nil,
+                selectedModel: "test-model",
+                messageCount: 0,
+                pendingQueuedCount: 0,
+                pendingAttachmentCount: 0,
+                isRecording: false,
+                activeSubagentCount: 0,
+                transcriptDiagnostics: nil
+            ),
+            computerUse: DebugSnapshot.ComputerUseState(
+                isActive: false,
+                isStarting: false
+            )
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(snapshot)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        let activeChat = json["activeChat"] as! [String: Any]
+        let td = activeChat["transcriptDiagnostics"]
+        let isAbsentOrNull = td == nil || td is NSNull
+        #expect(isAbsentOrNull, "transcriptDiagnostics should be null when no matching snapshot")
+    }
+
+    // MARK: - Content Safety
+
+    @Test @MainActor
+    func debugSnapshotContainsNoMessageContent() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("debug-state-content-safety-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let conversationId = UUID().uuidString
+        let store = ChatDiagnosticsStore()
+
+        store.updateSnapshot(ChatTranscriptSnapshot(
+            conversationId: conversationId,
+            capturedAt: Date(),
+            messageCount: 10,
+            toolCallCount: 3,
+            isPinnedToBottom: true,
+            isUserScrolling: false,
+            scrollOffsetY: 500.0,
+            contentHeight: 3000.0,
+            viewportHeight: 700.0,
+            isNearBottom: true,
+            hasReceivedScrollEvent: true,
+            isPaginationInFlight: false,
+            suppressionReason: nil,
+            anchorMessageId: "msg-1",
+            highlightedMessageId: nil,
+            anchorMinY: 100.0,
+            tailAnchorY: 2900.0,
+            scrollViewportHeight: 700.0,
+            containerWidth: 500.0,
+            lastScrollToReason: "streaming-pin",
+            lastLoopWarningTimestamp: nil
+        ))
+
+        let transcriptSnapshot = store.snapshot(for: conversationId)!
+        let diagnostics = DebugSnapshot.TranscriptDiagnostics(from: transcriptSnapshot)
+
+        let snapshot = DebugSnapshot(
+            timestamp: Date(),
+            appVersion: "test",
+            daemon: DebugSnapshot.DaemonState(
+                isConnected: true,
+                isConnecting: false,
+                daemonVersion: nil,
+                transport: "http"
+            ),
+            conversations: DebugSnapshot.ConversationsState(
+                activeConversationId: conversationId,
+                count: 1,
+                conversations: [
+                    DebugSnapshot.ConversationInfo(
+                        id: conversationId,
+                        title: "Test Conversation",
+                        conversationId: "daemon-conv-1",
+                        messageCount: 10,
+                        kind: "standard",
+                        isArchived: false,
+                        isPinned: false
+                    )
+                ]
+            ),
+            activeChat: DebugSnapshot.ActiveChatState(
+                conversationId: conversationId,
+                isThinking: true,
+                isSending: false,
+                isBootstrapping: false,
+                errorText: nil,
+                conversationErrorCategory: nil,
+                conversationErrorDebugDetails: nil,
+                selectedModel: "test-model",
+                messageCount: 10,
+                pendingQueuedCount: 0,
+                pendingAttachmentCount: 0,
+                isRecording: false,
+                activeSubagentCount: 1,
+                transcriptDiagnostics: diagnostics
+            ),
+            computerUse: DebugSnapshot.ComputerUseState(
+                isActive: false,
+                isStarting: false
+            )
+        )
+
+        // Write and read back.
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(snapshot)
+        let fileURL = tempDir.appendingPathComponent("debug-state.json")
+        try data.write(to: fileURL, options: .atomic)
+
+        let jsonString = String(data: data, encoding: .utf8)!
+
+        // The JSON must be valid.
+        let readData = try Data(contentsOf: fileURL)
+        let _ = try JSONSerialization.jsonObject(with: readData)
+
+        // The JSON must not contain any user-content keys or values.
+        let forbiddenKeys = [
+            "\"messageText\"", "\"text\"", "\"toolInput\"", "\"toolOutput\"",
+            "\"html\"", "\"surfaceHtml\"", "\"attachmentContent\"", "\"body\"",
+            "\"userMessage\"", "\"assistantMessage\""
+        ]
+        for key in forbiddenKeys {
+            #expect(!jsonString.contains(key),
+                    "Debug snapshot must not contain user-content key \(key)")
+        }
+    }
+
+    // MARK: - Field Mapping Fidelity
+
+    @Test @MainActor
+    func transcriptDiagnosticsMapsAllSnapshotFields() throws {
+        let loopDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let capturedAt = Date(timeIntervalSince1970: 1_700_000_100)
+
+        let snapshot = ChatTranscriptSnapshot(
+            conversationId: "conv-test",
+            capturedAt: capturedAt,
+            messageCount: 15,
+            toolCallCount: 4,
+            isPinnedToBottom: false,
+            isUserScrolling: true,
+            scrollOffsetY: 200.0,
+            contentHeight: 3000.0,
+            viewportHeight: 750.0,
+            isNearBottom: false,
+            hasReceivedScrollEvent: true,
+            isPaginationInFlight: true,
+            suppressionReason: "pagination-in-progress",
+            anchorMessageId: "msg-999",
+            highlightedMessageId: "msg-888",
+            anchorMinY: 50.0,
+            tailAnchorY: 2950.0,
+            scrollViewportHeight: 745.0,
+            containerWidth: 580.0,
+            lastScrollToReason: "pagination-restore",
+            lastLoopWarningTimestamp: loopDate
+        )
+
+        let diagnostics = DebugSnapshot.TranscriptDiagnostics(from: snapshot)
+
+        #expect(diagnostics.capturedAt == capturedAt)
+        #expect(diagnostics.messageCount == 15)
+        #expect(diagnostics.toolCallCount == 4)
+        #expect(diagnostics.isPinnedToBottom == false)
+        #expect(diagnostics.isUserScrolling == true)
+        #expect(diagnostics.scrollOffsetY == 200.0)
+        #expect(diagnostics.contentHeight == 3000.0)
+        #expect(diagnostics.viewportHeight == 750.0)
+        #expect(diagnostics.isNearBottom == false)
+        #expect(diagnostics.hasReceivedScrollEvent == true)
+        #expect(diagnostics.isPaginationInFlight == true)
+        #expect(diagnostics.suppressionReason == "pagination-in-progress")
+        #expect(diagnostics.anchorMessageId == "msg-999")
+        #expect(diagnostics.highlightedMessageId == "msg-888")
+        #expect(diagnostics.anchorMinY == 50.0)
+        #expect(diagnostics.tailAnchorY == 2950.0)
+        #expect(diagnostics.scrollViewportHeight == 745.0)
+        #expect(diagnostics.containerWidth == 580.0)
+        #expect(diagnostics.lastScrollToReason == "pagination-restore")
+        #expect(diagnostics.lastLoopWarningTimestamp == loopDate)
+    }
+
+    // MARK: - Valid JSON Output
+
+    @Test @MainActor
+    func debugSnapshotProducesValidJSON() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("debug-state-valid-json-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let store = ChatDiagnosticsStore()
+        let conversationId = UUID().uuidString
+
+        store.updateSnapshot(ChatTranscriptSnapshot(
+            conversationId: conversationId,
+            capturedAt: Date(),
+            messageCount: 3,
+            toolCallCount: 0,
+            isPinnedToBottom: true,
+            isUserScrolling: false,
+            scrollOffsetY: nil,
+            contentHeight: nil,
+            viewportHeight: nil,
+            isNearBottom: true,
+            hasReceivedScrollEvent: false
+        ))
+
+        let transcriptSnapshot = store.snapshot(for: conversationId)!
+        let diagnostics = DebugSnapshot.TranscriptDiagnostics(from: transcriptSnapshot)
+
+        let snapshot = DebugSnapshot(
+            timestamp: Date(),
+            appVersion: "1.0.0",
+            daemon: DebugSnapshot.DaemonState(
+                isConnected: true,
+                isConnecting: false,
+                daemonVersion: "2.0.0",
+                transport: "http"
+            ),
+            conversations: DebugSnapshot.ConversationsState(
+                activeConversationId: conversationId,
+                count: 1,
+                conversations: []
+            ),
+            activeChat: DebugSnapshot.ActiveChatState(
+                conversationId: conversationId,
+                isThinking: false,
+                isSending: false,
+                isBootstrapping: false,
+                errorText: nil,
+                conversationErrorCategory: nil,
+                conversationErrorDebugDetails: nil,
+                selectedModel: "test-model",
+                messageCount: 3,
+                pendingQueuedCount: 0,
+                pendingAttachmentCount: 0,
+                isRecording: false,
+                activeSubagentCount: 0,
+                transcriptDiagnostics: diagnostics
+            ),
+            computerUse: DebugSnapshot.ComputerUseState(
+                isActive: false,
+                isStarting: false
+            )
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(snapshot)
+        let fileURL = tempDir.appendingPathComponent("debug-state.json")
+        try data.write(to: fileURL, options: .atomic)
+
+        // Read back and verify it's valid JSON.
+        let readData = try Data(contentsOf: fileURL)
+        let parsed = try JSONSerialization.jsonObject(with: readData) as! [String: Any]
+
+        // Top-level structure is intact.
+        #expect(parsed["timestamp"] != nil)
+        #expect(parsed["appVersion"] as? String == "1.0.0")
+        #expect(parsed["daemon"] != nil)
+        #expect(parsed["conversations"] != nil)
+        #expect(parsed["activeChat"] != nil)
+        #expect(parsed["computerUse"] != nil)
+
+        // Round-trip: decode back into DebugSnapshot.
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(DebugSnapshot.self, from: readData)
+        #expect(decoded.activeChat?.transcriptDiagnostics != nil)
+        #expect(decoded.activeChat?.transcriptDiagnostics?.messageCount == 3)
+        #expect(decoded.activeChat?.transcriptDiagnostics?.isNearBottom == true)
+    }
+
+    // MARK: - Writer Directory Init
+
+    @Test @MainActor
+    func writerUsesCustomDirectory() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("debug-writer-dir-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let writer = DebugStateWriter(directory: tempDir)
+
+        #expect(writer.fileURL.deletingLastPathComponent().path == tempDir.path)
+        #expect(writer.fileURL.lastPathComponent == "debug-state.json")
+        #expect(FileManager.default.fileExists(atPath: tempDir.path))
+    }
+}


### PR DESCRIPTION
## Summary
- Extend DebugSnapshot.ActiveChatState with TranscriptDiagnostics payload from ChatDiagnosticsStore
- Include scroll state, anchor info, geometry, and loop-warning timestamps (content-safe only)
- Add DebugStateWriterTests verifying transcript fields present and message content absent

Part of plan: desktop-chat-freeze-logging.md (PR 5 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
