### PR TITLE
fix: fail closed when included child has inline commands and flag is off

### DIFF
--- a/assistant/src/__tests__/skill-load-inline-includes.test.ts
+++ b/assistant/src/__tests__/skill-load-inline-includes.test.ts
@@ -574,7 +574,7 @@ describe("skill_load inline command expansion for included skills", () => {
   // ── Feature flag off for child inline commands ────────────────────────
 
   describe("feature flag disabled for included skills", () => {
-    test("child inline commands are not expanded when flag is off", async () => {
+    test("skill_load returns error when child has inline commands and flag is off", async () => {
       testConfig.assistantFeatureFlagValues = {
         "feature_flags.inline-skill-commands.enabled": false,
       };
@@ -594,14 +594,14 @@ describe("skill_load inline command expansion for included skills", () => {
       );
 
       const result = await executeSkillLoad({ skill: "parent-flag-off" });
-      // Note: the root skill does NOT have inline commands, so loading succeeds.
-      // The child's inline commands are simply not expanded (raw body used).
-      expect(result.isError).toBe(false);
-      expect(result.content).toContain("Root content.");
-      // The child body should contain the raw token (not expanded)
-      expect(result.content).toContain("!`echo hello`");
-      // No inline_skill_command tags should appear for the child
-      expect(result.content).not.toContain("inline_skill_command");
+      // Fail closed: the entire skill_load must error when any included child
+      // has inline commands and the feature flag is off, matching the root
+      // skill behavior and the documented fail-closed contract.
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("child-flag-off");
+      expect(result.content).toContain(
+        "inline-skill-commands feature flag is disabled",
+      );
       // Runner should not be called
       expect(runInlineCommandCalls).toHaveLength(0);
     });

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -396,43 +396,53 @@ export class SkillLoadTool implements Tool {
               config,
             );
 
-            if (
-              childInlineFlagEnabled &&
-              childLoaded.skill.source !== "extra" &&
-              INLINE_COMMAND_ELIGIBLE_SOURCES.has(childLoaded.skill.source)
-            ) {
-              try {
-                const childRenderResult = await renderInlineCommands(
-                  childBody,
-                  childLoaded.skill.inlineCommandExpansions!,
-                  context.workingDir,
-                );
-                childBody = childRenderResult.renderedBody;
+            // Fail closed: if the flag is off, reject the entire skill_load
+            // just like we do for root skills. Leaving raw !`...` tokens in
+            // the prompt would violate the documented fail-closed contract.
+            if (!childInlineFlagEnabled) {
+              return {
+                content: `Error: included skill "${childId}" contains inline command expansions but the inline-skill-commands feature flag is disabled. Enable the flag to use skill "${skill.id}".`,
+                isError: true,
+              };
+            }
 
-                log.info(
-                  {
-                    skillId: childId,
-                    parentSkillId: skill.id,
-                    expandedCount: childRenderResult.expandedCount,
-                    failedCount: childRenderResult.failedCount,
-                  },
-                  "Rendered inline command expansions for included skill",
-                );
-              } catch (err) {
-                log.warn(
-                  { err, skillId: childId, parentSkillId: skill.id },
-                  "Failed to render inline commands for included skill, using raw body",
-                );
-              }
-            } else {
+            if (childLoaded.skill.source === "extra") {
+              return {
+                content: `Error: included skill "${childId}" contains inline command expansions but inline commands are not supported for third-party (extra) skill sources.`,
+                isError: true,
+              };
+            }
+
+            if (
+              !INLINE_COMMAND_ELIGIBLE_SOURCES.has(childLoaded.skill.source)
+            ) {
+              return {
+                content: `Error: included skill "${childId}" contains inline command expansions but source "${childLoaded.skill.source}" is not eligible for inline command expansion.`,
+                isError: true,
+              };
+            }
+
+            try {
+              const childRenderResult = await renderInlineCommands(
+                childBody,
+                childLoaded.skill.inlineCommandExpansions!,
+                context.workingDir,
+              );
+              childBody = childRenderResult.renderedBody;
+
               log.info(
                 {
                   skillId: childId,
                   parentSkillId: skill.id,
-                  flagEnabled: childInlineFlagEnabled,
-                  source: childLoaded.skill.source,
+                  expandedCount: childRenderResult.expandedCount,
+                  failedCount: childRenderResult.failedCount,
                 },
-                "Skipping inline command expansion for included skill (flag off or ineligible source)",
+                "Rendered inline command expansions for included skill",
+              );
+            } catch (err) {
+              log.warn(
+                { err, skillId: childId, parentSkillId: skill.id },
+                "Failed to render inline commands for included skill, using raw body",
               );
             }
           }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review round 2 for secure-skill-dynamic-context.md.

**Gap:** Child skills with inline commands silently passed raw tokens to the model when flag was off
**Fix:** Return error for entire skill_load when any child has inline commands and flag is disabled, matching root skill behavior and documented fail-closed contract
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
