### PR TITLE
feat: add getWorkspaceDirDisplay() helper for user-friendly workspace paths

### DIFF
--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -366,6 +366,24 @@ export function getWorkspaceDir(): string {
   return join(getRootDir(), "workspace");
 }
 
+/**
+ * Returns a display-friendly workspace path for embedding in agent-facing text
+ * (skill bodies, tool descriptions). Replaces the home directory prefix with `~`
+ * so paths stay concise and portable across machines.
+ *
+ * Examples:
+ *   /Users/sidd/.vellum/workspace → ~/.vellum/workspace
+ *   /data/.vellum/workspace       → /data/.vellum/workspace
+ */
+export function getWorkspaceDirDisplay(): string {
+  const abs = getWorkspaceDir();
+  const home = homedir();
+  if (abs.startsWith(home)) {
+    return "~" + abs.slice(home.length);
+  }
+  return abs;
+}
+
 /** Returns ~/.vellum/workspace/config.json */
 export function getWorkspaceConfigPath(): string {
   return join(getWorkspaceDir(), "config.json");


### PR DESCRIPTION
## Summary
- Add getWorkspaceDirDisplay() helper to platform.ts that returns a user-friendly workspace path (~ prefix when under home dir, absolute otherwise)
- This enables dynamic workspace path substitution in skill bodies and tool descriptions

Part of plan: clean-workspace-path-refs.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
