### PR TITLE
feat: add {workspaceDir} token substitution to TOOLS.json tool descriptions

### DIFF
--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -24,6 +24,7 @@ import {
 import { parseToolManifestFile } from "../../skills/tool-manifest.js";
 import { computeSkillVersionHash } from "../../skills/version-hash.js";
 import { getLogger } from "../../util/logger.js";
+import { getWorkspaceDirDisplay } from "../../util/platform.js";
 import { registerTool } from "../registry.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 
@@ -76,7 +77,9 @@ function formatToolSchemas(
 
   for (const tool of manifest.tools) {
     lines.push(`${toolHeadingLevel} ${tool.name}`);
-    lines.push(tool.description);
+    lines.push(
+      tool.description.replaceAll("{workspaceDir}", getWorkspaceDirDisplay()),
+    );
 
     const schema = tool.input_schema;
     const properties = schema.properties as


### PR DESCRIPTION
## Summary
- Add {workspaceDir} token substitution in formatToolSchemas() for TOOLS.json descriptions
- Tool descriptions containing {workspaceDir} tokens are resolved to the correct workspace path at runtime
- Enables bundled skill TOOLS.json files to use dynamic paths instead of hardcoded ~/.vellum/workspace

Part of plan: clean-workspace-path-refs.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
