### PR TITLE
fix: clear embedding backend cache on explicit API key deletion

### DIFF
--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -11,6 +11,7 @@ import {
 } from "../../config/loader.js";
 import type { CesClient } from "../../credential-execution/client.js";
 import { setSentryOrganizationId } from "../../instrument.js";
+import { clearEmbeddingBackendCache } from "../../memory/embedding-backend.js";
 import { syncManualTokenConnection } from "../../oauth/manual-token-connection.js";
 import { validateAnthropicApiKey } from "../../providers/anthropic/client.js";
 import { validateGeminiApiKey } from "../../providers/gemini/client.js";
@@ -346,6 +347,7 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
           500,
         );
       }
+      clearEmbeddingBackendCache();
       invalidateConfigCache();
       await initializeProviders(getConfig());
       log.info({ provider: name }, "API key deleted via HTTP");


### PR DESCRIPTION
## Summary
- Adds `clearEmbeddingBackendCache()` call to the key deletion handler in `secret-routes.ts` so that stale cached backends are evicted when a user explicitly deletes an API key via the HTTP API
- Previously, `getCached()` fallback in `embedding-backend.ts` would return a stale backend with the old key baked in after deletion, contradicting the JSDoc claim at line 211

## Test plan
- [ ] Delete an API key via `DELETE /v1/secrets` with `type: "api_key"`
- [ ] Verify that subsequent embedding requests do not use the deleted key's cached backend
- [ ] Verify that transient credential-store failures still benefit from the cache fallback (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
