### PR TITLE
fix: add Qdrant-level scope filtering to memory search

### DIFF
--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -326,6 +326,7 @@ export class VellumQdrantClient {
     limit: number,
     targetTypes: Array<"segment" | "item" | "summary" | "media">,
     excludeMessageIds?: string[],
+    scopeIds?: string[],
   ): Promise<QdrantSearchResult[]> {
     const mustConditions: Array<Record<string, unknown>> = [
       {
@@ -348,6 +349,18 @@ export class VellumQdrantClient {
             key: "target_type",
             match: { any: ["segment", "summary", "media"] },
           },
+        ],
+      });
+    }
+
+    // Scope filtering: accept points whose memory_scope_id matches one of the
+    // allowed scopes, OR points that lack the field entirely (legacy data).
+    // Post-query DB filtering remains as defense-in-depth for legacy points.
+    if (scopeIds && scopeIds.length > 0) {
+      mustConditions.push({
+        should: [
+          { key: "memory_scope_id", match: { any: scopeIds } },
+          { is_empty: { key: "memory_scope_id" } },
         ],
       });
     }

--- a/assistant/src/memory/search/semantic.ts
+++ b/assistant/src/memory/search/semantic.ts
@@ -61,6 +61,7 @@ export async function semanticSearch(
         fetchLimit,
         ["item", "summary", "segment", "media"],
         excludedMessageIds,
+        scopeIds,
       ),
     );
   }
@@ -277,13 +278,13 @@ export async function semanticSearch(
  * Build a Qdrant filter for hybrid search. Mirrors the logic in
  * `searchWithFilter` but as a standalone object for the query API.
  *
- * Scope filtering: items and media store `memory_scope_id` on the Qdrant
- * point payload, so we can filter at the Qdrant level. Segments and
- * summaries rely on post-query DB filtering (same as dense-only search).
+ * Scope filtering: points with a `memory_scope_id` payload field are
+ * filtered at the Qdrant level. Legacy points without the field pass
+ * through and are caught by post-query DB filtering.
  */
 function buildHybridFilter(
   excludeMessageIds: string[],
-  _scopeIds?: string[],
+  scopeIds?: string[],
 ): Record<string, unknown> {
   const mustConditions: Array<Record<string, unknown>> = [
     {
@@ -306,6 +307,18 @@ function buildHybridFilter(
           key: "target_type",
           match: { any: ["segment", "summary", "media"] },
         },
+      ],
+    });
+  }
+
+  // Scope filtering: accept points whose memory_scope_id matches one of the
+  // allowed scopes, OR points that lack the field entirely (legacy data).
+  // Post-query DB filtering remains as defense-in-depth for legacy points.
+  if (scopeIds && scopeIds.length > 0) {
+    mustConditions.push({
+      should: [
+        { key: "memory_scope_id", match: { any: scopeIds } },
+        { is_empty: { key: "memory_scope_id" } },
       ],
     });
   }


### PR DESCRIPTION
## Summary
- Activate `memory_scope_id` filtering at the Qdrant query level for both hybrid and dense-only search paths
- Use a `should` filter that accepts points matching allowed scopes OR legacy points without the field (caught by existing post-query DB filtering)
- Reduces overfetching of out-of-scope results, especially for private conversations where most default-scope results would be discarded

## Original prompt
Add Qdrant-level scope filtering to both the hybrid search (`buildHybridFilter`) and dense-only search (`searchWithFilter`) paths. The `_scopeIds` parameter in `buildHybridFilter` was previously unused (underscore prefix). Activate it by adding a `should` condition that matches points with `memory_scope_id` in the allowed scopes OR points lacking the field (legacy). Apply the same pattern to `searchWithFilter` by adding a `scopeIds` parameter and passing it from `semanticSearch`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
