### PR TITLE
Use sanitized geometry when logging chat scroll-wheel events

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -740,13 +740,17 @@ struct ScrollWheelDetector: NSViewRepresentable {
                                 "deltaY=%.1f isScrollable=%d clipH=%.0f docH=%.0f lookup=%{public}@",
                                 event.scrollingDeltaY, isScrollable ? 1 : 0, clipHeight, docHeight, lookupPath as NSString)
                     if coordinator.shouldRecordDiagnostic(kind: .scrollWheelUntether) {
-                        ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
+                        let diagEvent = ChatDiagnosticEvent.scrollWheelEvent(
                             kind: .scrollWheelUntether,
                             conversationId: coordinator.conversationId?.uuidString,
                             reason: "deltaY=\(String(format: "%.1f", event.scrollingDeltaY)) isScrollable=\(isScrollable) lookup=\(lookupPath)",
                             contentHeight: docHeight,
                             viewportHeight: clipHeight
-                        ))
+                        )
+                        ChatDiagnosticsStore.shared.record(diagEvent)
+                        if let dropped = diagEvent.nonFiniteFields {
+                            log.warning("ScrollWheelDetector: non-finite geometry dropped in untether diagnostic: \(dropped)")
+                        }
                     }
                     if isScrollable {
                         coordinator.onScrollUp?()
@@ -780,13 +784,17 @@ struct ScrollWheelDetector: NSViewRepresentable {
                                         "distFromBottom=%.1f isScrollable=%d lookup=%{public}@",
                                         distanceFromBottom, isScrollable ? 1 : 0, lookupPath as NSString)
                             if coordinator.shouldRecordDiagnostic(kind: .scrollWheelRetether) {
-                                ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
+                                let diagEvent = ChatDiagnosticEvent.scrollWheelEvent(
                                     kind: .scrollWheelRetether,
                                     conversationId: coordinator.conversationId?.uuidString,
                                     reason: "distFromBottom=\(String(format: "%.1f", distanceFromBottom)) isScrollable=\(isScrollable) lookup=\(lookupPath)",
                                     contentHeight: docHeight,
                                     viewportHeight: clipBounds.height
-                                ))
+                                )
+                                ChatDiagnosticsStore.shared.record(diagEvent)
+                                if let dropped = diagEvent.nonFiniteFields {
+                                    log.warning("ScrollWheelDetector: non-finite geometry dropped in retether diagnostic: \(dropped)")
+                                }
                             }
                             coordinator.onScrollToBottom?()
                         }


### PR DESCRIPTION
## Summary
- Replace direct ChatDiagnosticEvent construction in ScrollWheelDetector with the safe scrollWheelEvent() helper
- Add warning breadcrumb when non-finite geometry fields are dropped from diagnostic payloads
- Preserve existing throttle, lookup-path reporting, and registry breadcrumbs unchanged

Part of plan: macos-image-send-freeze.md (PR 6 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
