### PR TITLE
fix: reduce left padding in fullscreen when traffic lights hidden

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -632,10 +632,12 @@ struct MainWindowView: View {
             .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
                 conversationManager.markActiveConversationSeenIfNeeded()
             }
-            .onReceive(NotificationCenter.default.publisher(for: NSWindow.didEnterFullScreenNotification)) { _ in
+            .onReceive(NotificationCenter.default.publisher(for: NSWindow.didEnterFullScreenNotification)) { notification in
+                guard notification.object is TitleBarZoomableWindow else { return }
                 isInFullscreen = true
             }
-            .onReceive(NotificationCenter.default.publisher(for: NSWindow.didExitFullScreenNotification)) { _ in
+            .onReceive(NotificationCenter.default.publisher(for: NSWindow.didExitFullScreenNotification)) { notification in
+                guard notification.object is TitleBarZoomableWindow else { return }
                 isInFullscreen = false
             }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -690,6 +690,10 @@ struct MainWindowView: View {
     }
 
     private func handleCoreLayoutAppear() {
+        // Sync fullscreen state for windows restored into fullscreen by macOS state restoration.
+        if let window = NSApp.windows.first(where: { $0 is TitleBarZoomableWindow }) {
+            isInFullscreen = window.styleMask.contains(.fullScreen)
+        }
         // Reset stale chat-dock state for users upgrading from older versions.
         // Without this, isAppChatOpen could remain persisted as true with
         // no UI to disable it, leaving panels stuck in split mode.

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -505,7 +505,6 @@ struct MainWindowView: View {
             }
         }
         .padding(.leading, trafficLightPadding)
-        .animation(VAnimation.standard, value: isInFullscreen)
         .padding(.trailing, VSpacing.lg)
         .frame(height: 48)
         .background(VColor.surfaceOverlay)
@@ -632,11 +631,11 @@ struct MainWindowView: View {
             .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
                 conversationManager.markActiveConversationSeenIfNeeded()
             }
-            .onReceive(NotificationCenter.default.publisher(for: NSWindow.didEnterFullScreenNotification)) { notification in
+            .onReceive(NotificationCenter.default.publisher(for: NSWindow.willEnterFullScreenNotification)) { notification in
                 guard notification.object is TitleBarZoomableWindow else { return }
                 isInFullscreen = true
             }
-            .onReceive(NotificationCenter.default.publisher(for: NSWindow.didExitFullScreenNotification)) { notification in
+            .onReceive(NotificationCenter.default.publisher(for: NSWindow.willExitFullScreenNotification)) { notification in
                 guard notification.object is TitleBarZoomableWindow else { return }
                 isInFullscreen = false
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -63,6 +63,8 @@ struct MainWindowView: View {
     /// Mirrors `AppDelegate.daemonStartupError` so SwiftUI re-renders the
     /// daemon loading overlay when a structured error arrives or is cleared.
     @State private var daemonStartupError: DaemonStartupError?
+    /// Whether the main window is in native macOS fullscreen (traffic lights hidden).
+    @State private var isInFullscreen: Bool = false
 
     init(conversationManager: ConversationManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, updateManager: UpdateManager, onSendWakeUp: (() -> Void)? = nil) {
         self.conversationManager = conversationManager
@@ -93,10 +95,10 @@ struct MainWindowView: View {
     // MARK: - Layout Constants
 
     /// Leading padding to account for macOS traffic light buttons (red/yellow/green).
-    /// Note: This is a fixed value that may not be accurate for all window styles or
-    /// if Apple changes the traffic light spacing. Dynamic measurement would be better
-    /// but requires complex window geometry inspection.
-    let trafficLightPadding: CGFloat = 78
+    /// In native fullscreen the traffic lights are hidden, so we use standard padding.
+    var trafficLightPadding: CGFloat {
+        isInFullscreen ? VSpacing.lg : 78
+    }
 
     func toggleVoiceMode() {
         if voiceModeManager.state != .off {
@@ -503,6 +505,7 @@ struct MainWindowView: View {
             }
         }
         .padding(.leading, trafficLightPadding)
+        .animation(VAnimation.standard, value: isInFullscreen)
         .padding(.trailing, VSpacing.lg)
         .frame(height: 48)
         .background(VColor.surfaceOverlay)
@@ -628,6 +631,12 @@ struct MainWindowView: View {
             }
             .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
                 conversationManager.markActiveConversationSeenIfNeeded()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: NSWindow.didEnterFullScreenNotification)) { _ in
+                isInFullscreen = true
+            }
+            .onReceive(NotificationCenter.default.publisher(for: NSWindow.didExitFullScreenNotification)) { _ in
+                isInFullscreen = false
             }
     }
 


### PR DESCRIPTION
## Summary
- In native macOS fullscreen, traffic light buttons (close/minimize/zoom) are hidden, but the top bar still reserved 78pt of leading padding for them, leaving awkward empty space on the left
- Now detects fullscreen state via `NSWindow.didEnterFullScreenNotification` / `didExitFullScreenNotification` and reduces leading padding to standard `VSpacing.lg` (16pt) when in fullscreen
- Smooth animation on the padding transition

## Original prompt
--safe https://linear.app/vellum/issue/LUM-309/fullscreen-mode-hides-traffic-sign-and-misaligns-icons should take empty space on a left gracefully
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
