### PR TITLE
M2: Platform-specific — warning colors to systemMidStrong (LUM-297)

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -662,10 +662,10 @@ struct ChatContentView: View {
 
     private func conversationErrorAccent(_ category: ConversationErrorCategory) -> Color {
         switch category {
-        case .rateLimit: return VColor.systemMidStrong
+        case .rateLimit: return VColor.systemNegativeHover
         case .providerNetwork: return .orange
         case .conversationAborted: return VColor.contentSecondary
-        case .contextTooLarge: return VColor.systemMidStrong
+        case .contextTooLarge: return VColor.systemNegativeHover
         default: return VColor.systemNegativeStrong
         }
     }

--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -662,10 +662,10 @@ struct ChatContentView: View {
 
     private func conversationErrorAccent(_ category: ConversationErrorCategory) -> Color {
         switch category {
-        case .rateLimit: return VColor.systemNegativeHover
+        case .rateLimit: return VColor.systemMidStrong
         case .providerNetwork: return .orange
         case .conversationAborted: return VColor.contentSecondary
-        case .contextTooLarge: return VColor.systemNegativeHover
+        case .contextTooLarge: return VColor.systemMidStrong
         default: return VColor.systemNegativeStrong
         }
     }

--- a/clients/ios/Views/ConversationListView.swift
+++ b/clients/ios/Views/ConversationListView.swift
@@ -464,7 +464,7 @@ struct ConversationListView: View {
                         } label: {
                             Label { Text("Archive") } icon: { VIconView(.archive, size: 14) }
                         }
-                        .tint(VColor.systemMidStrong)
+                        .tint(VColor.systemNegativeHover)
                     }
                     .swipeActions(edge: .leading) {
                         Button {
@@ -594,7 +594,7 @@ struct ConversationListView: View {
                     } label: {
                         Label { Text("Archive") } icon: { VIconView(.archive, size: 14) }
                     }
-                    .tint(VColor.systemMidStrong)
+                    .tint(VColor.systemNegativeHover)
                 }
                 .swipeActions(edge: .leading) {
                     Button {
@@ -629,7 +629,7 @@ struct ConversationListView: View {
                             } label: {
                                 Label { Text("Archive") } icon: { VIconView(.archive, size: 14) }
                             }
-                            .tint(VColor.systemMidStrong)
+                            .tint(VColor.systemNegativeHover)
                         }
                         .swipeActions(edge: .leading) {
                             Button {

--- a/clients/ios/Views/ConversationListView.swift
+++ b/clients/ios/Views/ConversationListView.swift
@@ -464,7 +464,7 @@ struct ConversationListView: View {
                         } label: {
                             Label { Text("Archive") } icon: { VIconView(.archive, size: 14) }
                         }
-                        .tint(VColor.systemNegativeHover)
+                        .tint(VColor.systemMidStrong)
                     }
                     .swipeActions(edge: .leading) {
                         Button {
@@ -594,7 +594,7 @@ struct ConversationListView: View {
                     } label: {
                         Label { Text("Archive") } icon: { VIconView(.archive, size: 14) }
                     }
-                    .tint(VColor.systemNegativeHover)
+                    .tint(VColor.systemMidStrong)
                 }
                 .swipeActions(edge: .leading) {
                     Button {
@@ -629,7 +629,7 @@ struct ConversationListView: View {
                             } label: {
                                 Label { Text("Archive") } icon: { VIconView(.archive, size: 14) }
                             }
-                            .tint(VColor.systemNegativeHover)
+                            .tint(VColor.systemMidStrong)
                         }
                         .swipeActions(edge: .leading) {
                             Button {
@@ -655,7 +655,7 @@ struct ConversationListView: View {
                                 .accessibilityLabel("Pinned")
                         }
                         if scheduleGroupHasUnread(group) {
-                            VBadge(style: .dot, color: VColor.systemNegativeHover)
+                            VBadge(style: .dot, color: VColor.systemMidStrong)
                                 .accessibilityLabel("Unread")
                         }
                         Text("\(group.conversations.count)")
@@ -695,7 +695,7 @@ struct ConversationListView: View {
                         .accessibilityLabel("Pinned")
                 }
                 if store.isConnectedMode && conversation.hasUnseenLatestAssistantMessage {
-                    VBadge(style: .dot, color: VColor.systemNegativeHover)
+                    VBadge(style: .dot, color: VColor.systemMidStrong)
                         .accessibilityLabel("Unread")
                 }
                 Spacer()

--- a/clients/ios/Views/DebugPanelView.swift
+++ b/clients/ios/Views/DebugPanelView.swift
@@ -307,7 +307,7 @@ struct TraceTimelineIOSView: View {
                 if groupStatus == .cancelled {
                     Text("Cancelled")
                         .font(VFont.small)
-                        .foregroundColor(VColor.systemNegativeHover)
+                        .foregroundColor(VColor.systemMidStrong)
                 } else if groupStatus == .handedOff {
                     Text("Handed off")
                         .font(VFont.small)
@@ -343,7 +343,7 @@ struct TraceTimelineIOSView: View {
         switch status {
         case .active: return VColor.systemPositiveStrong
         case .completed: return VColor.systemPositiveStrong
-        case .cancelled: return VColor.systemNegativeHover
+        case .cancelled: return VColor.systemMidStrong
         case .handedOff: return VColor.systemPositiveWeak
         case .error: return VColor.systemNegativeStrong
         }
@@ -452,7 +452,7 @@ struct TraceTimelineIOSView: View {
     private func statusColor(for status: String?) -> Color {
         switch status {
         case "error": return VColor.systemNegativeStrong
-        case "warning": return VColor.systemNegativeHover
+        case "warning": return VColor.systemMidStrong
         case "success": return VColor.systemPositiveStrong
         default: return VColor.contentTertiary
         }

--- a/clients/ios/Views/Settings/ChannelsGuardianSection.swift
+++ b/clients/ios/Views/Settings/ChannelsGuardianSection.swift
@@ -156,7 +156,7 @@ struct ChannelsGuardianSection: View {
             switch policy {
             case "allow": return (VColor.systemPositiveStrong, "Allow")
             case "deny": return (VColor.systemNegativeStrong, "Deny")
-            case "escalate": return (VColor.systemNegativeHover, "Escalate")
+            case "escalate": return (VColor.systemMidStrong, "Escalate")
             default: return (VColor.contentTertiary, policy.capitalized)
             }
         }()
@@ -176,7 +176,7 @@ struct ChannelsGuardianSection: View {
             switch status {
             case "active": return (VColor.systemPositiveStrong, "Active")
             case "revoked": return (VColor.systemNegativeStrong, "Revoked")
-            case "pending": return (VColor.systemNegativeHover, "Pending")
+            case "pending": return (VColor.systemMidStrong, "Pending")
             default: return (VColor.contentTertiary, status.capitalized)
             }
         }()

--- a/clients/ios/Views/Settings/PrivacySection.swift
+++ b/clients/ios/Views/Settings/PrivacySection.swift
@@ -70,7 +70,7 @@ struct PrivacySection: View {
             switch status {
             case .granted: return (VColor.systemPositiveStrong, "Granted")
             case .denied: return (VColor.systemNegativeStrong, "Denied")
-            case .notDetermined: return (VColor.systemNegativeHover, "Not Set")
+            case .notDetermined: return (VColor.systemMidStrong, "Not Set")
             }
         }()
         Text(label)

--- a/clients/ios/Views/Settings/RemindersSection.swift
+++ b/clients/ios/Views/Settings/RemindersSection.swift
@@ -71,7 +71,7 @@ struct RemindersSection: View {
     private func statusBadge(_ status: String) -> some View {
         let (color, label): (Color, String) = {
             switch status {
-            case "active": return (VColor.systemNegativeHover, "Active")
+            case "active": return (VColor.systemMidStrong, "Active")
             case "fired": return (VColor.systemPositiveStrong, "Fired")
             case "cancelled": return (VColor.contentTertiary, "Cancelled")
             default: return (VColor.contentSecondary, status.capitalized)

--- a/clients/ios/Views/Settings/TrustRulesSection.swift
+++ b/clients/ios/Views/Settings/TrustRulesSection.swift
@@ -95,7 +95,7 @@ struct TrustRulesSection: View {
             switch decision {
             case "allow": return (VColor.systemPositiveStrong, "Allow")
             case "deny": return (VColor.systemNegativeStrong, "Deny")
-            default: return (VColor.systemNegativeHover, "Ask")
+            default: return (VColor.systemMidStrong, "Ask")
             }
         }()
         Text(label)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -32,7 +32,7 @@ extension MainWindowView {
     func interactionDotColor(for conversation: ConversationModel) -> Color? {
         switch conversationManager.interactionState(for: conversation.id) {
         case .processing: return VColor.primaryBase
-        case .waitingForInput: return VColor.systemNegativeHover
+        case .waitingForInput: return VColor.systemMidStrong
         case .error: return VColor.systemNegativeStrong
         case .idle: return nil
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
@@ -150,7 +150,7 @@ struct DebugPanel: View {
                             : memoryDegraded ? "Degraded"
                             : "Healthy",
                         color: !memory.enabled ? VColor.contentTertiary
-                            : memoryDegraded ? VColor.systemNegativeHover
+                            : memoryDegraded ? VColor.systemMidStrong
                             : VColor.systemPositiveStrong
                     )
                     if let provider = memory.provider {
@@ -165,7 +165,7 @@ struct DebugPanel: View {
                             icon: "exclamationmark.triangle",
                             label: "Degradation Reason",
                             value: reason,
-                            color: VColor.systemNegativeHover
+                            color: VColor.systemMidStrong
                         )
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -393,7 +393,7 @@ struct GeneratedPanel: View {
             case "signed":
                 return (.badgeCheck, VColor.contentSecondary)
             case "unsigned":
-                return (.triangleAlert, VColor.systemNegativeHover)
+                return (.triangleAlert, VColor.systemMidStrong)
             case "tampered":
                 return (.badgeX, VColor.systemNegativeStrong)
             default:

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceRowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceRowView.swift
@@ -75,7 +75,7 @@ struct TraceRowView: View {
         case "error":
             return VColor.systemNegativeStrong
         case "warning":
-            return VColor.systemNegativeHover
+            return VColor.systemMidStrong
         case "success":
             return VColor.systemPositiveStrong
         default:

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TraceTimelineView.swift
@@ -112,7 +112,7 @@ struct TraceTimelineView: View {
                 if groupStatus == .cancelled {
                     Text("Cancelled")
                         .font(VFont.small)
-                        .foregroundColor(VColor.systemNegativeHover)
+                        .foregroundColor(VColor.systemMidStrong)
                         .textSelection(.enabled)
                 } else if groupStatus == .handedOff {
                     Text("Handed off")
@@ -151,7 +151,7 @@ struct TraceTimelineView: View {
         switch status {
         case .active: return VColor.systemPositiveStrong
         case .completed: return VColor.systemPositiveStrong
-        case .cancelled: return VColor.systemNegativeHover
+        case .cancelled: return VColor.systemMidStrong
         case .handedOff: return VColor.systemPositiveWeak
         case .error: return VColor.systemNegativeStrong
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -75,7 +75,7 @@ struct SidebarConversationItem: View {
                             .accessibilityLabel("Processing")
                     case .waitingForInput:
                         VIconView(.circleAlert, size: 12)
-                            .foregroundColor(VColor.systemNegativeHover)
+                            .foregroundColor(VColor.systemMidStrong)
                             .frame(width: 20, height: 20)
                             .nativeTooltip("Waiting for input")
                             .accessibilityLabel("Waiting for input")
@@ -88,7 +88,7 @@ struct SidebarConversationItem: View {
                             .transition(.opacity)
                     case .idle:
                         if conversation.hasUnseenLatestAssistantMessage {
-                            VBadge(style: .dot, color: VColor.systemNegativeHover)
+                            VBadge(style: .dot, color: VColor.systemMidStrong)
                                 .accessibilityLabel("Unread")
                                 .frame(width: 20, height: 20)
                                 .nativeTooltip("Unread")

--- a/clients/macos/vellum-assistant/Features/Session/SessionOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/SessionOverlayWindow.swift
@@ -172,7 +172,7 @@ final class SessionOverlayWindow {
             return buildRunningView(step: step, maxSteps: maxSteps, lastAction: lastAction, reasoning: reasoning)
 
         case .paused(let step, let maxSteps):
-            return makeLabel("Paused at step \(step)/\(maxSteps)", font: .systemFont(ofSize: 11), color: NSColor(VColor.systemNegativeHover))
+            return makeLabel("Paused at step \(step)/\(maxSteps)", font: .systemFont(ofSize: 11), color: NSColor(VColor.systemMidStrong))
 
         case .awaitingConfirmation(let reason):
             return buildConfirmationView(reason: reason)
@@ -187,7 +187,7 @@ final class SessionOverlayWindow {
             return buildFailedView(reason: reason)
 
         case .cancelled:
-            return makeLabel("Cancelled", font: .boldSystemFont(ofSize: 11), color: NSColor(VColor.systemNegativeHover))
+            return makeLabel("Cancelled", font: .boldSystemFont(ofSize: 11), color: NSColor(VColor.systemMidStrong))
         }
     }
 
@@ -288,7 +288,7 @@ final class SessionOverlayWindow {
         let warningIcon = NSImageView()
         if let img = VIcon.triangleAlert.nsImage(size: 14) {
             warningIcon.image = img
-            warningIcon.contentTintColor = NSColor(VColor.systemNegativeHover)
+            warningIcon.contentTintColor = NSColor(VColor.systemMidStrong)
         }
         warningIcon.widthAnchor.constraint(equalToConstant: 14).isActive = true
         warningIcon.heightAnchor.constraint(equalToConstant: 14).isActive = true

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -313,7 +313,7 @@ struct ToolPermissionTesterView: View {
             switch decision.lowercased() {
             case "allow": return (VColor.systemPositiveStrong, .circleCheck)
             case "deny": return (VColor.systemNegativeStrong, .circleX)
-            case "prompt": return (VColor.systemNegativeHover, .info)
+            case "prompt": return (VColor.systemMidStrong, .info)
             default: return (VColor.contentTertiary, .circle)
             }
         }()
@@ -330,7 +330,7 @@ struct ToolPermissionTesterView: View {
     private func riskColor(_ level: String) -> Color {
         switch level.lowercased() {
         case "low": return VColor.contentTertiary
-        case "medium": return VColor.systemNegativeHover
+        case "medium": return VColor.systemMidStrong
         case "high": return VColor.systemNegativeStrong
         default: return VColor.contentTertiary
         }

--- a/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
@@ -131,7 +131,7 @@ private struct TrustRuleRow: View {
     private func decisionColor(_ decision: String) -> Color {
         switch decision {
         case "allow": return VColor.systemPositiveStrong
-        case "ask": return VColor.systemNegativeHover
+        case "ask": return VColor.systemMidStrong
         default: return VColor.systemNegativeStrong
         }
     }

--- a/clients/macos/vellum-assistant/Features/Terminal/SSHTerminalWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Terminal/SSHTerminalWindow.swift
@@ -136,7 +136,7 @@ private struct SSHTerminalContentView: View {
         case .idle, .closed:
             return VColor.contentTertiary
         case .connecting, .reconnecting:
-            return VColor.systemNegativeHover
+            return VColor.systemMidStrong
         case .connected:
             return VColor.systemPositiveStrong
         case .error:


### PR DESCRIPTION
## Summary
- Change `systemNegativeHover` to `systemMidStrong` for all warning/caution/pending usages in macOS and iOS platform-specific code
- Error usages (`systemNegativeStrong`) remain unchanged
- Covers 15 files across both platforms

## Test plan
- [ ] Verify warning indicators in trace views (macOS + iOS) display with the new `systemMidStrong` color
- [ ] Verify cancelled status badges use `systemMidStrong` instead of `systemNegativeHover`
- [ ] Verify error indicators still use `systemNegativeStrong` (unchanged)
- [ ] Check archive swipe actions, unread badges, permission badges, and settings status indicators on iOS

Part of #19613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19622" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
