### PR TITLE
fix: update 'Need help deciding?' link to hosting-options docs

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -42,7 +42,7 @@ struct APIKeyStepView: View {
                 }
 
                 OnboardingButton(title: "Need help deciding?", style: .ghostPrimary) {
-                    NSWorkspace.shared.open(URL(string: "https://vellum.ai/docs/environments")!)
+                    NSWorkspace.shared.open(URL(string: "https://vellum.ai/docs/hosting-options")!)
                 }
 
                 if !isAuthenticated {


### PR DESCRIPTION
## Summary
- Updated the "Need help deciding?" link in the onboarding API key step from `https://vellum.ai/docs/environments` to `https://vellum.ai/docs/hosting-options`

## Original prompt
Update the url that we use for the "Need help deciding?" link to point to https://vellum.ai/docs/hosting-options
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
