### PR TITLE
feat: compile open-loop simplified memory brief section

### DIFF
--- a/assistant/src/__tests__/memory-brief-open-loops.test.ts
+++ b/assistant/src/__tests__/memory-brief-open-loops.test.ts
@@ -1,0 +1,530 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "brief-open-loops-test-"));
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  getRootDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { createFollowUp } from "../followups/followup-store.js";
+import { compileOpenLoopBrief } from "../memory/brief-open-loops.js";
+import { initializeDb, resetDb } from "../memory/db.js";
+import { getSqlite } from "../memory/db-connection.js";
+import { resetTestTables } from "../memory/raw-query.js";
+import { createTask } from "../tasks/task-store.js";
+
+initializeDb();
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const SCOPE = "test-scope";
+const MS_HOUR = 60 * 60 * 1000;
+const MS_DAY = 24 * MS_HOUR;
+
+/** Get the raw bun:sqlite Database for parameterized inserts. */
+function getRawDb(): import("bun:sqlite").Database {
+  return getSqlite();
+}
+
+function insertOpenLoop(opts: {
+  id: string;
+  summary: string;
+  dueAt?: number | null;
+  surfacedAt?: number | null;
+  status?: string;
+  updatedAt?: number;
+  createdAt?: number;
+}): void {
+  const raw = getRawDb();
+  const now = Date.now();
+  raw.run(
+    `INSERT INTO open_loops (id, scope_id, summary, status, source, due_at, surfaced_at, created_at, updated_at)
+     VALUES (?, ?, ?, ?, 'conversation', ?, ?, ?, ?)`,
+    [
+      opts.id,
+      SCOPE,
+      opts.summary,
+      opts.status ?? "open",
+      opts.dueAt ?? null,
+      opts.surfacedAt ?? null,
+      opts.createdAt ?? now,
+      opts.updatedAt ?? now,
+    ],
+  );
+}
+
+function insertWorkItem(opts: {
+  id: string;
+  taskId: string;
+  title: string;
+  status?: string;
+  priorityTier?: number;
+  updatedAt?: number;
+}): void {
+  const raw = getRawDb();
+  const now = Date.now();
+  raw.run(
+    `INSERT INTO work_items (id, task_id, title, status, priority_tier, sort_index, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, 0, ?, ?)`,
+    [
+      opts.id,
+      opts.taskId,
+      opts.title,
+      opts.status ?? "queued",
+      opts.priorityTier ?? 1,
+      now,
+      opts.updatedAt ?? now,
+    ],
+  );
+}
+
+// ── Teardown ─────────────────────────────────────────────────────────
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+beforeEach(() => {
+  resetTestTables(
+    "open_loops",
+    "work_items",
+    "tasks",
+    "task_runs",
+    "followups",
+  );
+});
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("compileOpenLoopBrief", () => {
+  test("returns empty when no data exists", () => {
+    const result = compileOpenLoopBrief(SCOPE, "msg-1");
+    expect(result.bullets).toEqual([]);
+    expect(result.resurfacedLoopId).toBeNull();
+  });
+
+  // ── Tier ranking ──────────────────────────────────────────────────
+
+  describe("tier ranking", () => {
+    test("overdue loops are tier 1", () => {
+      const now = Date.now();
+      insertOpenLoop({
+        id: "ol-overdue",
+        summary: "Overdue task",
+        dueAt: now - MS_HOUR,
+        updatedAt: now - MS_DAY * 10,
+      });
+
+      const result = compileOpenLoopBrief(SCOPE, "msg-1", now);
+      expect(result.bullets).toHaveLength(1);
+      expect(result.bullets[0].tier).toBe(1);
+      expect(result.bullets[0].summary).toBe("Overdue task");
+    });
+
+    test("loops due within 24h are tier 2", () => {
+      const now = Date.now();
+      insertOpenLoop({
+        id: "ol-24h",
+        summary: "Due soon",
+        dueAt: now + 12 * MS_HOUR,
+        updatedAt: now - MS_DAY * 10,
+      });
+
+      const result = compileOpenLoopBrief(SCOPE, "msg-1", now);
+      expect(result.bullets).toHaveLength(1);
+      expect(result.bullets[0].tier).toBe(2);
+    });
+
+    test("loops due within 7d are tier 3", () => {
+      const now = Date.now();
+      insertOpenLoop({
+        id: "ol-7d",
+        summary: "Due this week",
+        dueAt: now + 3 * MS_DAY,
+        updatedAt: now - MS_DAY * 10,
+      });
+
+      const result = compileOpenLoopBrief(SCOPE, "msg-1", now);
+      expect(result.bullets).toHaveLength(1);
+      expect(result.bullets[0].tier).toBe(3);
+    });
+
+    test("high-priority work items are tier 4", () => {
+      const now = Date.now();
+      const task = createTask({ title: "t", template: "t" });
+      insertWorkItem({
+        id: "wi-high",
+        taskId: task.id,
+        title: "High priority item",
+        priorityTier: 0,
+        updatedAt: now - MS_DAY * 10,
+      });
+
+      const result = compileOpenLoopBrief(SCOPE, "msg-1", now);
+      const wiBullet = result.bullets.find((b) => b.source === "work_item");
+      expect(wiBullet).toBeDefined();
+      expect(wiBullet!.tier).toBe(4);
+    });
+
+    test("recently touched loops are tier 5", () => {
+      const now = Date.now();
+      insertOpenLoop({
+        id: "ol-recent",
+        summary: "Just updated",
+        updatedAt: now - MS_HOUR,
+      });
+
+      const result = compileOpenLoopBrief(SCOPE, "msg-1", now);
+      expect(result.bullets).toHaveLength(1);
+      expect(result.bullets[0].tier).toBe(5);
+    });
+
+    test("bullets are sorted by tier ascending", () => {
+      const now = Date.now();
+      insertOpenLoop({
+        id: "ol-tier3",
+        summary: "Due this week",
+        dueAt: now + 3 * MS_DAY,
+        updatedAt: now - MS_DAY * 10,
+      });
+      insertOpenLoop({
+        id: "ol-tier1",
+        summary: "Overdue",
+        dueAt: now - MS_HOUR,
+        updatedAt: now - MS_DAY * 10,
+      });
+      insertOpenLoop({
+        id: "ol-tier5",
+        summary: "Recent",
+        updatedAt: now - MS_HOUR,
+      });
+
+      const result = compileOpenLoopBrief(SCOPE, "msg-1", now);
+      const tiers = result.bullets.map((b) => b.tier);
+      expect(tiers).toEqual([...tiers].sort((a, b) => a - b));
+      expect(tiers[0]).toBe(1);
+    });
+  });
+
+  // ── Deduplication ─────────────────────────────────────────────────
+
+  describe("deduplication", () => {
+    test("work items with the same summary as an open loop are deduplicated", () => {
+      const now = Date.now();
+      const task = createTask({ title: "t", template: "t" });
+
+      insertOpenLoop({
+        id: "ol-dup",
+        summary: "Review PR",
+        dueAt: now + MS_HOUR,
+        updatedAt: now,
+      });
+      insertWorkItem({
+        id: "wi-dup",
+        taskId: task.id,
+        title: "Review PR",
+        updatedAt: now,
+      });
+
+      const result = compileOpenLoopBrief(SCOPE, "msg-1", now);
+      const summaries = result.bullets.map((b) => b.summary);
+      // Should only appear once (from the loop)
+      expect(summaries.filter((s) => s === "Review PR")).toHaveLength(1);
+      expect(
+        result.bullets.find((b) => b.summary === "Review PR")!.source,
+      ).toBe("loop");
+    });
+
+    test("case-insensitive deduplication", () => {
+      const now = Date.now();
+      const task = createTask({ title: "t", template: "t" });
+
+      insertOpenLoop({
+        id: "ol-case",
+        summary: "deploy release",
+        dueAt: now + MS_HOUR,
+        updatedAt: now,
+      });
+      insertWorkItem({
+        id: "wi-case",
+        taskId: task.id,
+        title: "Deploy Release",
+        updatedAt: now,
+      });
+
+      const result = compileOpenLoopBrief(SCOPE, "msg-1", now);
+      const matching = result.bullets.filter(
+        (b) => b.summary.toLowerCase() === "deploy release",
+      );
+      expect(matching).toHaveLength(1);
+    });
+
+    test("unique keys are not deduplicated", () => {
+      const now = Date.now();
+      const task = createTask({ title: "t", template: "t" });
+
+      insertOpenLoop({
+        id: "ol-a",
+        summary: "Fix bug",
+        dueAt: now + MS_HOUR,
+        updatedAt: now,
+      });
+      insertWorkItem({
+        id: "wi-b",
+        taskId: task.id,
+        title: "Write tests",
+        updatedAt: now,
+      });
+
+      const result = compileOpenLoopBrief(SCOPE, "msg-1", now);
+      expect(result.bullets).toHaveLength(2);
+    });
+  });
+
+  // ── Follow-up integration ────────────────────────────────────────
+
+  describe("follow-ups", () => {
+    test("overdue follow-ups appear as tier 1", () => {
+      const now = Date.now();
+      createFollowUp({
+        channel: "email",
+        conversationId: "conv-1",
+        expectedResponseBy: now - MS_HOUR,
+      });
+
+      const result = compileOpenLoopBrief(SCOPE, "msg-1", now);
+      const fuBullet = result.bullets.find((b) => b.source === "followup");
+      expect(fuBullet).toBeDefined();
+      expect(fuBullet!.tier).toBe(1);
+    });
+
+    test("pending follow-ups due within 24h are tier 2", () => {
+      const now = Date.now();
+      createFollowUp({
+        channel: "slack",
+        conversationId: "conv-2",
+        expectedResponseBy: now + 12 * MS_HOUR,
+      });
+
+      const result = compileOpenLoopBrief(SCOPE, "msg-1", now);
+      const fuBullet = result.bullets.find((b) => b.source === "followup");
+      expect(fuBullet).toBeDefined();
+      expect(fuBullet!.tier).toBe(2);
+    });
+  });
+
+  // ── Deterministic resurfacing ────────────────────────────────────
+
+  describe("deterministic resurfacing", () => {
+    test("resurfaces one low-salience loop from open_loops", () => {
+      const now = Date.now();
+      // Create loops that are old and have no due date → tier 6 (low salience)
+      insertOpenLoop({
+        id: "ol-old-1",
+        summary: "Old loop 1",
+        updatedAt: now - MS_DAY * 30,
+        createdAt: now - MS_DAY * 30,
+      });
+      insertOpenLoop({
+        id: "ol-old-2",
+        summary: "Old loop 2",
+        updatedAt: now - MS_DAY * 30,
+        createdAt: now - MS_DAY * 30,
+      });
+      insertOpenLoop({
+        id: "ol-old-3",
+        summary: "Old loop 3",
+        updatedAt: now - MS_DAY * 30,
+        createdAt: now - MS_DAY * 30,
+      });
+
+      const result = compileOpenLoopBrief(SCOPE, "msg-resurface", now);
+
+      // Exactly one should be resurfaced
+      expect(result.resurfacedLoopId).not.toBeNull();
+      expect(result.bullets).toHaveLength(1);
+      expect(result.bullets[0].tier).toBe(5);
+    });
+
+    test("resurfacing is deterministic for the same seed", () => {
+      const now = Date.now();
+      for (let i = 1; i <= 5; i++) {
+        insertOpenLoop({
+          id: `ol-det-${i}`,
+          summary: `Deterministic loop ${i}`,
+          updatedAt: now - MS_DAY * 30,
+          createdAt: now - MS_DAY * 30,
+        });
+      }
+
+      const r1 = compileOpenLoopBrief(SCOPE, "msg-det", now);
+
+      // Reset surfacedAt and updatedAt so the second call has same candidates
+      // (updateLastSurfacedAt also writes updatedAt, which would change tier)
+      const oldUpdatedAt = now - MS_DAY * 30;
+      getRawDb().run(
+        `UPDATE open_loops SET surfaced_at = NULL, updated_at = ?`,
+        [oldUpdatedAt],
+      );
+
+      const r2 = compileOpenLoopBrief(SCOPE, "msg-det", now);
+
+      expect(r1.resurfacedLoopId).toBe(r2.resurfacedLoopId);
+    });
+
+    test("different userMessageId produces different selection", () => {
+      const now = Date.now();
+      // Need enough loops that different seeds are likely to pick different ones
+      for (let i = 1; i <= 20; i++) {
+        insertOpenLoop({
+          id: `ol-vary-${i}`,
+          summary: `Varying loop ${i}`,
+          updatedAt: now - MS_DAY * 30,
+          createdAt: now - MS_DAY * 30,
+        });
+      }
+
+      const selections = new Set<string | null>();
+      const oldUpdatedAt = now - MS_DAY * 30;
+      for (let i = 0; i < 10; i++) {
+        // Reset surfacedAt and updatedAt between calls so all loops stay low-salience
+        getRawDb().run(
+          `UPDATE open_loops SET surfaced_at = NULL, updated_at = ?`,
+          [oldUpdatedAt],
+        );
+        const r = compileOpenLoopBrief(SCOPE, `msg-vary-${i}`, now);
+        selections.add(r.resurfacedLoopId);
+      }
+
+      // With 20 candidates and 10 different seeds, we should see at least 2
+      // different selections (overwhelmingly likely)
+      expect(selections.size).toBeGreaterThanOrEqual(2);
+    });
+
+    test("updates surfacedAt on the resurfaced loop", () => {
+      const now = Date.now();
+      insertOpenLoop({
+        id: "ol-surf",
+        summary: "Will be surfaced",
+        updatedAt: now - MS_DAY * 30,
+        createdAt: now - MS_DAY * 30,
+      });
+
+      const result = compileOpenLoopBrief(SCOPE, "msg-surf", now);
+      expect(result.resurfacedLoopId).toBe("ol-surf");
+
+      // Verify surfacedAt was written
+      const surfaced = getRawDb()
+        .query(`SELECT surfaced_at FROM open_loops WHERE id = 'ol-surf'`)
+        .get() as { surfaced_at: number } | null;
+      expect(surfaced).not.toBeNull();
+      expect(surfaced!.surfaced_at).toBe(now);
+    });
+
+    test("low-salience work items are not resurfaced", () => {
+      const now = Date.now();
+      const task = createTask({ title: "t", template: "t" });
+
+      // Only work items, no loops — should not resurface
+      insertWorkItem({
+        id: "wi-old",
+        taskId: task.id,
+        title: "Old work item",
+        updatedAt: now - MS_DAY * 30,
+      });
+
+      const result = compileOpenLoopBrief(SCOPE, "msg-no-resurface", now);
+      expect(result.resurfacedLoopId).toBeNull();
+      // Work item is tier 6, so it should not appear in ranked output
+      expect(result.bullets).toHaveLength(0);
+    });
+  });
+
+  // ── Scope isolation ──────────────────────────────────────────────
+
+  describe("scope isolation", () => {
+    test("only includes loops from the specified scope", () => {
+      const now = Date.now();
+      insertOpenLoop({
+        id: "ol-scope-a",
+        summary: "In scope",
+        dueAt: now + MS_HOUR,
+        updatedAt: now,
+      });
+
+      // Insert loop for a different scope directly
+      getRawDb().run(
+        `INSERT INTO open_loops (id, scope_id, summary, status, source, due_at, created_at, updated_at)
+         VALUES ('ol-scope-b', 'other-scope', 'Out of scope', 'open', 'conversation', ?, ?, ?)`,
+        [now + MS_HOUR, now, now],
+      );
+
+      const result = compileOpenLoopBrief(SCOPE, "msg-scope", now);
+      expect(result.bullets).toHaveLength(1);
+      expect(result.bullets[0].summary).toBe("In scope");
+    });
+  });
+
+  // ── Mixed sources ────────────────────────────────────────────────
+
+  describe("mixed sources", () => {
+    test("merges loops, work items, and follow-ups without duplicates", () => {
+      const now = Date.now();
+      const task = createTask({ title: "t", template: "t" });
+
+      insertOpenLoop({
+        id: "ol-mix",
+        summary: "Loop item",
+        dueAt: now - MS_HOUR,
+        updatedAt: now,
+      });
+      insertWorkItem({
+        id: "wi-mix",
+        taskId: task.id,
+        title: "Work item",
+        priorityTier: 0,
+        updatedAt: now,
+      });
+      createFollowUp({
+        channel: "email",
+        conversationId: "conv-mix",
+        expectedResponseBy: now + 6 * MS_HOUR,
+      });
+
+      const result = compileOpenLoopBrief(SCOPE, "msg-mix", now);
+      expect(result.bullets).toHaveLength(3);
+
+      const sources = result.bullets.map((b) => b.source);
+      expect(sources).toContain("loop");
+      expect(sources).toContain("work_item");
+      expect(sources).toContain("followup");
+
+      // All keys are unique
+      const keys = result.bullets.map((b) => b.key);
+      expect(new Set(keys).size).toBe(keys.length);
+    });
+  });
+});

--- a/assistant/src/followups/followup-store.ts
+++ b/assistant/src/followups/followup-store.ts
@@ -1,4 +1,4 @@
-import { and, eq, lte, or } from "drizzle-orm";
+import { and, desc, eq, lte, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../memory/db.js";
@@ -175,4 +175,50 @@ export function markNudged(id: string): FollowUp {
     .run();
 
   return getFollowUp(id)!;
+}
+
+// ── Brief Helpers ──────────────────────────────────────────────────────
+
+/**
+ * Lightweight projection of a follow-up used by the brief compiler.
+ */
+export interface BriefFollowUp {
+  id: string;
+  channel: string;
+  conversationId: string;
+  contactId: string | null;
+  expectedResponseBy: number | null;
+  status: FollowUpStatus;
+  updatedAt: number;
+}
+
+/**
+ * Return pending and overdue follow-ups for the brief compiler.
+ * Ordered by expectedResponseBy ascending (most urgent first).
+ */
+export function getPendingAndOverdueFollowUps(): BriefFollowUp[] {
+  const db = getDb();
+
+  const rows = db
+    .select({
+      id: followups.id,
+      channel: followups.channel,
+      conversationId: followups.conversationId,
+      contactId: followups.contactId,
+      expectedResponseBy: followups.expectedResponseBy,
+      status: followups.status,
+      updatedAt: followups.updatedAt,
+    })
+    .from(followups)
+    .where(
+      or(
+        eq(followups.status, "pending"),
+        eq(followups.status, "overdue"),
+        eq(followups.status, "nudged"),
+      ),
+    )
+    .orderBy(desc(followups.expectedResponseBy))
+    .all();
+
+  return rows as BriefFollowUp[];
 }

--- a/assistant/src/memory/brief-open-loops.ts
+++ b/assistant/src/memory/brief-open-loops.ts
@@ -1,0 +1,266 @@
+/**
+ * Open-loop brief compiler.
+ *
+ * Merges reducer-created open_loops rows with live task queue (work items)
+ * and follow-up state into a ranked, deduplicated list of bullets for the
+ * memory brief.
+ *
+ * Ranking tiers (highest first):
+ *   1. Overdue     — dueAt in the past
+ *   2. Due ≤ 24 h  — dueAt within the next 24 hours
+ *   3. Due ≤ 7 d   — dueAt within the next 7 days
+ *   4. High-priority / blocked — work items at priority tier 0 or
+ *      follow-ups with status "nudged"
+ *   5. Recently touched — updatedAt within the last 48 hours
+ *
+ * After ranked items, at most ONE low-salience loop is resurfaced via
+ * deterministic pseudo-random sampling seeded by `scopeId + userMessageId`.
+ * The resurfaced loop's `surfacedAt` is updated so it won't repeat
+ * immediately.
+ */
+
+import { and, eq } from "drizzle-orm";
+
+import {
+  type BriefFollowUp,
+  getPendingAndOverdueFollowUps,
+} from "../followups/followup-store.js";
+import {
+  type ActionableWorkItem,
+  getActionableWorkItems,
+} from "../tasks/task-store.js";
+import { getDb } from "./db.js";
+import { updateLastSurfacedAt } from "./reducer-store.js";
+import { openLoops } from "./schema.js";
+
+// ── Constants ─────────────────────────────────────────────────────────
+
+const MS_24H = 24 * 60 * 60 * 1000;
+const MS_7D = 7 * 24 * 60 * 60 * 1000;
+const MS_48H = 48 * 60 * 60 * 1000;
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+export interface OpenLoopBullet {
+  /** Dedupe key — one of `loop:<id>`, `work:<id>`, or `followup:<id>`. */
+  key: string;
+  summary: string;
+  tier: number; // 1–5, lower = higher priority
+  source: "loop" | "work_item" | "followup";
+  sourceId: string;
+}
+
+export interface OpenLoopBriefResult {
+  /** Bullets ordered by tier then recency. */
+  bullets: OpenLoopBullet[];
+  /** ID of the resurfaced low-salience loop, if any. */
+  resurfacedLoopId: string | null;
+}
+
+interface OpenLoopRow {
+  id: string;
+  scopeId: string;
+  summary: string;
+  status: string;
+  source: string;
+  dueAt: number | null;
+  surfacedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+// ── Deterministic hash ────────────────────────────────────────────────
+
+/**
+ * Simple 32-bit FNV-1a hash for deterministic pseudo-random selection.
+ * Not cryptographic — only needs to be well-distributed for sampling.
+ */
+function fnv1a(input: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0; // unsigned 32-bit
+}
+
+// ── Tier assignment ───────────────────────────────────────────────────
+
+function assignLoopTier(loop: OpenLoopRow, now: number): number {
+  if (loop.dueAt != null) {
+    if (loop.dueAt <= now) return 1; // overdue
+    if (loop.dueAt <= now + MS_24H) return 2; // due within 24h
+    if (loop.dueAt <= now + MS_7D) return 3; // due within 7d
+  }
+  if (now - loop.updatedAt <= MS_48H) return 5; // recently touched
+  return 6; // low salience — candidate for resurfacing
+}
+
+function assignWorkItemTier(item: ActionableWorkItem, now: number): number {
+  if (item.priorityTier === 0) return 4; // high priority
+  if (item.status === "awaiting_review") return 4;
+  if (now - item.updatedAt <= MS_48H) return 5;
+  return 6;
+}
+
+function assignFollowUpTier(fu: BriefFollowUp, now: number): number {
+  if (fu.expectedResponseBy != null && fu.expectedResponseBy <= now) return 1;
+  if (fu.expectedResponseBy != null && fu.expectedResponseBy <= now + MS_24H)
+    return 2;
+  if (fu.expectedResponseBy != null && fu.expectedResponseBy <= now + MS_7D)
+    return 3;
+  if (fu.status === "nudged") return 4;
+  if (now - fu.updatedAt <= MS_48H) return 5;
+  return 6;
+}
+
+// ── Compiler ──────────────────────────────────────────────────────────
+
+/**
+ * Compile the open-loop section of the memory brief.
+ *
+ * @param scopeId   Memory scope (e.g. assistant instance ID)
+ * @param userMessageId  Current user message ID — used as part of the
+ *                       resurfacing seed so the selection is deterministic
+ *                       per turn but varies across turns.
+ * @param now       Current epoch-ms timestamp (injectable for testing).
+ */
+export function compileOpenLoopBrief(
+  scopeId: string,
+  userMessageId: string,
+  now: number = Date.now(),
+): OpenLoopBriefResult {
+  // 1. Gather data from all three sources
+  const loops = getOpenLoopsForScope(scopeId);
+  const workItems = getActionableWorkItems();
+  const followUps = getPendingAndOverdueFollowUps();
+
+  // 2. Convert to bullets with tier assignment
+  const bullets: OpenLoopBullet[] = [];
+  const seenKeys = new Set<string>();
+
+  // Loops first (they are the authoritative open-loop source)
+  for (const loop of loops) {
+    const key = `loop:${loop.id}`;
+    if (seenKeys.has(key)) continue;
+    seenKeys.add(key);
+    bullets.push({
+      key,
+      summary: loop.summary,
+      tier: assignLoopTier(loop, now),
+      source: "loop",
+      sourceId: loop.id,
+    });
+  }
+
+  // Work items — skip if already represented by a loop with matching summary
+  const loopSummaries = new Set(loops.map((l) => l.summary.toLowerCase()));
+  for (const item of workItems) {
+    const key = `work:${item.id}`;
+    if (seenKeys.has(key)) continue;
+    // Deduplicate against loop summaries
+    if (loopSummaries.has(item.title.toLowerCase())) continue;
+    seenKeys.add(key);
+    bullets.push({
+      key,
+      summary: item.title,
+      tier: assignWorkItemTier(item, now),
+      source: "work_item",
+      sourceId: item.id,
+    });
+  }
+
+  // Follow-ups — skip if already represented by a loop
+  for (const fu of followUps) {
+    const key = `followup:${fu.id}`;
+    if (seenKeys.has(key)) continue;
+    const fuSummary =
+      `Awaiting reply on ${fu.channel} (${fu.conversationId})`.toLowerCase();
+    if (loopSummaries.has(fuSummary)) continue;
+    seenKeys.add(key);
+    bullets.push({
+      key,
+      summary: `Awaiting reply on ${fu.channel} (${fu.conversationId})`,
+      tier: assignFollowUpTier(fu, now),
+      source: "followup",
+      sourceId: fu.id,
+    });
+  }
+
+  // 3. Split into ranked (tiers 1–5) and low-salience (tier 6)
+  const ranked: OpenLoopBullet[] = [];
+  const lowSalience: OpenLoopBullet[] = [];
+
+  for (const b of bullets) {
+    if (b.tier <= 5) {
+      ranked.push(b);
+    } else {
+      lowSalience.push(b);
+    }
+  }
+
+  // Sort ranked: by tier ascending, then by source priority (loop > work > followup)
+  ranked.sort((a, b) => {
+    if (a.tier !== b.tier) return a.tier - b.tier;
+    return sourcePriority(a.source) - sourcePriority(b.source);
+  });
+
+  // 4. Deterministic resurfacing of ONE low-salience loop
+  let resurfacedLoopId: string | null = null;
+
+  if (lowSalience.length > 0) {
+    // Only consider loops from the open_loops table for resurfacing
+    // (work items and follow-ups have their own lifecycle)
+    const resurfaceCandidates = lowSalience.filter((b) => b.source === "loop");
+
+    if (resurfaceCandidates.length > 0) {
+      // Sort candidates deterministically by key for stable ordering
+      resurfaceCandidates.sort((a, b) => a.key.localeCompare(b.key));
+
+      const seed = `${scopeId}:${userMessageId}`;
+      const hash = fnv1a(seed);
+      const idx = hash % resurfaceCandidates.length;
+      const picked = resurfaceCandidates[idx];
+
+      // Promote picked to tier 5 and add to ranked output
+      ranked.push({ ...picked, tier: 5 });
+      resurfacedLoopId = picked.sourceId;
+
+      // Update surfacedAt so it is deprioritised on subsequent turns
+      updateLastSurfacedAt(picked.sourceId, now);
+    }
+  }
+
+  // Re-sort after potential resurfaced bullet insertion
+  ranked.sort((a, b) => {
+    if (a.tier !== b.tier) return a.tier - b.tier;
+    return sourcePriority(a.source) - sourcePriority(b.source);
+  });
+
+  return {
+    bullets: ranked,
+    resurfacedLoopId,
+  };
+}
+
+// ── Internals ─────────────────────────────────────────────────────────
+
+function sourcePriority(source: "loop" | "work_item" | "followup"): number {
+  switch (source) {
+    case "loop":
+      return 0;
+    case "work_item":
+      return 1;
+    case "followup":
+      return 2;
+  }
+}
+
+function getOpenLoopsForScope(scopeId: string): OpenLoopRow[] {
+  const db = getDb();
+  return db
+    .select()
+    .from(openLoops)
+    .where(and(eq(openLoops.scopeId, scopeId), eq(openLoops.status, "open")))
+    .all() as OpenLoopRow[];
+}

--- a/assistant/src/memory/reducer-store.ts
+++ b/assistant/src/memory/reducer-store.ts
@@ -1,0 +1,24 @@
+/**
+ * Minimal reducer store — provides helpers for the brief compiler to
+ * update reducer-created state.  PR 8 will add the full transactional
+ * apply logic and can extend or restructure as needed.
+ */
+
+import { eq } from "drizzle-orm";
+
+import { getDb } from "./db.js";
+import { openLoops } from "./schema.js";
+
+/**
+ * Update the `surfaced_at` timestamp on a single open loop.
+ *
+ * Called by the brief compiler after resurfacing a low-salience loop
+ * so it is not immediately resurfaced again on the next turn.
+ */
+export function updateLastSurfacedAt(loopId: string, surfacedAt: number): void {
+  const db = getDb();
+  db.update(openLoops)
+    .set({ surfacedAt, updatedAt: surfacedAt })
+    .where(eq(openLoops.id, loopId))
+    .run();
+}

--- a/assistant/src/tasks/task-store.ts
+++ b/assistant/src/tasks/task-store.ts
@@ -1,4 +1,4 @@
-import { desc, eq, inArray } from "drizzle-orm";
+import { asc, desc, eq, inArray, or } from "drizzle-orm";
 
 import { getDb } from "../memory/db.js";
 import { taskRuns, tasks, workItems } from "../memory/schema.js";
@@ -138,4 +138,46 @@ export function updateTaskRun(
 export function getTaskRun(id: string): TaskRun | undefined {
   const db = getDb();
   return db.select().from(taskRuns).where(eq(taskRuns.id, id)).get();
+}
+
+// ── Brief Helpers ─────────────────────────────────────────────────────
+
+/**
+ * Lightweight read-only projection of a work item used by the brief compiler.
+ * Avoids pulling the full WorkItem type with all its tool/approval fields.
+ */
+export interface ActionableWorkItem {
+  id: string;
+  taskId: string;
+  title: string;
+  status: string;
+  priorityTier: number;
+  updatedAt: number;
+}
+
+/**
+ * Return actionable work items — those that are queued, running, or
+ * awaiting review. Ordered by priority (high first) then most-recently-updated.
+ */
+export function getActionableWorkItems(): ActionableWorkItem[] {
+  const db = getDb();
+  return db
+    .select({
+      id: workItems.id,
+      taskId: workItems.taskId,
+      title: workItems.title,
+      status: workItems.status,
+      priorityTier: workItems.priorityTier,
+      updatedAt: workItems.updatedAt,
+    })
+    .from(workItems)
+    .where(
+      or(
+        eq(workItems.status, "queued"),
+        eq(workItems.status, "running"),
+        eq(workItems.status, "awaiting_review"),
+      ),
+    )
+    .orderBy(asc(workItems.priorityTier), desc(workItems.updatedAt))
+    .all();
 }


### PR DESCRIPTION
## Summary
- Add brief-open-loops.ts with deterministic compiler merging reducer loops, tasks, and follow-ups
- Add narrow read helpers to task-store and followup-store
- Implement ranked output with seeded pseudo-random low-salience resurfacing
- Add tests for deduplication, ranking, and deterministic resurfacing

Part of plan: simplified-memory-v1.md (PR 19 of 23)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
