### PR TITLE
fix: add Qdrant payload index for memory_scope_id

### DIFF
--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -574,6 +574,10 @@ export class VellumQdrantClient {
         field_name: "modality",
         field_schema: "keyword",
       }),
+      this.client.createPayloadIndex(this.collection, {
+        field_name: "memory_scope_id",
+        field_schema: "keyword",
+      }),
     ]);
   }
 


### PR DESCRIPTION
## Summary
- Fixes review feedback from #19537 where the new `memory_scope_id` filter field was missing a Qdrant payload index
- Adds `memory_scope_id` (keyword type) to `ensurePayloadIndexes()`, consistent with all other filtered fields

## Test plan
- [ ] Verify Qdrant starts and indexes are created on next assistant launch
- [ ] Memory search with scope filtering works correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
