### PR TITLE
fix: broadcast surface action events to SSE hub for real-time delivery

### DIFF
--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -172,6 +172,7 @@ export interface SurfaceConversationContext {
     emit(type: string, message: string, meta?: Record<string, unknown>): void;
   };
   sendToClient(msg: ServerMessage): void;
+  broadcastToAllClients?(msg: ServerMessage): void;
   pendingSurfaceActions: Map<string, { surfaceType: SurfaceType }>;
   lastSurfaceAction: Map<
     string,
@@ -640,7 +641,12 @@ export function handleSurfaceAction(
 
     const requestId = uuid();
     ctx.surfaceActionRequestIds.add(requestId);
-    const onEvent = (msg: ServerMessage) => ctx.sendToClient(msg);
+    // Use broadcastToAllClients (publishes to the SSE event hub) instead of
+    // sendToClient, which is reset to a no-op between HTTP requests. Without
+    // this, surface action responses are persisted to DB but never reach the
+    // client's SSE stream.
+    const emit = ctx.broadcastToAllClients ?? ctx.sendToClient.bind(ctx);
+    const onEvent = (msg: ServerMessage) => emit(msg);
 
     ctx.traceEmitter.emit("request_received", "Surface action received", {
       requestId,
@@ -668,7 +674,7 @@ export function handleSurfaceAction(
     // Echo the prompt to the client so it appears in the chat UI.
     // Deferred until after rejection check to avoid ghost messages.
     if (prompt) {
-      ctx.sendToClient({
+      emit({
         type: "user_message_echo",
         text: prompt,
         conversationId: ctx.conversationId,
@@ -833,7 +839,10 @@ export function handleSurfaceAction(
 
   const requestId = uuid();
   ctx.surfaceActionRequestIds.add(requestId);
-  const onEvent = (msg: ServerMessage) => ctx.sendToClient(msg);
+  // Use broadcastToAllClients so events reach the SSE hub (see history-restored
+  // path above for rationale).
+  const emit = ctx.broadcastToAllClients ?? ctx.sendToClient.bind(ctx);
+  const onEvent = (msg: ServerMessage) => emit(msg);
 
   ctx.traceEmitter.emit("request_received", "Surface action received", {
     requestId,
@@ -866,7 +875,7 @@ export function handleSurfaceAction(
   // Echo the user's prompt to the client so it appears in the chat UI.
   // Deferred until after rejection check to avoid ghost messages.
   if (shouldRelayPrompt && prompt) {
-    ctx.sendToClient({
+    emit({
       type: "user_message_echo",
       text: prompt,
       conversationId: ctx.conversationId,

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -203,6 +203,7 @@ export class Conversation {
     string,
     Record<string, unknown>
   >();
+  /** @internal */ broadcastToAllClients?: (msg: ServerMessage) => void;
   /** @internal */ withSurface = createSurfaceMutex();
   /** @internal */ currentTurnSurfaces: Array<{
     surfaceId: string;
@@ -249,6 +250,7 @@ export class Conversation {
     this.provider = provider;
     this.workingDir = workingDir;
     this.sendToClient = sendToClient;
+    this.broadcastToAllClients = broadcastToAllClients;
     this.memoryPolicy = memoryPolicy
       ? { ...memoryPolicy }
       : { ...DEFAULT_MEMORY_POLICY };


### PR DESCRIPTION
## Summary
- Surface action responses (e.g. from app interaction hooks) were being persisted to the DB but never reaching the client's SSE stream in real-time — they only appeared after app restart
- Root cause: `handleSurfaceAction` used `ctx.sendToClient(msg)` as its `onEvent` callback, but `sendToClient` is reset to `() => {}` after each HTTP request completes. Normal messages use `makeHubPublisher` which publishes to `assistantEventHub`, but surface actions bypassed this
- Fix: store `broadcastToAllClients` on the Conversation instance, expose it via `SurfaceConversationContext`, and use it as the event emitter in both surface action code paths (history-restored and active surfaces)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
