### PR TITLE
feat: resolve conversation titles for private-scoped memory items

### DIFF
--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -8,13 +8,17 @@
  * DELETE /v1/memory-items/:id    — delete a memory item and its embeddings
  */
 
-import { and, asc, count, desc, eq, like, ne, or } from "drizzle-orm";
+import { and, asc, count, desc, eq, inArray, like, ne, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../../memory/db.js";
 import { computeMemoryFingerprint } from "../../memory/fingerprint.js";
 import { enqueueMemoryJob } from "../../memory/jobs-store.js";
-import { memoryEmbeddings, memoryItems } from "../../memory/schema.js";
+import {
+  conversations,
+  memoryEmbeddings,
+  memoryItems,
+} from "../../memory/schema.js";
 import { truncate } from "../../util/truncate.js";
 import { httpError } from "../http-errors.js";
 import type { RouteContext, RouteDefinition } from "../http-router.js";
@@ -62,6 +66,54 @@ function isValidKind(value: string): value is MemoryItemKind {
 
 function isValidSortField(value: string): value is SortField {
   return (VALID_SORT_FIELDS as readonly string[]).includes(value);
+}
+
+/**
+ * Resolve a `scopeLabel` for a memory item based on its `scopeId`.
+ *
+ * - `"default"` → `null`
+ * - `"private:<conversationId>"` → `"Private · <title>"` when the conversation
+ *   has a title, or `"Private"` when it doesn't (or the conversation was deleted).
+ */
+function resolveScopeLabel(
+  scopeId: string,
+  titleMap: Map<string, string | null>,
+): string | null {
+  if (scopeId === "default") return null;
+  if (scopeId.startsWith("private:")) {
+    const conversationId = scopeId.slice("private:".length);
+    const title = titleMap.get(conversationId);
+    return title ? `Private · ${title}` : "Private";
+  }
+  return null;
+}
+
+/**
+ * Batch-fetch conversation titles for a set of private-scoped memory items.
+ * Returns a Map from conversation ID → title (or null).
+ */
+function buildConversationTitleMap(
+  db: ReturnType<typeof getDb>,
+  scopeIds: string[],
+): Map<string, string | null> {
+  const conversationIds = scopeIds
+    .filter((s) => s.startsWith("private:"))
+    .map((s) => s.slice("private:".length));
+
+  const uniqueIds = [...new Set(conversationIds)];
+  if (uniqueIds.length === 0) return new Map();
+
+  const rows = db
+    .select({ id: conversations.id, title: conversations.title })
+    .from(conversations)
+    .where(inArray(conversations.id, uniqueIds))
+    .all();
+
+  const map = new Map<string, string | null>();
+  for (const row of rows) {
+    map.set(row.id, row.title);
+  }
+  return map;
 }
 
 // ---------------------------------------------------------------------------
@@ -145,7 +197,17 @@ export function handleListMemoryItems(url: URL): Response {
     .offset(offsetParam)
     .all();
 
-  return Response.json({ items, total });
+  // Resolve scope labels for private-scoped items
+  const titleMap = buildConversationTitleMap(
+    db,
+    items.map((i) => i.scopeId),
+  );
+  const enrichedItems = items.map((item) => ({
+    ...item,
+    scopeLabel: resolveScopeLabel(item.scopeId, titleMap),
+  }));
+
+  return Response.json({ items: enrichedItems, total });
 }
 
 // ---------------------------------------------------------------------------
@@ -187,9 +249,14 @@ export function handleGetMemoryItem(ctx: RouteContext): Response {
     supersededBySubject = superseding?.subject;
   }
 
+  // Resolve scope label
+  const titleMap = buildConversationTitleMap(db, [item.scopeId]);
+  const scopeLabel = resolveScopeLabel(item.scopeId, titleMap);
+
   return Response.json({
     item: {
       ...item,
+      scopeLabel,
       ...(supersedesSubject !== undefined ? { supersedesSubject } : {}),
       ...(supersededBySubject !== undefined ? { supersededBySubject } : {}),
     },


### PR DESCRIPTION
## Summary
- Enrich memory item API responses with a `scopeLabel` field that resolves private scope IDs to human-readable labels including conversation titles
- Default-scoped items get `scopeLabel: null`, private-scoped items get `scopeLabel: "Private · <title>"` or `"Private"` if no title
- Applied to both list and detail endpoints

Part of plan: memory-scope-ui.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
