### PR TITLE
fix: migrate ChatView.composerMessages to shared ChatVisibleMessageFilter

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -265,11 +265,10 @@ struct ChatView: View {
                             containerWidth: containerWidth
                         )
 
-                        let composerMessages: [ChatMessage] = {
-                            let all = messages.filter { !$0.isSubagentNotification }
-                            guard displayedMessageCount < all.count else { return all }
-                            return Array(all.suffix(displayedMessageCount))
-                        }()
+                        let composerMessages = ChatVisibleMessageFilter.paginatedMessages(
+                            from: messages,
+                            displayedMessageCount: displayedMessageCount
+                        )
 
                         ComposerSection(
                             inputText: $inputText,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for desktop-scroll-jump-fix.md.

**Gap:** Incomplete migration of ChatView.composerMessages filtering
**What was expected:** All message visibility filtering should use the shared ChatVisibleMessageFilter helper
**What was found:** ChatView.composerMessages still used old inline filter that didn't exclude isHidden messages
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
