### PR TITLE
fix: include memory_scope_id in all Qdrant embed job payloads

### DIFF
--- a/assistant/src/memory/job-handlers/embedding.ts
+++ b/assistant/src/memory/job-handlers/embedding.ts
@@ -34,6 +34,7 @@ export async function embedSegmentJob(
     conversation_id: segment.conversationId,
     message_id: segment.messageId,
     created_at: segment.createdAt,
+    memory_scope_id: segment.scopeId,
   });
 }
 
@@ -58,6 +59,7 @@ export async function embedItemJob(
     confidence: item.confidence,
     created_at: item.firstSeenAt,
     last_seen_at: item.lastSeenAt,
+    memory_scope_id: item.scopeId,
   });
 }
 
@@ -83,6 +85,7 @@ export async function embedSummaryJob(
       kind: summary.scope,
       created_at: summary.startAt,
       last_seen_at: summary.endAt,
+      memory_scope_id: summary.scopeId,
     },
   );
 }
@@ -116,6 +119,7 @@ export async function embedMediaJob(
     created_at: asset.createdAt,
     kind: asset.mediaType,
     subject: asset.title,
+    memory_scope_id: "default",
   });
 }
 


### PR DESCRIPTION
## Summary
- Add `memory_scope_id` to Qdrant point payloads for segment, item, and summary embed jobs (previously only attachments had it)
- Standalone media assets default to `"default"` scope since they have no conversation context
- Enables Qdrant-level scope filtering in a follow-up PR (currently scope filtering happens post-query in application code)

## Original prompt
Add memory_scope_id to all embed job Qdrant payloads (segment, item, summary) so that Qdrant-level scope filtering is possible. Currently only embedAttachmentJob includes memory_scope_id. The other embed jobs (embedSegmentJob, embedItemJob, embedSummaryJob) omit it. For each: look up the scopeId from the already-fetched DB row and include memory_scope_id in the extraPayload passed to embedAndUpsert. For embedMediaJob (standalone media assets with no conversation), default to "default". No backfill needed — legacy points are handled gracefully by the filter in the next PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
