### PR TITLE
feat: add simplified memory reducer checkpoints to conversations

### DIFF
--- a/assistant/src/__tests__/db-memory-reducer-checkpoints.test.ts
+++ b/assistant/src/__tests__/db-memory-reducer-checkpoints.test.ts
@@ -1,0 +1,273 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+const testDir = mkdtempSync(join(tmpdir(), "memory-reducer-checkpoints-"));
+const dbPath = join(testDir, "test.db");
+const originalBunTest = process.env.BUN_TEST;
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => dbPath,
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+  getConversationsDir: () => join(testDir, "conversations"),
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { initializeDb, resetDb } from "../memory/db.js";
+import { getSqliteFrom } from "../memory/db-connection.js";
+import { migrateMemoryReducerCheckpoints } from "../memory/migrations/187-memory-reducer-checkpoints.js";
+import * as schema from "../memory/schema.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}
+
+function getColumnInfo(
+  raw: Database,
+): Array<{ name: string; notnull: number }> {
+  return raw.query(`PRAGMA table_info(conversations)`).all() as Array<{
+    name: string;
+    notnull: number;
+  }>;
+}
+
+function bootstrapPreCheckpointConversations(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      title TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      total_input_tokens INTEGER NOT NULL DEFAULT 0,
+      total_output_tokens INTEGER NOT NULL DEFAULT 0,
+      total_estimated_cost REAL NOT NULL DEFAULT 0,
+      context_summary TEXT,
+      context_compacted_message_count INTEGER NOT NULL DEFAULT 0,
+      context_compacted_at INTEGER,
+      conversation_type TEXT NOT NULL DEFAULT 'standard',
+      source TEXT NOT NULL DEFAULT 'user',
+      memory_scope_id TEXT NOT NULL DEFAULT 'default',
+      origin_channel TEXT,
+      origin_interface TEXT,
+      fork_parent_conversation_id TEXT,
+      fork_parent_message_id TEXT,
+      is_auto_title INTEGER NOT NULL DEFAULT 1,
+      schedule_job_id TEXT
+    )
+  `);
+}
+
+function removeTestDbFiles(): void {
+  rmSync(dbPath, { force: true });
+  rmSync(`${dbPath}-shm`, { force: true });
+  rmSync(`${dbPath}-wal`, { force: true });
+}
+
+describe("memory reducer checkpoint columns migration", () => {
+  beforeEach(() => {
+    process.env.BUN_TEST = "0";
+    resetDb();
+    removeTestDbFiles();
+  });
+
+  afterEach(() => {
+    resetDb();
+    removeTestDbFiles();
+  });
+
+  afterAll(() => {
+    if (originalBunTest === undefined) {
+      delete process.env.BUN_TEST;
+    } else {
+      process.env.BUN_TEST = originalBunTest;
+    }
+    resetDb();
+    removeTestDbFiles();
+    try {
+      rmSync(testDir, { recursive: true });
+    } catch {
+      /* best effort */
+    }
+  });
+
+  test("fresh DB initialization includes nullable reducer checkpoint columns", () => {
+    initializeDb();
+
+    const raw = new Database(dbPath);
+    const columns = getColumnInfo(raw);
+
+    const checkpointColumns = columns.filter(
+      (c) =>
+        c.name === "memory_reduced_through_message_id" ||
+        c.name === "memory_dirty_tail_since_message_id" ||
+        c.name === "memory_last_reduced_at",
+    );
+
+    expect(checkpointColumns).toHaveLength(3);
+    expect(checkpointColumns.every((c) => c.notnull === 0)).toBe(true);
+
+    raw.close();
+  });
+
+  test("migration upgrades the pre-checkpoint schema without disturbing existing rows", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    const now = Date.now();
+
+    bootstrapPreCheckpointConversations(raw);
+    raw.exec(/*sql*/ `
+      INSERT INTO conversations (
+        id,
+        title,
+        created_at,
+        updated_at,
+        conversation_type,
+        source,
+        memory_scope_id,
+        is_auto_title
+      ) VALUES (
+        'conv-upgrade',
+        'Existing conversation',
+        ${now},
+        ${now},
+        'standard',
+        'user',
+        'default',
+        1
+      )
+    `);
+
+    migrateMemoryReducerCheckpoints(db);
+
+    const columnNames = getColumnInfo(raw).map((c) => c.name);
+    expect(columnNames).toContain("memory_reduced_through_message_id");
+    expect(columnNames).toContain("memory_dirty_tail_since_message_id");
+    expect(columnNames).toContain("memory_last_reduced_at");
+
+    const row = raw
+      .query(
+        `SELECT id, title, memory_reduced_through_message_id, memory_dirty_tail_since_message_id, memory_last_reduced_at
+         FROM conversations WHERE id = 'conv-upgrade'`,
+      )
+      .get() as {
+      id: string;
+      title: string | null;
+      memory_reduced_through_message_id: string | null;
+      memory_dirty_tail_since_message_id: string | null;
+      memory_last_reduced_at: number | null;
+    } | null;
+
+    expect(row).toEqual({
+      id: "conv-upgrade",
+      title: "Existing conversation",
+      memory_reduced_through_message_id: null,
+      memory_dirty_tail_since_message_id: null,
+      memory_last_reduced_at: null,
+    });
+
+    raw.close();
+  });
+
+  test("re-running the migration preserves populated checkpoint values", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    const now = Date.now();
+
+    bootstrapPreCheckpointConversations(raw);
+    raw.exec(/*sql*/ `
+      INSERT INTO conversations (
+        id,
+        title,
+        created_at,
+        updated_at,
+        conversation_type,
+        source,
+        memory_scope_id,
+        is_auto_title
+      ) VALUES (
+        'conv-rerun',
+        'Reduced conversation',
+        ${now},
+        ${now},
+        'standard',
+        'user',
+        'default',
+        1
+      )
+    `);
+
+    migrateMemoryReducerCheckpoints(db);
+    raw.exec(/*sql*/ `
+      UPDATE conversations
+      SET memory_reduced_through_message_id = 'msg-100',
+          memory_dirty_tail_since_message_id = 'msg-101',
+          memory_last_reduced_at = ${now}
+      WHERE id = 'conv-rerun'
+    `);
+
+    expect(() => migrateMemoryReducerCheckpoints(db)).not.toThrow();
+
+    const row = raw
+      .query(
+        `SELECT memory_reduced_through_message_id, memory_dirty_tail_since_message_id, memory_last_reduced_at
+         FROM conversations WHERE id = 'conv-rerun'`,
+      )
+      .get() as {
+      memory_reduced_through_message_id: string | null;
+      memory_dirty_tail_since_message_id: string | null;
+      memory_last_reduced_at: number | null;
+    } | null;
+
+    expect(row).toEqual({
+      memory_reduced_through_message_id: "msg-100",
+      memory_dirty_tail_since_message_id: "msg-101",
+      memory_last_reduced_at: now,
+    });
+
+    raw.close();
+  });
+
+  test("getConversation exposes the new checkpoint fields as null for new rows", async () => {
+    initializeDb();
+
+    // Dynamic import to avoid circular module init issues — conversation-crud
+    // depends on getDb being initialized which happens in initializeDb above.
+    const { createConversation, getConversation } =
+      await import("../memory/conversation-crud.js");
+
+    const created = createConversation("Test conversation");
+    const loaded = getConversation(created.id);
+
+    expect(loaded).not.toBeNull();
+    expect(loaded!.memoryReducedThroughMessageId).toBeNull();
+    expect(loaded!.memoryDirtyTailSinceMessageId).toBeNull();
+    expect(loaded!.memoryLastReducedAt).toBeNull();
+  });
+});

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -171,6 +171,9 @@ export interface ConversationRow {
   forkParentMessageId: string | null;
   isAutoTitle: number;
   scheduleJobId: string | null;
+  memoryReducedThroughMessageId: string | null;
+  memoryDirtyTailSinceMessageId: string | null;
+  memoryLastReducedAt: number | null;
 }
 
 export const parseConversation = createRowMapper<
@@ -196,6 +199,9 @@ export const parseConversation = createRowMapper<
   forkParentMessageId: "forkParentMessageId",
   isAutoTitle: "isAutoTitle",
   scheduleJobId: "scheduleJobId",
+  memoryReducedThroughMessageId: "memoryReducedThroughMessageId",
+  memoryDirtyTailSinceMessageId: "memoryDirtyTailSinceMessageId",
+  memoryLastReducedAt: "memoryLastReducedAt",
 });
 
 export interface MessageRow {

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -83,6 +83,7 @@ import {
   migrateLlmRequestLogMessageId,
   migrateLlmRequestLogProvider,
   migrateMemoryItemSupersession,
+  migrateMemoryReducerCheckpoints,
   migrateMessagesFtsBackfill,
   migrateNormalizePhoneIdentities,
   migrateNotificationDeliveryThreadDecision,
@@ -483,6 +484,9 @@ export function initializeDb(): void {
 
   // 84. Add nullable conversation fork lineage columns and parent lookup index
   migrateConversationForkLineage(database);
+
+  // 85. Add memory reducer checkpoint columns to conversations
+  migrateMemoryReducerCheckpoints(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/187-memory-reducer-checkpoints.ts
+++ b/assistant/src/memory/migrations/187-memory-reducer-checkpoints.ts
@@ -1,0 +1,19 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateMemoryReducerCheckpoints(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  const columns = [
+    "memory_reduced_through_message_id TEXT",
+    "memory_dirty_tail_since_message_id TEXT",
+    "memory_last_reduced_at INTEGER",
+  ];
+
+  for (const column of columns) {
+    try {
+      raw.exec(`ALTER TABLE conversations ADD COLUMN ${column}`);
+    } catch {
+      // Column already exists — nothing to do.
+    }
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -126,6 +126,7 @@ export { migrateRenameThreadStartersCheckpoints } from "./181-rename-thread-star
 export { migrateOAuthProvidersDisplayMetadata } from "./182-oauth-providers-display-metadata.js";
 export { migrateConversationForkLineage } from "./183-add-conversation-fork-lineage.js";
 export { migrateLlmRequestLogProvider } from "./184-llm-request-log-provider.js";
+export { migrateMemoryReducerCheckpoints } from "./187-memory-reducer-checkpoints.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/conversations.ts
+++ b/assistant/src/memory/schema/conversations.ts
@@ -30,6 +30,9 @@ export const conversations = sqliteTable(
     forkParentMessageId: text("fork_parent_message_id"),
     isAutoTitle: integer("is_auto_title").notNull().default(1),
     scheduleJobId: text("schedule_job_id"),
+    memoryReducedThroughMessageId: text("memory_reduced_through_message_id"),
+    memoryDirtyTailSinceMessageId: text("memory_dirty_tail_since_message_id"),
+    memoryLastReducedAt: integer("memory_last_reduced_at"),
   },
   (table) => [
     index("idx_conversations_updated_at").on(table.updatedAt),


### PR DESCRIPTION
## Summary
- Add nullable memoryReducedThroughMessageId, memoryDirtyTailSinceMessageId, memoryLastReducedAt columns
- Add migration 187 to add the columns to existing databases
- Update ConversationRow and parseConversation to expose new fields

Part of plan: simplified-memory-v1.md (PR 3 of 23)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19630" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
