### PR TITLE
fix: flush streaming buffer in media embed baseline tests

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatMediaEmbedBaselineTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatMediaEmbedBaselineTests.swift
@@ -100,6 +100,7 @@ final class ChatMediaEmbedBaselineTests: XCTestCase {
         viewModel.handleServerMessage(.assistantTextDelta(
             AssistantTextDeltaMessage(text: "Here is a video: \(url)")
         ))
+        viewModel.flushStreamingBuffer()
 
         XCTAssertEqual(viewModel.messages.count, 1)
         let msg = viewModel.messages[0]
@@ -119,6 +120,7 @@ final class ChatMediaEmbedBaselineTests: XCTestCase {
         viewModel.handleServerMessage(.assistantTextDelta(
             AssistantTextDeltaMessage(text: "Check this video: \(url)")
         ))
+        viewModel.flushStreamingBuffer()
 
         XCTAssertEqual(viewModel.messages.count, 1)
         let msg = viewModel.messages[0]
@@ -134,6 +136,7 @@ final class ChatMediaEmbedBaselineTests: XCTestCase {
         viewModel.handleServerMessage(.assistantTextDelta(
             AssistantTextDeltaMessage(text: "Recording: \(url)")
         ))
+        viewModel.flushStreamingBuffer()
 
         XCTAssertEqual(viewModel.messages.count, 1)
         let msg = viewModel.messages[0]
@@ -149,6 +152,7 @@ final class ChatMediaEmbedBaselineTests: XCTestCase {
         viewModel.handleServerMessage(.assistantTextDelta(
             AssistantTextDeltaMessage(text: "Here's the chart: \(url)")
         ))
+        viewModel.flushStreamingBuffer()
 
         XCTAssertEqual(viewModel.messages.count, 1)
         let msg = viewModel.messages[0]
@@ -172,6 +176,7 @@ final class ChatMediaEmbedBaselineTests: XCTestCase {
         viewModel.handleServerMessage(.assistantTextDelta(
             AssistantTextDeltaMessage(text: text)
         ))
+        viewModel.flushStreamingBuffer()
 
         XCTAssertEqual(viewModel.messages.count, 1)
         let msg = viewModel.messages[0]


### PR DESCRIPTION
## Summary
- Five assistant-message tests in `ChatMediaEmbedBaselineTests` crash with "Fatal error: Index out of range" because `handleServerMessage(.assistantTextDelta)` buffers text and flushes asynchronously (100ms delay), but the tests access `messages[0]` synchronously before the flush runs
- Added `viewModel.flushStreamingBuffer()` after each text delta call to materialize the buffered message before assertions

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23294946286/job/67739851363

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
