### PR TITLE
fix: guard tilde replacement with path-separator boundary in getWorkspaceDirDisplay

### DIFF
--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -378,7 +378,7 @@ export function getWorkspaceDir(): string {
 export function getWorkspaceDirDisplay(): string {
   const abs = getWorkspaceDir();
   const home = homedir();
-  if (abs.startsWith(home)) {
+  if (abs.startsWith(home + "/") || abs === home) {
     return "~" + abs.slice(home.length);
   }
   return abs;


### PR DESCRIPTION
Guard `abs.startsWith(home)` with a path-separator boundary so that e.g. `/home/alice2/...` is not incorrectly matched when `homedir()` is `/home/alice`. Also handles the root homedir case (`/`) correctly.

Addresses feedback from #19540.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
