### PR TITLE
fix: align AssistantProgressView logging test with main actor isolation

### DIFF
--- a/clients/macos/vellum-assistantTests/AssistantProgressViewLoggingTests.swift
+++ b/clients/macos/vellum-assistantTests/AssistantProgressViewLoggingTests.swift
@@ -35,6 +35,7 @@ struct AssistantProgressViewLoggingTests {
     ///
     /// This mirrors the exact recording logic in AssistantProgressView.onAppear
     /// so that test assertions stay tightly coupled to production behavior.
+    @MainActor
     private static func simulateOnAppearAutoExpand(
         store: ChatDiagnosticsStore,
         toolCalls: [ToolCallData],


### PR DESCRIPTION
## Summary
- annotate the AssistantProgressView logging helper with @MainActor to match ChatDiagnosticsStore isolation
- fix the macOS CI compile failure in AssistantProgressViewLoggingTests without changing production behavior

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23308183969/job/67788083994
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
