### PR TITLE
fix: remove index signature causing TS2345 in surface-action-routes

### DIFF
--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -28,7 +28,6 @@ interface SurfaceActionTarget {
   setTrustContext?(ctx: {
     trustClass: "guardian" | "trusted_contact" | "unknown";
     sourceChannel: string;
-    [key: string]: unknown;
   }): void;
   trustContext?: { trustClass: string } | null;
 }


### PR DESCRIPTION
## Summary
- Removed `[key: string]: unknown` index signature from the `setTrustContext` parameter type in the `SurfaceActionTarget` interface
- The `TrustContext` interface (returned by `withSourceChannel`) doesn't have an index signature, making it incompatible with the inline type — this caused a TS2345 error in CI

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23297140658/job/67747509518
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
