### PR TITLE
fix: use getAppDirPath() in app file-edit instructions

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -398,8 +398,8 @@ export function handleInputJsonDelta(
   event: Extract<AgentEvent, { type: "input_json_delta" }>,
 ): void {
   // Only forward input deltas for app tools — the client only uses this
-  // stream for app_create/app_update code previews. Non-app tools would
-  // send large cumulative JSON on every delta with no benefit.
+  // stream for app_create code previews. Non-app tools would send large
+  // cumulative JSON on every delta with no benefit.
   if (!APP_TOOL_NAMES.has(event.toolName)) return;
   deps.onEvent({
     type: "tool_input_delta",

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -306,7 +306,7 @@ export function injectActiveSurfaceContext(
       'PREREQUISITE: If `app_refresh` is not yet available, call `skill_load` with `id: "app-builder"` first to load it.',
       "",
       "RULES FOR WORKSPACE MODIFICATION:",
-      `1. Use \`file_edit\` to make surgical changes to app files. The file path is \`~/.vellum/workspace/data/apps/${slug}/<path>\`.`,
+      `1. Use \`file_edit\` to make surgical changes to app files. The file path is \`${getAppDirPath(ctx.appId)}/<path>\`.`,
       "2. Use `file_write` to create new files or rewrite files.",
       "3. Use `file_read` to read any file with line numbers before editing.",
       "4. Use `bash ls` to see all files in the app directory.",


### PR DESCRIPTION
## Summary
- Replace hardcoded `~/.vellum/workspace/data/apps/${slug}/<path>` with `getAppDirPath(ctx.appId)/<path>` in the injected workspace context prompt, fixing the Multi-Instance Path Invariant violation
- Update stale comment in `conversation-agent-loop-handlers.ts` that still referenced the removed `app_update` tool

Addresses review feedback from PR #19415 (agent loop app_refresh)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
