### PR TITLE
fix: use injected settingsClient for embedding methods in SettingsStore

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -999,7 +999,6 @@ public final class SettingsStore: ObservableObject {
 
     func refreshEmbeddingConfig() {
         Task { @MainActor in
-            let settingsClient = SettingsClient()
             guard let config = await settingsClient.fetchEmbeddingConfig() else { return }
             self.embeddingProvider = config.provider
             self.embeddingModel = config.model
@@ -1017,12 +1016,14 @@ public final class SettingsStore: ObservableObject {
 
     func setEmbeddingProvider(_ provider: String, model: String?) {
         Task { @MainActor in
-            let settingsClient = SettingsClient()
             guard let config = await settingsClient.setEmbeddingConfig(provider: provider, model: model) else { return }
             self.embeddingProvider = config.provider
             self.embeddingModel = config.model
             self.embeddingActiveProvider = config.activeProvider
             self.embeddingActiveModel = config.activeModel
+            if let providers = config.availableProviders {
+                self.embeddingAvailableProviders = providers
+            }
             if let status = config.status {
                 self.embeddingEnabled = status.enabled
                 self.embeddingDegraded = status.degraded


### PR DESCRIPTION
## Summary
- Remove local `let settingsClient = SettingsClient()` in `refreshEmbeddingConfig()` and `setEmbeddingProvider()` — use the injected `self.settingsClient` instead, matching every other method in the class
- Add `embeddingAvailableProviders` update to `setEmbeddingProvider()` for consistency with `refreshEmbeddingConfig()`

Addresses review feedback from #19390

## Test plan
- [ ] Verify embedding config refresh uses injected client (mockable in tests)
- [ ] Verify setEmbeddingProvider updates availableProviders from response

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
