### PR TITLE
fix: validate model field type in PUT /v1/config/embeddings

### DIFF
--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -225,6 +225,13 @@ export function conversationQueryRouteDefinitions(
             400,
           );
         }
+        if (body.model !== undefined && typeof body.model !== "string") {
+          return httpError(
+            "BAD_REQUEST",
+            "Field 'model' must be a string",
+            400,
+          );
+        }
         try {
           const info = await setEmbeddingConfig(
             body.provider,


### PR DESCRIPTION
## Summary
- Adds runtime validation that the `model` field is a string (or undefined) before passing it to `setEmbeddingConfig`
- Previously, malformed payloads like `{"provider":"openai","model":42}` would be accepted and persisted as invalid config data
- The route-policy feedback (P1) was already addressed in #19407

Addresses review feedback from PR #19387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
