### PR TITLE
refactor: use shared parseIdentityFields in handleGetIdentity route

### DIFF
--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -8,7 +8,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { getBaseDataDir } from "../../config/env-registry.js";
-import { isTemplatePlaceholder } from "../../daemon/handlers/identity.js";
+import { parseIdentityFields } from "../../daemon/handlers/identity.js";
 import { getWorkspacePromptPath, readLockfile } from "../../util/platform.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
@@ -150,43 +150,7 @@ export function handleGetIdentity(): Response {
   }
 
   const content = readFileSync(identityPath, "utf-8");
-  const fields: Record<string, string> = {};
-  for (const line of content.split("\n")) {
-    const trimmed = line.trim();
-    const lower = trimmed.toLowerCase();
-    const extract = (prefix: string): string | null => {
-      if (!lower.startsWith(prefix)) return null;
-      const value = trimmed.split(":**").pop()?.trim() ?? null;
-      if (value && isTemplatePlaceholder(value)) return null;
-      return value;
-    };
-
-    const name = extract("- **name:**");
-    if (name) {
-      fields.name = name;
-      continue;
-    }
-    const role = extract("- **role:**");
-    if (role) {
-      fields.role = role;
-      continue;
-    }
-    const personality = extract("- **personality:**") ?? extract("- **vibe:**");
-    if (personality) {
-      fields.personality = personality;
-      continue;
-    }
-    const emoji = extract("- **emoji:**");
-    if (emoji) {
-      fields.emoji = emoji;
-      continue;
-    }
-    const home = extract("- **home:**");
-    if (home) {
-      fields.home = home;
-      continue;
-    }
-  }
+  const fields = parseIdentityFields(content);
 
   const version = getPackageVersion();
 


### PR DESCRIPTION
## Summary
- Replace duplicate inline identity field parsing in `handleGetIdentity` with shared `parseIdentityFields` function
- Remove now-unused `isTemplatePlaceholder` import since filtering is handled internally by the shared parser

Part of plan: role-not-yet-established.md (PR 2 of 2)
Closes JARVIS-262

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
