### PR TITLE
Defer chat bottom-pin retries when anchor geometry is unavailable

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -598,12 +598,17 @@ struct MessageListView: View {
             // Stage 2: ~9 frames — catches slower layout/materialization.
             try? await Task.sleep(nanoseconds: 150_000_000)
             guard !Task.isCancelled else { return }
+            // Only retry when the anchor genuinely drifted off-screen.
+            // `geometryUnavailable` means layout hasn't measured yet —
+            // the coordinator will pick up the next finite preference update
+            // instead of spinning retries on missing geometry.
+            let restoreOutcome = MessageListBottomAnchorPolicy.verify(
+                anchorMinY: anchorTracker.lastMinY,
+                viewportHeight: scrollViewportHeight
+            )
             if anchorMessageId == nil
                 && !hasReceivedScrollEvent
-                && MessageListBottomAnchorPolicy.needsRepin(
-                    anchorMinY: anchorTracker.lastMinY,
-                    viewportHeight: scrollViewportHeight
-                )
+                && restoreOutcome == .needsRepin
             {
                 os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=2 action=retry")
                 requestBottomPin(reason: .initialRestore, proxy: proxy)
@@ -811,10 +816,14 @@ struct MessageListView: View {
                 proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
             }
             // Check if the pin succeeded (anchor within viewport).
-            return !MessageListBottomAnchorPolicy.needsRepin(
+            // Use `verify()` so that `geometryUnavailable` returns false
+            // (wait for the next finite preference update) instead of being
+            // treated as an immediate failed pin that triggers retry churn.
+            let outcome = MessageListBottomAnchorPolicy.verify(
                 anchorMinY: anchorTracker.lastMinY,
                 viewportHeight: scrollViewportHeight
             )
+            return outcome == .anchored
         }
         bottomPinCoordinator.onFollowStateChanged = { isFollowing in
             isNearBottom = isFollowing
@@ -1374,10 +1383,14 @@ struct MessageListView: View {
                             // If the task was cancelled during the sleep (user scrolled up), do not fire trailing-edge scroll.
                             guard !Task.isCancelled else { return }
                             if isNearBottom && !isSuppressingBottomScroll {
-                                if MessageListBottomAnchorPolicy.needsRepin(
+                                // Only fire trailing-edge repin for genuinely off-screen
+                                // anchors. Transient missing geometry (geometryUnavailable)
+                                // waits for the next finite preference update.
+                                let trailingOutcome = MessageListBottomAnchorPolicy.verify(
                                     anchorMinY: anchorTracker.lastMinY,
                                     viewportHeight: scrollViewportHeight
-                                ) {
+                                )
+                                if trailingOutcome == .needsRepin {
                                     requestBottomPin(
                                         reason: .streaming,
                                         proxy: proxy,
@@ -1468,10 +1481,13 @@ struct MessageListView: View {
                         // Pin to bottom without animation to avoid visual bounce.
                         // Skip when an anchor is pending (deep-link / notification)
                         // to avoid yanking the viewport away from the target message.
-                        if MessageListBottomAnchorPolicy.needsRepin(
+                        // Only repin for genuinely off-screen anchors — transient
+                        // missing geometry waits for the next finite preference update.
+                        let resizeOutcome = MessageListBottomAnchorPolicy.verify(
                             anchorMinY: anchorTracker.lastMinY,
                             viewportHeight: scrollViewportHeight
-                        ) {
+                        )
+                        if resizeOutcome == .needsRepin {
                             requestBottomPin(reason: .resize, proxy: proxy)
                         }
                     }

--- a/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
@@ -580,4 +580,147 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(session.elapsedMs, 0,
                                     "elapsedMs should be non-negative for a freshly created session")
     }
+
+    // MARK: - Geometry Unavailable Regression
+
+    /// Regression: transient missing geometry must not trigger endless retry churn.
+    ///
+    /// Before the fix, `geometryUnavailable` was collapsed into `needsRepin = true`,
+    /// so the coordinator's `onPinRequested` callback would always return `false`
+    /// when geometry was missing, causing the session to exhaust its retry budget
+    /// and then potentially trigger new sessions from other call sites that also
+    /// treated missing geometry as "needs repin". With the fix, call sites only
+    /// request new pins for `.needsRepin` (genuine drift), and the coordinator
+    /// callback returns `outcome == .anchored` (only true for finite, in-bounds
+    /// geometry). This test verifies the session terminates within its retry budget
+    /// when geometry is persistently unavailable, and that follow state is preserved.
+    func testTransientMissingGeometryDoesNotCauseEndlessRetries() async throws {
+        let convId = UUID()
+        var callCount = 0
+
+        // Simulate geometry unavailable: onPinRequested always returns false
+        // (the verify() call would return .geometryUnavailable, so
+        // outcome == .anchored is false).
+        coordinator.onPinRequested = { reason, animated in
+            callCount += 1
+            return false // geometry unavailable — not anchored
+        }
+
+        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
+
+        // Wait long enough for the session to exhaust or timeout.
+        try await Task.sleep(nanoseconds: 700_000_000)
+
+        // The session must have terminated on its own (bounded retries or timeout).
+        XCTAssertNil(coordinator.activeSession,
+                     "Session should terminate after bounded retries, not run indefinitely")
+
+        // Total attempts must not exceed the session budget.
+        XCTAssertLessThanOrEqual(callCount, BottomPinSession.maxRetries,
+                                  "Retry count should be bounded by maxRetries")
+
+        // The coordinator should still be logically following bottom —
+        // transient geometry issues must not detach the follow state.
+        XCTAssertTrue(coordinator.isFollowingBottom,
+                      "Transient geometry unavailability should not detach follow state")
+
+        // Issuing the same pin reason again must NOT coalesce with the
+        // now-terminated session — it starts a fresh one, proving the old
+        // session was fully cleaned up.
+        let countBefore = callCount
+        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
+        XCTAssertGreaterThan(callCount, countBefore,
+                             "A new pin request after session cleanup should fire immediately")
+    }
+
+    /// Regression: when geometry transitions from unavailable to available
+    /// mid-session, the session should complete successfully without churning
+    /// through all retries.
+    func testGeometryBecomingAvailableMidSessionCompletesPin() async throws {
+        let convId = UUID()
+        var callCount = 0
+
+        // First few attempts simulate geometry unavailable (returns false),
+        // then geometry becomes available (returns true).
+        coordinator.onPinRequested = { reason, animated in
+            callCount += 1
+            return callCount >= 3 // anchored after attempt 3
+        }
+
+        coordinator.requestPin(reason: .streaming, conversationId: convId)
+
+        // Wait for retries to process.
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        // Session should have completed successfully once geometry appeared.
+        XCTAssertNil(coordinator.activeSession,
+                     "Session should complete once geometry becomes available")
+        XCTAssertGreaterThanOrEqual(callCount, 3,
+                                    "Should have retried until geometry was available")
+        XCTAssertLessThanOrEqual(callCount, BottomPinSession.maxRetries,
+                                  "Should not have retried beyond the success point")
+        XCTAssertTrue(coordinator.isFollowingBottom,
+                      "Should still be following bottom after successful pin")
+    }
+
+    // MARK: - VerificationOutcome Policy
+
+    /// Verifies that the anchor policy correctly distinguishes between
+    /// genuinely off-screen anchors and unavailable geometry.
+    func testVerificationOutcomeDistinguishesGeometryStates() {
+        // Finite, in-bounds anchor
+        let anchored = MessageListBottomAnchorPolicy.verify(
+            anchorMinY: 500, viewportHeight: 600
+        )
+        XCTAssertEqual(anchored, .anchored)
+
+        // Finite, genuinely off-screen
+        let offScreen = MessageListBottomAnchorPolicy.verify(
+            anchorMinY: 700, viewportHeight: 600
+        )
+        XCTAssertEqual(offScreen, .needsRepin)
+
+        // Non-finite anchor (geometry not yet measured)
+        let infiniteAnchor = MessageListBottomAnchorPolicy.verify(
+            anchorMinY: .infinity, viewportHeight: 600
+        )
+        XCTAssertEqual(infiniteAnchor, .geometryUnavailable)
+
+        // Non-finite viewport (geometry not yet measured)
+        let infiniteViewport = MessageListBottomAnchorPolicy.verify(
+            anchorMinY: 500, viewportHeight: .infinity
+        )
+        XCTAssertEqual(infiniteViewport, .geometryUnavailable)
+
+        // Both non-finite
+        let bothInfinite = MessageListBottomAnchorPolicy.verify(
+            anchorMinY: .infinity, viewportHeight: .infinity
+        )
+        XCTAssertEqual(bothInfinite, .geometryUnavailable)
+
+        // NaN anchor
+        let nanAnchor = MessageListBottomAnchorPolicy.verify(
+            anchorMinY: .nan, viewportHeight: 600
+        )
+        XCTAssertEqual(nanAnchor, .geometryUnavailable)
+    }
+
+    /// Verifies that the legacy `needsRepin` helper still collapses
+    /// `geometryUnavailable` into `true` for backwards compatibility.
+    func testLegacyNeedsRepinCollapsesGeometryUnavailable() {
+        // geometryUnavailable -> true (backwards-compatible behavior)
+        XCTAssertTrue(MessageListBottomAnchorPolicy.needsRepin(
+            anchorMinY: .infinity, viewportHeight: 600
+        ))
+
+        // anchored -> false
+        XCTAssertFalse(MessageListBottomAnchorPolicy.needsRepin(
+            anchorMinY: 500, viewportHeight: 600
+        ))
+
+        // needsRepin -> true
+        XCTAssertTrue(MessageListBottomAnchorPolicy.needsRepin(
+            anchorMinY: 700, viewportHeight: 600
+        ))
+    }
 }


### PR DESCRIPTION
## Summary
- Replace boolean needsRepin() checks with the VerificationOutcome decision API in bottom-pin coordinator and follow call sites
- Treat geometryUnavailable as wait-for-next-finite-update instead of immediate failed pin
- Add regression test proving transient missing geometry does not trigger retry churn

Part of plan: macos-image-send-freeze.md (PR 4 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
