### PR TITLE
fix: add initialRestore to bottom-pin coalescing logic

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBottomPinCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBottomPinCoordinator.swift
@@ -64,10 +64,11 @@ struct BottomPinSession: Sendable {
     func canCoalesce(reason: BottomPinRequestReason, conversationId: UUID) -> Bool {
         guard self.conversationId == conversationId else { return false }
         guard !isExhausted else { return false }
-        // Expansion and streaming requests coalesce freely within the same conversation.
+        // Requests coalesce freely when they share the same reason within the same conversation.
         // Different reasons (e.g. resize vs expansion) start a fresh session.
         switch (self.reason, reason) {
-        case (.expansion, .expansion),
+        case (.initialRestore, .initialRestore),
+             (.expansion, .expansion),
              (.streaming, .streaming),
              (.messageCount, .messageCount),
              (.resize, .resize):


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for desktop-chat-freeze-logging.md.

**Gap:** initialRestore not included in coalescing logic
**What was expected:** Multiple initialRestore requests coalesce into one bounded session
**What was found:** Stages 0/1/2 of restoreScrollToBottom() each cancelled the previous session
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
