### PR TITLE
fix: add missing conversationManager to ActiveChatViewWrapper

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -385,6 +385,7 @@ extension MainWindowView {
                 conversationStartersEnabled: conversationStartersEnabled,
                 showInspectButton: showInspectButton,
                 daemonClient: daemonClient,
+                conversationManager: conversationManager,
                 ambientAgent: ambientAgent,
                 settingsStore: settingsStore,
                 onMicrophoneToggle: onMicrophoneToggle,
@@ -586,6 +587,7 @@ struct ActiveChatViewWrapper: View {
     let daemonClient: DaemonClient
     @ObservedObject var ambientAgent: AmbientAgent
     @ObservedObject var settingsStore: SettingsStore
+    let conversationManager: ConversationManager
     let onMicrophoneToggle: () -> Void
     var isTemporaryChat: Bool = false
     var voiceModeManager: VoiceModeManager? = nil


### PR DESCRIPTION
## Summary
- PR #19522 added `onForkFromMessage` to `ActiveChatViewWrapper` that captures `conversationManager`, but forgot to add `conversationManager` as a property on the struct
- Add `let conversationManager: ConversationManager` to `ActiveChatViewWrapper` and pass it from `MainWindowView.chatView`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23301266105
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
