### PR TITLE
fix: restore composer focus when pending confirmation clears

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -153,6 +153,11 @@ struct ComposerView: View {
                 suppressSlashReopen = false
             }
         }
+        .onChange(of: hasPendingConfirmation) { _, pending in
+            if !pending, isInteractionEnabled {
+                composerFocus = true
+            }
+        }
     }
 
     /// The text overlays (slash highlighting, ghost text) rendered behind / on


### PR DESCRIPTION
## Summary
- Fixes review feedback from #19531 where composer focus could remain lost after confirmation dialog dismissal
- Adds `onChange(of: hasPendingConfirmation)` handler that restores focus when confirmation clears and interaction is enabled
- Matches the guard pattern established in the `isInteractionEnabled` handler

## Test plan
- [ ] Open inspector while confirmation dialog is visible, close inspector, then dismiss confirmation — composer should regain focus
- [ ] Dismiss confirmation dialog normally — composer should regain focus
- [ ] Verify focus is NOT restored if interaction is disabled when confirmation clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
