### PR TITLE
feat: mark conversations dirty for delayed memory reduction

### DIFF
--- a/assistant/src/__tests__/conversation-memory-dirty-tail.test.ts
+++ b/assistant/src/__tests__/conversation-memory-dirty-tail.test.ts
@@ -1,0 +1,150 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "conv-dirty-tail-test-"));
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  addMessage,
+  createConversation,
+  getConversation,
+  getMessages,
+  markConversationMemoryDirty,
+} from "../memory/conversation-crud.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe("markConversationMemoryDirty", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM messages`);
+    db.run(`DELETE FROM conversations`);
+  });
+
+  test("first message marks the conversation dirty with its message ID", async () => {
+    const conv = createConversation("test");
+    const msg = await addMessage(conv.id, "user", "hello world", undefined, {
+      skipIndexing: true,
+    });
+
+    const updated = getConversation(conv.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.memoryDirtyTailSinceMessageId).toBe(msg.id);
+  });
+
+  test("repeated messages preserve the original dirty boundary", async () => {
+    const conv = createConversation("test");
+    const msg1 = await addMessage(conv.id, "user", "first message", undefined, {
+      skipIndexing: true,
+    });
+    const msg2 = await addMessage(
+      conv.id,
+      "assistant",
+      "second message",
+      undefined,
+      { skipIndexing: true },
+    );
+
+    const updated = getConversation(conv.id);
+    expect(updated).not.toBeNull();
+    // The dirty tail should still point to msg1, not msg2.
+    expect(updated!.memoryDirtyTailSinceMessageId).toBe(msg1.id);
+    // msg2 should still be persisted normally.
+    expect(msg2.id).not.toBe(msg1.id);
+  });
+
+  test("markConversationMemoryDirty is a no-op when already dirty", () => {
+    const conv = createConversation("test");
+    const firstMessageId = "first-msg-id";
+    const secondMessageId = "second-msg-id";
+
+    markConversationMemoryDirty(conv.id, firstMessageId);
+    const after1 = getConversation(conv.id);
+    expect(after1!.memoryDirtyTailSinceMessageId).toBe(firstMessageId);
+
+    markConversationMemoryDirty(conv.id, secondMessageId);
+    const after2 = getConversation(conv.id);
+    // Still points to the first message — boundary preserved.
+    expect(after2!.memoryDirtyTailSinceMessageId).toBe(firstMessageId);
+  });
+
+  test("message ordering and persistence semantics are unchanged", async () => {
+    const conv = createConversation("test");
+    const msg1 = await addMessage(conv.id, "user", "question", undefined, {
+      skipIndexing: true,
+    });
+    const msg2 = await addMessage(conv.id, "assistant", "answer", undefined, {
+      skipIndexing: true,
+    });
+    const msg3 = await addMessage(conv.id, "user", "follow-up", undefined, {
+      skipIndexing: true,
+    });
+
+    const allMessages = getMessages(conv.id);
+    expect(allMessages).toHaveLength(3);
+    // Messages are ordered by createdAt ascending.
+    expect(allMessages[0].id).toBe(msg1.id);
+    expect(allMessages[1].id).toBe(msg2.id);
+    expect(allMessages[2].id).toBe(msg3.id);
+    expect(allMessages[0].content).toBe("question");
+    expect(allMessages[1].content).toBe("answer");
+    expect(allMessages[2].content).toBe("follow-up");
+    // createdAt is monotonically increasing.
+    expect(allMessages[1].createdAt).toBeGreaterThan(allMessages[0].createdAt);
+    expect(allMessages[2].createdAt).toBeGreaterThan(allMessages[1].createdAt);
+  });
+
+  test("every persisted message marks the conversation dirty", async () => {
+    const conv = createConversation("test");
+
+    // Before any messages, the conversation is not dirty.
+    const before = getConversation(conv.id);
+    expect(before!.memoryDirtyTailSinceMessageId).toBeNull();
+
+    // After the first message, it becomes dirty.
+    const msg1 = await addMessage(conv.id, "user", "msg1", undefined, {
+      skipIndexing: true,
+    });
+    const after1 = getConversation(conv.id);
+    expect(after1!.memoryDirtyTailSinceMessageId).toBe(msg1.id);
+
+    // After subsequent messages, the dirty boundary stays on msg1.
+    await addMessage(conv.id, "assistant", "msg2", undefined, {
+      skipIndexing: true,
+    });
+    await addMessage(conv.id, "user", "msg3", undefined, {
+      skipIndexing: true,
+    });
+    const afterAll = getConversation(conv.id);
+    expect(afterAll!.memoryDirtyTailSinceMessageId).toBe(msg1.id);
+  });
+});

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -952,6 +952,13 @@ export async function addMessage(
       throw err;
     }
   }
+
+  // Mark the conversation dirty for delayed memory reduction. This runs
+  // after the insert transaction succeeds so the reducer knows which
+  // conversations have unprocessed messages. The helper preserves the
+  // earliest unreduced boundary (no-op when already dirty).
+  markConversationMemoryDirty(conversationId, messageId);
+
   const message = {
     id: messageId,
     conversationId,
@@ -1402,6 +1409,28 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
   deleteOrphanAttachments(candidateAttachmentIds);
 
   return result;
+}
+
+/**
+ * Mark a conversation as having unreduced messages starting from the given
+ * message. Sets `memoryDirtyTailSinceMessageId` only when it is currently
+ * null so the earliest unreduced boundary is preserved across multiple
+ * messages — later messages must not clobber the original dirty marker.
+ */
+export function markConversationMemoryDirty(
+  conversationId: string,
+  messageId: string,
+): void {
+  const db = getDb();
+  db.update(conversations)
+    .set({ memoryDirtyTailSinceMessageId: messageId })
+    .where(
+      and(
+        eq(conversations.id, conversationId),
+        isNull(conversations.memoryDirtyTailSinceMessageId),
+      ),
+    )
+    .run();
 }
 
 export function setConversationOriginChannelIfUnset(


### PR DESCRIPTION
## Summary
- Add markConversationMemoryDirty helper that preserves earliest unreduced boundary
- Wire dirty marking into addMessage() after insert transaction
- Add tests for first-message marking, boundary preservation, and ordering semantics

Part of plan: simplified-memory-v1.md (PR 7 of 23)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
