### PR TITLE
fix: prevent suggestion pills from overflowing outside the container

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -151,6 +151,7 @@ struct ChatEmptyStateView: View {
                 starters: conversationStarters,
                 onSelect: { starter in onSelectStarter?(starter) }
             )
+            .padding(.horizontal, VSpacing.lg)
             .frame(maxWidth: VSpacing.chatBubbleMaxWidth)
             .padding(.top, VSpacing.xxl)
             .opacity(visible ? 1 : 0)


### PR DESCRIPTION
## Summary
- Added horizontal padding (`VSpacing.lg`) to the `ConversationStarterPillRow` in the empty state so the pills align with the composer box instead of overflowing its visual bounds.

## Original prompt
--safe https://linear.app/vellum/issue/LUM-305/suggestion-pills-overflow-outside-the-container
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
