### PR TITLE
fix: allow chunk embeddings in qdrant

### DIFF
--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -230,7 +230,7 @@ export class VellumQdrantClient {
   }
 
   async upsert(
-    targetType: "segment" | "item" | "summary" | "media",
+    targetType: "segment" | "item" | "summary" | "media" | "chunk",
     targetId: string,
     vector: number[],
     payload: Omit<QdrantPointPayload, "target_type" | "target_id">,
@@ -324,7 +324,7 @@ export class VellumQdrantClient {
   async searchWithFilter(
     vector: number[],
     limit: number,
-    targetTypes: Array<"segment" | "item" | "summary" | "media">,
+    targetTypes: Array<"segment" | "item" | "summary" | "media" | "chunk">,
     excludeMessageIds?: string[],
     scopeIds?: string[],
   ): Promise<QdrantSearchResult[]> {
@@ -347,7 +347,7 @@ export class VellumQdrantClient {
           },
           {
             key: "target_type",
-            match: { any: ["segment", "summary", "media"] },
+            match: { any: ["segment", "summary", "media", "chunk"] },
           },
         ],
       });


### PR DESCRIPTION
## Summary
- add `chunk` to the Qdrant target type union used by upserts and filtered searches
- treat chunk embeddings like other non-item records in the active-status filter branch
- fix the Type Check GitHub Actions job linked in the original prompt

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23309459789/job/67792542429
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
