### PR TITLE
fix: scan all DB messages for surface state restoration

### DIFF
--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -38,6 +38,7 @@ import {
 import { registerToolTraceListener } from "../events/tool-trace-listener.js";
 import { getHookManager } from "../hooks/manager.js";
 import { resolveCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
+import { getMessages } from "../memory/conversation-crud.js";
 import { PermissionPrompter } from "../permissions/prompter.js";
 import { SecretPrompter } from "../permissions/secret-prompter.js";
 import { patternMatchesCandidate } from "../permissions/trust-store.js";
@@ -385,22 +386,30 @@ export class Conversation {
   }
 
   /**
-   * Scan loaded conversation history for ui_surface content blocks and
-   * populate surfaceState so that findConversationBySurfaceId works for
-   * surfaces restored from history (e.g. after daemon restart).
+   * Scan ALL persisted messages (including compacted ones) for ui_surface
+   * content blocks and populate surfaceState so findConversationBySurfaceId
+   * works for surfaces restored from history (e.g. after daemon restart).
    */
   private restoreSurfaceStateFromHistory(): void {
-    for (const msg of this.messages) {
-      if (!Array.isArray(msg.content)) continue;
-      for (const block of msg.content) {
-        const b = block as unknown as Record<string, unknown>;
-        if (b.type === "ui_surface" && typeof b.surfaceId === "string") {
-          this.surfaceState.set(b.surfaceId, {
-            surfaceType: (b.surfaceType ?? "dynamic_page") as SurfaceType,
-            data: (b.data ?? {}) as SurfaceData,
-            title: b.title as string | undefined,
-          });
+    const dbMessages = getMessages(this.conversationId);
+    for (const row of dbMessages) {
+      try {
+        const content = JSON.parse(row.content);
+        if (!Array.isArray(content)) continue;
+        for (const block of content) {
+          if (
+            block.type === "ui_surface" &&
+            typeof block.surfaceId === "string"
+          ) {
+            this.surfaceState.set(block.surfaceId, {
+              surfaceType: (block.surfaceType ?? "dynamic_page") as SurfaceType,
+              data: (block.data ?? {}) as SurfaceData,
+              title: block.title as string | undefined,
+            });
+          }
         }
+      } catch {
+        // Content isn't valid JSON — skip
       }
     }
   }


### PR DESCRIPTION
## Summary
- Previous fix (#19471) only scanned `this.messages` which excludes compacted messages — if the `ui_surface` block was in a compacted portion of the conversation, surface hooks still returned 404
- Now queries `getMessages()` directly to scan ALL persisted messages including compacted ones
- This ensures `findConversationBySurfaceId` works regardless of conversation compaction state
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
