### PR TITLE
feat: add hover tooltips to constellation graph nodes

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -238,6 +238,7 @@ private struct CategoryNodeView: View {
         )
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         .contentShape(RoundedRectangle(cornerRadius: VRadius.xl))
+        .nativeTooltip(category.displayName)
         .onHover { hovering in
             withAnimation(.easeInOut(duration: 0.15)) {
                 isHovered = hovering
@@ -284,6 +285,7 @@ private struct SubCategoryNodeView: View {
         )
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .contentShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .nativeTooltip(label)
         .onHover { hovering in
             withAnimation(.easeInOut(duration: 0.15)) {
                 isHovered = hovering
@@ -334,6 +336,7 @@ private struct SkillNodeView: View {
         )
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .contentShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .nativeTooltip(item.label)
         .onHover { hovering in
             withAnimation(.easeInOut(duration: 0.15)) {
                 isHovered = hovering


### PR DESCRIPTION
## Summary
- Add `nativeTooltip()` to CategoryNodeView, SubCategoryNodeView, and SkillNodeView in the constellation graph
- Uses the existing AppKit-backed `NativeTooltipModifier` which reliably works alongside SwiftUI gesture recognizers (drag, tap, hover)
- Hovering over any node now shows its full label text, resolving truncated label readability

## Original prompt
Can you add hover tooltips and a zoom to read interaction in separate PRs?
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
