### PR TITLE
Remove Anthropic-specific API key forwarding from VellumCli

### DIFF
--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -81,7 +81,7 @@ final class VellumCli {
     /// Environment variable keys forwarded from the host process to CLI
     /// child processes. Centralised so every call site stays in sync.
     nonisolated private static let forwardedEnvKeys: [String] = [
-        "ANTHROPIC_API_KEY", "BASE_DATA_DIR",
+        "BASE_DATA_DIR",
         "VELLUM_PLATFORM_URL", "RUNTIME_HTTP_PORT",
         "SENTRY_DSN", "TMPDIR", "USER", "LANG",
         // Cloud provider auth — needed by hatch and retire flows.
@@ -349,7 +349,6 @@ final class VellumCli {
         var sshHost: String = ""
         var sshUser: String = ""
         var sshPrivateKey: String = ""
-        var anthropicApiKey: String = ""
     }
 
     func runRemoteHatch(
@@ -397,10 +396,6 @@ final class VellumCli {
             #else
             env["VELLUM_PLATFORM_URL"] = "https://vellum.ai"
             #endif
-        }
-
-        if !config.anthropicApiKey.isEmpty {
-            env["ANTHROPIC_API_KEY"] = config.anthropicApiKey
         }
 
         if config.remote == "gcp" {
@@ -693,14 +688,6 @@ final class VellumCli {
                 if env["RUNTIME_HTTP_PORT"] == nil,
                    let port = fullEnv["RUNTIME_HTTP_PORT"] ?? getenv("RUNTIME_HTTP_PORT").flatMap({ String(cString: $0) }) {
                     env["RUNTIME_HTTP_PORT"] = port
-                }
-                // Fall back to credential storage for the Anthropic API key
-                // when it's not in the process environment (e.g. app launched
-                // from Finder, not a terminal with ANTHROPIC_API_KEY set).
-                if env["ANTHROPIC_API_KEY"] == nil,
-                   let storedKey = APIKeyManager.getKey(for: "anthropic"),
-                   !storedKey.isEmpty {
-                    env["ANTHROPIC_API_KEY"] = storedKey
                 }
                 proc.environment = env
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -264,8 +264,6 @@ struct HatchingStepView: View {
     private static let dockerReadySentinel = "Docker containers are up and running"
 
     private func startRemoteHatch() {
-        let apiKey = APIKeyManager.getKey(for: "anthropic") ?? ""
-
         let config = VellumCli.RemoteHatchConfig(
             remote: state.cloudProvider,
             gcpProjectId: state.gcpProjectId,
@@ -274,8 +272,7 @@ struct HatchingStepView: View {
             awsRoleArn: state.awsRoleArn,
             sshHost: state.sshHost,
             sshUser: state.sshUser,
-            sshPrivateKey: state.sshPrivateKey,
-            anthropicApiKey: apiKey
+            sshPrivateKey: state.sshPrivateKey
         )
 
         Task {


### PR DESCRIPTION
## Summary
- Removes redundant `ANTHROPIC_API_KEY` env-var forwarding from `VellumCli`
- The daemon already receives all provider API keys via `syncAllKeysToDaemon` on connect, making this special-case handling unnecessary
- Removes `ANTHROPIC_API_KEY` from `forwardedEnvKeys`, `anthropicApiKey` from `RemoteHatchConfig`, and the keychain fallback in `runCLI`

## Test plan
- [ ] Verify local assistant startup still works (key arrives via sync)
- [ ] Verify remote hatch still works (key syncs after connect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
