### PR TITLE
fix: clear isSyncingProviderFromStore flag when draftProvider value is unchanged

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -200,8 +200,17 @@ struct InferenceServiceCard: View {
             // not flag a stale diff against the old provider's model.
             // Flag the update so onChange(of: draftProvider) skips the
             // model/key reset that is only appropriate for user picks.
+            let alreadyEqual = draftProvider == newValue
             isSyncingProviderFromStore = true
             draftProvider = newValue
+            // If draftProvider already held this value, SwiftUI's
+            // onChange(of: draftProvider) won't fire (it only fires on
+            // actual value transitions), so clear the flag immediately
+            // to prevent the next user-initiated change from being
+            // misclassified as a store sync.
+            if alreadyEqual {
+                isSyncingProviderFromStore = false
+            }
             initialProvider = newValue
             draftModel = store.selectedModel
             initialModel = store.selectedModel


### PR DESCRIPTION
## Summary
- Fixes a bug where the `isSyncingProviderFromStore` flag gets stuck at `true` when the store syncs a provider value that `draftProvider` already holds.
- Since SwiftUI's `onChange` only fires on actual value transitions, the flag was never cleared, causing the next user-initiated provider change to be misclassified as a store sync and skip the model/key reset.
- Adds a pre-assignment equality check and immediately clears the flag when no actual value transition occurs.

## Test plan
- [ ] Verify that when the store fires `onChange(of: store.selectedInferenceProvider)` with the same value `draftProvider` already holds, the `isSyncingProviderFromStore` flag is cleared immediately.
- [ ] Verify that subsequent user-initiated provider changes correctly trigger the model/key reset logic in `onChange(of: draftProvider)`.
- [ ] Verify that store-initiated provider changes (where the value actually differs) still correctly suppress the model/key reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
