### PR TITLE
fix: prevent quotes in home screen greeting text

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1398,7 +1398,7 @@ public final class ChatViewModel: ObservableObject {
             var result = ""
             do {
                 let stream = self.btwClient.sendMessage(
-                    content: "Generate a short, casual greeting for when the user opens a new conversation (under 8 words, like \"Ready when you are.\" or \"What's on your mind?\"). Match your personality. Output ONLY the greeting, nothing else.",
+                    content: "Generate a short, casual greeting for when the user opens a new conversation (under 8 words). Match your personality. Output ONLY the greeting text — no quotes, no formatting.",
                     conversationKey: key
                 )
                 for try await delta in stream {


### PR DESCRIPTION
## Summary
- Remove quoted example greetings from the LLM prompt that generates the home screen flavor text
- Add explicit "no quotes, no formatting" instruction to prevent the model from wrapping its output in quotes

## Original prompt
This flavor text should never be in quotes. Can we adjust the prompt to make sure that doesn't happen?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
