### PR TITLE
fix: address PR #19471 review feedback

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -208,7 +208,17 @@ export interface AgentLoopConversationContext {
   currentPage?: string;
   readonly surfaceState: Map<
     string,
-    { surfaceType: SurfaceType; data: SurfaceData; title?: string }
+    {
+      surfaceType: SurfaceType;
+      data: SurfaceData;
+      title?: string;
+      actions?: Array<{
+        id: string;
+        label: string;
+        style?: string;
+        data?: Record<string, unknown>;
+      }>;
+    }
   >;
   pendingSurfaceActions: Map<string, { surfaceType: SurfaceType }>;
   surfaceActionRequestIds: Set<string>;

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -123,7 +123,17 @@ export interface AbortContext {
   surfaceActionRequestIds: Set<string>;
   surfaceState: Map<
     string,
-    { surfaceType: SurfaceType; data: SurfaceData; title?: string }
+    {
+      surfaceType: SurfaceType;
+      data: SurfaceData;
+      title?: string;
+      actions?: Array<{
+        id: string;
+        label: string;
+        style?: string;
+        data?: Record<string, unknown>;
+      }>;
+    }
   >;
   accumulatedSurfaceState: Map<string, Record<string, unknown>>;
   readonly queue: MessageQueue;

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -196,7 +196,17 @@ export class Conversation {
   >();
   /** @internal */ surfaceState = new Map<
     string,
-    { surfaceType: SurfaceType; data: SurfaceData; title?: string }
+    {
+      surfaceType: SurfaceType;
+      data: SurfaceData;
+      title?: string;
+      actions?: Array<{
+        id: string;
+        label: string;
+        style?: string;
+        data?: Record<string, unknown>;
+      }>;
+    }
   >();
   /** @internal */ surfaceUndoStacks = new Map<string, string[]>();
   /** @internal */ accumulatedSurfaceState = new Map<
@@ -393,6 +403,7 @@ export class Conversation {
    * works for surfaces restored from history (e.g. after daemon restart).
    */
   private restoreSurfaceStateFromHistory(): void {
+    this.surfaceState.clear();
     const dbMessages = getMessages(this.conversationId);
     for (const row of dbMessages) {
       try {
@@ -407,6 +418,14 @@ export class Conversation {
               surfaceType: (block.surfaceType ?? "dynamic_page") as SurfaceType,
               data: (block.data ?? {}) as SurfaceData,
               title: block.title as string | undefined,
+              actions: Array.isArray(block.actions)
+                ? (block.actions as Array<{
+                    id: string;
+                    label: string;
+                    style?: string;
+                    data?: Record<string, unknown>;
+                  }>)
+                : undefined,
             });
           }
         }


### PR DESCRIPTION
## Summary
- Restore `actions` field in `restoreSurfaceStateFromHistory()` so `relay_prompt`/`agent_prompt` buttons work after daemon restart
- Widen `surfaceState` type on `Conversation` class and lifecycle/agent-loop interfaces to include `actions`, matching the context interface in `conversation-surfaces.ts`
- Clear `surfaceState` before rebuilding from history to prevent stale surface routing

Addresses review feedback from PR #19471 (surface state restoration)

## Test plan
- [ ] Verify surfaces with action buttons (relay_prompt, agent_prompt) survive daemon restart
- [ ] Verify `findConversationBySurfaceId` returns correct results after reload
- [ ] Verify no stale surfaces leak across scoped history loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
