### PR TITLE
fix: address PR #19264 review feedback

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -156,8 +156,10 @@ struct ChatBubble: View {
 
     /// Whether the text/attachment bubble should be rendered.
     /// Tool calls for assistant messages render outside the bubble as separate chips,
-    /// so only show the bubble when there's actual text, attachment content, or
-    /// attachment warnings to show.
+    /// so only show the bubble when there's actual text or attachment content.
+    /// Attachment warnings render independently outside the bubble (via
+    /// `attachmentWarningBanners`) and must NOT trigger bubble display — otherwise
+    /// a warning-only message produces an empty bubble chrome with nothing inside.
     ///
     /// NOTE: When inline surfaces are present, the bubble is intentionally hidden
     /// even if the message also contains text. This is by design — the assistant's
@@ -172,7 +174,7 @@ struct ChatBubble: View {
             let allCompleted = visibleSurfaces.allSatisfy { $0.completionState != nil }
             if !allCompleted { return false }
         }
-        return hasText || !message.attachments.isEmpty || !message.attachmentWarnings.isEmpty
+        return hasText || !message.attachments.isEmpty
     }
 
     var body: some View {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -285,9 +285,21 @@ extension ChatBubble {
     /// Returns the image attachments that should still render in the attachment grid.
     /// When inline tool previews are visible, the matching tool-block images are
     /// hidden so we do not duplicate the same image twice. Non-tool images remain.
+    ///
+    /// After a history reload, `sourceType` is nil (not persisted in the DB), so
+    /// we fall back to the old all-or-nothing approach: hide all image attachments
+    /// when the count matches the inline tool call count — this avoids duplicates
+    /// at the cost of hiding non-tool images (rare in practice).
     func visibleAttachmentImages(_ images: [ChatAttachment]) -> [ChatAttachment] {
         guard shouldRenderToolProgressInline, inlineToolCallImageCount > 0 else {
             return images
+        }
+
+        let anyHasSourceType = images.contains { $0.sourceType != nil }
+        if !anyHasSourceType {
+            // History reload: sourceType unavailable — fall back to hiding all
+            // images when count matches to avoid duplicating inline tool previews.
+            return images.count <= inlineToolCallImageCount ? [] : images
         }
 
         var remainingInlineToolImages = inlineToolCallImageCount


### PR DESCRIPTION
## Summary
- Fix empty bubble rendering when a message has only attachment warnings but no text/attachments (P2 feedback)
- Add sourceType fallback in `visibleAttachmentImages` for history reload where sourceType is nil
- P0 (regenerate wire types) was already resolved — GeneratedAPITypes.swift has the needed fields

## Test plan
- [ ] Verify warning-only assistant messages no longer produce an empty bubble chrome
- [ ] Verify tool-block image deduplication still works during live streaming (sourceType populated)
- [ ] Verify after history reload, tool images are not duplicated (fallback to count-based hiding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
