### PR TITLE
M1: Shared code — warning colors to systemMidStrong (LUM-297)

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VToast.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VToast.swift
@@ -138,7 +138,7 @@ public struct VToast: View {
     private var accentBorder: Color {
         switch style {
         case .error: return VColor.systemNegativeStrong.opacity(0.4)
-        case .warning: return VColor.systemNegativeHover.opacity(0.4)
+        case .warning: return VColor.systemMidStrong.opacity(0.4)
         default: return VColor.borderBase
         }
     }
@@ -156,7 +156,7 @@ public struct VToast: View {
         switch style {
         case .info: return VColor.primaryBase
         case .success: return VColor.systemPositiveStrong
-        case .warning: return VColor.systemNegativeHover
+        case .warning: return VColor.systemMidStrong
         case .error: return VColor.systemNegativeStrong
         }
     }

--- a/clients/shared/Features/Chat/ChatErrorBanner.swift
+++ b/clients/shared/Features/Chat/ChatErrorBanner.swift
@@ -13,7 +13,7 @@ public struct ChatErrorBanner: View {
     public var body: some View {
         HStack(spacing: 8) {
             VIconView(.triangleAlert, size: 14)
-                .foregroundStyle(VColor.systemNegativeHover)
+                .foregroundStyle(VColor.systemMidStrong)
             Text(message)
                 .font(.footnote)
                 .foregroundStyle(VColor.contentDefault)

--- a/clients/shared/Features/Chat/ChatErrorBanner.swift
+++ b/clients/shared/Features/Chat/ChatErrorBanner.swift
@@ -13,7 +13,7 @@ public struct ChatErrorBanner: View {
     public var body: some View {
         HStack(spacing: 8) {
             VIconView(.triangleAlert, size: 14)
-                .foregroundStyle(VColor.systemMidStrong)
+                .foregroundStyle(VColor.systemNegativeHover)
             Text(message)
                 .font(.footnote)
                 .foregroundStyle(VColor.contentDefault)

--- a/clients/shared/Features/Chat/GuardianDecisionBubble.swift
+++ b/clients/shared/Features/Chat/GuardianDecisionBubble.swift
@@ -27,11 +27,11 @@ public struct GuardianDecisionBubble: View {
         case "pending_question":
             return (.circleAlert, "Question Pending", VColor.primaryBase)
         case "access_request":
-            return (.circleUser, "Access Request", VColor.systemNegativeHover)
+            return (.circleUser, "Access Request", VColor.systemMidStrong)
         case "tool_approval":
-            return (.shieldAlert, "Tool Approval Required", VColor.systemNegativeHover)
+            return (.shieldAlert, "Tool Approval Required", VColor.systemMidStrong)
         default:
-            return (.shieldAlert, "Guardian Approval Required", VColor.systemNegativeHover)
+            return (.shieldAlert, "Guardian Approval Required", VColor.systemMidStrong)
         }
     }
 

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -140,7 +140,7 @@ public struct InlineTableWidget: View {
     private func resolveIconColor(_ token: String?) -> Color {
         switch token {
         case "success": return VColor.systemPositiveStrong
-        case "warning": return VColor.systemNegativeHover
+        case "warning": return VColor.systemMidStrong
         case "error": return VColor.systemNegativeStrong
         case "muted": return VColor.contentTertiary
         default: return VColor.contentDefault

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTaskProgressWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTaskProgressWidget.swift
@@ -152,10 +152,10 @@ public struct InlineTaskProgressWidget: View {
         case "in_progress":
             ProgressView()
                 .controlSize(.small)
-                .tint(VColor.systemNegativeHover)
+                .tint(VColor.systemMidStrong)
         case "waiting":
             VIconView(.clock, size: 14)
-                .foregroundColor(VColor.systemNegativeHover)
+                .foregroundColor(VColor.systemMidStrong)
         case "failed":
             VIconView(.circleX, size: 14)
                 .foregroundColor(VColor.systemNegativeStrong)
@@ -170,9 +170,9 @@ public struct InlineTaskProgressWidget: View {
         case "completed":
             return ("Completed", .circleCheck, VColor.systemPositiveStrong)
         case "in_progress":
-            return ("In Progress", .refreshCw, VColor.systemNegativeHover)
+            return ("In Progress", .refreshCw, VColor.systemMidStrong)
         case "waiting":
-            return ("Waiting", .clock, VColor.systemNegativeHover)
+            return ("Waiting", .clock, VColor.systemMidStrong)
         case "failed":
             return ("Failed", .circleX, VColor.systemNegativeStrong)
         default:

--- a/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
@@ -70,7 +70,7 @@ public struct ConfirmationSurfaceView: View {
             // Header with icon
             HStack(alignment: .top, spacing: VSpacing.md) {
                 VIconView(.triangleAlert, size: 24)
-                    .foregroundStyle(data.destructive ? VColor.systemNegativeStrong : VColor.systemNegativeHover)
+                    .foregroundStyle(data.destructive ? VColor.systemNegativeStrong : VColor.systemMidStrong)
                 Text(inlineMarkdown(data.message))
                     .font(VFont.headline)
                     .foregroundColor(VColor.contentDefault)


### PR DESCRIPTION
Change systemNegativeHover to systemMidStrong for all warning usages in shared code (VToast, InlineTableWidget, InlineTaskProgressWidget, GuardianDecisionBubble, ConfirmationSurfaceView, ChatErrorBanner). Error usages remain unchanged. Part of #19613.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
