### PR TITLE
test: fix conversation retry repair mocks for compaction retry

### DIFF
--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -27,6 +27,9 @@ mock.module("../providers/registry.js", () => ({
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
+    daemon: {
+      titleGenerationMaxTokens: 30,
+    },
 
     provider: "mock-provider",
     maxTokens: 4096,
@@ -172,6 +175,10 @@ mock.module("../memory/conversation-crud.js", () => ({
 
 mock.module("../memory/conversation-queries.js", () => ({
   listConversations: () => [],
+}));
+
+mock.module("../memory/archive-store.js", () => ({
+  insertCompactionEpisode: () => {},
 }));
 
 mock.module("../memory/retriever.js", () => ({


### PR DESCRIPTION
## Summary
- add the new daemon title-generation config field to the conversation retry test mock
- stub archive compaction dual-write storage so forced-compaction retry tests stay isolated from sqlite state
- keep the fix scoped to the failing GitHub Actions job

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23310506363/job/67796243179
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
