### PR TITLE
fix: cancel snapshotDebounceTask in onDisappear and conversation switch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1231,6 +1231,8 @@ struct MessageListView: View {
                 avatarSmoothingTask = nil
                 highlightDismissTask?.cancel()
                 highlightDismissTask = nil
+                snapshotDebounceTask?.cancel()
+                snapshotDebounceTask = nil
                 highlightedMessageId = nil
                 // Cancel any active pin session to prevent the coordinator's
                 // sessionTask from calling scrollTo on a stale ScrollViewProxy.
@@ -1391,6 +1393,8 @@ struct MessageListView: View {
                 expandSuppressionTask = nil
                 avatarSmoothingTask?.cancel()
                 avatarSmoothingTask = nil
+                snapshotDebounceTask?.cancel()
+                snapshotDebounceTask = nil
                 paginationTask?.cancel()
                 paginationTask = nil
                 isPaginationInFlight = false


### PR DESCRIPTION
## Summary
- Adds `snapshotDebounceTask?.cancel()` + `snapshotDebounceTask = nil` in `.onDisappear` block
- Adds `snapshotDebounceTask?.cancel()` + `snapshotDebounceTask = nil` in `.onChange(of: conversationId)` block
- Matches the established cancel+nil pattern used by all other `Task<Void, Never>?` state properties in this view

Addresses review feedback on #19521.

## Test plan
- [x] Verify all other task state variables still follow the same cancel+nil pattern in both locations
- [ ] Manual: switch conversations rapidly while scrolling — confirm no stale diagnostic snapshots appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
