### PR TITLE
fix: strip gateway URL and workspace dir from inline command sandbox env

### DIFF
--- a/assistant/src/skills/inline-command-runner.ts
+++ b/assistant/src/skills/inline-command-runner.ts
@@ -109,6 +109,8 @@ export async function runInlineCommand(
   // and workspace dir since inline commands have no business calling internal
   // APIs or mutating workspace state.
   const env = buildSanitizedEnv();
+  delete env.INTERNAL_GATEWAY_BASE_URL;
+  delete env.VELLUM_WORKSPACE_DIR;
 
   return new Promise<InlineCommandResult>((resolve) => {
     let timedOut = false;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for secure-skill-dynamic-context.md.

**Gap:** buildSanitizedEnv() leaks gateway URL and workspace dir
**What was expected:** Inline command sandbox should not expose internal gateway URL or workspace dir
**What was found:** buildSanitizedEnv() injects them; the code comment claimed they were excluded but they weren't stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
