### PR TITLE
feat: add episode archive store and embedding jobs

### DIFF
--- a/assistant/src/__tests__/memory-episode-archive.test.ts
+++ b/assistant/src/__tests__/memory-episode-archive.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Tests for episode archive store insertion helpers and embed_episode job dispatch.
+ *
+ * Verifies:
+ * - Episode rows can be inserted via compaction and resolution helpers
+ * - embed_episode jobs are enqueued on insertion
+ * - embed_episode dispatches correctly through the jobs worker
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+import { DEFAULT_CONFIG } from "../config/defaults.js";
+
+const testDir = mkdtempSync(join(tmpdir(), "memory-episode-archive-"));
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Track embedAndUpsert calls to verify embedding dispatch without needing a real backend
+const embedCalls: Array<{
+  targetType: string;
+  targetId: string;
+  text: string;
+  extraPayload: Record<string, unknown>;
+}> = [];
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realJobUtils = require("../memory/job-utils.js");
+mock.module("../memory/job-utils.js", () => ({
+  ...realJobUtils,
+  embedAndUpsert: async (
+    _config: unknown,
+    targetType: string,
+    targetId: string,
+    text: string,
+    extraPayload: Record<string, unknown>,
+  ) => {
+    embedCalls.push({ targetType, targetId, text, extraPayload });
+  },
+}));
+
+mock.module("../memory/qdrant-client.js", () => ({
+  getQdrantClient: () => ({
+    searchWithFilter: async () => [],
+    hybridSearch: async () => [],
+    upsertPoints: async () => {},
+    deletePoints: async () => {},
+  }),
+  initQdrantClient: () => {},
+}));
+
+const TEST_CONFIG = {
+  ...DEFAULT_CONFIG,
+  memory: {
+    ...DEFAULT_CONFIG.memory,
+    embeddings: {
+      ...DEFAULT_CONFIG.memory.embeddings,
+      provider: "openai" as const,
+      required: false,
+    },
+    extraction: {
+      ...DEFAULT_CONFIG.memory.extraction,
+      useLLM: false,
+    },
+  },
+};
+
+mock.module("../config/loader.js", () => ({
+  loadConfig: () => TEST_CONFIG,
+  getConfig: () => TEST_CONFIG,
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+import {
+  insertCompactionEpisode,
+  insertResolutionEpisode,
+} from "../memory/archive-store.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { claimMemoryJobs, enqueueMemoryJob } from "../memory/jobs-store.js";
+import { runMemoryJobsOnce } from "../memory/jobs-worker.js";
+import { conversations, memoryEpisodes, memoryJobs } from "../memory/schema.js";
+
+describe("episode archive store", () => {
+  const now = 1_710_000_000_000;
+  const convId = "conv-episode-test";
+
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    const db = getDb();
+    db.delete(memoryJobs).run();
+    db.delete(memoryEpisodes).run();
+    db.delete(conversations).run();
+    embedCalls.length = 0;
+
+    // Seed a conversation for FK references
+    db.insert(conversations)
+      .values({
+        id: convId,
+        title: null,
+        createdAt: now,
+        updatedAt: now,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalEstimatedCost: 0,
+        contextSummary: null,
+        contextCompactedMessageCount: 0,
+      })
+      .run();
+  });
+
+  afterAll(() => {
+    resetDb();
+    try {
+      rmSync(testDir, { recursive: true });
+    } catch {
+      // best effort
+    }
+  });
+
+  // ── Insertion helpers ───────────────────────────────────────────────
+
+  test("insertCompactionEpisode inserts an episode row", () => {
+    const { episodeId } = insertCompactionEpisode({
+      conversationId: convId,
+      title: "Morning standup discussion",
+      summary: "User discussed project blockers and timeline updates",
+      tokenEstimate: 42,
+      source: "vellum",
+      startAt: now - 60_000,
+      endAt: now,
+    });
+
+    const db = getDb();
+    const episode = db
+      .select()
+      .from(memoryEpisodes)
+      .where(eq(memoryEpisodes.id, episodeId))
+      .get();
+
+    expect(episode).not.toBeNull();
+    expect(episode!.conversationId).toBe(convId);
+    expect(episode!.title).toBe("Morning standup discussion");
+    expect(episode!.summary).toBe(
+      "User discussed project blockers and timeline updates",
+    );
+    expect(episode!.tokenEstimate).toBe(42);
+    expect(episode!.source).toBe("vellum");
+    expect(episode!.startAt).toBe(now - 60_000);
+    expect(episode!.endAt).toBe(now);
+    expect(episode!.scopeId).toBe("default");
+  });
+
+  test("insertResolutionEpisode inserts an episode row", () => {
+    const { episodeId } = insertResolutionEpisode({
+      conversationId: convId,
+      title: "Full conversation summary",
+      summary: "A complete discussion about project architecture decisions",
+      tokenEstimate: 100,
+      startAt: now - 3_600_000,
+      endAt: now,
+    });
+
+    const db = getDb();
+    const episode = db
+      .select()
+      .from(memoryEpisodes)
+      .where(eq(memoryEpisodes.id, episodeId))
+      .get();
+
+    expect(episode).not.toBeNull();
+    expect(episode!.title).toBe("Full conversation summary");
+    expect(episode!.source).toBeNull();
+  });
+
+  test("insertCompactionEpisode respects custom scopeId", () => {
+    const { episodeId } = insertCompactionEpisode({
+      scopeId: "project-alpha",
+      conversationId: convId,
+      title: "Scoped episode",
+      summary: "Testing scope assignment",
+      tokenEstimate: 10,
+      startAt: now,
+      endAt: now,
+    });
+
+    const db = getDb();
+    const episode = db
+      .select()
+      .from(memoryEpisodes)
+      .where(eq(memoryEpisodes.id, episodeId))
+      .get();
+
+    expect(episode!.scopeId).toBe("project-alpha");
+  });
+
+  // ── Job enqueue ──────────────────────────────────────────────────
+
+  test("insertCompactionEpisode enqueues an embed_episode job", () => {
+    const { episodeId, jobId } = insertCompactionEpisode({
+      conversationId: convId,
+      title: "Job test",
+      summary: "Verifying job enqueue",
+      tokenEstimate: 5,
+      startAt: now,
+      endAt: now,
+    });
+
+    expect(jobId).toBeTruthy();
+
+    const db = getDb();
+    const job = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.id, jobId))
+      .get();
+
+    expect(job).not.toBeNull();
+    expect(job!.type).toBe("embed_episode");
+    expect(job!.status).toBe("pending");
+
+    const payload = JSON.parse(job!.payload);
+    expect(payload.episodeId).toBe(episodeId);
+  });
+
+  test("insertResolutionEpisode enqueues an embed_episode job", () => {
+    const { episodeId, jobId } = insertResolutionEpisode({
+      conversationId: convId,
+      title: "Resolution job test",
+      summary: "Verifying resolution job enqueue",
+      tokenEstimate: 8,
+      startAt: now - 1000,
+      endAt: now,
+    });
+
+    expect(jobId).toBeTruthy();
+
+    const db = getDb();
+    const job = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.id, jobId))
+      .get();
+
+    expect(job).not.toBeNull();
+    expect(job!.type).toBe("embed_episode");
+
+    const payload = JSON.parse(job!.payload);
+    expect(payload.episodeId).toBe(episodeId);
+  });
+
+  // ── Worker dispatch ──────────────────────────────────────────────
+
+  test("embed_episode jobs are claimed and dispatched through the worker", async () => {
+    const { episodeId } = insertCompactionEpisode({
+      conversationId: convId,
+      title: "Worker dispatch test",
+      summary: "Verifying worker dispatches embed_episode correctly",
+      tokenEstimate: 15,
+      source: "telegram",
+      startAt: now - 30_000,
+      endAt: now,
+    });
+
+    const processed = await runMemoryJobsOnce();
+    expect(processed).toBe(1);
+
+    // The mock embedAndUpsert should have been called with "episode" targetType
+    expect(embedCalls.length).toBe(1);
+    expect(embedCalls[0]!.targetType).toBe("episode");
+    expect(embedCalls[0]!.targetId).toBe(episodeId);
+    expect(embedCalls[0]!.text).toContain("[episode]");
+    expect(embedCalls[0]!.text).toContain("Worker dispatch test");
+    expect(embedCalls[0]!.extraPayload.conversation_id).toBe(convId);
+    expect(embedCalls[0]!.extraPayload.memory_scope_id).toBe("default");
+  });
+
+  test("embed_episode job is classified as an embed job type for scheduling priority", () => {
+    // Verify that embed_episode jobs are claimed alongside other embed jobs
+    // by enqueuing both an embed_episode and checking claim behavior
+    enqueueMemoryJob("embed_episode", { episodeId: "nonexistent" });
+
+    const jobs = claimMemoryJobs(10);
+    expect(jobs.length).toBe(1);
+    expect(jobs[0]!.type).toBe("embed_episode");
+  });
+
+  // ── Multiple episodes per conversation ────────────────────────────
+
+  test("multiple episodes can be inserted for the same conversation", () => {
+    const { episodeId: ep1 } = insertCompactionEpisode({
+      conversationId: convId,
+      title: "First compaction",
+      summary: "First block of turns",
+      tokenEstimate: 20,
+      startAt: now - 120_000,
+      endAt: now - 60_000,
+    });
+
+    const { episodeId: ep2 } = insertCompactionEpisode({
+      conversationId: convId,
+      title: "Second compaction",
+      summary: "Second block of turns",
+      tokenEstimate: 25,
+      startAt: now - 60_000,
+      endAt: now,
+    });
+
+    const { episodeId: ep3 } = insertResolutionEpisode({
+      conversationId: convId,
+      title: "Final resolution",
+      summary: "Full conversation narrative",
+      tokenEstimate: 50,
+      startAt: now - 120_000,
+      endAt: now,
+    });
+
+    expect(ep1).not.toBe(ep2);
+    expect(ep2).not.toBe(ep3);
+
+    const db = getDb();
+    const episodes = db
+      .select()
+      .from(memoryEpisodes)
+      .where(eq(memoryEpisodes.conversationId, convId))
+      .all();
+
+    expect(episodes.length).toBe(3);
+
+    // All three should have enqueued embed jobs
+    const jobs = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.type, "embed_episode"))
+      .all();
+
+    expect(jobs.length).toBe(3);
+  });
+});

--- a/assistant/src/memory/archive-store.ts
+++ b/assistant/src/memory/archive-store.ts
@@ -1,0 +1,89 @@
+import { v4 as uuid } from "uuid";
+
+import { getLogger } from "../util/logger.js";
+import { getDb } from "./db.js";
+import { enqueueMemoryJob, type MemoryJobType } from "./jobs-store.js";
+import { memoryEpisodes } from "./schema.js";
+
+const log = getLogger("memory-archive-store");
+
+// ── Episode insertion helpers ───────────────────────────────────────
+
+export interface InsertEpisodeParams {
+  scopeId?: string;
+  conversationId: string;
+  title: string;
+  summary: string;
+  tokenEstimate: number;
+  source?: string;
+  startAt: number;
+  endAt: number;
+}
+
+/**
+ * Insert an episode row produced by conversation compaction.
+ * Compaction episodes summarize a contiguous block of turns that was
+ * compressed to free context-window space.
+ *
+ * An `embed_episode` job is enqueued automatically so the episode
+ * becomes searchable via vector recall.
+ */
+export function insertCompactionEpisode(params: InsertEpisodeParams): {
+  episodeId: string;
+  jobId: string;
+} {
+  return insertEpisodeAndEnqueue(params);
+}
+
+/**
+ * Insert an episode row produced by resolution (end-of-conversation)
+ * summarization. Resolution episodes capture the full narrative arc
+ * of a completed conversation.
+ *
+ * An `embed_episode` job is enqueued automatically so the episode
+ * becomes searchable via vector recall.
+ */
+export function insertResolutionEpisode(params: InsertEpisodeParams): {
+  episodeId: string;
+  jobId: string;
+} {
+  return insertEpisodeAndEnqueue(params);
+}
+
+// ── Internal ────────────────────────────────────────────────────────
+
+function insertEpisodeAndEnqueue(params: InsertEpisodeParams): {
+  episodeId: string;
+  jobId: string;
+} {
+  const db = getDb();
+  const episodeId = uuid();
+  const now = Date.now();
+
+  db.insert(memoryEpisodes)
+    .values({
+      id: episodeId,
+      scopeId: params.scopeId ?? "default",
+      conversationId: params.conversationId,
+      title: params.title,
+      summary: params.summary,
+      tokenEstimate: params.tokenEstimate,
+      source: params.source ?? null,
+      startAt: params.startAt,
+      endAt: params.endAt,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+
+  const jobId = enqueueMemoryJob("embed_episode" satisfies MemoryJobType, {
+    episodeId,
+  });
+
+  log.debug(
+    { episodeId, jobId, conversationId: params.conversationId },
+    "Inserted episode and enqueued embed job",
+  );
+
+  return { episodeId, jobId };
+}

--- a/assistant/src/memory/job-handlers/embedding.ts
+++ b/assistant/src/memory/job-handlers/embedding.ts
@@ -11,6 +11,7 @@ import type { MemoryJob } from "../jobs-store.js";
 import { extractMediaBlocks } from "../message-content.js";
 import {
   mediaAssets,
+  memoryEpisodes,
   memoryItems,
   memorySegments,
   memorySummaries,
@@ -157,5 +158,27 @@ export async function embedAttachmentJob(
     message_id: messageId,
     conversation_id: message.conversationId,
     memory_scope_id: memoryScopeId,
+  });
+}
+
+export async function embedEpisodeJob(
+  job: MemoryJob,
+  config: AssistantConfig,
+): Promise<void> {
+  const episodeId = asString(job.payload.episodeId);
+  if (!episodeId) return;
+  const db = getDb();
+  const episode = db
+    .select()
+    .from(memoryEpisodes)
+    .where(eq(memoryEpisodes.id, episodeId))
+    .get();
+  if (!episode) return;
+  const text = `[episode] ${episode.title}: ${episode.summary}`;
+  await embedAndUpsert(config, "episode", episode.id, text, {
+    conversation_id: episode.conversationId,
+    created_at: episode.startAt,
+    last_seen_at: episode.endAt,
+    memory_scope_id: episode.scopeId,
   });
 }

--- a/assistant/src/memory/job-utils.ts
+++ b/assistant/src/memory/job-utils.ts
@@ -142,7 +142,7 @@ export function truncate(text: string, max: number): string {
 
 export async function embedAndUpsert(
   config: AssistantConfig,
-  targetType: "segment" | "item" | "summary" | "media",
+  targetType: "segment" | "item" | "summary" | "media" | "episode",
   targetId: string,
   input: EmbeddingInput,
   extraPayload?: Record<string, unknown>,

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -12,6 +12,7 @@ export type MemoryJobType =
   | "embed_segment"
   | "embed_item"
   | "embed_summary"
+  | "embed_episode"
   | "extract_items"
   | "extract_entities"
   | "cleanup_stale_superseded_items"
@@ -34,6 +35,7 @@ const EMBED_JOB_TYPES: MemoryJobType[] = [
   "embed_segment",
   "embed_item",
   "embed_summary",
+  "embed_episode",
   "embed_media",
   "embed_attachment",
 ];

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -11,6 +11,7 @@ import { generateConversationStartersJob } from "./job-handlers/conversation-sta
 // ── Per-job-type handlers ──────────────────────────────────────────
 import {
   embedAttachmentJob,
+  embedEpisodeJob,
   embedItemJob,
   embedMediaJob,
   embedSegmentJob,
@@ -266,6 +267,9 @@ async function processJob(
       return;
     case "embed_summary":
       await embedSummaryJob(job, config);
+      return;
+    case "embed_episode":
+      await embedEpisodeJob(job, config);
       return;
     case "extract_items":
       await extractItemsJob(job);

--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -20,7 +20,7 @@ export interface QdrantClientConfig {
 }
 
 export interface QdrantPointPayload {
-  target_type: "segment" | "item" | "summary" | "media";
+  target_type: "segment" | "item" | "summary" | "media" | "episode";
   target_id: string;
   text: string;
   kind?: string;
@@ -230,7 +230,7 @@ export class VellumQdrantClient {
   }
 
   async upsert(
-    targetType: "segment" | "item" | "summary" | "media",
+    targetType: "segment" | "item" | "summary" | "media" | "episode",
     targetId: string,
     vector: number[],
     payload: Omit<QdrantPointPayload, "target_type" | "target_id">,
@@ -324,7 +324,7 @@ export class VellumQdrantClient {
   async searchWithFilter(
     vector: number[],
     limit: number,
-    targetTypes: Array<"segment" | "item" | "summary" | "media">,
+    targetTypes: Array<"segment" | "item" | "summary" | "media" | "episode">,
     excludeMessageIds?: string[],
     scopeIds?: string[],
   ): Promise<QdrantSearchResult[]> {


### PR DESCRIPTION
## Summary
- Add episode-specific insertion helpers to archive-store.ts (compaction and resolution)
- Extend job system with embed_episode job type in jobs-store.ts
- Add embedEpisodeJob handler in job-handlers/embedding.ts
- Wire embed_episode through jobs-worker.ts dispatch
- Update targetType unions in job-utils.ts and qdrant-client.ts to include episode
- Add comprehensive tests for episode insertion and embedding dispatch

Part of plan: simplified-memory-v1.md (PR 13 of 23)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
