### PR TITLE
Add session-level logging for chat bottom-pin retries

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBottomPinCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBottomPinCoordinator.swift
@@ -34,6 +34,8 @@ enum BottomPinUserAction: Sendable {
 /// Represents a single bounded scroll-to-bottom retry session.
 /// Sessions coalesce duplicate requests and cap total retry attempts.
 struct BottomPinSession: Sendable {
+    /// Stable identifier for tracing this session across log entries.
+    let sessionId: UUID
     /// The conversation this session targets.
     let conversationId: UUID
     /// The reason that initiated this session.
@@ -56,6 +58,11 @@ struct BottomPinSession: Sendable {
         guard !isExhausted else { return false }
         attemptCount += 1
         return true
+    }
+
+    /// Elapsed milliseconds since the session was created.
+    var elapsedMs: Int {
+        Int((CFAbsoluteTimeGetCurrent() - startTime) * 1000)
     }
 
     /// Whether this session can coalesce a new request with the given reason
@@ -153,7 +160,7 @@ final class ChatBottomPinCoordinator {
         cancelActiveSession(reason: trigger)
 
         if wasFollowing {
-            log.debug("Detached from bottom (trigger: \(trigger.rawValue))")
+            log.debug("[BottomPin] detach trigger=\(trigger.rawValue) isFollowingBottom=false")
             onFollowStateChanged?(false)
         }
     }
@@ -164,7 +171,7 @@ final class ChatBottomPinCoordinator {
         isFollowingBottom = true
 
         if wasDetached {
-            log.debug("Re-attached to bottom")
+            log.debug("[BottomPin] reattach isFollowingBottom=true")
             onFollowStateChanged?(true)
         }
     }
@@ -201,13 +208,13 @@ final class ChatBottomPinCoordinator {
     ) {
         // Decision-complete suppression: detached users are not yanked to bottom.
         guard isFollowingBottom else {
-            log.debug("Pin request suppressed (detached) — reason: \(reason.rawValue)")
+            log.debug("[BottomPin] suppressed reason=\(reason.rawValue) isFollowingBottom=false")
             return
         }
 
         // Coalesce into active session if possible.
         if let session = activeSession, session.canCoalesce(reason: reason, conversationId: conversationId) {
-            log.debug("Coalescing \(reason.rawValue) into active session (attempt \(session.attemptCount)/\(BottomPinSession.maxRetries))")
+            log.debug("[BottomPin] coalesce sid=\(session.sessionId) reason=\(reason.rawValue) attempt=\(session.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(session.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
             // The existing session task continues; no new task needed.
             // Just record that a new request arrived (the retry loop will
             // pick it up on its next iteration).
@@ -219,18 +226,20 @@ final class ChatBottomPinCoordinator {
 
         // Start a new bounded session.
         let session = BottomPinSession(
+            sessionId: UUID(),
             conversationId: conversationId,
             reason: reason,
             startTime: CFAbsoluteTimeGetCurrent()
         )
         activeSession = session
+        log.debug("[BottomPin] start sid=\(session.sessionId) reason=\(reason.rawValue) animated=\(animated) isFollowingBottom=\(self.isFollowingBottom)")
         startSessionTask(animated: animated)
     }
 
     /// Cancels the active pin session and its associated task.
     func cancelActiveSession(reason: BottomPinCancellationTrigger) {
-        guard activeSession != nil else { return }
-        log.debug("Cancelling active pin session (reason: \(reason.rawValue))")
+        guard let session = activeSession else { return }
+        log.debug("[BottomPin] cancel sid=\(session.sessionId) trigger=\(reason.rawValue) attempt=\(session.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(session.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
         sessionTask?.cancel()
         sessionTask = nil
         activeSession = nil
@@ -255,9 +264,11 @@ final class ChatBottomPinCoordinator {
         guard var session = activeSession else { return }
         session.recordAttempt()
         activeSession = session
+        log.debug("[BottomPin] immediateAttempt sid=\(session.sessionId) reason=\(session.reason.rawValue) animated=\(animated) attempt=\(session.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(session.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
         let pinned = onPinRequested?(session.reason, animated) ?? false
 
         if pinned {
+            log.debug("[BottomPin] success sid=\(session.sessionId) attempt=\(session.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(session.elapsedMs)")
             completeSession(generation: generation)
             return
         }
@@ -266,17 +277,23 @@ final class ChatBottomPinCoordinator {
         sessionTask = Task { @MainActor [weak self] in
             while !Task.isCancelled {
                 guard let self else { break }
-                guard self.sessionGeneration == generation else { break }
+                guard self.sessionGeneration == generation else {
+                    if let s = self.activeSession {
+                        log.debug("[BottomPin] generationMismatch sid=\(s.sessionId) staleGen=\(generation) currentGen=\(self.sessionGeneration)")
+                    }
+                    break
+                }
                 guard var currentSession = self.activeSession else { break }
                 guard !currentSession.isExhausted else {
-                    log.debug("Pin session exhausted after \(currentSession.attemptCount) attempts")
+                    log.debug("[BottomPin] exhausted sid=\(currentSession.sessionId) attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(currentSession.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
                     break
                 }
 
                 // Check session timeout.
                 let elapsed = CFAbsoluteTimeGetCurrent() - currentSession.startTime
                 if elapsed > Self.sessionTimeout {
-                    log.debug("Pin session timed out after \(String(format: "%.0f", elapsed * 1000))ms")
+                    let elapsedMs = Int(elapsed * 1000)
+                    log.debug("[BottomPin] timeout sid=\(currentSession.sessionId) attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
                     break
                 }
 
@@ -289,21 +306,26 @@ final class ChatBottomPinCoordinator {
 
                 // Re-check follow state after sleep — user may have scrolled up.
                 guard self.isFollowingBottom else {
-                    log.debug("Pin retry aborted — user detached during sleep")
+                    log.debug("[BottomPin] retryAborted sid=\(currentSession.sessionId) reason=detachedDuringSleep attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(currentSession.elapsedMs) isFollowingBottom=false")
                     break
                 }
 
                 currentSession.recordAttempt()
                 self.activeSession = currentSession
+                log.debug("[BottomPin] retryAttempt sid=\(currentSession.sessionId) reason=\(currentSession.reason.rawValue) animated=\(animated) attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(currentSession.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
                 let succeeded = self.onPinRequested?(currentSession.reason, animated) ?? false
 
                 if succeeded {
+                    log.debug("[BottomPin] success sid=\(currentSession.sessionId) attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(currentSession.elapsedMs)")
                     self.completeSession(generation: generation)
                     return
                 }
             }
 
             // Clean up if we fell through without completing.
+            if let self, let s = self.activeSession, self.sessionGeneration == generation {
+                log.debug("[BottomPin] sessionEnd sid=\(s.sessionId) attempt=\(s.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(s.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
+            }
             self?.completeSession(generation: generation)
         }
     }

--- a/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
@@ -204,6 +204,7 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
 
     func testSessionCapsRetries() {
         var session = BottomPinSession(
+            sessionId: UUID(),
             conversationId: UUID(),
             reason: .expansion,
             startTime: CFAbsoluteTimeGetCurrent()
@@ -223,6 +224,7 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
 
     func testExhaustedSessionDoesNotCoalesce() {
         var session = BottomPinSession(
+            sessionId: UUID(),
             conversationId: UUID(),
             reason: .expansion,
             startTime: CFAbsoluteTimeGetCurrent()
@@ -307,6 +309,7 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
         let convA = UUID()
         let convB = UUID()
         let session = BottomPinSession(
+            sessionId: UUID(),
             conversationId: convA,
             reason: .expansion,
             startTime: CFAbsoluteTimeGetCurrent()
@@ -319,6 +322,7 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
     func testSessionCoalesceRequiresSameReason() {
         let convId = UUID()
         let session = BottomPinSession(
+            sessionId: UUID(),
             conversationId: convId,
             reason: .streaming,
             startTime: CFAbsoluteTimeGetCurrent()
@@ -383,5 +387,197 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
         // No more attempts after detach.
         XCTAssertEqual(callCount, countAfterDetach)
         XCTAssertNil(coordinator.activeSession)
+    }
+
+    // MARK: - Session ID Stability
+
+    func testSessionHasStableSessionId() {
+        let convId = UUID()
+        pinShouldSucceed = false
+
+        coordinator.requestPin(reason: .streaming, conversationId: convId)
+
+        let sessionId = coordinator.activeSession?.sessionId
+        XCTAssertNotNil(sessionId, "Active session should have a stable sessionId")
+    }
+
+    func testCoalescingPreservesSessionId() {
+        let convId = UUID()
+        pinShouldSucceed = false
+
+        coordinator.requestPin(reason: .expansion, conversationId: convId)
+        let originalSessionId = coordinator.activeSession?.sessionId
+
+        // Second request with same reason coalesces.
+        coordinator.requestPin(reason: .expansion, conversationId: convId)
+
+        XCTAssertEqual(coordinator.activeSession?.sessionId, originalSessionId,
+                       "Coalesced request should preserve the original sessionId")
+    }
+
+    func testNewSessionGetsDistinctSessionId() {
+        let convId = UUID()
+        pinShouldSucceed = false
+
+        coordinator.requestPin(reason: .expansion, conversationId: convId)
+        let firstSessionId = coordinator.activeSession?.sessionId
+
+        // Different reason triggers a new session.
+        coordinator.requestPin(reason: .resize, conversationId: convId)
+        let secondSessionId = coordinator.activeSession?.sessionId
+
+        XCTAssertNotNil(firstSessionId)
+        XCTAssertNotNil(secondSessionId)
+        XCTAssertNotEqual(firstSessionId, secondSessionId,
+                          "A new session should get a distinct sessionId")
+    }
+
+    // MARK: - Timeout
+
+    func testSessionTimesOutAfterDeadline() async throws {
+        let convId = UUID()
+        pinShouldSucceed = false
+
+        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
+        XCTAssertNotNil(coordinator.activeSession)
+
+        // Wait longer than sessionTimeout (0.5s) + retry interval headroom.
+        try await Task.sleep(nanoseconds: 700_000_000)
+
+        // Session should have self-terminated via timeout.
+        XCTAssertNil(coordinator.activeSession,
+                     "Session should be nil after timeout expires")
+    }
+
+    // MARK: - Cancel on Detach
+
+    func testDetachCancelsActiveSessionAndSuppressesFutureRequests() {
+        let convId = UUID()
+        pinShouldSucceed = false
+
+        coordinator.requestPin(reason: .streaming, conversationId: convId)
+        XCTAssertNotNil(coordinator.activeSession)
+
+        coordinator.detach(trigger: .userScrollUp)
+
+        XCTAssertNil(coordinator.activeSession,
+                     "Detach should cancel the active session")
+        XCTAssertFalse(coordinator.isFollowingBottom)
+
+        // Subsequent requests should be suppressed.
+        let countBefore = pinRequestCount
+        coordinator.requestPin(reason: .messageCount, conversationId: convId)
+        XCTAssertEqual(pinRequestCount, countBefore,
+                       "Pin requests should be suppressed while detached")
+    }
+
+    func testCancelOnDetachDuringRetryLoop() async throws {
+        let convId = UUID()
+        var callCount = 0
+        pinShouldSucceed = false
+
+        coordinator.onPinRequested = { reason, animated in
+            callCount += 1
+            return false
+        }
+
+        coordinator.requestPin(reason: .streaming, conversationId: convId)
+        XCTAssertNotNil(coordinator.activeSession)
+
+        // Let a retry or two fire.
+        try await Task.sleep(nanoseconds: 120_000_000)
+        let countBeforeDetach = callCount
+
+        // Detach mid-retry loop.
+        coordinator.detach(trigger: .userScrollUp)
+
+        // Wait for the task to observe cancellation.
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        XCTAssertNil(coordinator.activeSession)
+        // No additional pin attempts should have been made after detach.
+        XCTAssertEqual(callCount, countBeforeDetach,
+                       "No retries should fire after detach")
+    }
+
+    // MARK: - Stale Task Cleanup (Generation Mismatch)
+
+    func testStaleTaskDoesNotClobberNewerSession() async throws {
+        let conv1 = UUID()
+        let conv2 = UUID()
+        pinShouldSucceed = false
+
+        // Start a session that will enter the retry loop.
+        coordinator.requestPin(reason: .streaming, conversationId: conv1)
+        let firstSessionId = coordinator.activeSession?.sessionId
+        XCTAssertNotNil(firstSessionId)
+
+        // Immediately start a new session for a different conversation,
+        // which bumps the generation counter and invalidates the first task.
+        coordinator.requestPin(reason: .expansion, conversationId: conv2)
+        let secondSessionId = coordinator.activeSession?.sessionId
+        XCTAssertNotNil(secondSessionId)
+        XCTAssertNotEqual(firstSessionId, secondSessionId)
+
+        // Let async tasks run to completion.
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        // The stale first task should not have cleared the second session.
+        // The second session either completed normally or timed out on its own.
+        // Either way, no leftover state from the first session should remain.
+        if let remaining = coordinator.activeSession {
+            XCTAssertEqual(remaining.sessionId, secondSessionId,
+                           "If a session remains, it must be the newer one")
+        }
+    }
+
+    func testRapidRequestsOnlyKeepLatestSession() {
+        let convId = UUID()
+        pinShouldSucceed = false
+
+        // Fire multiple requests with different reasons in rapid succession.
+        coordinator.requestPin(reason: .expansion, conversationId: convId)
+        coordinator.requestPin(reason: .resize, conversationId: convId)
+        coordinator.requestPin(reason: .streaming, conversationId: convId)
+
+        // Only the last session should be active.
+        XCTAssertEqual(coordinator.activeSession?.reason, .streaming,
+                       "Only the most recent session should remain active")
+    }
+
+    // MARK: - Completion Path
+
+    func testSuccessfulRetryCompletesSession() async throws {
+        let convId = UUID()
+        var callCount = 0
+
+        coordinator.onPinRequested = { reason, animated in
+            callCount += 1
+            // Succeed on the second attempt (first retry).
+            return callCount >= 2
+        }
+
+        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
+
+        // First attempt fails synchronously; retry loop should succeed.
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        XCTAssertGreaterThanOrEqual(callCount, 2)
+        XCTAssertNil(coordinator.activeSession,
+                     "Session should be cleared after successful retry")
+        XCTAssertTrue(coordinator.isFollowingBottom,
+                      "Coordinator should still be following bottom after success")
+    }
+
+    func testSessionElapsedMsIsNonNegative() {
+        let session = BottomPinSession(
+            sessionId: UUID(),
+            conversationId: UUID(),
+            reason: .streaming,
+            startTime: CFAbsoluteTimeGetCurrent()
+        )
+
+        XCTAssertGreaterThanOrEqual(session.elapsedMs, 0,
+                                    "elapsedMs should be non-negative for a freshly created session")
     }
 }


### PR DESCRIPTION
## Summary
- Add stable sessionId to BottomPinSession with full lifecycle transition logging
- Log reason, animated flag, attempt count, elapsed ms, and isFollowingBottom at each transition
- Add ChatBottomPinCoordinatorTests covering coalescing, timeout, cancel, and completion paths

Part of plan: desktop-freeze-diagnostics.md (PR 5 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
