### PR TITLE
feat: display OAuth scopes as human-readable labels

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -270,7 +270,7 @@ private struct PillButtonStyle: ButtonStyle {
 }
 
 /// Simple flow layout that wraps children horizontally.
-private struct FlowLayout: Layout {
+struct FlowLayout: Layout {
     var spacing: CGFloat
 
     func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {

--- a/clients/macos/vellum-assistant/Features/Settings/OAuthProviderServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/OAuthProviderServiceCard.swift
@@ -198,16 +198,27 @@ struct OAuthProviderServiceCard: View {
     }
 
     private func managedConnectionRow(for entry: OAuthConnectionEntry) -> some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 2) {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 4) {
                 Text(entry.account_label ?? "\(displayName) Account")
                     .font(VFont.body)
                     .foregroundColor(VColor.contentDefault)
                 if let scopes = entry.scopes_granted, !scopes.isEmpty {
-                    Text(scopes.joined(separator: ", "))
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
-                        .lineLimit(1)
+                    FlowLayout(spacing: 4) {
+                        ForEach(scopes.sorted(), id: \.self) { scope in
+                            Text(friendlyScopeName(scope))
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.contentSecondary)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(VColor.surfaceBase)
+                                .clipShape(RoundedRectangle(cornerRadius: 4))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 4)
+                                        .stroke(VColor.borderBase, lineWidth: 1)
+                                )
+                        }
+                    }
                 }
             }
             Spacer()
@@ -218,6 +229,31 @@ struct OAuthProviderServiceCard: View {
                 store.disconnectManagedOAuthConnection(entry.id, providerKey: providerKey, userId: currentUserId)
             }
         }
+    }
+
+    /// Maps OAuth scope URLs to short, human-readable labels.
+    private func friendlyScopeName(_ scope: String) -> String {
+        // Google scopes
+        if scope.hasPrefix("https://www.googleapis.com/auth/") {
+            let suffix = scope.replacingOccurrences(of: "https://www.googleapis.com/auth/", with: "")
+            switch suffix {
+            case "gmail.readonly": return "Gmail (read)"
+            case "gmail.modify": return "Gmail (modify)"
+            case "gmail.send": return "Gmail (send)"
+            case "calendar.readonly": return "Calendar (read)"
+            case "calendar.events": return "Calendar (events)"
+            case "userinfo.email": return "Email"
+            case "userinfo.profile": return "Profile"
+            case "contacts.readonly": return "Contacts (read)"
+            case "drive.readonly": return "Drive (read)"
+            case "drive.file": return "Drive (files)"
+            default: return suffix
+            }
+        }
+        // OpenID
+        if scope == "openid" { return "OpenID" }
+        // Fallback: return the scope as-is (works for short scopes like Slack, GitHub, etc.)
+        return scope
     }
 
     // MARK: - Your Own Content


### PR DESCRIPTION
## Summary
- Replace raw Google scope URLs with human-readable labels (e.g. `Gmail (read)`, `Calendar (events)`, `Email`) in the managed OAuth connection rows
- Render scopes as wrapped pill tags using `FlowLayout` instead of a single truncated comma-separated line
- Make `FlowLayout` in `ChatEmptyStateView` internal so it can be reused by the OAuth settings card

## Original prompt
Refactor the OAuth settings component so that we display the scopes granted in the UI after it is connected, with human-readable labels instead of raw URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
