### PR TITLE
Instrument dynamic-page load and preview capture timing on macOS

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -142,7 +142,11 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onAction: onAction, onDataRequest: onDataRequest, onPageChanged: onPageChanged, onSnapshotCaptured: onSnapshotCaptured, onLinkOpen: onLinkOpen, currentHTML: data.html, sandboxMode: sandboxMode)
+        let coordinator = Coordinator(onAction: onAction, onDataRequest: onDataRequest, onPageChanged: onPageChanged, onSnapshotCaptured: onSnapshotCaptured, onLinkOpen: onLinkOpen, currentHTML: data.html, sandboxMode: sandboxMode)
+        coordinator.surfaceId = data.appId ?? "ephemeral"
+        coordinator.appId = appId
+        coordinator.loadStartTime = CFAbsoluteTimeGetCurrent()
+        return coordinator
     }
 
     func makeNSView(context: Context) -> NSView {
@@ -531,6 +535,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         if let gen = data.reloadGeneration, gen != context.coordinator.lastReloadGeneration {
             context.coordinator.lastReloadGeneration = gen
             context.coordinator.hasCapturedSnapshot = false
+            context.coordinator.loadStartTime = CFAbsoluteTimeGetCurrent()
             // Stash any simultaneous status change for injection after reload completes
             if let status = data.status, status != context.coordinator.lastStatus {
                 context.coordinator.pendingStatus = status
@@ -544,6 +549,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             let previousHTML = context.coordinator.currentHTML
             context.coordinator.currentHTML = data.html
             context.coordinator.hasCapturedSnapshot = false
+            context.coordinator.loadStartTime = CFAbsoluteTimeGetCurrent()
             let origin = appId.map { "https://\($0).vellum.local/" } ?? "https://surface.vellum.local/"
 
             if previousHTML.isEmpty {
@@ -670,6 +676,21 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         var lastStatus: String?
         /// Status message to inject after the next page reload completes.
         var pendingStatus: String?
+
+        // MARK: - Timing diagnostics
+
+        /// Surface and app identifiers for diagnostic log lines.
+        var surfaceId: String?
+        var appId: String?
+        /// Monotonic timestamp (CFAbsoluteTimeGetCurrent) recorded when a page load begins.
+        var loadStartTime: CFAbsoluteTime = 0
+
+        /// Log a timing-trail phase with elapsed milliseconds since `loadStartTime`.
+        private func logPhase(_ phase: String) {
+            let elapsedMs = Int((CFAbsoluteTimeGetCurrent() - loadStartTime) * 1000)
+            log.info("[Timing] surface=\(self.surfaceId ?? "nil", privacy: .public) appId=\(self.appId ?? "nil", privacy: .public) page=\(self.currentPage, privacy: .public) phase=\(phase, privacy: .public) elapsed=\(elapsedMs)ms")
+        }
+
         init(
             onAction: @escaping (String, Any?) -> Void,
             onDataRequest: ((String, String, String?, [String: Any]?) -> Void)?,
@@ -903,11 +924,16 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
 
         func captureSnapshotAfterMorph(generation: Int) {
             guard let onSnapshotCaptured else { return }
+            logPhase("captureSnapshotAfterMorph:start")
             hasCapturedSnapshot = false
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
                 guard let self, self.morphGeneration == generation else { return }
+                self.logPhase("captureSnapshotAfterMorph:takeSnapshot")
                 self.captureSnapshot { base64 in
-                    if let base64 { onSnapshotCaptured(base64) }
+                    if let base64 {
+                        self.logPhase("captureSnapshotAfterMorph:complete")
+                        onSnapshotCaptured(base64)
+                    }
                 }
             }
         }
@@ -956,6 +982,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            logPhase("didFinish")
+
             // Restore scroll position if this load was a refinement update.
             if let scrollJSON = pendingScrollRestore {
                 pendingScrollRestore = nil
@@ -1048,9 +1076,12 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             // Capture a preview screenshot after the page has rendered (once per load).
             if !hasCapturedSnapshot, let onSnapshotCaptured {
                 hasCapturedSnapshot = true
+                logPhase("onSnapshotCaptured:scheduled")
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+                    self?.logPhase("onSnapshotCaptured:takeSnapshot")
                     self?.captureSnapshot { base64 in
                         if let base64 {
+                            self?.logPhase("onSnapshotCaptured:complete")
                             onSnapshotCaptured(base64)
                         }
                     }

--- a/clients/macos/vellum-assistant/Features/Surfaces/OffscreenPreviewCapture.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/OffscreenPreviewCapture.swift
@@ -14,6 +14,12 @@ enum OffscreenPreviewCapture {
     /// Returns `nil` if the capture fails for any reason. Safe to call from `@MainActor`.
     @MainActor
     static func capture(html: String) async -> String? {
+        let startTime = CFAbsoluteTimeGetCurrent()
+
+        func elapsedMs() -> Int {
+            Int((CFAbsoluteTimeGetCurrent() - startTime) * 1000)
+        }
+
         let width: CGFloat = 400
         let height: CGFloat = 300
 
@@ -25,6 +31,7 @@ enum OffscreenPreviewCapture {
             defer: false
         )
         window.isReleasedWhenClosed = false
+        log.info("[Timing] offscreen phase=windowCreated elapsed=\(elapsedMs())ms")
 
         let config = WKWebViewConfiguration()
         config.suppressesIncrementalRendering = true
@@ -40,6 +47,8 @@ enum OffscreenPreviewCapture {
             webView.loadHTMLString(html, baseURL: nil)
         }
 
+        log.info("[Timing] offscreen phase=htmlLoadComplete success=\(didLoad) elapsed=\(elapsedMs())ms")
+
         guard didLoad else {
             log.warning("Offscreen WKWebView failed to load HTML")
             tearDown(webView: webView, window: window)
@@ -48,13 +57,16 @@ enum OffscreenPreviewCapture {
 
         // Give the page a moment to finish rendering (CSS, fonts, initial paint).
         try? await Task.sleep(nanoseconds: 800_000_000) // 800ms
+        log.info("[Timing] offscreen phase=renderDelayComplete elapsed=\(elapsedMs())ms")
 
         // Capture the snapshot.
         let snapshotConfig = WKSnapshotConfiguration()
         snapshotConfig.afterScreenUpdates = true
         let base64 = await captureSnapshot(webView: webView, config: snapshotConfig)
+        log.info("[Timing] offscreen phase=snapshotCaptured hasImage=\(base64 != nil) elapsed=\(elapsedMs())ms")
 
         tearDown(webView: webView, window: window)
+        log.info("[Timing] offscreen phase=teardownComplete elapsed=\(elapsedMs())ms")
         return base64
     }
 
@@ -63,7 +75,10 @@ enum OffscreenPreviewCapture {
     @MainActor
     private static func captureSnapshot(webView: WKWebView, config: WKSnapshotConfiguration) async -> String? {
         await withCheckedContinuation { continuation in
+            let takeSnapshotStart = CFAbsoluteTimeGetCurrent()
             webView.takeSnapshot(with: config) { image, error in
+                let takeSnapshotMs = Int((CFAbsoluteTimeGetCurrent() - takeSnapshotStart) * 1000)
+                log.info("[Timing] offscreen phase=takeSnapshotCallback elapsed=\(takeSnapshotMs)ms")
                 if let error = error {
                     log.error("Offscreen snapshot failed: \(error.localizedDescription, privacy: .public)")
                     continuation.resume(returning: nil)
@@ -76,6 +91,7 @@ enum OffscreenPreviewCapture {
                     return
                 }
                 // Resize to max 400px wide thumbnail
+                let resizeStart = CFAbsoluteTimeGetCurrent()
                 let maxWidth: CGFloat = 400
                 let scale = min(1.0, maxWidth / image.size.width)
                 let targetSize = NSSize(
@@ -97,6 +113,8 @@ enum OffscreenPreviewCapture {
                     continuation.resume(returning: nil)
                     return
                 }
+                let resizeMs = Int((CFAbsoluteTimeGetCurrent() - resizeStart) * 1000)
+                log.info("[Timing] offscreen phase=imageResize elapsed=\(resizeMs)ms")
                 continuation.resume(returning: pngData.base64EncodedString())
             }
         }

--- a/clients/macos/vellum-assistantTests/ChatDynamicPreviewRegressionTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatDynamicPreviewRegressionTests.swift
@@ -561,4 +561,130 @@ final class ChatDynamicPreviewRegressionTests: XCTestCase {
         XCTAssertEqual(surface.surfaceRef?.surfaceId, "surface-msg-test")
         XCTAssertEqual(surface.surfaceRef?.conversationId, "sess-dp")
     }
+
+    // MARK: - Inline preview behavior after timing instrumentation
+
+    /// Regression test verifying the full inline-preview lifecycle is unaffected
+    /// by the timing instrumentation added to DynamicPageSurfaceView and
+    /// OffscreenPreviewCapture. Exercises show, update, complete, and dismiss
+    /// in sequence using the same helper that constructs dynamic page preview
+    /// messages, ensuring no log-related side effects alter the data flow.
+    func testInlinePreviewLifecycleIntactAfterTimingInstrumentation() {
+        // 1. Show a dynamic page with preview metadata
+        viewModel.handleServerMessage(.assistantTextDelta(
+            AssistantTextDeltaMessage(text: "Building your dashboard:")
+        ))
+
+        let showMsg = makeDynamicPageSurfaceMessage(
+            surfaceId: "surface-timing-lifecycle",
+            title: "Dashboard App",
+            html: "<div>Dashboard v1</div>",
+            preview: ["title": "Dashboard", "subtitle": "v1.0"],
+            appId: "app-dashboard"
+        )
+        viewModel.handleServerMessage(.uiSurfaceShow(showMsg))
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg1 = viewModel.messages[0]
+        XCTAssertEqual(msg1.inlineSurfaces.count, 1,
+                       "Inline preview should be created after show")
+        let surface1 = msg1.inlineSurfaces[0]
+        XCTAssertEqual(surface1.id, "surface-timing-lifecycle")
+        XCTAssertNil(surface1.completionState)
+        if case .dynamicPage(let dp1) = surface1.data {
+            XCTAssertEqual(dp1.preview?.title, "Dashboard")
+            XCTAssertEqual(dp1.preview?.subtitle, "v1.0")
+            XCTAssertEqual(dp1.appId, "app-dashboard")
+        } else {
+            XCTFail("Surface should be a dynamic page")
+        }
+
+        // 2. Update the surface with new content
+        let updateMsg = UiSurfaceUpdateMessage(
+            conversationId: "sess-dp",
+            surfaceId: "surface-timing-lifecycle",
+            data: AnyCodable([
+                "html": "<div>Dashboard v2</div>",
+                "preview": ["title": "Dashboard", "subtitle": "v2.0"] as [String: Any]
+            ] as [String: Any])
+        )
+        viewModel.handleServerMessage(.uiSurfaceUpdate(updateMsg))
+
+        let updatedSurface = viewModel.messages[0].inlineSurfaces[0]
+        if case .dynamicPage(let dp2) = updatedSurface.data {
+            XCTAssertEqual(dp2.html, "<div>Dashboard v2</div>",
+                           "HTML should be updated")
+            XCTAssertEqual(dp2.preview?.subtitle, "v2.0",
+                           "Preview subtitle should be updated")
+        } else {
+            XCTFail("Updated surface should still be a dynamic page")
+        }
+
+        // 3. Complete the surface
+        let completeMsg = UiSurfaceCompleteMessage(
+            conversationId: "sess-dp",
+            surfaceId: "surface-timing-lifecycle",
+            summary: "Dashboard deployed",
+            submittedData: nil
+        )
+        viewModel.handleServerMessage(.uiSurfaceComplete(completeMsg))
+
+        let completedSurface = viewModel.messages[0].inlineSurfaces[0]
+        XCTAssertNotNil(completedSurface.completionState,
+                        "Surface should be completed")
+        XCTAssertEqual(completedSurface.completionState?.summary, "Dashboard deployed")
+
+        // 4. Dismiss the surface
+        let dismissMsg = UiSurfaceDismissMessage(
+            type: "ui_surface_dismiss",
+            conversationId: "sess-dp",
+            surfaceId: "surface-timing-lifecycle"
+        )
+        viewModel.handleServerMessage(.uiSurfaceDismiss(dismissMsg))
+
+        XCTAssertTrue(viewModel.messages[0].inlineSurfaces.isEmpty,
+                      "Inline surface should be removed after dismiss")
+    }
+
+    /// Verify that a dynamic page with preview metadata followed by an
+    /// immediate second surface with different preview metadata correctly
+    /// produces two distinct inline surfaces, confirming that timing logs
+    /// don't interfere with multi-surface attachment ordering.
+    func testMultipleInlinePreviewsUnaffectedByInstrumentation() {
+        viewModel.handleServerMessage(.assistantTextDelta(
+            AssistantTextDeltaMessage(text: "Here are two apps:")
+        ))
+
+        let showMsg1 = makeDynamicPageSurfaceMessage(
+            surfaceId: "surface-multi-1",
+            title: "App One",
+            preview: ["title": "Weather"]
+        )
+        viewModel.handleServerMessage(.uiSurfaceShow(showMsg1))
+
+        let showMsg2 = makeDynamicPageSurfaceMessage(
+            surfaceId: "surface-multi-2",
+            title: "App Two",
+            preview: ["title": "Calendar"]
+        )
+        viewModel.handleServerMessage(.uiSurfaceShow(showMsg2))
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertEqual(msg.inlineSurfaces.count, 2,
+                       "Both inline surfaces should be attached")
+        XCTAssertEqual(msg.inlineSurfaces[0].id, "surface-multi-1")
+        XCTAssertEqual(msg.inlineSurfaces[1].id, "surface-multi-2")
+
+        if case .dynamicPage(let dp1) = msg.inlineSurfaces[0].data {
+            XCTAssertEqual(dp1.preview?.title, "Weather")
+        } else {
+            XCTFail("First surface should be a dynamic page")
+        }
+        if case .dynamicPage(let dp2) = msg.inlineSurfaces[1].data {
+            XCTAssertEqual(dp2.preview?.title, "Calendar")
+        } else {
+            XCTFail("Second surface should be a dynamic page")
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add timing logs around webView didFinish, captureSnapshotAfterMorph, and onSnapshotCaptured in DynamicPageSurfaceView
- Add phase logs for offscreen preview capture (window creation, HTML load, render delay, snapshot, image resize, teardown) in OffscreenPreviewCapture
- Extend ChatDynamicPreviewRegressionTests with lifecycle and multi-surface regression tests

Part of plan: desktop-freeze-diagnostics.md (PR 7 of 8)

## Test plan
- [ ] Verify timing log trail appears in Console.app when loading a dynamic-page surface
- [ ] Verify offscreen preview capture log trail appears during app-builder preview generation
- [ ] Run ChatDynamicPreviewRegressionTests to confirm inline-preview behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
