### PR TITLE
fix: optimistically remove OAuth connection on disconnect

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2403,7 +2403,8 @@ public final class SettingsStore: ObservableObject {
 
             do {
                 try await PlatformOAuthService.shared.disconnectConnection(assistantId: assistantId, connectionId: connectionId)
-                await fetchManagedOAuthConnections(providerKey: providerKey, userId: userId)
+                // Optimistically remove the connection from local state
+                managedOAuthConnections[providerKey]?.removeAll { $0.id == connectionId }
             } catch {
                 log.error("Failed to disconnect managed OAuth connection for \(providerKey): \(error)")
                 managedOAuthError[providerKey] = error.localizedDescription


### PR DESCRIPTION
## Summary

- After disconnecting a managed OAuth connection, optimistically remove it from local state instead of re-fetching from the server
- This ensures the connection disappears from the UI immediately without requiring an app refresh
- Previously, the re-fetch could fail (e.g. "Not found" error), leaving the disconnected connection visible

## Original prompt

fix: optimistically remove OAuth connection from local state on disconnect instead of re-fetching
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
