### PR TITLE
fix: repair 4 flaky macOS test assertions

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
@@ -53,6 +53,7 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
 
     func testScrollUpCancelsActiveSession() {
         let convId = UUID()
+        pinShouldSucceed = false
         coordinator.requestPin(reason: .streaming, conversationId: convId)
         XCTAssertNotNil(coordinator.activeSession)
 

--- a/clients/macos/vellum-assistantTests/ChatDynamicPreviewRegressionTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatDynamicPreviewRegressionTests.swift
@@ -286,6 +286,7 @@ final class ChatDynamicPreviewRegressionTests: XCTestCase {
         viewModel.handleServerMessage(.assistantTextDelta(
             AssistantTextDeltaMessage(text: "Check https://example.com for details. ")
         ))
+        viewModel.flushStreamingBuffer()
 
         // Then attach a dynamic page with preview
         let msg = makeDynamicPageSurfaceMessage(
@@ -525,6 +526,7 @@ final class ChatDynamicPreviewRegressionTests: XCTestCase {
         viewModel.handleServerMessage(.assistantTextDelta(
             AssistantTextDeltaMessage(text: "Check it out:")
         ))
+        viewModel.flushStreamingBuffer()
 
         let msg = makeDynamicPageSurfaceMessage(
             surfaceId: "surface-order-test",

--- a/clients/macos/vellum-assistantTests/ChatScrollLoopGuardTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatScrollLoopGuardTests.swift
@@ -186,8 +186,11 @@ final class ChatScrollLoopGuardTests: XCTestCase {
         }
         XCTAssertEqual(tripCount, 1)
 
-        // Advance by less than cooldown duration and fire another burst.
-        timestamp += ChatScrollLoopGuard.cooldownDuration * 0.5
+        // Advance slightly but stay well within the cooldown window.
+        // The trip fired at ~event 40 of the first burst, so elapsed time
+        // from the trip is (remaining burst) + gap + (second burst).
+        // Keep the total under cooldownDuration (2 s).
+        timestamp += 0.1
 
         for _ in 0..<50 {
             if guard_.record(.anchorPreferenceChange, conversationId: conversationId, timestamp: timestamp) != nil {


### PR DESCRIPTION
## Summary
- Fix `testScrollUpCancelsActiveSession`: set `pinShouldSucceed = false` so the session isn't immediately completed by the synchronous first-attempt path added in #19470.
- Fix `testDynamicPreviewDoesNotAffectPlainTextLinks` and `testDynamicPreviewAppearsInContentOrder`: add `flushStreamingBuffer()` before surface show, same pattern as the fixes applied to two other tests in #19470.
- Fix `testGuardDoesNotRearmDuringCooldown`: reduce inter-burst gap from `cooldownDuration * 0.5` to `0.1` so the second burst completes within the cooldown window (the trip fires mid-first-burst, not at the end).

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23295966649/job/67743348218

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
