### PR TITLE
fix: update embedding test assertions to include memory_scope_id

### DIFF
--- a/assistant/src/memory/job-handlers/embedding.test.ts
+++ b/assistant/src/memory/job-handlers/embedding.test.ts
@@ -183,6 +183,7 @@ describe("embedMediaJob", () => {
     expect(call.extraPayload).toEqual({
       created_at: now,
       kind: "image",
+      memory_scope_id: "default",
       subject: "My Screenshot",
     });
   });


### PR DESCRIPTION
## Summary
- Fixes review feedback from #19536 where test assertions were not updated to include the new `memory_scope_id` field
- Updates all `.toEqual()` assertions on `extraPayload` in embedding.test.ts

## Test plan
- [x] `bun test src/memory/job-handlers/embedding.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
