### PR TITLE
fix: update registry entry conversationId/windowId on conversation switch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -809,7 +809,12 @@ struct ScrollWheelDetector: NSViewRepresentable {
         let now = ProcessInfo.processInfo.systemUptime
         let convId = conversationId?.uuidString ?? "none"
         let winId = nsView.window.map { String($0.windowNumber) } ?? "pending"
-        registry.update(detectorId: coordinator.detectorId, timestamp: now)
+        registry.update(
+            detectorId: coordinator.detectorId,
+            timestamp: now,
+            conversationId: convId,
+            windowId: winId
+        )
 
         let activeCount = registry.activeCount
         let hasDuplicate = registry.hasDuplicates(conversationId: convId, windowId: winId)

--- a/clients/macos/vellum-assistant/Features/Chat/ScrollWheelDetectorRegistry.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollWheelDetectorRegistry.swift
@@ -33,11 +33,13 @@ final class ScrollWheelDetectorRegistry {
         let detectorId: String
 
         /// The conversation this detector is attached to.
-        let conversationId: String
+        /// Mutable so `update()` can reflect conversation switches.
+        var conversationId: String
 
         /// An opaque identifier for the window hosting this detector
         /// (e.g. `NSWindow.windowNumber` or a stable window UUID).
-        let windowId: String
+        /// Mutable so `update()` can reflect window changes.
+        var windowId: String
 
         /// Monotonic timestamp when the detector was registered
         /// (e.g. `ProcessInfo.processInfo.systemUptime`).
@@ -83,10 +85,30 @@ final class ScrollWheelDetectorRegistry {
         )
     }
 
-    /// Updates the `lastUpdatedAt` timestamp for an existing entry.
+    /// Updates an existing entry's timestamp and, optionally, its
+    /// conversation/window association.
+    ///
+    /// When a conversation switch occurs, the same detector instance stays
+    /// alive but is now associated with a different conversation (and
+    /// potentially a different window). Passing the current values here
+    /// keeps the registry in sync so that `hasDuplicates` queries match
+    /// the correct context.
+    ///
     /// No-op if the detector is not registered.
-    func update(detectorId: String, timestamp: TimeInterval) {
+    func update(
+        detectorId: String,
+        timestamp: TimeInterval,
+        conversationId: String? = nil,
+        windowId: String? = nil
+    ) {
+        guard entries[detectorId] != nil else { return }
         entries[detectorId]?.lastUpdatedAt = timestamp
+        if let conversationId {
+            entries[detectorId]?.conversationId = conversationId
+        }
+        if let windowId {
+            entries[detectorId]?.windowId = windowId
+        }
     }
 
     /// Removes a detector from the registry.

--- a/clients/macos/vellum-assistantTests/ScrollWheelDetectorRegistryTests.swift
+++ b/clients/macos/vellum-assistantTests/ScrollWheelDetectorRegistryTests.swift
@@ -101,6 +101,88 @@ final class ScrollWheelDetectorRegistryTests: XCTestCase {
         XCTAssertEqual(entry?.installedAt, 1000.0, "installedAt should not change on update")
     }
 
+    func testUpdateChangesConversationId() {
+        registry.register(
+            detectorId: "det-1",
+            conversationId: "conv-a",
+            windowId: "win-1",
+            timestamp: 1000.0
+        )
+
+        registry.update(detectorId: "det-1", timestamp: 2000.0, conversationId: "conv-b")
+
+        let entry = registry.snapshot().first
+        XCTAssertEqual(entry?.conversationId, "conv-b")
+        XCTAssertEqual(entry?.windowId, "win-1", "windowId should not change when only conversationId is passed")
+        XCTAssertEqual(entry?.lastUpdatedAt, 2000.0)
+    }
+
+    func testUpdateChangesWindowId() {
+        registry.register(
+            detectorId: "det-1",
+            conversationId: "conv-a",
+            windowId: "win-1",
+            timestamp: 1000.0
+        )
+
+        registry.update(detectorId: "det-1", timestamp: 2000.0, windowId: "win-2")
+
+        let entry = registry.snapshot().first
+        XCTAssertEqual(entry?.conversationId, "conv-a", "conversationId should not change when only windowId is passed")
+        XCTAssertEqual(entry?.windowId, "win-2")
+    }
+
+    func testUpdateChangesConversationAndWindowTogether() {
+        registry.register(
+            detectorId: "det-1",
+            conversationId: "conv-a",
+            windowId: "win-1",
+            timestamp: 1000.0
+        )
+
+        registry.update(detectorId: "det-1", timestamp: 2000.0, conversationId: "conv-b", windowId: "win-2")
+
+        let entry = registry.snapshot().first
+        XCTAssertEqual(entry?.conversationId, "conv-b")
+        XCTAssertEqual(entry?.windowId, "win-2")
+        XCTAssertEqual(entry?.lastUpdatedAt, 2000.0)
+        XCTAssertEqual(entry?.installedAt, 1000.0, "installedAt should not change on update")
+    }
+
+    func testUpdateConversationFixesStaleDuplicateDetection() {
+        // Simulate two detectors both initially on conv-a/win-1 (a duplicate).
+        registry.register(detectorId: "det-1", conversationId: "conv-a", windowId: "win-1", timestamp: 1000.0)
+        registry.register(detectorId: "det-2", conversationId: "conv-a", windowId: "win-1", timestamp: 1001.0)
+
+        XCTAssertTrue(registry.hasDuplicates(conversationId: "conv-a", windowId: "win-1"),
+                       "Should detect duplicates before conversation switch")
+
+        // Conversation switch: det-1 moves to conv-b.
+        registry.update(detectorId: "det-1", timestamp: 2000.0, conversationId: "conv-b", windowId: "win-1")
+
+        XCTAssertFalse(registry.hasDuplicates(conversationId: "conv-a", windowId: "win-1"),
+                        "After det-1 moves to conv-b, conv-a/win-1 should have no duplicates")
+        XCTAssertFalse(registry.hasDuplicates(conversationId: "conv-b", windowId: "win-1"),
+                        "conv-b/win-1 should have only one detector")
+    }
+
+    func testUpdateWithNilConversationAndWindowPreservesExisting() {
+        registry.register(
+            detectorId: "det-1",
+            conversationId: "conv-a",
+            windowId: "win-1",
+            timestamp: 1000.0
+        )
+
+        // Update with neither conversationId nor windowId — should only update timestamp.
+        registry.update(detectorId: "det-1", timestamp: 2000.0)
+
+        let entry = registry.snapshot().first
+        XCTAssertEqual(entry?.conversationId, "conv-a")
+        XCTAssertEqual(entry?.windowId, "win-1")
+        XCTAssertEqual(entry?.lastUpdatedAt, 2000.0)
+    }
+
     func testUpdateUnknownIdIsNoOp() {
         registry.register(
             detectorId: "det-1",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for desktop-freeze-diagnostics.md.

**Gap:** ScrollWheelDetectorRegistry.update() doesn't update conversationId/windowId
**What was expected:** Registry entries should reflect current conversation after switch
**What was found:** Entry properties were immutable, causing stale duplicate detection

- Made `Entry.conversationId` and `Entry.windowId` mutable (`var`)
- Extended `update()` to accept optional `conversationId` and `windowId` parameters
- Updated `updateNSView` in `ChatView.swift` to pass current conversation/window to registry
- Added tests for conversation/window update, combined update, stale duplicate fix, and nil preservation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
