### PR TITLE
fix: avoid double hang-context.json write when sampling is disabled

### DIFF
--- a/clients/macos/vellum-assistant/App/MainThreadStallDetector.swift
+++ b/clients/macos/vellum-assistant/App/MainThreadStallDetector.swift
@@ -168,23 +168,20 @@ final class MainThreadStallDetector {
             stageTwoFired = true
             log.warning("Stage 2 stall capture: main thread blocked for \(String(format: "%.1f", elapsed))s")
 
+            // Check sampling permission upfront so we can write the flag in a single pass.
+            let skipSampling = !isSamplingAllowed()
+
             // Update hang context with the longer duration (synchronous).
             let stallStart = Date(timeIntervalSinceNow: -elapsed)
             hangContextWriter.writeHangContextSync(
                 stallStartTime: stallStart,
-                stallDurationSeconds: elapsed
+                stallDurationSeconds: elapsed,
+                samplingSkipped: skipSampling
             )
 
             // Gate sampling on sendDiagnostics preference.
-            guard isSamplingAllowed() else {
+            guard !skipSampling else {
                 log.info("Skipping process sampling: sendDiagnostics is disabled")
-                // Rewrite hang context with samplingSkipped flag so the JSON
-                // records that sampling was deliberately skipped.
-                hangContextWriter.writeHangContextSync(
-                    stallStartTime: stallStart,
-                    stallDurationSeconds: elapsed,
-                    samplingSkipped: true
-                )
                 return
             }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for desktop-freeze-diagnostics.md.

**Gap:** Stage-2 sampling-disabled path writes hang-context.json twice
**What was expected:** Single write with samplingSkipped flag when sampling is disabled
**What was found:** Two sequential writes — first without flag, then rewrite with flag
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
