### PR TITLE
fix: dismiss panel forms on ui_surface_complete

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -71,6 +71,14 @@ extension AppDelegate {
             guard let self else { return }
             self.surfaceManager.dismissSurface(msg)
         }
+        daemonClient.onSurfaceComplete = { [weak self] msg in
+            guard let self else { return }
+            self.surfaceManager.dismissSurface(UiSurfaceDismissMessage(
+                type: "ui_surface_dismiss",
+                conversationId: msg.conversationId ?? "",
+                surfaceId: msg.surfaceId
+            ))
+        }
 
         // Reload webviews for surfaces whose app files changed (cross-conversation broadcast)
         daemonClient.onAppFilesChanged = { [weak self] appId in


### PR DESCRIPTION
## Summary
- Panel-type forms (floating NSPanels) were stuck on "Submitting..." after the user submitted them
- Root cause: `setupSurfaceManager()` wired `onSurfaceShow`, `onSurfaceUpdate`, and `onSurfaceDismiss` but never wired `onSurfaceComplete`
- Fix: wire `onSurfaceComplete` to `surfaceManager.dismissSurface()` so panels close when the daemon sends `ui_surface_complete`

## Original prompt
this plan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
