### PR TITLE
fix: use quiet-window semantics for scroll loop guard cooldown re-arm

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatScrollLoopGuard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatScrollLoopGuard.swift
@@ -66,6 +66,9 @@ final class ChatScrollLoopGuard {
         /// Timestamp when the guard last tripped (nil if never tripped or reset).
         var lastTripTime: TimeInterval?
 
+        /// Timestamp of the most recent event of any kind (for quiet-window detection).
+        var lastEventTime: TimeInterval?
+
         /// Whether the guard is currently in cooldown (suppressing warnings).
         var inCooldown: Bool = false
     }
@@ -99,13 +102,15 @@ final class ChatScrollLoopGuard {
         // Append the new event.
         state.events[kind, default: []].append(timestamp)
 
-        // Check if cooldown has expired (quiet window elapsed).
-        if state.inCooldown, let lastTrip = state.lastTripTime {
-            // Re-arm if cooldown duration has passed.
-            if timestamp - lastTrip >= Self.cooldownDuration {
+        // Re-arm cooldown only after a full quiet window with no events.
+        if state.inCooldown, let lastEvent = state.lastEventTime {
+            if timestamp - lastEvent >= Self.cooldownDuration {
                 state.inCooldown = false
             }
         }
+
+        // Track the latest event time (must come after the cooldown check).
+        state.lastEventTime = timestamp
 
         // Check thresholds.
         let anchorCount = state.events[.anchorPreferenceChange]?.count ?? 0


### PR DESCRIPTION
## Summary
- Fix cooldown re-arm logic in `ChatScrollLoopGuard` to use quiet-window semantics instead of wall-time-since-trip
- Track `lastEventTime` in `ConversationState` and only clear cooldown when no events have been received for a full `cooldownDuration`
- Prevents the guard from re-arming during sustained scroll loops, which would spam warnings every ~2s

Addresses review feedback from #19440.

## Test plan
- Existing `testGuardDoesNotRearmDuringCooldown` now correctly validates that the guard stays suppressed while events keep flowing
- `testGuardRearmsAfterQuietWindow` continues to verify that the guard re-arms after a genuine quiet period

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
