### PR TITLE
fix: set contextCompactedMessageCount for missed supersession test conversations

### DIFF
--- a/assistant/src/__tests__/memory-recall-quality.test.ts
+++ b/assistant/src/__tests__/memory-recall-quality.test.ts
@@ -517,7 +517,7 @@ describe("Memory Recall Quality", () => {
     test("superseded memory items do not appear in recall via recency", async () => {
       const db = getDb();
       const now = 1_700_000_200_000;
-      insertConversation(db, "conv-contra", now);
+      insertConversation(db, "conv-contra", now, 1);
 
       // New preference (active, supersedes the old one)
       insertMessage(
@@ -574,7 +574,7 @@ describe("Memory Recall Quality", () => {
     test("only active items are included in recall (superseded excluded)", async () => {
       const db = getDb();
       const now = 1_700_000_250_000;
-      insertConversation(db, "conv-entity-status", now);
+      insertConversation(db, "conv-entity-status", now, 1);
 
       insertMessage(
         db,


### PR DESCRIPTION
## Summary
- Set `contextCompactedMessageCount` to `1` for two `insertConversation` calls in supersession tests that were missed in PR #19403
- Without this, those tests pass vacuously because all messages are considered in-context and filtered out before supersession logic runs

Addresses review feedback from PR #19403

## Test plan
- [x] Verify the two `insertConversation` calls now pass `contextCompactedMessageCount=1`
- [x] Matches the pattern applied to all other test cases in #19403


🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
