### PR TITLE
fix: replace hardcoded workspace paths in skill-management skill with {workspaceDir} token

### DIFF
--- a/assistant/src/config/bundled-skills/skill-management/SKILL.md
+++ b/assistant/src/config/bundled-skills/skill-management/SKILL.md
@@ -7,7 +7,7 @@ metadata:
     display-name: "Skill Management"
 ---
 
-Manage the lifecycle of custom managed skills in `~/.vellum/workspace/skills`.
+Manage the lifecycle of custom managed skills in `{workspaceDir}/skills`.
 
 ## Capabilities
 

--- a/assistant/src/config/bundled-skills/skill-management/TOOLS.json
+++ b/assistant/src/config/bundled-skills/skill-management/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "scaffold_managed_skill",
-      "description": "Create or update a managed skill in ~/.vellum/workspace/skills. The skill becomes available for skill_load immediately. Never persist a skill without explicit user consent. Before persisting, test the snippet: write to a temp file with bash and run with `bun run /tmp/vellum-eval/snippet.ts`. Iterate up to 3 attempts, then ask the user. Clean up temp files after. Do not use file_write for temp files outside the working directory. After a skill is written, the next turn may run in a recreated conversation due to file-watcher eviction - continue normally.",
+      "description": "Create or update a managed skill in {workspaceDir}/skills. The skill becomes available for skill_load immediately. Never persist a skill without explicit user consent. Before persisting, test the snippet: write to a temp file with bash and run with `bun run /tmp/vellum-eval/snippet.ts`. Iterate up to 3 attempts, then ask the user. Clean up temp files after. Do not use file_write for temp files outside the working directory. After a skill is written, the next turn may run in a recreated conversation due to file-watcher eviction - continue normally.",
       "category": "skills",
       "risk": "high",
       "input_schema": {
@@ -54,7 +54,7 @@
     },
     {
       "name": "delete_managed_skill",
-      "description": "Delete a managed skill from ~/.vellum/workspace/skills and remove it from the SKILLS.md index. Never delete a skill without explicit user confirmation. After deletion, the next turn may run in a recreated conversation due to file-watcher eviction - continue normally.",
+      "description": "Delete a managed skill from {workspaceDir}/skills and remove it from the SKILLS.md index. Never delete a skill without explicit user confirmation. After deletion, the next turn may run in a recreated conversation due to file-watcher eviction - continue normally.",
       "category": "skills",
       "risk": "high",
       "input_schema": {


### PR DESCRIPTION
## Summary
- Replace hardcoded ~/.vellum/workspace/skills paths in skill-management SKILL.md and TOOLS.json with {workspaceDir}/skills token
- Paths are now dynamically resolved at runtime via the {workspaceDir} substitution mechanism
- Fixes incorrect paths in containerized and multi-instance deployments

Part of plan: clean-workspace-path-refs.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
