### PR TITLE
fix: cancel bottomPinCoordinator session on view disappear

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1204,6 +1204,10 @@ struct MessageListView: View {
                 highlightDismissTask?.cancel()
                 highlightDismissTask = nil
                 highlightedMessageId = nil
+                // Cancel any active pin session to prevent the coordinator's
+                // sessionTask from calling scrollTo on a stale ScrollViewProxy.
+                bottomPinCoordinator.cancelActiveSession(reason: .conversationSwitch)
+                bottomPinCoordinator.onPinRequested = nil
             }
             .onChange(of: isSending) {
                 if isSending {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for desktop-chat-freeze-logging.md.

**Gap:** bottomPinCoordinator active session not cancelled in onDisappear
**What was expected:** Active session cancelled when view disappears
**What was found:** Session could continue with stale ScrollViewProxy references

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
