### PR TITLE
fix: inject sampling queue in MainThreadStallDetector for deterministic tests

### DIFF
--- a/clients/macos/vellum-assistant/App/MainThreadStallDetector.swift
+++ b/clients/macos/vellum-assistant/App/MainThreadStallDetector.swift
@@ -45,6 +45,10 @@ final class MainThreadStallDetector {
     /// Process runner for `/usr/bin/sample`. Tests inject a mock.
     var sampleRunner: SampleRunner = DefaultSampleRunner()
 
+    /// Queue used to dispatch sampling off the detector queue. Production uses
+    /// a global utility queue; tests inject a serial queue they can drain.
+    var samplingQueue: DispatchQueue = .global(qos: .utility)
+
     /// Queue used to dispatch probes. Production uses `DispatchQueue.main`;
     /// tests inject a suspended or separate queue to simulate a blocked main thread.
     var probeTargetQueue: DispatchQueue = .main
@@ -182,7 +186,7 @@ final class MainThreadStallDetector {
             // Run sampling off the detector queue to avoid blocking stall detection
             // for the ~3s duration of /usr/bin/sample. stageTwoFired prevents re-entry.
             let runner = sampleRunner
-            DispatchQueue.global(qos: .utility).async { [log] in
+            samplingQueue.async { [log] in
                 let success = runner.runSample(pid: pid, outputURL: sampleURL)
                 if success {
                     log.info("Process sample written to hang-sample.txt")

--- a/clients/macos/vellum-assistantTests/MainThreadStallDetectorTests.swift
+++ b/clients/macos/vellum-assistantTests/MainThreadStallDetectorTests.swift
@@ -54,7 +54,7 @@ struct MainThreadStallDetectorTests {
         stageOneThreshold: TimeInterval = 2.0,
         stageTwoThreshold: TimeInterval = 5.0,
         samplingAllowed: Bool = true
-    ) -> (detector: MainThreadStallDetector, blockedQueue: DispatchQueue) {
+    ) -> (detector: MainThreadStallDetector, blockedQueue: DispatchQueue, samplingQueue: DispatchQueue) {
         let detector = MainThreadStallDetector(testInit: true)
         let outputDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("stall-test-\(UUID().uuidString)", isDirectory: true)
@@ -72,7 +72,11 @@ struct MainThreadStallDetectorTests {
         blockedQueue.suspend()
         detector.probeTargetQueue = blockedQueue
 
-        return (detector, blockedQueue)
+        // Inject a serial sampling queue so tests can drain it before asserting.
+        let samplingQueue = DispatchQueue(label: "com.vellum.test.sampling")
+        detector.samplingQueue = samplingQueue
+
+        return (detector, blockedQueue, samplingQueue)
     }
 
     // MARK: - Stage One: Capture Before Recovery
@@ -81,7 +85,7 @@ struct MainThreadStallDetectorTests {
     func stageOneCaptureFiresWithoutRecovery() throws {
         let clock = MockClock()
         let sampleRunner = MockSampleRunner()
-        let (detector, blockedQueue) = makeDetector(clock: clock, sampleRunner: sampleRunner)
+        let (detector, blockedQueue, _) = makeDetector(clock: clock, sampleRunner: sampleRunner)
         defer { blockedQueue.resume() }
 
         // First ping dispatches probe to the blocked queue.
@@ -109,7 +113,7 @@ struct MainThreadStallDetectorTests {
     func stageOneDoesNotFireBelowThreshold() throws {
         let clock = MockClock()
         let sampleRunner = MockSampleRunner()
-        let (detector, blockedQueue) = makeDetector(clock: clock, sampleRunner: sampleRunner)
+        let (detector, blockedQueue, _) = makeDetector(clock: clock, sampleRunner: sampleRunner)
         defer { blockedQueue.resume() }
 
         detector.queue.sync {
@@ -133,7 +137,7 @@ struct MainThreadStallDetectorTests {
     func stageOneCustomThreshold() throws {
         let clock = MockClock()
         let sampleRunner = MockSampleRunner()
-        let (detector, blockedQueue) = makeDetector(
+        let (detector, blockedQueue, _) = makeDetector(
             clock: clock,
             sampleRunner: sampleRunner,
             stageOneThreshold: 0.5
@@ -162,7 +166,7 @@ struct MainThreadStallDetectorTests {
     func stageTwoAttemptsSamplingOnce() throws {
         let clock = MockClock()
         let sampleRunner = MockSampleRunner()
-        let (detector, blockedQueue) = makeDetector(clock: clock, sampleRunner: sampleRunner)
+        let (detector, blockedQueue, samplingQueue) = makeDetector(clock: clock, sampleRunner: sampleRunner)
         defer { blockedQueue.resume() }
 
         detector.queue.sync {
@@ -176,6 +180,9 @@ struct MainThreadStallDetectorTests {
             detector.ping()
         }
 
+        // Drain the async sampling dispatch before asserting.
+        samplingQueue.sync {}
+
         #expect(sampleRunner.callCount == 1, "Stage two should attempt sampling exactly once")
 
         // Advance more — should NOT sample again.
@@ -185,6 +192,8 @@ struct MainThreadStallDetectorTests {
             detector.ping()
         }
 
+        samplingQueue.sync {}
+
         #expect(sampleRunner.callCount == 1, "Stage two should not attempt sampling twice for the same stall")
     }
 
@@ -192,7 +201,7 @@ struct MainThreadStallDetectorTests {
     func stageTwoSamplingGatedOnSendDiagnostics() throws {
         let clock = MockClock()
         let sampleRunner = MockSampleRunner()
-        let (detector, blockedQueue) = makeDetector(
+        let (detector, blockedQueue, _) = makeDetector(
             clock: clock,
             sampleRunner: sampleRunner,
             samplingAllowed: false
@@ -223,7 +232,7 @@ struct MainThreadStallDetectorTests {
         let clock = MockClock()
         let sampleRunner = MockSampleRunner()
         sampleRunner.shouldSucceed = false
-        let (detector, blockedQueue) = makeDetector(clock: clock, sampleRunner: sampleRunner)
+        let (detector, blockedQueue, samplingQueue) = makeDetector(clock: clock, sampleRunner: sampleRunner)
         defer { blockedQueue.resume() }
 
         detector.queue.sync {
@@ -237,6 +246,9 @@ struct MainThreadStallDetectorTests {
             detector.ping()
         }
 
+        // Drain the async sampling dispatch before asserting.
+        samplingQueue.sync {}
+
         #expect(sampleRunner.callCount == 1, "Sampling was attempted despite expected failure")
 
         // Detector should still be operational after the failure.
@@ -245,6 +257,8 @@ struct MainThreadStallDetectorTests {
         detector.queue.sync {
             detector.ping()
         }
+
+        samplingQueue.sync {}
 
         #expect(sampleRunner.callCount == 1, "No additional sampling after failure")
     }
@@ -255,7 +269,7 @@ struct MainThreadStallDetectorTests {
     func stageOneOnlyFiresOncePerStall() throws {
         let clock = MockClock()
         let sampleRunner = MockSampleRunner()
-        let (detector, blockedQueue) = makeDetector(clock: clock, sampleRunner: sampleRunner)
+        let (detector, blockedQueue, _) = makeDetector(clock: clock, sampleRunner: sampleRunner)
         defer { blockedQueue.resume() }
 
         // Dispatch probe.
@@ -292,7 +306,7 @@ struct MainThreadStallDetectorTests {
     func prolongedStallFiresBothStages() throws {
         let clock = MockClock()
         let sampleRunner = MockSampleRunner()
-        let (detector, blockedQueue) = makeDetector(clock: clock, sampleRunner: sampleRunner)
+        let (detector, blockedQueue, samplingQueue) = makeDetector(clock: clock, sampleRunner: sampleRunner)
         defer { blockedQueue.resume() }
 
         // Dispatch probe.
@@ -316,6 +330,9 @@ struct MainThreadStallDetectorTests {
         detector.queue.sync {
             detector.ping()
         }
+
+        // Drain the async sampling dispatch before asserting.
+        samplingQueue.sync {}
 
         #expect(sampleRunner.callCount == 1, "Stage two should fire at 5.5s")
     }
@@ -345,7 +362,7 @@ struct MainThreadStallDetectorTests {
     func hangContextJsonIsContentSafe() throws {
         let clock = MockClock()
         let sampleRunner = MockSampleRunner()
-        let (detector, blockedQueue) = makeDetector(clock: clock, sampleRunner: sampleRunner)
+        let (detector, blockedQueue, _) = makeDetector(clock: clock, sampleRunner: sampleRunner)
         defer { blockedQueue.resume() }
 
         detector.queue.sync {


### PR DESCRIPTION
## Summary
- Addresses review feedback on #19510
- Added injectable `samplingQueue` property to `MainThreadStallDetector` (defaults to `.global(qos: .utility)` in production)
- Tests inject a serial queue and drain it with `samplingQueue.sync {}` before asserting `callCount`, eliminating the race condition

## Test plan
- [x] `stageTwoAttemptsSamplingOnce` — drains sampling queue before checking callCount
- [x] `stageTwoSamplingFailureDoesNotCrash` — drains sampling queue before checking callCount
- [x] `prolongedStallFiresBothStages` — drains sampling queue before checking callCount
- [x] All other tests updated to accept new 3-tuple from `makeDetector`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
