### PR TITLE
fix: address PR #19348 review feedback

### DIFF
--- a/assistant/src/runtime/routes/llm-context-normalization.ts
+++ b/assistant/src/runtime/routes/llm-context-normalization.ts
@@ -86,7 +86,8 @@ export function normalizeLlmContextPayloads(
   }
 
   if (requestCandidate) {
-    return requestCandidate as LlmContextNormalizationResult;
+    const { summary, requestSections, responseSections } = requestCandidate;
+    return { summary, requestSections, responseSections };
   }
 
   if (responseCandidate) {
@@ -123,6 +124,7 @@ function normalizeOpenAiRequestPayload(
 
   const requestToolNames = extractOpenAiRequestToolNames(request.tools);
   const hasOpenAiSignal =
+    hasOpenAiModelPrefix(asString(request.model)) ||
     requestToolNames.length > 0 ||
     asString(request.tool_choice) !== undefined ||
     (request.parallel_tool_calls !== undefined &&
@@ -291,6 +293,7 @@ function normalizeAnthropicRequestPayload(
     }),
   );
   const hasAnthropicSignal =
+    hasAnthropicModelPrefix(asString(request.model)) ||
     request.system !== undefined ||
     requestToolNames.length > 0 ||
     isAnthropicToolChoice(request.tool_choice) ||
@@ -1169,6 +1172,16 @@ function normalizeCompatibleRequestPayload(
     case "gemini":
       return normalizeGeminiRequestPayload(requestPayload);
   }
+}
+
+function hasOpenAiModelPrefix(model: string | undefined): boolean {
+  if (!model) return false;
+  return /^(gpt-|chatgpt-|ft:|o[13](-|$))/.test(model);
+}
+
+function hasAnthropicModelPrefix(model: string | undefined): boolean {
+  if (!model) return false;
+  return model.startsWith("claude-");
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {


### PR DESCRIPTION
## Summary
- Strip `provider` field from single-candidate returns to prevent it leaking into the HTTP API response via spread
- Add model name prefix matching (`gpt-*`, `chatgpt-*`, `o1/o3`, `ft:`, `claude-*`) as additional provider signals in the OpenAI and Anthropic request detectors, so plain text requests (no tools) are correctly identified

Addresses review feedback from PR #19348 (LLM context normalization)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
