### PR TITLE
fix: show scope label in macOS memory detail sheet

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Content.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Content.swift
@@ -61,6 +61,20 @@ extension MemoryItemDetailSheet {
                 }
             }
 
+            if let scopeLabel = displayItem.scopeLabel {
+                HStack(spacing: VSpacing.xs) {
+                    Text("Scope")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentTertiary)
+                        .frame(width: 110, alignment: .leading)
+                    VIconView(.lock, size: 12)
+                        .foregroundColor(VColor.contentSecondary)
+                    Text(scopeLabel)
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(VColor.contentSecondary)
+                }
+            }
+
             metadataRow(label: "First seen", value: formattedDate(displayItem.firstSeenDate))
             metadataRow(label: "Last seen", value: formattedDate(displayItem.lastSeenDate))
             if let lastUsedDate = displayItem.lastUsedDate {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for memory-scope-ui.md.

**Gap:** macOS detail sheet does not display scopeLabel
**What was expected:** macOS memory detail view should show scope for private memories
**What was found:** MemoryItemDetailSheet+Content.swift has no reference to scopeLabel
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
