### PR TITLE
feat: add chunk archive store and embedding jobs

### DIFF
--- a/assistant/src/__tests__/memory-chunk-archive.test.ts
+++ b/assistant/src/__tests__/memory-chunk-archive.test.ts
@@ -1,0 +1,400 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+const testDir = mkdtempSync(join(tmpdir(), "memory-chunk-archive-test-"));
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Track calls to embedAndUpsert
+const embedAndUpsertCalls: Array<{
+  config: unknown;
+  targetType: string;
+  targetId: string;
+  input: unknown;
+  extraPayload: unknown;
+}> = [];
+
+mock.module("../memory/job-utils.js", () => ({
+  asString: (value: unknown) =>
+    typeof value === "string" && value.length > 0 ? value : null,
+  embedAndUpsert: async (
+    config: unknown,
+    targetType: string,
+    targetId: string,
+    input: unknown,
+    extraPayload: unknown,
+  ) => {
+    embedAndUpsertCalls.push({
+      config,
+      targetType,
+      targetId,
+      input,
+      extraPayload,
+    });
+  },
+}));
+
+import { DEFAULT_CONFIG } from "../config/defaults.js";
+import type { AssistantConfig } from "../config/types.js";
+import {
+  computeChunkContentHash,
+  estimateTokens,
+  getChunkById,
+  getChunksByObservationId,
+  upsertChunk,
+  upsertChunks,
+} from "../memory/archive-store.js";
+import { getDb, initializeDb, resetTestTables } from "../memory/db.js";
+import { embedChunkJob } from "../memory/job-handlers/embedding.js";
+import type { MemoryJob } from "../memory/jobs-store.js";
+import {
+  conversations,
+  memoryJobs,
+  memoryObservations,
+} from "../memory/schema.js";
+
+const TEST_CONFIG: AssistantConfig = {
+  ...DEFAULT_CONFIG,
+  memory: {
+    ...DEFAULT_CONFIG.memory,
+    extraction: {
+      ...DEFAULT_CONFIG.memory.extraction,
+      useLLM: false,
+    },
+  },
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function makeJob(payload: Record<string, unknown>): MemoryJob {
+  return {
+    id: "job-1",
+    type: "embed_chunk",
+    payload,
+    status: "running",
+    attempts: 0,
+    deferrals: 0,
+    runAfter: 0,
+    lastError: null,
+    startedAt: Date.now(),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+function seedConversation(id = "conv-1"): void {
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversations)
+    .values({
+      id,
+      title: "Test Conversation",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing()
+    .run();
+}
+
+function seedObservation(
+  id = "obs-1",
+  conversationId = "conv-1",
+  content = "The user prefers dark mode.",
+): void {
+  const db = getDb();
+  const now = Date.now();
+  db.insert(memoryObservations)
+    .values({
+      id,
+      scopeId: "default",
+      conversationId,
+      role: "user",
+      content,
+      modality: "text",
+      createdAt: now,
+    })
+    .onConflictDoNothing()
+    .run();
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe("archive-store chunk helpers", () => {
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    embedAndUpsertCalls.length = 0;
+    // Clear tables in FK-dependency order: chunks → observations → jobs, conversations
+    resetTestTables(
+      "memory_chunks",
+      "memory_observations",
+      "memory_jobs",
+      "conversations",
+    );
+    seedConversation();
+    seedObservation();
+  });
+
+  afterAll(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  // ── computeChunkContentHash ─────────────────────────────────────
+
+  describe("computeChunkContentHash", () => {
+    test("produces deterministic hash for same inputs", () => {
+      const h1 = computeChunkContentHash("default", "hello world");
+      const h2 = computeChunkContentHash("default", "hello world");
+      expect(h1).toBe(h2);
+    });
+
+    test("produces different hash for different scope", () => {
+      const h1 = computeChunkContentHash("default", "hello world");
+      const h2 = computeChunkContentHash("other-scope", "hello world");
+      expect(h1).not.toBe(h2);
+    });
+
+    test("produces different hash for different content", () => {
+      const h1 = computeChunkContentHash("default", "hello world");
+      const h2 = computeChunkContentHash("default", "goodbye world");
+      expect(h1).not.toBe(h2);
+    });
+  });
+
+  // ── estimateTokens ─────────────────────────────────────────────
+
+  describe("estimateTokens", () => {
+    test("returns at least 1 for empty string", () => {
+      expect(estimateTokens("")).toBe(1);
+    });
+
+    test("estimates roughly 4 chars per token", () => {
+      const text = "a".repeat(100);
+      expect(estimateTokens(text)).toBe(25);
+    });
+  });
+
+  // ── upsertChunk ────────────────────────────────────────────────
+
+  describe("upsertChunk", () => {
+    test("inserts a new chunk and enqueues embed_chunk job", () => {
+      const result = upsertChunk({
+        observationId: "obs-1",
+        content: "The user prefers dark mode.",
+      });
+
+      expect(result.inserted).toBe(true);
+      expect(result.chunkId).toBeTruthy();
+
+      // Verify chunk row exists
+      const chunk = getChunkById(result.chunkId);
+      expect(chunk).toBeDefined();
+      expect(chunk!.content).toBe("The user prefers dark mode.");
+      expect(chunk!.scopeId).toBe("default");
+      expect(chunk!.observationId).toBe("obs-1");
+      expect(chunk!.tokenEstimate).toBeGreaterThan(0);
+
+      // Verify embed_chunk job was enqueued
+      const db = getDb();
+      const jobs = db
+        .select()
+        .from(memoryJobs)
+        .where(eq(memoryJobs.type, "embed_chunk"))
+        .all();
+      expect(jobs).toHaveLength(1);
+      const payload = JSON.parse(jobs[0].payload);
+      expect(payload.chunkId).toBe(result.chunkId);
+      expect(payload.scopeId).toBe("default");
+    });
+
+    test("skips insert when content hash already exists (idempotence)", () => {
+      const first = upsertChunk({
+        observationId: "obs-1",
+        content: "The user prefers dark mode.",
+      });
+      expect(first.inserted).toBe(true);
+
+      const second = upsertChunk({
+        observationId: "obs-1",
+        content: "The user prefers dark mode.",
+      });
+      expect(second.inserted).toBe(false);
+      expect(second.chunkId).toBe(first.chunkId);
+
+      // Only one embed_chunk job should exist
+      const db = getDb();
+      const jobs = db
+        .select()
+        .from(memoryJobs)
+        .where(eq(memoryJobs.type, "embed_chunk"))
+        .all();
+      expect(jobs).toHaveLength(1);
+    });
+
+    test("inserts different chunks for different content", () => {
+      const r1 = upsertChunk({
+        observationId: "obs-1",
+        content: "Chunk A content",
+      });
+      const r2 = upsertChunk({
+        observationId: "obs-1",
+        content: "Chunk B content",
+      });
+
+      expect(r1.inserted).toBe(true);
+      expect(r2.inserted).toBe(true);
+      expect(r1.chunkId).not.toBe(r2.chunkId);
+    });
+
+    test("respects custom scopeId", () => {
+      const result = upsertChunk({
+        scopeId: "scope-42",
+        observationId: "obs-1",
+        content: "Scoped content",
+      });
+
+      const chunk = getChunkById(result.chunkId);
+      expect(chunk!.scopeId).toBe("scope-42");
+    });
+
+    test("uses provided tokenEstimate when given", () => {
+      const result = upsertChunk({
+        observationId: "obs-1",
+        content: "Short text",
+        tokenEstimate: 99,
+      });
+
+      const chunk = getChunkById(result.chunkId);
+      expect(chunk!.tokenEstimate).toBe(99);
+    });
+  });
+
+  // ── upsertChunks (batch) ──────────────────────────────────────
+
+  describe("upsertChunks", () => {
+    test("upserts multiple chunks and returns results in order", () => {
+      const results = upsertChunks([
+        { observationId: "obs-1", content: "First chunk" },
+        { observationId: "obs-1", content: "Second chunk" },
+        { observationId: "obs-1", content: "Third chunk" },
+      ]);
+
+      expect(results).toHaveLength(3);
+      expect(results.every((r) => r.inserted)).toBe(true);
+
+      // All chunk IDs are unique
+      const ids = new Set(results.map((r) => r.chunkId));
+      expect(ids.size).toBe(3);
+    });
+
+    test("batch upsert with duplicate content is idempotent", () => {
+      const results = upsertChunks([
+        { observationId: "obs-1", content: "Same content" },
+        { observationId: "obs-1", content: "Same content" },
+      ]);
+
+      expect(results[0].inserted).toBe(true);
+      expect(results[1].inserted).toBe(false);
+      expect(results[0].chunkId).toBe(results[1].chunkId);
+    });
+  });
+
+  // ── getChunksByObservationId ──────────────────────────────────
+
+  describe("getChunksByObservationId", () => {
+    test("returns all chunks for an observation", () => {
+      upsertChunk({ observationId: "obs-1", content: "Chunk A" });
+      upsertChunk({ observationId: "obs-1", content: "Chunk B" });
+
+      const chunks = getChunksByObservationId("obs-1");
+      expect(chunks).toHaveLength(2);
+    });
+
+    test("returns empty array for unknown observation", () => {
+      const chunks = getChunksByObservationId("obs-nonexistent");
+      expect(chunks).toHaveLength(0);
+    });
+  });
+
+  // ── embedChunkJob ─────────────────────────────────────────────
+
+  describe("embedChunkJob", () => {
+    test("skips when chunkId is missing from payload", async () => {
+      await embedChunkJob(makeJob({}), TEST_CONFIG);
+      expect(embedAndUpsertCalls).toHaveLength(0);
+    });
+
+    test("skips when chunk is not found", async () => {
+      await embedChunkJob(makeJob({ chunkId: "nonexistent" }), TEST_CONFIG);
+      expect(embedAndUpsertCalls).toHaveLength(0);
+    });
+
+    test("embeds chunk with correct targetType and payload", async () => {
+      const result = upsertChunk({
+        observationId: "obs-1",
+        content: "The user prefers dark mode.",
+      });
+
+      await embedChunkJob(makeJob({ chunkId: result.chunkId }), TEST_CONFIG);
+
+      expect(embedAndUpsertCalls).toHaveLength(1);
+      const call = embedAndUpsertCalls[0];
+      expect(call.targetType).toBe("chunk");
+      expect(call.targetId).toBe(result.chunkId);
+      expect(call.input).toBe("The user prefers dark mode.");
+      expect(call.extraPayload).toMatchObject({
+        observation_id: "obs-1",
+        memory_scope_id: "default",
+      });
+      expect(
+        (call.extraPayload as Record<string, unknown>).created_at,
+      ).toBeGreaterThan(0);
+    });
+
+    test("embeds chunk with correct scopeId in extra payload", async () => {
+      const result = upsertChunk({
+        scopeId: "custom-scope",
+        observationId: "obs-1",
+        content: "Scoped chunk content.",
+      });
+
+      await embedChunkJob(makeJob({ chunkId: result.chunkId }), TEST_CONFIG);
+
+      expect(embedAndUpsertCalls).toHaveLength(1);
+      const call = embedAndUpsertCalls[0];
+      expect(
+        (call.extraPayload as Record<string, unknown>).memory_scope_id,
+      ).toBe("custom-scope");
+    });
+  });
+});

--- a/assistant/src/memory/archive-store.ts
+++ b/assistant/src/memory/archive-store.ts
@@ -1,0 +1,148 @@
+import { createHash } from "node:crypto";
+
+import { eq } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import { getLogger } from "../util/logger.js";
+import { getDb } from "./db.js";
+import { enqueueMemoryJob } from "./jobs-store.js";
+import { memoryChunks } from "./schema.js";
+
+const log = getLogger("memory-archive-store");
+
+// ── Content hashing ─────────────────────────────────────────────────
+
+/**
+ * Compute a SHA-256 content hash for a chunk's content, scoped by scopeId.
+ * Used for idempotent upserts — if the hash already exists within the same
+ * scope, the chunk is skipped.
+ */
+export function computeChunkContentHash(
+  scopeId: string,
+  content: string,
+): string {
+  return createHash("sha256").update(`${scopeId}|${content}`).digest("hex");
+}
+
+// ── Token estimation ────────────────────────────────────────────────
+
+/**
+ * Rough token count estimate based on character length.
+ * Uses the common ~4 chars/token heuristic for English text.
+ */
+export function estimateTokens(text: string): number {
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+// ── Chunk upsert ────────────────────────────────────────────────────
+
+export interface UpsertChunkInput {
+  /** Scope for memory isolation. Defaults to "default". */
+  scopeId?: string;
+  /** FK to the parent observation. */
+  observationId: string;
+  /** The chunk text to embed and recall. */
+  content: string;
+  /** Optional pre-computed token estimate. If omitted, estimated from content length. */
+  tokenEstimate?: number;
+}
+
+export interface UpsertChunkResult {
+  chunkId: string;
+  /** True if a new row was inserted; false if an existing row matched the content hash. */
+  inserted: boolean;
+}
+
+/**
+ * Idempotently upsert a chunk into the archive. If a chunk with the same
+ * (scopeId, contentHash) already exists, the insert is skipped and the
+ * existing row's id is returned. Otherwise a new row is inserted and an
+ * `embed_chunk` job is enqueued.
+ */
+export function upsertChunk(input: UpsertChunkInput): UpsertChunkResult {
+  const scopeId = input.scopeId ?? "default";
+  const contentHash = computeChunkContentHash(scopeId, input.content);
+  const tokenEstimate = input.tokenEstimate ?? estimateTokens(input.content);
+  const db = getDb();
+
+  // Check for an existing chunk with the same content hash in this scope
+  const existing = db
+    .select({ id: memoryChunks.id })
+    .from(memoryChunks)
+    .where(eq(memoryChunks.contentHash, contentHash))
+    .get();
+
+  if (existing) {
+    log.debug(
+      { scopeId, contentHash, existingId: existing.id },
+      "Chunk already exists, skipping insert",
+    );
+    return { chunkId: existing.id, inserted: false };
+  }
+
+  const chunkId = uuid();
+  const now = Date.now();
+
+  db.insert(memoryChunks)
+    .values({
+      id: chunkId,
+      scopeId,
+      observationId: input.observationId,
+      content: input.content,
+      tokenEstimate,
+      contentHash,
+      createdAt: now,
+    })
+    .run();
+
+  // Enqueue an embedding job for the new chunk
+  enqueueMemoryJob("embed_chunk", {
+    chunkId,
+    scopeId,
+  });
+
+  log.debug(
+    { chunkId, scopeId, contentHash },
+    "Inserted new chunk and enqueued embed_chunk job",
+  );
+
+  return { chunkId, inserted: true };
+}
+
+/**
+ * Upsert multiple chunks for a single observation. Returns results for
+ * each input in the same order.
+ */
+export function upsertChunks(inputs: UpsertChunkInput[]): UpsertChunkResult[] {
+  return inputs.map((input) => upsertChunk(input));
+}
+
+// ── Chunk queries ───────────────────────────────────────────────────
+
+/**
+ * Get a chunk by its ID.
+ */
+export function getChunkById(
+  chunkId: string,
+): typeof memoryChunks.$inferSelect | undefined {
+  const db = getDb();
+  return db
+    .select()
+    .from(memoryChunks)
+    .where(eq(memoryChunks.id, chunkId))
+    .get();
+}
+
+/**
+ * Get all chunks for a given observation.
+ */
+export function getChunksByObservationId(
+  observationId: string,
+): Array<typeof memoryChunks.$inferSelect> {
+  const db = getDb();
+  return db
+    .select()
+    .from(memoryChunks)
+    .where(eq(memoryChunks.observationId, observationId))
+    .all();
+}

--- a/assistant/src/memory/job-handlers/embedding.ts
+++ b/assistant/src/memory/job-handlers/embedding.ts
@@ -11,6 +11,7 @@ import type { MemoryJob } from "../jobs-store.js";
 import { extractMediaBlocks } from "../message-content.js";
 import {
   mediaAssets,
+  memoryChunks,
   memoryItems,
   memorySegments,
   memorySummaries,
@@ -88,6 +89,26 @@ export async function embedSummaryJob(
       memory_scope_id: summary.scopeId,
     },
   );
+}
+
+export async function embedChunkJob(
+  job: MemoryJob,
+  config: AssistantConfig,
+): Promise<void> {
+  const chunkId = asString(job.payload.chunkId);
+  if (!chunkId) return;
+  const db = getDb();
+  const chunk = db
+    .select()
+    .from(memoryChunks)
+    .where(eq(memoryChunks.id, chunkId))
+    .get();
+  if (!chunk) return;
+  await embedAndUpsert(config, "chunk", chunk.id, chunk.content, {
+    observation_id: chunk.observationId,
+    created_at: chunk.createdAt,
+    memory_scope_id: chunk.scopeId,
+  });
 }
 
 export async function embedMediaJob(

--- a/assistant/src/memory/job-utils.ts
+++ b/assistant/src/memory/job-utils.ts
@@ -142,7 +142,7 @@ export function truncate(text: string, max: number): string {
 
 export async function embedAndUpsert(
   config: AssistantConfig,
-  targetType: "segment" | "item" | "summary" | "media",
+  targetType: "segment" | "item" | "summary" | "media" | "chunk",
   targetId: string,
   input: EmbeddingInput,
   extraPayload?: Record<string, unknown>,

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -12,6 +12,7 @@ export type MemoryJobType =
   | "embed_segment"
   | "embed_item"
   | "embed_summary"
+  | "embed_chunk"
   | "extract_items"
   | "extract_entities"
   | "cleanup_stale_superseded_items"
@@ -34,6 +35,7 @@ const EMBED_JOB_TYPES: MemoryJobType[] = [
   "embed_segment",
   "embed_item",
   "embed_summary",
+  "embed_chunk",
   "embed_media",
   "embed_attachment",
 ];

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -11,6 +11,7 @@ import { generateConversationStartersJob } from "./job-handlers/conversation-sta
 // ── Per-job-type handlers ──────────────────────────────────────────
 import {
   embedAttachmentJob,
+  embedChunkJob,
   embedItemJob,
   embedMediaJob,
   embedSegmentJob,
@@ -266,6 +267,9 @@ async function processJob(
       return;
     case "embed_summary":
       await embedSummaryJob(job, config);
+      return;
+    case "embed_chunk":
+      await embedChunkJob(job, config);
       return;
     case "extract_items":
       await extractItemsJob(job);


### PR DESCRIPTION
## Summary
- Add chunk-specific upsert helpers to archive-store.ts with contentHash idempotence
- Extend job system with embed_chunk job type
- Wire through jobs-worker and embedding handler with archive targetType
- Add tests for chunk upserts and embedding-job dispatch

Part of plan: simplified-memory-v1.md (PR 11 of 23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
