### PR TITLE
Sanitize scroll-loop and debug-state geometry diagnostics

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -232,6 +232,10 @@ struct MessageListView: View {
     /// follow/detach state machine. All automatic bottom-follow requests are
     /// routed through this coordinator instead of issuing direct scrollTo calls.
     @State private var bottomPinCoordinator = ChatBottomPinCoordinator()
+    /// One-shot flag: logs a warning the first time anchor, tail, or viewport
+    /// geometry is non-finite during a render pass. Visible even if the JSONL
+    /// session log later fails for an unrelated reason.
+    @State private var hasLoggedNonFiniteGeometry: Bool = false
 
     /// The subset of messages actually shown, honoring the pagination window.
     /// Uses the shared `ChatVisibleMessageFilter` so hidden automated messages
@@ -683,14 +687,19 @@ struct MessageListView: View {
             log.warning(
                 "Scroll loop detected — trippedBy=\(snapshot.trippedBy.rawValue) window=\(snapshot.windowDuration)s \(countsDescription) isNearBottom=\(isNearBottom) hasReceivedScrollEvent=\(hasReceivedScrollEvent) anchorMessageId=\(String(describing: anchorMessageId)) anchorLastMinY=\(anchorTracker.lastMinY) viewportHeight=\(scrollViewportHeight)"
             )
+            var sanitizer = NumericSanitizer()
+            let safeScrollOffsetY = sanitizer.sanitize(anchorTracker.lastMinY, field: "scrollOffsetY")
+            let safeViewportHeight = sanitizer.sanitize(scrollViewportHeight, field: "viewportHeight")
+            logNonFiniteGeometryOnce(sanitizer: sanitizer)
             ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
                 kind: .scrollLoopDetected,
                 conversationId: convId,
                 reason: "trippedBy=\(snapshot.trippedBy.rawValue) \(countsDescription)",
                 isPinnedToBottom: isNearBottom,
                 isUserScrolling: hasReceivedScrollEvent,
-                scrollOffsetY: Double(anchorTracker.lastMinY),
-                viewportHeight: Double(scrollViewportHeight)
+                scrollOffsetY: safeScrollOffsetY,
+                viewportHeight: safeViewportHeight,
+                nonFiniteFields: sanitizer.nonFiniteFields
             ))
         }
     }
@@ -715,13 +724,16 @@ struct MessageListView: View {
         let msgs = messages
         let totalToolCalls = msgs.reduce(0) { $0 + $1.toolCalls.count }
 
-        // Clamp non-finite geometry to nil so JSONEncoder doesn't reject the
-        // snapshot during DebugStateWriter / HangContextWriter serialization.
+        // Route all geometry through NumericSanitizer so non-finite values
+        // (inf, -inf, NaN) are replaced with nil and tracked in nonFiniteFields.
         // scrollViewportHeight and lastTailAnchorY start as .infinity before
         // their preference callbacks run.
-        let clampedAnchorMinY = anchorTracker.lastMinY.isFinite ? Double(anchorTracker.lastMinY) : nil
-        let clampedTailAnchorY = scrollTracking.lastTailAnchorY.isFinite ? Double(scrollTracking.lastTailAnchorY) : nil
-        let clampedViewportHeight = scrollViewportHeight.isFinite ? Double(scrollViewportHeight) : nil
+        var sanitizer = NumericSanitizer()
+        let safeAnchorMinY = sanitizer.sanitize(anchorTracker.lastMinY, field: "anchorMinY")
+        let safeTailAnchorY = sanitizer.sanitize(scrollTracking.lastTailAnchorY, field: "tailAnchorY")
+        let safeViewportHeight = sanitizer.sanitize(scrollViewportHeight, field: "scrollViewportHeight")
+        let safeContainerWidth = sanitizer.sanitize(containerWidth, field: "containerWidth")
+        logNonFiniteGeometryOnce(sanitizer: sanitizer)
 
         ChatDiagnosticsStore.shared.updateSnapshot(ChatTranscriptSnapshot(
             conversationId: convId.uuidString,
@@ -730,20 +742,30 @@ struct MessageListView: View {
             toolCallCount: totalToolCalls,
             isPinnedToBottom: isNearBottom,
             isUserScrolling: hasReceivedScrollEvent,
-            scrollOffsetY: clampedAnchorMinY,
+            scrollOffsetY: safeAnchorMinY,
             contentHeight: nil,
-            viewportHeight: clampedViewportHeight,
+            viewportHeight: safeViewportHeight,
             isNearBottom: isNearBottom,
             hasReceivedScrollEvent: hasReceivedScrollEvent,
             isPaginationInFlight: isPaginationInFlight,
             suppressionReason: isSuppressingBottomScroll ? "bottomScrollSuppressed" : nil,
             anchorMessageId: anchorMessageId?.uuidString,
             highlightedMessageId: highlightedMessageId?.uuidString,
-            anchorMinY: clampedAnchorMinY,
-            tailAnchorY: clampedTailAnchorY,
-            scrollViewportHeight: clampedViewportHeight,
-            containerWidth: Double(containerWidth)
+            anchorMinY: safeAnchorMinY,
+            tailAnchorY: safeTailAnchorY,
+            scrollViewportHeight: safeViewportHeight,
+            containerWidth: safeContainerWidth,
+            nonFiniteFields: sanitizer.nonFiniteFields
         ))
+    }
+
+    /// Logs a one-time warning when scroll geometry first becomes non-finite
+    /// during a render pass. Uses the MessageListView logger so the condition
+    /// is visible even if the JSONL session log later fails for another reason.
+    private func logNonFiniteGeometryOnce(sanitizer: NumericSanitizer) {
+        guard !hasLoggedNonFiniteGeometry, let fields = sanitizer.nonFiniteFields else { return }
+        hasLoggedNonFiniteGeometry = true
+        log.warning("Non-finite scroll geometry detected — sanitized fields: \(fields.joined(separator: ", "))")
     }
 
     /// Routes an automatic bottom-follow request through the coordinator.

--- a/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
+++ b/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
@@ -200,7 +200,9 @@ struct DebugSnapshot: Codable {
     ///
     /// Contains only identifiers, flags, counts, timestamps, and numeric geometry.
     /// Never includes message text, tool input/output bodies, surface HTML,
-    /// or attachment data.
+    /// or attachment data. Geometry fields are already sanitized upstream by
+    /// `NumericSanitizer` — non-finite values are replaced with `nil` and their
+    /// names are recorded in `nonFiniteFields`.
     struct TranscriptDiagnostics: Codable {
         let capturedAt: Date
         let messageCount: Int
@@ -222,6 +224,9 @@ struct DebugSnapshot: Codable {
         let containerWidth: Double?
         let lastScrollToReason: String?
         let lastLoopWarningTimestamp: Date?
+        /// Names of geometry fields whose original values were non-finite
+        /// (nan, inf, -inf) and were replaced with `nil` during sanitization.
+        let nonFiniteFields: [String]?
 
         init(from snapshot: ChatTranscriptSnapshot) {
             self.capturedAt = snapshot.capturedAt
@@ -244,6 +249,7 @@ struct DebugSnapshot: Codable {
             self.containerWidth = snapshot.containerWidth
             self.lastScrollToReason = snapshot.lastScrollToReason
             self.lastLoopWarningTimestamp = snapshot.lastLoopWarningTimestamp
+            self.nonFiniteFields = snapshot.nonFiniteFields
         }
     }
 

--- a/clients/macos/vellum-assistantTests/DebugStateWriterTests.swift
+++ b/clients/macos/vellum-assistantTests/DebugStateWriterTests.swift
@@ -490,4 +490,129 @@ struct DebugStateWriterTests {
         #expect(writer.fileURL.lastPathComponent == "debug-state.json")
         #expect(FileManager.default.fileExists(atPath: tempDir.path))
     }
+
+    // MARK: - Non-Finite Geometry Regression
+
+    /// Regression test: when transcript diagnostics contain sanitized non-finite
+    /// geometry (anchorMinY, tailAnchorY, scrollViewportHeight, containerWidth
+    /// replaced with nil via NumericSanitizer), `debug-state.json` must still
+    /// serialize successfully. Before the sanitizer was adopted, raw .infinity /
+    /// .nan values caused NSCocoaErrorDomain Code=4866 during JSON encoding.
+    @Test @MainActor
+    func debugStateSerializesWithNonFiniteGeometry() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("debug-state-nonfinite-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let store = ChatDiagnosticsStore()
+        let conversationId = UUID().uuidString
+
+        // Simulate what MessageListView produces when geometry is non-finite:
+        // NumericSanitizer replaces inf/NaN with nil and records the field names.
+        var sanitizer = NumericSanitizer()
+        let safeAnchorMinY = sanitizer.sanitize(Double.infinity, field: "anchorMinY")
+        let safeTailAnchorY = sanitizer.sanitize(Double.nan, field: "tailAnchorY")
+        let safeViewportHeight = sanitizer.sanitize(-Double.infinity, field: "scrollViewportHeight")
+        let safeContainerWidth = sanitizer.sanitize(Double(600), field: "containerWidth")
+
+        // Verify the sanitizer correctly replaced non-finite values.
+        #expect(safeAnchorMinY == nil)
+        #expect(safeTailAnchorY == nil)
+        #expect(safeViewportHeight == nil)
+        #expect(safeContainerWidth == 600.0)
+        #expect(sanitizer.nonFiniteFields == ["anchorMinY", "tailAnchorY", "scrollViewportHeight"])
+
+        store.updateSnapshot(ChatTranscriptSnapshot(
+            conversationId: conversationId,
+            capturedAt: Date(),
+            messageCount: 20,
+            toolCallCount: 5,
+            isPinnedToBottom: true,
+            isUserScrolling: false,
+            scrollOffsetY: safeAnchorMinY,
+            contentHeight: nil,
+            viewportHeight: safeViewportHeight,
+            isNearBottom: true,
+            hasReceivedScrollEvent: true,
+            isPaginationInFlight: false,
+            anchorMinY: safeAnchorMinY,
+            tailAnchorY: safeTailAnchorY,
+            scrollViewportHeight: safeViewportHeight,
+            containerWidth: safeContainerWidth,
+            nonFiniteFields: sanitizer.nonFiniteFields
+        ))
+
+        let transcriptSnapshot = store.snapshot(for: conversationId)!
+        let diagnostics = DebugSnapshot.TranscriptDiagnostics(from: transcriptSnapshot)
+
+        let snapshot = DebugSnapshot(
+            timestamp: Date(),
+            appVersion: "test",
+            daemon: DebugSnapshot.DaemonState(
+                isConnected: true,
+                isConnecting: false,
+                daemonVersion: "1.0.0",
+                transport: "http"
+            ),
+            conversations: DebugSnapshot.ConversationsState(
+                activeConversationId: conversationId,
+                count: 1,
+                conversations: []
+            ),
+            activeChat: DebugSnapshot.ActiveChatState(
+                conversationId: conversationId,
+                isThinking: false,
+                isSending: false,
+                isBootstrapping: false,
+                errorText: nil,
+                conversationErrorCategory: nil,
+                conversationErrorDebugDetails: nil,
+                selectedModel: "test-model",
+                messageCount: 20,
+                pendingQueuedCount: 0,
+                pendingAttachmentCount: 0,
+                isRecording: false,
+                activeSubagentCount: 0,
+                transcriptDiagnostics: diagnostics
+            ),
+            computerUse: DebugSnapshot.ComputerUseState(
+                isActive: false,
+                isStarting: false
+            )
+        )
+
+        // This must not throw — before the sanitizer, .infinity / .nan caused
+        // NSCocoaErrorDomain Code=4866 here.
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(snapshot)
+        let fileURL = tempDir.appendingPathComponent("debug-state.json")
+        try data.write(to: fileURL, options: .atomic)
+
+        // Verify the file is valid JSON and round-trips.
+        let readData = try Data(contentsOf: fileURL)
+        let json = try JSONSerialization.jsonObject(with: readData) as! [String: Any]
+        let activeChat = json["activeChat"] as! [String: Any]
+        let td = activeChat["transcriptDiagnostics"] as! [String: Any]
+
+        // Sanitized fields should be null in the output.
+        #expect(td["anchorMinY"] is NSNull || td["anchorMinY"] == nil)
+        #expect(td["tailAnchorY"] is NSNull || td["tailAnchorY"] == nil)
+        #expect(td["scrollViewportHeight"] is NSNull || td["scrollViewportHeight"] == nil)
+        // Finite field should be preserved.
+        #expect(td["containerWidth"] as? Double == 600.0)
+        // nonFiniteFields should list the dropped fields.
+        let droppedFields = td["nonFiniteFields"] as? [String]
+        #expect(droppedFields == ["anchorMinY", "tailAnchorY", "scrollViewportHeight"])
+
+        // Full round-trip decode must succeed.
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(DebugSnapshot.self, from: readData)
+        #expect(decoded.activeChat?.transcriptDiagnostics?.anchorMinY == nil)
+        #expect(decoded.activeChat?.transcriptDiagnostics?.containerWidth == 600.0)
+        #expect(decoded.activeChat?.transcriptDiagnostics?.nonFiniteFields == ["anchorMinY", "tailAnchorY", "scrollViewportHeight"])
+    }
 }


### PR DESCRIPTION
## Summary
- Route scroll-loop geometry (`anchorTracker.lastMinY`, `scrollViewportHeight`, `scrollTracking.lastTailAnchorY`, `containerWidth`) through `NumericSanitizer` to prevent `NSCocoaErrorDomain Code=4866` when values are non-finite
- Add one-time warning via MessageListView logger when scroll geometry first becomes non-finite during a render pass
- Preserve sanitized `nonFiniteFields` metadata in `DebugStateWriter`'s `TranscriptDiagnostics` so `debug-state.json` surfaces which fields were sanitized
- Add regression test verifying `debug-state.json` serializes when transcript diagnostics contain sanitized non-finite geometry

## Test plan
- [x] Regression test: `debugStateSerializesWithNonFiniteGeometry` verifies JSON encoding succeeds and round-trips when geometry fields are sanitized from inf/NaN
- [x] Existing `DebugStateWriterTests` continue to pass (no regressions in transcript diagnostics encoding)

Part of plan: desktop-freeze-diagnostics.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
