### PR TITLE
feat: add optional leading icon to VDropdown

### DIFF
--- a/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
@@ -13,19 +13,23 @@ public struct VDropdown<T: Hashable>: View {
     public var emptyValue: T? = nil
     /// The maximum width of the dropdown. Defaults to 400.
     public var maxWidth: CGFloat = 400
+    /// Optional leading icon displayed before the label text.
+    public var icon: VIcon? = nil
 
     public init(
         placeholder: String,
         selection: Binding<T>,
         options: [(label: String, value: T)],
         emptyValue: T? = nil,
-        maxWidth: CGFloat = 400
+        maxWidth: CGFloat = 400,
+        icon: VIcon? = nil
     ) {
         self.placeholder = placeholder
         self._selection = selection
         self.options = options
         self.emptyValue = emptyValue
         self.maxWidth = maxWidth
+        self.icon = icon
     }
 
     private var selectedLabel: String? {
@@ -46,16 +50,23 @@ public struct VDropdown<T: Hashable>: View {
             .labelsHidden()
         } label: {
             HStack(spacing: VSpacing.md) {
-                Group {
-                    if let label = selectedLabel {
-                        Text(label)
-                            .foregroundColor(VColor.contentDefault)
-                    } else {
-                        Text(placeholder)
+                HStack(spacing: VSpacing.sm) {
+                    if let icon = icon {
+                        VIconView(icon, size: 13)
                             .foregroundColor(VColor.contentTertiary)
                     }
+
+                    Group {
+                        if let label = selectedLabel {
+                            Text(label)
+                                .foregroundColor(VColor.contentDefault)
+                        } else {
+                            Text(placeholder)
+                                .foregroundColor(VColor.contentTertiary)
+                        }
+                    }
+                    .font(VFont.body)
                 }
-                .font(VFont.body)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 VIconView(.chevronDown, size: 13)


### PR DESCRIPTION
## Summary
- Add optional `icon: VIcon?` parameter to VDropdown with default nil
- When provided, renders a 13pt monotone icon left of the label text
- No change to existing callers — icon defaults to nil

Part of plan: memory-filter-dropdown.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
