### PR TITLE
fix: apply {workspaceDir} substitution to TOOLS.json parameter descriptions

### DIFF
--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -99,7 +99,7 @@ function formatToolSchemas(
           : "optional";
         const descPart =
           typeof paramDef.description === "string"
-            ? `: ${paramDef.description}`
+            ? `: ${paramDef.description.replaceAll("{workspaceDir}", getWorkspaceDirDisplay())}`
             : "";
         lines.push(
           `- ${paramName} (${paramType}, ${requiredLabel})${descPart}`,


### PR DESCRIPTION
Apply the same `{workspaceDir}` placeholder replacement to parameter descriptions that was already being applied to tool descriptions, so authors can use the token in both places.

Addresses feedback from #19544.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
