### PR TITLE
fix: always reset isPaginationInFlight in defer and add onDisappear reset

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -621,8 +621,8 @@ struct MessageListView: View {
         log.debug("[pagination] fired — anchorId: \(String(describing: anchorId))")
         paginationTask = Task {
             defer {
+                isPaginationInFlight = false
                 if !Task.isCancelled {
-                    isPaginationInFlight = false
                     paginationTask = nil
                 }
             }
@@ -1227,6 +1227,7 @@ struct MessageListView: View {
                 scrollRestoreTask = nil
                 paginationTask?.cancel()
                 paginationTask = nil
+                isPaginationInFlight = false
                 avatarSmoothingTask?.cancel()
                 avatarSmoothingTask = nil
                 highlightDismissTask?.cancel()


### PR DESCRIPTION
## Summary
- Fixes review feedback from #19529 where the `if !Task.isCancelled` guard in the defer block prevented `isPaginationInFlight` from being reset on task cancellation
- `isPaginationInFlight` guards against creating a second pagination task, so no successor can exist — it must always be cleaned up
- Added belt-and-suspenders `isPaginationInFlight = false` in onDisappear for consistency with the conversation-switch handler

## Test plan
- [ ] Navigate away from chat during pagination load — verify pagination works when returning
- [ ] Rapid conversation switching during pagination — verify no stuck state
- [ ] Normal pagination flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
