### PR TITLE
fix: strip VELLUM_DATA_DIR from inline command sandbox env

### DIFF
--- a/assistant/src/skills/inline-command-runner.ts
+++ b/assistant/src/skills/inline-command-runner.ts
@@ -105,12 +105,13 @@ export async function runInlineCommand(
     networkMode: "off",
   });
 
-  // Build a minimal, sanitized environment. Explicitly exclude gateway URL
-  // and workspace dir since inline commands have no business calling internal
-  // APIs or mutating workspace state.
+  // Build a minimal, sanitized environment. Explicitly exclude gateway URL,
+  // workspace dir, and data dir since inline commands have no business calling
+  // internal APIs, mutating workspace state, or accessing instance-scoped data.
   const env = buildSanitizedEnv();
   delete env.INTERNAL_GATEWAY_BASE_URL;
   delete env.VELLUM_WORKSPACE_DIR;
+  delete env.VELLUM_DATA_DIR;
 
   return new Promise<InlineCommandResult>((resolve) => {
     let timedOut = false;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review round 2 for secure-skill-dynamic-context.md.

**Gap:** VELLUM_DATA_DIR leaked into inline command sandbox
**Fix:** Add delete env.VELLUM_DATA_DIR alongside existing gateway URL and workspace dir stripping
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
