### PR TITLE
feat: add sandbox-only runner for inline skill commands

### DIFF
--- a/assistant/src/__tests__/inline-command-runner.test.ts
+++ b/assistant/src/__tests__/inline-command-runner.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type { InlineCommandResult } from "../skills/inline-command-runner.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before the module under test is imported
+// ---------------------------------------------------------------------------
+
+const mockConfig = {
+  provider: "anthropic",
+  model: "test",
+  maxTokens: 4096,
+  dataDir: "/tmp",
+  sandbox: { enabled: true },
+  timeouts: {
+    shellDefaultTimeoutSec: 120,
+    shellMaxTimeoutSec: 600,
+    permissionTimeoutSec: 300,
+  },
+  rateLimit: { maxRequestsPerMinute: 0 },
+  secretDetection: {
+    enabled: true,
+    action: "warn" as const,
+    entropyThreshold: 4.0,
+  },
+  auditLog: { retentionDays: 0 },
+};
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+  invalidateConfigCache: () => {},
+  saveConfig: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Track wrapCommand calls to verify sandbox-only execution
+let lastWrapCall: {
+  command: string;
+  workingDir: string;
+  config: { enabled: boolean };
+  options?: { networkMode?: string };
+} | null = null;
+
+mock.module("../tools/terminal/sandbox.js", () => ({
+  wrapCommand: (
+    command: string,
+    workingDir: string,
+    config: { enabled: boolean },
+    options?: { networkMode?: string },
+  ) => {
+    lastWrapCall = { command, workingDir, config, options };
+    return {
+      command: "bash",
+      args: ["-c", "--", command],
+      sandboxed: false,
+    };
+  },
+}));
+
+mock.module("../tools/terminal/safe-env.js", () => ({
+  buildSanitizedEnv: () => ({
+    PATH: process.env.PATH ?? "/usr/bin:/bin",
+    HOME: process.env.HOME ?? "/tmp",
+  }),
+}));
+
+import { runInlineCommand } from "../skills/inline-command-runner.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CWD = process.cwd();
+
+function expectOk(result: InlineCommandResult): void {
+  expect(result.ok).toBe(true);
+  expect(result.failureReason).toBeUndefined();
+}
+
+function expectFailure(
+  result: InlineCommandResult,
+  reason: InlineCommandResult["failureReason"],
+): void {
+  expect(result.ok).toBe(false);
+  expect(result.failureReason).toBe(reason);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("runInlineCommand", () => {
+  // ── Sandbox enforcement ──────────────────────────────────────────────────
+
+  describe("sandbox enforcement", () => {
+    test("always passes sandbox config with enabled=true", async () => {
+      lastWrapCall = null;
+      await runInlineCommand("echo sandbox-check", CWD);
+
+      expect(lastWrapCall).not.toBeNull();
+      expect(lastWrapCall!.config.enabled).toBe(true);
+    });
+
+    test("always passes networkMode=off", async () => {
+      lastWrapCall = null;
+      await runInlineCommand("echo network-check", CWD);
+
+      expect(lastWrapCall).not.toBeNull();
+      expect(lastWrapCall!.options?.networkMode).toBe("off");
+    });
+
+    test("uses the provided workingDir as cwd", async () => {
+      lastWrapCall = null;
+      const customDir = "/tmp/my-project";
+      await runInlineCommand("echo cwd-check", customDir);
+
+      expect(lastWrapCall).not.toBeNull();
+      expect(lastWrapCall!.workingDir).toBe(customDir);
+    });
+
+    test("passes the literal command string to the sandbox", async () => {
+      lastWrapCall = null;
+      await runInlineCommand("git log --oneline -n 5", CWD);
+
+      expect(lastWrapCall).not.toBeNull();
+      expect(lastWrapCall!.command).toBe("git log --oneline -n 5");
+    });
+  });
+
+  // ── Successful execution ─────────────────────────────────────────────────
+
+  describe("successful execution", () => {
+    test("captures stdout from a simple echo", async () => {
+      const result = await runInlineCommand("echo hello-world", CWD);
+
+      expectOk(result);
+      expect(result.output).toBe("hello-world");
+    });
+
+    test("captures multi-line stdout", async () => {
+      const result = await runInlineCommand(
+        "printf 'line1\\nline2\\nline3'",
+        CWD,
+      );
+
+      expectOk(result);
+      expect(result.output).toContain("line1");
+      expect(result.output).toContain("line2");
+      expect(result.output).toContain("line3");
+    });
+
+    test("returns empty string for command with no output", async () => {
+      const result = await runInlineCommand("true", CWD);
+
+      expectOk(result);
+      expect(result.output).toBe("");
+    });
+  });
+
+  // ── ANSI stripping ──────────────────────────────────────────────────────
+
+  describe("ANSI stripping", () => {
+    test("strips SGR color codes from output", async () => {
+      const result = await runInlineCommand(
+        "printf '\\033[31mred\\033[0m normal'",
+        CWD,
+      );
+
+      expectOk(result);
+      expect(result.output).toBe("red normal");
+      expect(result.output).not.toContain("\x1b");
+    });
+
+    test("strips cursor movement sequences", async () => {
+      const result = await runInlineCommand("printf '\\033[2Ahello'", CWD);
+
+      expectOk(result);
+      expect(result.output).toBe("hello");
+    });
+  });
+
+  // ── Binary output rejection ──────────────────────────────────────────────
+
+  describe("binary output rejection", () => {
+    test("rejects binary-ish output", async () => {
+      // Generate output with >10% control characters
+      const result = await runInlineCommand(
+        "printf '\\x00\\x01\\x02\\x03\\x04\\x05\\x06\\x07abc'",
+        CWD,
+      );
+
+      expectFailure(result, "binary_output");
+      expect(result.output).toBe("Inline command produced binary output.");
+    });
+  });
+
+  // ── Output clamping ──────────────────────────────────────────────────────
+
+  describe("output clamping", () => {
+    test("truncates output exceeding the cap", async () => {
+      // Generate output larger than a small cap
+      const result = await runInlineCommand("printf '%0.s-' {1..200}", CWD, {
+        maxOutputChars: 50,
+      });
+
+      expectOk(result);
+      expect(result.output.length).toBeLessThanOrEqual(
+        50 + "\n[output truncated]".length,
+      );
+      expect(result.output).toContain("[output truncated]");
+    });
+
+    test("does not truncate output under the cap", async () => {
+      const result = await runInlineCommand("echo short", CWD, {
+        maxOutputChars: 1000,
+      });
+
+      expectOk(result);
+      expect(result.output).toBe("short");
+      expect(result.output).not.toContain("[output truncated]");
+    });
+  });
+
+  // ── Timeout handling ─────────────────────────────────────────────────────
+
+  describe("timeout handling", () => {
+    test("produces deterministic timeout result", async () => {
+      const result = await runInlineCommand("sleep 60", CWD, {
+        timeoutMs: 200,
+      });
+
+      expectFailure(result, "timeout");
+      expect(result.output).toBe("Inline command timed out after 200ms.");
+    });
+  });
+
+  // ── Non-zero exit ────────────────────────────────────────────────────────
+
+  describe("non-zero exit", () => {
+    test("produces deterministic failure for exit code 1", async () => {
+      const result = await runInlineCommand("exit 1", CWD);
+
+      expectFailure(result, "non_zero_exit");
+      expect(result.output).toBe("Inline command failed (exit code 1).");
+    });
+
+    test("produces deterministic failure for exit code 127", async () => {
+      const result = await runInlineCommand(
+        "nonexistent_command_that_does_not_exist_xyz",
+        CWD,
+      );
+
+      expectFailure(result, "non_zero_exit");
+      expect(result.output).toMatch(
+        /Inline command failed \(exit code \d+\)\./,
+      );
+    });
+
+    test("does not expose stderr in the error result", async () => {
+      const result = await runInlineCommand("echo err-msg >&2 && exit 1", CWD);
+
+      expectFailure(result, "non_zero_exit");
+      expect(result.output).not.toContain("err-msg");
+      expect(result.output).toBe("Inline command failed (exit code 1).");
+    });
+  });
+
+  // ── Spawn failures ───────────────────────────────────────────────────────
+
+  describe("spawn failures", () => {
+    test("returns spawn_failure when cwd does not exist", async () => {
+      // When the working directory doesn't exist, the child process fails to
+      // start (ENOENT from posix_spawn). The runner should catch this and
+      // return a deterministic spawn_failure result.
+      const result = await runInlineCommand(
+        "echo hello",
+        "/nonexistent/path/that/does/not/exist",
+      );
+
+      expectFailure(result, "spawn_failure");
+      expect(result.output).toBe("Inline command could not be started.");
+    });
+  });
+
+  // ── stderr suppression ─────────────────────────────────────────────────
+
+  describe("stderr suppression", () => {
+    test("does not include stderr in successful output", async () => {
+      const result = await runInlineCommand(
+        "echo stdout-only && echo stderr-msg >&2",
+        CWD,
+      );
+
+      // Command may succeed (exit 0) — stderr should not leak into output
+      expectOk(result);
+      expect(result.output).toBe("stdout-only");
+      expect(result.output).not.toContain("stderr-msg");
+    });
+  });
+});

--- a/assistant/src/skills/inline-command-runner.ts
+++ b/assistant/src/skills/inline-command-runner.ts
@@ -1,0 +1,239 @@
+/**
+ * Sandbox-only runner for inline command expansions (`!\`command\``).
+ *
+ * Executes the literal command string in the sandbox without going through the
+ * general `bash` tool's permission path. Security constraints:
+ *
+ * - Network mode forced off (no outbound connections)
+ * - Sanitized environment variables only (no API keys, tokens, credentials)
+ * - No credential proxy, no CES client, no host fallback
+ * - Uses the conversation working directory as `cwd` so repo-local commands
+ *   remain interoperable with externally authored skills that expect project
+ *   context.
+ *
+ * Output handling:
+ * - Captures stdout only (stderr is discarded)
+ * - Strips ANSI escape sequences
+ * - Rejects binary-ish output
+ * - Clamps output to a fixed cap
+ * - Returns deterministic sanitized error results for timeout, non-zero exit,
+ *   or spawn failures (no raw stderr dumps)
+ */
+
+import { spawn } from "node:child_process";
+
+import { getConfig } from "../config/loader.js";
+import { buildSanitizedEnv } from "../tools/terminal/safe-env.js";
+import { wrapCommand } from "../tools/terminal/sandbox.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("inline-command-runner");
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/** Maximum wall-clock time for an inline command before it is killed. */
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/** Maximum output characters before truncation. */
+const MAX_OUTPUT_CHARS = 20_000;
+
+/**
+ * ANSI escape sequence pattern (covers SGR, cursor movement, erase, etc.).
+ * Matches: ESC[ ... final_byte  and  ESC] ... ST  (OSC sequences).
+ */
+const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*(?:\x07|\x1b\\)/g;
+
+/**
+ * Heuristic for binary output: if more than 10% of the characters are
+ * non-printable (control chars excluding \t, \n, \r) then reject.
+ */
+const BINARY_THRESHOLD = 0.1;
+
+// ─── Result type ─────────────────────────────────────────────────────────────
+
+/** Deterministic result shape returned by the inline command runner. */
+export interface InlineCommandResult {
+  /** The sanitized stdout output, or a human-readable error description. */
+  output: string;
+  /** Whether the command completed successfully. */
+  ok: boolean;
+  /**
+   * Machine-readable failure reason.
+   * - `"timeout"` — command exceeded the wall-clock limit
+   * - `"non_zero_exit"` — command exited with a non-zero code
+   * - `"binary_output"` — stdout contained binary-ish data
+   * - `"spawn_failure"` — the subprocess could not be spawned
+   * - `undefined` — success
+   */
+  failureReason?:
+    | "timeout"
+    | "non_zero_exit"
+    | "binary_output"
+    | "spawn_failure";
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+export interface InlineCommandRunnerOptions {
+  /** Override the default timeout (ms). */
+  timeoutMs?: number;
+  /** Override the default output cap (chars). */
+  maxOutputChars?: number;
+}
+
+/**
+ * Run an inline command expansion in the sandbox.
+ *
+ * @param command  The literal command string from the `!\`...\`` token.
+ * @param workingDir  The conversation's working directory (repo root).
+ * @param options  Optional overrides for timeout and output cap.
+ */
+export async function runInlineCommand(
+  command: string,
+  workingDir: string,
+  options?: InlineCommandRunnerOptions,
+): Promise<InlineCommandResult> {
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxChars = options?.maxOutputChars ?? MAX_OUTPUT_CHARS;
+
+  // Build sandbox-wrapped command. Always use the sandbox config with
+  // network forced off — inline commands never need network access.
+  const config = getConfig();
+  const sandboxConfig = { ...config.sandbox, enabled: true };
+
+  const wrapped = wrapCommand(command, workingDir, sandboxConfig, {
+    networkMode: "off",
+  });
+
+  // Build a minimal, sanitized environment. Explicitly exclude gateway URL
+  // and workspace dir since inline commands have no business calling internal
+  // APIs or mutating workspace state.
+  const env = buildSanitizedEnv();
+
+  return new Promise<InlineCommandResult>((resolve) => {
+    let timedOut = false;
+    const stdoutChunks: Buffer[] = [];
+
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(wrapped.command, wrapped.args, {
+        cwd: workingDir,
+        env,
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn({ command, error: message }, "Failed to spawn inline command");
+      resolve({
+        output: "Inline command could not be started.",
+        ok: false,
+        failureReason: "spawn_failure",
+      });
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
+
+    child.stdout!.on("data", (data: Buffer) => stdoutChunks.push(data));
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+
+      // ── Timeout ──────────────────────────────────────────────────────
+      if (timedOut) {
+        log.debug({ command, timeoutMs }, "Inline command timed out");
+        resolve({
+          output: `Inline command timed out after ${timeoutMs}ms.`,
+          ok: false,
+          failureReason: "timeout",
+        });
+        return;
+      }
+
+      // ── Non-zero exit ────────────────────────────────────────────────
+      if (code !== 0) {
+        log.debug(
+          { command, exitCode: code },
+          "Inline command exited with non-zero code",
+        );
+        resolve({
+          output: `Inline command failed (exit code ${code}).`,
+          ok: false,
+          failureReason: "non_zero_exit",
+        });
+        return;
+      }
+
+      // ── Process stdout ───────────────────────────────────────────────
+      const raw = Buffer.concat(stdoutChunks).toString("utf-8");
+
+      // Strip ANSI sequences first — these are terminal artifacts, not
+      // binary data. Stripping before the binary check prevents legitimate
+      // color-coded tool output from being rejected.
+      let cleaned = raw.replace(ANSI_RE, "");
+
+      // Reject binary-ish output (after ANSI stripping)
+      if (isBinaryish(cleaned)) {
+        log.debug({ command }, "Inline command produced binary-ish output");
+        resolve({
+          output: "Inline command produced binary output.",
+          ok: false,
+          failureReason: "binary_output",
+        });
+        return;
+      }
+
+      // Clamp to max output
+      if (cleaned.length > maxChars) {
+        cleaned = cleaned.slice(0, maxChars) + "\n[output truncated]";
+      }
+
+      // Trim trailing whitespace
+      cleaned = cleaned.trimEnd();
+
+      resolve({
+        output: cleaned,
+        ok: true,
+      });
+    });
+
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      log.warn({ command, error: err.message }, "Inline command spawn error");
+      resolve({
+        output: "Inline command could not be started.",
+        ok: false,
+        failureReason: "spawn_failure",
+      });
+    });
+  });
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Heuristic check for binary output. Returns true if more than
+ * {@link BINARY_THRESHOLD} of the characters are non-printable control
+ * characters (excluding tab, newline, carriage return).
+ */
+function isBinaryish(text: string): boolean {
+  if (text.length === 0) return false;
+
+  let controlCount = 0;
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    // Control characters: 0x00-0x1F (excluding \t=0x09, \n=0x0A, \r=0x0D)
+    // and 0x7F (DEL)
+    if (
+      (code <= 0x1f && code !== 0x09 && code !== 0x0a && code !== 0x0d) ||
+      code === 0x7f
+    ) {
+      controlCount++;
+    }
+  }
+
+  return controlCount / text.length > BINARY_THRESHOLD;
+}


### PR DESCRIPTION
## Summary
- Add dedicated runner for inline command expansions that always executes in sandbox
- Network forced off, sanitized env, no credential proxy or host fallback
- Deterministic error results for timeout, non-zero exit, oversized/binary output

Part of plan: secure-skill-dynamic-context.md (PR 5 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
