### PR TITLE
Add safe payload construction for macOS scroll-wheel diagnostics

### DIFF
--- a/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
+++ b/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
@@ -44,6 +44,40 @@ struct NumericSanitizer: Sendable {
     }
 }
 
+// MARK: - Safe Payload Builders
+
+extension ChatDiagnosticEvent {
+    /// Builds a scroll-wheel diagnostic event from raw geometry values,
+    /// sanitizing non-finite `contentHeight` and `viewportHeight` through
+    /// `NumericSanitizer` so the resulting event is always JSON-encodable.
+    ///
+    /// Callers pass raw `CGFloat` geometry straight from AppKit
+    /// (`NSScrollView.documentView.frame.height`, `contentView.bounds.height`)
+    /// without worrying about NaN or infinity — the sanitizer replaces
+    /// non-finite values with `nil` and records which fields were dropped
+    /// in `nonFiniteFields`.
+    static func scrollWheelEvent(
+        kind: ChatDiagnosticEventKind,
+        conversationId: String?,
+        reason: String?,
+        contentHeight: CGFloat?,
+        viewportHeight: CGFloat?
+    ) -> ChatDiagnosticEvent {
+        var sanitizer = NumericSanitizer()
+        let safeContentHeight = sanitizer.sanitize(contentHeight, field: "contentHeight")
+        let safeViewportHeight = sanitizer.sanitize(viewportHeight, field: "viewportHeight")
+
+        return ChatDiagnosticEvent(
+            kind: kind,
+            conversationId: conversationId,
+            reason: reason,
+            contentHeight: safeContentHeight,
+            viewportHeight: safeViewportHeight,
+            nonFiniteFields: sanitizer.nonFiniteFields
+        )
+    }
+}
+
 // MARK: - Event Payloads
 
 /// Kind of diagnostic event. Later PRs add new cases; the raw value is the

--- a/clients/macos/vellum-assistantTests/ChatDiagnosticsStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatDiagnosticsStoreTests.swift
@@ -451,6 +451,132 @@ struct ChatDiagnosticsStoreTests {
         #expect(sanitizer.nonFiniteFields == ["height"])
     }
 
+    // MARK: - Scroll-Wheel Safe Payload Builder
+
+    @Test @MainActor
+    func scrollWheelEventWithNanHeightsEncodesSuccessfully() throws {
+        let event = ChatDiagnosticEvent.scrollWheelEvent(
+            kind: .scrollWheelUntether,
+            conversationId: "conv-nan-scroll",
+            reason: "deltaY=5.0 nan geometry",
+            contentHeight: CGFloat.nan,
+            viewportHeight: CGFloat.nan
+        )
+
+        // Record into the store to exercise the full JSONL path.
+        let store = ChatDiagnosticsStore()
+        store.record(event)
+
+        // Encode to JSON — must not throw.
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(event)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        // Non-finite values should be absent or null.
+        let contentVal = json["contentHeight"]
+        #expect(contentVal == nil || contentVal is NSNull,
+                "contentHeight should be absent or null when NaN")
+        let viewportVal = json["viewportHeight"]
+        #expect(viewportVal == nil || viewportVal is NSNull,
+                "viewportHeight should be absent or null when NaN")
+
+        // nonFiniteFields should report which fields were dropped.
+        let dropped = json["nonFiniteFields"] as? [String]
+        #expect(dropped != nil, "nonFiniteFields should be present")
+        #expect(dropped?.contains("contentHeight") == true)
+        #expect(dropped?.contains("viewportHeight") == true)
+    }
+
+    @Test @MainActor
+    func scrollWheelEventWithInfHeightsEncodesSuccessfully() throws {
+        let event = ChatDiagnosticEvent.scrollWheelEvent(
+            kind: .scrollWheelRetether,
+            conversationId: "conv-inf-scroll",
+            reason: "distFromBottom=0.0 inf geometry",
+            contentHeight: CGFloat.infinity,
+            viewportHeight: -CGFloat.infinity
+        )
+
+        // Record into the store to exercise the full JSONL path.
+        let store = ChatDiagnosticsStore()
+        store.record(event)
+
+        // Encode to JSON — must not throw.
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(event)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        // Non-finite values should be absent or null.
+        let contentVal = json["contentHeight"]
+        #expect(contentVal == nil || contentVal is NSNull,
+                "contentHeight should be absent or null when infinity")
+        let viewportVal = json["viewportHeight"]
+        #expect(viewportVal == nil || viewportVal is NSNull,
+                "viewportHeight should be absent or null when -infinity")
+
+        // nonFiniteFields should report which fields were dropped.
+        let dropped = json["nonFiniteFields"] as? [String]
+        #expect(dropped != nil, "nonFiniteFields should be present")
+        #expect(dropped?.contains("contentHeight") == true)
+        #expect(dropped?.contains("viewportHeight") == true)
+    }
+
+    @Test @MainActor
+    func scrollWheelEventWithFiniteHeightsPreservesValues() throws {
+        let event = ChatDiagnosticEvent.scrollWheelEvent(
+            kind: .scrollWheelUntether,
+            conversationId: "conv-finite-scroll",
+            reason: "deltaY=3.0 normal geometry",
+            contentHeight: 5000.0,
+            viewportHeight: 800.0
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(event)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        // Finite values should be preserved.
+        #expect(json["contentHeight"] as? Double == 5000.0)
+        #expect(json["viewportHeight"] as? Double == 800.0)
+
+        // nonFiniteFields should be absent when all values are finite.
+        let dropped = json["nonFiniteFields"]
+        #expect(dropped == nil || dropped is NSNull,
+                "nonFiniteFields should be absent when all values are finite")
+    }
+
+    @Test @MainActor
+    func scrollWheelEventWithMixedFiniteAndNanPreservesFinite() throws {
+        let event = ChatDiagnosticEvent.scrollWheelEvent(
+            kind: .scrollWheelRetether,
+            conversationId: "conv-mixed-scroll",
+            reason: "mixed geometry",
+            contentHeight: CGFloat.nan,
+            viewportHeight: 600.0
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(event)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        // NaN value should be absent or null.
+        let contentVal = json["contentHeight"]
+        #expect(contentVal == nil || contentVal is NSNull,
+                "contentHeight should be absent or null when NaN")
+
+        // Finite value should be preserved.
+        #expect(json["viewportHeight"] as? Double == 600.0)
+
+        // nonFiniteFields should only list the dropped field.
+        let dropped = json["nonFiniteFields"] as? [String]
+        #expect(dropped != nil, "nonFiniteFields should be present")
+        #expect(dropped == ["contentHeight"])
+    }
+
     // MARK: - Event Kind Encoding
 
     @Test


### PR DESCRIPTION
## Summary
- Add helper for building ChatDiagnosticEvent payloads with finite-number sanitization for scroll-wheel geometry
- Preserve field-level nonFiniteFields reporting for dropped contentHeight and viewportHeight values
- Add regression tests for nan/inf geometry values in JSONL encoding path

Part of plan: macos-image-send-freeze.md (PR 5 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
