### PR TITLE
fix: consolidate memory archive writes

### DIFF
--- a/assistant/src/__tests__/memory-observation-dual-write.test.ts
+++ b/assistant/src/__tests__/memory-observation-dual-write.test.ts
@@ -171,7 +171,7 @@ describe("memory observation dual-write from addMessage", () => {
       );
     });
 
-    test("creates a chunk with embed_observation job for text message", async () => {
+    test("creates a chunk with embed_chunk job for text message", async () => {
       const conv = createConversation("test-conv");
       await addMessage(conv.id, "user", "My favorite language is TypeScript");
 
@@ -182,11 +182,11 @@ describe("memory observation dual-write from addMessage", () => {
       expect(chunk).toBeDefined();
       expect(chunk!.content).toBe("My favorite language is TypeScript");
 
-      const embedJobs = getJobsByType("embed_observation");
+      const embedJobs = getJobsByType("embed_chunk");
       expect(embedJobs.length).toBeGreaterThanOrEqual(1);
       const matchingJob = embedJobs.find((j) => {
         const payload = JSON.parse(j.payload);
-        return payload.observationId === observations[0].id;
+        return payload.chunkId === chunk!.id;
       });
       expect(matchingJob).toBeDefined();
     });

--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -3207,8 +3207,9 @@ describe("Memory regressions", () => {
       .filter((j) => JSON.parse(j.payload).messageId === "msg-untrusted-gate");
     expect(extractJobs.length).toBe(0);
 
-    // enqueuedJobs should reflect: embed jobs + summary (1), no extract (0)
-    const expectedJobs = result.indexedSegments + 1; // embed per segment + summary
+    // enqueuedJobs reflects legacy embed_segment + archive embed_chunk per
+    // segment, plus the summary job, with extract_items gated off.
+    const expectedJobs = result.indexedSegments * 2 + 1;
     expect(result.enqueuedJobs).toBe(expectedJobs);
   });
 
@@ -3389,8 +3390,9 @@ describe("Memory regressions", () => {
       .filter((j) => JSON.parse(j.payload).messageId === "msg-unverified-gate");
     expect(extractJobs.length).toBe(0);
 
-    // enqueuedJobs should reflect: embed jobs + summary (1), no extract (0)
-    const expectedJobs = result.indexedSegments + 1; // embed per segment + summary
+    // enqueuedJobs reflects legacy embed_segment + archive embed_chunk per
+    // segment, plus the summary job, with extract_items gated off.
+    const expectedJobs = result.indexedSegments * 2 + 1;
     expect(result.enqueuedJobs).toBe(expectedJobs);
   });
 

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -24,7 +24,6 @@ import { UserError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import { getConversationsDir } from "../util/platform.js";
 import { createRowMapper } from "../util/row-mapper.js";
-import { insertObservation } from "./archive-store.js";
 import {
   deleteOrphanAttachments,
   linkAttachmentToMessage,
@@ -43,10 +42,6 @@ import { ensureDisplayOrderMigration } from "./conversation-display-order-migrat
 import { getDb, rawAll, rawExec, rawGet, rawRun } from "./db.js";
 import { indexMessageNow } from "./indexer.js";
 import { enqueueMemoryJob } from "./jobs-store.js";
-import {
-  extractMediaBlockMeta,
-  extractTextFromStoredMessageContent,
-} from "./message-content.js";
 import {
   channelInboundEvents,
   conversations,
@@ -1080,37 +1075,6 @@ export async function addMessage(
       log.warn(
         { err, conversationId, messageId: message.id },
         "Failed to index message for memory",
-      );
-    }
-  }
-
-  // ── Archive observation dual-write ─────────────────────────────────
-  // Create a memory_observations row for every persisted message alongside
-  // the legacy indexer. Reuses the same text/media extraction helpers the
-  // indexer uses so the observation content matches what gets segmented.
-  if (!opts?.skipIndexing) {
-    try {
-      const scopeId = getConversationMemoryScopeId(conversationId);
-      const text = extractTextFromStoredMessageContent(content);
-      const hasMedia = extractMediaBlockMeta(content).length > 0;
-      const hasSearchableContent = text.length > 0 || hasMedia;
-
-      if (hasSearchableContent) {
-        const observationContent = text.length > 0 ? text : content;
-        const modality = hasMedia ? "multimodal" : "text";
-        insertObservation({
-          conversationId,
-          messageId,
-          role,
-          content: observationContent,
-          scopeId,
-          modality,
-        });
-      }
-    } catch (err) {
-      log.warn(
-        { err, conversationId, messageId },
-        "Failed to dual-write archive observation",
       );
     }
   }

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -54,7 +54,12 @@ export async function indexMessageNow(
     input.provenanceTrustClass === undefined;
 
   const text = extractTextFromStoredMessageContent(input.content);
-  if (text.length === 0) {
+  const hasText = text.length > 0;
+  const candidateMediaMeta = extractMediaBlockMeta(input.content).filter(
+    (b) => b.type === "image",
+  );
+  const hasMedia = candidateMediaMeta.length > 0;
+  if (!hasText && !hasMedia) {
     enqueueMemoryJob("build_conversation_summary", {
       conversationId: input.conversationId,
     });
@@ -63,11 +68,13 @@ export async function indexMessageNow(
 
   const db = getDb();
   const now = Date.now();
-  const segments = segmentText(
-    text,
-    config.segmentation.targetTokens,
-    config.segmentation.overlapTokens,
-  );
+  const segments = hasText
+    ? segmentText(
+        text,
+        config.segmentation.targetTokens,
+        config.segmentation.overlapTokens,
+      )
+    : [];
   const shouldExtract =
     input.role === "user" ||
     (input.role === "assistant" && config.extraction.extractFromAssistant);
@@ -77,9 +84,6 @@ export async function indexMessageNow(
   // overhead for messages on non-multimodal backends.
   // selectedBackendSupportsMultimodal requires async key resolution, so we
   // skip it entirely for text-only messages.
-  const candidateMediaMeta = extractMediaBlockMeta(input.content).filter(
-    (b) => b.type === "image",
-  );
   const mediaBlocks =
     candidateMediaMeta.length > 0 &&
     (await selectedBackendSupportsMultimodal(getConfig()))
@@ -150,8 +154,8 @@ export async function indexMessageNow(
         conversationId: input.conversationId,
         messageId: input.messageId,
         role: input.role,
-        content: text,
-        modality: "text",
+        content: hasText ? text : input.content,
+        modality: hasMedia ? "multimodal" : "text",
         source: null,
         createdAt: input.createdAt,
       })


### PR DESCRIPTION
## Summary
- make indexMessageNow the single writer for archive observations so addMessage no longer creates duplicate observation rows
- preserve multimodal observation coverage in the indexer for text-plus-image and image-only messages
- update the affected memory tests to match embed_chunk and the current enqueued job accounting

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23310088669/job/67794727509
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
