### PR TITLE
fix: expand OpenAI model prefix regex to match o4-mini and future o-series models

### DIFF
--- a/assistant/src/runtime/routes/llm-context-normalization.ts
+++ b/assistant/src/runtime/routes/llm-context-normalization.ts
@@ -1176,7 +1176,7 @@ function normalizeCompatibleRequestPayload(
 
 function hasOpenAiModelPrefix(model: string | undefined): boolean {
   if (!model) return false;
-  return /^(gpt-|chatgpt-|ft:|o[13](-|$))/.test(model);
+  return /^(gpt-|chatgpt-|ft:|o[1-9]\d*(-|$))/.test(model);
 }
 
 function hasAnthropicModelPrefix(model: string | undefined): boolean {


### PR DESCRIPTION
## Summary
- Expands the `hasOpenAiModelPrefix` regex from `o[13]` to `o[1-9]\d*` to match all o-series models (o1, o3, o4-mini, future models)
- Addresses review feedback on #19503: `o4-mini` is already in the pricing catalog but wasn't matched by the prefix regex

## Test plan
- [x] Existing `llm-context-normalization.test.ts` tests pass (14/14)
- [x] Regex now matches `o4-mini`, `o4`, and any future o-series models

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
