### PR TITLE
Add a registry for active macOS chat scroll-wheel detectors

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ScrollWheelDetectorRegistry.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollWheelDetectorRegistry.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+// MARK: - ScrollWheelDetectorRegistry
+
+/// A single source of truth for how many scroll-wheel detectors are currently
+/// active per conversation and window.
+///
+/// The existing `ScrollWheelDetector` (an `NSViewRepresentable` in ChatView)
+/// installs a local `NSEvent` monitor on each appearance. SwiftUI's view
+/// lifecycle can create duplicate instances when identity changes — for example
+/// during conversation switches, sidebar toggles, or window restorations.
+/// When multiple detectors exist for the same conversation/window pair, their
+/// competing `onScrollUp` / `onScrollToBottom` callbacks cause scroll-position
+/// fights that can freeze the UI.
+///
+/// This registry tracks every live detector by a caller-supplied ID so that:
+/// 1. Duplicate-detector conditions are detectable without touching view code.
+/// 2. Later instrumentation (PR 4) can call `register` / `unregister` from
+///    the detector lifecycle and log warnings when duplicates appear.
+/// 3. Stale entries (detectors that were never unregistered) can be identified
+///    by comparing their install timestamps against a staleness threshold.
+@MainActor
+final class ScrollWheelDetectorRegistry {
+
+    // MARK: - Entry
+
+    /// Metadata for a single registered detector.
+    struct Entry: Equatable, Sendable {
+        /// Caller-supplied identifier for this detector instance.
+        let detectorId: String
+
+        /// The conversation this detector is attached to.
+        let conversationId: String
+
+        /// An opaque identifier for the window hosting this detector
+        /// (e.g. `NSWindow.windowNumber` or a stable window UUID).
+        let windowId: String
+
+        /// Monotonic timestamp when the detector was registered
+        /// (e.g. `ProcessInfo.processInfo.systemUptime`).
+        let installedAt: TimeInterval
+
+        /// Monotonic timestamp of the most recent update to this entry.
+        var lastUpdatedAt: TimeInterval
+    }
+
+    // MARK: - Duplicate Report
+
+    /// Describes a duplicate-detector condition for a conversation/window pair.
+    struct DuplicateReport: Equatable, Sendable {
+        let conversationId: String
+        let windowId: String
+        let detectorIds: [String]
+        let count: Int
+    }
+
+    // MARK: - Internal State
+
+    private var entries: [String: Entry] = [:]
+
+    // MARK: - Public API
+
+    /// The number of currently registered detectors.
+    var activeCount: Int { entries.count }
+
+    /// Registers a new detector. If an entry with the same `detectorId`
+    /// already exists, it is replaced.
+    func register(
+        detectorId: String,
+        conversationId: String,
+        windowId: String,
+        timestamp: TimeInterval
+    ) {
+        entries[detectorId] = Entry(
+            detectorId: detectorId,
+            conversationId: conversationId,
+            windowId: windowId,
+            installedAt: timestamp,
+            lastUpdatedAt: timestamp
+        )
+    }
+
+    /// Updates the `lastUpdatedAt` timestamp for an existing entry.
+    /// No-op if the detector is not registered.
+    func update(detectorId: String, timestamp: TimeInterval) {
+        entries[detectorId]?.lastUpdatedAt = timestamp
+    }
+
+    /// Removes a detector from the registry.
+    func unregister(detectorId: String) {
+        entries.removeValue(forKey: detectorId)
+    }
+
+    /// Returns a snapshot of all currently registered entries.
+    func snapshot() -> [Entry] {
+        Array(entries.values)
+    }
+
+    /// Returns entries matching a specific conversation and window pair.
+    func entries(conversationId: String, windowId: String) -> [Entry] {
+        entries.values.filter {
+            $0.conversationId == conversationId && $0.windowId == windowId
+        }
+    }
+
+    // MARK: - Duplicate Detection
+
+    /// Reports duplicate-detector conditions: conversation/window pairs that
+    /// have more than one active detector.
+    ///
+    /// The per-detector throttle in `ScrollWheelDetector.Coordinator` assumes
+    /// at most one detector per conversation/window. When duplicates exist,
+    /// competing event monitors fight over scroll position and can cause
+    /// freezes. This method surfaces those conditions for logging/diagnostics.
+    func duplicates() -> [DuplicateReport] {
+        // Group entries by (conversationId, windowId).
+        var groups: [String: [Entry]] = [:]
+        for entry in entries.values {
+            let key = "\(entry.conversationId)|\(entry.windowId)"
+            groups[key, default: []].append(entry)
+        }
+
+        return groups.compactMap { _, groupEntries in
+            guard groupEntries.count > 1 else { return nil }
+            let first = groupEntries[0]
+            return DuplicateReport(
+                conversationId: first.conversationId,
+                windowId: first.windowId,
+                detectorIds: groupEntries.map(\.detectorId).sorted(),
+                count: groupEntries.count
+            )
+        }.sorted { $0.conversationId < $1.conversationId }
+    }
+
+    /// Returns true if more than one detector is registered for the given
+    /// conversation and window pair.
+    func hasDuplicates(conversationId: String, windowId: String) -> Bool {
+        entries(conversationId: conversationId, windowId: windowId).count > 1
+    }
+
+    // MARK: - Stale Detection
+
+    /// Returns entries whose `lastUpdatedAt` is older than the given threshold,
+    /// indicating detectors that may have leaked (never unregistered).
+    ///
+    /// - Parameters:
+    ///   - threshold: Maximum age in seconds. Entries older than
+    ///     `now - threshold` are considered stale.
+    ///   - now: The current monotonic timestamp.
+    func staleEntries(threshold: TimeInterval, now: TimeInterval) -> [Entry] {
+        let cutoff = now - threshold
+        return entries.values.filter { $0.lastUpdatedAt < cutoff }
+    }
+
+    /// Removes all entries whose `lastUpdatedAt` is older than the given
+    /// threshold. Returns the removed entries for logging.
+    @discardableResult
+    func purgeStale(threshold: TimeInterval, now: TimeInterval) -> [Entry] {
+        let stale = staleEntries(threshold: threshold, now: now)
+        for entry in stale {
+            entries.removeValue(forKey: entry.detectorId)
+        }
+        return stale
+    }
+
+    /// Removes all entries. Useful on conversation switch or teardown.
+    func removeAll() {
+        entries.removeAll()
+    }
+}

--- a/clients/macos/vellum-assistantTests/ScrollWheelDetectorRegistryTests.swift
+++ b/clients/macos/vellum-assistantTests/ScrollWheelDetectorRegistryTests.swift
@@ -1,0 +1,317 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class ScrollWheelDetectorRegistryTests: XCTestCase {
+
+    private var registry: ScrollWheelDetectorRegistry!
+
+    override func setUp() {
+        super.setUp()
+        registry = ScrollWheelDetectorRegistry()
+    }
+
+    override func tearDown() {
+        registry = nil
+        super.tearDown()
+    }
+
+    // MARK: - Register / Unregister
+
+    func testRegisterIncrementsActiveCount() {
+        XCTAssertEqual(registry.activeCount, 0)
+
+        registry.register(
+            detectorId: "det-1",
+            conversationId: "conv-a",
+            windowId: "win-1",
+            timestamp: 1000.0
+        )
+
+        XCTAssertEqual(registry.activeCount, 1)
+    }
+
+    func testUnregisterDecrementsActiveCount() {
+        registry.register(
+            detectorId: "det-1",
+            conversationId: "conv-a",
+            windowId: "win-1",
+            timestamp: 1000.0
+        )
+        registry.unregister(detectorId: "det-1")
+
+        XCTAssertEqual(registry.activeCount, 0)
+    }
+
+    func testUnregisterUnknownIdIsNoOp() {
+        registry.register(
+            detectorId: "det-1",
+            conversationId: "conv-a",
+            windowId: "win-1",
+            timestamp: 1000.0
+        )
+        registry.unregister(detectorId: "det-nonexistent")
+
+        XCTAssertEqual(registry.activeCount, 1, "Unregistering an unknown ID should not affect existing entries")
+    }
+
+    func testReRegisterSameIdReplacesEntry() {
+        registry.register(
+            detectorId: "det-1",
+            conversationId: "conv-a",
+            windowId: "win-1",
+            timestamp: 1000.0
+        )
+        registry.register(
+            detectorId: "det-1",
+            conversationId: "conv-b",
+            windowId: "win-2",
+            timestamp: 2000.0
+        )
+
+        XCTAssertEqual(registry.activeCount, 1, "Re-registering should replace, not add")
+
+        let entries = registry.snapshot()
+        XCTAssertEqual(entries.first?.conversationId, "conv-b")
+        XCTAssertEqual(entries.first?.windowId, "win-2")
+    }
+
+    func testMultipleRegistrations() {
+        registry.register(detectorId: "det-1", conversationId: "conv-a", windowId: "win-1", timestamp: 1000.0)
+        registry.register(detectorId: "det-2", conversationId: "conv-a", windowId: "win-1", timestamp: 1001.0)
+        registry.register(detectorId: "det-3", conversationId: "conv-b", windowId: "win-2", timestamp: 1002.0)
+
+        XCTAssertEqual(registry.activeCount, 3)
+    }
+
+    // MARK: - Update
+
+    func testUpdateChangesLastUpdatedAt() {
+        registry.register(
+            detectorId: "det-1",
+            conversationId: "conv-a",
+            windowId: "win-1",
+            timestamp: 1000.0
+        )
+
+        registry.update(detectorId: "det-1", timestamp: 2000.0)
+
+        let entry = registry.snapshot().first
+        XCTAssertEqual(entry?.lastUpdatedAt, 2000.0)
+        XCTAssertEqual(entry?.installedAt, 1000.0, "installedAt should not change on update")
+    }
+
+    func testUpdateUnknownIdIsNoOp() {
+        registry.register(
+            detectorId: "det-1",
+            conversationId: "conv-a",
+            windowId: "win-1",
+            timestamp: 1000.0
+        )
+
+        // Should not crash or create a new entry.
+        registry.update(detectorId: "det-nonexistent", timestamp: 2000.0)
+
+        XCTAssertEqual(registry.activeCount, 1)
+    }
+
+    // MARK: - Snapshot
+
+    func testSnapshotReturnsAllEntries() {
+        registry.register(detectorId: "det-1", conversationId: "conv-a", windowId: "win-1", timestamp: 1000.0)
+        registry.register(detectorId: "det-2", conversationId: "conv-b", windowId: "win-2", timestamp: 1001.0)
+
+        let snapshot = registry.snapshot()
+        let ids = Set(snapshot.map(\.detectorId))
+        XCTAssertEqual(ids, ["det-1", "det-2"])
+    }
+
+    func testSnapshotIsValueCopy() {
+        registry.register(detectorId: "det-1", conversationId: "conv-a", windowId: "win-1", timestamp: 1000.0)
+
+        let before = registry.snapshot()
+        registry.register(detectorId: "det-2", conversationId: "conv-a", windowId: "win-1", timestamp: 1001.0)
+        let after = registry.snapshot()
+
+        XCTAssertEqual(before.count, 1, "Snapshot taken before second registration should have 1 entry")
+        XCTAssertEqual(after.count, 2, "Snapshot taken after second registration should have 2 entries")
+    }
+
+    // MARK: - Entries by Conversation/Window
+
+    func testEntriesFiltersByConversationAndWindow() {
+        registry.register(detectorId: "det-1", conversationId: "conv-a", windowId: "win-1", timestamp: 1000.0)
+        registry.register(detectorId: "det-2", conversationId: "conv-a", windowId: "win-1", timestamp: 1001.0)
+        registry.register(detectorId: "det-3", conversationId: "conv-a", windowId: "win-2", timestamp: 1002.0)
+        registry.register(detectorId: "det-4", conversationId: "conv-b", windowId: "win-1", timestamp: 1003.0)
+
+        let matched = registry.entries(conversationId: "conv-a", windowId: "win-1")
+        let matchedIds = Set(matched.map(\.detectorId))
+        XCTAssertEqual(matchedIds, ["det-1", "det-2"])
+    }
+
+    // MARK: - Duplicate Detection
+
+    func testNoDuplicatesWhenSingleDetectorPerPair() {
+        registry.register(detectorId: "det-1", conversationId: "conv-a", windowId: "win-1", timestamp: 1000.0)
+        registry.register(detectorId: "det-2", conversationId: "conv-b", windowId: "win-2", timestamp: 1001.0)
+
+        let dups = registry.duplicates()
+        XCTAssertTrue(dups.isEmpty, "No duplicates when each conversation/window pair has one detector")
+    }
+
+    func testDuplicatesDetectedForSameConversationAndWindow() {
+        registry.register(detectorId: "det-1", conversationId: "conv-a", windowId: "win-1", timestamp: 1000.0)
+        registry.register(detectorId: "det-2", conversationId: "conv-a", windowId: "win-1", timestamp: 1001.0)
+
+        let dups = registry.duplicates()
+        XCTAssertEqual(dups.count, 1)
+
+        let report = dups[0]
+        XCTAssertEqual(report.conversationId, "conv-a")
+        XCTAssertEqual(report.windowId, "win-1")
+        XCTAssertEqual(report.count, 2)
+        XCTAssertEqual(report.detectorIds, ["det-1", "det-2"])
+    }
+
+    func testHasDuplicatesReturnsTrueWhenMultipleDetectors() {
+        registry.register(detectorId: "det-1", conversationId: "conv-a", windowId: "win-1", timestamp: 1000.0)
+        registry.register(detectorId: "det-2", conversationId: "conv-a", windowId: "win-1", timestamp: 1001.0)
+
+        XCTAssertTrue(registry.hasDuplicates(conversationId: "conv-a", windowId: "win-1"))
+        XCTAssertFalse(registry.hasDuplicates(conversationId: "conv-a", windowId: "win-2"))
+    }
+
+    func testDuplicateReportContainsSortedDetectorIds() {
+        registry.register(detectorId: "det-z", conversationId: "conv-a", windowId: "win-1", timestamp: 1000.0)
+        registry.register(detectorId: "det-a", conversationId: "conv-a", windowId: "win-1", timestamp: 1001.0)
+        registry.register(detectorId: "det-m", conversationId: "conv-a", windowId: "win-1", timestamp: 1002.0)
+
+        let report = registry.duplicates().first
+        XCTAssertEqual(report?.detectorIds, ["det-a", "det-m", "det-z"], "Detector IDs should be sorted")
+        XCTAssertEqual(report?.count, 3)
+    }
+
+    func testDuplicatesAcrossMultipleConversationWindowPairs() {
+        // Two duplicates for conv-a/win-1.
+        registry.register(detectorId: "det-1", conversationId: "conv-a", windowId: "win-1", timestamp: 1000.0)
+        registry.register(detectorId: "det-2", conversationId: "conv-a", windowId: "win-1", timestamp: 1001.0)
+
+        // Three duplicates for conv-b/win-2.
+        registry.register(detectorId: "det-3", conversationId: "conv-b", windowId: "win-2", timestamp: 1002.0)
+        registry.register(detectorId: "det-4", conversationId: "conv-b", windowId: "win-2", timestamp: 1003.0)
+        registry.register(detectorId: "det-5", conversationId: "conv-b", windowId: "win-2", timestamp: 1004.0)
+
+        // One singleton (no duplicate).
+        registry.register(detectorId: "det-6", conversationId: "conv-c", windowId: "win-3", timestamp: 1005.0)
+
+        let dups = registry.duplicates()
+        XCTAssertEqual(dups.count, 2, "Should report two pairs with duplicates")
+
+        let convAReport = dups.first { $0.conversationId == "conv-a" }
+        XCTAssertEqual(convAReport?.count, 2)
+
+        let convBReport = dups.first { $0.conversationId == "conv-b" }
+        XCTAssertEqual(convBReport?.count, 3)
+    }
+
+    func testUnregisterClearsDuplicateCondition() {
+        registry.register(detectorId: "det-1", conversationId: "conv-a", windowId: "win-1", timestamp: 1000.0)
+        registry.register(detectorId: "det-2", conversationId: "conv-a", windowId: "win-1", timestamp: 1001.0)
+
+        XCTAssertTrue(registry.hasDuplicates(conversationId: "conv-a", windowId: "win-1"))
+
+        registry.unregister(detectorId: "det-2")
+
+        XCTAssertFalse(registry.hasDuplicates(conversationId: "conv-a", windowId: "win-1"))
+    }
+
+    // MARK: - Stale Detection and Cleanup
+
+    func testStaleEntriesReturnsOldEntries() {
+        registry.register(detectorId: "det-1", conversationId: "conv-a", windowId: "win-1", timestamp: 1000.0)
+        registry.register(detectorId: "det-2", conversationId: "conv-b", windowId: "win-2", timestamp: 1050.0)
+
+        // At time 1070, with a 30-second threshold, det-1 (lastUpdated 1000) is stale
+        // but det-2 (lastUpdated 1050) is not.
+        let stale = registry.staleEntries(threshold: 30.0, now: 1070.0)
+        XCTAssertEqual(stale.count, 1)
+        XCTAssertEqual(stale.first?.detectorId, "det-1")
+    }
+
+    func testStaleEntriesRespectsUpdateTimestamp() {
+        registry.register(detectorId: "det-1", conversationId: "conv-a", windowId: "win-1", timestamp: 1000.0)
+
+        // Update det-1 to a recent timestamp.
+        registry.update(detectorId: "det-1", timestamp: 1060.0)
+
+        // At time 1070 with a 30-second threshold, det-1 is fresh (updated at 1060).
+        let stale = registry.staleEntries(threshold: 30.0, now: 1070.0)
+        XCTAssertTrue(stale.isEmpty, "Updated entry should not be stale")
+    }
+
+    func testPurgeStaleRemovesAndReturnsEntries() {
+        registry.register(detectorId: "det-1", conversationId: "conv-a", windowId: "win-1", timestamp: 1000.0)
+        registry.register(detectorId: "det-2", conversationId: "conv-b", windowId: "win-2", timestamp: 1050.0)
+
+        let purged = registry.purgeStale(threshold: 30.0, now: 1070.0)
+        XCTAssertEqual(purged.count, 1)
+        XCTAssertEqual(purged.first?.detectorId, "det-1")
+        XCTAssertEqual(registry.activeCount, 1, "Only the fresh entry should remain")
+    }
+
+    func testPurgeStaleIsIdempotent() {
+        registry.register(detectorId: "det-1", conversationId: "conv-a", windowId: "win-1", timestamp: 1000.0)
+
+        let first = registry.purgeStale(threshold: 30.0, now: 1070.0)
+        XCTAssertEqual(first.count, 1)
+
+        let second = registry.purgeStale(threshold: 30.0, now: 1070.0)
+        XCTAssertTrue(second.isEmpty, "Second purge should find nothing to remove")
+    }
+
+    func testPurgeStaleWithNothingStale() {
+        registry.register(detectorId: "det-1", conversationId: "conv-a", windowId: "win-1", timestamp: 1060.0)
+
+        let purged = registry.purgeStale(threshold: 30.0, now: 1070.0)
+        XCTAssertTrue(purged.isEmpty)
+        XCTAssertEqual(registry.activeCount, 1)
+    }
+
+    // MARK: - RemoveAll
+
+    func testRemoveAllClearsEverything() {
+        registry.register(detectorId: "det-1", conversationId: "conv-a", windowId: "win-1", timestamp: 1000.0)
+        registry.register(detectorId: "det-2", conversationId: "conv-b", windowId: "win-2", timestamp: 1001.0)
+
+        registry.removeAll()
+
+        XCTAssertEqual(registry.activeCount, 0)
+        XCTAssertTrue(registry.snapshot().isEmpty)
+        XCTAssertTrue(registry.duplicates().isEmpty)
+    }
+
+    // MARK: - Entry Equatable
+
+    func testEntryEquatable() {
+        let a = ScrollWheelDetectorRegistry.Entry(
+            detectorId: "det-1",
+            conversationId: "conv-a",
+            windowId: "win-1",
+            installedAt: 1000.0,
+            lastUpdatedAt: 1000.0
+        )
+        let b = ScrollWheelDetectorRegistry.Entry(
+            detectorId: "det-1",
+            conversationId: "conv-a",
+            windowId: "win-1",
+            installedAt: 1000.0,
+            lastUpdatedAt: 1000.0
+        )
+        var c = a
+        c.lastUpdatedAt = 2000.0
+
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(a, c)
+    }
+}


### PR DESCRIPTION
## Summary
- Create @MainActor ScrollWheelDetectorRegistry tracking detector ID, conversation, window, timestamps
- Add duplicate-detector detection helper for same conversation/window
- Add tests for register/unregister, duplicate detection, and stale cleanup

Part of plan: desktop-freeze-diagnostics.md (PR 3 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
