### PR TITLE
fix: dynamically center traffic light buttons in custom toolbar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -457,9 +457,17 @@ public final class MainWindow {
             defaultTrafficLightOrigin = containerView.frame.origin
         }
         guard let origin = defaultTrafficLightOrigin else { return }
+
+        // Vertically center the traffic light buttons in the 48pt custom toolbar.
+        // The default position centers them in the system titlebar; shift down
+        // by half the height difference so they sit centered in our taller bar.
+        let systemTitlebarHeight = containerView.superview?.frame.height ?? 28
+        let toolbarHeight: CGFloat = 48
+        let verticalShift = (toolbarHeight - systemTitlebarHeight) / 2
+
         containerView.setFrameOrigin(NSPoint(
             x: origin.x + 2,
-            y: origin.y - 8
+            y: origin.y - verticalShift
         ))
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -461,7 +461,10 @@ public final class MainWindow {
         // Vertically center the traffic light buttons in the 48pt custom toolbar.
         // The default position centers them in the system titlebar; shift down
         // by half the height difference so they sit centered in our taller bar.
-        let systemTitlebarHeight = containerView.superview?.frame.height ?? 28
+        // Clamp to a reasonable range in case Apple changes the private view
+        // hierarchy and the superview becomes the full theme frame.
+        let rawHeight = containerView.superview?.frame.height ?? 28
+        let systemTitlebarHeight = min(rawHeight, 60)
         let toolbarHeight: CGFloat = 48
         let verticalShift = (toolbarHeight - systemTitlebarHeight) / 2
 


### PR DESCRIPTION
## Summary
- Replace hardcoded y-offset (-8) for traffic light button positioning with a dynamic calculation based on the actual system titlebar height
- Computes the vertical shift as half the difference between our 48pt toolbar and the system titlebar, ensuring correct centering regardless of macOS version

## Original prompt
--safe https://linear.app/vellum/issue/LUM-295/traffic-light-icons-are-vertically-misaligned
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
