### PR TITLE
fix: guard isPaginationInFlight reset against successor task clobber

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -621,9 +621,11 @@ struct MessageListView: View {
         log.debug("[pagination] fired — anchorId: \(String(describing: anchorId))")
         paginationTask = Task {
             defer {
-                isPaginationInFlight = false
                 if !Task.isCancelled {
+                    isPaginationInFlight = false
                     paginationTask = nil
+                } else if paginationTask == nil {
+                    isPaginationInFlight = false
                 }
             }
             let hadMore = await loadPreviousMessagePage?() ?? false


### PR DESCRIPTION
Guard the `isPaginationInFlight = false` reset in the pagination defer block so it only fires when no successor task has been spawned. This prevents a cancelled task's defer from clobbering a newer task's flag, which could allow concurrent pagination loads.

Addresses feedback from #19546.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
