### PR TITLE
fix: resolve flaky macOS test crashes in pin coordinator and preview tests

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBottomPinCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBottomPinCoordinator.swift
@@ -244,22 +244,22 @@ final class ChatBottomPinCoordinator {
     private func startSessionTask(animated: Bool) {
         sessionTask?.cancel()
 
+        // Immediate first attempt — synchronous so callers see the result
+        // before yielding (important for tests and single-frame UI updates).
+        guard var session = activeSession else { return }
+        session.recordAttempt()
+        activeSession = session
+        let pinned = onPinRequested?(session.reason, animated) ?? false
+
+        if pinned {
+            completeSession()
+            return
+        }
+
+        // Async bounded retry loop for subsequent attempts.
         sessionTask = Task { @MainActor [weak self] in
-            guard let self else { return }
-
-            // Immediate first attempt.
-            guard var session = self.activeSession else { return }
-            session.recordAttempt()
-            self.activeSession = session
-            let pinned = self.onPinRequested?(session.reason, animated) ?? false
-
-            if pinned {
-                self.completeSession()
-                return
-            }
-
-            // Bounded retry loop.
             while !Task.isCancelled {
+                guard let self else { break }
                 guard var currentSession = self.activeSession else { break }
                 guard !currentSession.isExhausted else {
                     log.debug("Pin session exhausted after \(currentSession.attemptCount) attempts")
@@ -297,7 +297,7 @@ final class ChatBottomPinCoordinator {
             }
 
             // Clean up if we fell through without completing.
-            self.completeSession()
+            self?.completeSession()
         }
     }
 

--- a/clients/macos/vellum-assistantTests/ChatDynamicPreviewRegressionTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatDynamicPreviewRegressionTests.swift
@@ -97,6 +97,9 @@ final class ChatDynamicPreviewRegressionTests: XCTestCase {
         viewModel.handleServerMessage(.assistantTextDelta(
             AssistantTextDeltaMessage(text: "Built your app:")
         ))
+        // Flush the buffered text delta so the assistant message exists before
+        // uiSurfaceShow — the no-preview path breaks early without creating one.
+        viewModel.flushStreamingBuffer()
 
         // No preview metadata and no display mode (defaults to panel routing)
         let msg = makeDynamicPageSurfaceMessage(preview: nil, appId: "app-123")
@@ -112,6 +115,7 @@ final class ChatDynamicPreviewRegressionTests: XCTestCase {
         viewModel.handleServerMessage(.assistantTextDelta(
             AssistantTextDeltaMessage(text: "Opening panel:")
         ))
+        viewModel.flushStreamingBuffer()
 
         let msg = makeDynamicPageSurfaceMessage(display: "panel", preview: nil)
         viewModel.handleServerMessage(.uiSurfaceShow(msg))


### PR DESCRIPTION
## Summary
- Move the immediate first pin attempt out of the async Task in `ChatBottomPinCoordinator.startSessionTask` so callers see the result synchronously — fixes 5 assertion failures in `ChatBottomPinCoordinatorTests`
- Flush the streaming text buffer before accessing `messages[0]` in two `ChatDynamicPreviewRegressionTests` tests where the `uiSurfaceShow` handler breaks early without creating a message — fixes fatal `Index out of range` crash that killed the test process

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23293804960/job/67735845941
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
