### PR TITLE
fix: strip <no_response/> from conversation history API

### DIFF
--- a/assistant/src/__tests__/list-messages-attachments.test.ts
+++ b/assistant/src/__tests__/list-messages-attachments.test.ts
@@ -190,3 +190,47 @@ describe("handleListMessages attachments", () => {
     expect(docAtt!.data).toBeUndefined();
   });
 });
+
+describe("handleListMessages no_response filtering", () => {
+  beforeEach(resetTables);
+
+  test("strips <no_response/> from assistant message content", async () => {
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([{ type: "text", text: "<no_response/>" }]),
+    );
+
+    const response = handleListMessages(createTestUrl(conv.id), null);
+    const body = (await response.json()) as {
+      messages: { content: string; textSegments: string[] }[];
+    };
+
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].content).toBe("");
+    // textSegments is omitted from payload when empty
+    expect(body.messages[0].textSegments).toBeUndefined();
+  });
+
+  test("strips <no_response/> but keeps other text segments", async () => {
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([
+        { type: "text", text: "<no_response/>" },
+        { type: "text", text: "Real reply." },
+      ]),
+    );
+
+    const response = handleListMessages(createTestUrl(conv.id), null);
+    const body = (await response.json()) as {
+      messages: { content: string; textSegments: string[] }[];
+    };
+
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].content).toBe("Real reply.");
+    expect(body.messages[0].textSegments).toEqual(["Real reply."]);
+  });
+});

--- a/assistant/src/__tests__/list-messages-attachments.test.ts
+++ b/assistant/src/__tests__/list-messages-attachments.test.ts
@@ -233,4 +233,56 @@ describe("handleListMessages no_response filtering", () => {
     expect(body.messages[0].content).toBe("Real reply.");
     expect(body.messages[0].textSegments).toEqual(["Real reply."]);
   });
+
+  test("remaps contentOrder when <no_response/> segment is removed", async () => {
+    const conv = createConversation();
+    // Simulate: text("<no_response/>") -> tool_use -> tool_result -> text("Answer")
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([
+        { type: "text", text: "<no_response/>" },
+        {
+          type: "tool_use",
+          id: "tu1",
+          name: "search",
+          input: { q: "test" },
+        },
+        { type: "tool_result", tool_use_id: "tu1", content: "result" },
+        { type: "text", text: "Answer" },
+      ]),
+    );
+
+    const response = handleListMessages(createTestUrl(conv.id), null);
+    const body = (await response.json()) as {
+      messages: {
+        content: string;
+        textSegments: string[];
+        contentOrder: string[];
+      }[];
+    };
+
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].textSegments).toEqual(["Answer"]);
+    // text:0 (no_response) should be removed, text:1 remapped to text:0
+    expect(body.messages[0].contentOrder).toContain("text:0");
+    expect(body.messages[0].contentOrder).not.toContain("text:1");
+  });
+
+  test("does not strip <no_response/> from user messages", async () => {
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "What does <no_response/> do?" }]),
+    );
+
+    const response = handleListMessages(createTestUrl(conv.id), null);
+    const body = (await response.json()) as {
+      messages: { content: string }[];
+    };
+
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].content).toBe("What does <no_response/> do?");
+  });
 });

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -81,6 +81,9 @@ import {
 
 const log = getLogger("conversation-routes");
 
+/** Matches the `<no_response/>` sentinel used by channel delivery suppression. */
+const NO_RESPONSE_INLINE_RE = /<no_response\s*\/?>/g;
+
 const SUGGESTION_CACHE_MAX = 100;
 
 function collectCanonicalGuardianRequestHintIds(
@@ -363,13 +366,21 @@ export function handleListMessages(
       content = msg.content;
     }
     const rendered = renderHistoryContent(content);
+    // Strip <no_response/> markers so web/API clients never see the raw
+    // sentinel that the delivery layer uses to suppress channel output.
+    const filteredSegments = rendered.textSegments
+      ?.map((s) => s.replace(NO_RESPONSE_INLINE_RE, "").trim())
+      .filter((s) => s.length > 0);
+    const filteredText = rendered.text
+      .replace(NO_RESPONSE_INLINE_RE, "")
+      .trim();
     return {
       role: msg.role,
-      text: rendered.text,
+      text: filteredText,
       timestamp: msg.createdAt,
       toolCalls: rendered.toolCalls,
       toolCallsBeforeText: rendered.toolCallsBeforeText,
-      textSegments: rendered.textSegments,
+      textSegments: filteredSegments,
       contentOrder: rendered.contentOrder,
       surfaces: rendered.surfaces,
       id: msg.id,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -366,21 +366,55 @@ export function handleListMessages(
       content = msg.content;
     }
     const rendered = renderHistoryContent(content);
-    // Strip <no_response/> markers so web/API clients never see the raw
-    // sentinel that the delivery layer uses to suppress channel output.
-    const filteredSegments = rendered.textSegments
-      ?.map((s) => s.replace(NO_RESPONSE_INLINE_RE, "").trim())
-      .filter((s) => s.length > 0);
-    const filteredText = rendered.text
-      .replace(NO_RESPONSE_INLINE_RE, "")
-      .trim();
+
+    // Strip <no_response/> markers from assistant messages so web/API
+    // clients never see the raw sentinel. Only assistant messages produce
+    // this marker; user messages are left untouched.
+    if (msg.role === "assistant") {
+      const originalSegments = rendered.textSegments;
+      const keepIndices: number[] = [];
+      const filteredSegments: string[] = [];
+      for (let i = 0; i < originalSegments.length; i++) {
+        const cleaned = originalSegments[i]
+          .replace(NO_RESPONSE_INLINE_RE, "")
+          .trim();
+        if (cleaned.length > 0) {
+          keepIndices.push(i);
+          filteredSegments.push(cleaned);
+        }
+      }
+      // Remap contentOrder text:N indices to account for removed segments
+      const indexMap = new Map<number, number>();
+      keepIndices.forEach((oldIdx, newIdx) => indexMap.set(oldIdx, newIdx));
+      const filteredContentOrder = rendered.contentOrder
+        .map((entry) => {
+          const m = entry.match(/^text:(\d+)$/);
+          if (!m) return entry;
+          const newIdx = indexMap.get(Number(m[1]));
+          return newIdx !== undefined ? `text:${newIdx}` : undefined;
+        })
+        .filter((e): e is string => e !== undefined);
+
+      return {
+        role: msg.role,
+        text: rendered.text.replace(NO_RESPONSE_INLINE_RE, "").trim(),
+        timestamp: msg.createdAt,
+        toolCalls: rendered.toolCalls,
+        toolCallsBeforeText: rendered.toolCallsBeforeText,
+        textSegments: filteredSegments,
+        contentOrder: filteredContentOrder,
+        surfaces: rendered.surfaces,
+        id: msg.id,
+      };
+    }
+
     return {
       role: msg.role,
-      text: filteredText,
+      text: rendered.text,
       timestamp: msg.createdAt,
       toolCalls: rendered.toolCalls,
       toolCallsBeforeText: rendered.toolCallsBeforeText,
-      textSegments: filteredSegments,
+      textSegments: rendered.textSegments,
       contentOrder: rendered.contentOrder,
       surfaces: rendered.surfaces,
       id: msg.id,


### PR DESCRIPTION
## Summary
- Strips `<no_response/>` markers from conversation history API responses so web/desktop clients never see the raw sentinel tag
- Addresses [review feedback from #18822](https://github.com/vellum-ai/vellum-assistant/pull/18822#discussion) where Devin flagged that the marker was only filtered at the channel delivery layer but still visible via the conversation history API

## Changes
- `conversation-routes.ts`: Added `NO_RESPONSE_INLINE_RE` regex to strip `<no_response/>` from both `text` and `textSegments` in `handleListMessages`
- `list-messages-attachments.test.ts`: Added 2 tests covering no_response-only messages and mixed content

## Test plan
- [x] Existing `list-messages-attachments` tests pass (6/6)
- [x] Existing `channel-reply-delivery` tests pass (15/15)
- [x] New test: `<no_response/>`-only assistant message returns empty content
- [x] New test: mixed `<no_response/>` + real text returns only real text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
