### PR TITLE
fix: soften thinking glow animation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -970,9 +970,9 @@ private struct AssistantProgressPulsingModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .opacity(isPulsing ? 0.4 : 1.0)
+            .opacity(isPulsing ? 0.6 : 1.0)
             .animation(
-                Animation.easeInOut(duration: 1.0).repeatForever(autoreverses: true),
+                Animation.easeInOut(duration: 1.8).repeatForever(autoreverses: true),
                 value: isPulsing
             )
             .onAppear { isPulsing = true }

--- a/clients/macos/vellum-assistant/Features/Chat/ClaudeCodeProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ClaudeCodeProgressView.swift
@@ -144,9 +144,9 @@ private struct PulsingModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .opacity(isPulsing ? 0.4 : 1.0)
+            .opacity(isPulsing ? 0.6 : 1.0)
             .animation(
-                Animation.easeInOut(duration: 1.0).repeatForever(autoreverses: true),
+                Animation.easeInOut(duration: 1.8).repeatForever(autoreverses: true),
                 value: isPulsing
             )
             .onAppear { isPulsing = true }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1897,12 +1897,12 @@ private struct AvatarGlowModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .shadow(color: VColor.primaryActive.opacity(glowIntensity), radius: 6 + glowIntensity * 16, x: 0, y: 0)
-            .shadow(color: VColor.primaryActive.opacity(glowIntensity * 0.5), radius: 2 + glowIntensity * 6, x: 0, y: 0)
+            .shadow(color: VColor.primaryActive.opacity(glowIntensity), radius: 6 + glowIntensity * 10, x: 0, y: 0)
+            .shadow(color: VColor.primaryActive.opacity(glowIntensity * 0.5), radius: 2 + glowIntensity * 4, x: 0, y: 0)
             .onChange(of: isActive) {
                 if isActive {
-                    withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
-                        glowIntensity = 0.5
+                    withAnimation(.easeInOut(duration: 2.5).repeatForever(autoreverses: true)) {
+                        glowIntensity = 0.25
                     }
                 } else {
                     withAnimation(.easeOut(duration: 0.4)) {
@@ -1913,8 +1913,8 @@ private struct AvatarGlowModifier: ViewModifier {
             .onAppear {
                 if isActive {
                     DispatchQueue.main.async {
-                        withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
-                            glowIntensity = 0.5
+                        withAnimation(.easeInOut(duration: 2.5).repeatForever(autoreverses: true)) {
+                            glowIntensity = 0.25
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- **Avatar glow**: halved intensity (0.5→0.25), reduced shadow spread, slowed cycle from 1.5s to 2.5s
- **Status dot pulse**: narrowed opacity swing from 0.4–1.0 to 0.6–1.0, slowed from 1.0s to 1.8s
- **Tool call dot pulse**: same adjustments as status dot

## Original prompt
The green glow when the assistant is thinking is too aggressive
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
