### PR TITLE
feat: show private scope badge in memory item rows

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -17,6 +17,10 @@ struct MemoryItemRow: View {
                             .foregroundColor(VColor.contentDefault)
 
                         kindTag
+
+                        if let scopeLabel = item.scopeLabel {
+                            VBadge(label: scopeLabel, icon: .lock, tone: .neutral, emphasis: .subtle, shape: .rounded)
+                        }
                     }
 
                     Text(item.statement)


### PR DESCRIPTION
## Summary
- Add a neutral-toned VBadge with lock icon for private-scoped memory items in the macOS memory list
- Default-scoped memories remain unchanged (no badge)
- Badge shows "Private · <conversation title>" or "Private" for untitled conversations

Part of plan: memory-scope-ui.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
