### PR TITLE
fix: add scopeLabel enrichment to POST/PATCH memory item responses

### DIFF
--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -370,7 +370,14 @@ export async function handleCreateMemoryItem(
     .where(eq(memoryItems.id, id))
     .get();
 
-  return Response.json({ item: insertedRow }, { status: 201 });
+  // Enrich with scopeLabel for API consistency
+  const titleMap = buildConversationTitleMap(db, [scopeId]);
+  const scopeLabel = resolveScopeLabel(scopeId, titleMap);
+
+  return Response.json(
+    { item: { ...insertedRow, scopeLabel } },
+    { status: 201 },
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -497,7 +504,18 @@ export async function handleUpdateMemoryItem(
     .where(eq(memoryItems.id, id))
     .get();
 
-  return Response.json({ item: updatedRow });
+  // Enrich with scopeLabel for API consistency
+  const patchTitleMap = buildConversationTitleMap(db, [
+    updatedRow?.scopeId ?? existing.scopeId,
+  ]);
+  const patchScopeLabel = resolveScopeLabel(
+    updatedRow?.scopeId ?? existing.scopeId,
+    patchTitleMap,
+  );
+
+  return Response.json({
+    item: { ...updatedRow, scopeLabel: patchScopeLabel },
+  });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for memory-scope-ui.md.

**Gap:** POST and PATCH handlers omit scopeLabel from response
**What was expected:** All memory item endpoints return consistent shape including scopeLabel
**What was found:** POST and PATCH return raw DB row without scopeLabel enrichment

- Added `buildConversationTitleMap` + `resolveScopeLabel` enrichment to `handleCreateMemoryItem` (POST) response
- Added the same enrichment to `handleUpdateMemoryItem` (PATCH) response
- Now all memory item endpoints return a consistent shape including `scopeLabel`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
