### PR TITLE
fix: address PR #19394 review feedback

### DIFF
--- a/assistant/src/config/raw-config-utils.ts
+++ b/assistant/src/config/raw-config-utils.ts
@@ -58,3 +58,31 @@ export function setMemoryEmbeddingField(
   memory.embeddings = embeddings;
   raw.memory = memory;
 }
+
+/**
+ * Safely delete a nested field from a raw config object's `memory.embeddings`
+ * map, allowing Zod schema defaults to take effect on the next config reload.
+ */
+export function deleteMemoryEmbeddingField(
+  raw: Record<string, unknown>,
+  field: string,
+): void {
+  if (
+    raw.memory == null ||
+    typeof raw.memory !== "object" ||
+    Array.isArray(raw.memory)
+  ) {
+    return;
+  }
+  const memory = raw.memory as Record<string, unknown>;
+  const existing = memory.embeddings;
+  if (
+    existing == null ||
+    typeof existing !== "object" ||
+    Array.isArray(existing)
+  ) {
+    return;
+  }
+  const embeddings = existing as Record<string, unknown>;
+  delete embeddings[field];
+}

--- a/assistant/src/daemon/handlers/config-embeddings.ts
+++ b/assistant/src/daemon/handlers/config-embeddings.ts
@@ -3,7 +3,10 @@ import {
   loadRawConfig,
   saveRawConfig,
 } from "../../config/loader.js";
-import { setMemoryEmbeddingField } from "../../config/raw-config-utils.js";
+import {
+  deleteMemoryEmbeddingField,
+  setMemoryEmbeddingField,
+} from "../../config/raw-config-utils.js";
 import { VALID_MEMORY_EMBEDDING_PROVIDERS } from "../../config/schemas/memory-storage.js";
 import {
   clearEmbeddingBackendCache,
@@ -118,7 +121,12 @@ export async function setEmbeddingConfig(
   if (model !== undefined) {
     const fieldName = PROVIDER_MODEL_FIELD[provider];
     if (fieldName) {
-      setMemoryEmbeddingField(raw, fieldName, model);
+      if (model === "") {
+        // Empty string means "clear override — use schema default"
+        deleteMemoryEmbeddingField(raw, fieldName);
+      } else {
+        setMemoryEmbeddingField(raw, fieldName, model);
+      }
     }
   }
 

--- a/clients/macos/vellum-assistant/Features/Settings/EmbeddingServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/EmbeddingServiceCard.swift
@@ -155,7 +155,16 @@ struct EmbeddingServiceCard: View {
                 .foregroundColor(VColor.contentSecondary)
             VDropdown(
                 placeholder: "Select a provider\u{2026}",
-                selection: $draftProvider,
+                selection: Binding(
+                    get: { draftProvider },
+                    set: { newValue in
+                        if newValue != draftProvider {
+                            draftModel = ""
+                            apiKeyText = ""
+                        }
+                        draftProvider = newValue
+                    }
+                ),
                 options: providerOptions
             )
         }

--- a/clients/shared/Network/SettingsClient.swift
+++ b/clients/shared/Network/SettingsClient.swift
@@ -125,7 +125,7 @@ public struct SettingsClient: SettingsClientProtocol {
     public func setEmbeddingConfig(provider: String, model: String?) async -> EmbeddingConfigMessage? {
         do {
             var body: [String: Any] = ["provider": provider]
-            if let model { body["model"] = model }
+            body["model"] = model ?? ""
             let response = try await GatewayHTTPClient.put(
                 path: "config/embeddings", json: body, timeout: 10
             )


### PR DESCRIPTION
## Summary
- Reset `draftModel` and `apiKeyText` when the user switches embedding providers in the dropdown, preventing stale model IDs from being saved under the wrong provider
- Always include `model` in `setEmbeddingConfig` HTTP body (send `""` when clearing), so users can actually clear custom model overrides back to the schema default
- Handle empty-string model on the daemon side by deleting the field from raw config, allowing Zod schema defaults to take effect on reload

Addresses review feedback from PR #19394 (embedding config card)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
