### PR TITLE
fix: preserve optional model semantics in embedding config requests

### DIFF
--- a/clients/shared/Network/SettingsClient.swift
+++ b/clients/shared/Network/SettingsClient.swift
@@ -163,7 +163,7 @@ public struct SettingsClient: SettingsClientProtocol {
     public func setEmbeddingConfig(provider: String, model: String?) async -> EmbeddingConfigMessage? {
         do {
             var body: [String: Any] = ["provider": provider]
-            body["model"] = model ?? ""
+            if let model { body["model"] = model }
             let response = try await GatewayHTTPClient.put(
                 path: "config/embeddings", json: body, timeout: 10
             )


### PR DESCRIPTION
## Summary
- Fixes review feedback from #19513 where `model ?? ""` in `SettingsClient.setEmbeddingConfig()` converted nil model to empty string
- The daemon interprets empty string as "delete the provider model override," causing silent erasure of custom model settings on provider-only saves
- Changed to `if let model { body["model"] = model }` to preserve optional semantics — nil means "don't change"

## Test plan
- [ ] Save embedding config with only provider change (no model change) — verify existing custom model is preserved
- [ ] Save embedding config with explicit model — verify model is updated
- [ ] Clear model explicitly — verify model is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
