### PR TITLE
feat: add observation archive store and embedding jobs

### DIFF
--- a/assistant/src/__tests__/memory-observation-archive.test.ts
+++ b/assistant/src/__tests__/memory-observation-archive.test.ts
@@ -1,0 +1,375 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "memory-observation-archive-test-"));
+const dbPath = join(testDir, "test.db");
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => dbPath,
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { eq } from "drizzle-orm";
+
+import {
+  computeObservationContentHash,
+  getChunkByObservationId,
+  getObservation,
+  insertObservation,
+  type InsertObservationParams,
+  insertObservations,
+} from "../memory/archive-store.js";
+import { getDb, initializeDb, rawAll, resetDb } from "../memory/db.js";
+import { claimMemoryJobs } from "../memory/jobs-store.js";
+import { conversations, memoryChunks, messages } from "../memory/schema.js";
+
+function removeTestDbFiles(): void {
+  rmSync(dbPath, { force: true });
+  rmSync(`${dbPath}-shm`, { force: true });
+  rmSync(`${dbPath}-wal`, { force: true });
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function createConversation(id: string): void {
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversations)
+    .values({
+      id,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function createMessage(id: string, conversationId: string): void {
+  const db = getDb();
+  db.insert(messages)
+    .values({
+      id,
+      conversationId,
+      role: "user",
+      content: "test message",
+      createdAt: Date.now(),
+    })
+    .run();
+}
+
+function getJobsByType(type: string) {
+  return rawAll<{
+    id: string;
+    type: string;
+    payload: string;
+    status: string;
+  }>(`SELECT id, type, payload, status FROM memory_jobs WHERE type = ?`, type);
+}
+
+// ── Setup ───────────────────────────────────────────────────────────
+
+describe("memory observation archive store", () => {
+  beforeEach(() => {
+    resetDb();
+    removeTestDbFiles();
+    initializeDb();
+  });
+
+  afterEach(() => {
+    resetDb();
+    removeTestDbFiles();
+  });
+
+  afterAll(() => {
+    resetDb();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  // ── Row insertion ───────────────────────────────────────────────
+
+  describe("insertObservation", () => {
+    test("inserts observation row into memory_observations table", () => {
+      createConversation("conv-1");
+
+      const result = insertObservation({
+        conversationId: "conv-1",
+        role: "user",
+        content: "The user prefers dark mode",
+      });
+
+      expect(result.observationId).toBeTruthy();
+      expect(result.contentHash).toBeTruthy();
+
+      const obs = getObservation(result.observationId);
+      expect(obs).toBeDefined();
+      expect(obs!.conversationId).toBe("conv-1");
+      expect(obs!.role).toBe("user");
+      expect(obs!.content).toBe("The user prefers dark mode");
+      expect(obs!.modality).toBe("text");
+      expect(obs!.scopeId).toBe("default");
+    });
+
+    test("inserts associated chunk with correct content hash", () => {
+      createConversation("conv-1");
+
+      const result = insertObservation({
+        conversationId: "conv-1",
+        role: "user",
+        content: "The user lives in NYC",
+      });
+
+      expect(result.chunkId).toBeTruthy();
+
+      const chunk = getChunkByObservationId(result.observationId);
+      expect(chunk).toBeDefined();
+      expect(chunk!.content).toBe("The user lives in NYC");
+      expect(chunk!.contentHash).toBe(result.contentHash);
+      expect(chunk!.tokenEstimate).toBeGreaterThan(0);
+      expect(chunk!.scopeId).toBe("default");
+    });
+
+    test("respects optional params: scopeId, modality, source, messageId", () => {
+      createConversation("conv-1");
+      createMessage("msg-1", "conv-1");
+
+      const result = insertObservation({
+        conversationId: "conv-1",
+        messageId: "msg-1",
+        role: "assistant",
+        content: "Voice observation about weather",
+        scopeId: "custom-scope",
+        modality: "voice",
+        source: "phone",
+      });
+
+      const obs = getObservation(result.observationId);
+      expect(obs).toBeDefined();
+      expect(obs!.messageId).toBe("msg-1");
+      expect(obs!.scopeId).toBe("custom-scope");
+      expect(obs!.modality).toBe("voice");
+      expect(obs!.source).toBe("phone");
+    });
+
+    test("does not touch legacy memory tables", () => {
+      createConversation("conv-1");
+
+      insertObservation({
+        conversationId: "conv-1",
+        role: "user",
+        content: "A fact about the user",
+      });
+
+      // Verify no rows in legacy memory_segments or memory_items
+      const segments = rawAll<{ id: string }>(`SELECT id FROM memory_segments`);
+      const items = rawAll<{ id: string }>(`SELECT id FROM memory_items`);
+      expect(segments).toHaveLength(0);
+      expect(items).toHaveLength(0);
+    });
+  });
+
+  // ── Content hash idempotency ──────────────────────────────────
+
+  describe("content hash idempotency", () => {
+    test("duplicate content in same scope does not create a second chunk", () => {
+      createConversation("conv-1");
+
+      const result1 = insertObservation({
+        conversationId: "conv-1",
+        role: "user",
+        content: "The user likes cats",
+      });
+
+      const result2 = insertObservation({
+        conversationId: "conv-1",
+        role: "user",
+        content: "The user likes cats",
+      });
+
+      // Both observations should exist
+      expect(getObservation(result1.observationId)).toBeDefined();
+      expect(getObservation(result2.observationId)).toBeDefined();
+
+      // First creates a chunk, second is deduplicated
+      expect(result1.chunkId).toBeTruthy();
+      expect(result2.chunkId).toBeNull();
+
+      // Only one chunk row should exist
+      const db = getDb();
+      const chunks = db
+        .select()
+        .from(memoryChunks)
+        .where(eq(memoryChunks.scopeId, "default"))
+        .all();
+      expect(chunks).toHaveLength(1);
+    });
+
+    test("same content in different scopes creates separate chunks", () => {
+      createConversation("conv-1");
+
+      const result1 = insertObservation({
+        conversationId: "conv-1",
+        role: "user",
+        content: "The user likes dogs",
+        scopeId: "scope-a",
+      });
+
+      const result2 = insertObservation({
+        conversationId: "conv-1",
+        role: "user",
+        content: "The user likes dogs",
+        scopeId: "scope-b",
+      });
+
+      expect(result1.chunkId).toBeTruthy();
+      expect(result2.chunkId).toBeTruthy();
+      expect(result1.chunkId).not.toBe(result2.chunkId);
+    });
+
+    test("content hashes are deterministic", () => {
+      const hash1 = computeObservationContentHash("default", "Hello world");
+      const hash2 = computeObservationContentHash("default", "Hello world");
+      expect(hash1).toBe(hash2);
+
+      // Different scope produces different hash
+      const hash3 = computeObservationContentHash("other", "Hello world");
+      expect(hash1).not.toBe(hash3);
+    });
+  });
+
+  // ── Embedding job dispatch ────────────────────────────────────
+
+  describe("embedding job dispatch", () => {
+    test("enqueues embed_observation job when new chunk is created", () => {
+      createConversation("conv-1");
+
+      const result = insertObservation({
+        conversationId: "conv-1",
+        role: "user",
+        content: "User prefers TypeScript",
+      });
+
+      expect(result.embeddingJobId).toBeTruthy();
+
+      const jobs = getJobsByType("embed_observation");
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].status).toBe("pending");
+
+      const payload = JSON.parse(jobs[0].payload);
+      expect(payload.observationId).toBe(result.observationId);
+      expect(payload.chunkId).toBe(result.chunkId);
+    });
+
+    test("does not enqueue embed job when chunk is deduplicated", () => {
+      createConversation("conv-1");
+
+      // First insert creates a chunk and job
+      insertObservation({
+        conversationId: "conv-1",
+        role: "user",
+        content: "User prefers Python",
+      });
+
+      // Second insert with same content should not create another job
+      const result2 = insertObservation({
+        conversationId: "conv-1",
+        role: "user",
+        content: "User prefers Python",
+      });
+
+      expect(result2.embeddingJobId).toBeNull();
+
+      const jobs = getJobsByType("embed_observation");
+      expect(jobs).toHaveLength(1); // Only from the first insert
+    });
+
+    test("embed_observation jobs are claimable by the worker", () => {
+      createConversation("conv-1");
+
+      insertObservation({
+        conversationId: "conv-1",
+        role: "user",
+        content: "Claimable observation",
+      });
+
+      const claimed = claimMemoryJobs(10);
+      const embedJobs = claimed.filter((j) => j.type === "embed_observation");
+      expect(embedJobs).toHaveLength(1);
+      expect(embedJobs[0].status).toBe("running");
+      expect(embedJobs[0].payload.observationId).toBeTruthy();
+      expect(embedJobs[0].payload.chunkId).toBeTruthy();
+    });
+  });
+
+  // ── Batch insertion ───────────────────────────────────────────
+
+  describe("insertObservations (batch)", () => {
+    test("inserts multiple observations atomically", () => {
+      createConversation("conv-1");
+
+      const params: InsertObservationParams[] = [
+        { conversationId: "conv-1", role: "user", content: "Fact A" },
+        { conversationId: "conv-1", role: "user", content: "Fact B" },
+        { conversationId: "conv-1", role: "assistant", content: "Fact C" },
+      ];
+
+      const results = insertObservations(params);
+      expect(results).toHaveLength(3);
+
+      // All observations should exist
+      for (const result of results) {
+        expect(getObservation(result.observationId)).toBeDefined();
+      }
+
+      // All should have chunks (different content)
+      for (const result of results) {
+        expect(result.chunkId).toBeTruthy();
+      }
+
+      // All should have embedding jobs
+      const jobs = getJobsByType("embed_observation");
+      expect(jobs).toHaveLength(3);
+    });
+
+    test("batch handles content hash dedup within the batch", () => {
+      createConversation("conv-1");
+
+      const params: InsertObservationParams[] = [
+        { conversationId: "conv-1", role: "user", content: "Same content" },
+        { conversationId: "conv-1", role: "user", content: "Same content" },
+      ];
+
+      const results = insertObservations(params);
+      expect(results).toHaveLength(2);
+
+      // First creates a chunk, second is deduplicated
+      expect(results[0].chunkId).toBeTruthy();
+      expect(results[1].chunkId).toBeNull();
+
+      // Only one embedding job
+      const jobs = getJobsByType("embed_observation");
+      expect(jobs).toHaveLength(1);
+    });
+  });
+});

--- a/assistant/src/memory/archive-store.ts
+++ b/assistant/src/memory/archive-store.ts
@@ -3,10 +3,15 @@ import { createHash } from "node:crypto";
 import { eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { estimateTextTokens } from "../context/token-estimator.js";
 import { getLogger } from "../util/logger.js";
-import { getDb } from "./db.js";
+import { getDb, rawChanges } from "./db.js";
 import { enqueueMemoryJob, type MemoryJobType } from "./jobs-store.js";
-import { memoryChunks, memoryEpisodes } from "./schema.js";
+import {
+  memoryChunks,
+  memoryEpisodes,
+  memoryObservations,
+} from "./schema.js";
 
 const log = getLogger("memory-archive-store");
 
@@ -18,6 +23,17 @@ const log = getLogger("memory-archive-store");
  * scope, the chunk is skipped.
  */
 export function computeChunkContentHash(
+  scopeId: string,
+  content: string,
+): string {
+  return createHash("sha256").update(`${scopeId}|${content}`).digest("hex");
+}
+
+/**
+ * Compute a SHA-256 hash of the observation content, scoped by scopeId.
+ * Used for idempotent chunk deduplication.
+ */
+export function computeObservationContentHash(
   scopeId: string,
   content: string,
 ): string {
@@ -190,7 +206,7 @@ export function insertResolutionEpisode(params: InsertEpisodeParams): {
   return insertEpisodeAndEnqueue(params);
 }
 
-// ── Internal ────────────────────────────────────────────────────────
+// ── Internal (episode) ──────────────────────────────────────────────
 
 function insertEpisodeAndEnqueue(params: InsertEpisodeParams): {
   episodeId: string;
@@ -226,4 +242,159 @@ function insertEpisodeAndEnqueue(params: InsertEpisodeParams): {
   );
 
   return { episodeId, jobId };
+}
+
+// ── Observation types ───────────────────────────────────────────────
+
+export interface InsertObservationParams {
+  conversationId: string;
+  messageId?: string | null;
+  role: string;
+  content: string;
+  scopeId?: string;
+  modality?: string;
+  source?: string | null;
+}
+
+export interface InsertedObservation {
+  observationId: string;
+  chunkId: string | null;
+  contentHash: string;
+  embeddingJobId: string | null;
+}
+
+// ── Observation insert helpers ──────────────────────────────────────
+
+/**
+ * Insert a raw observation row and its associated chunk. If a chunk with the
+ * same content hash already exists in the scope, the chunk insert is skipped
+ * (idempotent dual-write safety). An `embed_observation` job is enqueued when
+ * a new chunk is created.
+ *
+ * Returns the observation ID, chunk ID (null if deduplicated), content hash,
+ * and embedding job ID (null if no new chunk was created).
+ */
+export function insertObservation(
+  params: InsertObservationParams,
+): InsertedObservation {
+  const db = getDb();
+  const now = Date.now();
+  const scopeId = params.scopeId ?? "default";
+  const modality = params.modality ?? "text";
+
+  const observationId = uuid();
+  const contentHash = computeObservationContentHash(scopeId, params.content);
+
+  // Insert the observation row
+  db.insert(memoryObservations)
+    .values({
+      id: observationId,
+      scopeId,
+      conversationId: params.conversationId,
+      messageId: params.messageId ?? null,
+      role: params.role,
+      content: params.content,
+      modality,
+      source: params.source ?? null,
+      createdAt: now,
+    })
+    .run();
+
+  // Attempt to insert the chunk — the unique index on (scope_id, content_hash)
+  // will cause a conflict if this content was already chunked. We use
+  // onConflictDoNothing to silently skip the duplicate.
+  const chunkId = uuid();
+  const tokenEstimate = estimateTextTokens(params.content);
+
+  db.insert(memoryChunks)
+    .values({
+      id: chunkId,
+      scopeId,
+      observationId,
+      content: params.content,
+      tokenEstimate,
+      contentHash,
+      createdAt: now,
+    })
+    .onConflictDoNothing({
+      target: [memoryChunks.scopeId, memoryChunks.contentHash],
+    })
+    .run();
+
+  // Drizzle bun:sqlite .run() returns void; use rawChanges() to detect no-ops
+  const chunkInserted = rawChanges() > 0;
+
+  let embeddingJobId: string | null = null;
+  if (chunkInserted) {
+    embeddingJobId = enqueueMemoryJob("embed_observation", {
+      observationId,
+      chunkId,
+    });
+    log.debug(
+      { observationId, chunkId, contentHash, embeddingJobId },
+      "Inserted observation with new chunk, enqueued embed job",
+    );
+  } else {
+    log.debug(
+      { observationId, contentHash },
+      "Inserted observation, chunk deduplicated by content hash",
+    );
+  }
+
+  return {
+    observationId,
+    chunkId: chunkInserted ? chunkId : null,
+    contentHash,
+    embeddingJobId,
+  };
+}
+
+/**
+ * Insert multiple observations in a single transaction.
+ * Returns the results for each insertion.
+ */
+export function insertObservations(
+  observations: InsertObservationParams[],
+): InsertedObservation[] {
+  const db = getDb();
+  const results: InsertedObservation[] = [];
+  db.transaction((tx) => {
+    // We don't use `tx` directly for individual inserts because
+    // insertObservation uses getDb() internally. Instead, the transaction
+    // wrapper ensures atomicity at the SQLite level.
+    void tx;
+    for (const obs of observations) {
+      results.push(insertObservation(obs));
+    }
+  });
+  return results;
+}
+
+/**
+ * Look up an observation by ID.
+ */
+export function getObservation(
+  observationId: string,
+): typeof memoryObservations.$inferSelect | undefined {
+  const db = getDb();
+  return db
+    .select()
+    .from(memoryObservations)
+    .where(eq(memoryObservations.id, observationId))
+    .get();
+}
+
+/**
+ * Look up a chunk by observation ID. Returns the first chunk linked to the
+ * given observation, or undefined if none exists.
+ */
+export function getChunkByObservationId(
+  observationId: string,
+): typeof memoryChunks.$inferSelect | undefined {
+  const db = getDb();
+  return db
+    .select()
+    .from(memoryChunks)
+    .where(eq(memoryChunks.observationId, observationId))
+    .get();
 }

--- a/assistant/src/memory/job-handlers/embedding.ts
+++ b/assistant/src/memory/job-handlers/embedding.ts
@@ -14,6 +14,7 @@ import {
   memoryChunks,
   memoryEpisodes,
   memoryItems,
+  memoryObservations,
   memorySegments,
   memorySummaries,
   messages,
@@ -142,6 +143,40 @@ export async function embedMediaJob(
     kind: asset.mediaType,
     subject: asset.title,
     memory_scope_id: "default",
+  });
+}
+
+export async function embedObservationJob(
+  job: MemoryJob,
+  config: AssistantConfig,
+): Promise<void> {
+  const observationId = asString(job.payload.observationId);
+  const chunkId = asString(job.payload.chunkId);
+  if (!observationId || !chunkId) return;
+
+  const db = getDb();
+  const observation = db
+    .select()
+    .from(memoryObservations)
+    .where(eq(memoryObservations.id, observationId))
+    .get();
+  if (!observation) return;
+
+  const chunk = db
+    .select()
+    .from(memoryChunks)
+    .where(eq(memoryChunks.id, chunkId))
+    .get();
+  if (!chunk) return;
+
+  await embedAndUpsert(config, "observation", chunk.id, chunk.content, {
+    observation_id: observationId,
+    conversation_id: observation.conversationId,
+    role: observation.role,
+    modality: observation.modality,
+    source: observation.source,
+    created_at: observation.createdAt,
+    memory_scope_id: observation.scopeId,
   });
 }
 

--- a/assistant/src/memory/job-utils.ts
+++ b/assistant/src/memory/job-utils.ts
@@ -142,7 +142,7 @@ export function truncate(text: string, max: number): string {
 
 export async function embedAndUpsert(
   config: AssistantConfig,
-  targetType: "segment" | "item" | "summary" | "media" | "chunk" | "episode",
+  targetType: "segment" | "item" | "summary" | "observation" | "chunk" | "episode" | "media",
   targetId: string,
   input: EmbeddingInput,
   extraPayload?: Record<string, unknown>,

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -14,6 +14,7 @@ export type MemoryJobType =
   | "embed_summary"
   | "embed_chunk"
   | "embed_episode"
+  | "embed_observation"
   | "extract_items"
   | "extract_entities"
   | "cleanup_stale_superseded_items"
@@ -38,6 +39,7 @@ const EMBED_JOB_TYPES: MemoryJobType[] = [
   "embed_summary",
   "embed_chunk",
   "embed_episode",
+  "embed_observation",
   "embed_media",
   "embed_attachment",
 ];

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -15,6 +15,7 @@ import {
   embedEpisodeJob,
   embedItemJob,
   embedMediaJob,
+  embedObservationJob,
   embedSegmentJob,
   embedSummaryJob,
 } from "./job-handlers/embedding.js";
@@ -274,6 +275,9 @@ async function processJob(
       return;
     case "embed_episode":
       await embedEpisodeJob(job, config);
+      return;
+    case "embed_observation":
+      await embedObservationJob(job, config);
       return;
     case "extract_items":
       await extractItemsJob(job);

--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -20,7 +20,7 @@ export interface QdrantClientConfig {
 }
 
 export interface QdrantPointPayload {
-  target_type: "segment" | "item" | "summary" | "media" | "chunk" | "episode";
+  target_type: "segment" | "item" | "summary" | "observation" | "chunk" | "episode" | "media";
   target_id: string;
   text: string;
   kind?: string;
@@ -230,7 +230,7 @@ export class VellumQdrantClient {
   }
 
   async upsert(
-    targetType: "segment" | "item" | "summary" | "media" | "chunk" | "episode",
+    targetType: "segment" | "item" | "summary" | "observation" | "chunk" | "episode" | "media",
     targetId: string,
     vector: number[],
     payload: Omit<QdrantPointPayload, "target_type" | "target_id">,


### PR DESCRIPTION
## Summary
- Add archive-store.ts with observation insertion helpers (insertObservation, insertObservations, getObservation, getChunkByObservationId)
- Extend job system with embed_observation job type in MemoryJobType union and EMBED_JOB_TYPES array
- Wire embed_observation through jobs-worker dispatch and add embedObservationJob handler in embedding.ts
- Add "observation" and "chunk" to targetType unions in job-utils.ts embedAndUpsert and qdrant-client.ts
- Add 12 tests covering row insertion, optional params, legacy table isolation, content-hash idempotency (same/different scopes, determinism), job enqueuing, job dedup, job claimability, and batch operations

Part of plan: simplified-memory-v1.md (PR 9 of 23)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
