### PR TITLE
fix: correct detectorUpdate throttle test classification

### DIFF
--- a/clients/macos/vellum-assistantTests/ScrollWheelDetectorCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ScrollWheelDetectorCoordinatorTests.swift
@@ -115,9 +115,38 @@ final class ScrollWheelDetectorCoordinatorTests: XCTestCase {
         // Other diagnostic kinds should not be throttled.
         XCTAssertTrue(coordinator.shouldRecordDiagnostic(kind: .detectorInstall))
         XCTAssertTrue(coordinator.shouldRecordDiagnostic(kind: .detectorInstall))
-        XCTAssertTrue(coordinator.shouldRecordDiagnostic(kind: .detectorUpdate))
         XCTAssertTrue(coordinator.shouldRecordDiagnostic(kind: .detectorRemove))
         XCTAssertTrue(coordinator.shouldRecordDiagnostic(kind: .scrollPositionChanged))
+    }
+
+    // MARK: - Detector Update Throttle
+
+    func testFirstDetectorUpdateCallIsAllowed() {
+        let coordinator = makeCoordinator()
+        XCTAssertTrue(
+            coordinator.shouldRecordDiagnostic(kind: .detectorUpdate),
+            "First detectorUpdate diagnostic should always be recorded"
+        )
+    }
+
+    func testRapidDetectorUpdateCallsAreThrottled() {
+        let coordinator = makeCoordinator()
+
+        // First call passes.
+        let first = coordinator.shouldRecordDiagnostic(kind: .detectorUpdate)
+        XCTAssertTrue(first)
+
+        // Immediate second call should be throttled (< 1.0s has elapsed).
+        let second = coordinator.shouldRecordDiagnostic(kind: .detectorUpdate)
+        XCTAssertFalse(second, "Rapid detectorUpdate call should be throttled")
+    }
+
+    func testDetectorUpdateThrottleIntervalIsOneSecond() {
+        XCTAssertEqual(
+            ScrollWheelDetector.Coordinator.detectorUpdateThrottleInterval,
+            1.0,
+            "Detector update throttle interval should be 1.0 seconds"
+        )
     }
 
     // MARK: - Stable Detector ID


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for desktop-freeze-diagnostics.md.

**Gap:** Test testNonScrollKindsAlwaysPass incorrectly classifies .detectorUpdate as unthrottled
**What was expected:** .detectorUpdate should be tested as throttled (1.0s interval)
**What was found:** Test only called it once, missing the throttle behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
