### PR TITLE
fix: restore surfaceState from history so app hooks work after restart

### DIFF
--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -381,6 +381,28 @@ export class Conversation {
 
   async loadFromDb(): Promise<void> {
     await loadFromDbImpl(this);
+    this.restoreSurfaceStateFromHistory();
+  }
+
+  /**
+   * Scan loaded conversation history for ui_surface content blocks and
+   * populate surfaceState so that findConversationBySurfaceId works for
+   * surfaces restored from history (e.g. after daemon restart).
+   */
+  private restoreSurfaceStateFromHistory(): void {
+    for (const msg of this.messages) {
+      if (!Array.isArray(msg.content)) continue;
+      for (const block of msg.content) {
+        const b = block as unknown as Record<string, unknown>;
+        if (b.type === "ui_surface" && typeof b.surfaceId === "string") {
+          this.surfaceState.set(b.surfaceId, {
+            surfaceType: (b.surfaceType ?? "dynamic_page") as SurfaceType,
+            data: (b.data ?? {}) as SurfaceData,
+            title: b.title as string | undefined,
+          });
+        }
+      }
+    }
   }
 
   async ensureActorScopedHistory(): Promise<void> {


### PR DESCRIPTION
## Summary
- After daemon restart, `findConversationBySurfaceId` returned `undefined` for history-restored surfaces because `surfaceState` (an in-memory Map) was never repopulated from persisted messages
- This caused all `POST /v1/surface-actions` requests to return 404, silently dropping `sendAction` hooks from apps (confirmed by daemon logs showing 15+ consecutive 404s)
- Added `restoreSurfaceStateFromHistory()` to scan loaded messages for `ui_surface` content blocks after `loadFromDb` and populate `surfaceState`

## Original prompt
Restore surfaceState from conversation history after loadFromDb so findConversationBySurfaceId works for history-restored surfaces. In conversation.ts loadFromDb(), after calling loadFromDbImpl(this), scan this.messages for ui_surface content blocks and populate this.surfaceState with {surfaceType, data, title} for each surfaceId found. Later entries should overwrite earlier ones (giving latest state). This fixes the 404s on POST /v1/surface-actions/ after daemon restart.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
