### PR TITLE
fix: restore clickCount == 1 guard in ClickReportingTextView to prevent double-click edit mode

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/VCodeView.swift
+++ b/clients/shared/DesignSystem/Components/Display/VCodeView.swift
@@ -448,6 +448,7 @@ private class ClickReportingTextView: NSTextView {
         // loop for text selection). Detect click vs drag here, not in mouseUp
         // which is never called through the normal responder chain.
         guard let currentEvent = window?.currentEvent else { return }
+        guard event.clickCount == 1 else { return }
         let upLocation = currentEvent.locationInWindow
         let dx = abs(upLocation.x - downLocation.x)
         let dy = abs(upLocation.y - downLocation.y)


### PR DESCRIPTION
## Summary
- Restores the `guard event.clickCount == 1 else { return }` check that was accidentally removed during the `window.currentEvent` refactor in PR #19285
- Without this guard, double-clicks (word selection) and triple-clicks (line selection) would also pass the distance threshold and fire `onContentClick?()`, unintentionally switching to edit mode in `HighlightedTextView`
- The class docstring documents that `ClickReportingTextView` "detects single clicks", so this guard is part of the documented contract

## Test plan
- [ ] Double-click on code text to select a word — should select the word without switching to edit mode
- [ ] Triple-click on code text to select a line — should select the line without switching to edit mode
- [ ] Single-click on code text — should still trigger `onContentClick` and switch to edit mode as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
