### PR TITLE
feat: compile time-relevant simplified memory brief section

### DIFF
--- a/assistant/src/__tests__/memory-brief-time.test.ts
+++ b/assistant/src/__tests__/memory-brief-time.test.ts
@@ -1,0 +1,285 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "brief-time-test-"));
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  truncateForLog: (value: string) => value,
+}));
+
+import { compileTimeBrief } from "../memory/brief-time.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { createSchedule } from "../schedule/schedule-store.js";
+
+initializeDb();
+
+const SCOPE_ID = "default";
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+function getRawDb(): import("bun:sqlite").Database {
+  return (getDb() as unknown as { $client: import("bun:sqlite").Database })
+    .$client;
+}
+
+function insertTimeContext(opts: {
+  id: string;
+  summary: string;
+  source?: string;
+  activeFrom: number;
+  activeUntil: number;
+  scopeId?: string;
+}): void {
+  const now = Date.now();
+  getRawDb().run(
+    `INSERT INTO time_contexts (id, scope_id, summary, source, active_from, active_until, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      opts.id,
+      opts.scopeId ?? SCOPE_ID,
+      opts.summary,
+      opts.source ?? "conversation",
+      opts.activeFrom,
+      opts.activeUntil,
+      now,
+      now,
+    ],
+  );
+}
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+beforeEach(() => {
+  getRawDb().run("DELETE FROM time_contexts");
+  getRawDb().run("DELETE FROM cron_runs");
+  getRawDb().run("DELETE FROM cron_jobs");
+});
+
+// ────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────
+
+describe("compileTimeBrief", () => {
+  test("returns null when nothing qualifies", () => {
+    const now = Date.now();
+    const result = compileTimeBrief(getDb(), SCOPE_ID, now);
+    expect(result).toBeNull();
+  });
+
+  test("surfaces a tomorrow-morning event from time_contexts", () => {
+    const now = Date.now();
+    // Active window that starts before now and ends tomorrow
+    insertTimeContext({
+      id: "tc-morning",
+      summary: "Team standup tomorrow at 9am",
+      activeFrom: now - HOUR,
+      activeUntil: now + DAY,
+    });
+
+    const result = compileTimeBrief(getDb(), SCOPE_ID, now);
+    expect(result).not.toBeNull();
+    expect(result).toContain("### Time-Relevant Context");
+    expect(result).toContain("Team standup tomorrow at 9am");
+  });
+
+  test("surfaces a temporary situation (currently happening)", () => {
+    const now = Date.now();
+    // Active for the next 2 hours
+    insertTimeContext({
+      id: "tc-situation",
+      summary: "User is in a meeting until 3pm",
+      activeFrom: now - 30 * 60 * 1000,
+      activeUntil: now + 2 * HOUR,
+    });
+
+    const result = compileTimeBrief(getDb(), SCOPE_ID, now);
+    expect(result).not.toBeNull();
+    expect(result).toContain("User is in a meeting until 3pm");
+  });
+
+  test("expired time_contexts are not surfaced", () => {
+    const now = Date.now();
+    // Expired yesterday
+    insertTimeContext({
+      id: "tc-expired",
+      summary: "Dentist appointment yesterday",
+      activeFrom: now - 2 * DAY,
+      activeUntil: now - DAY,
+    });
+
+    const result = compileTimeBrief(getDb(), SCOPE_ID, now);
+    expect(result).toBeNull();
+  });
+
+  test("future time_contexts not yet active are not surfaced", () => {
+    const now = Date.now();
+    // Starts tomorrow
+    insertTimeContext({
+      id: "tc-future",
+      summary: "Vacation starts next week",
+      activeFrom: now + DAY,
+      activeUntil: now + 8 * DAY,
+    });
+
+    const result = compileTimeBrief(getDb(), SCOPE_ID, now);
+    expect(result).toBeNull();
+  });
+
+  test("includes due-soon schedule jobs", () => {
+    const now = Date.now();
+    // Create a one-shot schedule due in 2 hours
+    createSchedule({
+      name: "Send weekly report",
+      message: "Time to send the weekly report",
+      nextRunAt: now + 2 * HOUR,
+    });
+
+    const result = compileTimeBrief(getDb(), SCOPE_ID, now);
+    expect(result).not.toBeNull();
+    expect(result).toContain("### Time-Relevant Context");
+    expect(result).toContain('Scheduled: "Send weekly report"');
+    expect(result).toContain("in 2 hours");
+  });
+
+  test("sorts by urgency: happening now > overdue > within 24h > within 7d", () => {
+    const now = Date.now();
+
+    // Within 7 days (lower priority)
+    insertTimeContext({
+      id: "tc-week",
+      summary: "Quarterly review ends Friday",
+      activeFrom: now - DAY,
+      activeUntil: now + 5 * DAY,
+    });
+
+    // Happening now (expiring in 6 hours — highest priority)
+    insertTimeContext({
+      id: "tc-now",
+      summary: "User traveling today",
+      activeFrom: now - 2 * HOUR,
+      activeUntil: now + 6 * HOUR,
+    });
+
+    // Within 24h (ending tomorrow — medium priority)
+    insertTimeContext({
+      id: "tc-24h",
+      summary: "Project deadline tomorrow morning",
+      activeFrom: now - DAY,
+      activeUntil: now + 20 * HOUR,
+    });
+
+    const result = compileTimeBrief(getDb(), SCOPE_ID, now);
+    expect(result).not.toBeNull();
+
+    const lines = result!.split("\n").filter((l) => l.startsWith("- "));
+    expect(lines.length).toBe(3);
+    // Happening now (remaining <= 24h) comes first
+    expect(lines[0]).toContain("User traveling today");
+    // Within 24h comes second
+    expect(lines[1]).toContain("Project deadline tomorrow morning");
+    // Within 7d comes last
+    expect(lines[2]).toContain("Quarterly review ends Friday");
+  });
+
+  test("caps at 3 entries", () => {
+    const now = Date.now();
+
+    insertTimeContext({
+      id: "tc-1",
+      summary: "Context one",
+      activeFrom: now - HOUR,
+      activeUntil: now + 2 * HOUR,
+    });
+    insertTimeContext({
+      id: "tc-2",
+      summary: "Context two",
+      activeFrom: now - HOUR,
+      activeUntil: now + 3 * HOUR,
+    });
+    insertTimeContext({
+      id: "tc-3",
+      summary: "Context three",
+      activeFrom: now - HOUR,
+      activeUntil: now + 4 * HOUR,
+    });
+    insertTimeContext({
+      id: "tc-4",
+      summary: "Context four (should be dropped)",
+      activeFrom: now - HOUR,
+      activeUntil: now + 5 * HOUR,
+    });
+
+    const result = compileTimeBrief(getDb(), SCOPE_ID, now);
+    expect(result).not.toBeNull();
+
+    const lines = result!.split("\n").filter((l) => l.startsWith("- "));
+    expect(lines.length).toBe(3);
+    expect(result).not.toContain("Context four");
+  });
+
+  test("filters by scopeId — ignores other scopes", () => {
+    const now = Date.now();
+    insertTimeContext({
+      id: "tc-other",
+      summary: "Other scope context",
+      activeFrom: now - HOUR,
+      activeUntil: now + DAY,
+      scopeId: "other-scope",
+    });
+
+    const result = compileTimeBrief(getDb(), SCOPE_ID, now);
+    expect(result).toBeNull();
+  });
+
+  test("mixes time_contexts and schedules in deterministic order", () => {
+    const now = Date.now();
+
+    // A schedule due in 30 minutes (within 24h bucket)
+    createSchedule({
+      name: "Daily standup reminder",
+      message: "Standup time",
+      nextRunAt: now + 30 * 60 * 1000,
+    });
+
+    // A time context happening now (remaining 3 hours)
+    insertTimeContext({
+      id: "tc-active",
+      summary: "Focus time until noon",
+      activeFrom: now - HOUR,
+      activeUntil: now + 3 * HOUR,
+    });
+
+    const result = compileTimeBrief(getDb(), SCOPE_ID, now);
+    expect(result).not.toBeNull();
+
+    const lines = result!.split("\n").filter((l) => l.startsWith("- "));
+    expect(lines.length).toBe(2);
+    // Both happening-now time context and within-24h schedule should appear
+    expect(result).toContain("Focus time until noon");
+    expect(result).toContain("Daily standup reminder");
+  });
+});

--- a/assistant/src/memory/brief-formatting.ts
+++ b/assistant/src/memory/brief-formatting.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared formatting helpers for rendering capped markdown sections
+ * inside the `<memory_brief>` wrapper.
+ */
+
+export interface BriefEntry {
+  /** One-line markdown bullet text (no leading `- `). */
+  text: string;
+}
+
+/**
+ * Render a titled markdown section with a capped number of bullet entries.
+ *
+ * Returns `null` when `entries` is empty so callers can easily omit absent
+ * sections.  The output is a markdown string like:
+ *
+ * ```
+ * ### Time-Relevant Context
+ * - Meeting with Alice in 2 hours
+ * - Quarterly review deadline tomorrow
+ * ```
+ */
+export function renderBriefSection(
+  title: string,
+  entries: BriefEntry[],
+  maxEntries: number,
+): string | null {
+  if (entries.length === 0) return null;
+
+  const capped = entries.slice(0, maxEntries);
+  const bullets = capped.map((e) => `- ${e.text}`).join("\n");
+  return `### ${title}\n${bullets}`;
+}

--- a/assistant/src/memory/brief-time.ts
+++ b/assistant/src/memory/brief-time.ts
@@ -1,0 +1,161 @@
+/**
+ * Deterministic compiler for the "Time-Relevant Context" section of the
+ * memory brief.  Reads active `time_contexts` rows plus due-soon live
+ * schedule jobs, sorts them by urgency bucket, and caps the output.
+ */
+
+import { and, gte, lte } from "drizzle-orm";
+
+import { getDueSoonSchedules } from "../schedule/schedule-store.js";
+import type { BriefEntry } from "./brief-formatting.js";
+import { renderBriefSection } from "./brief-formatting.js";
+import type { DrizzleDb } from "./db-connection.js";
+import { timeContexts } from "./schema/memory-brief.js";
+
+const MAX_ENTRIES = 3;
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Urgency buckets — lower number = higher priority. */
+const enum Bucket {
+  HappeningNow = 0,
+  Overdue = 1,
+  Within24h = 2,
+  Within7d = 3,
+}
+
+interface Candidate {
+  bucket: Bucket;
+  /** Epoch ms timestamp used for secondary sort within a bucket. */
+  sortKey: number;
+  entry: BriefEntry;
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Public API
+// ────────────────────────────────────────────────────────────────────
+
+/**
+ * Compile the time-relevant brief section.
+ *
+ * @param db    Drizzle database instance
+ * @param now   Current epoch-ms timestamp (injectable for deterministic tests)
+ * @returns     Markdown string for the section, or `null` if nothing qualifies
+ */
+export function compileTimeBrief(
+  db: DrizzleDb,
+  scopeId: string,
+  now: number,
+): string | null {
+  const candidates: Candidate[] = [];
+
+  collectTimeContexts(db, scopeId, now, candidates);
+  collectDueSoonSchedules(now, candidates);
+
+  // Sort: primary = bucket ascending, secondary = sortKey ascending (sooner first)
+  candidates.sort((a, b) => a.bucket - b.bucket || a.sortKey - b.sortKey);
+
+  const entries = candidates.slice(0, MAX_ENTRIES).map((c) => c.entry);
+  return renderBriefSection("Time-Relevant Context", entries, MAX_ENTRIES);
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Internal collectors
+// ────────────────────────────────────────────────────────────────────
+
+function collectTimeContexts(
+  db: DrizzleDb,
+  scopeId: string,
+  now: number,
+  out: Candidate[],
+): void {
+  // Active time contexts: activeFrom <= now AND activeUntil >= now
+  const rows = db
+    .select()
+    .from(timeContexts)
+    .where(
+      and(
+        lte(timeContexts.activeFrom, now),
+        gte(timeContexts.activeUntil, now),
+      ),
+    )
+    .all()
+    .filter((r) => r.scopeId === scopeId);
+
+  for (const row of rows) {
+    const remaining = row.activeUntil - now;
+    let bucket: Bucket;
+
+    if (row.activeFrom <= now && row.activeUntil >= now) {
+      // Currently active — classify by how much time remains
+      if (remaining <= ONE_DAY_MS) {
+        bucket = Bucket.HappeningNow;
+      } else if (remaining <= SEVEN_DAYS_MS) {
+        bucket = Bucket.Within24h;
+      } else {
+        bucket = Bucket.Within7d;
+      }
+    } else {
+      bucket = Bucket.Within7d;
+    }
+
+    out.push({
+      bucket,
+      sortKey: row.activeUntil,
+      entry: { text: row.summary },
+    });
+  }
+}
+
+function collectDueSoonSchedules(now: number, out: Candidate[]): void {
+  const jobs = getDueSoonSchedules(now, SEVEN_DAYS_MS);
+
+  for (const job of jobs) {
+    const delta = job.nextRunAt - now;
+    let bucket: Bucket;
+
+    if (delta <= 0) {
+      bucket = Bucket.Overdue;
+    } else if (delta <= ONE_DAY_MS) {
+      bucket = Bucket.Within24h;
+    } else {
+      bucket = Bucket.Within7d;
+    }
+
+    const label = formatScheduleLabel(job.name, job.nextRunAt, now);
+    out.push({
+      bucket,
+      sortKey: job.nextRunAt,
+      entry: { text: label },
+    });
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Formatting
+// ────────────────────────────────────────────────────────────────────
+
+function formatScheduleLabel(
+  name: string,
+  nextRunAt: number,
+  now: number,
+): string {
+  const delta = nextRunAt - now;
+
+  if (delta <= 0) {
+    return `Scheduled: "${name}" — overdue`;
+  }
+
+  const minutes = Math.round(delta / 60_000);
+  if (minutes < 60) {
+    return `Scheduled: "${name}" — in ${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+
+  const hours = Math.round(delta / 3_600_000);
+  if (hours < 24) {
+    return `Scheduled: "${name}" — in ${hours} hour${hours === 1 ? "" : "s"}`;
+  }
+
+  const days = Math.round(delta / 86_400_000);
+  return `Scheduled: "${name}" — in ${days} day${days === 1 ? "" : "s"}`;
+}

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -202,6 +202,27 @@ export function listSchedules(options?: {
   return rows.map(parseJobRow);
 }
 
+/**
+ * Return enabled schedules whose next run falls within a time window.
+ * Used by the memory brief compiler to surface due-soon schedule entries.
+ */
+export function getDueSoonSchedules(
+  now: number,
+  horizonMs: number,
+): ScheduleJob[] {
+  const db = getDb();
+  const cutoff = now + horizonMs;
+  const rows = db
+    .select()
+    .from(scheduleJobs)
+    .where(
+      and(eq(scheduleJobs.enabled, true), lte(scheduleJobs.nextRunAt, cutoff)),
+    )
+    .orderBy(asc(scheduleJobs.nextRunAt))
+    .all();
+  return rows.map(parseJobRow);
+}
+
 export function updateSchedule(
   id: string,
   updates: {


### PR DESCRIPTION
## Summary
- Add brief-formatting.ts with capped markdown section rendering helper
- Add brief-time.ts with deterministic compiler for active time_contexts + due-soon schedules
- Sort by happening now > overdue > within 24h > within 7d, cap at 3 entries
- Add tests for events, situations, expired filtering, and empty omission

Part of plan: simplified-memory-v1.md (PR 18 of 23)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
