### PR TITLE
fix: stop global Escape key from dismissing workspace apps

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -549,7 +549,7 @@ extension AppDelegate {
                     self?.startSessionTask?.cancel()
                     self?.currentSession?.cancel()
                     self?.ambientAgent.resume()
-                    self?.surfaceManager.dismissAll()
+                    self?.surfaceManager.dismissFloatingOnly()
                     self?.toolConfirmationNotificationService.dismissAll()
                     self?.secretPromptManager.dismissAll()
                 }

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -329,6 +329,16 @@ final class SurfaceManager: ObservableObject {
         dismissSurfaceById(message.surfaceId)
     }
 
+    /// Dismiss only floating panel surfaces, leaving workspace-routed surfaces untouched.
+    /// Used by the global Escape handler to avoid destroying workspace apps when the user
+    /// presses Escape in another application.
+    func dismissFloatingOnly() {
+        let floatingIds = Array(panels.keys).filter { !workspaceRoutedSurfaces.contains($0) }
+        for id in floatingIds {
+            dismissSurfaceById(id)
+        }
+    }
+
     func dismissAll() {
         for observer in closeObservers.values {
             NotificationCenter.default.removeObserver(observer)


### PR DESCRIPTION
## Summary
- The global Escape key monitor (`addGlobalMonitorForEvents`) fires on Escape keypresses in **all other macOS apps**. It was calling `surfaceManager.dismissAll()`, which closed workspace app surfaces — so pressing Escape in Chrome/Terminal/etc. would silently close whatever app was open in the Vellum workspace.
- Added `dismissFloatingOnly()` to `SurfaceManager` that only closes floating NSPanel surfaces, skipping workspace-routed surfaces.
- The global Escape handler now calls `dismissFloatingOnly()` instead of `dismissAll()`. `applicationWillTerminate` retains `dismissAll()` for full cleanup on quit.

## Original prompt
this fix, 1 PR or multiple PRs, your choice
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
