### PR TITLE
feat: parse inline skill command expansion tokens

### DIFF
--- a/assistant/src/__tests__/skills-inline-command-expansions.test.ts
+++ b/assistant/src/__tests__/skills-inline-command-expansions.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseInlineCommandExpansions } from "../skills/inline-command-expansions.js";
+
+// ─── Basic parsing ────────────────────────────────────────────────────────────
+
+describe("parseInlineCommandExpansions", () => {
+  test("parses a single inline command expansion", () => {
+    const body = "Run this: !`gh pr diff`";
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(1);
+    expect(result.errors).toHaveLength(0);
+
+    const exp = result.expansions[0];
+    expect(exp.command).toBe("gh pr diff");
+    expect(exp.placeholderId).toBe(0);
+    expect(exp.startOffset).toBe(10);
+    expect(exp.endOffset).toBe(23);
+  });
+
+  test("parses multiple inline command expansions in order", () => {
+    const body = "First: !`ls -la` and second: !`echo hello`";
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(2);
+    expect(result.errors).toHaveLength(0);
+
+    expect(result.expansions[0].command).toBe("ls -la");
+    expect(result.expansions[0].placeholderId).toBe(0);
+
+    expect(result.expansions[1].command).toBe("echo hello");
+    expect(result.expansions[1].placeholderId).toBe(1);
+  });
+
+  test("preserves literal command text including internal spaces", () => {
+    const body = "!`git log --oneline -n 10`";
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(1);
+    expect(result.expansions[0].command).toBe("git log --oneline -n 10");
+  });
+
+  test("trims whitespace from command text", () => {
+    const body = "!`  gh pr diff  `";
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(1);
+    expect(result.expansions[0].command).toBe("gh pr diff");
+  });
+
+  test("returns empty expansions for body with no tokens", () => {
+    const body = "Just a normal skill body with no inline commands.";
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("returns empty expansions for empty body", () => {
+    const result = parseInlineCommandExpansions("");
+
+    expect(result.expansions).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  // ─── Byte offsets ───────────────────────────────────────────────────────────
+
+  test("startOffset and endOffset match the token positions", () => {
+    const body = "abc !`cmd` def";
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(1);
+    const exp = result.expansions[0];
+    // "abc " = 4 chars, then !`cmd` = 6 chars
+    expect(exp.startOffset).toBe(4);
+    expect(exp.endOffset).toBe(10);
+    expect(body.slice(exp.startOffset, exp.endOffset)).toBe("!`cmd`");
+  });
+
+  // ─── Fenced code block handling ─────────────────────────────────────────────
+
+  test("ignores tokens inside fenced code blocks with backtick fence", () => {
+    const body = [
+      "Normal text with !`real command`",
+      "",
+      "```",
+      "Example: !`gh pr diff`",
+      "```",
+      "",
+      "More text with !`another real command`",
+    ].join("\n");
+
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(2);
+    expect(result.expansions[0].command).toBe("real command");
+    expect(result.expansions[1].command).toBe("another real command");
+  });
+
+  test("ignores tokens inside fenced code blocks with tilde fence", () => {
+    const body = [
+      "~~~",
+      "!`should be ignored`",
+      "~~~",
+      "",
+      "!`should be found`",
+    ].join("\n");
+
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(1);
+    expect(result.expansions[0].command).toBe("should be found");
+  });
+
+  test("ignores tokens inside fenced code blocks with info string", () => {
+    const body = [
+      "```markdown",
+      "Use !`gh pr diff` to view changes",
+      "```",
+      "",
+      "!`real command`",
+    ].join("\n");
+
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(1);
+    expect(result.expansions[0].command).toBe("real command");
+  });
+
+  test("handles nested-like fence delimiters (longer opening fence)", () => {
+    const body = [
+      "````",
+      "```",
+      "!`inside nested`",
+      "```",
+      "````",
+      "",
+      "!`outside`",
+    ].join("\n");
+
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(1);
+    expect(result.expansions[0].command).toBe("outside");
+  });
+
+  test("treats unclosed fenced code block as extending to EOF", () => {
+    const body = [
+      "```",
+      "!`inside unclosed fence`",
+      "This code block is never closed",
+    ].join("\n");
+
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  // ─── Fail-closed on malformed tokens ────────────────────────────────────────
+
+  test("rejects empty command text", () => {
+    const body = "!``";
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].reason).toBe("Empty command text");
+    expect(result.errors[0].raw).toBe("!``");
+    expect(result.errors[0].offset).toBe(0);
+  });
+
+  test("rejects whitespace-only command text", () => {
+    const body = "!`   `";
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].reason).toBe("Empty command text");
+  });
+
+  test("reports unmatched opening backtick", () => {
+    const body = "Some text !`unmatched";
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].reason).toContain("Unmatched opening backtick");
+    expect(result.errors[0].offset).toBe(10);
+  });
+
+  test("valid and malformed tokens can coexist", () => {
+    const body = "!`good command` and !`` and !`another good`";
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(2);
+    expect(result.expansions[0].command).toBe("good command");
+    expect(result.expansions[0].placeholderId).toBe(0);
+    expect(result.expansions[1].command).toBe("another good");
+    expect(result.expansions[1].placeholderId).toBe(1);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].reason).toBe("Empty command text");
+  });
+
+  // ─── Placeholder ID stability ───────────────────────────────────────────────
+
+  test("placeholder IDs are sequential by encounter order", () => {
+    const body = "!`first` then !`second` and !`third`";
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(3);
+    expect(result.expansions[0].placeholderId).toBe(0);
+    expect(result.expansions[1].placeholderId).toBe(1);
+    expect(result.expansions[2].placeholderId).toBe(2);
+  });
+
+  test("malformed tokens do not consume placeholder IDs", () => {
+    const body = "!`first` then !`` then !`second`";
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(2);
+    expect(result.expansions[0].placeholderId).toBe(0);
+    expect(result.expansions[1].placeholderId).toBe(1);
+  });
+
+  // ─── List items and paragraphs ──────────────────────────────────────────────
+
+  test("detects tokens in list items", () => {
+    const body = [
+      "- Step 1: !`git fetch`",
+      "- Step 2: !`git rebase origin/main`",
+    ].join("\n");
+
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(2);
+    expect(result.expansions[0].command).toBe("git fetch");
+    expect(result.expansions[1].command).toBe("git rebase origin/main");
+  });
+
+  test("detects tokens across multiple paragraphs", () => {
+    const body = [
+      "First paragraph with !`cmd1`.",
+      "",
+      "Second paragraph with !`cmd2`.",
+    ].join("\n");
+
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(2);
+    expect(result.expansions[0].command).toBe("cmd1");
+    expect(result.expansions[1].command).toBe("cmd2");
+  });
+
+  // ─── Edge cases ─────────────────────────────────────────────────────────────
+
+  test("does not match regular backtick code spans", () => {
+    const body = "Use `gh pr diff` to view changes";
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("does not match bare exclamation marks", () => {
+    const body = "This is exciting! And `code` too!";
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("handles token at start of body", () => {
+    const body = "!`first thing`";
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(1);
+    expect(result.expansions[0].command).toBe("first thing");
+    expect(result.expansions[0].startOffset).toBe(0);
+  });
+
+  test("handles token at end of body", () => {
+    const body = "Do this: !`last thing`";
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(1);
+    expect(result.expansions[0].command).toBe("last thing");
+    expect(result.expansions[0].endOffset).toBe(body.length);
+  });
+
+  test("unmatched backtick inside fenced code block is not an error", () => {
+    const body = ["```", "!`unmatched inside fence", "```"].join("\n");
+
+    const result = parseInlineCommandExpansions(body);
+
+    expect(result.expansions).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -25,6 +25,8 @@ import {
   userMessage,
 } from "../providers/provider-send-message.js";
 import { parseFrontmatterFields } from "../skills/frontmatter.js";
+import type { InlineCommandExpansion } from "../skills/inline-command-expansions.js";
+import { parseInlineCommandExpansions } from "../skills/inline-command-expansions.js";
 import { parseToolManifestFile } from "../skills/tool-manifest.js";
 import { computeSkillVersionHash } from "../skills/version-hash.js";
 import { getLogger } from "../util/logger.js";
@@ -83,6 +85,8 @@ export interface SkillSummary {
   activationHints?: string[];
   /** Conditions under which this skill should NOT be loaded. */
   avoidWhen?: string[];
+  /** Parsed inline command expansion descriptors (`!\`command\``) found in the skill body. */
+  inlineCommandExpansions?: InlineCommandExpansion[];
 }
 
 export interface SkillDefinition extends SkillSummary {
@@ -201,6 +205,7 @@ interface ParsedFrontmatter {
   featureFlag?: string;
   activationHints?: string[];
   avoidWhen?: string[];
+  inlineCommandExpansions?: InlineCommandExpansion[];
 }
 
 function normalizeStringArray(raw: unknown): string[] | undefined {
@@ -305,16 +310,29 @@ function parseFrontmatter(
   const activationHints = normalizeStringArray(vellum?.["activation-hints"]);
   const avoidWhen = normalizeStringArray(vellum?.["avoid-when"]);
 
+  const strippedBody = stripCommentLines(body);
+
+  // Parse inline command expansions from the body (after frontmatter/comment stripping)
+  const expansionResult = parseInlineCommandExpansions(strippedBody);
+  const inlineCommandExpansions =
+    expansionResult.expansions.length > 0
+      ? expansionResult.expansions
+      : undefined;
+
+  // Fail closed: if there are malformed tokens, log and exclude from parsed expansions
+  // (errors are already logged inside parseInlineCommandExpansions)
+
   return {
     name,
     displayName,
     description,
-    body: stripCommentLines(body),
+    body: strippedBody,
     emoji,
     includes,
     featureFlag,
     activationHints,
     avoidWhen,
+    inlineCommandExpansions,
   };
 }
 
@@ -469,6 +487,7 @@ function readSkillFromDirectory(
       featureFlag: parsed.featureFlag,
       activationHints: parsed.activationHints,
       avoidWhen: parsed.avoidWhen,
+      inlineCommandExpansions: parsed.inlineCommandExpansions,
     };
   } catch (err) {
     log.warn({ err, skillFilePath }, "Failed to read skill file");
@@ -519,6 +538,7 @@ function readBundledSkillFromDirectory(
       featureFlag: parsed.featureFlag,
       activationHints: parsed.activationHints,
       avoidWhen: parsed.avoidWhen,
+      inlineCommandExpansions: parsed.inlineCommandExpansions,
     };
   } catch (err) {
     log.warn({ err, skillFilePath }, "Failed to read bundled skill file");
@@ -577,6 +597,7 @@ function loadBundledSkills(): SkillSummary[] {
       featureFlag: skill.featureFlag,
       activationHints: skill.activationHints,
       avoidWhen: skill.avoidWhen,
+      inlineCommandExpansions: skill.inlineCommandExpansions,
     });
   }
 
@@ -713,6 +734,7 @@ function skillSummaryFromDefinition(
     featureFlag: skill.featureFlag,
     activationHints: skill.activationHints,
     avoidWhen: skill.avoidWhen,
+    inlineCommandExpansions: skill.inlineCommandExpansions,
   };
 }
 
@@ -763,6 +785,7 @@ export function loadSkillCatalog(
             toolManifest: detectToolManifest(directory),
             includes: parsed.includes,
             featureFlag: parsed.featureFlag,
+            inlineCommandExpansions: parsed.inlineCommandExpansions,
           });
         } catch (err) {
           log.warn({ err, directory }, "Failed to read skill from extraDirs");
@@ -857,6 +880,7 @@ export function loadSkillCatalog(
           toolManifest: detectToolManifest(directory),
           includes: parsed.includes,
           featureFlag: parsed.featureFlag,
+          inlineCommandExpansions: parsed.inlineCommandExpansions,
         };
 
         if (seenIds.has(id)) {

--- a/assistant/src/skills/inline-command-expansions.ts
+++ b/assistant/src/skills/inline-command-expansions.ts
@@ -1,0 +1,204 @@
+/**
+ * Canonical parser for inline command expansion tokens in skill bodies.
+ *
+ * Syntax: !\`command\`
+ *
+ * These tokens are parsed from the markdown body of a SKILL.md file (after
+ * frontmatter extraction). Tokens inside fenced code blocks are ignored so
+ * that documentation examples or literal snippets do not accidentally execute.
+ *
+ * The parser fails closed on malformed tokens: unmatched backticks, empty
+ * commands, or nested backticks that make the command text ambiguous are
+ * rejected rather than best-effort expanded.
+ */
+
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("inline-command-expansions");
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** A single parsed inline command expansion descriptor. */
+export interface InlineCommandExpansion {
+  /** The raw command text between the backticks (trimmed). */
+  command: string;
+  /** Byte offset of the `!` character in the original body string. */
+  startOffset: number;
+  /** Byte offset one past the closing backtick in the original body string. */
+  endOffset: number;
+  /** Stable placeholder ID derived from encounter order (0-indexed). */
+  placeholderId: number;
+}
+
+/** Result of parsing a skill body for inline command expansions. */
+export interface InlineCommandExpansionResult {
+  /** Successfully parsed expansion descriptors, in encounter order. */
+  expansions: InlineCommandExpansion[];
+  /** Malformed tokens that were rejected (fail-closed). */
+  errors: InlineCommandExpansionError[];
+}
+
+/** A malformed inline command expansion token. */
+export interface InlineCommandExpansionError {
+  /** The raw matched text that was rejected. */
+  raw: string;
+  /** Byte offset in the original body. */
+  offset: number;
+  /** Human-readable reason for rejection. */
+  reason: string;
+}
+
+// ─── Fenced code block stripping ──────────────────────────────────────────────
+
+/**
+ * Build a set of character ranges that fall inside fenced code blocks.
+ * A fenced code block starts with a line matching ``` (with optional info
+ * string) and ends with a line matching ``` (or end of string).
+ */
+function buildFencedCodeRanges(body: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  // Match fenced code block delimiters: ``` optionally followed by info string
+  const fenceRe = /^(`{3,}|~{3,})(.*)?$/gm;
+  let openFence: { index: number; delimiter: string } | undefined;
+
+  let match: RegExpExecArray | undefined;
+  while ((match = fenceRe.exec(body) ?? undefined) !== undefined) {
+    const delimiter = match[1];
+    if (openFence === undefined) {
+      // Opening fence
+      openFence = {
+        index: match.index,
+        delimiter: delimiter[0].repeat(delimiter.length),
+      };
+    } else if (
+      delimiter[0] === openFence.delimiter[0] &&
+      delimiter.length >= openFence.delimiter.length &&
+      // Closing fence must be bare (no info string after it)
+      (!match[2] || match[2].trim() === "")
+    ) {
+      // Closing fence — range covers from opening fence to end of closing fence line
+      ranges.push([openFence.index, match.index + match[0].length]);
+      openFence = undefined;
+    }
+    // Otherwise ignore (nested fence-like lines inside a code block)
+  }
+
+  // If a fence was opened but never closed, treat everything from the opening
+  // fence to EOF as inside a code block.
+  if (openFence !== undefined) {
+    ranges.push([openFence.index, body.length]);
+  }
+
+  return ranges;
+}
+
+function isInsideFencedCode(
+  offset: number,
+  ranges: Array<[number, number]>,
+): boolean {
+  for (const [start, end] of ranges) {
+    if (offset >= start && offset < end) return true;
+  }
+  return false;
+}
+
+// ─── Parser ───────────────────────────────────────────────────────────────────
+
+/**
+ * Parse inline command expansion tokens (`!\`...\``) from a skill body.
+ *
+ * The body must be the markdown content _after_ frontmatter has been stripped.
+ * Tokens inside fenced code blocks are skipped.
+ *
+ * Returns both the successfully parsed expansions and any malformed tokens
+ * that were rejected (fail-closed).
+ */
+export function parseInlineCommandExpansions(
+  body: string,
+): InlineCommandExpansionResult {
+  const expansions: InlineCommandExpansion[] = [];
+  const errors: InlineCommandExpansionError[] = [];
+
+  const fencedRanges = buildFencedCodeRanges(body);
+
+  // Match !\`...\` tokens. The regex captures the content between the backticks.
+  // We use a non-greedy match to find the first closing backtick.
+  const tokenRe = /!\`([^`]*)\`/g;
+
+  let match: RegExpExecArray | undefined;
+  let placeholderCounter = 0;
+
+  while ((match = tokenRe.exec(body) ?? undefined) !== undefined) {
+    const startOffset = match.index;
+    const endOffset = startOffset + match[0].length;
+    const rawCommand = match[1];
+
+    // Skip tokens inside fenced code blocks
+    if (isInsideFencedCode(startOffset, fencedRanges)) {
+      continue;
+    }
+
+    // Fail closed: empty command
+    if (rawCommand.trim().length === 0) {
+      errors.push({
+        raw: match[0],
+        offset: startOffset,
+        reason: "Empty command text",
+      });
+      continue;
+    }
+
+    // Fail closed: nested backticks (would make command text ambiguous)
+    if (rawCommand.includes("`")) {
+      errors.push({
+        raw: match[0],
+        offset: startOffset,
+        reason: "Nested backticks in command text",
+      });
+      continue;
+    }
+
+    expansions.push({
+      command: rawCommand.trim(),
+      startOffset,
+      endOffset,
+      placeholderId: placeholderCounter++,
+    });
+  }
+
+  // Also detect malformed tokens: !\` without a closing backtick.
+  // These are unmatched opening tokens that didn't match the regex above.
+  const unmatchedRe = /!\`/g;
+  const matchedStarts = new Set<number>();
+  // Re-run the token regex to collect all matched positions
+  tokenRe.lastIndex = 0;
+  while ((match = tokenRe.exec(body) ?? undefined) !== undefined) {
+    matchedStarts.add(match.index);
+  }
+
+  let unmatchedMatch: RegExpExecArray | undefined;
+  while ((unmatchedMatch = unmatchedRe.exec(body) ?? undefined) !== undefined) {
+    const offset = unmatchedMatch.index;
+
+    // Skip if this was already matched as a complete token
+    if (matchedStarts.has(offset)) continue;
+
+    // Skip if inside a fenced code block
+    if (isInsideFencedCode(offset, fencedRanges)) continue;
+
+    errors.push({
+      raw: body.slice(offset, Math.min(offset + 40, body.length)),
+      offset,
+      reason: "Unmatched opening backtick (no closing backtick found)",
+    });
+  }
+
+  if (errors.length > 0) {
+    log.warn(
+      { errorCount: errors.length, errors },
+      "Malformed inline command expansion tokens detected",
+    );
+  }
+
+  return { expansions, errors };
+}


### PR DESCRIPTION
## Summary
- Add canonical parser for `!\`command\`` inline expansion syntax in skill bodies
- Extend SkillSummary and SkillDefinition with inlineCommandExpansions field
- Fail closed on malformed tokens; ignore fenced code blocks

Part of plan: secure-skill-dynamic-context.md (PR 1 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
