### PR TITLE
Add explicit outcomes for chat bottom-anchor verification

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -2019,15 +2019,50 @@ private struct PaginationSentinelMinYKey: PreferenceKey {
 /// paths so expansion/streaming guards stop once the tail anchor re-enters
 /// the viewport.
 enum MessageListBottomAnchorPolicy {
+    /// Distinguishes why a bottom-anchor check passed or failed, so callers
+    /// can handle missing geometry differently from a genuine scroll drift.
+    enum VerificationOutcome: Equatable {
+        /// The anchor is within tolerance of the viewport bottom — no action needed.
+        case anchored
+        /// The anchor has drifted below the viewport and should be re-pinned.
+        case needsRepin
+        /// One or both geometry inputs are non-finite (e.g. `.infinity`, `.nan`),
+        /// meaning the layout has not been measured yet or is in a transient state.
+        case geometryUnavailable
+    }
+
     static let repinTolerance: CGFloat = 2
 
+    /// Evaluates the bottom-anchor position against the viewport and returns
+    /// a structured outcome describing the result.
+    static func verify(
+        anchorMinY: CGFloat,
+        viewportHeight: CGFloat,
+        tolerance: CGFloat = repinTolerance
+    ) -> VerificationOutcome {
+        guard anchorMinY.isFinite, viewportHeight.isFinite else {
+            return .geometryUnavailable
+        }
+        if anchorMinY > viewportHeight + tolerance {
+            return .needsRepin
+        }
+        return .anchored
+    }
+
+    /// Returns `true` when the anchor needs re-pinning OR geometry is unavailable.
+    /// Existing call sites rely on this collapsing `geometryUnavailable` into `true`,
+    /// preserving current behavior until callers adopt `verify(...)` directly.
     static func needsRepin(
         anchorMinY: CGFloat,
         viewportHeight: CGFloat,
         tolerance: CGFloat = repinTolerance
     ) -> Bool {
-        guard anchorMinY.isFinite, viewportHeight.isFinite else { return true }
-        return anchorMinY > viewportHeight + tolerance
+        switch verify(anchorMinY: anchorMinY, viewportHeight: viewportHeight, tolerance: tolerance) {
+        case .anchored:
+            return false
+        case .needsRepin, .geometryUnavailable:
+            return true
+        }
     }
 }
 

--- a/clients/macos/vellum-assistantTests/MessageListBottomAnchorPolicyTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListBottomAnchorPolicyTests.swift
@@ -2,6 +2,9 @@ import XCTest
 @testable import VellumAssistantLib
 
 final class MessageListBottomAnchorPolicyTests: XCTestCase {
+
+    // MARK: - needsRepin (existing API — behavior preserved)
+
     func testNeedsRepinWhenAnchorFallsBelowViewport() {
         XCTAssertTrue(
             MessageListBottomAnchorPolicy.needsRepin(
@@ -39,5 +42,147 @@ final class MessageListBottomAnchorPolicyTests: XCTestCase {
                 viewportHeight: .infinity
             )
         )
+    }
+
+    // MARK: - verify (new decision API)
+
+    // -- Anchored outcomes --
+
+    func testVerifyAnchoredWhenExactlyAtViewportBottom() {
+        let outcome = MessageListBottomAnchorPolicy.verify(
+            anchorMinY: 500,
+            viewportHeight: 500
+        )
+        XCTAssertEqual(outcome, .anchored)
+    }
+
+    func testVerifyAnchoredWhenWithinTolerance() {
+        let outcome = MessageListBottomAnchorPolicy.verify(
+            anchorMinY: 501.5,
+            viewportHeight: 500
+        )
+        XCTAssertEqual(outcome, .anchored)
+    }
+
+    func testVerifyAnchoredWhenAnchorAboveViewportBottom() {
+        let outcome = MessageListBottomAnchorPolicy.verify(
+            anchorMinY: 400,
+            viewportHeight: 500
+        )
+        XCTAssertEqual(outcome, .anchored)
+    }
+
+    // -- NeedsRepin outcomes --
+
+    func testVerifyNeedsRepinWhenAnchorBelowViewport() {
+        let outcome = MessageListBottomAnchorPolicy.verify(
+            anchorMinY: 540,
+            viewportHeight: 500
+        )
+        XCTAssertEqual(outcome, .needsRepin)
+    }
+
+    func testVerifyNeedsRepinJustOutsideTolerance() {
+        let outcome = MessageListBottomAnchorPolicy.verify(
+            anchorMinY: 502.01,
+            viewportHeight: 500
+        )
+        XCTAssertEqual(outcome, .needsRepin)
+    }
+
+    // -- GeometryUnavailable outcomes --
+
+    func testVerifyGeometryUnavailableWhenAnchorIsInfinity() {
+        let outcome = MessageListBottomAnchorPolicy.verify(
+            anchorMinY: .infinity,
+            viewportHeight: 500
+        )
+        XCTAssertEqual(outcome, .geometryUnavailable)
+    }
+
+    func testVerifyGeometryUnavailableWhenViewportIsInfinity() {
+        let outcome = MessageListBottomAnchorPolicy.verify(
+            anchorMinY: 500,
+            viewportHeight: .infinity
+        )
+        XCTAssertEqual(outcome, .geometryUnavailable)
+    }
+
+    func testVerifyGeometryUnavailableWhenBothAreInfinity() {
+        let outcome = MessageListBottomAnchorPolicy.verify(
+            anchorMinY: .infinity,
+            viewportHeight: .infinity
+        )
+        XCTAssertEqual(outcome, .geometryUnavailable)
+    }
+
+    func testVerifyGeometryUnavailableWhenAnchorIsNaN() {
+        let outcome = MessageListBottomAnchorPolicy.verify(
+            anchorMinY: .nan,
+            viewportHeight: 500
+        )
+        XCTAssertEqual(outcome, .geometryUnavailable)
+    }
+
+    func testVerifyGeometryUnavailableWhenViewportIsNaN() {
+        let outcome = MessageListBottomAnchorPolicy.verify(
+            anchorMinY: 500,
+            viewportHeight: .nan
+        )
+        XCTAssertEqual(outcome, .geometryUnavailable)
+    }
+
+    func testVerifyGeometryUnavailableWhenAnchorIsNegativeInfinity() {
+        let outcome = MessageListBottomAnchorPolicy.verify(
+            anchorMinY: -.infinity,
+            viewportHeight: 500
+        )
+        XCTAssertEqual(outcome, .geometryUnavailable)
+    }
+
+    // MARK: - needsRepin agrees with verify
+
+    func testNeedsRepinAgreesWithVerifyForFiniteInputs() {
+        let cases: [(CGFloat, CGFloat)] = [
+            (400, 500),
+            (500, 500),
+            (501, 500),
+            (502, 500),
+            (540, 500),
+        ]
+        for (anchor, viewport) in cases {
+            let outcome = MessageListBottomAnchorPolicy.verify(
+                anchorMinY: anchor,
+                viewportHeight: viewport
+            )
+            let legacy = MessageListBottomAnchorPolicy.needsRepin(
+                anchorMinY: anchor,
+                viewportHeight: viewport
+            )
+            switch outcome {
+            case .anchored:
+                XCTAssertFalse(legacy, "needsRepin should be false when verify returns .anchored (anchor=\(anchor), viewport=\(viewport))")
+            case .needsRepin:
+                XCTAssertTrue(legacy, "needsRepin should be true when verify returns .needsRepin (anchor=\(anchor), viewport=\(viewport))")
+            case .geometryUnavailable:
+                XCTAssertTrue(legacy, "needsRepin should be true when verify returns .geometryUnavailable (anchor=\(anchor), viewport=\(viewport))")
+            }
+        }
+    }
+
+    func testNeedsRepinReturnsTrueForGeometryUnavailable() {
+        // Confirms the existing behavior: non-finite inputs collapse to true
+        // in needsRepin, while verify distinguishes them as .geometryUnavailable.
+        let outcome = MessageListBottomAnchorPolicy.verify(
+            anchorMinY: .infinity,
+            viewportHeight: 500
+        )
+        XCTAssertEqual(outcome, .geometryUnavailable)
+
+        let legacy = MessageListBottomAnchorPolicy.needsRepin(
+            anchorMinY: .infinity,
+            viewportHeight: 500
+        )
+        XCTAssertTrue(legacy)
     }
 }


### PR DESCRIPTION
## Summary
- Extend MessageListBottomAnchorPolicy with a decision API distinguishing anchored, needsRepin, and geometryUnavailable outcomes
- Keep existing needsRepin() helper implemented in terms of the new API for compatibility
- Add test coverage for finite, non-finite, and edge-case geometry inputs

Part of plan: macos-image-send-freeze.md (PR 1 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
