### PR TITLE
feat: capture hang context for prolonged main-thread stalls

### DIFF
--- a/clients/macos/vellum-assistant/App/MainThreadStallDetector.swift
+++ b/clients/macos/vellum-assistant/App/MainThreadStallDetector.swift
@@ -1,28 +1,91 @@
 import Foundation
 import os
 
-/// Lightweight watchdog that detects main-thread stalls.
+/// Lightweight watchdog that detects main-thread stalls with two-stage capture.
 ///
 /// A background `DispatchSource` timer fires every 500ms and dispatches
-/// a block to the main queue.  If the block runs >1 second late the main
-/// thread was blocked — the detector logs a warning with the stall duration
-/// so the event shows up in Console / OSLog / diagnostic exports.
+/// a probe to the main queue. When a probe remains unacknowledged:
+///
+/// - **Stage 1** (>2s): Writes `hang-context.json` with diagnostic events
+///   and transcript snapshots. This fires _before_ the main thread recovers,
+///   while the stall is still in progress.
+/// - **Stage 2** (>5s): Best-effort runs `/usr/bin/sample` to capture a
+///   process sample alongside the hang context. Only the sampling step is
+///   gated on the `sendDiagnostics` preference; the JSON hang context is
+///   always written because it is content-safe and low cost.
 ///
 /// Start once from `applicationDidFinishLaunching`; the detector runs for
 /// the lifetime of the process with negligible overhead (<0.1% CPU).
 final class MainThreadStallDetector {
     static let shared = MainThreadStallDetector()
 
+    // MARK: - Configuration (injectable for tests)
+
+    /// Duration in seconds before stage-one capture fires.
+    var stageOneThreshold: TimeInterval = 2.0
+
+    /// Duration in seconds before stage-two sampling fires.
+    var stageTwoThreshold: TimeInterval = 5.0
+
+    /// Closure that returns the current time as nanoseconds (monotonic).
+    /// Tests inject a controllable clock; production uses `DispatchTime.now()`.
+    var nowNanos: () -> UInt64 = { DispatchTime.now().uptimeNanoseconds }
+
+    /// Writer used to persist hang context. Tests inject a mock.
+    var hangContextWriter: HangContextWriter = HangContextWriter(
+        diagnosticsProvider: MainActorDiagnosticsProvider()
+    )
+
+    /// Closure that returns whether `/usr/bin/sample` capture is allowed.
+    /// Defaults to reading the `sendDiagnostics` user preference.
+    var isSamplingAllowed: () -> Bool = {
+        UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool ?? true
+    }
+
+    /// Process runner for `/usr/bin/sample`. Tests inject a mock.
+    var sampleRunner: SampleRunner = DefaultSampleRunner()
+
+    /// Queue used to dispatch probes. Production uses `DispatchQueue.main`;
+    /// tests inject a suspended or separate queue to simulate a blocked main thread.
+    var probeTargetQueue: DispatchQueue = .main
+
+    // MARK: - Protocol for sample runner
+
+    /// Abstraction over `/usr/bin/sample` for testability.
+    protocol SampleRunner: Sendable {
+        func runSample(pid: Int32, outputURL: URL) -> Bool
+    }
+
+    // MARK: - Private State
+
     private let log = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant",
         category: "MainThreadStall"
     )
 
-    private let queue = DispatchQueue(label: "com.vellum.stall-detector", qos: .utility)
+    let queue = DispatchQueue(label: "com.vellum.stall-detector", qos: .utility)
     private var timer: DispatchSourceTimer?
+
+    /// Nanos timestamp when the current probe was dispatched to main.
+    /// Access only from `queue`.
+    private var probeScheduledNanos: UInt64 = 0
+
+    /// Whether a probe is currently waiting on the main queue.
+    /// Access only from `queue`.
     private var probeInFlight = false
 
+    /// Whether stage-one capture has fired for the current stall.
+    /// Access only from `queue`.
+    private var stageOneFired = false
+
+    /// Whether stage-two sampling has been attempted for the current stall.
+    /// Access only from `queue`.
+    private var stageTwoFired = false
+
     private init() {}
+
+    /// Test-only initializer for dependency injection.
+    init(testInit: Bool) {}
 
     func start() {
         guard timer == nil else { return }
@@ -35,20 +98,113 @@ final class MainThreadStallDetector {
         timer = source
     }
 
-    private func ping() {
-        guard !probeInFlight else { return }
+    func stop() {
+        timer?.cancel()
+        timer = nil
+    }
+
+    // MARK: - Probe Logic
+
+    func ping() {
+        if probeInFlight {
+            // Probe is still waiting on the target queue. Check stall duration.
+            let elapsedNanos = nowNanos() - probeScheduledNanos
+            let elapsed = Double(elapsedNanos) / 1_000_000_000
+            checkStallStages(elapsed: elapsed)
+            return
+        }
+
+        // Dispatch a new probe to the target queue (main in production).
         probeInFlight = true
-        let scheduledNanos = DispatchTime.now().uptimeNanoseconds
-        DispatchQueue.main.async { [weak self] in
+        stageOneFired = false
+        stageTwoFired = false
+        probeScheduledNanos = nowNanos()
+
+        let scheduledNanos = probeScheduledNanos
+        probeTargetQueue.async { [weak self] in
             guard let self else { return }
             self.queue.async {
+                let delayNanos = self.nowNanos() - scheduledNanos
+                let delay = Double(delayNanos) / 1_000_000_000
+                if delay > 1.0 {
+                    self.log.warning("Main thread stall recovered: \(String(format: "%.1f", delay))s delay")
+                }
                 self.probeInFlight = false
             }
-            let delayNanos = DispatchTime.now().uptimeNanoseconds - scheduledNanos
-            let delay = Double(delayNanos) / 1_000_000_000
-            if delay > 1.0 {
-                self.log.warning("Main thread stall detected: \(String(format: "%.1f", delay))s delay")
+        }
+    }
+
+    /// Called from the detector's background queue when a probe is outstanding.
+    /// Fires stage-one and stage-two captures at their respective thresholds.
+    ///
+    /// All writes are synchronous on the calling queue so the hang-context file
+    /// exists immediately after this method returns. An async enrichment pass
+    /// attempts to add diagnostic events from the main actor; if the main thread
+    /// is wedged, the enrichment simply never completes.
+    private func checkStallStages(elapsed: TimeInterval) {
+        // Stage 1: Write hang-context.json synchronously.
+        if !stageOneFired && elapsed >= stageOneThreshold {
+            stageOneFired = true
+            let stallStart = Date(timeIntervalSinceNow: -elapsed)
+            log.warning("Stage 1 stall capture: main thread blocked for \(String(format: "%.1f", elapsed))s")
+            hangContextWriter.writeHangContextSync(
+                stallStartTime: stallStart,
+                stallDurationSeconds: elapsed
+            )
+            // Best-effort: try to enrich with diagnostics from main actor.
+            hangContextWriter.enrichWithDiagnosticsAsync(
+                stallStartTime: stallStart,
+                stallDurationSeconds: elapsed
+            )
+        }
+
+        // Stage 2: Best-effort process sampling.
+        if !stageTwoFired && elapsed >= stageTwoThreshold {
+            stageTwoFired = true
+            log.warning("Stage 2 stall capture: main thread blocked for \(String(format: "%.1f", elapsed))s")
+
+            // Update hang context with the longer duration (synchronous).
+            let stallStart = Date(timeIntervalSinceNow: -elapsed)
+            hangContextWriter.writeHangContextSync(
+                stallStartTime: stallStart,
+                stallDurationSeconds: elapsed
+            )
+
+            // Gate sampling on sendDiagnostics preference.
+            guard isSamplingAllowed() else {
+                log.info("Skipping process sampling: sendDiagnostics is disabled")
+                return
             }
+
+            let pid = ProcessInfo.processInfo.processIdentifier
+            let sampleURL = hangContextWriter.outputDirectory
+                .appendingPathComponent("hang-sample.txt")
+            let success = sampleRunner.runSample(pid: pid, outputURL: sampleURL)
+            if success {
+                log.info("Process sample written to hang-sample.txt")
+            } else {
+                log.warning("Process sampling failed (non-fatal)")
+            }
+        }
+    }
+}
+
+// MARK: - Default Sample Runner
+
+/// Production implementation that runs `/usr/bin/sample <pid> 3 1`.
+struct DefaultSampleRunner: MainThreadStallDetector.SampleRunner {
+    func runSample(pid: Int32, outputURL: URL) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/sample")
+        process.arguments = ["\(pid)", "3", "1", "-file", outputURL.path]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            return false
         }
     }
 }

--- a/clients/macos/vellum-assistant/Logging/HangContextWriter.swift
+++ b/clients/macos/vellum-assistant/Logging/HangContextWriter.swift
@@ -1,0 +1,154 @@
+import Foundation
+import os
+
+private let log = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant",
+    category: "HangContextWriter"
+)
+
+/// Writes `hang-context.json` to Application Support when the main thread
+/// is wedged, capturing enough diagnostic context for post-mortem analysis.
+///
+/// The `writeHangContextSync` method performs file I/O on the calling thread,
+/// which is expected to be the stall detector's background queue. This avoids
+/// double-dispatching and ensures the file exists by the time the caller
+/// continues. A separate `enrichWithDiagnostics` path attempts a best-effort
+/// main-actor read; if the main thread is wedged it simply won't complete.
+final class HangContextWriter: @unchecked Sendable {
+
+    /// Protocol for providing diagnostic events from a background queue.
+    /// The concrete implementation reads from `ChatDiagnosticsStore` on the main actor.
+    /// Tests inject a synchronous stub.
+    protocol DiagnosticsProvider: Sendable {
+        func recentEvents() async -> [ChatDiagnosticEvent]
+        func transcriptSnapshots() async -> [String: ChatTranscriptSnapshot]
+    }
+
+    // MARK: - Configuration
+
+    /// Directory where hang-context.json is written.
+    let outputDirectory: URL
+
+    /// Provider for diagnostic events and snapshots.
+    let diagnosticsProvider: DiagnosticsProvider?
+
+    // MARK: - Private
+
+    private let encoder: JSONEncoder
+
+    // MARK: - Init
+
+    init(
+        outputDirectory: URL? = nil,
+        diagnosticsProvider: DiagnosticsProvider? = nil
+    ) {
+        if let dir = outputDirectory {
+            self.outputDirectory = dir
+        } else {
+            let appSupport = FileManager.default.urls(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask
+            ).first ?? FileManager.default.temporaryDirectory
+            self.outputDirectory = appSupport
+                .appendingPathComponent("vellum-assistant", isDirectory: true)
+        }
+        self.diagnosticsProvider = diagnosticsProvider
+
+        self.encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    }
+
+    // MARK: - Synchronous Write
+
+    /// Writes `hang-context.json` synchronously on the calling thread.
+    ///
+    /// This is safe to call from any background queue. The caller (typically
+    /// `MainThreadStallDetector`) is responsible for ensuring this is not
+    /// called from the main thread.
+    func writeHangContextSync(
+        stallStartTime: Date,
+        stallDurationSeconds: Double,
+        recentEvents: [ChatDiagnosticEvent] = [],
+        transcriptSnapshots: [ChatTranscriptSnapshot] = []
+    ) {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+        let pid = ProcessInfo.processInfo.processIdentifier
+
+        let context = HangContext(
+            stallStartTime: stallStartTime,
+            stallDurationSeconds: stallDurationSeconds,
+            pid: Int(pid),
+            appVersion: version ?? "unknown",
+            recentDiagnosticEvents: recentEvents,
+            transcriptSnapshots: transcriptSnapshots
+        )
+
+        do {
+            try FileManager.default.createDirectory(
+                at: outputDirectory,
+                withIntermediateDirectories: true
+            )
+            let fileURL = outputDirectory.appendingPathComponent("hang-context.json")
+            let data = try encoder.encode(context)
+            try data.write(to: fileURL, options: .atomic)
+            log.info("Wrote hang context: stall=\(String(format: "%.1f", stallDurationSeconds))s")
+        } catch {
+            log.error("Failed to write hang-context.json: \(error)")
+        }
+    }
+
+    // MARK: - Async Enrichment
+
+    /// Best-effort enrichment: reads diagnostics from the main actor and
+    /// rewrites `hang-context.json` with the additional data. If the main
+    /// thread is wedged, this call will not complete — which is fine because
+    /// the synchronous initial write already captured the stall metadata.
+    func enrichWithDiagnosticsAsync(
+        stallStartTime: Date,
+        stallDurationSeconds: Double
+    ) {
+        guard let provider = diagnosticsProvider else { return }
+        Task.detached(priority: .utility) { [self] in
+            let events = await provider.recentEvents()
+            let snapshots = await provider.transcriptSnapshots()
+            let sortedSnapshots = snapshots.values.sorted { $0.conversationId < $1.conversationId }
+            self.writeHangContextSync(
+                stallStartTime: stallStartTime,
+                stallDurationSeconds: stallDurationSeconds,
+                recentEvents: events,
+                transcriptSnapshots: sortedSnapshots
+            )
+        }
+    }
+}
+
+// MARK: - Hang Context Model
+
+/// Content-safe hang context written to disk during main-thread stalls.
+struct HangContext: Codable, Sendable {
+    let stallStartTime: Date
+    let stallDurationSeconds: Double
+    let pid: Int
+    let appVersion: String
+    let recentDiagnosticEvents: [ChatDiagnosticEvent]
+    let transcriptSnapshots: [ChatTranscriptSnapshot]
+}
+
+// MARK: - Default Diagnostics Provider
+
+/// Production diagnostics provider that reads from `ChatDiagnosticsStore`
+/// on the main actor.
+struct MainActorDiagnosticsProvider: HangContextWriter.DiagnosticsProvider {
+    func recentEvents() async -> [ChatDiagnosticEvent] {
+        await MainActor.run {
+            ChatDiagnosticsStore.shared.recentEvents(50)
+        }
+    }
+
+    func transcriptSnapshots() async -> [String: ChatTranscriptSnapshot] {
+        await MainActor.run {
+            ChatDiagnosticsStore.shared.transcriptSnapshots
+        }
+    }
+}

--- a/clients/macos/vellum-assistantTests/MainThreadStallDetectorTests.swift
+++ b/clients/macos/vellum-assistantTests/MainThreadStallDetectorTests.swift
@@ -1,0 +1,360 @@
+import Foundation
+import Testing
+@testable import VellumAssistantLib
+
+@Suite("MainThreadStallDetector")
+struct MainThreadStallDetectorTests {
+
+    // MARK: - Test Infrastructure
+
+    /// Controllable clock for deterministic stall duration simulation.
+    final class MockClock: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _nanos: UInt64 = 1_000_000_000 // Start at 1s to avoid zero edge cases.
+
+        var nanos: UInt64 {
+            lock.lock()
+            defer { lock.unlock() }
+            return _nanos
+        }
+
+        func advance(by seconds: TimeInterval) {
+            lock.lock()
+            _nanos += UInt64(seconds * 1_000_000_000)
+            lock.unlock()
+        }
+    }
+
+    /// Records whether sampling was attempted and allows controlling success/failure.
+    final class MockSampleRunner: MainThreadStallDetector.SampleRunner, @unchecked Sendable {
+        private let lock = NSLock()
+        private var _callCount = 0
+        var shouldSucceed = true
+
+        var callCount: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return _callCount
+        }
+
+        func runSample(pid: Int32, outputURL: URL) -> Bool {
+            lock.lock()
+            _callCount += 1
+            lock.unlock()
+            return shouldSucceed
+        }
+    }
+
+    /// Creates a detector with injected test dependencies.
+    /// The `probeTargetQueue` is a suspended queue to simulate a wedged main thread
+    /// (the probe callback never runs, so `probeInFlight` stays true).
+    private func makeDetector(
+        clock: MockClock,
+        sampleRunner: MockSampleRunner,
+        stageOneThreshold: TimeInterval = 2.0,
+        stageTwoThreshold: TimeInterval = 5.0,
+        samplingAllowed: Bool = true
+    ) -> (detector: MainThreadStallDetector, blockedQueue: DispatchQueue) {
+        let detector = MainThreadStallDetector(testInit: true)
+        let outputDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("stall-test-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
+        detector.hangContextWriter = HangContextWriter(outputDirectory: outputDir, diagnosticsProvider: nil)
+        detector.stageOneThreshold = stageOneThreshold
+        detector.stageTwoThreshold = stageTwoThreshold
+        detector.nowNanos = { clock.nanos }
+        detector.sampleRunner = sampleRunner
+        detector.isSamplingAllowed = { samplingAllowed }
+
+        // Use a suspended queue to simulate a wedged main thread.
+        // Probes dispatched here will never execute, keeping probeInFlight = true.
+        let blockedQueue = DispatchQueue(label: "com.vellum.test.blocked-main")
+        blockedQueue.suspend()
+        detector.probeTargetQueue = blockedQueue
+
+        return (detector, blockedQueue)
+    }
+
+    // MARK: - Stage One: Capture Before Recovery
+
+    @Test
+    func stageOneCaptureFiresWithoutRecovery() throws {
+        let clock = MockClock()
+        let sampleRunner = MockSampleRunner()
+        let (detector, blockedQueue) = makeDetector(clock: clock, sampleRunner: sampleRunner)
+        defer { blockedQueue.resume() }
+
+        // First ping dispatches probe to the blocked queue.
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        // Simulate 2.5 seconds passing without the probe running.
+        clock.advance(by: 2.5)
+
+        // Second ping sees the outstanding probe and triggers stage one.
+        var hangContextWritten = false
+        detector.queue.sync {
+            detector.ping()
+            let fileURL = detector.hangContextWriter.outputDirectory
+                .appendingPathComponent("hang-context.json")
+            hangContextWritten = FileManager.default.fileExists(atPath: fileURL.path)
+        }
+
+        #expect(hangContextWritten, "Stage one should write hang-context.json before main thread recovers")
+        #expect(sampleRunner.callCount == 0, "Stage two sampling should not fire at 2.5s")
+    }
+
+    @Test
+    func stageOneDoesNotFireBelowThreshold() throws {
+        let clock = MockClock()
+        let sampleRunner = MockSampleRunner()
+        let (detector, blockedQueue) = makeDetector(clock: clock, sampleRunner: sampleRunner)
+        defer { blockedQueue.resume() }
+
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        // Only 1 second — below the 2s threshold.
+        clock.advance(by: 1.0)
+
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        let fileURL = detector.hangContextWriter.outputDirectory
+            .appendingPathComponent("hang-context.json")
+        let exists = FileManager.default.fileExists(atPath: fileURL.path)
+        #expect(!exists, "Stage one should not fire below threshold")
+    }
+
+    @Test
+    func stageOneCustomThreshold() throws {
+        let clock = MockClock()
+        let sampleRunner = MockSampleRunner()
+        let (detector, blockedQueue) = makeDetector(
+            clock: clock,
+            sampleRunner: sampleRunner,
+            stageOneThreshold: 0.5
+        )
+        defer { blockedQueue.resume() }
+
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        clock.advance(by: 0.6)
+
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        let fileURL = detector.hangContextWriter.outputDirectory
+            .appendingPathComponent("hang-context.json")
+        let exists = FileManager.default.fileExists(atPath: fileURL.path)
+        #expect(exists, "Stage one should fire with custom 0.5s threshold")
+    }
+
+    // MARK: - Stage Two: Sampling
+
+    @Test
+    func stageTwoAttemptsSamplingOnce() throws {
+        let clock = MockClock()
+        let sampleRunner = MockSampleRunner()
+        let (detector, blockedQueue) = makeDetector(clock: clock, sampleRunner: sampleRunner)
+        defer { blockedQueue.resume() }
+
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        // Advance past stage-two threshold.
+        clock.advance(by: 5.5)
+
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        #expect(sampleRunner.callCount == 1, "Stage two should attempt sampling exactly once")
+
+        // Advance more — should NOT sample again.
+        clock.advance(by: 2.0)
+
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        #expect(sampleRunner.callCount == 1, "Stage two should not attempt sampling twice for the same stall")
+    }
+
+    @Test
+    func stageTwoSamplingGatedOnSendDiagnostics() throws {
+        let clock = MockClock()
+        let sampleRunner = MockSampleRunner()
+        let (detector, blockedQueue) = makeDetector(
+            clock: clock,
+            sampleRunner: sampleRunner,
+            samplingAllowed: false
+        )
+        defer { blockedQueue.resume() }
+
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        clock.advance(by: 6.0)
+
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        #expect(sampleRunner.callCount == 0, "Sampling should be skipped when sendDiagnostics is disabled")
+
+        // Hang context JSON should still be written even with diagnostics disabled.
+        let fileURL = detector.hangContextWriter.outputDirectory
+            .appendingPathComponent("hang-context.json")
+        let exists = FileManager.default.fileExists(atPath: fileURL.path)
+        #expect(exists, "Hang context JSON should always be written regardless of sendDiagnostics")
+    }
+
+    @Test
+    func stageTwoSamplingFailureDoesNotCrash() throws {
+        let clock = MockClock()
+        let sampleRunner = MockSampleRunner()
+        sampleRunner.shouldSucceed = false
+        let (detector, blockedQueue) = makeDetector(clock: clock, sampleRunner: sampleRunner)
+        defer { blockedQueue.resume() }
+
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        clock.advance(by: 6.0)
+
+        // This should not throw or deadlock.
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        #expect(sampleRunner.callCount == 1, "Sampling was attempted despite expected failure")
+
+        // Detector should still be operational after the failure.
+        clock.advance(by: 2.0)
+
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        #expect(sampleRunner.callCount == 1, "No additional sampling after failure")
+    }
+
+    // MARK: - Recovery and Re-detection
+
+    @Test
+    func stageOneOnlyFiresOncePerStall() throws {
+        let clock = MockClock()
+        let sampleRunner = MockSampleRunner()
+        let (detector, blockedQueue) = makeDetector(clock: clock, sampleRunner: sampleRunner)
+        defer { blockedQueue.resume() }
+
+        // Dispatch probe.
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        clock.advance(by: 3.0)
+
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        let fileURL = detector.hangContextWriter.outputDirectory
+            .appendingPathComponent("hang-context.json")
+        #expect(FileManager.default.fileExists(atPath: fileURL.path))
+
+        // Remove the file to verify stage one does not write it again.
+        try? FileManager.default.removeItem(at: fileURL)
+
+        // Continue stalling — stage one should not fire again.
+        clock.advance(by: 1.0)
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        let existsAfterRemoval = FileManager.default.fileExists(atPath: fileURL.path)
+        #expect(!existsAfterRemoval, "Stage one should only fire once per stall")
+    }
+
+    // MARK: - Both Stages Fire on Prolonged Stall
+
+    @Test
+    func prolongedStallFiresBothStages() throws {
+        let clock = MockClock()
+        let sampleRunner = MockSampleRunner()
+        let (detector, blockedQueue) = makeDetector(clock: clock, sampleRunner: sampleRunner)
+        defer { blockedQueue.resume() }
+
+        // Dispatch probe.
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        // Advance past stage one.
+        clock.advance(by: 2.5)
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        let fileURL = detector.hangContextWriter.outputDirectory
+            .appendingPathComponent("hang-context.json")
+        #expect(FileManager.default.fileExists(atPath: fileURL.path), "Stage one should fire at 2.5s")
+        #expect(sampleRunner.callCount == 0, "Stage two should not fire at 2.5s")
+
+        // Advance past stage two.
+        clock.advance(by: 3.0) // Total elapsed: 5.5s
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        #expect(sampleRunner.callCount == 1, "Stage two should fire at 5.5s")
+    }
+
+    // MARK: - Content Safety
+
+    @Test
+    func hangContextJsonIsContentSafe() throws {
+        let clock = MockClock()
+        let sampleRunner = MockSampleRunner()
+        let (detector, blockedQueue) = makeDetector(clock: clock, sampleRunner: sampleRunner)
+        defer { blockedQueue.resume() }
+
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        clock.advance(by: 3.0)
+
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        let fileURL = detector.hangContextWriter.outputDirectory
+            .appendingPathComponent("hang-context.json")
+        let data = try Data(contentsOf: fileURL)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        // Must contain structural fields.
+        #expect(json["stallStartTime"] != nil)
+        #expect(json["stallDurationSeconds"] != nil)
+        #expect(json["pid"] != nil)
+        #expect(json["appVersion"] != nil)
+
+        // Must NOT contain user-content keys.
+        let forbiddenKeys = ["messageText", "text", "toolInput", "toolOutput",
+                             "html", "surfaceHtml", "attachmentContent", "body"]
+        for key in forbiddenKeys {
+            #expect(json[key] == nil, "Hang context must not contain user-content key '\(key)'")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add HangContextWriter to write hang-context.json from background queue when main thread is wedged
- Refactor MainThreadStallDetector for staged capture: 2s first-stage JSON, 5s second-stage sampling
- Gate sampling on sendDiagnostics; always write content-safe JSON hang context
- Add MainThreadStallDetectorTests with injected thresholds and clock hooks

Part of plan: desktop-chat-freeze-logging.md (PR 6 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
