### PR TITLE
feat: add simplified memory brief state tables

### DIFF
--- a/assistant/src/__tests__/db-memory-brief-state-migration.test.ts
+++ b/assistant/src/__tests__/db-memory-brief-state-migration.test.ts
@@ -1,0 +1,213 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+const testDir = mkdtempSync(join(tmpdir(), "memory-brief-state-"));
+const dbPath = join(testDir, "test.db");
+const originalBunTest = process.env.BUN_TEST;
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => dbPath,
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { initializeDb, resetDb } from "../memory/db.js";
+import { getSqliteFrom } from "../memory/db-connection.js";
+import { migrateMemoryBriefState } from "../memory/migrations/185-memory-brief-state.js";
+import * as schema from "../memory/schema.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}
+
+function hasTable(raw: Database, tableName: string): boolean {
+  const row = raw
+    .query(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?`)
+    .get(tableName);
+  return row != null;
+}
+
+function hasIndex(raw: Database, indexName: string): boolean {
+  const row = raw
+    .query(`SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?`)
+    .get(indexName);
+  return row != null;
+}
+
+function getColumnNames(raw: Database, tableName: string): string[] {
+  return (
+    raw.query(`PRAGMA table_info(${tableName})`).all() as Array<{
+      name: string;
+    }>
+  ).map((column) => column.name);
+}
+
+function removeTestDbFiles(): void {
+  rmSync(dbPath, { force: true });
+  rmSync(`${dbPath}-shm`, { force: true });
+  rmSync(`${dbPath}-wal`, { force: true });
+}
+
+describe("memory brief state migration", () => {
+  beforeEach(() => {
+    process.env.BUN_TEST = "0";
+    resetDb();
+    removeTestDbFiles();
+  });
+
+  afterEach(() => {
+    resetDb();
+    removeTestDbFiles();
+  });
+
+  afterAll(() => {
+    if (originalBunTest === undefined) {
+      delete process.env.BUN_TEST;
+    } else {
+      process.env.BUN_TEST = originalBunTest;
+    }
+    resetDb();
+    removeTestDbFiles();
+    try {
+      rmSync(testDir, { recursive: true });
+    } catch {
+      /* best effort */
+    }
+  });
+
+  test("fresh DB initialization creates both tables and their indexes", () => {
+    initializeDb();
+
+    const raw = new Database(dbPath);
+
+    // time_contexts table
+    expect(hasTable(raw, "time_contexts")).toBe(true);
+    expect(getColumnNames(raw, "time_contexts")).toEqual([
+      "id",
+      "scope_id",
+      "summary",
+      "source",
+      "active_from",
+      "active_until",
+      "created_at",
+      "updated_at",
+    ]);
+    expect(hasIndex(raw, "idx_time_contexts_scope_active_until")).toBe(true);
+
+    // open_loops table
+    expect(hasTable(raw, "open_loops")).toBe(true);
+    expect(getColumnNames(raw, "open_loops")).toEqual([
+      "id",
+      "scope_id",
+      "summary",
+      "status",
+      "source",
+      "due_at",
+      "surfaced_at",
+      "created_at",
+      "updated_at",
+    ]);
+    expect(hasIndex(raw, "idx_open_loops_scope_status_due")).toBe(true);
+
+    raw.close();
+  });
+
+  test("migration on an empty DB creates tables and indexes", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+
+    migrateMemoryBriefState(db);
+
+    expect(hasTable(raw, "time_contexts")).toBe(true);
+    expect(hasTable(raw, "open_loops")).toBe(true);
+    expect(hasIndex(raw, "idx_time_contexts_scope_active_until")).toBe(true);
+    expect(hasIndex(raw, "idx_open_loops_scope_status_due")).toBe(true);
+  });
+
+  test("re-running the migration preserves existing rows and does not throw", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    const now = Date.now();
+
+    migrateMemoryBriefState(db);
+
+    // Insert rows into both tables
+    raw.exec(/*sql*/ `
+      INSERT INTO time_contexts (
+        id, scope_id, summary, source, active_from, active_until, created_at, updated_at
+      ) VALUES (
+        'tc-1', 'default', 'User traveling next week', 'conversation', ${now}, ${now + 604800000}, ${now}, ${now}
+      )
+    `);
+
+    raw.exec(/*sql*/ `
+      INSERT INTO open_loops (
+        id, scope_id, summary, status, source, due_at, surfaced_at, created_at, updated_at
+      ) VALUES (
+        'ol-1', 'default', 'Waiting for Bob reply', 'open', 'conversation', ${now + 86400000}, ${now}, ${now}, ${now}
+      )
+    `);
+
+    // Re-run migration — should not throw
+    expect(() => migrateMemoryBriefState(db)).not.toThrow();
+
+    // Verify rows are intact
+    const tcRow = raw
+      .query(
+        `SELECT id, scope_id, summary FROM time_contexts WHERE id = 'tc-1'`,
+      )
+      .get() as { id: string; scope_id: string; summary: string } | null;
+
+    expect(tcRow).toEqual({
+      id: "tc-1",
+      scope_id: "default",
+      summary: "User traveling next week",
+    });
+
+    const olRow = raw
+      .query(
+        `SELECT id, scope_id, summary, status FROM open_loops WHERE id = 'ol-1'`,
+      )
+      .get() as {
+      id: string;
+      scope_id: string;
+      summary: string;
+      status: string;
+    } | null;
+
+    expect(olRow).toEqual({
+      id: "ol-1",
+      scope_id: "default",
+      summary: "Waiting for Bob reply",
+      status: "open",
+    });
+  });
+});

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -82,6 +82,7 @@ import {
   migrateInviteContactId,
   migrateLlmRequestLogMessageId,
   migrateLlmRequestLogProvider,
+  migrateMemoryBriefState,
   migrateMemoryItemSupersession,
   migrateMessagesFtsBackfill,
   migrateNormalizePhoneIdentities,
@@ -483,6 +484,9 @@ export function initializeDb(): void {
 
   // 84. Add nullable conversation fork lineage columns and parent lookup index
   migrateConversationForkLineage(database);
+
+  // 85. Memory brief state tables (time_contexts, open_loops) for simplified memory system
+  migrateMemoryBriefState(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/185-memory-brief-state.ts
+++ b/assistant/src/memory/migrations/185-memory-brief-state.ts
@@ -1,0 +1,52 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Create the memory brief state tables: time_contexts and open_loops.
+ *
+ * Both tables use CREATE TABLE IF NOT EXISTS and CREATE INDEX IF NOT EXISTS,
+ * making this migration inherently idempotent — safe to re-run on every startup
+ * without a checkpoint guard.
+ */
+export function migrateMemoryBriefState(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  // -- time_contexts: bounded temporal windows for the brief --
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS time_contexts (
+      id TEXT PRIMARY KEY,
+      scope_id TEXT NOT NULL,
+      summary TEXT NOT NULL,
+      source TEXT NOT NULL,
+      active_from INTEGER NOT NULL,
+      active_until INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_time_contexts_scope_active_until
+    ON time_contexts (scope_id, active_until)
+  `);
+
+  // -- open_loops: unresolved items the brief should surface --
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS open_loops (
+      id TEXT PRIMARY KEY,
+      scope_id TEXT NOT NULL,
+      summary TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'open',
+      source TEXT NOT NULL,
+      due_at INTEGER,
+      surfaced_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_open_loops_scope_status_due
+    ON open_loops (scope_id, status, due_at)
+  `);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -126,6 +126,7 @@ export { migrateRenameThreadStartersCheckpoints } from "./181-rename-thread-star
 export { migrateOAuthProvidersDisplayMetadata } from "./182-oauth-providers-display-metadata.js";
 export { migrateConversationForkLineage } from "./183-add-conversation-fork-lineage.js";
 export { migrateLlmRequestLogProvider } from "./184-llm-request-log-provider.js";
+export { migrateMemoryBriefState } from "./185-memory-brief-state.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/index.ts
+++ b/assistant/src/memory/schema/index.ts
@@ -3,6 +3,7 @@ export * from "./contacts.js";
 export * from "./conversations.js";
 export * from "./guardian.js";
 export * from "./infrastructure.js";
+export * from "./memory-brief.js";
 export * from "./memory-core.js";
 export * from "./notifications.js";
 export * from "./oauth.js";

--- a/assistant/src/memory/schema/memory-brief.ts
+++ b/assistant/src/memory/schema/memory-brief.ts
@@ -1,0 +1,55 @@
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+/**
+ * Time contexts represent bounded temporal windows that are relevant to the
+ * assistant's current awareness — e.g. "user is traveling next week",
+ * "quarterly planning period ends Friday".  Each row captures one window
+ * with an activation range and a human-readable summary the brief can surface.
+ */
+export const timeContexts = sqliteTable(
+  "time_contexts",
+  {
+    id: text("id").primaryKey(),
+    scopeId: text("scope_id").notNull(),
+    summary: text("summary").notNull(),
+    source: text("source").notNull(), // e.g. 'conversation', 'schedule', 'manual'
+    activeFrom: integer("active_from").notNull(), // epoch ms — window start
+    activeUntil: integer("active_until").notNull(), // epoch ms — window end
+    createdAt: integer("created_at").notNull(),
+    updatedAt: integer("updated_at").notNull(),
+  },
+  (table) => [
+    index("idx_time_contexts_scope_active_until").on(
+      table.scopeId,
+      table.activeUntil,
+    ),
+  ],
+);
+
+/**
+ * Open loops track unresolved items the assistant should follow up on —
+ * e.g. "waiting for Bob's reply", "need to file taxes before April 15".
+ * Each row carries a status and an optional due date so the brief can
+ * prioritise which loops to surface.
+ */
+export const openLoops = sqliteTable(
+  "open_loops",
+  {
+    id: text("id").primaryKey(),
+    scopeId: text("scope_id").notNull(),
+    summary: text("summary").notNull(),
+    status: text("status").notNull().default("open"), // 'open' | 'resolved' | 'expired'
+    source: text("source").notNull(), // e.g. 'conversation', 'followup', 'manual'
+    dueAt: integer("due_at"), // epoch ms — optional deadline
+    surfacedAt: integer("surfaced_at"), // epoch ms — last time shown in brief
+    createdAt: integer("created_at").notNull(),
+    updatedAt: integer("updated_at").notNull(),
+  },
+  (table) => [
+    index("idx_open_loops_scope_status_due").on(
+      table.scopeId,
+      table.status,
+      table.dueAt,
+    ),
+  ],
+);


### PR DESCRIPTION
## Summary
- Add Drizzle schema for time_contexts and open_loops tables
- Add migration 185 to create both tables with read-path indexes
- Add migration tests for fresh init, upgrade, and safe re-run

Part of plan: simplified-memory-v1.md (PR 1 of 23)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
