### PR TITLE
Dev mode: route local hatch through Docker by default

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -69,7 +69,12 @@ struct APIKeyStepView: View {
     // MARK: - Hosting Cards
 
     private var availableHostingModes: [OnboardingState.HostingMode] {
-        var modes: [OnboardingState.HostingMode] = [.local, .docker, .vellumCloud]
+        var modes: [OnboardingState.HostingMode] = [.local, .vellumCloud]
+        // In dev mode, local already uses Docker under the hood, so hide the
+        // separate Docker card to reduce confusion.
+        if !DevModeManager.shared.isDevMode {
+            modes.insert(.docker, at: 1)
+        }
         if userHostedEnabled {
             modes.append(contentsOf: [.aws, .gcp, .customHardware])
         }
@@ -204,7 +209,12 @@ struct APIKeyStepView: View {
     private func handleContinue() {
         guard canContinue else { return }
 
-        state.cloudProvider = state.selectedHostingMode.rawValue
+        // In dev mode, "Local" uses Docker under the hood for sandboxed execution.
+        if DevModeManager.shared.isDevMode && state.selectedHostingMode == .local {
+            state.cloudProvider = OnboardingState.HostingMode.docker.rawValue
+        } else {
+            state.cloudProvider = state.selectedHostingMode.rawValue
+        }
 
         if isAuthenticated {
             // Authenticated user selecting Local: skip API key, advance to consent step


### PR DESCRIPTION
## Summary
- Hide the "Local (Container)" hosting card in the setup flow when dev mode is active
- When dev mode is on and the user selects "Local", automatically use `--remote docker` for the hatch command instead of plain local

## Test plan
- [ ] In dev mode, setup flow shows Local and Vellum Cloud but not "Local (Container)"
- [ ] Selecting Local in dev mode triggers `hatch --remote docker`
- [ ] Non-dev mode still shows all three options and routes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
