### PR TITLE
fix: address PR #19466 review feedback

### DIFF
--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -618,10 +618,18 @@ export function handleSurfaceAction(
     const prompt =
       isRelay && typeof data?.prompt === "string" ? data.prompt.trim() : "";
 
+    // Read accumulated state once — used by both relay and custom action paths.
+    const accState = ctx.accumulatedSurfaceState.get(surfaceId);
+    const hasAccState = accState && Object.keys(accState).length > 0;
+
     let content: string;
     let displayContent: string | undefined;
     if (prompt) {
       content = prompt;
+      // Re-append accumulated state so the LLM sees it, matching the pending path.
+      if (hasAccState) {
+        content += `\n\nAccumulated surface state: ${JSON.stringify(accState)}`;
+      }
     } else {
       // Custom action from an app (e.g. sendAction('answer_selected', {...}))
       const summary = actionId
@@ -631,10 +639,8 @@ export function handleSurfaceAction(
       if (data && Object.keys(data).length > 0) {
         content += `\n\nAction data: ${JSON.stringify(data)}`;
       }
-      const accState = ctx.accumulatedSurfaceState.get(surfaceId);
-      if (accState && Object.keys(accState).length > 0) {
+      if (hasAccState) {
         content += `\n\nAccumulated surface state: ${JSON.stringify(accState)}`;
-        ctx.accumulatedSurfaceState.delete(surfaceId);
       }
       displayContent = summary;
     }
@@ -669,6 +675,12 @@ export function handleSurfaceAction(
     if (result.rejected) {
       ctx.surfaceActionRequestIds.delete(requestId);
       return;
+    }
+
+    // One-shot: clear accumulated state now that the message has been accepted.
+    // Deferred until after rejection check so state is preserved for retry on rejection.
+    if (hasAccState) {
+      ctx.accumulatedSurfaceState.delete(surfaceId);
     }
 
     // Echo the prompt to the client so it appears in the chat UI.


### PR DESCRIPTION
## Summary
- Fixes accumulated surface state being silently dropped for `relay_prompt`/`agent_prompt` actions in the history-restored (`!pending`) path. Now appends accumulated state to content, matching the `pending` path.
- Defers `accumulatedSurfaceState.delete()` until after the `enqueueMessage` rejection check, so state is preserved for retry on rejection — consistent with the `pending` path pattern.

Addresses review feedback from PR #19466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
