### PR TITLE
Remove ElevenLabs credential special-case, treat as standard api_key provider

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -29,6 +29,7 @@ export const API_KEY_PROVIDERS = [
   "fireworks",
   "openrouter",
   "brave",
+  "elevenlabs",
   "perplexity",
 ] as const;
 

--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -36,12 +36,11 @@ enum APIKeyManager {
     }()
 
     /// Provider identifiers whose API keys are synced to the daemon as
-    /// `type: "api_key"`. ElevenLabs is excluded because the daemon expects
-    /// it as `type: "credential"` with name `"elevenlabs:api_key"` — the
-    /// sync loops in AppDelegate and SettingsStore handle it separately.
+    /// `type: "api_key"`.
     static let allSyncableProviders = [
         "anthropic",
         "brave",
+        "elevenlabs",
         "fireworks",
         "gemini",
         "openai",
@@ -54,9 +53,6 @@ enum APIKeyManager {
         for provider in allSyncableProviders {
             if getKey(for: provider) != nil { return true }
         }
-        // ElevenLabs is not in allSyncableProviders (different sync type)
-        // but still counts as a configured key.
-        if getKey(for: "elevenlabs") != nil { return true }
         return false
     }
 
@@ -67,12 +63,9 @@ enum APIKeyManager {
     /// Safe to call multiple times — skips providers that already have a
     /// value in credential storage.
     static func migrateFromUserDefaults() {
-        // Migrate api_key-type providers
         for provider in allSyncableProviders {
             migrateProviderFromUserDefaults(provider)
         }
-        // ElevenLabs uses a different sync type but still needs migration
-        migrateProviderFromUserDefaults("elevenlabs")
     }
 
     /// Migrate a single provider's key from UserDefaults to credential storage.

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -524,12 +524,6 @@ extension AppDelegate {
             _ = try? await GatewayHTTPClient.post(path: "assistants/\(assistantId)/secrets", json: body, timeout: 5)
         }
 
-        // ElevenLabs uses the credential type, not api_key
-        if let elevenLabsKey = APIKeyManager.getKey(for: "elevenlabs"), !elevenLabsKey.isEmpty {
-            let body: [String: Any] = ["type": "credential", "name": "elevenlabs:api_key", "value": elevenLabsKey]
-            _ = try? await GatewayHTTPClient.post(path: "assistants/\(assistantId)/secrets", json: body, timeout: 5)
-        }
-
         log.info("syncApiKeysViaGateway: pushed API keys for \(assistantId, privacy: .public)")
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -791,16 +791,16 @@ public final class SettingsStore: ObservableObject {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         APIKeyManager.setKey(trimmed, for: "elevenlabs")
-        removeDeletionTombstone(type: "credential", name: "elevenlabs:api_key")
-        syncCredentialToDaemon(name: "elevenlabs:api_key", value: trimmed)
+        removeDeletionTombstone(type: "api_key", name: "elevenlabs")
+        syncKeyToDaemon(provider: "elevenlabs", value: trimmed)
         hasElevenLabsKey = true
         maskedElevenLabsKey = Self.maskKey(trimmed)
     }
 
     func clearElevenLabsKey() {
         APIKeyManager.deleteKey(for: "elevenlabs")
-        addDeletionTombstone(type: "credential", name: "elevenlabs:api_key")
-        deleteCredentialFromDaemon(name: "elevenlabs:api_key")
+        addDeletionTombstone(type: "api_key", name: "elevenlabs")
+        deleteKeyFromDaemon(provider: "elevenlabs")
         hasElevenLabsKey = false
         maskedElevenLabsKey = ""
     }
@@ -1246,11 +1246,6 @@ public final class SettingsStore: ObservableObject {
                 if let key = APIKeyManager.getKey(for: provider) {
                     syncKeyToDaemon(provider: provider, value: key)
                 }
-            }
-
-            // ElevenLabs uses the credential type, not api_key
-            if let key = APIKeyManager.getKey(for: "elevenlabs") {
-                syncCredentialToDaemon(name: "elevenlabs:api_key", value: key)
             }
 
             replayDeletionTombstones()


### PR DESCRIPTION
## Summary
- Adds `elevenlabs` to `API_KEY_PROVIDERS` (daemon) and `allSyncableProviders` (macOS client) so it syncs through the standard `api_key` path like every other provider
- Removes all `type: credential, name: elevenlabs:api_key` special handling from SettingsStore, AppDelegate, and APIKeyManager
- The daemon never actually consumed the ElevenLabs key (TTS goes through Twilio ConversationRelay), so this is purely a sync-path simplification

## Original prompt
Remove the ElevenLabs credential special-case handling and treat it as a standard api_key provider

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
