### PR TITLE
Persist last-known diagnostics for richer main-thread stall capture

### DIFF
--- a/clients/macos/vellum-assistant/App/MainThreadStallDetector.swift
+++ b/clients/macos/vellum-assistant/App/MainThreadStallDetector.swift
@@ -33,7 +33,8 @@ final class MainThreadStallDetector {
 
     /// Writer used to persist hang context. Tests inject a mock.
     var hangContextWriter: HangContextWriter = HangContextWriter(
-        diagnosticsProvider: MainActorDiagnosticsProvider()
+        diagnosticsProvider: MainActorDiagnosticsProvider(),
+        lastKnownProvider: BackgroundDiagnosticsProvider()
     )
 
     /// Closure that returns whether `/usr/bin/sample` capture is allowed.
@@ -177,6 +178,13 @@ final class MainThreadStallDetector {
             // Gate sampling on sendDiagnostics preference.
             guard isSamplingAllowed() else {
                 log.info("Skipping process sampling: sendDiagnostics is disabled")
+                // Rewrite hang context with samplingSkipped flag so the JSON
+                // records that sampling was deliberately skipped.
+                hangContextWriter.writeHangContextSync(
+                    stallStartTime: stallStart,
+                    stallDurationSeconds: elapsed,
+                    samplingSkipped: true
+                )
                 return
             }
 

--- a/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
+++ b/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
@@ -373,6 +373,9 @@ final class ChatDiagnosticsStore {
 
         // Write to session log if under size cap.
         writeToSessionLog(event)
+
+        // Refresh the background-safe snapshot.
+        refreshLastKnownSnapshot()
     }
 
     // MARK: - Transcript Snapshots
@@ -397,6 +400,9 @@ final class ChatDiagnosticsStore {
             let evicted = snapshotOrder.removeFirst()
             transcriptSnapshots.removeValue(forKey: evicted)
         }
+
+        // Refresh the background-safe snapshot.
+        refreshLastKnownSnapshot()
     }
 
     /// Returns the current snapshot for a conversation, if any.
@@ -482,4 +488,68 @@ final class ChatDiagnosticsStore {
     func recentEvents(_ count: Int) -> [ChatDiagnosticEvent] {
         Array(events.suffix(count))
     }
+
+    // MARK: - Background-Safe Last-Known Snapshot
+
+    /// Maximum number of events retained in the last-known snapshot.
+    static let lastKnownEventCapacity = 50
+
+    /// A background-safe snapshot of the most recent sanitized diagnostics.
+    ///
+    /// Updated on every `record(_:)` and `updateSnapshot(_:)` call so that
+    /// the stall detector's background queue can read it without awaiting
+    /// the main actor. This is the fallback data source when the main thread
+    /// is wedged and `enrichWithDiagnosticsAsync()` never completes.
+    ///
+    /// **Thread safety**: Written only from `@MainActor`; read atomically
+    /// via `nonisolated` accessor through the `NSLock`-guarded getter.
+    private(set) var lastKnownDiagnostics: LastKnownDiagnosticsSnapshot? {
+        didSet {
+            _lastKnownLock.lock()
+            _lastKnownBackgroundCopy = lastKnownDiagnostics
+            _lastKnownLock.unlock()
+        }
+    }
+
+    /// Lock protecting the background-readable copy.
+    private let _lastKnownLock = NSLock()
+
+    /// Background-readable copy of `lastKnownDiagnostics`, guarded by `_lastKnownLock`.
+    private var _lastKnownBackgroundCopy: LastKnownDiagnosticsSnapshot?
+
+    /// Returns the last-known diagnostics snapshot from any thread.
+    /// This is safe to call from the stall detector's background queue.
+    nonisolated func lastKnownDiagnosticsFromBackground() -> LastKnownDiagnosticsSnapshot? {
+        _lastKnownLock.lock()
+        defer { _lastKnownLock.unlock() }
+        return _lastKnownBackgroundCopy
+    }
+
+    /// Rebuilds the last-known diagnostics snapshot from current state.
+    private func refreshLastKnownSnapshot() {
+        let recentEvents = Array(events.suffix(Self.lastKnownEventCapacity))
+        let snapshots = transcriptSnapshots.values.sorted { $0.conversationId < $1.conversationId }
+        lastKnownDiagnostics = LastKnownDiagnosticsSnapshot(
+            capturedAt: Date(),
+            recentEvents: recentEvents,
+            transcriptSnapshots: snapshots
+        )
+    }
+}
+
+// MARK: - Last-Known Diagnostics Snapshot
+
+/// A point-in-time snapshot of the most recent sanitized diagnostic events
+/// and transcript snapshots. Designed to be read from a background queue
+/// without awaiting the main actor.
+///
+/// **Privacy invariant**: Contains only the same content-safe data as
+/// `ChatDiagnosticEvent` and `ChatTranscriptSnapshot` — no user content.
+struct LastKnownDiagnosticsSnapshot: Codable, Sendable {
+    /// When this snapshot was captured.
+    let capturedAt: Date
+    /// Recent diagnostic events (up to `ChatDiagnosticsStore.lastKnownEventCapacity`).
+    let recentEvents: [ChatDiagnosticEvent]
+    /// Per-conversation transcript snapshots, sorted by conversation ID.
+    let transcriptSnapshots: [ChatTranscriptSnapshot]
 }

--- a/clients/macos/vellum-assistant/Logging/HangContextWriter.swift
+++ b/clients/macos/vellum-assistant/Logging/HangContextWriter.swift
@@ -24,6 +24,13 @@ final class HangContextWriter: @unchecked Sendable {
         func transcriptSnapshots() async -> [String: ChatTranscriptSnapshot]
     }
 
+    /// Protocol for providing last-known diagnostics without awaiting the main actor.
+    /// The concrete implementation reads the lock-guarded background copy from
+    /// `ChatDiagnosticsStore`. Tests inject a stub.
+    protocol LastKnownDiagnosticsProvider: Sendable {
+        func lastKnownDiagnostics() -> LastKnownDiagnosticsSnapshot?
+    }
+
     // MARK: - Configuration
 
     /// Directory where hang-context.json is written.
@@ -31,6 +38,9 @@ final class HangContextWriter: @unchecked Sendable {
 
     /// Provider for diagnostic events and snapshots.
     let diagnosticsProvider: DiagnosticsProvider?
+
+    /// Provider for last-known diagnostics readable from any thread.
+    let lastKnownProvider: LastKnownDiagnosticsProvider?
 
     // MARK: - Private
 
@@ -45,7 +55,8 @@ final class HangContextWriter: @unchecked Sendable {
 
     init(
         outputDirectory: URL? = nil,
-        diagnosticsProvider: DiagnosticsProvider? = nil
+        diagnosticsProvider: DiagnosticsProvider? = nil,
+        lastKnownProvider: LastKnownDiagnosticsProvider? = nil
     ) {
         if let dir = outputDirectory {
             self.outputDirectory = dir
@@ -58,6 +69,7 @@ final class HangContextWriter: @unchecked Sendable {
                 .appendingPathComponent("vellum-assistant", isDirectory: true)
         }
         self.diagnosticsProvider = diagnosticsProvider
+        self.lastKnownProvider = lastKnownProvider
 
         self.encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
@@ -75,7 +87,8 @@ final class HangContextWriter: @unchecked Sendable {
         stallStartTime: Date,
         stallDurationSeconds: Double,
         recentEvents: [ChatDiagnosticEvent] = [],
-        transcriptSnapshots: [ChatTranscriptSnapshot] = []
+        transcriptSnapshots: [ChatTranscriptSnapshot] = [],
+        samplingSkipped: Bool = false
     ) {
         lock.lock()
         writeGeneration += 1
@@ -86,13 +99,28 @@ final class HangContextWriter: @unchecked Sendable {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
         let pid = ProcessInfo.processInfo.processIdentifier
 
+        // If no explicit events/snapshots were provided, fall back to the
+        // last-known background-safe snapshot so stage-one capture is useful
+        // even when the main actor never satisfies enrichWithDiagnosticsAsync().
+        var effectiveEvents = recentEvents
+        var effectiveSnapshots = transcriptSnapshots
+        var lastKnownCapturedAt: Date? = nil
+        if effectiveEvents.isEmpty && effectiveSnapshots.isEmpty,
+           let lastKnown = lastKnownProvider?.lastKnownDiagnostics() {
+            effectiveEvents = lastKnown.recentEvents
+            effectiveSnapshots = lastKnown.transcriptSnapshots
+            lastKnownCapturedAt = lastKnown.capturedAt
+        }
+
         let context = HangContext(
             stallStartTime: stallStartTime,
             stallDurationSeconds: stallDurationSeconds,
             pid: Int(pid),
             appVersion: version ?? "unknown",
-            recentDiagnosticEvents: recentEvents,
-            transcriptSnapshots: transcriptSnapshots
+            recentDiagnosticEvents: effectiveEvents,
+            transcriptSnapshots: effectiveSnapshots,
+            lastKnownDiagnosticsCapturedAt: lastKnownCapturedAt,
+            samplingSkipped: samplingSkipped ? true : nil
         )
 
         do {
@@ -157,6 +185,33 @@ struct HangContext: Codable, Sendable {
     let appVersion: String
     let recentDiagnosticEvents: [ChatDiagnosticEvent]
     let transcriptSnapshots: [ChatTranscriptSnapshot]
+    /// When the last-known diagnostics snapshot was captured, if the events and
+    /// snapshots were sourced from the background-safe fallback rather than
+    /// a live main-actor read. `nil` when diagnostics came from async enrichment.
+    let lastKnownDiagnosticsCapturedAt: Date?
+    /// Whether process sampling was skipped because `sendDiagnostics` is disabled.
+    /// Present (and `true`) only when sampling was explicitly skipped.
+    let samplingSkipped: Bool?
+
+    init(
+        stallStartTime: Date,
+        stallDurationSeconds: Double,
+        pid: Int,
+        appVersion: String,
+        recentDiagnosticEvents: [ChatDiagnosticEvent],
+        transcriptSnapshots: [ChatTranscriptSnapshot],
+        lastKnownDiagnosticsCapturedAt: Date? = nil,
+        samplingSkipped: Bool? = nil
+    ) {
+        self.stallStartTime = stallStartTime
+        self.stallDurationSeconds = stallDurationSeconds
+        self.pid = pid
+        self.appVersion = appVersion
+        self.recentDiagnosticEvents = recentDiagnosticEvents
+        self.transcriptSnapshots = transcriptSnapshots
+        self.lastKnownDiagnosticsCapturedAt = lastKnownDiagnosticsCapturedAt
+        self.samplingSkipped = samplingSkipped
+    }
 }
 
 // MARK: - Default Diagnostics Provider
@@ -174,5 +229,13 @@ struct MainActorDiagnosticsProvider: HangContextWriter.DiagnosticsProvider {
         await MainActor.run {
             ChatDiagnosticsStore.shared.transcriptSnapshots
         }
+    }
+}
+
+/// Production last-known diagnostics provider that reads the lock-guarded
+/// background copy from `ChatDiagnosticsStore`. Safe to call from any thread.
+struct BackgroundDiagnosticsProvider: HangContextWriter.LastKnownDiagnosticsProvider {
+    func lastKnownDiagnostics() -> LastKnownDiagnosticsSnapshot? {
+        ChatDiagnosticsStore.shared.lastKnownDiagnosticsFromBackground()
     }
 }

--- a/clients/macos/vellum-assistantTests/MainThreadStallDetectorTests.swift
+++ b/clients/macos/vellum-assistantTests/MainThreadStallDetectorTests.swift
@@ -45,6 +45,29 @@ struct MainThreadStallDetectorTests {
         }
     }
 
+    /// Stub last-known diagnostics provider for tests. Returns a fixed snapshot.
+    final class StubLastKnownProvider: HangContextWriter.LastKnownDiagnosticsProvider, @unchecked Sendable {
+        private let lock = NSLock()
+        private var _snapshot: LastKnownDiagnosticsSnapshot?
+
+        var snapshot: LastKnownDiagnosticsSnapshot? {
+            get {
+                lock.lock()
+                defer { lock.unlock() }
+                return _snapshot
+            }
+            set {
+                lock.lock()
+                _snapshot = newValue
+                lock.unlock()
+            }
+        }
+
+        func lastKnownDiagnostics() -> LastKnownDiagnosticsSnapshot? {
+            snapshot
+        }
+    }
+
     /// Creates a detector with injected test dependencies.
     /// The `probeTargetQueue` is a suspended queue to simulate a wedged main thread
     /// (the probe callback never runs, so `probeInFlight` stays true).
@@ -53,13 +76,18 @@ struct MainThreadStallDetectorTests {
         sampleRunner: MockSampleRunner,
         stageOneThreshold: TimeInterval = 2.0,
         stageTwoThreshold: TimeInterval = 5.0,
-        samplingAllowed: Bool = true
+        samplingAllowed: Bool = true,
+        lastKnownProvider: HangContextWriter.LastKnownDiagnosticsProvider? = nil
     ) -> (detector: MainThreadStallDetector, blockedQueue: DispatchQueue, samplingQueue: DispatchQueue) {
         let detector = MainThreadStallDetector(testInit: true)
         let outputDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("stall-test-\(UUID().uuidString)", isDirectory: true)
         try? FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
-        detector.hangContextWriter = HangContextWriter(outputDirectory: outputDir, diagnosticsProvider: nil)
+        detector.hangContextWriter = HangContextWriter(
+            outputDirectory: outputDir,
+            diagnosticsProvider: nil,
+            lastKnownProvider: lastKnownProvider
+        )
         detector.stageOneThreshold = stageOneThreshold
         detector.stageTwoThreshold = stageTwoThreshold
         detector.nowNanos = { clock.nanos }
@@ -395,5 +423,186 @@ struct MainThreadStallDetectorTests {
         let presentKeys = allKeys(in: json)
         let violations = presentKeys.intersection(forbiddenKeys)
         #expect(violations.isEmpty, "Hang context must not contain user-content keys: \(violations.sorted())")
+    }
+
+    // MARK: - Sampling Disabled Flag
+
+    @Test
+    func samplingDisabledWritesSamplingSkippedFlag() throws {
+        let clock = MockClock()
+        let sampleRunner = MockSampleRunner()
+        let (detector, blockedQueue, _) = makeDetector(
+            clock: clock,
+            sampleRunner: sampleRunner,
+            samplingAllowed: false
+        )
+        defer { blockedQueue.resume() }
+
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        // Advance past stage-two threshold so the sampling-disabled path runs.
+        clock.advance(by: 6.0)
+
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        let fileURL = detector.hangContextWriter.outputDirectory
+            .appendingPathComponent("hang-context.json")
+        let data = try Data(contentsOf: fileURL)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        // The samplingSkipped flag should be present and true.
+        let samplingSkipped = json["samplingSkipped"] as? Bool
+        #expect(samplingSkipped == true, "hang-context.json should contain samplingSkipped: true when sampling is disabled")
+
+        // Sampling should not have been attempted.
+        #expect(sampleRunner.callCount == 0, "Sampling should not be attempted when disabled")
+    }
+
+    @Test
+    func samplingEnabledDoesNotWriteSamplingSkippedFlag() throws {
+        let clock = MockClock()
+        let sampleRunner = MockSampleRunner()
+        let (detector, blockedQueue, samplingQueue) = makeDetector(
+            clock: clock,
+            sampleRunner: sampleRunner,
+            samplingAllowed: true
+        )
+        defer { blockedQueue.resume() }
+
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        clock.advance(by: 6.0)
+
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        samplingQueue.sync {}
+
+        let fileURL = detector.hangContextWriter.outputDirectory
+            .appendingPathComponent("hang-context.json")
+        let data = try Data(contentsOf: fileURL)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        // samplingSkipped should not be present (or should be null).
+        let samplingSkipped = json["samplingSkipped"]
+        let isAbsentOrNull = samplingSkipped == nil || samplingSkipped is NSNull
+        #expect(isAbsentOrNull, "hang-context.json should not contain samplingSkipped when sampling is enabled")
+    }
+
+    // MARK: - Last-Known Diagnostics in Stage One
+
+    @Test
+    func stageOneIncludesLastKnownDiagnostics() throws {
+        let clock = MockClock()
+        let sampleRunner = MockSampleRunner()
+        let lastKnownProvider = StubLastKnownProvider()
+
+        // Seed the provider with a diagnostic event and transcript snapshot.
+        let seedEvent = ChatDiagnosticEvent(
+            id: "test-event-1",
+            timestamp: Date(timeIntervalSince1970: 1000),
+            kind: .scrollPositionChanged,
+            conversationId: "conv-1",
+            reason: "test breadcrumb"
+        )
+        let seedSnapshot = ChatTranscriptSnapshot(
+            conversationId: "conv-1",
+            capturedAt: Date(timeIntervalSince1970: 1000),
+            messageCount: 5,
+            toolCallCount: 2,
+            isPinnedToBottom: true,
+            isUserScrolling: false
+        )
+        lastKnownProvider.snapshot = LastKnownDiagnosticsSnapshot(
+            capturedAt: Date(timeIntervalSince1970: 1000),
+            recentEvents: [seedEvent],
+            transcriptSnapshots: [seedSnapshot]
+        )
+
+        let (detector, blockedQueue, _) = makeDetector(
+            clock: clock,
+            sampleRunner: sampleRunner,
+            lastKnownProvider: lastKnownProvider
+        )
+        defer { blockedQueue.resume() }
+
+        // Dispatch probe.
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        // Advance past stage-one threshold.
+        clock.advance(by: 2.5)
+
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        // Read and parse the hang-context.json.
+        let fileURL = detector.hangContextWriter.outputDirectory
+            .appendingPathComponent("hang-context.json")
+        let data = try Data(contentsOf: fileURL)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        // The last-known diagnostics should be included in the stage-one write.
+        let events = json["recentDiagnosticEvents"] as? [[String: Any]] ?? []
+        #expect(!events.isEmpty, "Stage-one hang context should contain last-known diagnostic events")
+        #expect(events[0]["id"] as? String == "test-event-1", "Event ID should match the seeded event")
+
+        let snapshots = json["transcriptSnapshots"] as? [[String: Any]] ?? []
+        #expect(!snapshots.isEmpty, "Stage-one hang context should contain last-known transcript snapshots")
+        #expect(snapshots[0]["conversationId"] as? String == "conv-1", "Snapshot conversation ID should match")
+
+        // lastKnownDiagnosticsCapturedAt should be present since we used the fallback.
+        let capturedAt = json["lastKnownDiagnosticsCapturedAt"]
+        #expect(capturedAt != nil && !(capturedAt is NSNull), "lastKnownDiagnosticsCapturedAt should be present when using fallback")
+    }
+
+    @Test
+    func stageOneWithoutLastKnownProviderHasEmptyDiagnostics() throws {
+        let clock = MockClock()
+        let sampleRunner = MockSampleRunner()
+
+        // No lastKnownProvider — simulates the case where the main actor
+        // never gets a chance to populate diagnostics.
+        let (detector, blockedQueue, _) = makeDetector(
+            clock: clock,
+            sampleRunner: sampleRunner
+        )
+        defer { blockedQueue.resume() }
+
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        clock.advance(by: 2.5)
+
+        detector.queue.sync {
+            detector.ping()
+        }
+
+        let fileURL = detector.hangContextWriter.outputDirectory
+            .appendingPathComponent("hang-context.json")
+        let data = try Data(contentsOf: fileURL)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        // Without a last-known provider, events and snapshots should be empty arrays.
+        let events = json["recentDiagnosticEvents"] as? [Any] ?? []
+        #expect(events.isEmpty, "Stage-one should have empty events when no last-known provider exists")
+
+        let snapshots = json["transcriptSnapshots"] as? [Any] ?? []
+        #expect(snapshots.isEmpty, "Stage-one should have empty snapshots when no last-known provider exists")
+
+        // lastKnownDiagnosticsCapturedAt should be absent or null.
+        let capturedAt = json["lastKnownDiagnosticsCapturedAt"]
+        let isAbsentOrNull = capturedAt == nil || capturedAt is NSNull
+        #expect(isAbsentOrNull, "lastKnownDiagnosticsCapturedAt should be absent without a last-known provider")
     }
 }


### PR DESCRIPTION
## Summary
- Add background-safe last-known sanitized diagnostics snapshot to ChatDiagnosticsStore
- Teach HangContextWriter to include diagnostic breadcrumbs in stage-one stall capture
- Add sampling-disabled flag to MainThreadStallDetector with test coverage for both paths

Part of plan: desktop-freeze-diagnostics.md (PR 8 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
