### PR TITLE
fix: throttle detectorUpdate diagnostics to avoid flooding during streaming

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -814,14 +814,16 @@ struct ScrollWheelDetector: NSViewRepresentable {
         let activeCount = registry.activeCount
         let hasDuplicate = registry.hasDuplicates(conversationId: convId, windowId: winId)
 
-        log.debug(
-            "ScrollWheelDetector.update detectorId=\(coordinator.detectorId) conv=\(convId) win=\(winId) activeDetectors=\(activeCount) duplicate=\(hasDuplicate)"
-        )
-        ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
-            kind: .detectorUpdate,
-            conversationId: convId,
-            reason: "detectorId=\(coordinator.detectorId) win=\(winId) activeDetectors=\(activeCount) duplicate=\(hasDuplicate)"
-        ))
+        if coordinator.shouldRecordDiagnostic(kind: .detectorUpdate) {
+            log.debug(
+                "ScrollWheelDetector.update detectorId=\(coordinator.detectorId) conv=\(convId) win=\(winId) activeDetectors=\(activeCount) duplicate=\(hasDuplicate)"
+            )
+            ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
+                kind: .detectorUpdate,
+                conversationId: convId,
+                reason: "detectorId=\(coordinator.detectorId) win=\(winId) activeDetectors=\(activeCount) duplicate=\(hasDuplicate)"
+            ))
+        }
     }
 
     static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
@@ -861,8 +863,13 @@ struct ScrollWheelDetector: NSViewRepresentable {
         /// Throttle interval for scroll-wheel diagnostics recording.
         /// Prevents synchronous JSON-encode + FileHandle.write on every tick.
         static let diagnosticThrottleInterval: TimeInterval = 0.5
+        /// Throttle interval for detectorUpdate diagnostics. Longer than scroll-wheel
+        /// events because updateNSView fires on every SwiftUI render pass during
+        /// streaming, which can be many times per second.
+        static let detectorUpdateThrottleInterval: TimeInterval = 1.0
         private var lastUntetherRecordTime: TimeInterval = 0
         private var lastRetetherRecordTime: TimeInterval = 0
+        private var lastDetectorUpdateRecordTime: TimeInterval = 0
 
         /// Returns true and updates the timestamp if enough time has elapsed
         /// since the last recording for the given kind.
@@ -876,6 +883,10 @@ struct ScrollWheelDetector: NSViewRepresentable {
             case .scrollWheelRetether:
                 guard now - lastRetetherRecordTime >= Self.diagnosticThrottleInterval else { return false }
                 lastRetetherRecordTime = now
+                return true
+            case .detectorUpdate:
+                guard now - lastDetectorUpdateRecordTime >= Self.detectorUpdateThrottleInterval else { return false }
+                lastDetectorUpdateRecordTime = now
                 return true
             default:
                 return true


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for desktop-freeze-diagnostics.md.

**Gap:** Unthrottled detectorUpdate diagnostics fire on every SwiftUI render pass
**What was expected:** detectorUpdate events should be throttled like untether/retether events
**What was found:** updateNSView records a detectorUpdate event on every call without rate limiting

- Routes `.detectorUpdate` events through the coordinator's existing `shouldRecordDiagnostic` throttle
- Uses a 1-second throttle interval (longer than the 0.5s scroll-wheel throttle since detector updates are less actionable and fire much more frequently during streaming)
- Both the `log.debug` call and the `ChatDiagnosticsStore.shared.record` call are gated behind the throttle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
