### PR TITLE
docs: add inline skill command authoring guardrails

### DIFF
--- a/assistant/docs/skills.md
+++ b/assistant/docs/skills.md
@@ -156,3 +156,103 @@ Trust rules are stored in `~/.vellum/protected/trust.json`. You can inspect this
 ### "A skill tool keeps prompting even though I approved it."
 
 Check whether the rule has the correct `executionTarget` — a rule scoped to `sandbox` will not match a tool running on `host`.
+
+## Inline Command Expansions
+
+Skills can embed dynamic content by using the **inline command expansion** syntax. When a skill containing these tokens is loaded, each token is executed and replaced with its output before the skill body is delivered to the model. The syntax is shown in the fenced block below.
+
+This syntax is intentionally compatible with the convention established by [inline skill commands](https://x.com) for portable cross-agent skill authoring. Vellum adopts the exact same token format so that externally authored skills load without rewriting — but applies stricter execution constraints.
+
+### Syntax
+
+The canonical syntax is:
+
+```
+!`command`
+```
+
+Where `command` is any shell command string. The exclamation mark immediately precedes the opening backtick with no whitespace in between. Examples:
+
+```markdown
+Current branch: !`git branch --show-current`
+Recent changes: !`git log --oneline -5`
+Project info: !`cat package.json | jq '.name, .version'`
+```
+
+Tokens inside fenced code blocks (` ``` ` or `~~~`) are **not** expanded — they are treated as documentation examples. This allows skills to safely include syntax examples without triggering execution.
+
+### Parsing rules
+
+The parser (`parseInlineCommandExpansions`) enforces fail-closed semantics:
+
+| Condition                                         | Behavior               |
+| ------------------------------------------------- | ---------------------- |
+| Well-formed token outside fenced code             | Parsed as an expansion |
+| Token inside a fenced code block                  | Skipped (not expanded) |
+| Empty command text (no content between backticks) | Rejected as malformed  |
+| Whitespace-only command text                      | Rejected as malformed  |
+| Unmatched opening (no closing backtick found)     | Rejected as malformed  |
+| Nested backticks inside command text              | Rejected as malformed  |
+
+Malformed tokens do not silently pass through — they are collected as errors and logged. If a skill body contains any malformed tokens, the valid tokens are still expanded, but the errors are reported for diagnostics.
+
+### Feature flag
+
+Inline command expansion is gated by the `inline-skill-commands` feature flag (key: `feature_flags.inline-skill-commands.enabled`). The flag defaults to **disabled**.
+
+When the flag is disabled and a skill contains inline command expansion tokens, `skill_load` returns an error rather than delivering unexpanded tokens to the model. This fail-closed behavior prevents the LLM from seeing raw expansion tokens and attempting to interpret them.
+
+### Approval model
+
+Skills with inline command expansions use a separate permission namespace: `skill_load_dynamic:*`. This ensures they do not silently inherit the permissive default `skill_load:*` allow rule.
+
+When a user is prompted to approve a dynamic skill load, the allowlist options are:
+
+| Option         | Pattern                                     | Behavior                                                                                            |
+| -------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Version-pinned | `skill_load_dynamic:<id>@<transitive-hash>` | Approved for this exact version only. Any change to the skill or its includes invalidates the rule. |
+| Any-version    | `skill_load_dynamic:<id>`                   | Approved for all versions of this skill.                                                            |
+
+The transitive hash covers the skill's own content plus all included skills, so a change anywhere in the dependency graph triggers re-approval for version-pinned rules.
+
+### v1 execution limits
+
+In the initial implementation, inline command execution enforces these constraints:
+
+| Constraint       | Value                                                   |
+| ---------------- | ------------------------------------------------------- |
+| Execution target | Sandbox only (no host fallback)                         |
+| Network access   | Off (no outbound connections)                           |
+| Environment      | Sanitized (no API keys, tokens, or credentials)         |
+| Timeout          | 10 seconds per command                                  |
+| Output cap       | 20,000 characters (truncated with `[output truncated]`) |
+| Binary output    | Rejected if >10% non-printable characters               |
+| ANSI sequences   | Stripped before output processing                       |
+| stderr           | Discarded (only stdout is captured)                     |
+
+Commands that fail (timeout, non-zero exit, spawn failure, binary output) produce a deterministic stub in the rendered body rather than leaking raw error output:
+
+```
+<inline_skill_command index="0">[inline command unavailable: command timed out]</inline_skill_command>
+```
+
+### Eligible skill sources
+
+Only **bundled**, **managed**, and **workspace** skills may use inline command expansions. Third-party **extra** skill sources are explicitly rejected — `skill_load` returns an error if an extra-source skill contains inline expansion tokens.
+
+| Source      | Eligible | Reason                                 |
+| ----------- | -------- | -------------------------------------- |
+| `bundled`   | Yes      | Shipped with the application, trusted  |
+| `managed`   | Yes      | User-installed, subject to approval    |
+| `workspace` | Yes      | Project-local, subject to approval     |
+| `extra`     | No       | Third-party roots, out of scope for v1 |
+
+### Fail-closed summary
+
+The system fails closed at every layer:
+
+1. **Flag off** — skill_load returns an error, tokens never reach the model.
+2. **Malformed syntax** — rejected by the parser, logged as errors.
+3. **Unsupported source** — skill_load returns an error for extra-source skills.
+4. **Command failure** — deterministic stub replaces the token, no raw stderr.
+5. **No permission** — `skill_load_dynamic:*` namespace requires explicit approval.

--- a/assistant/src/__tests__/inline-skill-authoring-guard.test.ts
+++ b/assistant/src/__tests__/inline-skill-authoring-guard.test.ts
@@ -1,0 +1,220 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { parseFrontmatterFields } from "../skills/frontmatter.js";
+import { parseInlineCommandExpansions } from "../skills/inline-command-expansions.js";
+
+/**
+ * Guard test: scan bundled and first-party skills for malformed inline
+ * command expansion syntax (`!\`...\``).
+ *
+ * This guard ensures that:
+ * 1. No skill ships with malformed inline expansion tokens (empty commands,
+ *    unmatched backticks, nested backticks) that would be rejected by the
+ *    parser at runtime.
+ * 2. Fenced-code examples containing `!\`...\`` syntax are correctly
+ *    ignored by the parser and not treated as live commands — verified by
+ *    fixture coverage below.
+ *
+ * See assistant/docs/skills.md "Inline Command Expansions" for the full
+ * syntax specification and security model.
+ */
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getRepoRoot(): string {
+  return join(process.cwd(), "..");
+}
+
+function getBundledSkillsDir(): string {
+  return join(process.cwd(), "src", "config", "bundled-skills");
+}
+
+function getFirstPartySkillsDir(): string {
+  return join(getRepoRoot(), "skills");
+}
+
+/**
+ * Discover all SKILL.md files under a given directory (one level deep).
+ * Returns an array of { id, skillFilePath } entries.
+ */
+function discoverSkillFiles(
+  dir: string,
+): Array<{ id: string; skillFilePath: string }> {
+  if (!existsSync(dir)) return [];
+
+  const results: Array<{ id: string; skillFilePath: string }> = [];
+  const entries = readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const skillFilePath = join(dir, entry.name, "SKILL.md");
+    if (existsSync(skillFilePath) && statSync(skillFilePath).isFile()) {
+      results.push({ id: entry.name, skillFilePath });
+    }
+  }
+
+  return results.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/**
+ * Extract the markdown body from a SKILL.md file (strip frontmatter).
+ * Returns the body text, or null if the file has no valid frontmatter.
+ */
+function extractBody(filePath: string): string | undefined {
+  const content = readFileSync(filePath, "utf-8");
+  const result = parseFrontmatterFields(content);
+  return result?.body;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("inline skill authoring guard", () => {
+  test("bundled skills contain no malformed inline command expansion tokens", () => {
+    const bundledDir = getBundledSkillsDir();
+    const skills = discoverSkillFiles(bundledDir);
+
+    const violations: string[] = [];
+
+    for (const { id, skillFilePath } of skills) {
+      const body = extractBody(skillFilePath);
+      if (body === undefined) continue;
+
+      const result = parseInlineCommandExpansions(body);
+      if (result.errors.length > 0) {
+        for (const error of result.errors) {
+          violations.push(
+            `bundled/${id}: ${error.reason} at offset ${error.offset} — ${JSON.stringify(error.raw)}`,
+          );
+        }
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        "Found bundled skills with malformed inline command expansion tokens.",
+        "Fix the syntax or move examples inside fenced code blocks.",
+        "",
+        "Violations:",
+        ...violations.map((v) => `  - ${v}`),
+      ].join("\n");
+
+      expect(violations, message).toEqual([]);
+    }
+  });
+
+  test("first-party skills contain no malformed inline command expansion tokens", () => {
+    const firstPartyDir = getFirstPartySkillsDir();
+    const skills = discoverSkillFiles(firstPartyDir);
+
+    const violations: string[] = [];
+
+    for (const { id, skillFilePath } of skills) {
+      const body = extractBody(skillFilePath);
+      if (body === undefined) continue;
+
+      const result = parseInlineCommandExpansions(body);
+      if (result.errors.length > 0) {
+        for (const error of result.errors) {
+          violations.push(
+            `skills/${id}: ${error.reason} at offset ${error.offset} — ${JSON.stringify(error.raw)}`,
+          );
+        }
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        "Found first-party skills with malformed inline command expansion tokens.",
+        "Fix the syntax or move examples inside fenced code blocks.",
+        "",
+        "Violations:",
+        ...violations.map((v) => `  - ${v}`),
+      ].join("\n");
+
+      expect(violations, message).toEqual([]);
+    }
+  });
+
+  test("fenced-code examples containing inline expansion syntax are not treated as live commands", () => {
+    // This fixture verifies the parser's fenced-code-block exclusion logic.
+    // Skills that document the `!\`command\`` syntax in fenced code blocks
+    // must not have those examples picked up as live expansions.
+    const fixture = [
+      "# Example Skill",
+      "",
+      "Use inline commands to inject dynamic context:",
+      "",
+      "```markdown",
+      "Current branch: !`git branch --show-current`",
+      "Recent commits: !`git log --oneline -5`",
+      "```",
+      "",
+      "~~~",
+      "!`echo hello`",
+      "~~~",
+      "",
+      "````",
+      "```",
+      "!`nested example`",
+      "```",
+      "````",
+      "",
+      "The above examples are documentation only and should not execute.",
+    ].join("\n");
+
+    const result = parseInlineCommandExpansions(fixture);
+
+    expect(result.expansions).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("skills docs file itself contains no accidentally live inline expansion tokens", () => {
+    // The skills.md documentation describes the `!\`command\`` syntax
+    // extensively. Verify that all examples are inside fenced code blocks
+    // and the parser does not detect any live or malformed tokens.
+    const docsPath = join(process.cwd(), "docs", "skills.md");
+    if (!existsSync(docsPath)) {
+      // Skip if the docs file doesn't exist (should not happen in normal checkout)
+      return;
+    }
+
+    const content = readFileSync(docsPath, "utf-8");
+    const result = parseInlineCommandExpansions(content);
+
+    if (result.errors.length > 0) {
+      const message = [
+        "assistant/docs/skills.md contains malformed inline command expansion tokens.",
+        "Ensure all examples are inside fenced code blocks.",
+        "",
+        "Errors:",
+        ...result.errors.map(
+          (e) =>
+            `  - ${e.reason} at offset ${e.offset}: ${JSON.stringify(e.raw)}`,
+        ),
+      ].join("\n");
+
+      expect(result.errors, message).toEqual([]);
+    }
+
+    // Also verify no tokens are accidentally detected as live expansions
+    // outside of fenced code blocks. The docs should only have examples
+    // inside fences.
+    if (result.expansions.length > 0) {
+      const message = [
+        "assistant/docs/skills.md has inline expansion tokens outside fenced code blocks.",
+        "These would be treated as live commands if the file were loaded as a skill.",
+        "Move all examples inside ``` or ~~~ fenced blocks.",
+        "",
+        "Live tokens found:",
+        ...result.expansions.map(
+          (e) =>
+            "  - !" + "`" + e.command + "`" + " at offset " + e.startOffset,
+        ),
+      ].join("\n");
+
+      expect(result.expansions, message).toEqual([]);
+    }
+  });
+});

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -25,5 +25,14 @@
   - It is fine to refer to tools/utils/etc. directly by name if it is bundled with the skill (likely in `scripts/`)
   - Use standard frontmatter according to the [Agent Skills specification](https://agentskills.io/specification) - linters validate this
 
+- **Inline command expansions (`!`command``)**
+  - First-party skills may use the interoperable `` !`command` `` syntax to embed dynamic content that is resolved at skill-load time (e.g., `` !`git branch --show-current` ``, `` !`cat package.json | jq '.version'` ``)
+  - This syntax is intentionally compatible with the cross-agent inline skill command convention so that externally authored skills load in Vellum without rewriting
+  - **Vellum's execution semantics are intentionally stricter than the tweet's host-shell behavior**: commands run only in the sandbox, with network off, sanitized environment, 10-second timeout, and stdout-only capture. Do not assume host-shell capabilities (network access, credential availability, interactive prompts)
+  - Place documentation examples of the syntax inside fenced code blocks (`` ``` `` or `~~~`) — the parser skips tokens inside fences, so examples will not accidentally execute
+  - Never use empty commands (`` !`` ``), whitespace-only commands, or unmatched backticks — these are rejected by the parser as malformed
+  - The `inline-skill-commands` feature flag must be enabled for inline expansions to work. When the flag is off, skills containing expansion tokens fail closed at load time
+  - Inline command expansions are only supported for `bundled`, `managed`, and `workspace` skill sources. Skills distributed as `extra` sources cannot use this syntax
+
 - **Vellum-specific extensions**
   - If you must do something Vellum-system specific, use the `metadata` field to connect the skill in a structured way


### PR DESCRIPTION
## Summary
- Document inline command syntax, v1 execution limits, and approval model in skills.md
- Update skills/AGENTS.md with interoperable syntax guidance and security warnings
- Add guard test scanning bundled/first-party skills for malformed inline expansions

Part of plan: secure-skill-dynamic-context.md (PR 8 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
