### PR TITLE
fix: strip RTF colors from pasteboard on dark mode copy (LUM-286)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1033,6 +1033,7 @@ struct MessageListView: View {
                 .frame(maxWidth: .infinity)
             }
             .scrollContentBackground(.hidden)
+            .plainTextCopy()
             .coordinateSpace(name: "chatScrollView")
             .scrollDisabled(messages.isEmpty && !isSending)
             .environment(\.suppressAutoScroll, { [self] in

--- a/clients/macos/vellum-assistant/Features/Chat/PlainTextCopyModifier.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/PlainTextCopyModifier.swift
@@ -20,7 +20,6 @@ final class PasteboardSanitizer {
 
     private var eventMonitor: Any?
     private var refCount = 0
-    private var lastChangeCount: Int = NSPasteboard.general.changeCount
 
     private init() {}
 
@@ -30,13 +29,14 @@ final class PasteboardSanitizer {
     func install() {
         refCount += 1
         guard eventMonitor == nil else { return }
-        lastChangeCount = NSPasteboard.general.changeCount
         eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             if event.modifierFlags.contains(.command),
                event.charactersIgnoringModifiers == "c" {
+                // Snapshot the change count before SwiftUI processes the copy
+                let preEventCount = NSPasteboard.general.changeCount
                 // Delay to let SwiftUI's text selection copy complete first
                 DispatchQueue.main.async {
-                    self?.sanitizePasteboard()
+                    self?.sanitizePasteboard(preEventCount: preEventCount)
                 }
             }
             return event
@@ -56,11 +56,14 @@ final class PasteboardSanitizer {
         }
     }
 
-    private func sanitizePasteboard() {
+    /// Strips RTF/HTML from the pasteboard if a copy actually occurred
+    /// during this Cmd+C event. Compares against the pre-event change
+    /// count to avoid corrupting clipboard content from other apps.
+    private func sanitizePasteboard(preEventCount: Int) {
         let pb = NSPasteboard.general
-        // Only act if the pasteboard changed (a copy actually happened)
-        guard pb.changeCount != lastChangeCount else { return }
-        lastChangeCount = pb.changeCount
+        // Only act if the pasteboard changed since the key event fired,
+        // confirming that this Cmd+C actually produced a new copy
+        guard pb.changeCount > preEventCount else { return }
 
         // Only strip if RTF or HTML is present (rich text copy from text selection)
         guard pb.data(forType: .rtf) != nil || pb.data(forType: .html) != nil else { return }
@@ -68,7 +71,6 @@ final class PasteboardSanitizer {
         guard let plainText = pb.string(forType: .string) else { return }
         pb.clearContents()
         pb.setString(plainText, forType: .string)
-        lastChangeCount = pb.changeCount
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/PlainTextCopyModifier.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/PlainTextCopyModifier.swift
@@ -1,0 +1,97 @@
+@preconcurrency import AppKit
+import SwiftUI
+
+/// Singleton that manages a single app-wide keyDown event monitor for
+/// stripping rich text formatting from the pasteboard after Cmd+C.
+///
+/// When `.textSelection(.enabled)` copies text, SwiftUI embeds resolved
+/// foreground colors into RTF pasteboard data. In dark mode these are
+/// green-tinted Forest/Moss palette colors that render poorly on light
+/// backgrounds in external apps. This class intercepts Cmd+C, lets
+/// SwiftUI's copy complete, then replaces the pasteboard contents with
+/// plain text only.
+///
+/// Uses reference counting so multiple `.plainTextCopy()` view modifiers
+/// share a single monitor. The monitor is installed when the first view
+/// appears and removed when the last view disappears.
+@MainActor
+final class PasteboardSanitizer {
+    static let shared = PasteboardSanitizer()
+
+    private var eventMonitor: Any?
+    private var refCount = 0
+    private var lastChangeCount: Int = NSPasteboard.general.changeCount
+
+    private init() {}
+
+    /// Increments the reference count and installs the event monitor if
+    /// it is not already installed. Safe to call multiple times — only
+    /// one monitor is ever active.
+    func install() {
+        refCount += 1
+        guard eventMonitor == nil else { return }
+        lastChangeCount = NSPasteboard.general.changeCount
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            if event.modifierFlags.contains(.command),
+               event.charactersIgnoringModifiers == "c" {
+                // Delay to let SwiftUI's text selection copy complete first
+                DispatchQueue.main.async {
+                    self?.sanitizePasteboard()
+                }
+            }
+            return event
+        }
+    }
+
+    /// Decrements the reference count and removes the event monitor when
+    /// no views are using it. Also guards against double-`onAppear`
+    /// without an intervening `onDisappear` by clamping refCount to 0.
+    func uninstall() {
+        refCount -= 1
+        guard refCount <= 0 else { return }
+        refCount = 0
+        if let monitor = eventMonitor {
+            NSEvent.removeMonitor(monitor)
+            eventMonitor = nil
+        }
+    }
+
+    private func sanitizePasteboard() {
+        let pb = NSPasteboard.general
+        // Only act if the pasteboard changed (a copy actually happened)
+        guard pb.changeCount != lastChangeCount else { return }
+        lastChangeCount = pb.changeCount
+
+        // Only strip if RTF or HTML is present (rich text copy from text selection)
+        guard pb.data(forType: .rtf) != nil || pb.data(forType: .html) != nil else { return }
+
+        guard let plainText = pb.string(forType: .string) else { return }
+        pb.clearContents()
+        pb.setString(plainText, forType: .string)
+        lastChangeCount = pb.changeCount
+    }
+}
+
+/// View modifier that participates in `PasteboardSanitizer`'s
+/// reference-counted singleton monitor. Apply once at a container level
+/// (e.g. the chat message list) rather than per-message to avoid O(N)
+/// monitors.
+struct PlainTextCopyModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .onAppear { PasteboardSanitizer.shared.install() }
+            .onDisappear { PasteboardSanitizer.shared.uninstall() }
+    }
+}
+
+extension View {
+    /// Strips RTF/HTML color attributes from the pasteboard after text selection
+    /// copy (Cmd+C), keeping only plain text. Prevents dark-mode theme colors
+    /// from appearing when pasting into external apps.
+    ///
+    /// Uses a singleton event monitor — safe to call from multiple views without
+    /// creating duplicate monitors.
+    func plainTextCopy() -> some View {
+        modifier(PlainTextCopyModifier())
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `PasteboardSanitizer` singleton that monitors Cmd+C and strips RTF/HTML color attributes from the pasteboard, keeping only plain text
- Fixes dark mode copy/paste producing green text when pasted into external apps
- Uses reference-counted singleton pattern — only one app-wide event monitor regardless of view count
- Applied at `MessageListView` ScrollView level for O(1) overhead per keypress

## Changes
- `clients/macos/vellum-assistant/Features/Chat/PlainTextCopyModifier.swift` (new) — PasteboardSanitizer singleton + PlainTextCopyModifier ViewModifier
- `clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift` — No per-message modifier (kept clean)
- `clients/macos/vellum-assistant/Features/Chat/MessageListView.swift` — Applied `.plainTextCopy()` once at ScrollView level

## Milestone PRs (merged into feature branch)
- #19615: fix: strip RTF colors from pasteboard on dark mode copy (LUM-286)

## Project issue
Closes #19611

## Test plan
- [ ] Dark mode: select chat response text, Cmd+C, paste into TextEdit → text should be standard black
- [ ] Light mode: same test → text should be standard black
- [ ] Copy button (overflow menu): verify still works correctly (plain text, no regression)
- [ ] Code blocks: verify code text copies as plain text
- [ ] External app copy → paste into our app → content should not be stripped (lastChangeCount guard)

Closes LUM-286
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
