### PR TITLE
feat: implement simplified memory reducer service

### DIFF
--- a/assistant/src/__tests__/memory-reducer.test.ts
+++ b/assistant/src/__tests__/memory-reducer.test.ts
@@ -1,0 +1,698 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { Provider, ProviderResponse } from "../providers/types.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before imports that depend on them
+// ---------------------------------------------------------------------------
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock provider
+// ---------------------------------------------------------------------------
+
+const mockSendMessage = mock<Provider["sendMessage"]>();
+const mockProvider: Provider = {
+  name: "mock-reducer-provider",
+  sendMessage: mockSendMessage,
+};
+
+let providerAvailable = true;
+
+mock.module("../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: async () => (providerAvailable ? mockProvider : null),
+  createTimeout: (ms: number) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ms);
+    return {
+      signal: controller.signal,
+      cleanup: () => clearTimeout(timer),
+    };
+  },
+  extractText: (response: ProviderResponse) => {
+    const block = response.content.find(
+      (b): b is Extract<(typeof response.content)[number], { type: "text" }> =>
+        b.type === "text",
+    );
+    return block?.text?.trim() ?? "";
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test AFTER mocks
+// ---------------------------------------------------------------------------
+
+import {
+  buildReducerSystemPrompt,
+  buildReducerUserMessage,
+  type ReducerPromptInput,
+  runReducer,
+} from "../memory/reducer.js";
+import { EMPTY_REDUCER_RESULT } from "../memory/reducer-types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeInput(
+  overrides: Partial<ReducerPromptInput> = {},
+): ReducerPromptInput {
+  return {
+    conversationId: "conv-test-1",
+    newMessages: [
+      { role: "user", content: "I'm traveling to Paris next week." },
+      {
+        role: "assistant",
+        content: "That sounds exciting! Do you need help planning?",
+      },
+    ],
+    existingTimeContexts: [],
+    existingOpenLoops: [],
+    nowMs: 1700000000000,
+    scopeId: "scope-default",
+    ...overrides,
+  };
+}
+
+function makeProviderResponse(jsonOutput: unknown): ProviderResponse {
+  return {
+    content: [{ type: "text", text: JSON.stringify(jsonOutput) }],
+    model: "mock-model",
+    usage: { inputTokens: 100, outputTokens: 50 },
+    stopReason: "end_turn",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: buildReducerSystemPrompt
+// ---------------------------------------------------------------------------
+
+describe("buildReducerSystemPrompt", () => {
+  test("contains key structural instructions", () => {
+    const prompt = buildReducerSystemPrompt();
+    expect(prompt).toContain("timeContexts");
+    expect(prompt).toContain("openLoops");
+    expect(prompt).toContain("archiveObservations");
+    expect(prompt).toContain("archiveEpisodes");
+    expect(prompt).toContain("JSON");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: buildReducerUserMessage
+// ---------------------------------------------------------------------------
+
+describe("buildReducerUserMessage", () => {
+  test("includes current time, conversation ID, and scope", () => {
+    const input = makeInput();
+    const msg = buildReducerUserMessage(input);
+    expect(msg).toContain("conv-test-1");
+    expect(msg).toContain("scope-default");
+    expect(msg).toContain("1700000000000");
+  });
+
+  test("includes new messages", () => {
+    const input = makeInput();
+    const msg = buildReducerUserMessage(input);
+    expect(msg).toContain("[user]: I'm traveling to Paris next week.");
+    expect(msg).toContain("[assistant]: That sounds exciting!");
+  });
+
+  test("includes existing time contexts when provided", () => {
+    const input = makeInput({
+      existingTimeContexts: [
+        { id: "tc-1", summary: "User on vacation until Friday" },
+      ],
+    });
+    const msg = buildReducerUserMessage(input);
+    expect(msg).toContain("Active time contexts");
+    expect(msg).toContain("[tc-1] User on vacation until Friday");
+  });
+
+  test("includes existing open loops when provided", () => {
+    const input = makeInput({
+      existingOpenLoops: [
+        { id: "ol-1", summary: "Follow up with Bob", status: "open" },
+      ],
+    });
+    const msg = buildReducerUserMessage(input);
+    expect(msg).toContain("Active open loops");
+    expect(msg).toContain("[ol-1] (open) Follow up with Bob");
+  });
+
+  test("omits time context section when none exist", () => {
+    const input = makeInput({ existingTimeContexts: [] });
+    const msg = buildReducerUserMessage(input);
+    expect(msg).not.toContain("Active time contexts");
+  });
+
+  test("omits open loop section when none exist", () => {
+    const input = makeInput({ existingOpenLoops: [] });
+    const msg = buildReducerUserMessage(input);
+    expect(msg).not.toContain("Active open loops");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: runReducer — event extraction
+// ---------------------------------------------------------------------------
+
+describe("runReducer — event extraction", () => {
+  beforeEach(() => {
+    mockSendMessage.mockClear();
+    providerAvailable = true;
+  });
+
+  test("extracts archive observations from provider response", async () => {
+    mockSendMessage.mockResolvedValueOnce(
+      makeProviderResponse({
+        archiveObservations: [
+          {
+            content: "User is planning a trip to Paris",
+            role: "user",
+            modality: "text",
+            source: "vellum",
+          },
+          {
+            content: "User prefers window seats on flights",
+            role: "user",
+          },
+        ],
+      }),
+    );
+
+    const result = await runReducer(makeInput());
+
+    expect(result.archiveObservations).toHaveLength(2);
+    expect(result.archiveObservations[0]).toEqual({
+      content: "User is planning a trip to Paris",
+      role: "user",
+      modality: "text",
+      source: "vellum",
+    });
+    expect(result.archiveObservations[1]).toEqual({
+      content: "User prefers window seats on flights",
+      role: "user",
+    });
+  });
+
+  test("extracts archive episodes from provider response", async () => {
+    mockSendMessage.mockResolvedValueOnce(
+      makeProviderResponse({
+        archiveEpisodes: [
+          {
+            title: "Paris trip planning",
+            summary:
+              "User discussed upcoming trip to Paris, mentioned interest in museums.",
+            source: "vellum",
+          },
+        ],
+      }),
+    );
+
+    const result = await runReducer(makeInput());
+
+    expect(result.archiveEpisodes).toHaveLength(1);
+    expect(result.archiveEpisodes[0]).toEqual({
+      title: "Paris trip planning",
+      summary:
+        "User discussed upcoming trip to Paris, mentioned interest in museums.",
+      source: "vellum",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: runReducer — temporary situation extraction
+// ---------------------------------------------------------------------------
+
+describe("runReducer — temporary situation extraction", () => {
+  beforeEach(() => {
+    mockSendMessage.mockClear();
+    providerAvailable = true;
+  });
+
+  test("extracts time context create operations", async () => {
+    mockSendMessage.mockResolvedValueOnce(
+      makeProviderResponse({
+        timeContexts: [
+          {
+            action: "create",
+            summary: "User traveling to Paris next week",
+            source: "conversation",
+            activeFrom: 1700000000000,
+            activeUntil: 1700604800000,
+          },
+        ],
+      }),
+    );
+
+    const result = await runReducer(makeInput());
+
+    expect(result.timeContexts).toHaveLength(1);
+    expect(result.timeContexts[0]).toEqual({
+      action: "create",
+      summary: "User traveling to Paris next week",
+      source: "conversation",
+      activeFrom: 1700000000000,
+      activeUntil: 1700604800000,
+    });
+  });
+
+  test("extracts time context update operations referencing existing IDs", async () => {
+    mockSendMessage.mockResolvedValueOnce(
+      makeProviderResponse({
+        timeContexts: [
+          {
+            action: "update",
+            id: "tc-existing-1",
+            summary: "Trip extended to two weeks",
+            activeUntil: 1701209600000,
+          },
+        ],
+      }),
+    );
+
+    const result = await runReducer(
+      makeInput({
+        existingTimeContexts: [
+          { id: "tc-existing-1", summary: "User traveling next week" },
+        ],
+      }),
+    );
+
+    expect(result.timeContexts).toHaveLength(1);
+    expect(result.timeContexts[0]).toEqual({
+      action: "update",
+      id: "tc-existing-1",
+      summary: "Trip extended to two weeks",
+      activeUntil: 1701209600000,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: runReducer — open-loop creation
+// ---------------------------------------------------------------------------
+
+describe("runReducer — open-loop creation", () => {
+  beforeEach(() => {
+    mockSendMessage.mockClear();
+    providerAvailable = true;
+  });
+
+  test("extracts open loop create operations", async () => {
+    mockSendMessage.mockResolvedValueOnce(
+      makeProviderResponse({
+        openLoops: [
+          {
+            action: "create",
+            summary: "Book hotel in Paris",
+            source: "conversation",
+            dueAt: 1700172800000,
+          },
+        ],
+      }),
+    );
+
+    const result = await runReducer(makeInput());
+
+    expect(result.openLoops).toHaveLength(1);
+    expect(result.openLoops[0]).toEqual({
+      action: "create",
+      summary: "Book hotel in Paris",
+      source: "conversation",
+      dueAt: 1700172800000,
+    });
+  });
+
+  test("extracts open loop create without optional dueAt", async () => {
+    mockSendMessage.mockResolvedValueOnce(
+      makeProviderResponse({
+        openLoops: [
+          {
+            action: "create",
+            summary: "Research museums in Paris",
+            source: "conversation",
+          },
+        ],
+      }),
+    );
+
+    const result = await runReducer(makeInput());
+
+    expect(result.openLoops).toHaveLength(1);
+    const op = result.openLoops[0];
+    expect(op.action).toBe("create");
+    if (op.action === "create") {
+      expect(op.summary).toBe("Research museums in Paris");
+      expect(op.dueAt).toBeUndefined();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: runReducer — explicit resolution
+// ---------------------------------------------------------------------------
+
+describe("runReducer — explicit resolution", () => {
+  beforeEach(() => {
+    mockSendMessage.mockClear();
+    providerAvailable = true;
+  });
+
+  test("extracts time context resolve operations", async () => {
+    mockSendMessage.mockResolvedValueOnce(
+      makeProviderResponse({
+        timeContexts: [
+          {
+            action: "resolve",
+            id: "tc-old-1",
+          },
+        ],
+      }),
+    );
+
+    const result = await runReducer(
+      makeInput({
+        existingTimeContexts: [
+          { id: "tc-old-1", summary: "Conference this week" },
+        ],
+      }),
+    );
+
+    expect(result.timeContexts).toHaveLength(1);
+    expect(result.timeContexts[0]).toEqual({
+      action: "resolve",
+      id: "tc-old-1",
+    });
+  });
+
+  test("extracts open loop resolve with 'resolved' status", async () => {
+    mockSendMessage.mockResolvedValueOnce(
+      makeProviderResponse({
+        openLoops: [
+          {
+            action: "resolve",
+            id: "ol-done-1",
+            status: "resolved",
+          },
+        ],
+      }),
+    );
+
+    const result = await runReducer(
+      makeInput({
+        existingOpenLoops: [
+          { id: "ol-done-1", summary: "Send report to Alice", status: "open" },
+        ],
+      }),
+    );
+
+    expect(result.openLoops).toHaveLength(1);
+    expect(result.openLoops[0]).toEqual({
+      action: "resolve",
+      id: "ol-done-1",
+      status: "resolved",
+    });
+  });
+
+  test("extracts open loop resolve with 'expired' status", async () => {
+    mockSendMessage.mockResolvedValueOnce(
+      makeProviderResponse({
+        openLoops: [
+          {
+            action: "resolve",
+            id: "ol-expired-1",
+            status: "expired",
+          },
+        ],
+      }),
+    );
+
+    const result = await runReducer(
+      makeInput({
+        existingOpenLoops: [
+          {
+            id: "ol-expired-1",
+            summary: "RSVP deadline passed",
+            status: "open",
+          },
+        ],
+      }),
+    );
+
+    expect(result.openLoops).toHaveLength(1);
+    expect(result.openLoops[0]).toEqual({
+      action: "resolve",
+      id: "ol-expired-1",
+      status: "expired",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: runReducer — provider unavailable / error handling
+// ---------------------------------------------------------------------------
+
+describe("runReducer — error handling", () => {
+  beforeEach(() => {
+    mockSendMessage.mockClear();
+    providerAvailable = true;
+  });
+
+  test("returns EMPTY_REDUCER_RESULT when no provider is available", async () => {
+    providerAvailable = false;
+
+    const result = await runReducer(makeInput());
+
+    expect(result).toBe(EMPTY_REDUCER_RESULT);
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  test("returns EMPTY_REDUCER_RESULT when provider throws", async () => {
+    mockSendMessage.mockRejectedValueOnce(new Error("Provider error"));
+
+    const result = await runReducer(makeInput());
+
+    expect(result).toBe(EMPTY_REDUCER_RESULT);
+  });
+
+  test("returns EMPTY_REDUCER_RESULT when provider returns empty text", async () => {
+    mockSendMessage.mockResolvedValueOnce({
+      content: [{ type: "text", text: "" }],
+      model: "mock-model",
+      usage: { inputTokens: 10, outputTokens: 0 },
+      stopReason: "end_turn",
+    });
+
+    const result = await runReducer(makeInput());
+
+    expect(result).toBe(EMPTY_REDUCER_RESULT);
+  });
+
+  test("returns EMPTY_REDUCER_RESULT when provider returns invalid JSON", async () => {
+    mockSendMessage.mockResolvedValueOnce({
+      content: [{ type: "text", text: "not valid json at all" }],
+      model: "mock-model",
+      usage: { inputTokens: 10, outputTokens: 5 },
+      stopReason: "end_turn",
+    });
+
+    const result = await runReducer(makeInput());
+
+    expect(result).toBe(EMPTY_REDUCER_RESULT);
+  });
+
+  test("returns EMPTY_REDUCER_RESULT when provider returns empty object", async () => {
+    mockSendMessage.mockResolvedValueOnce(makeProviderResponse({}));
+
+    const result = await runReducer(makeInput());
+
+    expect(result).toBe(EMPTY_REDUCER_RESULT);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: runReducer — provider call arguments
+// ---------------------------------------------------------------------------
+
+describe("runReducer — provider call arguments", () => {
+  beforeEach(() => {
+    mockSendMessage.mockClear();
+    providerAvailable = true;
+    mockSendMessage.mockResolvedValue(makeProviderResponse({}));
+  });
+
+  test("sends messages with correct structure", async () => {
+    await runReducer(makeInput());
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+    const [messages] = mockSendMessage.mock.calls[0] as Parameters<
+      Provider["sendMessage"]
+    >;
+
+    // Should be a single user message
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe("user");
+    expect(messages[0].content).toHaveLength(1);
+    expect(messages[0].content[0].type).toBe("text");
+  });
+
+  test("does not send any tool definitions", async () => {
+    await runReducer(makeInput());
+
+    const [, tools] = mockSendMessage.mock.calls[0] as Parameters<
+      Provider["sendMessage"]
+    >;
+    expect(tools).toBeUndefined();
+  });
+
+  test("sends a system prompt", async () => {
+    await runReducer(makeInput());
+
+    const [, , systemPrompt] = mockSendMessage.mock.calls[0] as Parameters<
+      Provider["sendMessage"]
+    >;
+    expect(systemPrompt).toBeTruthy();
+    expect(typeof systemPrompt).toBe("string");
+  });
+
+  test("uses latency-optimized model intent", async () => {
+    await runReducer(makeInput());
+
+    const [, , , options] = mockSendMessage.mock.calls[0] as Parameters<
+      Provider["sendMessage"]
+    >;
+    expect(options?.config?.modelIntent).toBe("latency-optimized");
+  });
+
+  test("passes abort signal to provider", async () => {
+    await runReducer(makeInput());
+
+    const [, , , options] = mockSendMessage.mock.calls[0] as Parameters<
+      Provider["sendMessage"]
+    >;
+    expect(options?.signal).toBeDefined();
+    expect(options?.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: runReducer — side-effect-free guarantee
+// ---------------------------------------------------------------------------
+
+describe("runReducer — side-effect-free", () => {
+  beforeEach(() => {
+    mockSendMessage.mockClear();
+    providerAvailable = true;
+  });
+
+  test("returns typed result without performing any writes", async () => {
+    const fullResponse = {
+      timeContexts: [
+        {
+          action: "create",
+          summary: "Paris trip",
+          source: "conversation",
+          activeFrom: 1700000000000,
+          activeUntil: 1700604800000,
+        },
+      ],
+      openLoops: [
+        {
+          action: "create",
+          summary: "Book hotel",
+          source: "conversation",
+        },
+      ],
+      archiveObservations: [
+        {
+          content: "User likes museums",
+          role: "user",
+        },
+      ],
+      archiveEpisodes: [
+        {
+          title: "Trip planning",
+          summary: "Discussed Paris trip",
+        },
+      ],
+    };
+
+    mockSendMessage.mockResolvedValueOnce(makeProviderResponse(fullResponse));
+
+    const result = await runReducer(makeInput());
+
+    // Verify the result is correctly typed and populated
+    expect(result.timeContexts).toHaveLength(1);
+    expect(result.openLoops).toHaveLength(1);
+    expect(result.archiveObservations).toHaveLength(1);
+    expect(result.archiveEpisodes).toHaveLength(1);
+
+    // The function only called sendMessage — no other side effects
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  test("handles mixed valid and invalid operations gracefully", async () => {
+    mockSendMessage.mockResolvedValueOnce(
+      makeProviderResponse({
+        timeContexts: [
+          // valid
+          {
+            action: "create",
+            summary: "Valid context",
+            source: "conversation",
+            activeFrom: 1000,
+            activeUntil: 2000,
+          },
+          // invalid — missing summary
+          {
+            action: "create",
+            source: "conversation",
+            activeFrom: 1000,
+            activeUntil: 2000,
+          },
+        ],
+        openLoops: [
+          // valid
+          {
+            action: "create",
+            summary: "Valid loop",
+            source: "conversation",
+          },
+          // invalid — missing source
+          { action: "create", summary: "Bad loop" },
+        ],
+      }),
+    );
+
+    const result = await runReducer(makeInput());
+
+    // Only valid operations should be present
+    expect(result.timeContexts).toHaveLength(1);
+    expect(result.timeContexts[0].action).toBe("create");
+    expect(result.openLoops).toHaveLength(1);
+    expect(result.openLoops[0].action).toBe("create");
+  });
+});

--- a/assistant/src/memory/reducer.ts
+++ b/assistant/src/memory/reducer.ts
@@ -1,14 +1,21 @@
 /**
- * Parsing and validation layer for the simplified memory reducer.
+ * Simplified memory reducer — provider-backed conversation turn processor.
  *
- * This module owns the contract between the LLM's JSON output and the typed
- * ReducerResult. The actual provider call lives in a later PR — this file
- * only handles:
- *   1. ReducerPromptInput — what goes into the provider call
- *   2. parseReducerOutput — raw string -> validated ReducerResult
- *   3. Fallback to EMPTY_REDUCER_RESULT on any invalid output
+ * This module owns:
+ *   1. ReducerPromptInput — structured input for the provider call
+ *   2. runReducer — send the transcript span to the LLM and return a typed result
+ *   3. parseReducerOutput — raw string -> validated ReducerResult
+ *   4. Fallback to EMPTY_REDUCER_RESULT on any invalid output
+ *
+ * The reducer is intentionally side-effect-free: it never writes to the
+ * database. Callers are responsible for applying the returned ReducerResult.
  */
 
+import {
+  createTimeout,
+  extractText,
+  getConfiguredProvider,
+} from "../providers/provider-send-message.js";
 import { getLogger } from "../util/logger.js";
 import {
   type ArchiveEpisodeCandidate,
@@ -24,6 +31,9 @@ import {
 
 const log = getLogger("memory-reducer");
 
+/** Timeout for the reducer provider call (ms). */
+const REDUCER_TIMEOUT_MS = 30_000;
+
 // ── Prompt input type ──────────────────────────────────────────────────
 
 /** The structured input that will be fed to the reducer provider call. */
@@ -36,6 +46,164 @@ export interface ReducerPromptInput {
   existingTimeContexts: Array<{ id: string; summary: string }>;
   /** Current open-loop rows the model can reference for updates. */
   existingOpenLoops: Array<{ id: string; summary: string; status: string }>;
+  /** Current time as epoch ms — injected for deterministic tests. */
+  nowMs: number;
+  /** Memory scope identifier (e.g. assistant instance ID). */
+  scopeId: string;
+}
+
+// ── System prompt ─────────────────────────────────────────────────────
+
+/**
+ * Build the reducer system prompt. Extracted as a named function so tests can
+ * assert on prompt content without coupling to string literals.
+ */
+export function buildReducerSystemPrompt(): string {
+  return [
+    "You are a memory reducer for a personal assistant. Your job is to analyze",
+    "a span of new conversation messages and produce structured JSON output that",
+    "captures important information for the assistant's long-term memory.",
+    "",
+    "You output a single JSON object with four optional arrays:",
+    "",
+    "1. `timeContexts` — time-bounded situational context (e.g. 'user traveling next week').",
+    "   Each entry has: action ('create'|'update'|'resolve'), and fields depending on the action.",
+    "   - create: summary (string), source (string), activeFrom (epoch ms), activeUntil (epoch ms)",
+    "   - update: id (string), and at least one of: summary, activeFrom, activeUntil",
+    "   - resolve: id (string)",
+    "",
+    "2. `openLoops` — unresolved items to track (e.g. 'waiting for Bob's reply').",
+    "   Each entry has: action ('create'|'update'|'resolve'), and fields depending on the action.",
+    "   - create: summary (string), source (string), optional dueAt (epoch ms)",
+    "   - update: id (string), and at least one of: summary, dueAt",
+    "   - resolve: id (string), status ('resolved'|'expired')",
+    "",
+    "3. `archiveObservations` — factual statements extracted from the conversation.",
+    "   Each entry has: content (string), role (string), optional modality (string), optional source (string)",
+    "",
+    "4. `archiveEpisodes` — coherent narrative summaries of interaction spans.",
+    "   Each entry has: title (string), summary (string), optional source (string)",
+    "",
+    "Rules:",
+    "- Output ONLY valid JSON. No markdown, no explanation, no wrapping.",
+    "- Omit arrays that would be empty rather than including empty arrays.",
+    "- For updates and resolves, reference existing IDs from the provided context.",
+    "- Be selective: only extract genuinely important or actionable information.",
+    "- Timestamps are in epoch milliseconds.",
+    "- If there is nothing meaningful to extract, output: {}",
+  ].join("\n");
+}
+
+/**
+ * Build the user-message content for the reducer prompt from the structured input.
+ */
+export function buildReducerUserMessage(input: ReducerPromptInput): string {
+  const parts: string[] = [];
+
+  parts.push(
+    `Current time: ${new Date(input.nowMs).toISOString()} (${input.nowMs}ms)`,
+  );
+  parts.push(`Conversation: ${input.conversationId}`);
+  parts.push(`Scope: ${input.scopeId}`);
+  parts.push("");
+
+  // Existing state the model can reference for updates/resolves
+  if (input.existingTimeContexts.length > 0) {
+    parts.push("## Active time contexts");
+    for (const tc of input.existingTimeContexts) {
+      parts.push(`- [${tc.id}] ${tc.summary}`);
+    }
+    parts.push("");
+  }
+
+  if (input.existingOpenLoops.length > 0) {
+    parts.push("## Active open loops");
+    for (const ol of input.existingOpenLoops) {
+      parts.push(`- [${ol.id}] (${ol.status}) ${ol.summary}`);
+    }
+    parts.push("");
+  }
+
+  // The unreduced transcript span
+  parts.push("## New messages to process");
+  for (const msg of input.newMessages) {
+    parts.push(`[${msg.role}]: ${msg.content}`);
+  }
+
+  return parts.join("\n");
+}
+
+// ── Provider-backed reducer call ──────────────────────────────────────
+
+/**
+ * Run the memory reducer against a transcript span.
+ *
+ * Sends the unreduced messages, active time contexts, active open loops,
+ * current time, and scope metadata to the configured LLM provider. Parses
+ * the response into a typed {@link ReducerResult}.
+ *
+ * This function is **side-effect-free**: it never writes to the database.
+ * The caller is responsible for applying the returned result.
+ *
+ * Returns {@link EMPTY_REDUCER_RESULT} when:
+ * - No provider is configured/available
+ * - The provider call fails or times out
+ * - The model output is unparseable
+ *
+ * @param input  Structured reducer input
+ * @param signal Optional external abort signal
+ */
+export async function runReducer(
+  input: ReducerPromptInput,
+  signal?: AbortSignal,
+): Promise<ReducerResult> {
+  const provider = await getConfiguredProvider();
+  if (!provider) {
+    log.warn(
+      "No provider available for memory reducer — returning empty result",
+    );
+    return EMPTY_REDUCER_RESULT;
+  }
+
+  const systemPrompt = buildReducerSystemPrompt();
+  const userText = buildReducerUserMessage(input);
+
+  const { signal: timeoutSignal, cleanup } = createTimeout(REDUCER_TIMEOUT_MS);
+  const combinedSignal = signal
+    ? AbortSignal.any([signal, timeoutSignal])
+    : timeoutSignal;
+
+  try {
+    const response = await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: userText }] }],
+      undefined,
+      systemPrompt,
+      {
+        signal: combinedSignal,
+        config: {
+          modelIntent: "latency-optimized" as const,
+          max_tokens: 4096,
+        },
+      },
+    );
+
+    const rawText = extractText(response);
+    if (!rawText) {
+      log.warn("Reducer provider returned empty text — returning empty result");
+      return EMPTY_REDUCER_RESULT;
+    }
+
+    return parseReducerOutput(rawText);
+  } catch (err) {
+    if (combinedSignal.aborted) {
+      log.warn("Memory reducer provider call timed out or was aborted");
+    } else {
+      log.warn({ err }, "Memory reducer provider call failed");
+    }
+    return EMPTY_REDUCER_RESULT;
+  } finally {
+    cleanup();
+  }
 }
 
 // ── Validation helpers ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Implement provider-backed reducer call using provider abstraction
- Pass unreduced transcript, active time_contexts/open_loops, current time, scope metadata
- Keep reducer side-effect-free — returns typed result, no DB writes
- Add tests with mocked provider responses for event/situation extraction and loop creation/resolution

Part of plan: simplified-memory-v1.md (PR 6 of 23)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
