### PR TITLE
feat: add transitive hash helper for inline-command skill loads

### DIFF
--- a/assistant/src/__tests__/skills-transitive-hash.test.ts
+++ b/assistant/src/__tests__/skills-transitive-hash.test.ts
@@ -1,0 +1,333 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type { SkillSummary } from "../config/skills.js";
+import { indexCatalogById } from "../skills/include-graph.js";
+import {
+  computeTransitiveSkillVersionHash,
+  TransitiveHashError,
+} from "../skills/transitive-version-hash.js";
+
+const testDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "transitive-hash-test-"));
+  testDirs.push(dir);
+  return dir;
+}
+
+/** Create a minimal SkillSummary with just the fields we need. */
+function makeSkill(
+  id: string,
+  directoryPath: string,
+  includes?: string[],
+): SkillSummary {
+  return {
+    id,
+    name: id,
+    displayName: id,
+    description: `Test skill ${id}`,
+    directoryPath,
+    skillFilePath: join(directoryPath, "SKILL.md"),
+    source: "managed",
+    includes,
+  };
+}
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("computeTransitiveSkillVersionHash", () => {
+  test("returns a tv1: prefixed sha256 hash for a single skill", () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "SKILL.md"), "# Root Skill\n");
+
+    const catalog = [makeSkill("root", dir)];
+    const index = indexCatalogById(catalog);
+
+    const hash = computeTransitiveSkillVersionHash("root", index);
+    expect(hash).toMatch(/^tv1:[0-9a-f]{64}$/);
+  });
+
+  test("is deterministic for same content", () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "SKILL.md"), "# Root Skill\n");
+
+    const catalog = [makeSkill("root", dir)];
+    const index = indexCatalogById(catalog);
+
+    const hash1 = computeTransitiveSkillVersionHash("root", index);
+    const hash2 = computeTransitiveSkillVersionHash("root", index);
+    expect(hash1).toBe(hash2);
+  });
+
+  test("is stable across separate index builds with unchanged content", () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "SKILL.md"), "# Root Skill\n");
+
+    const catalog1 = [makeSkill("root", dir)];
+    const index1 = indexCatalogById(catalog1);
+    const hash1 = computeTransitiveSkillVersionHash("root", index1);
+
+    // Build a fresh catalog and index from the same directory
+    const catalog2 = [makeSkill("root", dir)];
+    const index2 = indexCatalogById(catalog2);
+    const hash2 = computeTransitiveSkillVersionHash("root", index2);
+
+    expect(hash1).toBe(hash2);
+  });
+
+  test("changes when root skill content changes", () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "SKILL.md"), "# Root v1\n");
+
+    const catalog = [makeSkill("root", dir)];
+    const index = indexCatalogById(catalog);
+    const hash1 = computeTransitiveSkillVersionHash("root", index);
+
+    writeFileSync(join(dir, "SKILL.md"), "# Root v2\n");
+    const hash2 = computeTransitiveSkillVersionHash("root", index);
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test("changes when an included child skill content changes", () => {
+    const rootDir = makeTempDir();
+    const childDir = makeTempDir();
+    writeFileSync(join(rootDir, "SKILL.md"), "# Root\n");
+    writeFileSync(join(childDir, "SKILL.md"), "# Child v1\n");
+
+    const catalog = [
+      makeSkill("root", rootDir, ["child"]),
+      makeSkill("child", childDir),
+    ];
+    const index = indexCatalogById(catalog);
+
+    const hash1 = computeTransitiveSkillVersionHash("root", index);
+
+    // Modify child
+    writeFileSync(join(childDir, "SKILL.md"), "# Child v2\n");
+    const hash2 = computeTransitiveSkillVersionHash("root", index);
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test("changes when a deeply nested child skill changes", () => {
+    const rootDir = makeTempDir();
+    const childDir = makeTempDir();
+    const grandchildDir = makeTempDir();
+    writeFileSync(join(rootDir, "SKILL.md"), "# Root\n");
+    writeFileSync(join(childDir, "SKILL.md"), "# Child\n");
+    writeFileSync(join(grandchildDir, "SKILL.md"), "# Grandchild v1\n");
+
+    const catalog = [
+      makeSkill("root", rootDir, ["child"]),
+      makeSkill("child", childDir, ["grandchild"]),
+      makeSkill("grandchild", grandchildDir),
+    ];
+    const index = indexCatalogById(catalog);
+
+    const hash1 = computeTransitiveSkillVersionHash("root", index);
+
+    writeFileSync(join(grandchildDir, "SKILL.md"), "# Grandchild v2\n");
+    const hash2 = computeTransitiveSkillVersionHash("root", index);
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test("includes all children in a diamond dependency graph", () => {
+    const rootDir = makeTempDir();
+    const leftDir = makeTempDir();
+    const rightDir = makeTempDir();
+    const bottomDir = makeTempDir();
+    writeFileSync(join(rootDir, "SKILL.md"), "# Root\n");
+    writeFileSync(join(leftDir, "SKILL.md"), "# Left\n");
+    writeFileSync(join(rightDir, "SKILL.md"), "# Right\n");
+    writeFileSync(join(bottomDir, "SKILL.md"), "# Bottom v1\n");
+
+    // Diamond: root -> [left, right], left -> [bottom], right -> [bottom]
+    const catalog = [
+      makeSkill("root", rootDir, ["left", "right"]),
+      makeSkill("left", leftDir, ["bottom"]),
+      makeSkill("right", rightDir, ["bottom"]),
+      makeSkill("bottom", bottomDir),
+    ];
+    const index = indexCatalogById(catalog);
+
+    const hash1 = computeTransitiveSkillVersionHash("root", index);
+
+    // Changing the shared bottom skill must change the root's transitive hash
+    writeFileSync(join(bottomDir, "SKILL.md"), "# Bottom v2\n");
+    const hash2 = computeTransitiveSkillVersionHash("root", index);
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test("throws TransitiveHashError with code 'missing' for missing child", () => {
+    const rootDir = makeTempDir();
+    writeFileSync(join(rootDir, "SKILL.md"), "# Root\n");
+
+    // Root references "missing-child" which is not in the catalog
+    const catalog = [makeSkill("root", rootDir, ["missing-child"])];
+    const index = indexCatalogById(catalog);
+
+    expect(() => computeTransitiveSkillVersionHash("root", index)).toThrow(
+      TransitiveHashError,
+    );
+
+    try {
+      computeTransitiveSkillVersionHash("root", index);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransitiveHashError);
+      expect((err as TransitiveHashError).code).toBe("missing");
+      expect((err as TransitiveHashError).message).toContain("missing-child");
+    }
+  });
+
+  test("throws TransitiveHashError with code 'cycle' for cyclic includes", () => {
+    const dirA = makeTempDir();
+    const dirB = makeTempDir();
+    writeFileSync(join(dirA, "SKILL.md"), "# A\n");
+    writeFileSync(join(dirB, "SKILL.md"), "# B\n");
+
+    // Cycle: a -> b -> a
+    const catalog = [makeSkill("a", dirA, ["b"]), makeSkill("b", dirB, ["a"])];
+    const index = indexCatalogById(catalog);
+
+    expect(() => computeTransitiveSkillVersionHash("a", index)).toThrow(
+      TransitiveHashError,
+    );
+
+    try {
+      computeTransitiveSkillVersionHash("a", index);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransitiveHashError);
+      expect((err as TransitiveHashError).code).toBe("cycle");
+    }
+  });
+
+  test("throws for a self-referencing cycle", () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "SKILL.md"), "# Self\n");
+
+    const catalog = [makeSkill("self-ref", dir, ["self-ref"])];
+    const index = indexCatalogById(catalog);
+
+    expect(() => computeTransitiveSkillVersionHash("self-ref", index)).toThrow(
+      TransitiveHashError,
+    );
+
+    try {
+      computeTransitiveSkillVersionHash("self-ref", index);
+    } catch (err) {
+      expect((err as TransitiveHashError).code).toBe("cycle");
+    }
+  });
+
+  test("throws for missing deeply nested child", () => {
+    const rootDir = makeTempDir();
+    const childDir = makeTempDir();
+    writeFileSync(join(rootDir, "SKILL.md"), "# Root\n");
+    writeFileSync(join(childDir, "SKILL.md"), "# Child\n");
+
+    // child references "ghost" which doesn't exist
+    const catalog = [
+      makeSkill("root", rootDir, ["child"]),
+      makeSkill("child", childDir, ["ghost"]),
+    ];
+    const index = indexCatalogById(catalog);
+
+    expect(() => computeTransitiveSkillVersionHash("root", index)).toThrow(
+      TransitiveHashError,
+    );
+
+    try {
+      computeTransitiveSkillVersionHash("root", index);
+    } catch (err) {
+      expect((err as TransitiveHashError).code).toBe("missing");
+      expect((err as TransitiveHashError).message).toContain("ghost");
+    }
+  });
+
+  test("skill with no includes behaves like a leaf", () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "SKILL.md"), "# Leaf Skill\n");
+
+    const catalog = [makeSkill("leaf", dir)];
+    const index = indexCatalogById(catalog);
+
+    // Should succeed with no errors
+    const hash = computeTransitiveSkillVersionHash("leaf", index);
+    expect(hash).toMatch(/^tv1:[0-9a-f]{64}$/);
+  });
+
+  test("skill with empty includes array behaves like a leaf", () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "SKILL.md"), "# Leaf Skill\n");
+
+    const catalog = [makeSkill("leaf", dir, [])];
+    const index = indexCatalogById(catalog);
+
+    const hash = computeTransitiveSkillVersionHash("leaf", index);
+    expect(hash).toMatch(/^tv1:[0-9a-f]{64}$/);
+  });
+
+  test("adding a new file to a child changes the parent transitive hash", () => {
+    const rootDir = makeTempDir();
+    const childDir = makeTempDir();
+    writeFileSync(join(rootDir, "SKILL.md"), "# Root\n");
+    writeFileSync(join(childDir, "SKILL.md"), "# Child\n");
+
+    const catalog = [
+      makeSkill("root", rootDir, ["child"]),
+      makeSkill("child", childDir),
+    ];
+    const index = indexCatalogById(catalog);
+
+    const hash1 = computeTransitiveSkillVersionHash("root", index);
+
+    // Add a new file to child
+    writeFileSync(join(childDir, "helper.ts"), "export {};");
+    const hash2 = computeTransitiveSkillVersionHash("root", index);
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test("different include orderings produce different hashes", () => {
+    // The include graph structure is encoded by the DFS visit order,
+    // so different graphs must produce different hashes.
+    const rootDir1 = makeTempDir();
+    const rootDir2 = makeTempDir();
+    const childADir = makeTempDir();
+    const childBDir = makeTempDir();
+    writeFileSync(join(rootDir1, "SKILL.md"), "# Root\n");
+    writeFileSync(join(rootDir2, "SKILL.md"), "# Root\n");
+    writeFileSync(join(childADir, "SKILL.md"), "# A\n");
+    writeFileSync(join(childBDir, "SKILL.md"), "# B\n");
+
+    // Graph 1: root includes only A
+    const catalog1 = [
+      makeSkill("root", rootDir1, ["a"]),
+      makeSkill("a", childADir),
+      makeSkill("b", childBDir),
+    ];
+    const index1 = indexCatalogById(catalog1);
+    const hash1 = computeTransitiveSkillVersionHash("root", index1);
+
+    // Graph 2: root includes A and B
+    const catalog2 = [
+      makeSkill("root", rootDir2, ["a", "b"]),
+      makeSkill("a", childADir),
+      makeSkill("b", childBDir),
+    ];
+    const index2 = indexCatalogById(catalog2);
+    const hash2 = computeTransitiveSkillVersionHash("root", index2);
+
+    expect(hash1).not.toBe(hash2);
+  });
+});

--- a/assistant/src/skills/transitive-version-hash.ts
+++ b/assistant/src/skills/transitive-version-hash.ts
@@ -1,0 +1,88 @@
+import { createHash } from "node:crypto";
+
+import type { SkillSummary } from "../config/skills.js";
+import { validateIncludes } from "./include-graph.js";
+import { computeSkillVersionHash } from "./version-hash.js";
+
+/**
+ * Error thrown when the include graph is invalid (missing nodes or cycles).
+ * The permission layer depends on exact approval candidates, so we fail closed
+ * rather than returning a partial or potentially misleading hash.
+ */
+export class TransitiveHashError extends Error {
+  constructor(
+    message: string,
+    public readonly code: "missing" | "cycle",
+  ) {
+    super(message);
+    this.name = "TransitiveHashError";
+  }
+}
+
+/**
+ * Compute a transitive version hash for a skill and all its included children.
+ *
+ * The hash covers:
+ * 1. The DFS-ordered list of visited skill IDs (so the graph structure matters)
+ * 2. Each visited skill's directory hash (via `computeSkillVersionHash`)
+ *
+ * This means editing any included child skill invalidates the parent's
+ * transitive hash, which is required for version-pinned inline-command
+ * approval.
+ *
+ * Fails closed (throws `TransitiveHashError`) when:
+ * - A child referenced in `includes` is missing from the catalog index
+ * - The include graph contains a cycle
+ *
+ * @param rootSkillId  The skill ID to start traversal from.
+ * @param catalogIndex A `Map<skillId, SkillSummary>` built via `indexCatalogById`.
+ * @returns A canonical hash string in the format `tv1:<hex-sha256>`.
+ */
+export function computeTransitiveSkillVersionHash(
+  rootSkillId: string,
+  catalogIndex: Map<string, SkillSummary>,
+): string {
+  // Validate the include graph first — fail closed on any issue.
+  const validation = validateIncludes(rootSkillId, catalogIndex);
+
+  if (!validation.ok) {
+    if (validation.error === "cycle") {
+      throw new TransitiveHashError(
+        `Cycle detected in include graph: ${validation.cyclePath.join(" -> ")}`,
+        "cycle",
+      );
+    }
+    // validation.error === "missing"
+    throw new TransitiveHashError(
+      `Missing child skill "${validation.missingChildId}" referenced by "${validation.parentId}" (path: ${validation.path.join(" -> ")})`,
+      "missing",
+    );
+  }
+
+  // validation.ok === true, so visited contains all skill IDs in DFS pre-order.
+  const { visited } = validation;
+
+  const hash = createHash("sha256");
+
+  for (const skillId of visited) {
+    // Fold the skill ID into the digest so graph structure matters.
+    hash.update(skillId);
+    hash.update("\0");
+
+    const skill = catalogIndex.get(skillId);
+    if (!skill) {
+      // Should be unreachable after validateIncludes succeeds, but fail closed.
+      throw new TransitiveHashError(
+        `Skill "${skillId}" disappeared from catalog index after validation`,
+        "missing",
+      );
+    }
+
+    // Fold the per-directory content hash so file changes propagate.
+    const dirHash = computeSkillVersionHash(skill.directoryPath);
+    hash.update(dirHash);
+    hash.update("\n");
+  }
+
+  return `tv1:${hash.digest("hex")}`;
+}


### PR DESCRIPTION
## Summary
- Add computeTransitiveSkillVersionHash() that covers root + all included children
- Deterministic DFS traversal with cycle and missing-node detection
- Fail closed on invalid include graphs

Part of plan: secure-skill-dynamic-context.md (PR 2 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
