### PR TITLE
fix: guard yourOwnOAuthConnectingAppId cleanup against clobbering a newer connect call

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2563,7 +2563,7 @@ public final class SettingsStore: ObservableObject {
                         errorMsg = "HTTP \(response.statusCode)"
                     }
                     if let providerKey { self.yourOwnOAuthError[providerKey] = "Failed to start connect: \(errorMsg)" }
-                    self.yourOwnOAuthConnectingAppId = nil
+                    if self.yourOwnOAuthConnectingAppId == appId { self.yourOwnOAuthConnectingAppId = nil }
                     return
                 }
 
@@ -2572,7 +2572,7 @@ public final class SettingsStore: ObservableObject {
 
                 guard let authURL = URL(string: connectResponse.auth_url) else {
                     if let providerKey { self.yourOwnOAuthError[providerKey] = "Invalid auth URL" }
-                    self.yourOwnOAuthConnectingAppId = nil
+                    if self.yourOwnOAuthConnectingAppId == appId { self.yourOwnOAuthConnectingAppId = nil }
                     return
                 }
 
@@ -2606,12 +2606,12 @@ public final class SettingsStore: ObservableObject {
                         if elapsed >= timeout { break }
                     }
 
-                    self.yourOwnOAuthConnectingAppId = nil
+                    if self.yourOwnOAuthConnectingAppId == appId { self.yourOwnOAuthConnectingAppId = nil }
                 }
             } catch {
                 log.error("Failed to start Your Own OAuth connect: \(error)")
                 if let providerKey { self.yourOwnOAuthError[providerKey] = "Failed to start connect: \(error.localizedDescription)" }
-                self.yourOwnOAuthConnectingAppId = nil
+                if self.yourOwnOAuthConnectingAppId == appId { self.yourOwnOAuthConnectingAppId = nil }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Guards all nil-assignments to `yourOwnOAuthConnectingAppId` in `startYourOwnOAuthConnect(appId:)` with a check that the property still points to the current `appId`, preventing a cancelled/failed connect from clobbering state for a concurrent connect call.
- Follows the `clients/AGENTS.md` rule: "Guard `defer` cleanup blocks against clobbering a newer reference — check that the property still points to this task before nil-ing it."

## Test plan
- [x] Verify each nil-assignment to `yourOwnOAuthConnectingAppId` in `startYourOwnOAuthConnect` is guarded with `if self.yourOwnOAuthConnectingAppId == appId`
- [x] Verify `cancelYourOwnOAuthConnect()` remains unconditional (explicit user cancel should always clear state)
- [x] Swift build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
