### PR TITLE
fix: add debug log for word-boundary truncation rejection

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1245,7 +1245,14 @@ async function generateLlmSuggestion(
     .slice(0, 50)
     .replace(/\s+\S*$/, "")
     .trim();
-  return wordTruncated.length >= 15 ? wordTruncated : null; // too short after truncation = bad suggestion
+  if (wordTruncated.length < 15) {
+    log.debug(
+      { rawLength: firstLine.length, truncatedLength: wordTruncated.length },
+      "Suggestion rejected: too short after word-boundary truncation",
+    );
+    return null;
+  }
+  return wordTruncated;
 }
 
 export async function handleGetSuggestion(


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-suggestion-ghost.md.

**Gap:** Missing debug log for word-boundary truncation rejection
**What was expected:** All null-return paths in generateLlmSuggestion should have diagnostic logging
**What was found:** The too-short-after-truncation path silently returned null

[skip ci]
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
