### PR TITLE
fix: filter template placeholder values from parsed identity fields

### DIFF
--- a/assistant/src/__tests__/parse-identity-fields.test.ts
+++ b/assistant/src/__tests__/parse-identity-fields.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Unit tests for identity field parsing and template placeholder filtering.
+ *
+ * Validates that parseIdentityFields correctly extracts real values from
+ * IDENTITY.md content while treating template placeholders (e.g.
+ * `_(not yet chosen)_`) as empty/unset.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  isTemplatePlaceholder,
+  parseIdentityFields,
+} from "../daemon/handlers/identity.js";
+
+// ---------------------------------------------------------------------------
+// isTemplatePlaceholder
+// ---------------------------------------------------------------------------
+
+describe("isTemplatePlaceholder", () => {
+  test("returns true for _(not yet chosen)_", () => {
+    expect(isTemplatePlaceholder("_(not yet chosen)_")).toBe(true);
+  });
+
+  test("returns true for _(not yet established)_", () => {
+    expect(isTemplatePlaceholder("_(not yet established)_")).toBe(true);
+  });
+
+  test("returns true for any value matching _(…)_ pattern", () => {
+    expect(isTemplatePlaceholder("_(something else)_")).toBe(true);
+  });
+
+  test("returns false for normal values", () => {
+    expect(isTemplatePlaceholder("Your helpful coding assistant")).toBe(false);
+    expect(isTemplatePlaceholder("Jarvis")).toBe(false);
+    expect(isTemplatePlaceholder("")).toBe(false);
+  });
+
+  test("returns false for partial matches", () => {
+    expect(isTemplatePlaceholder("_(incomplete")).toBe(false);
+    expect(isTemplatePlaceholder("incomplete)_")).toBe(false);
+    expect(isTemplatePlaceholder("_(")).toBe(false);
+    expect(isTemplatePlaceholder(")_")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseIdentityFields — placeholder filtering
+// ---------------------------------------------------------------------------
+
+describe("parseIdentityFields", () => {
+  test("returns empty strings for all template placeholder values", () => {
+    const content = [
+      "- **Name:** _(not yet chosen)_",
+      "- **Role:** _(not yet established)_",
+      "- **Personality:** _(not yet chosen)_",
+      "- **Emoji:** _(not yet chosen)_",
+      "- **Home:** _(not yet chosen)_",
+    ].join("\n");
+
+    const fields = parseIdentityFields(content);
+    expect(fields.name).toBe("");
+    expect(fields.role).toBe("");
+    expect(fields.personality).toBe("");
+    expect(fields.emoji).toBe("");
+    expect(fields.home).toBe("");
+  });
+
+  test("preserves real user-provided values", () => {
+    const content = [
+      "- **Name:** Jarvis",
+      "- **Role:** Coding assistant",
+      "- **Personality:** Friendly and helpful",
+      "- **Emoji:** 🤖",
+      "- **Home:** ~/projects",
+    ].join("\n");
+
+    const fields = parseIdentityFields(content);
+    expect(fields.name).toBe("Jarvis");
+    expect(fields.role).toBe("Coding assistant");
+    expect(fields.personality).toBe("Friendly and helpful");
+    expect(fields.emoji).toBe("🤖");
+    expect(fields.home).toBe("~/projects");
+  });
+
+  test("handles a mix of real and placeholder values", () => {
+    const content = [
+      "- **Name:** Jarvis",
+      "- **Role:** _(not yet established)_",
+      "- **Personality:** Friendly",
+      "- **Emoji:** _(not yet chosen)_",
+      "- **Home:** ~/dev",
+    ].join("\n");
+
+    const fields = parseIdentityFields(content);
+    expect(fields.name).toBe("Jarvis");
+    expect(fields.role).toBe("");
+    expect(fields.personality).toBe("Friendly");
+    expect(fields.emoji).toBe("");
+    expect(fields.home).toBe("~/dev");
+  });
+
+  test("returns role: '' when IDENTITY.md contains placeholder role", () => {
+    const content = "- **Role:** _(not yet established)_";
+    const fields = parseIdentityFields(content);
+    expect(fields.role).toBe("");
+  });
+
+  test("returns name: '' when IDENTITY.md contains placeholder name", () => {
+    const content = "- **Name:** _(not yet chosen)_";
+    const fields = parseIdentityFields(content);
+    expect(fields.name).toBe("");
+  });
+
+  test('parses role: "Coding assistant" for real values', () => {
+    const content = "- **Role:** Coding assistant";
+    const fields = parseIdentityFields(content);
+    expect(fields.role).toBe("Coding assistant");
+  });
+
+  test("returns empty strings when content has no identity fields", () => {
+    const fields = parseIdentityFields("# Some other content\nHello world");
+    expect(fields.name).toBe("");
+    expect(fields.role).toBe("");
+    expect(fields.personality).toBe("");
+    expect(fields.emoji).toBe("");
+    expect(fields.home).toBe("");
+  });
+});

--- a/assistant/src/daemon/handlers/identity.ts
+++ b/assistant/src/daemon/handlers/identity.ts
@@ -1,3 +1,12 @@
+/**
+ * Returns true when the value is a template placeholder that should be treated
+ * as empty/unset. Placeholders follow the pattern `_(…)_`, e.g.
+ * `_(not yet chosen)_` or `_(not yet established)_`.
+ */
+export function isTemplatePlaceholder(value: string): boolean {
+  return value.startsWith("_(") && value.endsWith(")_");
+}
+
 export interface IdentityFields {
   name: string;
   role: string;
@@ -14,7 +23,9 @@ export function parseIdentityFields(content: string): IdentityFields {
     const lower = trimmed.toLowerCase();
     const extract = (prefix: string): string | null => {
       if (!lower.startsWith(prefix)) return null;
-      return trimmed.split(":**").pop()?.trim() ?? null;
+      const value = trimmed.split(":**").pop()?.trim() ?? null;
+      if (value && isTemplatePlaceholder(value)) return null;
+      return value;
     };
 
     const name = extract("- **name:**");

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -8,6 +8,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { getBaseDataDir } from "../../config/env-registry.js";
+import { isTemplatePlaceholder } from "../../daemon/handlers/identity.js";
 import { getWorkspacePromptPath, readLockfile } from "../../util/platform.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
@@ -155,7 +156,9 @@ export function handleGetIdentity(): Response {
     const lower = trimmed.toLowerCase();
     const extract = (prefix: string): string | null => {
       if (!lower.startsWith(prefix)) return null;
-      return trimmed.split(":**").pop()?.trim() ?? null;
+      const value = trimmed.split(":**").pop()?.trim() ?? null;
+      if (value && isTemplatePlaceholder(value)) return null;
+      return value;
     };
 
     const name = extract("- **name:**");


### PR DESCRIPTION
## Summary
- Add `isTemplatePlaceholder` helper to detect unmodified template values like `_(not yet established)_`
- Apply filtering in both `parseIdentityFields` and `handleGetIdentity` so placeholder values are returned as empty strings
- Add comprehensive tests for placeholder detection and identity field parsing

Part of plan: role-not-yet-established.md (PR 1 of 2)
Part of JARVIS-262

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
