### PR TITLE
feat: add simplified memory reducer result types

### DIFF
--- a/assistant/src/__tests__/memory-reducer-types.test.ts
+++ b/assistant/src/__tests__/memory-reducer-types.test.ts
@@ -1,0 +1,713 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before imports that depend on logger
+// ---------------------------------------------------------------------------
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+import {
+  EMPTY_REDUCER_RESULT,
+  type ReducerResult,
+} from "../memory/reducer-types.js";
+import { parseReducerOutput } from "../memory/reducer.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Wrap a JS object through JSON.stringify so parseReducerOutput can consume it. */
+function toRaw(obj: unknown): string {
+  return JSON.stringify(obj);
+}
+
+// ---------------------------------------------------------------------------
+// Tests: EMPTY_REDUCER_RESULT
+// ---------------------------------------------------------------------------
+
+describe("EMPTY_REDUCER_RESULT", () => {
+  test("has all four arrays empty", () => {
+    expect(EMPTY_REDUCER_RESULT.timeContexts).toEqual([]);
+    expect(EMPTY_REDUCER_RESULT.openLoops).toEqual([]);
+    expect(EMPTY_REDUCER_RESULT.archiveObservations).toEqual([]);
+    expect(EMPTY_REDUCER_RESULT.archiveEpisodes).toEqual([]);
+  });
+
+  test("is frozen (immutable)", () => {
+    expect(Object.isFrozen(EMPTY_REDUCER_RESULT)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: parseReducerOutput — invalid inputs
+// ---------------------------------------------------------------------------
+
+describe("parseReducerOutput — invalid inputs", () => {
+  test("returns empty result for non-JSON string", () => {
+    expect(parseReducerOutput("not json at all")).toBe(EMPTY_REDUCER_RESULT);
+  });
+
+  test("returns empty result for empty string", () => {
+    expect(parseReducerOutput("")).toBe(EMPTY_REDUCER_RESULT);
+  });
+
+  test("returns empty result for JSON array", () => {
+    expect(parseReducerOutput("[]")).toBe(EMPTY_REDUCER_RESULT);
+  });
+
+  test("returns empty result for JSON null", () => {
+    expect(parseReducerOutput("null")).toBe(EMPTY_REDUCER_RESULT);
+  });
+
+  test("returns empty result for JSON number", () => {
+    expect(parseReducerOutput("42")).toBe(EMPTY_REDUCER_RESULT);
+  });
+
+  test("returns empty result for JSON string", () => {
+    expect(parseReducerOutput('"hello"')).toBe(EMPTY_REDUCER_RESULT);
+  });
+
+  test("returns empty result for object with no recognized arrays", () => {
+    expect(parseReducerOutput(toRaw({ foo: "bar" }))).toBe(
+      EMPTY_REDUCER_RESULT,
+    );
+  });
+
+  test("returns empty result when all recognized keys are not arrays", () => {
+    expect(
+      parseReducerOutput(
+        toRaw({
+          timeContexts: "not an array",
+          openLoops: 42,
+          archiveObservations: null,
+          archiveEpisodes: true,
+        }),
+      ),
+    ).toBe(EMPTY_REDUCER_RESULT);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: parseReducerOutput — valid full output
+// ---------------------------------------------------------------------------
+
+describe("parseReducerOutput — valid full output", () => {
+  test("parses a complete valid reducer output", () => {
+    const raw: Record<string, unknown> = {
+      timeContexts: [
+        {
+          action: "create",
+          summary: "User traveling next week",
+          source: "conversation",
+          activeFrom: 1700000000000,
+          activeUntil: 1700604800000,
+        },
+        {
+          action: "update",
+          id: "tc-1",
+          summary: "Updated travel dates",
+        },
+        {
+          action: "resolve",
+          id: "tc-2",
+        },
+      ],
+      openLoops: [
+        {
+          action: "create",
+          summary: "Follow up with Bob",
+          source: "conversation",
+          dueAt: 1700172800000,
+        },
+        {
+          action: "update",
+          id: "ol-1",
+          summary: "Bob replied — need to review",
+        },
+        {
+          action: "resolve",
+          id: "ol-2",
+          status: "resolved",
+        },
+      ],
+      archiveObservations: [
+        {
+          content: "User prefers dark mode",
+          role: "user",
+          modality: "text",
+          source: "vellum",
+        },
+      ],
+      archiveEpisodes: [
+        {
+          title: "Setup discussion",
+          summary: "User configured their workspace preferences",
+          source: "vellum",
+        },
+      ],
+    };
+
+    const result = parseReducerOutput(toRaw(raw));
+
+    expect(result.timeContexts).toHaveLength(3);
+    expect(result.timeContexts[0]).toEqual({
+      action: "create",
+      summary: "User traveling next week",
+      source: "conversation",
+      activeFrom: 1700000000000,
+      activeUntil: 1700604800000,
+    });
+    expect(result.timeContexts[1]).toEqual({
+      action: "update",
+      id: "tc-1",
+      summary: "Updated travel dates",
+    });
+    expect(result.timeContexts[2]).toEqual({
+      action: "resolve",
+      id: "tc-2",
+    });
+
+    expect(result.openLoops).toHaveLength(3);
+    expect(result.openLoops[0]).toEqual({
+      action: "create",
+      summary: "Follow up with Bob",
+      source: "conversation",
+      dueAt: 1700172800000,
+    });
+    expect(result.openLoops[1]).toEqual({
+      action: "update",
+      id: "ol-1",
+      summary: "Bob replied — need to review",
+    });
+    expect(result.openLoops[2]).toEqual({
+      action: "resolve",
+      id: "ol-2",
+      status: "resolved",
+    });
+
+    expect(result.archiveObservations).toHaveLength(1);
+    expect(result.archiveObservations[0]).toEqual({
+      content: "User prefers dark mode",
+      role: "user",
+      modality: "text",
+      source: "vellum",
+    });
+
+    expect(result.archiveEpisodes).toHaveLength(1);
+    expect(result.archiveEpisodes[0]).toEqual({
+      title: "Setup discussion",
+      summary: "User configured their workspace preferences",
+      source: "vellum",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: parseReducerOutput — partial outputs
+// ---------------------------------------------------------------------------
+
+describe("parseReducerOutput — partial outputs", () => {
+  test("accepts output with only timeContexts", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        timeContexts: [
+          {
+            action: "create",
+            summary: "Deadline Friday",
+            source: "conversation",
+            activeFrom: 1700000000000,
+            activeUntil: 1700604800000,
+          },
+        ],
+      }),
+    );
+    expect(result.timeContexts).toHaveLength(1);
+    expect(result.openLoops).toHaveLength(0);
+    expect(result.archiveObservations).toHaveLength(0);
+    expect(result.archiveEpisodes).toHaveLength(0);
+  });
+
+  test("accepts output with only openLoops", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        openLoops: [
+          {
+            action: "create",
+            summary: "Need to reply to Alice",
+            source: "conversation",
+          },
+        ],
+      }),
+    );
+    expect(result.openLoops).toHaveLength(1);
+    expect(result.timeContexts).toHaveLength(0);
+  });
+
+  test("accepts output with only archiveObservations", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        archiveObservations: [
+          { content: "User likes coffee", role: "user" },
+        ],
+      }),
+    );
+    expect(result.archiveObservations).toHaveLength(1);
+    expect(result.archiveObservations[0]).toEqual({
+      content: "User likes coffee",
+      role: "user",
+    });
+  });
+
+  test("accepts output with only archiveEpisodes", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        archiveEpisodes: [
+          { title: "Onboarding", summary: "First session" },
+        ],
+      }),
+    );
+    expect(result.archiveEpisodes).toHaveLength(1);
+    expect(result.archiveEpisodes[0]).toEqual({
+      title: "Onboarding",
+      summary: "First session",
+    });
+  });
+
+  test("accepts empty arrays for all keys", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        timeContexts: [],
+        openLoops: [],
+        archiveObservations: [],
+        archiveEpisodes: [],
+      }),
+    );
+    expect(result.timeContexts).toHaveLength(0);
+    expect(result.openLoops).toHaveLength(0);
+    expect(result.archiveObservations).toHaveLength(0);
+    expect(result.archiveEpisodes).toHaveLength(0);
+    // Should be a fresh object, not EMPTY_REDUCER_RESULT reference
+    expect(result).not.toBe(EMPTY_REDUCER_RESULT);
+  });
+
+  test("drops invalid individual operations while keeping valid ones", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        timeContexts: [
+          // valid create
+          {
+            action: "create",
+            summary: "Valid",
+            source: "conversation",
+            activeFrom: 1000,
+            activeUntil: 2000,
+          },
+          // invalid — missing summary
+          {
+            action: "create",
+            source: "conversation",
+            activeFrom: 1000,
+            activeUntil: 2000,
+          },
+          // invalid — unknown action
+          { action: "delete", id: "tc-1" },
+          // valid resolve
+          { action: "resolve", id: "tc-3" },
+        ],
+        openLoops: [
+          // valid create
+          {
+            action: "create",
+            summary: "Valid loop",
+            source: "conversation",
+          },
+          // invalid resolve — missing status
+          { action: "resolve", id: "ol-1" },
+          // invalid resolve — invalid status
+          { action: "resolve", id: "ol-2", status: "cancelled" },
+          // null entry
+          null,
+        ],
+      }),
+    );
+
+    expect(result.timeContexts).toHaveLength(2);
+    expect(result.timeContexts[0].action).toBe("create");
+    expect(result.timeContexts[1].action).toBe("resolve");
+
+    expect(result.openLoops).toHaveLength(1);
+    expect(result.openLoops[0].action).toBe("create");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: parseReducerOutput — time-context validation edge cases
+// ---------------------------------------------------------------------------
+
+describe("parseReducerOutput — time-context validation", () => {
+  test("rejects create with empty summary", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        timeContexts: [
+          {
+            action: "create",
+            summary: "",
+            source: "conversation",
+            activeFrom: 1000,
+            activeUntil: 2000,
+          },
+        ],
+      }),
+    );
+    expect(result.timeContexts).toHaveLength(0);
+  });
+
+  test("rejects create with non-string summary", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        timeContexts: [
+          {
+            action: "create",
+            summary: 123,
+            source: "conversation",
+            activeFrom: 1000,
+            activeUntil: 2000,
+          },
+        ],
+      }),
+    );
+    expect(result.timeContexts).toHaveLength(0);
+  });
+
+  test("rejects create with negative activeUntil", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        timeContexts: [
+          {
+            action: "create",
+            summary: "Test",
+            source: "conversation",
+            activeFrom: 1000,
+            activeUntil: -1,
+          },
+        ],
+      }),
+    );
+    expect(result.timeContexts).toHaveLength(0);
+  });
+
+  test("accepts create with activeFrom of 0 (epoch)", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        timeContexts: [
+          {
+            action: "create",
+            summary: "From epoch",
+            source: "conversation",
+            activeFrom: 0,
+            activeUntil: 1000,
+          },
+        ],
+      }),
+    );
+    expect(result.timeContexts).toHaveLength(1);
+  });
+
+  test("rejects update with no updatable fields", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        timeContexts: [{ action: "update", id: "tc-1" }],
+      }),
+    );
+    expect(result.timeContexts).toHaveLength(0);
+  });
+
+  test("accepts update with only summary", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        timeContexts: [
+          { action: "update", id: "tc-1", summary: "New summary" },
+        ],
+      }),
+    );
+    expect(result.timeContexts).toHaveLength(1);
+    const op = result.timeContexts[0];
+    expect(op.action).toBe("update");
+    if (op.action === "update") {
+      expect(op.summary).toBe("New summary");
+      expect(op.activeFrom).toBeUndefined();
+      expect(op.activeUntil).toBeUndefined();
+    }
+  });
+
+  test("rejects resolve with missing id", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        timeContexts: [{ action: "resolve" }],
+      }),
+    );
+    expect(result.timeContexts).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: parseReducerOutput — open-loop validation edge cases
+// ---------------------------------------------------------------------------
+
+describe("parseReducerOutput — open-loop validation", () => {
+  test("accepts create without optional dueAt", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        openLoops: [
+          {
+            action: "create",
+            summary: "No deadline",
+            source: "conversation",
+          },
+        ],
+      }),
+    );
+    expect(result.openLoops).toHaveLength(1);
+    if (result.openLoops[0].action === "create") {
+      expect(result.openLoops[0].dueAt).toBeUndefined();
+    }
+  });
+
+  test("accepts create with dueAt", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        openLoops: [
+          {
+            action: "create",
+            summary: "With deadline",
+            source: "conversation",
+            dueAt: 1700000000000,
+          },
+        ],
+      }),
+    );
+    expect(result.openLoops).toHaveLength(1);
+    if (result.openLoops[0].action === "create") {
+      expect(result.openLoops[0].dueAt).toBe(1700000000000);
+    }
+  });
+
+  test("rejects create with missing source", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        openLoops: [{ action: "create", summary: "Missing source" }],
+      }),
+    );
+    expect(result.openLoops).toHaveLength(0);
+  });
+
+  test("rejects update with no updatable fields", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        openLoops: [{ action: "update", id: "ol-1" }],
+      }),
+    );
+    expect(result.openLoops).toHaveLength(0);
+  });
+
+  test("accepts update with only dueAt", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        openLoops: [
+          { action: "update", id: "ol-1", dueAt: 1700000000000 },
+        ],
+      }),
+    );
+    expect(result.openLoops).toHaveLength(1);
+  });
+
+  test("accepts resolve with status 'expired'", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        openLoops: [
+          { action: "resolve", id: "ol-1", status: "expired" },
+        ],
+      }),
+    );
+    expect(result.openLoops).toHaveLength(1);
+    if (result.openLoops[0].action === "resolve") {
+      expect(result.openLoops[0].status).toBe("expired");
+    }
+  });
+
+  test("rejects resolve with invalid status value", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        openLoops: [
+          { action: "resolve", id: "ol-1", status: "deleted" },
+        ],
+      }),
+    );
+    expect(result.openLoops).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: parseReducerOutput — archive observation validation
+// ---------------------------------------------------------------------------
+
+describe("parseReducerOutput — archive observation validation", () => {
+  test("rejects observation with missing content", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        archiveObservations: [{ role: "user" }],
+      }),
+    );
+    expect(result.archiveObservations).toHaveLength(0);
+  });
+
+  test("rejects observation with missing role", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        archiveObservations: [{ content: "Something" }],
+      }),
+    );
+    expect(result.archiveObservations).toHaveLength(0);
+  });
+
+  test("includes optional modality and source when present", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        archiveObservations: [
+          {
+            content: "User likes tea",
+            role: "user",
+            modality: "voice",
+            source: "phone",
+          },
+        ],
+      }),
+    );
+    expect(result.archiveObservations).toHaveLength(1);
+    expect(result.archiveObservations[0].modality).toBe("voice");
+    expect(result.archiveObservations[0].source).toBe("phone");
+  });
+
+  test("omits modality and source when not valid strings", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        archiveObservations: [
+          {
+            content: "Fact",
+            role: "user",
+            modality: 123,
+            source: false,
+          },
+        ],
+      }),
+    );
+    expect(result.archiveObservations).toHaveLength(1);
+    expect(result.archiveObservations[0].modality).toBeUndefined();
+    expect(result.archiveObservations[0].source).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: parseReducerOutput — archive episode validation
+// ---------------------------------------------------------------------------
+
+describe("parseReducerOutput — archive episode validation", () => {
+  test("rejects episode with missing title", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        archiveEpisodes: [{ summary: "Some summary" }],
+      }),
+    );
+    expect(result.archiveEpisodes).toHaveLength(0);
+  });
+
+  test("rejects episode with missing summary", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        archiveEpisodes: [{ title: "Some title" }],
+      }),
+    );
+    expect(result.archiveEpisodes).toHaveLength(0);
+  });
+
+  test("includes optional source when present", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        archiveEpisodes: [
+          { title: "Chat", summary: "A chat happened", source: "telegram" },
+        ],
+      }),
+    );
+    expect(result.archiveEpisodes).toHaveLength(1);
+    expect(result.archiveEpisodes[0].source).toBe("telegram");
+  });
+
+  test("omits source when not a valid string", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        archiveEpisodes: [
+          { title: "Chat", summary: "A chat happened", source: 42 },
+        ],
+      }),
+    );
+    expect(result.archiveEpisodes).toHaveLength(1);
+    expect(result.archiveEpisodes[0].source).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: parseReducerOutput — extra/unknown keys are tolerated
+// ---------------------------------------------------------------------------
+
+describe("parseReducerOutput — tolerates extra keys", () => {
+  test("ignores unknown top-level keys", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        timeContexts: [],
+        unknownKey: "whatever",
+        anotherOne: [1, 2, 3],
+      }),
+    );
+    expect(result).not.toBe(EMPTY_REDUCER_RESULT);
+    expect(result.timeContexts).toHaveLength(0);
+  });
+
+  test("ignores extra fields on individual operations", () => {
+    const result = parseReducerOutput(
+      toRaw({
+        openLoops: [
+          {
+            action: "create",
+            summary: "Valid",
+            source: "conversation",
+            extraField: true,
+            nested: { deep: 1 },
+          },
+        ],
+      }),
+    );
+    expect(result.openLoops).toHaveLength(1);
+    // Extra fields should NOT be present on the validated result
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((result.openLoops[0] as any).extraField).toBeUndefined();
+  });
+});

--- a/assistant/src/memory/reducer-types.ts
+++ b/assistant/src/memory/reducer-types.ts
@@ -1,0 +1,99 @@
+/**
+ * Structured result types for the simplified memory reducer.
+ *
+ * The reducer processes conversation turns and produces CRUD operations for
+ * two brief-state tables (time_contexts, open_loops) and optional archive
+ * candidates (observations, episodes).
+ *
+ * These types are consumed by the reducer parser/validator and eventually by
+ * the DB-write layer that applies them atomically.
+ */
+
+// ── Time-context CRUD ──────────────────────────────────────────────────
+
+export interface TimeContextCreate {
+  action: "create";
+  summary: string;
+  source: string;
+  activeFrom: number; // epoch ms
+  activeUntil: number; // epoch ms
+}
+
+export interface TimeContextUpdate {
+  action: "update";
+  id: string;
+  summary?: string;
+  activeFrom?: number;
+  activeUntil?: number;
+}
+
+export interface TimeContextResolve {
+  action: "resolve";
+  id: string;
+}
+
+export type TimeContextOp =
+  | TimeContextCreate
+  | TimeContextUpdate
+  | TimeContextResolve;
+
+// ── Open-loop CRUD ─────────────────────────────────────────────────────
+
+export interface OpenLoopCreate {
+  action: "create";
+  summary: string;
+  source: string;
+  dueAt?: number; // epoch ms, optional deadline
+}
+
+export interface OpenLoopUpdate {
+  action: "update";
+  id: string;
+  summary?: string;
+  dueAt?: number;
+}
+
+export interface OpenLoopResolve {
+  action: "resolve";
+  id: string;
+  status: "resolved" | "expired";
+}
+
+export type OpenLoopOp = OpenLoopCreate | OpenLoopUpdate | OpenLoopResolve;
+
+// ── Archive candidates ─────────────────────────────────────────────────
+
+export interface ArchiveObservationCandidate {
+  content: string;
+  role: string;
+  modality?: string;
+  source?: string;
+}
+
+export interface ArchiveEpisodeCandidate {
+  title: string;
+  summary: string;
+  source?: string;
+}
+
+// ── Top-level reducer result ───────────────────────────────────────────
+
+export interface ReducerResult {
+  timeContexts: TimeContextOp[];
+  openLoops: OpenLoopOp[];
+  archiveObservations: ArchiveObservationCandidate[];
+  archiveEpisodes: ArchiveEpisodeCandidate[];
+}
+
+/**
+ * An empty result used as fallback when the reducer output is invalid or
+ * unparseable. Guarantees no side-effects on the DB.
+ */
+export const EMPTY_REDUCER_RESULT: Readonly<ReducerResult> = Object.freeze({
+  timeContexts: Object.freeze([]) as unknown as TimeContextOp[],
+  openLoops: Object.freeze([]) as unknown as OpenLoopOp[],
+  archiveObservations: Object.freeze(
+    [],
+  ) as unknown as ArchiveObservationCandidate[],
+  archiveEpisodes: Object.freeze([]) as unknown as ArchiveEpisodeCandidate[],
+});

--- a/assistant/src/memory/reducer.ts
+++ b/assistant/src/memory/reducer.ts
@@ -1,0 +1,287 @@
+/**
+ * Parsing and validation layer for the simplified memory reducer.
+ *
+ * This module owns the contract between the LLM's JSON output and the typed
+ * ReducerResult. The actual provider call lives in a later PR — this file
+ * only handles:
+ *   1. ReducerPromptInput — what goes into the provider call
+ *   2. parseReducerOutput — raw string -> validated ReducerResult
+ *   3. Fallback to EMPTY_REDUCER_RESULT on any invalid output
+ */
+
+import { getLogger } from "../util/logger.js";
+import {
+  EMPTY_REDUCER_RESULT,
+  type ArchiveEpisodeCandidate,
+  type ArchiveObservationCandidate,
+  type OpenLoopCreate,
+  type OpenLoopOp,
+  type OpenLoopUpdate,
+  type ReducerResult,
+  type TimeContextOp,
+  type TimeContextUpdate,
+} from "./reducer-types.js";
+
+const log = getLogger("memory-reducer");
+
+// ── Prompt input type ──────────────────────────────────────────────────
+
+/** The structured input that will be fed to the reducer provider call. */
+export interface ReducerPromptInput {
+  /** Conversation ID being reduced. */
+  conversationId: string;
+  /** New messages since the last reduction checkpoint (role + content). */
+  newMessages: Array<{ role: string; content: string }>;
+  /** Current time-context rows the model can reference for updates. */
+  existingTimeContexts: Array<{ id: string; summary: string }>;
+  /** Current open-loop rows the model can reference for updates. */
+  existingOpenLoops: Array<{ id: string; summary: string; status: string }>;
+}
+
+// ── Validation helpers ─────────────────────────────────────────────────
+
+const VALID_TIME_CONTEXT_ACTIONS = new Set(["create", "update", "resolve"]);
+const VALID_OPEN_LOOP_ACTIONS = new Set(["create", "update", "resolve"]);
+const VALID_OPEN_LOOP_RESOLVE_STATUSES = new Set(["resolved", "expired"]);
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === "string" && v.length > 0;
+}
+
+function isPositiveNumber(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v) && v > 0;
+}
+
+function isNonNegativeNumber(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v) && v >= 0;
+}
+
+function validateTimeContextOp(raw: unknown): TimeContextOp | null {
+  if (raw == null || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  const action = obj.action;
+
+  if (!isNonEmptyString(action) || !VALID_TIME_CONTEXT_ACTIONS.has(action)) {
+    return null;
+  }
+
+  if (action === "create") {
+    if (
+      !isNonEmptyString(obj.summary) ||
+      !isNonEmptyString(obj.source) ||
+      !isNonNegativeNumber(obj.activeFrom) ||
+      !isPositiveNumber(obj.activeUntil)
+    ) {
+      return null;
+    }
+    return {
+      action: "create",
+      summary: obj.summary,
+      source: obj.source,
+      activeFrom: obj.activeFrom,
+      activeUntil: obj.activeUntil,
+    };
+  }
+
+  if (action === "update") {
+    if (!isNonEmptyString(obj.id)) return null;
+    // Extract and narrow optional fields
+    const summary = isNonEmptyString(obj.summary) ? obj.summary : undefined;
+    const activeFrom = isNonNegativeNumber(obj.activeFrom)
+      ? obj.activeFrom
+      : undefined;
+    const activeUntil = isPositiveNumber(obj.activeUntil)
+      ? obj.activeUntil
+      : undefined;
+    // At least one field must be provided for the update to be meaningful
+    if (
+      summary === undefined &&
+      activeFrom === undefined &&
+      activeUntil === undefined
+    ) {
+      return null;
+    }
+    const result: TimeContextUpdate = {
+      action: "update",
+      id: obj.id,
+    };
+    if (summary !== undefined) result.summary = summary;
+    if (activeFrom !== undefined) result.activeFrom = activeFrom;
+    if (activeUntil !== undefined) result.activeUntil = activeUntil;
+    return result;
+  }
+
+  // resolve
+  if (!isNonEmptyString(obj.id)) return null;
+  return { action: "resolve", id: obj.id };
+}
+
+function validateOpenLoopOp(raw: unknown): OpenLoopOp | null {
+  if (raw == null || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  const action = obj.action;
+
+  if (!isNonEmptyString(action) || !VALID_OPEN_LOOP_ACTIONS.has(action)) {
+    return null;
+  }
+
+  if (action === "create") {
+    if (!isNonEmptyString(obj.summary) || !isNonEmptyString(obj.source)) {
+      return null;
+    }
+    const result: OpenLoopCreate = {
+      action: "create",
+      summary: obj.summary,
+      source: obj.source,
+    };
+    const dueAt = isNonNegativeNumber(obj.dueAt) ? obj.dueAt : undefined;
+    if (dueAt !== undefined) result.dueAt = dueAt;
+    return result;
+  }
+
+  if (action === "update") {
+    if (!isNonEmptyString(obj.id)) return null;
+    const summary = isNonEmptyString(obj.summary) ? obj.summary : undefined;
+    const dueAt = isNonNegativeNumber(obj.dueAt) ? obj.dueAt : undefined;
+    if (summary === undefined && dueAt === undefined) return null;
+
+    const result: OpenLoopUpdate = {
+      action: "update",
+      id: obj.id,
+    };
+    if (summary !== undefined) result.summary = summary;
+    if (dueAt !== undefined) result.dueAt = dueAt;
+    return result;
+  }
+
+  // resolve
+  if (!isNonEmptyString(obj.id)) return null;
+  if (
+    !isNonEmptyString(obj.status) ||
+    !VALID_OPEN_LOOP_RESOLVE_STATUSES.has(obj.status)
+  ) {
+    return null;
+  }
+  return {
+    action: "resolve",
+    id: obj.id,
+    status: obj.status as "resolved" | "expired",
+  };
+}
+
+function validateArchiveObservation(
+  raw: unknown,
+): ArchiveObservationCandidate | null {
+  if (raw == null || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  if (!isNonEmptyString(obj.content) || !isNonEmptyString(obj.role)) {
+    return null;
+  }
+  const result: ArchiveObservationCandidate = {
+    content: obj.content,
+    role: obj.role,
+  };
+  if (isNonEmptyString(obj.modality)) result.modality = obj.modality;
+  if (isNonEmptyString(obj.source)) result.source = obj.source;
+  return result;
+}
+
+function validateArchiveEpisode(
+  raw: unknown,
+): ArchiveEpisodeCandidate | null {
+  if (raw == null || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  if (!isNonEmptyString(obj.title) || !isNonEmptyString(obj.summary)) {
+    return null;
+  }
+  const result: ArchiveEpisodeCandidate = {
+    title: obj.title,
+    summary: obj.summary,
+  };
+  if (isNonEmptyString(obj.source)) result.source = obj.source;
+  return result;
+}
+
+// ── Public API ─────────────────────────────────────────────────────────
+
+/**
+ * Parse raw model output into a validated ReducerResult.
+ *
+ * On any structural error (non-JSON, missing top-level keys, wrong types)
+ * the function returns EMPTY_REDUCER_RESULT rather than throwing. Individual
+ * invalid operations within an otherwise valid structure are silently dropped
+ * to preserve the rest of the result.
+ *
+ * However, if **all four** top-level arrays are absent or not arrays, the
+ * entire output is treated as invalid and returns the empty result.
+ */
+export function parseReducerOutput(raw: string): ReducerResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    log.warn("reducer output is not valid JSON — falling back to empty result");
+    return EMPTY_REDUCER_RESULT;
+  }
+
+  if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    log.warn(
+      "reducer output is not a JSON object — falling back to empty result",
+    );
+    return EMPTY_REDUCER_RESULT;
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  // Check that at least one top-level array key exists
+  const hasTimeContexts = Array.isArray(obj.timeContexts);
+  const hasOpenLoops = Array.isArray(obj.openLoops);
+  const hasArchiveObservations = Array.isArray(obj.archiveObservations);
+  const hasArchiveEpisodes = Array.isArray(obj.archiveEpisodes);
+
+  if (
+    !hasTimeContexts &&
+    !hasOpenLoops &&
+    !hasArchiveObservations &&
+    !hasArchiveEpisodes
+  ) {
+    log.warn(
+      "reducer output has no recognized top-level arrays — falling back to empty result",
+    );
+    return EMPTY_REDUCER_RESULT;
+  }
+
+  const timeContexts: TimeContextOp[] = [];
+  if (hasTimeContexts) {
+    for (const item of obj.timeContexts as unknown[]) {
+      const validated = validateTimeContextOp(item);
+      if (validated) timeContexts.push(validated);
+    }
+  }
+
+  const openLoops: OpenLoopOp[] = [];
+  if (hasOpenLoops) {
+    for (const item of obj.openLoops as unknown[]) {
+      const validated = validateOpenLoopOp(item);
+      if (validated) openLoops.push(validated);
+    }
+  }
+
+  const archiveObservations: ArchiveObservationCandidate[] = [];
+  if (hasArchiveObservations) {
+    for (const item of obj.archiveObservations as unknown[]) {
+      const validated = validateArchiveObservation(item);
+      if (validated) archiveObservations.push(validated);
+    }
+  }
+
+  const archiveEpisodes: ArchiveEpisodeCandidate[] = [];
+  if (hasArchiveEpisodes) {
+    for (const item of obj.archiveEpisodes as unknown[]) {
+      const validated = validateArchiveEpisode(item);
+      if (validated) archiveEpisodes.push(validated);
+    }
+  }
+
+  return { timeContexts, openLoops, archiveObservations, archiveEpisodes };
+}


### PR DESCRIPTION
## Summary
- Add structured reducer result types for time-context and open-loop CRUD
- Add parsing/validation layer with invalid-output fallback to empty result
- Add tests locking parser behavior for valid, partial, and invalid outputs

Part of plan: simplified-memory-v1.md (PR 5 of 23)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
