### PR TITLE
fix: repair usage dashboard panel view tests broken by SettingsCard closures

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -105,7 +105,7 @@ struct UsageDashboardPanel: View {
     // MARK: - Totals Section
 
     @ViewBuilder
-    private func totalsSection(store: UsageDashboardStore) -> some View {
+    func totalsSection(store: UsageDashboardStore) -> some View {
         SettingsCard(title: "Totals") {
             switch store.totalsState {
             case .idle, .loading:
@@ -141,7 +141,7 @@ struct UsageDashboardPanel: View {
     // MARK: - Daily Trend Section
 
     @ViewBuilder
-    private func dailySection(store: UsageDashboardStore) -> some View {
+    func dailySection(store: UsageDashboardStore) -> some View {
         SettingsCard(title: "Daily Trend") {
             switch store.dailyState {
             case .idle, .loading:
@@ -241,7 +241,7 @@ struct UsageDashboardPanel: View {
     // MARK: - Breakdown Section
 
     @ViewBuilder
-    private func breakdownSection(store: UsageDashboardStore) -> some View {
+    func breakdownSection(store: UsageDashboardStore) -> some View {
         SettingsCard(title: "Breakdown") {
             groupByPicker(store: store)
 

--- a/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
@@ -224,12 +224,20 @@ struct UsageDashboardPanelPopulatedTests {
 
 /// Dumps the panel's content view tree (bypassing the VSidePanel closure wrapper)
 /// so that all Text content is captured as strings in the dump output.
+/// SettingsCard stores its content as @ViewBuilder closures which dump() shows as
+/// "(Function)". We additionally evaluate each section's body to expand those
+/// closures so the actual content (stat labels, empty states, error messages,
+/// data values) appears in the output.
 @MainActor
 private func collectPanelContent(store: UsageDashboardStore) -> String {
     let panel = UsageDashboardPanel(store: store, onClose: {})
     let content = panel.contentView(store: store)
     var output = ""
     dump(content, to: &output)
+    // Evaluate each section's SettingsCard body to expand closure content
+    dump(panel.totalsSection(store: store).body, to: &output)
+    dump(panel.dailySection(store: store).body, to: &output)
+    dump(panel.breakdownSection(store: store).body, to: &output)
     return output
 }
 
@@ -260,8 +268,8 @@ struct UsageDashboardPanelViewIdleTests {
         store.updateClient(client)
         let joined = collectPanelContent(store: store)
 
-        // Idle state shows loading indicators for all sections
-        #expect(joined.contains("Loading"))
+        // Idle state shows skeleton loading indicators for all sections
+        #expect(joined.contains("VSkeletonBone"))
     }
 }
 


### PR DESCRIPTION
## Summary
- `SettingsCard` wraps content in `@ViewBuilder` closures, so `dump()` shows them as `(Function)` — all content assertions in UsageDashboardPanel view tests were invisible to the test helper
- Make `totalsSection`/`dailySection`/`breakdownSection` internal so tests can evaluate each section's `.body` (which expands the closures)
- Fix idle state test assertion: skeleton views use `VSkeletonBone`, not `Text("Loading")`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23290978590/job/67726258214

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
