### PR TITLE
fix: address PR #19450 review feedback

### DIFF
--- a/clients/macos/vellum-assistant/App/MainThreadStallDetector.swift
+++ b/clients/macos/vellum-assistant/App/MainThreadStallDetector.swift
@@ -179,11 +179,16 @@ final class MainThreadStallDetector {
             let pid = ProcessInfo.processInfo.processIdentifier
             let sampleURL = hangContextWriter.outputDirectory
                 .appendingPathComponent("hang-sample.txt")
-            let success = sampleRunner.runSample(pid: pid, outputURL: sampleURL)
-            if success {
-                log.info("Process sample written to hang-sample.txt")
-            } else {
-                log.warning("Process sampling failed (non-fatal)")
+            // Run sampling off the detector queue to avoid blocking stall detection
+            // for the ~3s duration of /usr/bin/sample. stageTwoFired prevents re-entry.
+            let runner = sampleRunner
+            DispatchQueue.global(qos: .utility).async { [log] in
+                let success = runner.runSample(pid: pid, outputURL: sampleURL)
+                if success {
+                    log.info("Process sample written to hang-sample.txt")
+                } else {
+                    log.warning("Process sampling failed (non-fatal)")
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Logging/HangContextWriter.swift
+++ b/clients/macos/vellum-assistant/Logging/HangContextWriter.swift
@@ -34,6 +34,11 @@ final class HangContextWriter: @unchecked Sendable {
 
     // MARK: - Private
 
+    private let lock = NSLock()
+    private var writeGeneration: Int = 0
+    private var latestStallStartTime: Date?
+    private var latestStallDurationSeconds: Double = 0
+
     private let encoder: JSONEncoder
 
     // MARK: - Init
@@ -72,6 +77,12 @@ final class HangContextWriter: @unchecked Sendable {
         recentEvents: [ChatDiagnosticEvent] = [],
         transcriptSnapshots: [ChatTranscriptSnapshot] = []
     ) {
+        lock.lock()
+        writeGeneration += 1
+        latestStallStartTime = stallStartTime
+        latestStallDurationSeconds = stallDurationSeconds
+        lock.unlock()
+
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
         let pid = ProcessInfo.processInfo.processIdentifier
 
@@ -109,13 +120,26 @@ final class HangContextWriter: @unchecked Sendable {
         stallDurationSeconds: Double
     ) {
         guard let provider = diagnosticsProvider else { return }
+        lock.lock()
+        let capturedGeneration = writeGeneration
+        lock.unlock()
+
         Task.detached(priority: .utility) { [self] in
             let events = await provider.recentEvents()
             let snapshots = await provider.transcriptSnapshots()
             let sortedSnapshots = snapshots.values.sorted { $0.conversationId < $1.conversationId }
+
+            // If a newer write occurred (e.g. Stage 2) while we were awaiting
+            // diagnostics, use its duration so we don't overwrite with a stale value.
+            self.lock.lock()
+            let useLatest = self.writeGeneration > capturedGeneration
+            let actualStartTime = useLatest ? (self.latestStallStartTime ?? stallStartTime) : stallStartTime
+            let actualDuration = useLatest ? self.latestStallDurationSeconds : stallDurationSeconds
+            self.lock.unlock()
+
             self.writeHangContextSync(
-                stallStartTime: stallStartTime,
-                stallDurationSeconds: stallDurationSeconds,
+                stallStartTime: actualStartTime,
+                stallDurationSeconds: actualDuration,
                 recentEvents: events,
                 transcriptSnapshots: sortedSnapshots
             )

--- a/clients/macos/vellum-assistantTests/MainThreadStallDetectorTests.swift
+++ b/clients/macos/vellum-assistantTests/MainThreadStallDetectorTests.swift
@@ -322,6 +322,25 @@ struct MainThreadStallDetectorTests {
 
     // MARK: - Content Safety
 
+    /// Recursively collects all keys from a JSON structure (dictionaries and arrays).
+    private func allKeys(in value: Any) -> Set<String> {
+        var keys = Set<String>()
+        switch value {
+        case let dict as [String: Any]:
+            for (key, val) in dict {
+                keys.insert(key)
+                keys.formUnion(allKeys(in: val))
+            }
+        case let array as [Any]:
+            for element in array {
+                keys.formUnion(allKeys(in: element))
+            }
+        default:
+            break
+        }
+        return keys
+    }
+
     @Test
     func hangContextJsonIsContentSafe() throws {
         let clock = MockClock()
@@ -350,11 +369,14 @@ struct MainThreadStallDetectorTests {
         #expect(json["pid"] != nil)
         #expect(json["appVersion"] != nil)
 
-        // Must NOT contain user-content keys.
-        let forbiddenKeys = ["messageText", "text", "toolInput", "toolOutput",
-                             "html", "surfaceHtml", "attachmentContent", "body"]
-        for key in forbiddenKeys {
-            #expect(json[key] == nil, "Hang context must not contain user-content key '\(key)'")
-        }
+        // Must NOT contain user-content keys — check recursively through all
+        // nested objects (e.g. recentDiagnosticEvents, transcriptSnapshots).
+        let forbiddenKeys: Set<String> = [
+            "messageText", "text", "toolInput", "toolOutput",
+            "html", "surfaceHtml", "attachmentContent", "body",
+        ]
+        let presentKeys = allKeys(in: json)
+        let violations = presentKeys.intersection(forbiddenKeys)
+        #expect(violations.isEmpty, "Hang context must not contain user-content keys: \(violations.sorted())")
     }
 }


### PR DESCRIPTION
## Summary
- **Stale duration fix**: `enrichWithDiagnosticsAsync` now captures a write generation counter. When the enrichment Task completes after Stage 2 has already written, it uses the latest stall duration instead of the stale Stage 1 value.
- **Non-blocking sampling**: `runSample` is dispatched to a global utility queue so the detector timer continues running during the ~3s `/usr/bin/sample` execution.
- **Recursive content safety test**: `hangContextJsonIsContentSafe` now recursively checks all keys in the JSON tree, not just top-level, catching regressions in nested types like `ChatDiagnosticEvent`.

## Test plan
- [x] Verify enrichment uses latest duration when Stage 2 fires before enrichment completes
- [x] Verify sampling no longer blocks the detector queue
- [x] Verify content safety test catches forbidden keys in nested objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
