### PR TITLE
fix: immediate drop feedback and persistent drag type guard for composer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -25,6 +25,8 @@ struct ChatView: View {
     let onDropImageData: (Data, String?) -> Void
     let onPaste: () -> Void
     let onMicrophoneToggle: () -> Void
+    var onDropStarted: (() -> Void)?
+    var onDropEnded: (() -> Void)?
     var selectedModel: String = ""
     var configuredProviders: Set<String> = []
     var providerCatalog: [ProviderCatalogEntry] = []
@@ -476,6 +478,10 @@ struct ChatView: View {
         // NSTextView inside the composer) intercepts the drag session.
         isDropTargeted = false
 
+        // Signal loading immediately so the "Processing…" chip appears without
+        // waiting for NSItemProvider async callbacks to resolve.
+        onDropStarted?()
+
         var urls: [URL] = []
         var imageDataItems: [NSItemProvider] = []
         let group = DispatchGroup()
@@ -557,6 +563,9 @@ struct ChatView: View {
 
         group.notify(queue: .main) {
             if !urls.isEmpty { onDropFiles(urls) }
+            // End the external load now that all providers have resolved and
+            // the individual addAttachment calls have taken over tracking.
+            onDropEnded?()
         }
         return true
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
@@ -78,16 +78,13 @@ struct ComposerFocusBridge: NSViewRepresentable {
         }
         window.composerContainerView = container
 
-        // Unregister all drag types from the internal NSTextView so it doesn't
+        // Strip file drag types from the internal NSTextView so it doesn't
         // intercept file drops (which would insert the file path as text).
-        // With no registered types the NSTextView is invisible to the drag
-        // system and drops fall through to the ChatView's full-surface handler.
-        // Done immediately and deferred because the NSTextView may not be in
-        // the hierarchy yet (e.g. after composerResetId forces a rebuild).
+        // AppKit's NSTextView can re-register its default drag types after
+        // layout passes, so we use a RunLoop observer in the coordinator to
+        // continuously re-apply the restriction.
         Self.unregisterDragTypes(in: container)
-        DispatchQueue.main.async {
-            Self.unregisterDragTypes(in: container)
-        }
+        context.coordinator.startDragTypeGuard(container: container)
     }
 
     private static func unregisterDragTypes(in view: NSView) {
@@ -111,9 +108,48 @@ struct ComposerFocusBridge: NSViewRepresentable {
     final class Coordinator {
         var parent: ComposerFocusBridge
         var eventMonitor: Any?
+        private var dragTypeGuardObserver: CFRunLoopObserver?
+        private weak var guardedContainer: NSView?
 
         init(parent: ComposerFocusBridge) {
             self.parent = parent
+        }
+
+        /// Install a RunLoop observer that re-strips file drag types from the
+        /// NSTextView after every layout/display pass. AppKit's text system can
+        /// re-register default drag types internally (e.g. when the view
+        /// reconfigures after a SwiftUI state change), so a one-shot deferred
+        /// call isn't reliable.
+        func startDragTypeGuard(container: NSView) {
+            // Avoid duplicate observers for the same container.
+            if guardedContainer === container, dragTypeGuardObserver != nil { return }
+            stopDragTypeGuard()
+            guardedContainer = container
+
+            let observer = CFRunLoopObserverCreateWithHandler(
+                kCFAllocatorDefault,
+                CFRunLoopActivity.beforeWaiting.rawValue,
+                true,  // repeats
+                0      // order
+            ) { [weak self, weak container] _, _ in
+                guard let container else {
+                    self?.stopDragTypeGuard()
+                    return
+                }
+                ComposerFocusBridge.unregisterDragTypes(in: container)
+            }
+            if let observer {
+                CFRunLoopAddObserver(CFRunLoopGetMain(), observer, .commonModes)
+                dragTypeGuardObserver = observer
+            }
+        }
+
+        func stopDragTypeGuard() {
+            if let observer = dragTypeGuardObserver {
+                CFRunLoopRemoveObserver(CFRunLoopGetMain(), observer, .commonModes)
+                dragTypeGuardObserver = nil
+            }
+            guardedContainer = nil
         }
 
         func setupEventMonitor() {
@@ -175,6 +211,7 @@ struct ComposerFocusBridge: NSViewRepresentable {
                 NSEvent.removeMonitor(monitor)
                 eventMonitor = nil
             }
+            stopDragTypeGuard()
         }
 
         static func pasteboardHasImageContent() -> Bool {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -664,6 +664,8 @@ struct ActiveChatViewWrapper: View {
             },
             onPaste: { viewModel.addAttachmentFromPasteboard() },
             onMicrophoneToggle: onMicrophoneToggle,
+            onDropStarted: { viewModel.attachmentManager.beginExternalLoad() },
+            onDropEnded: { viewModel.attachmentManager.endExternalLoad() },
             selectedModel: settingsStore.selectedModel,
             configuredProviders: settingsStore.configuredProviders,
             providerCatalog: settingsStore.providerCatalog,

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -53,6 +53,19 @@ public final class ChatAttachmentManager: ObservableObject {
         didSet { isLoadingAttachment = loadingCount > 0 }
     }
 
+    /// Increment the loading count from an external source (e.g. drag-and-drop
+    /// that needs immediate feedback before NSItemProvider async loads resolve).
+    /// Must be balanced by a call to `endExternalLoad()`.
+    public func beginExternalLoad() {
+        loadingCount += 1
+    }
+
+    /// Decrement the loading count after an external load completes or the
+    /// actual `addAttachment` call takes over tracking.
+    public func endExternalLoad() {
+        loadingCount = max(loadingCount - 1, 0)
+    }
+
     /// Limits concurrent attachment I/O to keep memory usage reasonable.
     private static let maxConcurrentLoads = 2
     private let loadSemaphore = AsyncSemaphore(value: maxConcurrentLoads)


### PR DESCRIPTION
## Summary
- Show "Processing…" chip immediately on file drop instead of waiting for NSItemProvider async resolution (adds `beginExternalLoad`/`endExternalLoad` to ChatAttachmentManager)
- Replace one-shot deferred `unregisterDragTypes` with a `CFRunLoopObserver` that continuously re-strips file drag types from the composer's NSTextView, preventing AppKit from re-registering them after SwiftUI view rebuilds

## Original prompt
JARVIS-261: Fix file drag-and-drop: laggy feedback and second drop inserts path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
