### PR TITLE
fix: preserve bottom pin requests when conversationId is nil during bootstrap

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -735,12 +735,16 @@ struct MessageListView: View {
     /// (duplicate request within an active session), or start a new bounded
     /// retry session. Anchor-message jumps and pagination restoration bypass
     /// this helper entirely — they are higher-priority flows.
+    /// Sentinel UUID used for pin requests before the daemon assigns a real
+    /// conversation ID. Lets bootstrap-window requests coalesce normally.
+    private static let bootstrapConversationId = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
+
     private func requestBottomPin(
         reason: BottomPinRequestReason,
         proxy: ScrollViewProxy,
         animated: Bool = false
     ) {
-        guard let convId = conversationId else { return }
+        let convId = conversationId ?? Self.bootstrapConversationId
         bottomPinCoordinator.requestPin(
             reason: reason,
             conversationId: convId,


### PR DESCRIPTION
## Summary
- `requestBottomPin` previously returned early when `conversationId` was nil, dropping all automatic bottom-follow requests during the bootstrap window of a new chat — a regression in first-turn chat behavior
- Uses a static sentinel UUID for pin requests when `conversationId` is nil so bootstrap requests flow through the coordinator normally and coalesce until the real ID arrives
- The onDisappear coordinator cancellation (second review comment on #19456) was already addressed in a prior commit

## Test plan
- [ ] Open a brand-new chat and verify the transcript auto-follows streaming output from the very first message (before daemon assigns conversation ID)
- [ ] Verify scroll-to-bottom still works normally after conversation ID is assigned
- [ ] Verify detach/reattach behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
