### PR TITLE
fix: preserve samplingSkipped flag across enrichWithDiagnosticsAsync rewrites

### DIFF
--- a/clients/macos/vellum-assistant/Logging/HangContextWriter.swift
+++ b/clients/macos/vellum-assistant/Logging/HangContextWriter.swift
@@ -48,6 +48,7 @@ final class HangContextWriter: @unchecked Sendable {
     private var writeGeneration: Int = 0
     private var latestStallStartTime: Date?
     private var latestStallDurationSeconds: Double = 0
+    private var latestSamplingSkipped: Bool = false
 
     private let encoder: JSONEncoder
 
@@ -94,6 +95,7 @@ final class HangContextWriter: @unchecked Sendable {
         writeGeneration += 1
         latestStallStartTime = stallStartTime
         latestStallDurationSeconds = stallDurationSeconds
+        latestSamplingSkipped = samplingSkipped
         lock.unlock()
 
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
@@ -158,18 +160,20 @@ final class HangContextWriter: @unchecked Sendable {
             let sortedSnapshots = snapshots.values.sorted { $0.conversationId < $1.conversationId }
 
             // If a newer write occurred (e.g. Stage 2) while we were awaiting
-            // diagnostics, use its duration so we don't overwrite with a stale value.
+            // diagnostics, use its values so we don't overwrite with stale data.
             self.lock.lock()
             let useLatest = self.writeGeneration > capturedGeneration
             let actualStartTime = useLatest ? (self.latestStallStartTime ?? stallStartTime) : stallStartTime
             let actualDuration = useLatest ? self.latestStallDurationSeconds : stallDurationSeconds
+            let actualSamplingSkipped = self.latestSamplingSkipped
             self.lock.unlock()
 
             self.writeHangContextSync(
                 stallStartTime: actualStartTime,
                 stallDurationSeconds: actualDuration,
                 recentEvents: events,
-                transcriptSnapshots: sortedSnapshots
+                transcriptSnapshots: sortedSnapshots,
+                samplingSkipped: actualSamplingSkipped
             )
         }
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for desktop-freeze-diagnostics.md.

**Gap:** enrichWithDiagnosticsAsync overwrites Stage 2's samplingSkipped flag
**What was expected:** Enrichment should preserve the samplingSkipped flag set by Stage 2
**What was found:** Enrichment defaulted samplingSkipped to false, overwriting the Stage 2 value

- Added `latestSamplingSkipped` to `HangContextWriter`'s lock-guarded state
- `writeHangContextSync` now stores `samplingSkipped` alongside other stall metadata
- `enrichWithDiagnosticsAsync` reads `latestSamplingSkipped` from the guarded state and forwards it

Part of JARVIS-596
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19607" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
