### PR TITLE
fix: use dynamic workspace path in resolveSkillSelector error message

### DIFF
--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -1029,8 +1029,7 @@ export function resolveSkillSelector(
   const catalog = loadSkillCatalog(workspaceSkillsDir);
   if (catalog.length === 0) {
     return {
-      error:
-        "No skills are available. Configure ~/.vellum/workspace/skills/SKILLS.md or add skill directories.",
+      error: `No skills are available. Configure ${getWorkspaceDirDisplay()}/skills/SKILLS.md or add skill directories.`,
       errorCode: "empty_catalog",
     };
   }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for clean-workspace-path-refs.md.

**Gap:** Agent-facing error message in resolveSkillSelector still has hardcoded workspace path
**What was expected:** All agent-facing workspace paths should use getWorkspaceDirDisplay() for dynamic resolution
**What was found:** Hardcoded ~/.vellum/workspace/skills/SKILLS.md in error message surfaced to agent
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
