### PR TITLE
fix: address PR #19334 review feedback

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -42,6 +42,7 @@ struct ChatView: View {
     let watchSession: WatchSession?
     let onStopWatch: () -> Void
     var onReportMessage: ((String?) -> Void)?
+    var onForkFromMessage: ((String) -> Void)? = nil
     var showInspectButton: Bool = false
     var onInspectMessage: ((String?) -> Void)?
     var mediaEmbedSettings: MediaEmbedResolverSettings?
@@ -240,6 +241,7 @@ struct ChatView: View {
                             onGuardianAction: onGuardianAction,
                             onDismissDocumentWidget: onDismissDocumentWidget,
                             onReportMessage: onReportMessage,
+                            onForkFromMessage: onForkFromMessage,
                             showInspectButton: showInspectButton,
                             onInspectMessage: onInspectMessage,
                             mediaEmbedSettings: mediaEmbedSettings,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -330,28 +330,16 @@ struct MessageListView: View {
         )
     }
 
-    var hasForkActionHandler: Bool {
-        onForkFromMessage != nil || AppDelegate.shared?.mainWindow?.conversationManager != nil
-    }
-
     func canFork(from message: ChatMessage) -> Bool {
-        hasForkActionHandler && message.daemonMessageId != nil && !message.isStreaming
+        onForkFromMessage != nil && message.daemonMessageId != nil && !message.isStreaming
     }
 
     func forkFromMessage(_ daemonMessageId: String) {
-        if let onForkFromMessage {
-            onForkFromMessage(daemonMessageId)
-            return
-        }
-
-        Task { @MainActor in
-            await AppDelegate.shared?.mainWindow?.conversationManager
-                .forkConversation(throughDaemonMessageId: daemonMessageId)
-        }
+        onForkFromMessage?(daemonMessageId)
     }
 
     var forkFromMessageAction: ((String) -> Void)? {
-        guard hasForkActionHandler else { return nil }
+        guard onForkFromMessage != nil else { return nil }
         return { daemonMessageId in
             forkFromMessage(daemonMessageId)
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -692,6 +692,11 @@ struct ActiveChatViewWrapper: View {
                     }
                 }
             },
+            onForkFromMessage: { [conversationManager] daemonMessageId in
+                Task { @MainActor in
+                    await conversationManager.forkConversation(throughDaemonMessageId: daemonMessageId)
+                }
+            },
             showInspectButton: showInspectButton,
             onInspectMessage: { daemonMessageId in
                 presentInspector(for: daemonMessageId)


### PR DESCRIPTION
## Summary
- Remove direct `AppDelegate.shared?.mainWindow?.conversationManager` singleton access from `MessageListView`'s fork handler
- Inject the fork callback through the view hierarchy (`PanelCoordinator` → `ChatView` → `MessageListView`) following the DI rule in `clients/macos/AGENTS.md`
- Simplify `canFork`/`forkFromMessage`/`forkFromMessageAction` by removing the fallback branch

Addresses review feedback from PR #19334 (message-level fork action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
