### PR TITLE
fix: return fresh updatedAt after bumping it in upsertApp existing-row path

### DIFF
--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -274,10 +274,12 @@ export async function upsertApp(
       // can detect that a concurrent caller has claimed this row. Without
       // this, a concurrent inserter's rollback DELETE would still match on
       // the original updatedAt and delete the row we just validated.
+      const newUpdatedAt = Date.now();
       db.update(oauthApps)
-        .set({ updatedAt: Date.now() })
+        .set({ updatedAt: newUpdatedAt })
         .where(eq(oauthApps.id, existingRow.id))
         .run();
+      return { ...existingRow, updatedAt: newUpdatedAt };
     }
     if (clientSecretCredentialPath) {
       db.update(oauthApps)


### PR DESCRIPTION
## Summary
- Fixes read-after-write inconsistency in `oauth-store.ts` `upsertApp` where the existing row with stale `updatedAt` was returned after bumping the timestamp in the DB
- Now returns a fresh object with the new timestamp, matching the pattern used in the adjacent `clientSecretCredentialPath` branch
- Callers that surface `updatedAt` (e.g., the HTTP route at `oauth-apps.ts:146`) now get the correct timestamp

## Test plan
- [x] Verified the `clientSecretValue` branch now returns early with `{ ...existingRow, updatedAt: newUpdatedAt }` after the DB update
- [x] Confirmed the adjacent `clientSecretCredentialPath` branch is unchanged (already re-reads from DB)
- [x] Pre-push hooks passed (type-check + lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
