### PR TITLE
Revert masked key carry-over fixes (#19206, #19245, #19251, #19273)

### DIFF
--- a/assistant/src/daemon/handlers/config-model.ts
+++ b/assistant/src/daemon/handlers/config-model.ts
@@ -16,7 +16,6 @@ import {
   isProviderAvailable,
 } from "../../providers/provider-availability.js";
 import { initializeProviders } from "../../providers/registry.js";
-import { getMaskedProviderKey } from "../../security/secure-keys.js";
 import type {
   ImageGenModelSetRequest,
   ModelSetRequest,
@@ -44,7 +43,6 @@ export interface ModelInfo {
   configuredProviders?: string[];
   availableModels?: Array<{ id: string; displayName: string }>;
   allProviders?: ProviderCatalogEntry[];
-  maskedKeys?: Record<string, string>;
 }
 
 /** Return current model configuration. */
@@ -52,19 +50,12 @@ export async function getModelInfo(): Promise<ModelInfo> {
   const config = getConfig();
   const provider = config.services.inference.provider;
 
-  const maskedKeys: Record<string, string> = {};
-  for (const p of VALID_INFERENCE_PROVIDERS) {
-    const masked = await getMaskedProviderKey(p);
-    if (masked) maskedKeys[p] = masked;
-  }
-
   return {
     model: config.services.inference.model,
     provider,
     configuredProviders: await getConfiguredProviders(),
     availableModels: PROVIDER_CATALOG.find((p) => p.id === provider)?.models,
     allProviders: PROVIDER_CATALOG,
-    maskedKeys,
   };
 }
 

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -258,7 +258,6 @@ export interface ModelInfo {
     apiKeyUrl?: string;
     apiKeyPlaceholder?: string;
   }>;
-  maskedKeys?: Record<string, string>;
 }
 
 export interface HistoryResponseToolCall {

--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -81,10 +81,7 @@ final class VellumCli {
     /// Environment variable keys forwarded from the host process to CLI
     /// child processes. Centralised so every call site stays in sync.
     nonisolated private static let forwardedEnvKeys: [String] = [
-        // Inference provider API keys
-        "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY",
-        "FIREWORKS_API_KEY", "OPENROUTER_API_KEY",
-        "BASE_DATA_DIR",
+        "ANTHROPIC_API_KEY", "BASE_DATA_DIR",
         "VELLUM_PLATFORM_URL", "RUNTIME_HTTP_PORT",
         "SENTRY_DSN", "TMPDIR", "USER", "LANG",
         // Cloud provider auth — needed by hatch and retire flows.
@@ -343,16 +340,6 @@ final class VellumCli {
 
     // MARK: - Remote Hatch (pass-through to CLI)
 
-    /// Maps inference provider IDs to the environment variable name
-    /// the daemon expects for that provider's API key.
-    nonisolated private static let providerEnvVars: [String: String] = [
-        "anthropic": "ANTHROPIC_API_KEY",
-        "openai": "OPENAI_API_KEY",
-        "gemini": "GEMINI_API_KEY",
-        "fireworks": "FIREWORKS_API_KEY",
-        "openrouter": "OPENROUTER_API_KEY",
-    ]
-
     struct RemoteHatchConfig {
         let remote: String
         var gcpProjectId: String = ""
@@ -362,10 +349,7 @@ final class VellumCli {
         var sshHost: String = ""
         var sshUser: String = ""
         var sshPrivateKey: String = ""
-        /// The inference provider selected during onboarding (e.g. "anthropic", "openai").
-        var inferenceProvider: String = "anthropic"
-        /// The API key for the selected inference provider.
-        var inferenceApiKey: String = ""
+        var anthropicApiKey: String = ""
     }
 
     func runRemoteHatch(
@@ -415,9 +399,8 @@ final class VellumCli {
             #endif
         }
 
-        if !config.inferenceApiKey.isEmpty {
-            let envVar = Self.providerEnvVars[config.inferenceProvider] ?? "ANTHROPIC_API_KEY"
-            env[envVar] = config.inferenceApiKey
+        if !config.anthropicApiKey.isEmpty {
+            env["ANTHROPIC_API_KEY"] = config.anthropicApiKey
         }
 
         if config.remote == "gcp" {
@@ -711,15 +694,13 @@ final class VellumCli {
                    let port = fullEnv["RUNTIME_HTTP_PORT"] ?? getenv("RUNTIME_HTTP_PORT").flatMap({ String(cString: $0) }) {
                     env["RUNTIME_HTTP_PORT"] = port
                 }
-                // Fall back to credential storage for provider API keys
-                // when they're not in the process environment (e.g. app launched
-                // from Finder, not a terminal with API key env vars set).
-                for (provider, envVar) in VellumCli.providerEnvVars {
-                    if env[envVar] == nil,
-                       let storedKey = APIKeyManager.getKey(for: provider),
-                       !storedKey.isEmpty {
-                        env[envVar] = storedKey
-                    }
+                // Fall back to credential storage for the Anthropic API key
+                // when it's not in the process environment (e.g. app launched
+                // from Finder, not a terminal with ANTHROPIC_API_KEY set).
+                if env["ANTHROPIC_API_KEY"] == nil,
+                   let storedKey = APIKeyManager.getKey(for: "anthropic"),
+                   !storedKey.isEmpty {
+                    env["ANTHROPIC_API_KEY"] = storedKey
                 }
                 proc.environment = env
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -165,8 +165,6 @@ struct APIKeyEntryStepView: View {
                 state.selectedModel = entry.defaultModel
             }
             apiKey = ""
-            hasExistingKey = false
-            isEditing = false
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -264,8 +264,7 @@ struct HatchingStepView: View {
     private static let dockerReadySentinel = "Docker containers are up and running"
 
     private func startRemoteHatch() {
-        let provider = state.selectedProvider.isEmpty ? "anthropic" : state.selectedProvider
-        let apiKey = APIKeyManager.getKey(for: provider) ?? ""
+        let apiKey = APIKeyManager.getKey(for: "anthropic") ?? ""
 
         let config = VellumCli.RemoteHatchConfig(
             remote: state.cloudProvider,
@@ -276,8 +275,7 @@ struct HatchingStepView: View {
             sshHost: state.sshHost,
             sshUser: state.sshUser,
             sshPrivateKey: state.sshPrivateKey,
-            inferenceProvider: provider,
-            inferenceApiKey: apiKey
+            anthropicApiKey: apiKey
         )
 
         Task {

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -329,7 +329,6 @@ struct InferenceServiceCard: View {
                 .font(VFont.inputLabel)
                 .foregroundColor(VColor.contentSecondary)
             SecureField(placeholder, text: $apiKeyText)
-                .id("inference-api-key-\(effectiveProvider)-\(placeholder)")
                 .vInputStyle()
                 .font(VFont.body)
                 .foregroundColor(VColor.contentDefault)

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -57,11 +57,7 @@ struct InferenceServiceCard: View {
     // MARK: - Computed State
 
     private var isConnected: Bool {
-        let daemonHasMaskedKey = !(store.providerMaskedKeys[effectiveProvider] ?? "").isEmpty
-        if isCustomProviderEnabled {
-            return store.hasKeyForProvider(effectiveProvider) || daemonHasMaskedKey
-        }
-        return store.hasKey || daemonHasMaskedKey
+        isCustomProviderEnabled ? store.hasKeyForProvider(effectiveProvider) : store.hasKey
     }
 
     private var isLoggedIn: Bool {
@@ -303,15 +299,8 @@ struct InferenceServiceCard: View {
 
     private var apiKeyField: some View {
         let currentMask: String = {
-            // Prefer daemon-reported masks when available (authoritative for
-            // remote/managed contexts), but fall back to local keychain masks
-            // so onboarding-written keys render immediately before daemon sync.
-            if let daemonMask = store.providerMaskedKeys[effectiveProvider], !daemonMask.isEmpty {
-                return daemonMask
-            }
-            let localMask = store.maskedKeyForProvider(effectiveProvider)
-            if !localMask.isEmpty {
-                return localMask
+            if isConnected, let masked = store.providerMaskedKeys[effectiveProvider], !masked.isEmpty {
+                return masked
             }
             return ""
         }()

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -298,15 +298,9 @@ struct InferenceServiceCard: View {
     // MARK: - API Key Field
 
     private var apiKeyField: some View {
-        let currentMask: String = {
-            if isConnected, let masked = store.providerMaskedKeys[effectiveProvider], !masked.isEmpty {
-                return masked
-            }
-            return ""
-        }()
         let placeholder: String = {
-            if !currentMask.isEmpty {
-                return currentMask
+            if isConnected {
+                return "••••••••••••••••"
             }
             if let providerPlaceholder = store.dynamicProviderApiKeyPlaceholder(effectiveProvider), !providerPlaceholder.isEmpty {
                 return providerPlaceholder

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -63,8 +63,6 @@ public final class SettingsStore: ObservableObject {
 
     /// Full provider catalog from daemon. Seeded with inline defaults for pre-fetch rendering.
     @Published var providerCatalog: [ProviderCatalogEntry] = []
-    /// Masked API keys per provider from daemon (e.g. "sk-ant-api...Ab1x").
-    @Published var providerMaskedKeys: [String: String] = [:]
 
     static let availableImageGenModels: [String] = [
         "gemini-3.1-flash-image-preview",
@@ -972,9 +970,6 @@ public final class SettingsStore: ObservableObject {
         }
         if let allProviders = response.allProviders, !allProviders.isEmpty {
             self.providerCatalog = allProviders
-        }
-        if let maskedKeys = response.maskedKeys {
-            self.providerMaskedKeys = maskedKeys
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -316,7 +316,6 @@ public final class SettingsStore: ObservableObject {
     /// that would otherwise reinitialize providers and evict idle conversations.
     private var lastDaemonModel: String?
     private var lastDaemonProvider: String?
-    private var lastDaemonMaskedKeys: [String: String] = [:]
     private var pendingVerificationSessionChannel: String?
     private var verificationSessionTimeoutWorkItem: DispatchWorkItem?
     private var verificationStatusPollingWorkItems: [String: DispatchWorkItem] = [:]
@@ -901,7 +900,6 @@ public final class SettingsStore: ObservableObject {
         hasElevenLabsKey = elevenLabsKey != nil
         maskedElevenLabsKey = Self.maskKey(elevenLabsKey)
 
-        applyLocalMaskedKeyFallback()
     }
 
     func hasKeyForProvider(_ provider: String) -> Bool {
@@ -910,28 +908,6 @@ public final class SettingsStore: ObservableObject {
 
     func maskedKeyForProvider(_ provider: String) -> String {
         Self.maskKey(APIKeyManager.getKey(for: provider))
-    }
-
-    /// Backfills daemon-masked keys with local keychain/file-storage masks
-    /// when the daemon has not reported a value yet.
-    private func applyLocalMaskedKeyFallback() {
-        var merged = lastDaemonMaskedKeys
-        for provider in APIKeyManager.allSyncableProviders {
-            if let existing = merged[provider], !existing.isEmpty {
-                continue
-            }
-            let localMask = maskedKeyForProvider(provider)
-            if !localMask.isEmpty {
-                merged[provider] = localMask
-            }
-        }
-        let elevenLabsMask = maskedKeyForProvider("elevenlabs")
-        if (merged["elevenlabs"] ?? "").isEmpty, !elevenLabsMask.isEmpty {
-            merged["elevenlabs"] = elevenLabsMask
-        }
-        if merged != providerMaskedKeys {
-            providerMaskedKeys = merged
-        }
     }
 
     /// Shows the first 10 and last 4 characters of a key, e.g. "sk-ant-api...Ab1x".
@@ -998,9 +974,8 @@ public final class SettingsStore: ObservableObject {
             self.providerCatalog = allProviders
         }
         if let maskedKeys = response.maskedKeys {
-            self.lastDaemonMaskedKeys = maskedKeys
+            self.providerMaskedKeys = maskedKeys
         }
-        applyLocalMaskedKeyFallback()
     }
 
     // MARK: - Dynamic Provider Catalog Helpers
@@ -1137,15 +1112,6 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    /// Awaitable variant used by reconnect sync so follow-up refreshes happen
-    /// only after the daemon has accepted key updates.
-    private func syncKeyToDaemonAwaiting(provider: String, value: String) async {
-        guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") else { return }
-        let body: [String: String] = ["type": "api_key", "name": provider, "value": value]
-        guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else { return }
-        _ = try? await GatewayHTTPClient.post(path: "assistants/\(assistantId)/secrets", body: bodyData)
-    }
-
     /// Sync an API key to the daemon with server-side validation.
     /// Returns a result indicating success or a validation error message.
     private func syncKeyToDaemonWithValidation(provider: String, value: String) async -> (success: Bool, error: String?, isTransient: Bool) {
@@ -1251,15 +1217,6 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    /// Awaitable variant used by reconnect sync so model refresh happens after
-    /// credential updates land in daemon state.
-    private func syncCredentialToDaemonAwaiting(name: String, value: String) async {
-        guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") else { return }
-        let body: [String: String] = ["type": "credential", "name": name, "value": value]
-        guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else { return }
-        _ = try? await GatewayHTTPClient.post(path: "assistants/\(assistantId)/secrets", body: bodyData)
-    }
-
     /// Notify the daemon that a credential was deleted.
     /// Returns true if the HTTP endpoint was available and the request was dispatched.
     @discardableResult
@@ -1292,28 +1249,20 @@ public final class SettingsStore: ObservableObject {
 
             for provider in APIKeyManager.allSyncableProviders {
                 if let key = APIKeyManager.getKey(for: provider) {
-                    await syncKeyToDaemonAwaiting(provider: provider, value: key)
+                    syncKeyToDaemon(provider: provider, value: key)
                 }
             }
 
             // ElevenLabs uses the credential type, not api_key
             if let key = APIKeyManager.getKey(for: "elevenlabs") {
-                await syncCredentialToDaemonAwaiting(name: "elevenlabs:api_key", value: key)
+                syncCredentialToDaemon(name: "elevenlabs:api_key", value: key)
             }
 
             replayDeletionTombstones()
             // Re-fetch model info after reconnect-time key replay so maskedKeys
-            // reflect newly synced provider secrets.
+            // can reflect newly synced provider secrets.
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
             refreshModelInfo()
-            // Some runtime environments can lag slightly after POST /secrets.
-            // Follow up once more to converge UI state without requiring user
-            // interaction.
-            Task { [weak self] in
-                try? await Task.sleep(nanoseconds: 1_000_000_000)
-                await MainActor.run {
-                    self?.refreshModelInfo()
-                }
-            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1259,10 +1259,6 @@ public final class SettingsStore: ObservableObject {
             }
 
             replayDeletionTombstones()
-            // Re-fetch model info after reconnect-time key replay so maskedKeys
-            // can reflect newly synced provider secrets.
-            try? await Task.sleep(nanoseconds: 1_000_000_000)
-            refreshModelInfo()
         }
     }
 
@@ -2158,18 +2154,14 @@ public final class SettingsStore: ObservableObject {
         guard let services = config["services"] as? [String: Any] else { return }
         if let inference = services["inference"] as? [String: Any] {
             if let mode = inference["mode"] as? String { self.inferenceMode = mode }
-            // Local assistants should always reflect persisted workspace config.
-            // Remote assistants may not have local workspace state, so retain
-            // daemon-reported provider/model once available.
-            if !isCurrentAssistantRemote {
-                if let provider = inference["provider"] as? String { self.selectedInferenceProvider = provider }
-                if let model = inference["model"] as? String { self.selectedModel = model }
-            } else {
-                if lastDaemonProvider == nil,
-                   let provider = inference["provider"] as? String { self.selectedInferenceProvider = provider }
-                if lastDaemonProvider == nil,
-                   let model = inference["model"] as? String { self.selectedModel = model }
-            }
+            // Only apply local config provider/model as a fallback when the daemon
+            // hasn't yet reported an authoritative value. Once the daemon responds
+            // via applyModelInfoResponse, its values take precedence over local
+            // config which may be stale (especially for remote assistants).
+            if lastDaemonProvider == nil,
+               let provider = inference["provider"] as? String { self.selectedInferenceProvider = provider }
+            if lastDaemonProvider == nil,
+               let model = inference["model"] as? String { self.selectedModel = model }
         }
         if let imageGen = services["image-generation"] as? [String: Any] {
             if let mode = imageGen["mode"] as? String {

--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -81,8 +81,6 @@ public final class ChatMessageManager: ObservableObject {
     /// Full provider catalog from daemon, updated via `model_info` messages.
     /// Seeded with inline defaults so the UI has data before the first daemon fetch completes.
     @Published public var providerCatalog: [ProviderCatalogEntry] = ProviderCatalogEntry.defaultCatalog
-    /// Masked API keys per provider from daemon (e.g. "sk-ant-api...Ab1x"), updated via `model_info` messages.
-    @Published public var providerMaskedKeys: [String: String] = [:]
 
 }
 

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1991,9 +1991,6 @@ extension ChatViewModel {
             if let allProviders = msg.allProviders, !allProviders.isEmpty {
                 providerCatalog = allProviders
             }
-            if let maskedKeys = msg.maskedKeys {
-                providerMaskedKeys = maskedKeys
-            }
 
         case .memoryStatus(let status):
             // Log degradation state so developers can diagnose memory issues

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -309,11 +309,6 @@ public final class ChatViewModel: ObservableObject {
         get { messageManager.providerCatalog }
         set { messageManager.providerCatalog = newValue }
     }
-    /// Masked API keys per provider from daemon (e.g. "sk-ant-api...Ab1x"), updated via `model_info` messages.
-    public var providerMaskedKeys: [String: String] {
-        get { messageManager.providerMaskedKeys }
-        set { messageManager.providerMaskedKeys = newValue }
-    }
 
     // MARK: - Forwarding properties — ChatAttachmentManager
 
@@ -1206,9 +1201,6 @@ public final class ChatViewModel: ObservableObject {
                 if let allProviders = info?.allProviders, !allProviders.isEmpty {
                     self.providerCatalog = allProviders
                 }
-                if let maskedKeys = info?.maskedKeys {
-                    self.providerMaskedKeys = maskedKeys
-                }
             }
         }
 
@@ -1782,9 +1774,6 @@ public final class ChatViewModel: ObservableObject {
             }
             if let allProviders = info?.allProviders, !allProviders.isEmpty {
                 self.providerCatalog = allProviders
-            }
-            if let maskedKeys = info?.maskedKeys {
-                self.providerMaskedKeys = maskedKeys
             }
         }
     }
@@ -3048,9 +3037,6 @@ public final class ChatViewModel: ObservableObject {
             }
             if let allProviders = info?.allProviders, !allProviders.isEmpty {
                 self.providerCatalog = allProviders
-            }
-            if let maskedKeys = info?.maskedKeys {
-                self.providerMaskedKeys = maskedKeys
             }
         }
     }

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -2700,16 +2700,14 @@ public struct ModelInfo: Codable, Sendable {
     public let configuredProviders: [String]?
     public let availableModels: [CatalogModel]?
     public let allProviders: [ProviderCatalogEntry]?
-    public let maskedKeys: [String: String]?
 
-    public init(type: String, model: String, provider: String, configuredProviders: [String]? = nil, availableModels: [CatalogModel]? = nil, allProviders: [ProviderCatalogEntry]? = nil, maskedKeys: [String: String]? = nil) {
+    public init(type: String, model: String, provider: String, configuredProviders: [String]? = nil, availableModels: [CatalogModel]? = nil, allProviders: [ProviderCatalogEntry]? = nil) {
         self.type = type
         self.model = model
         self.provider = provider
         self.configuredProviders = configuredProviders
         self.availableModels = availableModels
         self.allProviders = allProviders
-        self.maskedKeys = maskedKeys
     }
 }
 


### PR DESCRIPTION
## Summary
- Reverts 4 PRs that attempted to fix the bug where the LLM provider API key entered during onboarding is not carried over and displayed as a masked value on the Inference card's "Your Own" section in Settings
- None of these fixes resolved the issue, so reverting to simplify before taking a fresh approach

### Reverted PRs:
- #19206 — fall back to local keychain mask in Inference card, include daemon masks in isConnected
- #19245 — local assistants always use workspace config for provider/model, refresh masked keys after key replay
- #19251 — route provider-specific API keys through onboarding hatch flow
- #19273 — restore inference masked key hydration on reconnect

## Test plan
- [ ] Verify onboarding flow still works (API key entry, hatching)
- [ ] Verify Inference card still displays correctly in Settings
- [ ] Confirm no regressions in API key management

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
