### PR TITLE
fix: cast SurfaceData through unknown for Record assertion

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1262,7 +1262,7 @@ export class DaemonServer {
       const appId = surfaceId.slice(appOpenPrefix.length);
       for (const c of this.conversations.values()) {
         for (const [, state] of c.surfaceState.entries()) {
-          const data = state.data as Record<string, unknown>;
+          const data = state.data as unknown as Record<string, unknown>;
           if (data?.appId === appId) {
             // Register this surfaceId so subsequent lookups are O(1)
             c.surfaceState.set(surfaceId, state);


### PR DESCRIPTION
## Summary
- Fix TS2352 type error in `server.ts` where `SurfaceData` was directly cast to `Record<string, unknown>` — cast through `unknown` first since `DocumentPreviewSurfaceData` lacks an index signature.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23296134110/job/67743906015
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
