### PR TITLE
fix: update skills.md to reflect enabled-by-default inline command flag

### DIFF
--- a/assistant/docs/skills.md
+++ b/assistant/docs/skills.md
@@ -198,7 +198,7 @@ Malformed tokens do not silently pass through — they are collected as errors a
 
 ### Feature flag
 
-Inline command expansion is gated by the `inline-skill-commands` feature flag (key: `feature_flags.inline-skill-commands.enabled`). The flag defaults to **disabled**.
+Inline command expansion is gated by the `inline-skill-commands` feature flag (key: `feature_flags.inline-skill-commands.enabled`). The flag defaults to **enabled**.
 
 When the flag is disabled and a skill contains inline command expansion tokens, `skill_load` returns an error rather than delivering unexpanded tokens to the model. This fail-closed behavior prevents the LLM from seeing raw expansion tokens and attempting to interpret them.
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for secure-skill-dynamic-context.md.

**Gap:** Documentation says flag defaults to disabled
**What was expected:** Documentation should say enabled after PR 9 flip
**What was found:** skills.md still said disabled
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
