### PR TITLE
fix: remove manual percent-encoding in ConversationDetailClient

### DIFF
--- a/clients/shared/Network/ConversationDetailClient.swift
+++ b/clients/shared/Network/ConversationDetailClient.swift
@@ -16,9 +16,8 @@ public struct ConversationDetailClient: ConversationDetailClientProtocol {
 
     public func fetchConversation(conversationId: String) async -> ConversationListResponseItem? {
         do {
-            let encodedConversationId = conversationId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? conversationId
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/conversations/\(encodedConversationId)",
+                path: "assistants/{assistantId}/conversations/\(conversationId)",
                 timeout: 15
             )
             guard response.isSuccess else {


### PR DESCRIPTION
## Summary
- Removes manual `addingPercentEncoding` call on `conversationId` in `ConversationDetailClient.fetchConversation()`
- `GatewayHTTPClient.constructURL()` already percent-encodes the full path, so pre-encoding causes double-encoding (e.g. `%2F` → `%252F`) resulting in 404s for conversation IDs with reserved characters
- Addresses review feedback from PR #19304

## Test plan
- [ ] Verify conversation detail lookups work for IDs with reserved characters
- [ ] Verify normal conversation ID lookups continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
