### PR TITLE
fix: clean up private-scoped memory items when deleting private conversations

### DIFF
--- a/assistant/src/__tests__/conversation-wipe.test.ts
+++ b/assistant/src/__tests__/conversation-wipe.test.ts
@@ -26,6 +26,7 @@ mock.module("../util/logger.js", () => ({
 import {
   addMessage,
   createConversation,
+  deleteConversation,
   getConversation,
   getMessages,
   wipeConversation,
@@ -434,5 +435,188 @@ describe("wipeConversation", () => {
       .query("SELECT * FROM memory_items WHERE id = 'itemB'")
       .get();
     expect(itemBRow).not.toBeNull();
+  });
+});
+
+describe("deleteConversation — private scope cleanup", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM conversation_starters`);
+    db.run(`DELETE FROM memory_item_sources`);
+    db.run(`DELETE FROM memory_segments`);
+    db.run(`DELETE FROM memory_items`);
+    db.run(`DELETE FROM memory_summaries`);
+    db.run(`DELETE FROM memory_embeddings`);
+    db.run(`DELETE FROM memory_jobs`);
+    db.run(`DELETE FROM tool_invocations`);
+    db.run(`DELETE FROM llm_request_logs`);
+    db.run(`DELETE FROM messages`);
+    db.run(`DELETE FROM conversations`);
+  });
+
+  test("sourceless items cleaned up", () => {
+    const conv = createConversation({ conversationType: "private" });
+    const scopeId = conv.memoryScopeId;
+    const now = Date.now();
+
+    const raw = (
+      getDb() as unknown as {
+        $client: import("bun:sqlite").Database;
+      }
+    ).$client;
+
+    // Insert a memory item with matching scopeId but no memory_item_sources
+    raw
+      .query(
+        `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
+         VALUES ('priv-item-1', 'active', 'fact', 'test', 'test fact', 0.8, 'fp-priv-1', ?, ?, ?)`,
+      )
+      .run(scopeId, now, now);
+
+    const result = deleteConversation(conv.id);
+
+    // Item should be gone
+    const itemRow = raw
+      .query("SELECT * FROM memory_items WHERE id = 'priv-item-1'")
+      .get();
+    expect(itemRow).toBeNull();
+
+    // Its ID should be in orphanedItemIds
+    expect(result.orphanedItemIds).toContain("priv-item-1");
+  });
+
+  test("summaries cleaned up", () => {
+    const conv = createConversation({ conversationType: "private" });
+    const scopeId = conv.memoryScopeId;
+    const now = Date.now();
+
+    const raw = (
+      getDb() as unknown as {
+        $client: import("bun:sqlite").Database;
+      }
+    ).$client;
+
+    // Insert a memory summary with matching scopeId
+    raw
+      .query(
+        `INSERT INTO memory_summaries (id, scope, scope_key, summary, token_estimate, version, scope_id, start_at, end_at, created_at, updated_at)
+         VALUES ('priv-sum-1', 'global', 'all', 'private summary', 100, 1, ?, ?, ?, ?, ?)`,
+      )
+      .run(scopeId, now, now, now, now);
+
+    const result = deleteConversation(conv.id);
+
+    // Summary should be gone
+    const summaryRow = raw
+      .query("SELECT * FROM memory_summaries WHERE id = 'priv-sum-1'")
+      .get();
+    expect(summaryRow).toBeNull();
+
+    // Its ID should be in deletedSummaryIds
+    expect(result.deletedSummaryIds).toContain("priv-sum-1");
+  });
+
+  test("standard conversations unaffected", async () => {
+    const conv = createConversation("standard test");
+    const now = Date.now();
+
+    const raw = (
+      getDb() as unknown as {
+        $client: import("bun:sqlite").Database;
+      }
+    ).$client;
+
+    // Insert items with scopeId = "default"
+    raw
+      .query(
+        `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
+         VALUES ('default-item-1', 'active', 'fact', 'test', 'test fact', 0.8, 'fp-default', 'default', ?, ?)`,
+      )
+      .run(now, now);
+
+    deleteConversation(conv.id);
+
+    // Default-scope items should still exist
+    const itemRow = raw
+      .query("SELECT * FROM memory_items WHERE id = 'default-item-1'")
+      .get();
+    expect(itemRow).not.toBeNull();
+  });
+
+  test("embeddings cleaned up", () => {
+    const conv = createConversation({ conversationType: "private" });
+    const scopeId = conv.memoryScopeId;
+    const now = Date.now();
+
+    const raw = (
+      getDb() as unknown as {
+        $client: import("bun:sqlite").Database;
+      }
+    ).$client;
+
+    // Insert a memory item with matching scopeId
+    raw
+      .query(
+        `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
+         VALUES ('priv-item-emb', 'active', 'fact', 'test', 'test fact', 0.8, 'fp-priv-emb', ?, ?, ?)`,
+      )
+      .run(scopeId, now, now);
+
+    // Insert a corresponding embedding
+    raw
+      .query(
+        `INSERT INTO memory_embeddings (id, target_type, target_id, provider, model, dimensions, created_at, updated_at)
+         VALUES ('emb-priv-item', 'item', 'priv-item-emb', 'test', 'test', 384, ?, ?)`,
+      )
+      .run(now, now);
+
+    deleteConversation(conv.id);
+
+    // Both item and embedding should be deleted
+    const itemRow = raw
+      .query("SELECT * FROM memory_items WHERE id = 'priv-item-emb'")
+      .get();
+    expect(itemRow).toBeNull();
+
+    const embeddingRow = raw
+      .query("SELECT * FROM memory_embeddings WHERE id = 'emb-priv-item'")
+      .get();
+    expect(embeddingRow).toBeNull();
+  });
+
+  test("no duplicate IDs", async () => {
+    const conv = createConversation({ conversationType: "private" });
+    const scopeId = conv.memoryScopeId;
+    const msg = await addMessage(conv.id, "user", "hello");
+    const now = Date.now();
+
+    const raw = (
+      getDb() as unknown as {
+        $client: import("bun:sqlite").Database;
+      }
+    ).$client;
+
+    // Insert a memory item with the private scopeId AND a source linking to the message
+    raw
+      .query(
+        `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
+         VALUES ('priv-item-dup', 'active', 'fact', 'test', 'test fact', 0.8, 'fp-priv-dup', ?, ?, ?)`,
+      )
+      .run(scopeId, now, now);
+
+    raw
+      .query(
+        `INSERT INTO memory_item_sources (memory_item_id, message_id, created_at) VALUES ('priv-item-dup', ?, ?)`,
+      )
+      .run(msg.id, now);
+
+    const result = deleteConversation(conv.id);
+
+    // The item ID should appear exactly once in orphanedItemIds (caught by
+    // source-based cleanup, not double-counted by scope sweep).
+    const count = result.orphanedItemIds.filter(
+      (id) => id === "priv-item-dup",
+    ).length;
+    expect(count).toBe(1);
   });
 });

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -200,14 +200,22 @@ export async function runDaemon(): Promise<void> {
           targetId: itemId,
         });
       }
+      for (const summaryId of deletedMemory.deletedSummaryIds) {
+        enqueueMemoryJob("delete_qdrant_vectors", {
+          targetType: "summary",
+          targetId: summaryId,
+        });
+      }
       if (
         deletedMemory.segmentIds.length > 0 ||
-        deletedMemory.orphanedItemIds.length > 0
+        deletedMemory.orphanedItemIds.length > 0 ||
+        deletedMemory.deletedSummaryIds.length > 0
       ) {
         log.info(
           {
             segments: deletedMemory.segmentIds.length,
             orphanedItems: deletedMemory.orphanedItemIds.length,
+            deletedSummaries: deletedMemory.deletedSummaryIds.length,
           },
           "Enqueued Qdrant vector cleanup jobs for purged private conversations",
         );

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -45,6 +45,7 @@ import { enqueueMemoryJob } from "./jobs-store.js";
 import {
   channelInboundEvents,
   conversations,
+  conversationStarters,
   llmRequestLogs,
   memoryEmbeddings,
   memoryItems,
@@ -545,12 +546,18 @@ export function forkConversation(params: {
  */
 export function deleteConversation(id: string): DeletedMemoryIds {
   const db = getDb();
-  const result: DeletedMemoryIds = { segmentIds: [], orphanedItemIds: [] };
+  const result: DeletedMemoryIds = {
+    segmentIds: [],
+    orphanedItemIds: [],
+    deletedSummaryIds: [],
+  };
 
   // Capture createdAt before the transaction deletes the row — needed to
   // resolve the conversation's disk-view directory path after deletion.
   const convBeforeDelete = getConversation(id);
   const createdAtForDiskCleanup = convBeforeDelete?.createdAt;
+  const memoryScopeId = convBeforeDelete?.memoryScopeId;
+  const isPrivateScope = memoryScopeId?.startsWith("private:") ?? false;
 
   db.transaction((tx) => {
     // Collect all message IDs for this conversation.
@@ -636,6 +643,65 @@ export function deleteConversation(id: string): DeletedMemoryIds {
         .run();
       tx.delete(toolInvocations)
         .where(eq(toolInvocations.conversationId, id))
+        .run();
+    }
+
+    if (isPrivateScope && memoryScopeId) {
+      // Sweep remaining memory items with this private scopeId.
+      const scopeItems = tx
+        .select({ id: memoryItems.id })
+        .from(memoryItems)
+        .where(eq(memoryItems.scopeId, memoryScopeId))
+        .all();
+      const alreadyDeleted = new Set(result.orphanedItemIds);
+      const scopeItemIds = scopeItems
+        .map((r) => r.id)
+        .filter((id) => !alreadyDeleted.has(id));
+
+      if (scopeItemIds.length > 0) {
+        tx.delete(memoryEmbeddings)
+          .where(
+            and(
+              eq(memoryEmbeddings.targetType, "item"),
+              inArray(memoryEmbeddings.targetId, scopeItemIds),
+            ),
+          )
+          .run();
+        tx.delete(memoryItemSources)
+          .where(inArray(memoryItemSources.memoryItemId, scopeItemIds))
+          .run();
+        tx.delete(memoryItems)
+          .where(inArray(memoryItems.id, scopeItemIds))
+          .run();
+        result.orphanedItemIds.push(...scopeItemIds);
+      }
+
+      // Sweep memory summaries with this private scopeId.
+      const scopeSummaries = tx
+        .select({ id: memorySummaries.id })
+        .from(memorySummaries)
+        .where(eq(memorySummaries.scopeId, memoryScopeId))
+        .all();
+      const scopeSummaryIds = scopeSummaries.map((r) => r.id);
+
+      if (scopeSummaryIds.length > 0) {
+        tx.delete(memoryEmbeddings)
+          .where(
+            and(
+              eq(memoryEmbeddings.targetType, "summary"),
+              inArray(memoryEmbeddings.targetId, scopeSummaryIds),
+            ),
+          )
+          .run();
+        tx.delete(memorySummaries)
+          .where(inArray(memorySummaries.id, scopeSummaryIds))
+          .run();
+        result.deletedSummaryIds.push(...scopeSummaryIds);
+      }
+
+      // Sweep conversation starters with this private scopeId.
+      tx.delete(conversationStarters)
+        .where(eq(conversationStarters.scopeId, memoryScopeId))
         .run();
     }
 
@@ -831,7 +897,10 @@ export function wipeConversation(id: string): WipeConversationResult {
   return {
     ...deletedMemoryIds,
     unsupersededItemIds,
-    deletedSummaryIds,
+    deletedSummaryIds: [
+      ...deletedSummaryIds,
+      ...deletedMemoryIds.deletedSummaryIds,
+    ],
     cancelledJobCount,
   };
 }
@@ -853,16 +922,25 @@ export function purgePrivateConversations(): {
     .all();
 
   if (privateConvs.length === 0) {
-    return { count: 0, deletedMemory: { segmentIds: [], orphanedItemIds: [] } };
+    return {
+      count: 0,
+      deletedMemory: {
+        segmentIds: [],
+        orphanedItemIds: [],
+        deletedSummaryIds: [],
+      },
+    };
   }
 
   const allSegmentIds: string[] = [];
   const allOrphanedItemIds: string[] = [];
+  const allDeletedSummaryIds: string[] = [];
 
   for (const conv of privateConvs) {
     const deleted = deleteConversation(conv.id);
     allSegmentIds.push(...deleted.segmentIds);
     allOrphanedItemIds.push(...deleted.orphanedItemIds);
+    allDeletedSummaryIds.push(...deleted.deletedSummaryIds);
   }
 
   return {
@@ -870,6 +948,7 @@ export function purgePrivateConversations(): {
     deletedMemory: {
       segmentIds: allSegmentIds,
       orphanedItemIds: allOrphanedItemIds,
+      deletedSummaryIds: allDeletedSummaryIds,
     },
   };
 }
@@ -1246,11 +1325,11 @@ export function deleteLastExchange(conversationId: string): number {
 export interface DeletedMemoryIds {
   segmentIds: string[];
   orphanedItemIds: string[];
+  deletedSummaryIds: string[];
 }
 
 export interface WipeConversationResult extends DeletedMemoryIds {
   unsupersededItemIds: string[];
-  deletedSummaryIds: string[];
   cancelledJobCount: number;
 }
 
@@ -1316,7 +1395,11 @@ export function relinkAttachments(
  */
 export function deleteMessageById(messageId: string): DeletedMemoryIds {
   const db = getDb();
-  const result: DeletedMemoryIds = { segmentIds: [], orphanedItemIds: [] };
+  const result: DeletedMemoryIds = {
+    segmentIds: [],
+    orphanedItemIds: [],
+    deletedSummaryIds: [],
+  };
 
   // Collect attachment IDs linked to this message before cascade-delete
   // so we can scope orphan cleanup to only those candidates.

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -275,6 +275,12 @@ export function conversationManagementRouteDefinitions(
             targetId: itemId,
           });
         }
+        for (const summaryId of deleted.deletedSummaryIds) {
+          enqueueMemoryJob("delete_qdrant_vectors", {
+            targetType: "summary",
+            targetId: summaryId,
+          });
+        }
         log.info({ conversationId: resolvedId }, "Deleted conversation");
         return new Response(null, { status: 204 });
       },


### PR DESCRIPTION
## Summary
- Add scope-based sweep in deleteConversation() for private conversations that catches remaining memoryItems, memorySummaries, and conversationStarters with the private scopeId
- Update callers (DELETE route, lifecycle.ts, purgePrivateConversations) to handle new deletedSummaryIds for Qdrant vector cleanup
- Add tests for private scope cleanup edge cases

Part of plan: private-memory-scope-cleanup.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
