### PR TITLE
fix: address PR #19260 review feedback

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -349,6 +349,7 @@ struct ChatView: View {
             handleDrop(providers: providers)
         }
         .onKeyPress(.escape) {
+            guard isInteractionEnabled else { return .ignored }
             if isSearchActive {
                 dismissSearch()
                 return .handled
@@ -360,7 +361,7 @@ struct ChatView: View {
             return .ignored
         }
         .onKeyPress("f", phases: .down) { press in
-            guard press.modifiers == .command else { return .ignored }
+            guard isInteractionEnabled, press.modifiers == .command else { return .ignored }
             activateSearch()
             return .handled
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -145,10 +145,13 @@ struct ComposerView: View {
             }
         }
         .onChange(of: isInteractionEnabled) { _, enabled in
-            guard !enabled else { return }
-            composerFocus = false
-            showSlashMenu = false
-            suppressSlashReopen = false
+            if enabled {
+                composerFocus = true
+            } else {
+                composerFocus = false
+                showSlashMenu = false
+                suppressSlashReopen = false
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- **Restore composer focus on re-enable**: The `onChange(of: isInteractionEnabled)` handler now sets `composerFocus = true` when transitioning back to `true`, fixing the regression where the composer permanently lost focus after the inspector was dismissed.
- **Gate chat key handlers**: `onKeyPress(.escape)` and `onKeyPress("f")` in `ChatView` now early-return `.ignored` when `isInteractionEnabled` is false, preventing search/overlay state mutations while the inspector is showing.
- The focus-restore fix also covers the conversation-switch scenario — when `ActiveChatViewWrapper` clears the inspector after a conversation change, `isInteractionEnabled` transitions to `true` and focus is automatically restored.

Addresses review feedback from PR #19260 (composer bridge).

## Test plan
- [ ] Open inspector on a message → dismiss → verify composer regains focus automatically
- [ ] Switch conversations while inspector is open → verify focus restores in new conversation
- [ ] With inspector open, press Escape and Cmd+F → verify neither search nor overlay state changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
