### PR TITLE
fix: clear zoomedNodeId on manual zoom/pan to fix double-click toggle

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -999,6 +999,7 @@ struct ConstellationView: View {
                                 height: panOffset.height + value.translation.height
                             )
                             dragOffset = .zero
+                            zoomedNodeId = nil
                         }
                 )
                 .gesture(
@@ -1009,6 +1010,7 @@ struct ConstellationView: View {
                         .onEnded { value in
                             zoomScale = max(0.4, min(3.0, baseZoomScale * value.magnification))
                             baseZoomScale = zoomScale
+                            zoomedNodeId = nil
                         }
                 )
                 .onAppear {
@@ -1059,6 +1061,7 @@ struct ConstellationView: View {
                     zoomScale = min(3.0, zoomScale + 0.25)
                     baseZoomScale = zoomScale
                 }
+                zoomedNodeId = nil
             }
 
             VButton(label: "Zoom out", iconOnly: VIcon.zoomOut.rawValue, style: .ghost, tooltip: "Zoom out") {
@@ -1066,6 +1069,7 @@ struct ConstellationView: View {
                     zoomScale = max(0.4, zoomScale - 0.25)
                     baseZoomScale = zoomScale
                 }
+                zoomedNodeId = nil
             }
 
             VButton(label: "Fit all", iconOnly: VIcon.scan.rawValue, style: .ghost, tooltip: "Fit all skills") {


### PR DESCRIPTION
## Summary
- Clears `zoomedNodeId` on zoom-in button, zoom-out button, MagnifyGesture, and DragGesture to fix stale toggle state
- Addresses review feedback from Codex and Devin on #19508: after double-clicking a node to zoom, then manually zooming/panning away, a second double-click on the same node incorrectly triggered `fitAll` instead of re-zooming

## Test plan
- [ ] Double-click a node to zoom in, then use zoom-out button → double-click same node should zoom in again (not fitAll)
- [ ] Double-click a node to zoom in, then pinch-zoom out → double-click same node should zoom in again
- [ ] Double-click a node to zoom in, then drag/pan away → double-click same node should zoom in again
- [ ] Double-click a node twice in a row still toggles between zoom and fitAll (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
