### PR TITLE
Remove expand/collapse fullscreen toggle from ConstellationView

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -692,7 +692,6 @@ struct ConstellationView: View {
     let skills: [SkillInfo]
     let workspaceFiles: [WorkspaceFileNode]
     var onFileSelected: ((String) -> Void)?
-    @Binding var isFullscreen: Bool
     @State private var appearance = AvatarAppearanceManager.shared
 
     @State private var phase: AnimationPhase = .hidden
@@ -980,10 +979,6 @@ struct ConstellationView: View {
                 .frame(width: proxy.size.width, height: proxy.size.height)
                 .clipped()
                 .contentShape(Rectangle())
-                .overlay(alignment: .topLeading) {
-                    fullscreenToggle
-                        .padding(VSpacing.lg)
-                }
                 .overlay(alignment: .bottomTrailing) {
                     viewportControls(viewSize: proxy.size)
                         .padding(VSpacing.lg)
@@ -1031,23 +1026,6 @@ struct ConstellationView: View {
                     return .ignored
                 }
                 #endif
-        }
-    }
-
-    // MARK: - Fullscreen Toggle (top-left)
-
-    private var fullscreenToggle: some View {
-        VButton(
-            label: isFullscreen ? "Collapse" : "Expand",
-            iconOnly: isFullscreen
-                ? VIcon.minimize.rawValue
-                : VIcon.maximize.rawValue,
-            style: .ghost,
-            tooltip: isFullscreen ? "Exit fullscreen" : "Enter fullscreen"
-        ) {
-            withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
-                isFullscreen.toggle()
-            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -115,8 +115,7 @@ struct IdentityPanel: View {
                 workspaceFiles: workspaceFiles,
                 onFileSelected: { path in
                     viewingFilePath = path
-                },
-                isFullscreen: $isFullscreen
+                }
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(isFullscreen ? Color.clear : VColor.surfaceOverlay)


### PR DESCRIPTION
## Summary
- Remove the `isFullscreen` binding and fullscreen toggle button from ConstellationView
- Remove the top-left overlay that showed the expand/collapse button
- Update IdentityPanel caller to no longer pass the removed `isFullscreen` parameter

Part of plan: shrink-identity-panel.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
