### PR TITLE
feat: add simplified memory archive tables

### DIFF
--- a/assistant/src/__tests__/db-memory-archive-migration.test.ts
+++ b/assistant/src/__tests__/db-memory-archive-migration.test.ts
@@ -1,0 +1,372 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+const testDir = mkdtempSync(join(tmpdir(), "memory-archive-migration-"));
+const dbPath = join(testDir, "test.db");
+const originalBunTest = process.env.BUN_TEST;
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => dbPath,
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { initializeDb, resetDb } from "../memory/db.js";
+import { getSqliteFrom } from "../memory/db-connection.js";
+import { migrateMemoryArchiveTables } from "../memory/migrations/186-memory-archive.js";
+import * as schema from "../memory/schema.js";
+
+const ARCHIVE_TABLES = [
+  "memory_observations",
+  "memory_chunks",
+  "memory_episodes",
+] as const;
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}
+
+function tableExists(raw: Database, tableName: string): boolean {
+  const row = raw
+    .query(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?`)
+    .get(tableName);
+  return row != null;
+}
+
+function hasIndex(raw: Database, indexName: string): boolean {
+  const row = raw
+    .query(`SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?`)
+    .get(indexName);
+  return row != null;
+}
+
+function getColumnNames(raw: Database, tableName: string): string[] {
+  return (
+    raw.query(`PRAGMA table_info(${tableName})`).all() as Array<{
+      name: string;
+    }>
+  ).map((column) => column.name);
+}
+
+/** Bootstrap the minimal prerequisite tables that the archive tables reference. */
+function bootstrapPrerequisiteTables(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS conversations (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS messages (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      created_at INTEGER NOT NULL
+    )
+  `);
+}
+
+function removeTestDbFiles(): void {
+  rmSync(dbPath, { force: true });
+  rmSync(`${dbPath}-shm`, { force: true });
+  rmSync(`${dbPath}-wal`, { force: true });
+}
+
+describe("memory archive migration (186)", () => {
+  beforeEach(() => {
+    process.env.BUN_TEST = "0";
+    resetDb();
+    removeTestDbFiles();
+  });
+
+  afterEach(() => {
+    resetDb();
+    removeTestDbFiles();
+  });
+
+  afterAll(() => {
+    if (originalBunTest === undefined) {
+      delete process.env.BUN_TEST;
+    } else {
+      process.env.BUN_TEST = originalBunTest;
+    }
+    resetDb();
+    removeTestDbFiles();
+    try {
+      rmSync(testDir, { recursive: true });
+    } catch {
+      /* best effort */
+    }
+  });
+
+  // ---------- Fresh init ----------
+
+  test("fresh DB initialization creates all three archive tables", () => {
+    initializeDb();
+
+    const raw = new Database(dbPath);
+    for (const table of ARCHIVE_TABLES) {
+      expect(tableExists(raw, table)).toBe(true);
+    }
+    raw.close();
+  });
+
+  test("fresh DB initialization creates prefetch indexes on archive tables", () => {
+    initializeDb();
+
+    const raw = new Database(dbPath);
+
+    // memory_observations indexes
+    expect(hasIndex(raw, "idx_memory_observations_scope_id")).toBe(true);
+    expect(hasIndex(raw, "idx_memory_observations_conversation_id")).toBe(true);
+    expect(hasIndex(raw, "idx_memory_observations_created_at")).toBe(true);
+
+    // memory_chunks indexes
+    expect(hasIndex(raw, "idx_memory_chunks_scope_id")).toBe(true);
+    expect(hasIndex(raw, "idx_memory_chunks_observation_id")).toBe(true);
+    expect(hasIndex(raw, "idx_memory_chunks_content_hash")).toBe(true);
+    expect(hasIndex(raw, "idx_memory_chunks_created_at")).toBe(true);
+
+    // memory_episodes indexes
+    expect(hasIndex(raw, "idx_memory_episodes_scope_id")).toBe(true);
+    expect(hasIndex(raw, "idx_memory_episodes_conversation_id")).toBe(true);
+    expect(hasIndex(raw, "idx_memory_episodes_created_at")).toBe(true);
+
+    raw.close();
+  });
+
+  test("fresh DB initialization includes correct columns on memory_observations", () => {
+    initializeDb();
+
+    const raw = new Database(dbPath);
+    const columns = getColumnNames(raw, "memory_observations");
+
+    expect(columns).toContain("id");
+    expect(columns).toContain("scope_id");
+    expect(columns).toContain("conversation_id");
+    expect(columns).toContain("message_id");
+    expect(columns).toContain("role");
+    expect(columns).toContain("content");
+    expect(columns).toContain("modality");
+    expect(columns).toContain("source");
+    expect(columns).toContain("created_at");
+
+    raw.close();
+  });
+
+  test("fresh DB initialization includes contentHash on memory_chunks", () => {
+    initializeDb();
+
+    const raw = new Database(dbPath);
+    const columns = getColumnNames(raw, "memory_chunks");
+
+    expect(columns).toContain("content_hash");
+    expect(columns).toContain("observation_id");
+    expect(columns).toContain("token_estimate");
+
+    raw.close();
+  });
+
+  test("fresh DB initialization includes source-link metadata on memory_episodes", () => {
+    initializeDb();
+
+    const raw = new Database(dbPath);
+    const columns = getColumnNames(raw, "memory_episodes");
+
+    expect(columns).toContain("source");
+    expect(columns).toContain("title");
+    expect(columns).toContain("summary");
+    expect(columns).toContain("start_at");
+    expect(columns).toContain("end_at");
+
+    raw.close();
+  });
+
+  // ---------- Upgrade (migration on a pre-archive DB) ----------
+
+  test("migration creates archive tables on a database that has no archive tables", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+
+    bootstrapPrerequisiteTables(raw);
+
+    for (const table of ARCHIVE_TABLES) {
+      expect(tableExists(raw, table)).toBe(false);
+    }
+
+    migrateMemoryArchiveTables(db);
+
+    for (const table of ARCHIVE_TABLES) {
+      expect(tableExists(raw, table)).toBe(true);
+    }
+
+    raw.close();
+  });
+
+  // ---------- Re-run safety ----------
+
+  test("re-running the migration is safe and preserves existing data", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    const now = Date.now();
+
+    bootstrapPrerequisiteTables(raw);
+    migrateMemoryArchiveTables(db);
+
+    // Insert a conversation and an observation
+    raw.exec(/*sql*/ `
+      INSERT INTO conversations (id, created_at, updated_at)
+      VALUES ('conv-1', ${now}, ${now})
+    `);
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_observations (id, scope_id, conversation_id, role, content, modality, created_at)
+      VALUES ('obs-1', 'default', 'conv-1', 'user', 'The sky is blue', 'text', ${now})
+    `);
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_chunks (id, scope_id, observation_id, content, token_estimate, content_hash, created_at)
+      VALUES ('chunk-1', 'default', 'obs-1', 'The sky is blue', 5, 'abc123', ${now})
+    `);
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_episodes (id, scope_id, conversation_id, title, summary, token_estimate, source, start_at, end_at, created_at, updated_at)
+      VALUES ('ep-1', 'default', 'conv-1', 'Sky color', 'User mentioned sky is blue', 8, 'vellum', ${now}, ${now}, ${now}, ${now})
+    `);
+
+    // Re-run should not throw
+    expect(() => migrateMemoryArchiveTables(db)).not.toThrow();
+
+    // Verify data is preserved
+    const obs = raw
+      .query(`SELECT id, content FROM memory_observations WHERE id = 'obs-1'`)
+      .get() as { id: string; content: string } | null;
+    expect(obs).toEqual({ id: "obs-1", content: "The sky is blue" });
+
+    const chunk = raw
+      .query(`SELECT id, content_hash FROM memory_chunks WHERE id = 'chunk-1'`)
+      .get() as { id: string; content_hash: string } | null;
+    expect(chunk).toEqual({ id: "chunk-1", content_hash: "abc123" });
+
+    const ep = raw
+      .query(`SELECT id, title FROM memory_episodes WHERE id = 'ep-1'`)
+      .get() as { id: string; title: string } | null;
+    expect(ep).toEqual({ id: "ep-1", title: "Sky color" });
+
+    raw.close();
+  });
+
+  // ---------- Legacy table isolation ----------
+
+  test("migration does not modify legacy memory tables", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+
+    bootstrapPrerequisiteTables(raw);
+
+    // Create legacy memory tables
+    raw.exec(/*sql*/ `
+      CREATE TABLE memory_segments (
+        id TEXT PRIMARY KEY,
+        message_id TEXT NOT NULL,
+        conversation_id TEXT NOT NULL,
+        role TEXT NOT NULL,
+        segment_index INTEGER NOT NULL,
+        text TEXT NOT NULL,
+        token_estimate INTEGER NOT NULL,
+        scope_id TEXT NOT NULL DEFAULT 'default',
+        content_hash TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+    raw.exec(/*sql*/ `
+      CREATE TABLE memory_items (
+        id TEXT PRIMARY KEY,
+        kind TEXT NOT NULL,
+        subject TEXT NOT NULL,
+        statement TEXT NOT NULL,
+        status TEXT NOT NULL,
+        confidence REAL NOT NULL,
+        fingerprint TEXT NOT NULL,
+        scope_id TEXT NOT NULL DEFAULT 'default',
+        first_seen_at INTEGER NOT NULL,
+        last_seen_at INTEGER NOT NULL
+      )
+    `);
+
+    // Capture pre-migration column sets
+    const segmentColumnsBefore = getColumnNames(raw, "memory_segments");
+    const itemColumnsBefore = getColumnNames(raw, "memory_items");
+
+    migrateMemoryArchiveTables(db);
+
+    // Legacy tables should be completely untouched
+    const segmentColumnsAfter = getColumnNames(raw, "memory_segments");
+    const itemColumnsAfter = getColumnNames(raw, "memory_items");
+
+    expect(segmentColumnsAfter).toEqual(segmentColumnsBefore);
+    expect(itemColumnsAfter).toEqual(itemColumnsBefore);
+
+    raw.close();
+  });
+
+  // ---------- Unique constraint on content_hash ----------
+
+  test("memory_chunks content_hash unique index prevents duplicate inserts within same scope", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    const now = Date.now();
+
+    bootstrapPrerequisiteTables(raw);
+    migrateMemoryArchiveTables(db);
+
+    raw.exec(/*sql*/ `
+      INSERT INTO conversations (id, created_at, updated_at)
+      VALUES ('conv-dup', ${now}, ${now})
+    `);
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_observations (id, scope_id, conversation_id, role, content, modality, created_at)
+      VALUES ('obs-dup', 'default', 'conv-dup', 'user', 'Duplicate test', 'text', ${now})
+    `);
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_chunks (id, scope_id, observation_id, content, token_estimate, content_hash, created_at)
+      VALUES ('chunk-dup-1', 'default', 'obs-dup', 'Duplicate test', 3, 'hash-dup', ${now})
+    `);
+
+    // Same scope + content_hash should fail
+    expect(() => {
+      raw.exec(/*sql*/ `
+        INSERT INTO memory_chunks (id, scope_id, observation_id, content, token_estimate, content_hash, created_at)
+        VALUES ('chunk-dup-2', 'default', 'obs-dup', 'Duplicate test', 3, 'hash-dup', ${now})
+      `);
+    }).toThrow();
+
+    raw.close();
+  });
+});

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -82,6 +82,7 @@ import {
   migrateInviteContactId,
   migrateLlmRequestLogMessageId,
   migrateLlmRequestLogProvider,
+  migrateMemoryArchiveTables,
   migrateMemoryItemSupersession,
   migrateMessagesFtsBackfill,
   migrateNormalizePhoneIdentities,
@@ -483,6 +484,9 @@ export function initializeDb(): void {
 
   // 84. Add nullable conversation fork lineage columns and parent lookup index
   migrateConversationForkLineage(database);
+
+  // 85. Memory archive tables (observations, chunks, episodes) for simplified memory v1
+  migrateMemoryArchiveTables(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/186-memory-archive.ts
+++ b/assistant/src/memory/migrations/186-memory-archive.ts
@@ -1,0 +1,109 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Create the memory archive tables (memory_observations, memory_chunks,
+ * memory_episodes) with prefetch indexes on scopeId, conversationId, and
+ * createdAt.
+ *
+ * All statements use IF NOT EXISTS / IF NOT EXISTS guards so the migration
+ * is safe to re-run on every startup.
+ */
+export function migrateMemoryArchiveTables(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  // -- memory_observations --------------------------------------------------
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_observations (
+      id TEXT PRIMARY KEY,
+      scope_id TEXT NOT NULL DEFAULT 'default',
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      message_id TEXT REFERENCES messages(id) ON DELETE SET NULL,
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      modality TEXT NOT NULL DEFAULT 'text',
+      source TEXT,
+      created_at INTEGER NOT NULL
+    )
+  `);
+
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_observations_scope_id
+    ON memory_observations (scope_id)
+  `);
+
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_observations_conversation_id
+    ON memory_observations (conversation_id)
+  `);
+
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_observations_created_at
+    ON memory_observations (created_at)
+  `);
+
+  // -- memory_chunks --------------------------------------------------------
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_chunks (
+      id TEXT PRIMARY KEY,
+      scope_id TEXT NOT NULL DEFAULT 'default',
+      observation_id TEXT NOT NULL REFERENCES memory_observations(id) ON DELETE CASCADE,
+      content TEXT NOT NULL,
+      token_estimate INTEGER NOT NULL,
+      content_hash TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `);
+
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_chunks_scope_id
+    ON memory_chunks (scope_id)
+  `);
+
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_chunks_observation_id
+    ON memory_chunks (observation_id)
+  `);
+
+  raw.exec(/*sql*/ `
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_chunks_content_hash
+    ON memory_chunks (scope_id, content_hash)
+  `);
+
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_chunks_created_at
+    ON memory_chunks (created_at)
+  `);
+
+  // -- memory_episodes ------------------------------------------------------
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_episodes (
+      id TEXT PRIMARY KEY,
+      scope_id TEXT NOT NULL DEFAULT 'default',
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      summary TEXT NOT NULL,
+      token_estimate INTEGER NOT NULL,
+      source TEXT,
+      start_at INTEGER NOT NULL,
+      end_at INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_episodes_scope_id
+    ON memory_episodes (scope_id)
+  `);
+
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_episodes_conversation_id
+    ON memory_episodes (conversation_id)
+  `);
+
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_episodes_created_at
+    ON memory_episodes (created_at)
+  `);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -126,6 +126,7 @@ export { migrateRenameThreadStartersCheckpoints } from "./181-rename-thread-star
 export { migrateOAuthProvidersDisplayMetadata } from "./182-oauth-providers-display-metadata.js";
 export { migrateConversationForkLineage } from "./183-add-conversation-fork-lineage.js";
 export { migrateLlmRequestLogProvider } from "./184-llm-request-log-provider.js";
+export { migrateMemoryArchiveTables } from "./186-memory-archive.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/index.ts
+++ b/assistant/src/memory/schema/index.ts
@@ -3,6 +3,7 @@ export * from "./contacts.js";
 export * from "./conversations.js";
 export * from "./guardian.js";
 export * from "./infrastructure.js";
+export * from "./memory-archive.js";
 export * from "./memory-core.js";
 export * from "./notifications.js";
 export * from "./oauth.js";

--- a/assistant/src/memory/schema/memory-archive.ts
+++ b/assistant/src/memory/schema/memory-archive.ts
@@ -1,0 +1,121 @@
+import {
+  index,
+  integer,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+
+import { conversations, messages } from "./conversations.js";
+
+/**
+ * Raw observation records captured from conversation turns. Each observation
+ * is a single factual statement extracted from user or assistant messages,
+ * annotated with modality and source metadata for downstream recall.
+ */
+export const memoryObservations = sqliteTable(
+  "memory_observations",
+  {
+    id: text("id").primaryKey(),
+    scopeId: text("scope_id").notNull().default("default"),
+    conversationId: text("conversation_id")
+      .notNull()
+      .references(() => conversations.id, { onDelete: "cascade" }),
+    messageId: text("message_id").references(() => messages.id, {
+      onDelete: "set null",
+    }),
+    /** The role that produced the observation (e.g. "user", "assistant"). */
+    role: text("role").notNull(),
+    /** Free-text statement capturing the observed fact. */
+    content: text("content").notNull(),
+    /**
+     * Modality of the source material: "text", "voice", "image", etc.
+     * Enables downstream filters for recall relevance.
+     */
+    modality: text("modality").notNull().default("text"),
+    /**
+     * Source channel or interface that produced the observation
+     * (e.g. "vellum", "telegram", "phone").
+     */
+    source: text("source"),
+    createdAt: integer("created_at").notNull(),
+  },
+  (table) => [
+    index("idx_memory_observations_scope_id").on(table.scopeId),
+    index("idx_memory_observations_conversation_id").on(table.conversationId),
+    index("idx_memory_observations_created_at").on(table.createdAt),
+  ],
+);
+
+/**
+ * Deduplicated content chunks derived from observations. Chunks are the unit
+ * of embedding and recall — each chunk carries a contentHash for idempotent
+ * dual-write safety so the same content is never stored twice.
+ */
+export const memoryChunks = sqliteTable(
+  "memory_chunks",
+  {
+    id: text("id").primaryKey(),
+    scopeId: text("scope_id").notNull().default("default"),
+    observationId: text("observation_id")
+      .notNull()
+      .references(() => memoryObservations.id, { onDelete: "cascade" }),
+    /** The chunk text used for embedding and recall. */
+    content: text("content").notNull(),
+    /** Token count estimate for context-window budgeting. */
+    tokenEstimate: integer("token_estimate").notNull(),
+    /**
+     * SHA-256 hash of the normalized content, used to skip duplicate inserts
+     * during dual-write windows.
+     */
+    contentHash: text("content_hash").notNull(),
+    createdAt: integer("created_at").notNull(),
+  },
+  (table) => [
+    index("idx_memory_chunks_scope_id").on(table.scopeId),
+    index("idx_memory_chunks_observation_id").on(table.observationId),
+    uniqueIndex("idx_memory_chunks_content_hash").on(
+      table.scopeId,
+      table.contentHash,
+    ),
+    index("idx_memory_chunks_created_at").on(table.createdAt),
+  ],
+);
+
+/**
+ * Episode records that group related observations into coherent narrative
+ * units. An episode represents a meaningful interaction or topic span,
+ * with source-link metadata for provenance tracking.
+ */
+export const memoryEpisodes = sqliteTable(
+  "memory_episodes",
+  {
+    id: text("id").primaryKey(),
+    scopeId: text("scope_id").notNull().default("default"),
+    conversationId: text("conversation_id")
+      .notNull()
+      .references(() => conversations.id, { onDelete: "cascade" }),
+    /** Human-readable title summarizing the episode. */
+    title: text("title").notNull(),
+    /** Longer narrative summary of the episode content. */
+    summary: text("summary").notNull(),
+    /** Token count estimate for the summary. */
+    tokenEstimate: integer("token_estimate").notNull(),
+    /**
+     * Source channel or interface that produced the episode
+     * (mirrors observation.source for episode-level filtering).
+     */
+    source: text("source"),
+    /** Epoch-ms timestamp of the earliest observation in the episode. */
+    startAt: integer("start_at").notNull(),
+    /** Epoch-ms timestamp of the latest observation in the episode. */
+    endAt: integer("end_at").notNull(),
+    createdAt: integer("created_at").notNull(),
+    updatedAt: integer("updated_at").notNull(),
+  },
+  (table) => [
+    index("idx_memory_episodes_scope_id").on(table.scopeId),
+    index("idx_memory_episodes_conversation_id").on(table.conversationId),
+    index("idx_memory_episodes_created_at").on(table.createdAt),
+  ],
+);


### PR DESCRIPTION
## Summary
- Add Drizzle schema for memory_observations, memory_chunks, and memory_episodes tables
- Add migration 186 to create tables with prefetch indexes on scopeId, conversationId, createdAt
- Add migration tests for fresh init, upgrade, and safe re-run

Part of plan: simplified-memory-v1.md (PR 2 of 23)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
