### PR TITLE
fix: resolve standalone app surfaces by appId for sendAction hooks

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1249,9 +1249,29 @@ export class DaemonServer {
    * Look up an active conversation that owns a given surfaceId.
    */
   findConversationBySurfaceId(surfaceId: string): Conversation | undefined {
+    // Fast path: exact surfaceId match in surfaceState
     for (const c of this.conversations.values()) {
       if (c.surfaceState.has(surfaceId)) return c;
     }
+
+    // Fallback: standalone app surfaces use "app-open-{appId}" IDs that
+    // were never part of any conversation.  Extract the appId and find
+    // a conversation whose surfaceState has a surface for that app.
+    const appOpenPrefix = "app-open-";
+    if (surfaceId.startsWith(appOpenPrefix)) {
+      const appId = surfaceId.slice(appOpenPrefix.length);
+      for (const c of this.conversations.values()) {
+        for (const [, state] of c.surfaceState.entries()) {
+          const data = state.data as Record<string, unknown>;
+          if (data?.appId === appId) {
+            // Register this surfaceId so subsequent lookups are O(1)
+            c.surfaceState.set(surfaceId, state);
+            return c;
+          }
+        }
+      }
+    }
+
     return undefined;
   }
 


### PR DESCRIPTION
## Summary
- When apps are opened from the sidebar, the client generates `"app-open-{appId}"` surface IDs that were never part of any conversation — `findConversationBySurfaceId` returned undefined and all `sendAction` hooks got 404s
- Added a fallback: when the exact surfaceId lookup misses and the ID matches the `"app-open-"` prefix, extract the appId and search conversations for a matching app surface
- Caches the result in surfaceState for O(1) subsequent lookups
- Verified working: surface actions now return 200 instead of 404
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
