### PR TITLE
fix: mark _lastKnownBackgroundCopy as nonisolated(unsafe) in ChatDiagnosticsStore

### DIFF
--- a/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
+++ b/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
@@ -515,7 +515,7 @@ final class ChatDiagnosticsStore {
     private let _lastKnownLock = NSLock()
 
     /// Background-readable copy of `lastKnownDiagnostics`, guarded by `_lastKnownLock`.
-    private var _lastKnownBackgroundCopy: LastKnownDiagnosticsSnapshot?
+    private nonisolated(unsafe) var _lastKnownBackgroundCopy: LastKnownDiagnosticsSnapshot?
 
     /// Returns the last-known diagnostics snapshot from any thread.
     /// This is safe to call from the stall detector's background queue.


### PR DESCRIPTION
## Summary
- Mark `_lastKnownBackgroundCopy` as `nonisolated(unsafe)` so the `nonisolated` method `lastKnownDiagnosticsFromBackground()` can access it without violating actor isolation
- This property is explicitly designed for cross-thread access with NSLock providing thread safety

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23307486832/job/67785557903
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
