### PR TITLE
feat: require explicit approval for inline-command skill loads

### DIFF
--- a/assistant/src/__tests__/inline-skill-load-permissions.test.ts
+++ b/assistant/src/__tests__/inline-skill-load-permissions.test.ts
@@ -1,0 +1,435 @@
+/**
+ * Tests for inline-command skill load permission handling.
+ *
+ * When a skill contains inline command expansions (!\`...\`) and the
+ * feature_flags.inline-skill-commands.enabled flag is on, the permission
+ * system must:
+ *
+ * 1. Emit skill_load_dynamic:<id>@<hash> / skill_load_dynamic:<id> candidates
+ *    instead of skill_load:<id>@<hash> / skill_load:<id>.
+ * 2. Match the default ask rule for skill_load_dynamic:* (prompting by default).
+ * 3. Allow exact-hash rules to auto-allow pinned versions.
+ * 4. Re-prompt when the transitive hash changes (skill edited).
+ * 5. Continue matching the existing skill_load:* flow for non-dynamic skills.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Mock setup (must be before any imports from the project) ──────────────
+
+const testDir = mkdtempSync(join(tmpdir(), "inline-skill-perm-test-"));
+
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => join(testDir, "data"),
+  getWorkspaceSkillsDir: () => join(testDir, "skills"),
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+interface TestConfig {
+  permissions: { mode: "strict" | "workspace" };
+  skills: { load: { extraDirs: string[] } };
+  sandbox: { enabled: boolean };
+  assistantFeatureFlagValues?: Record<string, boolean>;
+  [key: string]: unknown;
+}
+
+const testConfig: TestConfig = {
+  permissions: { mode: "workspace" },
+  skills: { load: { extraDirs: [] } },
+  sandbox: { enabled: true },
+  assistantFeatureFlagValues: {
+    "feature_flags.inline-skill-commands.enabled": true,
+  },
+};
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => testConfig,
+  loadConfig: () => testConfig,
+  invalidateConfigCache: () => {},
+  saveConfig: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────
+
+import { check, generateAllowlistOptions } from "../permissions/checker.js";
+import { addRule, clearCache } from "../permissions/trust-store.js";
+import { computeSkillVersionHash } from "../skills/version-hash.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function ensureSkillsDir(): void {
+  mkdirSync(join(testDir, "skills"), { recursive: true });
+}
+
+/** Write a plain skill (no inline command expansions). */
+function writePlainSkill(
+  skillId: string,
+  name: string,
+  description = "Test skill",
+): void {
+  const skillDir = join(testDir, "skills", skillId);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, "SKILL.md"),
+    `---\nname: "${name}"\ndescription: "${description}"\n---\n\nPlain skill body.\n`,
+  );
+}
+
+/** Write a skill with inline command expansions. */
+function writeDynamicSkill(
+  skillId: string,
+  name: string,
+  command = "echo hello",
+  description = "Dynamic test skill",
+): void {
+  const skillDir = join(testDir, "skills", skillId);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, "SKILL.md"),
+    `---\nname: "${name}"\ndescription: "${description}"\n---\n\nThis skill uses !\`${command}\` inline.\n`,
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("inline-command skill_load permissions", () => {
+  beforeEach(() => {
+    clearCache();
+    testConfig.permissions = { mode: "workspace" };
+    testConfig.skills = { load: { extraDirs: [] } };
+    testConfig.assistantFeatureFlagValues = {
+      "feature_flags.inline-skill-commands.enabled": true,
+    };
+    try {
+      rmSync(join(testDir, "protected", "trust.json"));
+    } catch {
+      /* may not exist */
+    }
+    try {
+      rmSync(join(testDir, "skills"), { recursive: true, force: true });
+    } catch {
+      /* may not exist */
+    }
+  });
+
+  // ── Default prompt behavior ──────────────────────────────────────────
+
+  describe("default prompt behavior", () => {
+    test("dynamic skill prompts by default (matches skill_load_dynamic:* ask rule)", async () => {
+      ensureSkillsDir();
+      writeDynamicSkill("dynamic-prompt", "Dynamic Prompt Skill");
+
+      const result = await check(
+        "skill_load",
+        { skill: "dynamic-prompt" },
+        "/tmp",
+      );
+      expect(result.decision).toBe("prompt");
+      expect(result.matchedRule).toBeDefined();
+      expect(result.matchedRule!.pattern).toBe("skill_load_dynamic:*");
+      expect(result.matchedRule!.decision).toBe("ask");
+    });
+
+    test("dynamic skill prompts in strict mode too", async () => {
+      ensureSkillsDir();
+      writeDynamicSkill("dynamic-strict", "Dynamic Strict Skill");
+      testConfig.permissions.mode = "strict";
+
+      const result = await check(
+        "skill_load",
+        { skill: "dynamic-strict" },
+        "/tmp",
+      );
+      expect(result.decision).toBe("prompt");
+      expect(result.matchedRule).toBeDefined();
+      expect(result.matchedRule!.pattern).toBe("skill_load_dynamic:*");
+    });
+  });
+
+  // ── Exact-hash allow rules ───────────────────────────────────────────
+
+  describe("exact-hash allow rules", () => {
+    test("exact skill_load_dynamic:<id>@<hash> rule auto-allows", async () => {
+      ensureSkillsDir();
+      writeDynamicSkill("dynamic-pinned", "Dynamic Pinned Skill");
+
+      // Compute the transitive hash to create a version-pinned rule.
+      const { computeTransitiveSkillVersionHash } =
+        await import("../skills/transitive-version-hash.js");
+      const { indexCatalogById } = await import("../skills/include-graph.js");
+      const { loadSkillCatalog } = await import("../config/skills.js");
+
+      const catalog = loadSkillCatalog();
+      const index = indexCatalogById(catalog);
+      const transitiveHash = computeTransitiveSkillVersionHash(
+        "dynamic-pinned",
+        index,
+      );
+
+      // Add an exact hash rule
+      addRule(
+        "skill_load",
+        `skill_load_dynamic:dynamic-pinned@${transitiveHash}`,
+        "everywhere",
+        "allow",
+        2000,
+      );
+
+      const result = await check(
+        "skill_load",
+        { skill: "dynamic-pinned" },
+        "/tmp",
+      );
+      expect(result.decision).toBe("allow");
+      expect(result.matchedRule).toBeDefined();
+      expect(result.matchedRule!.pattern).toBe(
+        `skill_load_dynamic:dynamic-pinned@${transitiveHash}`,
+      );
+    });
+  });
+
+  // ── Any-version allow rules ──────────────────────────────────────────
+
+  describe("any-version allow rules", () => {
+    test("skill_load_dynamic:<id> rule auto-allows any version", async () => {
+      ensureSkillsDir();
+      writeDynamicSkill("dynamic-anyver", "Dynamic Any Version Skill");
+
+      addRule(
+        "skill_load",
+        "skill_load_dynamic:dynamic-anyver",
+        "everywhere",
+        "allow",
+        2000,
+      );
+
+      const result = await check(
+        "skill_load",
+        { skill: "dynamic-anyver" },
+        "/tmp",
+      );
+      expect(result.decision).toBe("allow");
+      expect(result.matchedRule).toBeDefined();
+      expect(result.matchedRule!.pattern).toBe(
+        "skill_load_dynamic:dynamic-anyver",
+      );
+    });
+  });
+
+  // ── Changed transitive hash re-prompting ─────────────────────────────
+
+  describe("changed transitive hash re-prompting", () => {
+    test("editing a dynamic skill changes the hash, causing version-pinned rule to stop matching", async () => {
+      ensureSkillsDir();
+      writeDynamicSkill("dynamic-reprompt", "Dynamic Reprompt", "echo v1");
+
+      const { computeTransitiveSkillVersionHash } =
+        await import("../skills/transitive-version-hash.js");
+      const { indexCatalogById } = await import("../skills/include-graph.js");
+      const { loadSkillCatalog } = await import("../config/skills.js");
+
+      const catalog1 = loadSkillCatalog();
+      const index1 = indexCatalogById(catalog1);
+      const hashV1 = computeTransitiveSkillVersionHash(
+        "dynamic-reprompt",
+        index1,
+      );
+
+      // Add a version-specific rule for v1
+      addRule(
+        "skill_load",
+        `skill_load_dynamic:dynamic-reprompt@${hashV1}`,
+        "everywhere",
+        "allow",
+        2000,
+      );
+
+      // v1: should auto-allow
+      const resultV1 = await check(
+        "skill_load",
+        { skill: "dynamic-reprompt" },
+        "/tmp",
+      );
+      expect(resultV1.decision).toBe("allow");
+      expect(resultV1.matchedRule!.pattern).toBe(
+        `skill_load_dynamic:dynamic-reprompt@${hashV1}`,
+      );
+
+      // Edit the skill (change the command)
+      writeDynamicSkill("dynamic-reprompt", "Dynamic Reprompt", "echo v2");
+
+      const catalog2 = loadSkillCatalog();
+      const index2 = indexCatalogById(catalog2);
+      const hashV2 = computeTransitiveSkillVersionHash(
+        "dynamic-reprompt",
+        index2,
+      );
+      expect(hashV2).not.toBe(hashV1);
+
+      // v2: the version-specific rule no longer matches; falls through
+      // to the default skill_load_dynamic:* ask rule
+      const resultV2 = await check(
+        "skill_load",
+        { skill: "dynamic-reprompt" },
+        "/tmp",
+      );
+      expect(resultV2.decision).toBe("prompt");
+      expect(resultV2.matchedRule!.pattern).toBe("skill_load_dynamic:*");
+    });
+  });
+
+  // ── Non-dynamic skills continue matching skill_load:* ────────────────
+
+  describe("non-dynamic skills continue to use skill_load:* flow", () => {
+    test("plain skill (no inline expansions) matches skill_load:* allow rule", async () => {
+      ensureSkillsDir();
+      writePlainSkill("plain-skill", "Plain Skill");
+
+      const result = await check(
+        "skill_load",
+        { skill: "plain-skill" },
+        "/tmp",
+      );
+      expect(result.decision).toBe("allow");
+      expect(result.matchedRule).toBeDefined();
+      expect(result.matchedRule!.pattern).toBe("skill_load:*");
+    });
+
+    test("plain skill with version-specific rule still uses skill_load: namespace", async () => {
+      ensureSkillsDir();
+      writePlainSkill("plain-pinned", "Plain Pinned Skill");
+      testConfig.permissions.mode = "strict";
+
+      const skillDir = join(testDir, "skills", "plain-pinned");
+      const diskHash = computeSkillVersionHash(skillDir);
+
+      addRule(
+        "skill_load",
+        `skill_load:plain-pinned@${diskHash}`,
+        "everywhere",
+        "allow",
+        2000,
+      );
+
+      const result = await check(
+        "skill_load",
+        { skill: "plain-pinned" },
+        "/tmp",
+      );
+      expect(result.decision).toBe("allow");
+      expect(result.matchedRule!.pattern).toBe(
+        `skill_load:plain-pinned@${diskHash}`,
+      );
+    });
+  });
+
+  // ── Feature flag disabled ────────────────────────────────────────────
+
+  describe("feature flag disabled", () => {
+    test("dynamic skill falls through to skill_load:* when flag is off", async () => {
+      ensureSkillsDir();
+      writeDynamicSkill("dynamic-flag-off", "Dynamic Flag Off Skill");
+
+      // Disable the feature flag
+      testConfig.assistantFeatureFlagValues = {
+        "feature_flags.inline-skill-commands.enabled": false,
+      };
+
+      const result = await check(
+        "skill_load",
+        { skill: "dynamic-flag-off" },
+        "/tmp",
+      );
+      // With the flag off, the skill is treated as a normal skill_load
+      expect(result.decision).toBe("allow");
+      expect(result.matchedRule!.pattern).toBe("skill_load:*");
+    });
+  });
+
+  // ── Allowlist options ────────────────────────────────────────────────
+
+  describe("allowlist options", () => {
+    test("dynamic skill allowlist options use skill_load_dynamic: namespace", async () => {
+      ensureSkillsDir();
+      writeDynamicSkill("dynamic-opts", "Dynamic Opts Skill");
+
+      const options = await generateAllowlistOptions("skill_load", {
+        skill: "dynamic-opts",
+      });
+
+      expect(options.length).toBeGreaterThanOrEqual(1);
+      // All options should use skill_load_dynamic: prefix
+      for (const option of options) {
+        expect(option.pattern).toMatch(/^skill_load_dynamic:/);
+      }
+
+      // Should have an any-version option
+      const anyVersionOption = options.find(
+        (o) => o.pattern === "skill_load_dynamic:dynamic-opts",
+      );
+      expect(anyVersionOption).toBeDefined();
+      expect(anyVersionOption!.description).toBe("This skill (any version)");
+    });
+
+    test("plain skill allowlist options use skill_load: namespace", async () => {
+      ensureSkillsDir();
+      writePlainSkill("plain-opts", "Plain Opts Skill");
+
+      const options = await generateAllowlistOptions("skill_load", {
+        skill: "plain-opts",
+      });
+
+      expect(options.length).toBeGreaterThanOrEqual(1);
+      // Should use skill_load: prefix, not skill_load_dynamic:
+      for (const option of options) {
+        expect(option.pattern).toMatch(/^skill_load:/);
+        expect(option.pattern).not.toMatch(/^skill_load_dynamic:/);
+      }
+    });
+  });
+
+  // ── Default rule priority ────────────────────────────────────────────
+
+  describe("default rule priority", () => {
+    test("skill_load_dynamic:* ask rule has higher priority than skill_load:* allow rule", async () => {
+      const { getDefaultRuleTemplates } =
+        await import("../permissions/defaults.js");
+      const rules = getDefaultRuleTemplates();
+
+      const dynamicRule = rules.find(
+        (r) => r.id === "default:ask-skill_load_dynamic-global",
+      );
+      const loadRule = rules.find(
+        (r) => r.id === "default:allow-skill_load-global",
+      );
+
+      expect(dynamicRule).toBeDefined();
+      expect(loadRule).toBeDefined();
+      expect(dynamicRule!.priority).toBeGreaterThan(loadRule!.priority);
+      expect(dynamicRule!.decision).toBe("ask");
+      expect(dynamicRule!.pattern).toBe("skill_load_dynamic:*");
+      expect(dynamicRule!.tool).toBe("skill_load");
+    });
+  });
+});

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -2,12 +2,15 @@ import { createHash } from "node:crypto";
 import { homedir } from "node:os";
 import { dirname, resolve } from "node:path";
 
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
-import { resolveSkillSelector } from "../config/skills.js";
+import { loadSkillCatalog, resolveSkillSelector } from "../config/skills.js";
+import { indexCatalogById } from "../skills/include-graph.js";
 import {
   isSkillSourcePath,
   normalizeFilePath,
 } from "../skills/path-classifier.js";
+import { computeTransitiveSkillVersionHash } from "../skills/transitive-version-hash.js";
 import { computeSkillVersionHash } from "../skills/version-hash.js";
 import type { ManifestOverride } from "../tools/execution-target.js";
 import {
@@ -352,6 +355,34 @@ function resolveSkillIdAndHash(
   }
 }
 
+/**
+ * Check whether a skill (by id) has parsed inline command expansions.
+ * Returns false when the skill is not found in the catalog.
+ */
+function hasInlineExpansions(skillId: string): boolean {
+  const catalog = loadSkillCatalog();
+  const skill = catalog.find((s) => s.id === skillId);
+  return (
+    skill?.inlineCommandExpansions != null &&
+    skill.inlineCommandExpansions.length > 0
+  );
+}
+
+/**
+ * Compute the transitive version hash for a skill, returning `undefined`
+ * when computation fails (missing includes, cycle, etc.). The permission
+ * layer falls back to the any-version candidate in that case.
+ */
+function computeTransitiveHashSafe(skillId: string): string | undefined {
+  try {
+    const catalog = loadSkillCatalog();
+    const index = indexCatalogById(catalog);
+    return computeTransitiveSkillVersionHash(skillId, index);
+  } catch {
+    return undefined;
+  }
+}
+
 function canonicalizeWebFetchUrl(parsed: URL): URL {
   parsed.hash = "";
   parsed.username = "";
@@ -433,13 +464,39 @@ async function buildCommandCandidates(
       targets.push("");
     } else {
       const resolved = resolveSkillIdAndHash(rawSelector);
-      if (resolved && resolved.versionHash) {
-        // Version-specific candidate lets rules pin to an exact skill version
-        targets.push(`${resolved.id}@${resolved.versionHash}`);
+
+      // When the resolved skill contains inline command expansions and the
+      // feature flag is on, emit skill_load_dynamic: candidates so the
+      // higher-priority default ask rule catches them instead of falling
+      // through to the permissive skill_load:* allow rule.
+      const config = getConfig();
+      const inlineEnabled = isAssistantFeatureFlagEnabled(
+        "feature_flags.inline-skill-commands.enabled",
+        config,
+      );
+
+      if (resolved && inlineEnabled && hasInlineExpansions(resolved.id)) {
+        const transitiveHash = computeTransitiveHashSafe(resolved.id);
+        if (transitiveHash) {
+          targets.push(`skill_load_dynamic:${resolved.id}@${transitiveHash}`);
+        }
+        targets.push(`skill_load_dynamic:${resolved.id}`);
+        // Don't fall through to skill_load:* — dynamic skills use their own
+        // candidate namespace so the default ask rule applies.
+      } else {
+        if (resolved && resolved.versionHash) {
+          // Version-specific candidate lets rules pin to an exact skill version
+          targets.push(`${resolved.id}@${resolved.versionHash}`);
+        }
+        targets.push(rawSelector);
       }
-      targets.push(rawSelector);
     }
-    return [...new Set(targets)].map((target) => `${toolName}:${target}`);
+
+    // Dynamic candidates use skill_load_dynamic: prefix; normal ones use skill_load:
+    return [...new Set(targets)].map((target) => {
+      if (target.startsWith("skill_load_dynamic:")) return target;
+      return `${toolName}:${target}`;
+    });
   }
 
   if (
@@ -1084,6 +1141,32 @@ function skillLoadAllowlistStrategy(
 
   if (rawSelector) {
     const resolved = resolveSkillIdAndHash(rawSelector);
+
+    // Check whether this is a dynamic (inline-command) skill load
+    const config = getConfig();
+    const inlineEnabled = isAssistantFeatureFlagEnabled(
+      "feature_flags.inline-skill-commands.enabled",
+      config,
+    );
+
+    if (resolved && inlineEnabled && hasInlineExpansions(resolved.id)) {
+      const transitiveHash = computeTransitiveHashSafe(resolved.id);
+      const options: AllowlistOption[] = [];
+      if (transitiveHash) {
+        options.push({
+          label: `${resolved.id}@${transitiveHash}`,
+          description: "This exact version (pinned)",
+          pattern: `skill_load_dynamic:${resolved.id}@${transitiveHash}`,
+        });
+      }
+      options.push({
+        label: resolved.id,
+        description: "This skill (any version)",
+        pattern: `skill_load_dynamic:${resolved.id}`,
+      });
+      return options;
+    }
+
     if (resolved && resolved.versionHash) {
       return [
         {

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -198,6 +198,19 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     })),
   );
 
+  // Inline-command skill loads use a distinct candidate namespace
+  // (skill_load_dynamic:*) so they prompt by default instead of falling
+  // through to the permissive skill_load:* allow rule below. The higher
+  // priority ensures this rule wins when both could match.
+  const skillLoadDynamicRule: DefaultRuleTemplate = {
+    id: "default:ask-skill_load_dynamic-global",
+    tool: "skill_load",
+    pattern: "skill_load_dynamic:*",
+    scope: "everywhere",
+    decision: "ask",
+    priority: 200,
+  };
+
   const skillLoadRule: DefaultRuleTemplate = {
     id: "default:allow-skill_load-global",
     tool: "skill_load",
@@ -294,6 +307,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     bootstrapDeleteRule,
     updatesDeleteRule,
     ...skillSourceMutationRules,
+    skillLoadDynamicRule,
     skillLoadRule,
     skillExecuteRule,
     browserNavigateRule,

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -142,10 +142,17 @@ export class PermissionChecker {
         // is the owner - prompting makes no sense when there is no client.
         // Exception: requireFreshApproval tools cannot be auto-approved -
         // without a human present, bundle installation must be denied.
+        // Exception: inline-command skill loads (skill_load_dynamic:*) must
+        // never be silently auto-approved — they execute embedded commands
+        // and require explicit human review or a pinned trust rule.
+        const isDynamicSkillLoad =
+          result.matchedRule?.pattern.startsWith("skill_load_dynamic:") ===
+          true;
         if (
           context.isInteractive === false &&
           context.trustClass === "guardian" &&
-          !context.requireFreshApproval
+          !context.requireFreshApproval &&
+          !isDynamicSkillLoad
         ) {
           log.info(
             { toolName: name, riskLevel },


### PR DESCRIPTION
## Summary
- Extend skill_load permission candidates with skill_load_dynamic:<id>@<hash> for inline-command skills
- Add higher-priority default ask rule for skill_load_dynamic:* pattern
- Bypass non-interactive guardian auto-approve for dynamic skill loads

Part of plan: secure-skill-dynamic-context.md (PR 4 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
