### PR TITLE
feat: add monotone icons to memory status and sort dropdowns

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -117,7 +117,8 @@ struct MemoriesPanel: View {
                 placeholder: "Status",
                 selection: $statusFilter,
                 options: MemoryStatusFilter.allCases.map { ($0.rawValue, $0) },
-                maxWidth: 130
+                maxWidth: 130,
+                icon: .circleCheck
             )
             .onChange(of: statusFilter) {
                 store.statusFilter = statusFilter.apiValue
@@ -128,7 +129,8 @@ struct MemoriesPanel: View {
                 placeholder: "Sort",
                 selection: $sortOption,
                 options: MemorySortOption.allCases.map { ($0.rawValue, $0) },
-                maxWidth: 130
+                maxWidth: 130,
+                icon: .list
             )
             .onChange(of: sortOption) {
                 store.sortField = sortOption.sortField


### PR DESCRIPTION
## Summary
- Add circleCheck icon to the Status filter dropdown
- Add list icon to the Sort filter dropdown
- Both render at 13pt monotone in contentTertiary, matching the kind filter dropdown style

Part of plan: memory-filter-dropdown.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
