### PR TITLE
feat: add {workspaceDir} token substitution to skill body loading

### DIFF
--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -28,7 +28,10 @@ import { parseFrontmatterFields } from "../skills/frontmatter.js";
 import { parseToolManifestFile } from "../skills/tool-manifest.js";
 import { computeSkillVersionHash } from "../skills/version-hash.js";
 import { getLogger } from "../util/logger.js";
-import { getWorkspaceSkillsDir } from "../util/platform.js";
+import {
+  getWorkspaceDirDisplay,
+  getWorkspaceSkillsDir,
+} from "../util/platform.js";
 import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
 import { getConfig } from "./loader.js";
 
@@ -1001,6 +1004,11 @@ function loadSkillDefinition(skill: SkillSummary): SkillLookupResult {
   }
   // Replace {baseDir} placeholders with the actual skill directory path
   loaded.body = loaded.body.replaceAll("{baseDir}", loaded.directoryPath);
+  // Replace {workspaceDir} placeholders with the runtime workspace display path
+  loaded.body = loaded.body.replaceAll(
+    "{workspaceDir}",
+    getWorkspaceDirDisplay(),
+  );
   // Strip feature-gated sections based on assistant feature flags
   loaded.body = applyFeatureGatedSections(loaded.body);
   return { skill: loaded };


### PR DESCRIPTION
## Summary
- Add {workspaceDir} token substitution in loadSkillDefinition() alongside existing {baseDir} pattern
- Tokens in SKILL.md bodies are replaced with the runtime workspace display path at load time
- Enables bundled skills to use {workspaceDir} instead of hardcoded ~/.vellum/workspace paths

Part of plan: clean-workspace-path-refs.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
