### PR TITLE
fix: route form ui_surface_complete through broadcastToAllClients

### DIFF
--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -774,11 +774,16 @@ export function handleSurfaceAction(
     surfaceData,
   );
 
+  // Use broadcastToAllClients so events reach the SSE hub — sendToClient is
+  // reset to a no-op between HTTP requests (see history-restored path for
+  // full rationale).
+  const emit = ctx.broadcastToAllClients ?? ctx.sendToClient.bind(ctx);
+
   // Forms are one-shot surfaces — auto-complete immediately so the client
   // transitions from the "Submitting…" spinner to a completion chip without
   // requiring the LLM to call ui_dismiss.
   if (pending.surfaceType === "form") {
-    ctx.sendToClient({
+    emit({
       type: "ui_surface_complete",
       conversationId: ctx.conversationId,
       surfaceId,
@@ -839,9 +844,6 @@ export function handleSurfaceAction(
 
   const requestId = uuid();
   ctx.surfaceActionRequestIds.add(requestId);
-  // Use broadcastToAllClients so events reach the SSE hub (see history-restored
-  // path above for rationale).
-  const emit = ctx.broadcastToAllClients ?? ctx.sendToClient.bind(ctx);
   const onEvent = (msg: ServerMessage) => emit(msg);
 
   ctx.traceEmitter.emit("request_received", "Surface action received", {


### PR DESCRIPTION
## Summary
- Fixes a bug where form `ui_surface_complete` messages were sent via `ctx.sendToClient` instead of `broadcastToAllClients`, causing the client to get stuck on the "Submitting…" spinner when `sendToClient` is a no-op
- Moved the `emit` variable definition (which prefers `broadcastToAllClients`) before the form auto-complete block so it's used consistently for all event emission in `handleSurfaceAction`

## Test plan
- [ ] Verify form surface actions emit `ui_surface_complete` to the SSE stream
- [ ] Verify non-form surface actions continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
