### PR TITLE
fix: add hasPendingConfirmation guard to composer focus restore

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -145,9 +145,9 @@ struct ComposerView: View {
             }
         }
         .onChange(of: isInteractionEnabled) { _, enabled in
-            if enabled {
+            if enabled, !hasPendingConfirmation {
                 composerFocus = true
-            } else {
+            } else if !enabled {
                 composerFocus = false
                 showSlashMenu = false
                 suppressSlashReopen = false


### PR DESCRIPTION
## Summary
- Addresses review feedback on #19516
- The `onChange(of: isInteractionEnabled)` handler unconditionally set `composerFocus = true` when interaction was re-enabled, bypassing the `hasPendingConfirmation` safeguard used in other auto-focus paths
- Added `!hasPendingConfirmation` guard to match `onChange(of: conversationId)` and `onReceive(didBecomeActiveNotification)` patterns

## Test plan
- [ ] Open inspector while a confirmation dialog is visible, then close it — composer should not steal focus
- [ ] Close inspector without pending confirmation — composer should regain focus as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
