### PR TITLE
fix: guard pagination defer block against clobbering newer task

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -621,8 +621,10 @@ struct MessageListView: View {
         log.debug("[pagination] fired — anchorId: \(String(describing: anchorId))")
         paginationTask = Task {
             defer {
-                isPaginationInFlight = false
-                paginationTask = nil
+                if !Task.isCancelled {
+                    isPaginationInFlight = false
+                    paginationTask = nil
+                }
             }
             let hadMore = await loadPreviousMessagePage?() ?? false
             log.debug("[pagination] loadPreviousMessagePage returned hadMore=\(hadMore)")


### PR DESCRIPTION
## Summary
- Addresses review feedback on #19511
- The `defer` block in `triggerPagination` unconditionally cleared `isPaginationInFlight` and `paginationTask`, which could clobber a newer task's state after the old task was cancelled
- Added `Task.isCancelled` guard to match the established pattern used by `scrollDebounceTask`

## Test plan
- [ ] Verify pagination works correctly in normal flow
- [ ] Verify rapid conversation switching doesn't leave pagination in a broken state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
