### PR TITLE
Add safe numeric sanitization for macOS chat diagnostics

### DIFF
--- a/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
+++ b/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 import os
 
@@ -5,6 +6,43 @@ private let log = Logger(
     subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant",
     category: "ChatDiagnostics"
 )
+
+// MARK: - Numeric Sanitization
+
+/// Collects the names of fields whose values were non-finite (nan, inf, -inf)
+/// so they can be reported downstream without crashing JSON encoding.
+struct NumericSanitizer: Sendable {
+    /// Names of fields that were dropped because their value was non-finite.
+    private(set) var droppedFields: [String] = []
+
+    /// Returns a finite `Double` if the input is finite, otherwise records the
+    /// field name and returns `nil`.
+    mutating func sanitize(_ value: CGFloat?, field: String) -> Double? {
+        guard let v = value else { return nil }
+        let d = Double(v)
+        guard d.isFinite else {
+            droppedFields.append(field)
+            return nil
+        }
+        return d
+    }
+
+    /// Returns a finite `Double` if the input is finite, otherwise records the
+    /// field name and returns `nil`.
+    mutating func sanitize(_ value: Double?, field: String) -> Double? {
+        guard let v = value else { return nil }
+        guard v.isFinite else {
+            droppedFields.append(field)
+            return nil
+        }
+        return v
+    }
+
+    /// The list of dropped field names, or `nil` if no fields were dropped.
+    var nonFiniteFields: [String]? {
+        droppedFields.isEmpty ? nil : droppedFields
+    }
+}
 
 // MARK: - Event Payloads
 
@@ -58,6 +96,12 @@ struct ChatDiagnosticEvent: Codable, Sendable {
     /// Viewport height at event time.
     let viewportHeight: Double?
 
+    // MARK: Sanitization metadata
+
+    /// Names of geometry fields whose original values were non-finite
+    /// (nan, inf, -inf) and were replaced with `nil` during construction.
+    let nonFiniteFields: [String]?
+
     init(
         kind: ChatDiagnosticEventKind,
         conversationId: String? = nil,
@@ -68,7 +112,8 @@ struct ChatDiagnosticEvent: Codable, Sendable {
         isUserScrolling: Bool? = nil,
         scrollOffsetY: Double? = nil,
         contentHeight: Double? = nil,
-        viewportHeight: Double? = nil
+        viewportHeight: Double? = nil,
+        nonFiniteFields: [String]? = nil
     ) {
         self.id = UUID().uuidString
         self.timestamp = Date()
@@ -82,6 +127,7 @@ struct ChatDiagnosticEvent: Codable, Sendable {
         self.scrollOffsetY = scrollOffsetY
         self.contentHeight = contentHeight
         self.viewportHeight = viewportHeight
+        self.nonFiniteFields = nonFiniteFields
     }
 
     /// Test-only initializer that allows setting id and timestamp explicitly.
@@ -97,7 +143,8 @@ struct ChatDiagnosticEvent: Codable, Sendable {
         isUserScrolling: Bool? = nil,
         scrollOffsetY: Double? = nil,
         contentHeight: Double? = nil,
-        viewportHeight: Double? = nil
+        viewportHeight: Double? = nil,
+        nonFiniteFields: [String]? = nil
     ) {
         self.id = id
         self.timestamp = timestamp
@@ -111,6 +158,7 @@ struct ChatDiagnosticEvent: Codable, Sendable {
         self.scrollOffsetY = scrollOffsetY
         self.contentHeight = contentHeight
         self.viewportHeight = viewportHeight
+        self.nonFiniteFields = nonFiniteFields
     }
 }
 
@@ -160,6 +208,12 @@ struct ChatTranscriptSnapshot: Codable, Sendable {
     /// Timestamp of the last scroll-loop warning from `ChatScrollLoopGuard`.
     let lastLoopWarningTimestamp: Date?
 
+    // MARK: Sanitization metadata
+
+    /// Names of geometry fields whose original values were non-finite
+    /// (nan, inf, -inf) and were replaced with `nil` during construction.
+    let nonFiniteFields: [String]?
+
     init(
         conversationId: String,
         capturedAt: Date,
@@ -181,7 +235,8 @@ struct ChatTranscriptSnapshot: Codable, Sendable {
         scrollViewportHeight: Double? = nil,
         containerWidth: Double? = nil,
         lastScrollToReason: String? = nil,
-        lastLoopWarningTimestamp: Date? = nil
+        lastLoopWarningTimestamp: Date? = nil,
+        nonFiniteFields: [String]? = nil
     ) {
         self.conversationId = conversationId
         self.capturedAt = capturedAt
@@ -204,6 +259,7 @@ struct ChatTranscriptSnapshot: Codable, Sendable {
         self.containerWidth = containerWidth
         self.lastScrollToReason = lastScrollToReason
         self.lastLoopWarningTimestamp = lastLoopWarningTimestamp
+        self.nonFiniteFields = nonFiniteFields
     }
 }
 

--- a/clients/macos/vellum-assistantTests/ChatDiagnosticsStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatDiagnosticsStoreTests.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 import Testing
 @testable import VellumAssistantLib
@@ -321,6 +322,133 @@ struct ChatDiagnosticsStoreTests {
         #expect(recent.count == 5)
         #expect(recent.first?.id == "event-15")
         #expect(recent.last?.id == "event-19")
+    }
+
+    // MARK: - Non-Finite Numeric Sanitization
+
+    @Test @MainActor
+    func eventWithNonFiniteFieldsEncodesSuccessfully() throws {
+        // Build an event using the sanitizer to handle non-finite values.
+        var sanitizer = NumericSanitizer()
+        let scrollY = sanitizer.sanitize(Double.nan, field: "scrollOffsetY")
+        let content = sanitizer.sanitize(Double.infinity, field: "contentHeight")
+        let viewport = sanitizer.sanitize(-Double.infinity, field: "viewportHeight")
+
+        let event = ChatDiagnosticEvent(
+            kind: .scrollPositionChanged,
+            conversationId: "conv-nan",
+            scrollOffsetY: scrollY,
+            contentHeight: content,
+            viewportHeight: viewport,
+            nonFiniteFields: sanitizer.nonFiniteFields
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(event)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        // Non-finite values should have been sanitized to nil.
+        let scrollVal = json["scrollOffsetY"]
+        #expect(scrollVal == nil || scrollVal is NSNull,
+                "scrollOffsetY should be absent or null when NaN")
+        let contentVal = json["contentHeight"]
+        #expect(contentVal == nil || contentVal is NSNull,
+                "contentHeight should be absent or null when infinity")
+        let viewportVal = json["viewportHeight"]
+        #expect(viewportVal == nil || viewportVal is NSNull,
+                "viewportHeight should be absent or null when -infinity")
+
+        // nonFiniteFields should list the sanitized field names.
+        let dropped = json["nonFiniteFields"] as? [String]
+        #expect(dropped != nil, "nonFiniteFields should be present")
+        #expect(dropped?.contains("scrollOffsetY") == true)
+        #expect(dropped?.contains("contentHeight") == true)
+        #expect(dropped?.contains("viewportHeight") == true)
+    }
+
+    @Test @MainActor
+    func snapshotWithNonFiniteFieldsEncodesSuccessfully() throws {
+        var sanitizer = NumericSanitizer()
+        let scrollY = sanitizer.sanitize(Double.nan, field: "scrollOffsetY")
+        let content = sanitizer.sanitize(Double.infinity, field: "contentHeight")
+        let viewport = sanitizer.sanitize(600.0, field: "viewportHeight") // finite — kept
+        let anchorMinY = sanitizer.sanitize(-Double.infinity, field: "anchorMinY")
+
+        let snapshot = ChatTranscriptSnapshot(
+            conversationId: "conv-nan-snap",
+            capturedAt: Date(),
+            messageCount: 5,
+            toolCallCount: 1,
+            isPinnedToBottom: true,
+            isUserScrolling: false,
+            scrollOffsetY: scrollY,
+            contentHeight: content,
+            viewportHeight: viewport,
+            anchorMinY: anchorMinY,
+            nonFiniteFields: sanitizer.nonFiniteFields
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(snapshot)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        // Finite value should survive.
+        #expect(json["viewportHeight"] as? Double == 600.0)
+
+        // Non-finite values should be absent or null.
+        let scrollVal = json["scrollOffsetY"]
+        #expect(scrollVal == nil || scrollVal is NSNull)
+        let contentVal = json["contentHeight"]
+        #expect(contentVal == nil || contentVal is NSNull)
+        let anchorVal = json["anchorMinY"]
+        #expect(anchorVal == nil || anchorVal is NSNull)
+
+        // nonFiniteFields should list exactly the dropped fields.
+        let dropped = json["nonFiniteFields"] as? [String]
+        #expect(dropped != nil, "nonFiniteFields should be present")
+        #expect(dropped?.count == 3)
+        #expect(dropped?.contains("scrollOffsetY") == true)
+        #expect(dropped?.contains("contentHeight") == true)
+        #expect(dropped?.contains("anchorMinY") == true)
+        // Finite field should NOT be listed.
+        #expect(dropped?.contains("viewportHeight") != true)
+    }
+
+    @Test @MainActor
+    func sanitizerPreservesFiniteValues() {
+        var sanitizer = NumericSanitizer()
+        let result = sanitizer.sanitize(42.5, field: "testField")
+        #expect(result == 42.5)
+        #expect(sanitizer.nonFiniteFields == nil)
+    }
+
+    @Test @MainActor
+    func sanitizerHandlesNilInput() {
+        var sanitizer = NumericSanitizer()
+        let doubleResult = sanitizer.sanitize(Double?(nil), field: "testDouble")
+        #expect(doubleResult == nil)
+        let cgResult = sanitizer.sanitize(CGFloat?(nil), field: "testCG")
+        #expect(cgResult == nil)
+        // nil inputs should not be recorded as dropped.
+        #expect(sanitizer.nonFiniteFields == nil)
+    }
+
+    @Test @MainActor
+    func sanitizerHandlesCGFloatNaN() {
+        var sanitizer = NumericSanitizer()
+        let result = sanitizer.sanitize(CGFloat.nan, field: "width")
+        #expect(result == nil)
+        #expect(sanitizer.nonFiniteFields == ["width"])
+    }
+
+    @Test @MainActor
+    func sanitizerHandlesCGFloatInfinity() {
+        var sanitizer = NumericSanitizer()
+        let result = sanitizer.sanitize(CGFloat.infinity, field: "height")
+        #expect(result == nil)
+        #expect(sanitizer.nonFiniteFields == ["height"])
     }
 
     // MARK: - Event Kind Encoding


### PR DESCRIPTION
## Summary
- Add shared `NumericSanitizer` helper for sanitizing non-finite CGFloat/Double values in diagnostic payloads
- Extend `ChatDiagnosticEvent` and `ChatTranscriptSnapshot` with optional `nonFiniteFields` tracking
- Add encoding tests for non-finite numeric inputs (NaN, infinity, -infinity)

Part of plan: desktop-freeze-diagnostics.md (PR 1 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
