### PR TITLE
feat: show private scope in iOS memory detail view

### DIFF
--- a/clients/ios/Views/Intelligence/MemoryItemDetailView.swift
+++ b/clients/ios/Views/Intelligence/MemoryItemDetailView.swift
@@ -177,6 +177,24 @@ struct MemoryItemDetailView: View {
 
                 detailRow(label: "Status", value: liveItem.status.capitalized)
                 detailRow(label: "Verification", value: formatVerificationState(liveItem.verificationState))
+
+                if let scopeLabel = liveItem.scopeLabel {
+                    HStack {
+                        Text("Scope")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentTertiary)
+                        Spacer()
+                        HStack(spacing: VSpacing.xxs) {
+                            VIconView(.lock, size: 12)
+                                .foregroundColor(VColor.contentSecondary)
+                            Text(scopeLabel)
+                                .font(VFont.body)
+                                .foregroundColor(VColor.contentDefault)
+                        }
+                    }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("Scope: \(scopeLabel)")
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add a "Scope" row with lock icon to the iOS memory detail view for private-scoped memories
- Default-scoped memories show no scope row (unchanged)
- Shows the resolved scope label (e.g. "Private · Chat title")

Part of plan: memory-scope-ui.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
