### PR TITLE
fix: align all VToggle instances to the left (LUM-300)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -35,34 +35,20 @@ struct ImproveExperienceStepView: View {
                 // Privacy toggles card
                 VStack(spacing: VSpacing.lg) {
                     // Usage analytics toggle
-                    HStack {
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Share Analytics")
-                                .font(VFont.body)
-                                .foregroundColor(VColor.contentSecondary)
-                            Text("Send anonymous product usage data. Your conversations and personal data are never included.")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.contentTertiary)
-                        }
-                        Spacer()
-                        VToggle(isOn: $collectUsageData)
-                    }
+                    VToggle(
+                        isOn: $collectUsageData,
+                        label: "Share Analytics",
+                        helperText: "Send anonymous product usage data. Your conversations and personal data are never included."
+                    )
 
                     SettingsDivider()
 
                     // Diagnostics toggle
-                    HStack {
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Share Diagnostics")
-                                .font(VFont.body)
-                                .foregroundColor(VColor.contentSecondary)
-                            Text("Send crash reports and performance metrics. Your conversations and personal data are never included.")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.contentTertiary)
-                        }
-                        Spacer()
-                        VToggle(isOn: $sendDiagnostics)
-                    }
+                    VToggle(
+                        isOn: $sendDiagnostics,
+                        label: "Share Diagnostics",
+                        helperText: "Send crash reports and performance metrics. Your conversations and personal data are never included."
+                    )
                 }
                 .padding(VSpacing.lg)
                 .overlay(

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -40,6 +40,7 @@ struct ImproveExperienceStepView: View {
                         label: "Share Analytics",
                         helperText: "Send anonymous product usage data. Your conversations and personal data are never included."
                     )
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
                     SettingsDivider()
 
@@ -49,6 +50,7 @@ struct ImproveExperienceStepView: View {
                         label: "Share Diagnostics",
                         helperText: "Send crash reports and performance metrics. Your conversations and personal data are never included."
                     )
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .padding(VSpacing.lg)
                 .overlay(

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -1024,32 +1024,32 @@ struct SettingsDeveloperTab: View {
                 }
             }
         )
-        return HStack {
-            VToggle(isOn: flagBinding)
-                .accessibilityLabel(flag.label)
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                HStack(spacing: VSpacing.xs) {
-                    Text(flag.label)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.contentSecondary)
-                    VBadge(label: flag.scope == .assistant ? "Assistant" : "macOS",
-                           tone: flag.scope == .assistant ? .accent : .neutral,
-                           emphasis: .subtle)
-                }
-                if !flag.description.isEmpty {
-                    Text(flag.description)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
-                }
-                HStack(spacing: VSpacing.xxs) {
-                    Text("Default:")
-                        .font(VFont.small)
-                        .foregroundColor(VColor.contentTertiary)
-                    VBadge(label: flag.defaultEnabled ? "On" : "Off",
-                           tone: flag.defaultEnabled ? .danger : .neutral,
-                           emphasis: .subtle)
-                }
+        return VStack(alignment: .leading, spacing: VSpacing.xs) {
+            HStack(spacing: VSpacing.sm) {
+                VToggle(isOn: flagBinding)
+                    .accessibilityLabel(flag.label)
+                Text(flag.label)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentSecondary)
+                VBadge(label: flag.scope == .assistant ? "Assistant" : "macOS",
+                       tone: flag.scope == .assistant ? .accent : .neutral,
+                       emphasis: .subtle)
             }
+            if !flag.description.isEmpty {
+                Text(flag.description)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+                    .padding(.leading, 46)
+            }
+            HStack(spacing: VSpacing.xxs) {
+                Text("Default:")
+                    .font(VFont.small)
+                    .foregroundColor(VColor.contentTertiary)
+                VBadge(label: flag.defaultEnabled ? "On" : "Off",
+                       tone: flag.defaultEnabled ? .danger : .neutral,
+                       emphasis: .subtle)
+            }
+            .padding(.leading, 46)
         }
         .contentShape(Rectangle())
         .onTapGesture { withAnimation { flagBinding.wrappedValue.toggle() } }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -575,17 +575,6 @@ struct SettingsDeveloperTab: View {
             SettingsCard(title: "Assistants") {
                 ForEach(lockfileAssistants, id: \.assistantId) { assistant in
                     HStack(spacing: VSpacing.sm) {
-                        VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                            Text(displayLabel(for: assistant))
-                                .font(VFont.bodyMedium)
-                                .foregroundColor(VColor.contentDefault)
-                            Text(displayNames[assistant.assistantId] != nil
-                                ? "\(assistant.assistantId) · \(assistant.home.displayLabel)"
-                                : assistant.home.displayLabel)
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.contentTertiary)
-                        }
-                        Spacer()
                         if transitioningStates.contains(assistant.assistantId) {
                             ProgressView()
                                 .controlSize(.small)
@@ -597,6 +586,16 @@ struct SettingsDeveloperTab: View {
                             }
                         ))
                         .disabled(toggleDisabled(for: assistant))
+                        VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                            Text(displayLabel(for: assistant))
+                                .font(VFont.bodyMedium)
+                                .foregroundColor(VColor.contentDefault)
+                            Text(displayNames[assistant.assistantId] != nil
+                                ? "\(assistant.assistantId) · \(assistant.home.displayLabel)"
+                                : assistant.home.displayLabel)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.contentTertiary)
+                        }
                     }
                     .padding(.vertical, VSpacing.xs)
                 }
@@ -1026,6 +1025,8 @@ struct SettingsDeveloperTab: View {
             }
         )
         return HStack {
+            VToggle(isOn: flagBinding)
+                .accessibilityLabel(flag.label)
             VStack(alignment: .leading, spacing: VSpacing.xs) {
                 HStack(spacing: VSpacing.xs) {
                     Text(flag.label)
@@ -1049,9 +1050,6 @@ struct SettingsDeveloperTab: View {
                            emphasis: .subtle)
                 }
             }
-            Spacer()
-            VToggle(isOn: flagBinding)
-                .accessibilityLabel(flag.label)
         }
         .contentShape(Rectangle())
         .onTapGesture { withAnimation { flagBinding.wrappedValue.toggle() } }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -1024,31 +1024,33 @@ struct SettingsDeveloperTab: View {
                 }
             }
         )
-        return VStack(alignment: .leading, spacing: VSpacing.xs) {
-            HStack(spacing: VSpacing.sm) {
-                VToggle(isOn: flagBinding)
-                    .accessibilityLabel(flag.label)
-                Text(flag.label)
-                    .font(VFont.body)
-                    .foregroundColor(VColor.contentSecondary)
-                VBadge(label: flag.scope == .assistant ? "Assistant" : "macOS",
-                       tone: flag.scope == .assistant ? .accent : .neutral,
-                       emphasis: .subtle)
+        return HStack(alignment: .top, spacing: VSpacing.sm) {
+            VToggle(isOn: flagBinding)
+                .accessibilityLabel(flag.label)
+                .padding(.top, 2)
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                HStack(spacing: VSpacing.xs) {
+                    Text(flag.label)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentSecondary)
+                    VBadge(label: flag.scope == .assistant ? "Assistant" : "macOS",
+                           tone: flag.scope == .assistant ? .accent : .neutral,
+                           emphasis: .subtle)
+                }
+                if !flag.description.isEmpty {
+                    Text(flag.description)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                }
+                HStack(spacing: VSpacing.xxs) {
+                    Text("Default:")
+                        .font(VFont.small)
+                        .foregroundColor(VColor.contentTertiary)
+                    VBadge(label: flag.defaultEnabled ? "On" : "Off",
+                           tone: flag.defaultEnabled ? .danger : .neutral,
+                           emphasis: .subtle)
+                }
             }
-            if !flag.description.isEmpty {
-                Text(flag.description)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.contentTertiary)
-            }
-            HStack(spacing: VSpacing.xxs) {
-                Text("Default:")
-                    .font(VFont.small)
-                    .foregroundColor(VColor.contentTertiary)
-                VBadge(label: flag.defaultEnabled ? "On" : "Off",
-                       tone: flag.defaultEnabled ? .danger : .neutral,
-                       emphasis: .subtle)
-            }
-            .padding(.leading, 46)
         }
         .contentShape(Rectangle())
         .onTapGesture { withAnimation { flagBinding.wrappedValue.toggle() } }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -1039,7 +1039,6 @@ struct SettingsDeveloperTab: View {
                 Text(flag.description)
                     .font(VFont.caption)
                     .foregroundColor(VColor.contentTertiary)
-                    .padding(.leading, 46)
             }
             HStack(spacing: VSpacing.xxs) {
                 Text("Default:")

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -23,38 +23,22 @@ struct SettingsPrivacyTab: View {
 
     private var privacySection: some View {
         SettingsCard(title: "Privacy") {
-            HStack {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("Share Analytics")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.contentSecondary)
-                    Text("Send anonymous product usage data. Your conversations and personal data are never included.")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
-                }
-                Spacer()
-                VToggle(isOn: Binding(
+            VToggle(
+                isOn: Binding(
                     get: { store.collectUsageData },
                     set: { newValue in
                         store.collectUsageData = newValue
                         syncPrivacyConfig()
                     }
-                ))
-            }
+                ),
+                label: "Share Analytics",
+                helperText: "Send anonymous product usage data. Your conversations and personal data are never included."
+            )
 
             SettingsDivider()
 
-            HStack {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("Share Diagnostics")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.contentSecondary)
-                    Text("Send crash reports and performance metrics. Your conversations and personal data are never included.")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
-                }
-                Spacer()
-                VToggle(isOn: Binding(
+            VToggle(
+                isOn: Binding(
                     get: { store.sendDiagnostics },
                     set: { newValue in
                         store.sendDiagnostics = newValue
@@ -65,8 +49,10 @@ struct SettingsPrivacyTab: View {
                         }
                         syncPrivacyConfig()
                     }
-                ))
-            }
+                ),
+                label: "Share Diagnostics",
+                helperText: "Send crash reports and performance metrics. Your conversations and personal data are never included."
+            )
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -34,6 +34,7 @@ struct SettingsPrivacyTab: View {
                 label: "Share Analytics",
                 helperText: "Send anonymous product usage data. Your conversations and personal data are never included."
             )
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             SettingsDivider()
 
@@ -53,6 +54,7 @@ struct SettingsPrivacyTab: View {
                 label: "Share Diagnostics",
                 helperText: "Send crash reports and performance metrics. Your conversations and personal data are never included."
             )
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -294,31 +294,29 @@ struct RecordingSourcePickerView: View {
 
     private var bottomBar: some View {
         VStack(spacing: VSpacing.lg) {
-            // Audio toggles — icon + text left, toggle right (space-between)
+            // Audio toggles — toggle left, icon + text right
             HStack(spacing: VSpacing.sm) {
+                VToggle(isOn: $viewModel.includeAudio)
+                    .accessibilityLabel("System audio")
                 VIconView(.volume2, size: 14)
                     .foregroundColor(VColor.contentSecondary)
                     .frame(width: 20)
                 Text("System audio")
                     .font(VFont.body)
                     .foregroundColor(VColor.contentDefault)
-                Spacer()
-                VToggle(isOn: $viewModel.includeAudio)
-                    .accessibilityLabel("System audio")
             }
             .padding(.horizontal, VSpacing.xl)
 
             if #available(macOS 14, *) {
                 HStack(spacing: VSpacing.sm) {
+                    VToggle(isOn: $viewModel.includeMicrophone)
+                        .accessibilityLabel("Microphone")
                     VIconView(.mic, size: 14)
                         .foregroundColor(VColor.contentSecondary)
                         .frame(width: 20)
                     Text("Microphone")
                         .font(VFont.body)
                         .foregroundColor(VColor.contentDefault)
-                    Spacer()
-                    VToggle(isOn: $viewModel.includeMicrophone)
-                        .accessibilityLabel("Microphone")
                 }
                 .padding(.horizontal, VSpacing.xl)
             }

--- a/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
@@ -63,7 +63,6 @@ public struct VToggle: View {
                             .foregroundColor(VColor.contentTertiary)
                     }
                 }
-                Spacer(minLength: 0)
             }
         }
     }

--- a/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
@@ -63,6 +63,7 @@ public struct VToggle: View {
                             .foregroundColor(VColor.contentTertiary)
                     }
                 }
+                Spacer(minLength: 0)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Fixes inconsistent toggle alignment across the settings page and other views
- Toggles in Privacy, Onboarding, Developer (feature flags + assistants), and Recording views now consistently appear on the left
- Uses VToggle's built-in `label`/`helperText` parameters where possible (Privacy, Onboarding), and reorders HStack children elsewhere (Developer, Recording)

## Original prompt
--safe https://linear.app/vellum/issue/LUM-300/toggle-alignment-is-inconsistent-across-settings-page everywhere where we have VToggle we should only align to the left
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
