### PR TITLE
fix: remove erroneous double-invocation of db.transaction in forkConversation

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -514,7 +514,7 @@ export function forkConversation(params: {
     });
 
     return fc;
-  })();
+  });
 
   // Disk-view sync runs after commit — file I/O is idempotent and
   // conversation deletion cleans up orphaned directories.


### PR DESCRIPTION
## Summary
- Removes the extra `()` after `db.transaction(() => { ... })` in `forkConversation`. Drizzle's `db.transaction()` immediately executes the callback and returns its result — the trailing `()` tried to call the returned `ConversationRow` as a function, breaking all 3 fork-related test files in CI.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23300518055/job/67759967937
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
