### PR TITLE
Instrument macOS chat scroll-wheel detector lifecycle and duplicate installs

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -674,6 +674,10 @@ struct ScrollWheelDetector: NSViewRepresentable {
     let onScrollToBottom: () -> Void
     var conversationId: UUID?
 
+    /// Shared registry tracking all active detector instances.
+    /// Injected from outside for testability; defaults to the app-wide singleton.
+    var registry: ScrollWheelDetectorRegistry = .shared
+
     func makeCoordinator() -> Coordinator {
         Coordinator()
     }
@@ -685,6 +689,33 @@ struct ScrollWheelDetector: NSViewRepresentable {
         coordinator.onScrollUp = onScrollUp
         coordinator.onScrollToBottom = onScrollToBottom
         coordinator.conversationId = conversationId
+        coordinator.registry = registry
+
+        // Register with the detector registry.
+        let now = ProcessInfo.processInfo.systemUptime
+        let convId = conversationId?.uuidString ?? "none"
+        // Window may not be available yet during makeNSView; windowId is resolved
+        // lazily and updated in updateNSView once the view is installed.
+        let winId = view.window.map { String($0.windowNumber) } ?? "pending"
+        registry.register(
+            detectorId: coordinator.detectorId,
+            conversationId: convId,
+            windowId: winId,
+            timestamp: now
+        )
+
+        let activeCount = registry.activeCount
+        let hasDuplicate = registry.hasDuplicates(conversationId: convId, windowId: winId)
+
+        log.info(
+            "ScrollWheelDetector.install detectorId=\(coordinator.detectorId) conv=\(convId) win=\(winId) activeDetectors=\(activeCount) duplicate=\(hasDuplicate)"
+        )
+        ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
+            kind: .detectorInstall,
+            conversationId: convId,
+            reason: "detectorId=\(coordinator.detectorId) win=\(winId) activeDetectors=\(activeCount) duplicate=\(hasDuplicate)"
+        ))
+
         coordinator.monitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { event in
             // Only process events within this view's bounds (scoped to the chat scroll area)
             guard let view = coordinator.view,
@@ -700,18 +731,19 @@ struct ScrollWheelDetector: NSViewRepresentable {
                 // layout pass can trigger an auto-scroll-to-bottom.
                 // Guard: only untether if content is actually scrollable (prevents false
                 // untethers on short conversations that can't scroll).
-                if let scrollView = coordinator.findEnclosingScrollView() {
+                let (scrollView, lookupPath) = coordinator.findEnclosingScrollViewWithPath()
+                if let scrollView {
                     let clipHeight = scrollView.contentView.bounds.height
                     let docHeight = scrollView.documentView?.frame.height ?? 0
                     let isScrollable = docHeight > clipHeight
                     os_signpost(.event, log: PerfSignposts.log, name: "scrollWheelUntether",
-                                "deltaY=%.1f isScrollable=%d clipH=%.0f docH=%.0f",
-                                event.scrollingDeltaY, isScrollable ? 1 : 0, clipHeight, docHeight)
+                                "deltaY=%.1f isScrollable=%d clipH=%.0f docH=%.0f lookup=%{public}@",
+                                event.scrollingDeltaY, isScrollable ? 1 : 0, clipHeight, docHeight, lookupPath as NSString)
                     if coordinator.shouldRecordDiagnostic(kind: .scrollWheelUntether) {
                         ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
                             kind: .scrollWheelUntether,
                             conversationId: coordinator.conversationId?.uuidString,
-                            reason: "deltaY=\(String(format: "%.1f", event.scrollingDeltaY)) isScrollable=\(isScrollable)",
+                            reason: "deltaY=\(String(format: "%.1f", event.scrollingDeltaY)) isScrollable=\(isScrollable) lookup=\(lookupPath)",
                             contentHeight: docHeight,
                             viewportHeight: clipHeight
                         ))
@@ -721,12 +753,13 @@ struct ScrollWheelDetector: NSViewRepresentable {
                     }
                 } else {
                     os_signpost(.event, log: PerfSignposts.log, name: "scrollWheelUntether",
-                                "deltaY=%.1f scrollViewNotFound=1", event.scrollingDeltaY)
+                                "deltaY=%.1f scrollViewNotFound=1 lookup=%{public}@",
+                                event.scrollingDeltaY, lookupPath as NSString)
                     if coordinator.shouldRecordDiagnostic(kind: .scrollWheelUntether) {
                         ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
                             kind: .scrollWheelUntether,
                             conversationId: coordinator.conversationId?.uuidString,
-                            reason: "deltaY=\(String(format: "%.1f", event.scrollingDeltaY)) scrollViewNotFound=true"
+                            reason: "deltaY=\(String(format: "%.1f", event.scrollingDeltaY)) scrollViewNotFound=true lookup=\(lookupPath)"
                         ))
                     }
                     coordinator.onScrollUp?()
@@ -736,20 +769,21 @@ struct ScrollWheelDetector: NSViewRepresentable {
                 // Deferred to next run-loop tick so clipBounds reflects the post-scroll position;
                 // reading it synchronously in the event monitor sees the pre-scroll state.
                 DispatchQueue.main.async {
-                    if let scrollView = coordinator.findEnclosingScrollView() {
+                    let (scrollView, lookupPath) = coordinator.findEnclosingScrollViewWithPath()
+                    if let scrollView {
                         let clipBounds = scrollView.contentView.bounds
                         let docHeight = scrollView.documentView?.frame.height ?? 0
                         let distanceFromBottom = docHeight - clipBounds.maxY
                         let isScrollable = docHeight > clipBounds.height
                         if distanceFromBottom < 20 {
                             os_signpost(.event, log: PerfSignposts.log, name: "scrollWheelRetether",
-                                        "distFromBottom=%.1f isScrollable=%d",
-                                        distanceFromBottom, isScrollable ? 1 : 0)
+                                        "distFromBottom=%.1f isScrollable=%d lookup=%{public}@",
+                                        distanceFromBottom, isScrollable ? 1 : 0, lookupPath as NSString)
                             if coordinator.shouldRecordDiagnostic(kind: .scrollWheelRetether) {
                                 ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
                                     kind: .scrollWheelRetether,
                                     conversationId: coordinator.conversationId?.uuidString,
-                                    reason: "distFromBottom=\(String(format: "%.1f", distanceFromBottom)) isScrollable=\(isScrollable)",
+                                    reason: "distFromBottom=\(String(format: "%.1f", distanceFromBottom)) isScrollable=\(isScrollable) lookup=\(lookupPath)",
                                     contentHeight: docHeight,
                                     viewportHeight: clipBounds.height
                                 ))
@@ -765,27 +799,68 @@ struct ScrollWheelDetector: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        context.coordinator.onScrollUp = onScrollUp
-        context.coordinator.onScrollToBottom = onScrollToBottom
-        context.coordinator.conversationId = conversationId
+        let coordinator = context.coordinator
+        coordinator.onScrollUp = onScrollUp
+        coordinator.onScrollToBottom = onScrollToBottom
+        coordinator.conversationId = conversationId
+        coordinator.registry = registry
+
+        // Update the registry entry with the current conversation/window.
+        let now = ProcessInfo.processInfo.systemUptime
+        let convId = conversationId?.uuidString ?? "none"
+        let winId = nsView.window.map { String($0.windowNumber) } ?? "pending"
+        registry.update(detectorId: coordinator.detectorId, timestamp: now)
+
+        let activeCount = registry.activeCount
+        let hasDuplicate = registry.hasDuplicates(conversationId: convId, windowId: winId)
+
+        log.debug(
+            "ScrollWheelDetector.update detectorId=\(coordinator.detectorId) conv=\(convId) win=\(winId) activeDetectors=\(activeCount) duplicate=\(hasDuplicate)"
+        )
+        ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
+            kind: .detectorUpdate,
+            conversationId: convId,
+            reason: "detectorId=\(coordinator.detectorId) win=\(winId) activeDetectors=\(activeCount) duplicate=\(hasDuplicate)"
+        ))
     }
 
     static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
         if let monitor = coordinator.monitor {
             NSEvent.removeMonitor(monitor)
         }
+
+        // Unregister from the detector registry.
+        let convId = coordinator.conversationId?.uuidString ?? "none"
+        let winId = nsView.window.map { String($0.windowNumber) } ?? "unknown"
+        coordinator.registry?.unregister(detectorId: coordinator.detectorId)
+
+        let activeCount = coordinator.registry?.activeCount ?? 0
+
+        log.info(
+            "ScrollWheelDetector.remove detectorId=\(coordinator.detectorId) conv=\(convId) win=\(winId) activeDetectors=\(activeCount)"
+        )
+        ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
+            kind: .detectorRemove,
+            conversationId: convId,
+            reason: "detectorId=\(coordinator.detectorId) win=\(winId) activeDetectors=\(activeCount)"
+        ))
     }
 
     class Coordinator {
+        /// Stable identifier for this detector instance, assigned once at creation.
+        let detectorId: String = UUID().uuidString
         weak var view: NSView?
         var onScrollUp: (() -> Void)?
         var onScrollToBottom: (() -> Void)?
         var conversationId: UUID?
         var monitor: Any?
+        /// Reference to the registry for unregistration on dismantle.
+        /// Weak-optional because the registry is @MainActor and may outlive the coordinator.
+        var registry: ScrollWheelDetectorRegistry?
 
         /// Throttle interval for scroll-wheel diagnostics recording.
         /// Prevents synchronous JSON-encode + FileHandle.write on every tick.
-        private static let diagnosticThrottleInterval: TimeInterval = 0.5
+        static let diagnosticThrottleInterval: TimeInterval = 0.5
         private var lastUntetherRecordTime: TimeInterval = 0
         private var lastRetetherRecordTime: TimeInterval = 0
 
@@ -807,26 +882,40 @@ struct ScrollWheelDetector: NSViewRepresentable {
             }
         }
 
+        /// Resolves the chat's vertical NSScrollView and reports which lookup
+        /// path was used: `"enclosing"` for the fast superview walk, or
+        /// `"hitTest"` for the fallback window-root hit-test.
+        func findEnclosingScrollViewWithPath() -> (NSScrollView?, String) {
+            // Fast path: walk up the superview chain.
+            if let sv = view?.enclosingScrollView, sv.hasVerticalScroller {
+                return (sv, "enclosing")
+            }
+            var current = view?.superview
+            while let v = current {
+                if let sv = v as? NSScrollView, sv.hasVerticalScroller {
+                    return (sv, "enclosing")
+                }
+                current = v.superview
+            }
+            // Fallback: hit-test from the window root for a vertical scroll view.
+            guard let window = view?.window, let contentView = window.contentView else {
+                return (nil, "hitTest")
+            }
+            let probe = view?.convert(
+                NSPoint(x: view?.bounds.midX ?? 0, y: view?.bounds.midY ?? 0),
+                to: nil
+            ) ?? .zero
+            let sv = Self.verticalScrollView(in: contentView, containing: probe)
+            return (sv, "hitTest")
+        }
+
         /// Resolves the chat's vertical NSScrollView.
         /// The detector sits in a `.background` modifier (sibling of the scroll view),
         /// so walking up the superview chain may miss it or find a wrong parent.
         /// The hit-test fallback searches for a *vertical* scroll view to avoid
         /// resolving to nested horizontal scrollers (e.g. markdown code blocks).
         func findEnclosingScrollView() -> NSScrollView? {
-            // Fast path: walk up the superview chain.
-            if let sv = view?.enclosingScrollView, sv.hasVerticalScroller { return sv }
-            var current = view?.superview
-            while let v = current {
-                if let sv = v as? NSScrollView, sv.hasVerticalScroller { return sv }
-                current = v.superview
-            }
-            // Fallback: hit-test from the window root for a vertical scroll view.
-            guard let window = view?.window, let contentView = window.contentView else { return nil }
-            let probe = view?.convert(
-                NSPoint(x: view?.bounds.midX ?? 0, y: view?.bounds.midY ?? 0),
-                to: nil
-            ) ?? .zero
-            return Self.verticalScrollView(in: contentView, containing: probe)
+            findEnclosingScrollViewWithPath().0
         }
 
         /// Finds the outermost vertical NSScrollView containing `windowPoint`.

--- a/clients/macos/vellum-assistant/Features/Chat/ScrollWheelDetectorRegistry.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollWheelDetectorRegistry.swift
@@ -22,6 +22,9 @@ import Foundation
 @MainActor
 final class ScrollWheelDetectorRegistry {
 
+    /// App-wide shared instance used by `ScrollWheelDetector` lifecycle hooks.
+    static let shared = ScrollWheelDetectorRegistry()
+
     // MARK: - Entry
 
     /// Metadata for a single registered detector.

--- a/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
+++ b/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
@@ -57,6 +57,9 @@ enum ChatDiagnosticEventKind: String, Codable, Sendable {
     case appLifecycle
     case scrollWheelUntether
     case scrollWheelRetether
+    case detectorInstall
+    case detectorUpdate
+    case detectorRemove
 }
 
 /// Content-safe diagnostic event.

--- a/clients/macos/vellum-assistantTests/ScrollWheelDetectorCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ScrollWheelDetectorCoordinatorTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+@testable import VellumAssistantLib
+
+/// Exercises the throttle bookkeeping on `ScrollWheelDetector.Coordinator`,
+/// proving that retether and untether diagnostics stay rate-limited per
+/// detector instance.
+@MainActor
+final class ScrollWheelDetectorCoordinatorTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Creates a fresh coordinator for testing.
+    private func makeCoordinator() -> ScrollWheelDetector.Coordinator {
+        ScrollWheelDetector.Coordinator()
+    }
+
+    // MARK: - Throttle Interval
+
+    func testThrottleIntervalIsHalfSecond() {
+        // The throttle interval is a public static so instrumentation and tests
+        // can reference the same constant.
+        XCTAssertEqual(
+            ScrollWheelDetector.Coordinator.diagnosticThrottleInterval,
+            0.5,
+            "Throttle interval should be 0.5 seconds"
+        )
+    }
+
+    // MARK: - First Call Always Passes
+
+    func testFirstUntetherCallIsAllowed() {
+        let coordinator = makeCoordinator()
+        XCTAssertTrue(
+            coordinator.shouldRecordDiagnostic(kind: .scrollWheelUntether),
+            "First untether diagnostic should always be recorded"
+        )
+    }
+
+    func testFirstRetetherCallIsAllowed() {
+        let coordinator = makeCoordinator()
+        XCTAssertTrue(
+            coordinator.shouldRecordDiagnostic(kind: .scrollWheelRetether),
+            "First retether diagnostic should always be recorded"
+        )
+    }
+
+    // MARK: - Rapid Successive Calls Are Throttled
+
+    func testRapidUntetherCallsAreThrottled() {
+        let coordinator = makeCoordinator()
+
+        // First call passes.
+        let first = coordinator.shouldRecordDiagnostic(kind: .scrollWheelUntether)
+        XCTAssertTrue(first)
+
+        // Immediate second call should be throttled (< 0.5s has elapsed).
+        let second = coordinator.shouldRecordDiagnostic(kind: .scrollWheelUntether)
+        XCTAssertFalse(second, "Rapid untether call should be throttled")
+    }
+
+    func testRapidRetetherCallsAreThrottled() {
+        let coordinator = makeCoordinator()
+
+        let first = coordinator.shouldRecordDiagnostic(kind: .scrollWheelRetether)
+        XCTAssertTrue(first)
+
+        let second = coordinator.shouldRecordDiagnostic(kind: .scrollWheelRetether)
+        XCTAssertFalse(second, "Rapid retether call should be throttled")
+    }
+
+    // MARK: - Independent Throttle Per Kind
+
+    func testUntetherAndRetetherThrottleIndependently() {
+        let coordinator = makeCoordinator()
+
+        // Record one untether — passes.
+        XCTAssertTrue(coordinator.shouldRecordDiagnostic(kind: .scrollWheelUntether))
+
+        // Immediately record a retether — should also pass (different kind).
+        XCTAssertTrue(
+            coordinator.shouldRecordDiagnostic(kind: .scrollWheelRetether),
+            "Retether throttle should be independent of untether"
+        )
+
+        // Rapid second untether — throttled.
+        XCTAssertFalse(coordinator.shouldRecordDiagnostic(kind: .scrollWheelUntether))
+
+        // Rapid second retether — throttled.
+        XCTAssertFalse(coordinator.shouldRecordDiagnostic(kind: .scrollWheelRetether))
+    }
+
+    // MARK: - Independent Throttle Per Detector Instance
+
+    func testDifferentCoordinatorsThrottleIndependently() {
+        let coordinatorA = makeCoordinator()
+        let coordinatorB = makeCoordinator()
+
+        // Both should allow the first call.
+        XCTAssertTrue(coordinatorA.shouldRecordDiagnostic(kind: .scrollWheelUntether))
+        XCTAssertTrue(
+            coordinatorB.shouldRecordDiagnostic(kind: .scrollWheelUntether),
+            "Different coordinator instances should have independent throttle state"
+        )
+
+        // Both should throttle the immediate second call.
+        XCTAssertFalse(coordinatorA.shouldRecordDiagnostic(kind: .scrollWheelUntether))
+        XCTAssertFalse(coordinatorB.shouldRecordDiagnostic(kind: .scrollWheelUntether))
+    }
+
+    // MARK: - Non-Scroll Kinds Are Not Throttled
+
+    func testNonScrollKindsAlwaysPass() {
+        let coordinator = makeCoordinator()
+
+        // Other diagnostic kinds should not be throttled.
+        XCTAssertTrue(coordinator.shouldRecordDiagnostic(kind: .detectorInstall))
+        XCTAssertTrue(coordinator.shouldRecordDiagnostic(kind: .detectorInstall))
+        XCTAssertTrue(coordinator.shouldRecordDiagnostic(kind: .detectorUpdate))
+        XCTAssertTrue(coordinator.shouldRecordDiagnostic(kind: .detectorRemove))
+        XCTAssertTrue(coordinator.shouldRecordDiagnostic(kind: .scrollPositionChanged))
+    }
+
+    // MARK: - Stable Detector ID
+
+    func testDetectorIdIsStableAcrossAccesses() {
+        let coordinator = makeCoordinator()
+        let id1 = coordinator.detectorId
+        let id2 = coordinator.detectorId
+        XCTAssertEqual(id1, id2, "detectorId should be stable across accesses")
+        XCTAssertFalse(id1.isEmpty, "detectorId should not be empty")
+    }
+
+    func testEachCoordinatorGetsUniqueDetectorId() {
+        let a = makeCoordinator()
+        let b = makeCoordinator()
+        XCTAssertNotEqual(
+            a.detectorId, b.detectorId,
+            "Each coordinator should have a unique detectorId"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add stable detectorId to ScrollWheelDetector with registry integration for lifecycle tracking
- Log install/update/remove events with detector counts and duplicate status
- Log scroll-view lookup path (fast vs fallback) for incident differentiation
- Add ScrollWheelDetectorCoordinatorTests for throttle bookkeeping

Part of plan: desktop-freeze-diagnostics.md (PR 4 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
