### PR TITLE
fix: address PR #19428 review feedback

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/VDiffView.swift
+++ b/clients/shared/DesignSystem/Components/Display/VDiffView.swift
@@ -19,8 +19,10 @@ public struct VDiffView: View {
     }
 
     private static func classify(_ line: Substring) -> LineKind {
-        // Unified diff file headers ("--- a/..." and "+++ b/...") are metadata, not changes.
-        if line.hasPrefix("--- ") || line.hasPrefix("+++ ") { return .context }
+        // Unified diff file headers ("--- a/...", "+++ b/...", "--- /dev/null", "+++ /dev/null").
+        // Only match real headers to avoid misclassifying removed/added lines like "--- note".
+        if line.hasPrefix("--- a/") || line.hasPrefix("--- /dev/null") { return .context }
+        if line.hasPrefix("+++ b/") || line.hasPrefix("+++ /dev/null") { return .context }
         if line.hasPrefix("@@") { return .hunk }
         if line.hasPrefix("+") { return .added }
         if line.hasPrefix("-") { return .removed }
@@ -53,7 +55,7 @@ public struct VDiffView: View {
 
     private func diffScrollView(lines: [Substring], axes: Axis.Set) -> some View {
         ScrollView(axes, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 0) {
+            LazyVStack(alignment: .leading, spacing: 0) {
                 ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
                     diffLine(line)
                 }

--- a/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
@@ -250,6 +250,28 @@ struct DisplayGallerySection: View {
             Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
             #endif
 
+            // MARK: - VDiffView
+            GallerySectionHeader(
+                title: "VDiffView",
+                description: "Renders unified diff text with per-line colored backgrounds. Green for additions, red for removals, blue for hunk headers."
+            )
+
+            VCard {
+                VDiffView(Self.sampleDiff)
+                    .padding(VSpacing.sm)
+            }
+
+            Text("With maxHeight constraint")
+                .font(VFont.headline)
+                .foregroundColor(VColor.contentSecondary)
+
+            VCard {
+                VDiffView(Self.sampleDiff, maxHeight: 120)
+                    .padding(VSpacing.sm)
+            }
+
+            Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+
             // MARK: - VStreamingWaveform
             GallerySectionHeader(
                 title: "VStreamingWaveform",
@@ -305,5 +327,19 @@ struct DisplayGallerySection: View {
             }
         }
     }
+
+    // MARK: - Sample Data
+
+    private static let sampleDiff = """
+    --- a/src/config.ts
+    +++ b/src/config.ts
+    @@ -10,7 +10,8 @@ export const config = {
+       timeout: 5000,
+    -  retries: 3,
+    +  retries: 5,
+    +  backoff: "exponential",
+       verbose: false,
+     };
+    """
 }
 #endif

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -365,19 +365,22 @@ public struct ToolConfirmationBubble: View {
 
             if showDiff, let diffInfo = confirmation.diff {
                 let computedDiff = confirmation.unifiedDiffPreview ?? ""
-                let diffBody = computedDiff.isEmpty ? diffInfo.newContent : computedDiff
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     Text(diffInfo.filePath)
                         .font(VFont.monoSmall)
                         .foregroundColor(VColor.contentTertiary)
 
-                    VDiffView(diffBody, maxHeight: 260)
-                        .padding(VSpacing.sm)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(
-                            RoundedRectangle(cornerRadius: VRadius.sm)
-                                .fill(VColor.surfaceOverlay)
-                        )
+                    if computedDiff.isEmpty {
+                        codePreviewBlock(diffInfo.newContent, maxHeight: 260)
+                    } else {
+                        VDiffView(computedDiff, maxHeight: 260)
+                            .padding(VSpacing.sm)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(
+                                RoundedRectangle(cornerRadius: VRadius.sm)
+                                    .fill(VColor.surfaceOverlay)
+                            )
+                    }
                 }
                 .textSelection(.enabled)
                 .transition(.opacity.combined(with: .move(edge: .top)))


### PR DESCRIPTION
## Summary
- **Fix raw content fallback**: When unified diff is empty, fall back to `codePreviewBlock` instead of `VDiffView` to avoid incorrectly coloring non-diff lines (e.g. source lines starting with `+`, `-`, `@@`)
- **Restrict file-header detection**: Only match real diff headers (`--- a/`, `+++ b/`, `/dev/null`) instead of any `--- `/`+++ ` prefix to avoid misclassifying removed/added content
- **Use LazyVStack**: Replace eager `VStack` with `LazyVStack` in the scrollable diff view for better performance with large diffs
- **Add gallery section**: Add VDiffView to DisplayGallerySection with sample diff in both unconstrained and maxHeight-constrained modes

## Test plan
- [ ] Open a conversation where the assistant edits a file — verify diff highlighting still works
- [ ] Trigger a file edit confirmation where old/new content are identical — verify plain code preview (no spurious coloring)
- [ ] Check component gallery shows VDiffView section with sample diff
- [ ] Verify light/dark mode appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
