### PR TITLE
fix: fully unregister drag types from composer to prevent file path insertion

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
@@ -89,9 +89,12 @@ struct ComposerFocusBridge: NSViewRepresentable {
 
     private static func unregisterDragTypes(in view: NSView) {
         if view is NSTextView {
-            // Re-register with text-only types so text drag-and-drop still
-            // works while file/image drops fall through to the ChatView handler.
-            view.registerForDraggedTypes([.string, .rtf, .rtfd])
+            // Completely remove all drag types so the NSTextView never
+            // intercepts drops. Finder file drags include the path as
+            // .string, so even text-only registration would accept them.
+            // Text can still be pasted via Cmd+V; only text drag-and-drop
+            // from other apps is lost (very rare use case).
+            view.unregisterDraggedTypes()
         }
         for subview in view.subviews {
             unregisterDragTypes(in: subview)


### PR DESCRIPTION
## Summary
- Finder file drags include the path as `.string`, so the previous text-only drag type registration (`.string`/`.rtf`/`.rtfd`) still caused the NSTextView to accept file drops and insert the path as text
- Switch to `unregisterDraggedTypes()` to completely remove all drag types from the composer's NSTextView, ensuring all drops fall through to the ChatView handler

## Test plan
- [ ] Drag a file from Finder over the composer — overlay should stay visible, drop should attach
- [ ] Drag a second file — should also attach correctly
- [ ] Cmd+V paste still works for text and images

JARVIS-261

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
