### PR TITLE
fix: guard completeSession from clobbering newer pin sessions

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBottomPinCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBottomPinCoordinator.swift
@@ -121,6 +121,10 @@ final class ChatBottomPinCoordinator {
     /// The in-flight async task driving the active session's retry loop.
     private var sessionTask: Task<Void, Never>?
 
+    /// Monotonically increasing generation counter. Incremented each time a new
+    /// session task is started so that stale tasks don't clobber newer sessions.
+    private var sessionGeneration: Int = 0
+
     /// Callback invoked when the coordinator decides a scroll-to-bottom should
     /// be executed. The caller (typically MessageListView) performs the actual
     /// `proxy.scrollTo` call. The Bool return indicates whether the pin was
@@ -243,6 +247,8 @@ final class ChatBottomPinCoordinator {
 
     private func startSessionTask(animated: Bool) {
         sessionTask?.cancel()
+        sessionGeneration += 1
+        let generation = sessionGeneration
 
         // Immediate first attempt — synchronous so callers see the result
         // before yielding (important for tests and single-frame UI updates).
@@ -252,7 +258,7 @@ final class ChatBottomPinCoordinator {
         let pinned = onPinRequested?(session.reason, animated) ?? false
 
         if pinned {
-            completeSession()
+            completeSession(generation: generation)
             return
         }
 
@@ -260,6 +266,7 @@ final class ChatBottomPinCoordinator {
         sessionTask = Task { @MainActor [weak self] in
             while !Task.isCancelled {
                 guard let self else { break }
+                guard self.sessionGeneration == generation else { break }
                 guard var currentSession = self.activeSession else { break }
                 guard !currentSession.isExhausted else {
                     log.debug("Pin session exhausted after \(currentSession.attemptCount) attempts")
@@ -291,17 +298,18 @@ final class ChatBottomPinCoordinator {
                 let succeeded = self.onPinRequested?(currentSession.reason, animated) ?? false
 
                 if succeeded {
-                    self.completeSession()
+                    self.completeSession(generation: generation)
                     return
                 }
             }
 
             // Clean up if we fell through without completing.
-            self?.completeSession()
+            self?.completeSession(generation: generation)
         }
     }
 
-    private func completeSession() {
+    private func completeSession(generation: Int) {
+        guard sessionGeneration == generation else { return }
         sessionTask = nil
         activeSession = nil
     }


### PR DESCRIPTION
## Summary
- Add `sessionGeneration` counter to `ChatBottomPinCoordinator` that increments each time `startSessionTask` is called
- `completeSession(generation:)` now checks the generation matches before nil-ing `sessionTask`/`activeSession`
- The retry loop also checks generation at each iteration, breaking early if a newer session has started

Fixes the race where a cancelled task's continuation resumes after a new session is set up and clobbers it.

Addresses review feedback from #19441

## Test plan
- [ ] Verify rapid `requestPin` calls with different reasons don't drop the newest session
- [ ] Verify normal pin-and-complete flow still works (generation matches)
- [ ] Verify exhausted/timed-out sessions still clean up when generation matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
