### PR TITLE
fix: show human-readable error messages for OAuth and auth failures

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2385,9 +2385,11 @@ public final class SettingsStore: ObservableObject {
                     let errorCode = components?.queryItems?.first(where: { $0.name == "oauth_code" })?.value
                     managedOAuthError[providerKey] = errorCode ?? "OAuth connection failed"
                 }
+            } catch let error as ASWebAuthenticationSessionError where error.code == .canceledLogin {
+                log.info("User cancelled managed OAuth connect for \(providerKey)")
             } catch {
                 log.error("Managed OAuth connect failed for \(providerKey): \(error)")
-                managedOAuthError[providerKey] = error.localizedDescription
+                managedOAuthError[providerKey] = "Unable to connect your account. Please try again."
             }
         }
     }

--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -166,7 +166,7 @@ public final class AuthManager {
             log.info("User cancelled WorkOS login")
         } catch {
             log.error("WorkOS login failed: baseURL=\(self.authService.baseURL, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
-            errorMessage = error.localizedDescription
+            errorMessage = "Unable to sign in. Please try again."
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace raw `error.localizedDescription` strings with human-readable error messages in OAuth connect and sign-in flows
- Add explicit handling for user cancellation (`ASWebAuthenticationSessionError.canceledLogin`) in managed OAuth connect to suppress unnecessary error display
- Affects both `SettingsStore.swift` (managed OAuth) and `AuthManager.swift` (sign-in)

## Original prompt
Make the OAuth error message human-readable instead of showing the raw Apple framework error code.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
