### PR TITLE
feat: add scopeLabel to MemoryItemPayload

### DIFF
--- a/clients/shared/Features/Memory/MemoryItemPayload.swift
+++ b/clients/shared/Features/Memory/MemoryItemPayload.swift
@@ -12,6 +12,7 @@ public struct MemoryItemPayload: Codable, Identifiable, Hashable, Sendable {
     public let accessCount: Int
     public let verificationState: String
     public let scopeId: String
+    public let scopeLabel: String?
     public let firstSeenAt: Int      // epoch ms
     public let lastSeenAt: Int       // epoch ms
     public let lastUsedAt: Int?      // epoch ms
@@ -22,7 +23,7 @@ public struct MemoryItemPayload: Codable, Identifiable, Hashable, Sendable {
 
     enum CodingKeys: String, CodingKey {
         case id, kind, subject, statement, status, confidence, importance
-        case accessCount, verificationState, scopeId
+        case accessCount, verificationState, scopeId, scopeLabel
         case firstSeenAt, lastSeenAt, lastUsedAt
         case supersedes, supersededBy
         case supersedesSubject, supersededBySubject


### PR DESCRIPTION
## Summary
- Add optional `scopeLabel: String?` property to `MemoryItemPayload` to surface scope information in the client
- Add corresponding `CodingKeys` entry for JSON decoding

Part of plan: memory-scope-ui.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
