### PR TITLE
fix: reset scrollLoopGuard for old conversation on switch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1347,7 +1347,7 @@ struct MessageListView: View {
                     // If not near bottom or anchor is set, preserve viewport.
                 }
             }
-            .onChange(of: conversationId) {
+            .onChange(of: conversationId) { oldConversationId, _ in
                 // Keep the underlying NSScrollView instance stable across conversation
                 // switches (prevents default-scroller flash), and reset view-local
                 // scroll state explicitly instead of remounting the whole view.
@@ -1377,7 +1377,9 @@ struct MessageListView: View {
                 // hasFreshAnchorMeasurement from becoming true.
                 anchorTracker.lastMinY = .infinity
                 hasReceivedScrollEvent = false
-                if let oldConvId = conversationId {
+                // Reset the OLD conversation's scroll-loop guard state so it
+                // doesn't leak into future sessions for that conversation.
+                if let oldConvId = oldConversationId {
                     scrollLoopGuard.reset(conversationId: oldConvId.uuidString)
                 }
                 lastHandledContainerWidth = containerWidth


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for desktop-chat-freeze-logging.md.

**Gap:** scrollLoopGuard.reset resets NEW conversation instead of OLD
**What was expected:** Old conversation's guard state cleaned up on switch
**What was found:** Parameter-less onChange reads new value, so old state leaked
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
