### PR TITLE
Add a finite-geometry filter for chat preference updates

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListPreferenceGeometry.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListPreferenceGeometry.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Decision type returned by `PreferenceGeometryFilter` indicating whether
+/// a new preference value should be accepted or ignored.
+enum PreferenceFilterDecision: Equatable {
+    /// The new value is finite and passed dead-zone checks — apply it.
+    case accept(CGFloat)
+    /// The new value is non-finite (nan / inf / -inf) — keep the previous value.
+    case rejectNonFinite
+    /// The new value is finite but within the dead-zone threshold of the
+    /// previous value — skip the update to avoid layout invalidation churn.
+    case rejectDeadZone
+}
+
+/// Pure helpers for filtering scroll-geometry preference values in
+/// `MessageListView`'s `onPreferenceChange` handlers.
+///
+/// SwiftUI's layout engine can transiently report `nan`, `inf`, or `-inf`
+/// for geometry values — especially during attachment insertion, image
+/// loading, and conversation switches. Treating these non-finite values as
+/// real measurements causes downstream logic (bottom-pin detection, avatar
+/// follower, pagination) to misbehave, potentially triggering layout
+/// feedback loops that freeze the UI.
+///
+/// This filter centralises the finite-number gate and dead-zone suppression
+/// that was previously duplicated across multiple `onPreferenceChange`
+/// closures in the view body, and adds the rule that the *last known finite
+/// measurement* is preserved when a non-finite value arrives.
+///
+/// The type is deliberately free of SwiftUI imports so it can be exercised
+/// entirely through unit tests.
+enum PreferenceGeometryFilter {
+
+    /// Default dead-zone threshold in points. Preference updates whose
+    /// absolute delta from the previous value is at or below this threshold
+    /// are suppressed to reduce layout invalidation cascades during rapid
+    /// scrolling.
+    static let defaultDeadZone: CGFloat = 2
+
+    /// Evaluate whether a new preference value should be accepted.
+    ///
+    /// - Parameters:
+    ///   - newValue: The incoming preference value from SwiftUI's
+    ///     `onPreferenceChange`.
+    ///   - previous: The last accepted (stored) value. Pass `.infinity` when
+    ///     no measurement has been recorded yet.
+    ///   - deadZone: The minimum absolute change required for acceptance.
+    ///     Pass `0` to disable dead-zone suppression (used by keys where
+    ///     every finite change matters, such as `ScrollViewportHeightKey`).
+    /// - Returns: A `PreferenceFilterDecision` describing whether and how
+    ///   the caller should act on the new value.
+    static func evaluate(
+        newValue: CGFloat,
+        previous: CGFloat,
+        deadZone: CGFloat = defaultDeadZone
+    ) -> PreferenceFilterDecision {
+        // Gate 1: reject non-finite values outright.
+        guard newValue.isFinite else {
+            return .rejectNonFinite
+        }
+
+        // Gate 2: dead-zone suppression. When the previous value is also
+        // finite, skip updates that haven't moved meaningfully.
+        if deadZone > 0, previous.isFinite {
+            guard abs(newValue - previous) > deadZone else {
+                return .rejectDeadZone
+            }
+        }
+
+        return .accept(newValue)
+    }
+}

--- a/clients/macos/vellum-assistantTests/MessageListPreferenceGeometryTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListPreferenceGeometryTests.swift
@@ -1,0 +1,246 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class MessageListPreferenceGeometryTests: XCTestCase {
+
+    // MARK: - Finite-to-finite acceptance
+
+    /// A normal finite update that exceeds the dead-zone should be accepted.
+    func testFiniteToFiniteAccepted() {
+        let result = PreferenceGeometryFilter.evaluate(
+            newValue: 100,
+            previous: 50
+        )
+        XCTAssertEqual(result, .accept(100))
+    }
+
+    /// A finite value arriving when no previous measurement exists (.infinity)
+    /// should always be accepted regardless of dead-zone.
+    func testFirstFiniteMeasurementAccepted() {
+        let result = PreferenceGeometryFilter.evaluate(
+            newValue: 300,
+            previous: .infinity
+        )
+        XCTAssertEqual(result, .accept(300))
+    }
+
+    /// Negative finite values are valid geometry positions and should be
+    /// accepted when they exceed the dead-zone.
+    func testNegativeFiniteValueAccepted() {
+        let result = PreferenceGeometryFilter.evaluate(
+            newValue: -20,
+            previous: 100
+        )
+        XCTAssertEqual(result, .accept(-20))
+    }
+
+    /// Zero is a valid finite measurement.
+    func testZeroIsAccepted() {
+        let result = PreferenceGeometryFilter.evaluate(
+            newValue: 0,
+            previous: 500
+        )
+        XCTAssertEqual(result, .accept(0))
+    }
+
+    // MARK: - Non-finite rejection
+
+    /// NaN must be rejected to preserve the last known finite measurement.
+    func testNaNRejected() {
+        let result = PreferenceGeometryFilter.evaluate(
+            newValue: .nan,
+            previous: 100
+        )
+        XCTAssertEqual(result, .rejectNonFinite)
+    }
+
+    /// Positive infinity must be rejected.
+    func testPositiveInfinityRejected() {
+        let result = PreferenceGeometryFilter.evaluate(
+            newValue: .infinity,
+            previous: 100
+        )
+        XCTAssertEqual(result, .rejectNonFinite)
+    }
+
+    /// Negative infinity must be rejected.
+    func testNegativeInfinityRejected() {
+        let result = PreferenceGeometryFilter.evaluate(
+            newValue: -.infinity,
+            previous: 100
+        )
+        XCTAssertEqual(result, .rejectNonFinite)
+    }
+
+    /// Non-finite values must also be rejected when there is no prior
+    /// measurement (previous = .infinity).
+    func testNonFiniteRejectedWhenNoPriorMeasurement() {
+        XCTAssertEqual(
+            PreferenceGeometryFilter.evaluate(newValue: .nan, previous: .infinity),
+            .rejectNonFinite
+        )
+        XCTAssertEqual(
+            PreferenceGeometryFilter.evaluate(newValue: .infinity, previous: .infinity),
+            .rejectNonFinite
+        )
+        XCTAssertEqual(
+            PreferenceGeometryFilter.evaluate(newValue: -.infinity, previous: .infinity),
+            .rejectNonFinite
+        )
+    }
+
+    // MARK: - Recovery from unknown geometry
+
+    /// After a non-finite rejection, the next finite value must be accepted
+    /// (the previous value stays at whatever the caller last stored, which
+    /// could be .infinity if no finite value was ever recorded).
+    func testRecoveryFromNeverMeasured() {
+        // First update is non-finite — rejected.
+        let first = PreferenceGeometryFilter.evaluate(
+            newValue: .nan,
+            previous: .infinity
+        )
+        XCTAssertEqual(first, .rejectNonFinite)
+
+        // Second update is finite — accepted (previous is still .infinity
+        // because the caller never stored anything).
+        let second = PreferenceGeometryFilter.evaluate(
+            newValue: 200,
+            previous: .infinity
+        )
+        XCTAssertEqual(second, .accept(200))
+    }
+
+    /// Simulates the sequence: finite -> non-finite -> finite. The non-finite
+    /// value is rejected (preserving the previous finite value), then the
+    /// next finite value is evaluated against the preserved previous.
+    func testRecoveryAfterTransientNonFinite() {
+        // 1. Initial finite measurement accepted.
+        let first = PreferenceGeometryFilter.evaluate(
+            newValue: 100,
+            previous: .infinity
+        )
+        XCTAssertEqual(first, .accept(100))
+
+        // 2. Non-finite arrives — rejected; caller keeps previous = 100.
+        let second = PreferenceGeometryFilter.evaluate(
+            newValue: .nan,
+            previous: 100
+        )
+        XCTAssertEqual(second, .rejectNonFinite)
+
+        // 3. Finite recovery — evaluated against preserved previous (100).
+        let third = PreferenceGeometryFilter.evaluate(
+            newValue: 150,
+            previous: 100
+        )
+        XCTAssertEqual(third, .accept(150))
+    }
+
+    // MARK: - Dead-zone suppression
+
+    /// An update within the default 2pt dead-zone should be suppressed.
+    func testWithinDeadZoneSuppressed() {
+        let result = PreferenceGeometryFilter.evaluate(
+            newValue: 101,
+            previous: 100
+        )
+        XCTAssertEqual(result, .rejectDeadZone)
+    }
+
+    /// An update exactly at the dead-zone boundary (delta == 2) should be
+    /// suppressed (the threshold is exclusive: abs(delta) must be > deadZone).
+    func testExactDeadZoneBoundarySuppressed() {
+        let result = PreferenceGeometryFilter.evaluate(
+            newValue: 102,
+            previous: 100
+        )
+        XCTAssertEqual(result, .rejectDeadZone)
+    }
+
+    /// An update just past the dead-zone boundary should be accepted.
+    func testJustPastDeadZoneAccepted() {
+        let result = PreferenceGeometryFilter.evaluate(
+            newValue: 102.01,
+            previous: 100
+        )
+        XCTAssertEqual(result, .accept(102.01))
+    }
+
+    /// Dead-zone applies symmetrically for negative deltas.
+    func testNegativeDeltaDeadZoneSuppressed() {
+        let result = PreferenceGeometryFilter.evaluate(
+            newValue: 99,
+            previous: 100
+        )
+        XCTAssertEqual(result, .rejectDeadZone)
+    }
+
+    /// Dead-zone is not applied when previous is non-finite (.infinity),
+    /// because there is no valid baseline to compare against.
+    func testDeadZoneSkippedWhenNoPriorMeasurement() {
+        // Delta from .infinity to 0 would be infinite, but the dead-zone
+        // check is only entered when previous.isFinite, so this is accepted.
+        let result = PreferenceGeometryFilter.evaluate(
+            newValue: 0,
+            previous: .infinity
+        )
+        XCTAssertEqual(result, .accept(0))
+    }
+
+    // MARK: - Zero dead-zone (disabled suppression)
+
+    /// When dead-zone is 0, every finite change is accepted regardless of
+    /// magnitude. This is used for preference keys like ScrollViewportHeightKey
+    /// where every change matters.
+    func testZeroDeadZoneAcceptsSmallChange() {
+        let result = PreferenceGeometryFilter.evaluate(
+            newValue: 100.5,
+            previous: 100,
+            deadZone: 0
+        )
+        XCTAssertEqual(result, .accept(100.5))
+    }
+
+    /// Even with zero dead-zone, non-finite values are still rejected.
+    func testZeroDeadZoneStillRejectsNonFinite() {
+        let result = PreferenceGeometryFilter.evaluate(
+            newValue: .nan,
+            previous: 100,
+            deadZone: 0
+        )
+        XCTAssertEqual(result, .rejectNonFinite)
+    }
+
+    // MARK: - Custom dead-zone
+
+    /// A larger custom dead-zone should suppress larger deltas.
+    func testCustomLargerDeadZone() {
+        let result = PreferenceGeometryFilter.evaluate(
+            newValue: 108,
+            previous: 100,
+            deadZone: 10
+        )
+        XCTAssertEqual(result, .rejectDeadZone)
+
+        let result2 = PreferenceGeometryFilter.evaluate(
+            newValue: 111,
+            previous: 100,
+            deadZone: 10
+        )
+        XCTAssertEqual(result2, .accept(111))
+    }
+
+    // MARK: - Decision type equality
+
+    /// Verify that two `.accept` decisions with the same value are equal,
+    /// and different values are not.
+    func testDecisionEquality() {
+        XCTAssertEqual(PreferenceFilterDecision.accept(10), PreferenceFilterDecision.accept(10))
+        XCTAssertNotEqual(PreferenceFilterDecision.accept(10), PreferenceFilterDecision.accept(20))
+        XCTAssertNotEqual(PreferenceFilterDecision.accept(10), PreferenceFilterDecision.rejectNonFinite)
+        XCTAssertNotEqual(PreferenceFilterDecision.rejectNonFinite, PreferenceFilterDecision.rejectDeadZone)
+        XCTAssertEqual(PreferenceFilterDecision.rejectNonFinite, PreferenceFilterDecision.rejectNonFinite)
+        XCTAssertEqual(PreferenceFilterDecision.rejectDeadZone, PreferenceFilterDecision.rejectDeadZone)
+    }
+}


### PR DESCRIPTION
## Summary
- Create MessageListPreferenceGeometry with pure helpers for finite-number validation of scroll geometry preference keys
- Preserve last known finite measurement when new values are nan/inf/-inf
- Add comprehensive test coverage for acceptance, rejection, recovery, and dead-zone suppression

Part of plan: macos-image-send-freeze.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
