### PR TITLE
fix: keep legacy app_update alias in macOS tool label mappings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolHelpers.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolHelpers.swift
@@ -85,7 +85,7 @@ extension ChatBubble {
     static func friendlyRunningLabel(_ toolName: String, inputSummary: String? = nil, buildingStatus: String? = nil) -> String {
         // For app file tools, prefer the descriptive building status from tool input
         if let status = buildingStatus {
-            if toolName == "app_create" || toolName == "app_refresh" {
+            if toolName == "app_create" || toolName == "app_refresh" || toolName == "app_update" {
                 return status
             }
         }
@@ -102,7 +102,7 @@ extension ChatBubble {
         case "browser_click":                   return "Clicking on the page"
         case "browser_screenshot":              return "Taking a screenshot"
         case "app_create":                      return "Building your app"
-        case "app_refresh":                     return "Refreshing your app"
+        case "app_refresh", "app_update":       return "Refreshing your app"
         case "skill_load":
             if let name = inputSummary, !name.isEmpty {
                 // App-builder skill gets a more contextual label
@@ -127,7 +127,7 @@ extension ChatBubble {
         if let status = buildingStatus { return status }
         switch toolName {
         case "app_create":                              return "Building your app"
-        case "app_refresh":                             return "Refreshing your app"
+        case "app_refresh", "app_update":               return "Refreshing your app"
         case "skill_load":                              return "Loading skill"
         case "web_search":                              return "Researching"
         case "web_fetch":                               return "Gathering information"
@@ -152,7 +152,7 @@ extension ChatBubble {
                 "Polishing the details",
                 "Almost there",
             ]
-        case "app_refresh":
+        case "app_refresh", "app_update":
             return [
                 "Reviewing your app",
                 "Applying changes",

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -937,7 +937,7 @@ public struct ToolCallData: Identifiable, Equatable {
         case "browser_click":                      return "Click Element"
         case "browser_type":                       return "Type Text"
         case "app_create":                         return "Create App"
-        case "app_refresh":                        return "Refresh App"
+        case "app_refresh", "app_update":          return "Refresh App"
         case "request_system_permission":          return "Request Permission"
         default:
             return toolName
@@ -962,7 +962,7 @@ public struct ToolCallData: Identifiable, Equatable {
         case "browser_screenshot":                 return .scan
         case "browser_click":                      return .mousePointerClick
         case "browser_type":                       return .keyboard
-        case "app_create", "app_refresh":           return .smartphone
+        case "app_create", "app_refresh", "app_update": return .smartphone
         case "request_system_permission":          return .shield
         default:                                   return .puzzle
         }
@@ -998,7 +998,7 @@ public struct ToolCallData: Identifiable, Equatable {
             return "Typed in a field"
         case "app_create":
             return "Created an app"
-        case "app_refresh":
+        case "app_refresh", "app_update":
             return "Refreshed the app"
         case "app_open":
             return inputSummary.isEmpty ? "Opened an app" : "Opened \(inputSummary)"

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -265,10 +265,10 @@ extension ChatViewModel {
     }
 
     /// Extract a code preview from accumulated tool input JSON.
-    /// Shows the HTML code as it streams during app_create/app_refresh.
+    /// Shows the HTML code as it streams during app_create/app_refresh/app_update.
     static func extractCodePreview(from accumulatedJson: String, toolName: String) -> String? {
         guard !accumulatedJson.isEmpty else { return nil }
-        let isAppTool = toolName == "app_create" || toolName == "app_refresh"
+        let isAppTool = toolName == "app_create" || toolName == "app_refresh" || toolName == "app_update"
         guard isAppTool else { return nil }
 
         // Find the html JSON string value by locating the opening quote
@@ -1309,12 +1309,12 @@ extension ChatViewModel {
             isThinking = false
             // Extract building status for app tools
             let buildingStatus: String? = {
-                let appTools: Set<String> = ["app_create", "app_refresh"]
+                let appTools: Set<String> = ["app_create", "app_refresh", "app_update"]
                 guard appTools.contains(msg.toolName) else { return nil }
                 if let status = msg.input["status"]?.value as? String, !status.isEmpty {
                     return status
                 }
-                // app_create/app_refresh rely on friendlyRunningLabel + progressive label cycling
+                // app_create/app_refresh/app_update rely on friendlyRunningLabel + progressive label cycling
                 return nil
             }()
             // Upsert by toolUseId: if a preview chip already exists for this tool, update it


### PR DESCRIPTION
## Summary
- Adds `app_update` as a legacy alias alongside `app_refresh` in all macOS client display mappings
- Ensures existing saved conversations with `toolName: "app_update"` continue to show proper labels, icons, and progressive states instead of falling back to generic formatting

Addresses review feedback from PR #19424.

## Test plan
- [ ] Verify that tool chips for both `app_refresh` and `app_update` show correct friendly names, icons, and progressive labels
- [ ] Verify existing conversations with historical `app_update` entries still render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
