### PR TITLE
fix: revert LazyVStack to VStack in VDiffView to fix sizing and text selection

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/VDiffView.swift
+++ b/clients/shared/DesignSystem/Components/Display/VDiffView.swift
@@ -55,7 +55,7 @@ public struct VDiffView: View {
 
     private func diffScrollView(lines: [Substring], axes: Axis.Set) -> some View {
         ScrollView(axes, showsIndicators: false) {
-            LazyVStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 0) {
                 ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
                     diffLine(line)
                 }


### PR DESCRIPTION
## Summary
- Addresses review feedback on #19506
- LazyVStack with .fixedSize only measures visible children, breaking horizontal scroll sizing for off-screen lines and text selection
- Reverts to VStack which eagerly measures all children

## Test plan
- [ ] Verify diff views render correctly with horizontal scrolling for wide lines
- [ ] Verify text selection works across all lines in scrollable diffs
- [ ] Check ToolConfirmationBubble and ToolCallChip diff displays with maxHeight

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
