### PR TITLE
fix: keep migration ID as 011 to avoid re-run on existing installs while preserving ordering

### DIFF
--- a/assistant/src/__tests__/workspace-migration-backfill-installation-id.test.ts
+++ b/assistant/src/__tests__/workspace-migration-backfill-installation-id.test.ts
@@ -41,7 +41,7 @@ mock.module("../runtime/auth/external-assistant-id.js", () => ({
 }));
 
 // Import after mocking
-import { backfillInstallationIdMigration } from "../workspace/migrations/002-backfill-installation-id.js";
+import { backfillInstallationIdMigration } from "../workspace/migrations/011-backfill-installation-id.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -68,7 +68,7 @@ function setupFs(fileContents: Record<string, string>): void {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("002-backfill-installation-id migration", () => {
+describe("011-backfill-installation-id migration", () => {
   beforeEach(() => {
     existsSyncFn.mockClear();
     readFileSyncFn.mockClear();
@@ -320,9 +320,9 @@ describe("002-backfill-installation-id migration", () => {
     expect(parsed.assistants[1].installationId).toBe("sqlite-id");
   });
 
-  test("has migration id 002-backfill-installation-id", () => {
+  test("has migration id 011-backfill-installation-id", () => {
     expect(backfillInstallationIdMigration.id).toBe(
-      "002-backfill-installation-id",
+      "011-backfill-installation-id",
     );
   });
 });

--- a/assistant/src/workspace/migrations/011-backfill-installation-id.ts
+++ b/assistant/src/workspace/migrations/011-backfill-installation-id.ts
@@ -11,7 +11,7 @@ import { getExternalAssistantId } from "../../runtime/auth/external-assistant-id
 import type { WorkspaceMigration } from "./types.js";
 
 export const backfillInstallationIdMigration: WorkspaceMigration = {
-  id: "002-backfill-installation-id",
+  id: "011-backfill-installation-id",
   description:
     "Backfill installationId into lockfile from SQLite checkpoint and clean up stale row",
   run(_workspaceDir: string): void {

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -1,5 +1,4 @@
 import { avatarRenameMigration } from "./001-avatar-rename.js";
-import { backfillInstallationIdMigration } from "./002-backfill-installation-id.js";
 import { seedDeviceIdMigration } from "./003-seed-device-id.js";
 import { extractCollectUsageDataMigration } from "./004-extract-collect-usage-data.js";
 import { addSendDiagnosticsMigration } from "./005-add-send-diagnostics.js";
@@ -8,6 +7,7 @@ import { webSearchProviderRenameMigration } from "./007-web-search-provider-rena
 import { voiceTimeoutAndMaxStepsMigration } from "./008-voice-timeout-and-max-steps.js";
 import { backfillConversationDiskViewMigration } from "./009-backfill-conversation-disk-view.js";
 import { appDirRenameMigration } from "./010-app-dir-rename.js";
+import { backfillInstallationIdMigration } from "./011-backfill-installation-id.js";
 import { renameConversationDiskViewDirsMigration } from "./012-rename-conversation-disk-view-dirs.js";
 import { repairConversationDiskViewMigration } from "./013-repair-conversation-disk-view.js";
 import type { WorkspaceMigration } from "./types.js";


### PR DESCRIPTION
Reverts the migration ID rename from 002 back to 011-backfill-installation-id to avoid re-running the migration on existing installations. Keeps the array position before 003-seed-device-id to fix the dependency ordering for fresh installs. The runner uses ID-based checkpointing, so reordering the array alone changes execution order without causing re-runs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
