### PR TITLE
fix: preserve final word when suggestion truncation hits boundary

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1285,11 +1285,13 @@ async function generateLlmSuggestion(
     return null;
   }
   if (firstLine.length <= 50) return firstLine;
-  // Truncate at last word boundary within 50 chars
-  const wordTruncated = firstLine
-    .slice(0, 50)
-    .replace(/\s+\S*$/, "")
-    .trim();
+  // Truncate at last word boundary within 50 chars.
+  // Only strip the trailing partial word if the slice actually cut mid-word;
+  // if the character right after the cut is whitespace, the slice is already clean.
+  const sliced = firstLine.slice(0, 50);
+  const wordTruncated = (
+    /\s/.test(firstLine[50]) ? sliced : sliced.replace(/\s+\S*$/, "")
+  ).trim();
   if (wordTruncated.length < 15) {
     log.debug(
       { rawLength: firstLine.length, truncatedLength: wordTruncated.length },


### PR DESCRIPTION
## Summary
- Only strip the trailing partial word during suggestion truncation when the slice actually cut mid-word
- If `slice(0, 50)` already ends at a clean word boundary (next char is whitespace), use the slice as-is
- Prevents unnecessarily shortened suggestions and avoids dropping below the 15-char minimum threshold

Addresses review feedback from PR #19436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
