### PR TITLE
fix: use exact count match for attachment image dedup fallback

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -288,8 +288,8 @@ extension ChatBubble {
     ///
     /// After a history reload, `sourceType` is nil (not persisted in the DB), so
     /// we fall back to the old all-or-nothing approach: hide all image attachments
-    /// when the count matches the inline tool call count — this avoids duplicates
-    /// at the cost of hiding non-tool images (rare in practice).
+    /// when the count exactly matches the inline tool call count — this avoids
+    /// duplicates while preserving non-tool images when counts differ.
     func visibleAttachmentImages(_ images: [ChatAttachment]) -> [ChatAttachment] {
         guard shouldRenderToolProgressInline, inlineToolCallImageCount > 0 else {
             return images
@@ -299,7 +299,7 @@ extension ChatBubble {
         if !anyHasSourceType {
             // History reload: sourceType unavailable — fall back to hiding all
             // images when count matches to avoid duplicating inline tool previews.
-            return images.count <= inlineToolCallImageCount ? [] : images
+            return images.count == inlineToolCallImageCount ? [] : images
         }
 
         var remainingInlineToolImages = inlineToolCallImageCount


### PR DESCRIPTION
Addresses review feedback on #19520. The fallback used `<=` which could hide legitimate non-tool images when there are fewer attachments than tool-call images. Changed to `==` to only hide when counts exactly match.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
