### PR TITLE
feat: add simplified archive recall over raw memory tables

### DIFF
--- a/assistant/src/__tests__/archive-recall.test.ts
+++ b/assistant/src/__tests__/archive-recall.test.ts
@@ -1,0 +1,560 @@
+/**
+ * Tests for the archive recall module.
+ *
+ * Covers:
+ * - Explicit artifact recall (past-reference triggers)
+ * - Analogy/debugging-shaped recall
+ * - Strong prefetch triggers
+ * - Empty result omission (no `<supporting_recall>` when nothing found)
+ * - Keyword extraction
+ * - Rendering format
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "archive-recall-test-"));
+const dbPath = join(testDir, "test.db");
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => dbPath,
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { v4 as uuid } from "uuid";
+
+import {
+  buildArchiveRecall,
+  classifyRecallTrigger,
+  extractKeywords,
+  prefetchArchive,
+  type RecallBullet,
+  renderSupportingRecall,
+} from "../memory/archive-recall.js";
+import {
+  insertCompactionEpisode,
+  insertObservation,
+} from "../memory/archive-store.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { conversations, messages } from "../memory/schema.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function removeTestDbFiles(): void {
+  rmSync(dbPath, { force: true });
+  rmSync(`${dbPath}-shm`, { force: true });
+  rmSync(`${dbPath}-wal`, { force: true });
+}
+
+function createConversation(id: string, title: string | null = null): void {
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversations)
+    .values({
+      id,
+      title,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function createMessage(
+  id: string,
+  conversationId: string,
+  role: string = "user",
+  content: string = "test message",
+): void {
+  const db = getDb();
+  db.insert(messages)
+    .values({
+      id,
+      conversationId,
+      role,
+      content,
+      createdAt: Date.now(),
+    })
+    .run();
+}
+
+// ── Test suite ──────────────────────────────────────────────────────
+
+describe("Archive Recall", () => {
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    resetDb();
+    removeTestDbFiles();
+    initializeDb();
+  });
+
+  afterAll(() => {
+    resetDb();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // classifyRecallTrigger
+  // ─────────────────────────────────────────────────────────────────
+
+  describe("classifyRecallTrigger", () => {
+    test("detects explicit past-reference phrases", () => {
+      expect(
+        classifyRecallTrigger("Do you remember the API we discussed?", 0),
+      ).toBe("explicit_past_reference");
+      expect(classifyRecallTrigger("We talked about this last time", 0)).toBe(
+        "explicit_past_reference",
+      );
+      expect(
+        classifyRecallTrigger("As I mentioned earlier, the config is wrong", 0),
+      ).toBe("explicit_past_reference");
+      expect(
+        classifyRecallTrigger("I previously told you about the bug", 0),
+      ).toBe("explicit_past_reference");
+    });
+
+    test("detects analogy/debugging-shaped phrases", () => {
+      expect(
+        classifyRecallTrigger("This is similar to the issue we had", 0),
+      ).toBe("analogy_debug");
+      expect(classifyRecallTrigger("I keep getting this error", 0)).toBe(
+        "analogy_debug",
+      );
+      expect(classifyRecallTrigger("Same problem as yesterday", 0)).toBe(
+        "analogy_debug",
+      );
+    });
+
+    test("detects strong prefetch hits", () => {
+      expect(
+        classifyRecallTrigger("How should I configure the database?", 2),
+      ).toBe("strong_prefetch");
+      expect(
+        classifyRecallTrigger("How should I configure the database?", 5),
+      ).toBe("strong_prefetch");
+    });
+
+    test("returns none for ordinary turns", () => {
+      expect(classifyRecallTrigger("What is the capital of France?", 0)).toBe(
+        "none",
+      );
+      expect(
+        classifyRecallTrigger("Write a function to sort an array", 1),
+      ).toBe("none");
+    });
+
+    test("explicit past-reference takes priority over analogy", () => {
+      // "remember" matches past-reference, "same issue" matches analogy
+      expect(
+        classifyRecallTrigger("Do you remember the same issue we had?", 0),
+      ).toBe("explicit_past_reference");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // extractKeywords
+  // ─────────────────────────────────────────────────────────────────
+
+  describe("extractKeywords", () => {
+    test("extracts meaningful words >= 4 chars", () => {
+      const kw = extractKeywords("How do I fix the authentication error?");
+      expect(kw).toContain("authentication");
+      expect(kw).toContain("error");
+      // "how", "do", "I", "fix", "the" are too short or stop words
+      expect(kw).not.toContain("how");
+      expect(kw).not.toContain("the");
+    });
+
+    test("removes stop words", () => {
+      const kw = extractKeywords("I want to make this very much better");
+      expect(kw).not.toContain("want");
+      expect(kw).not.toContain("very");
+      expect(kw).not.toContain("much");
+      expect(kw).toContain("better");
+    });
+
+    test("deduplicates keywords", () => {
+      const kw = extractKeywords("error error error authentication");
+      expect(kw.filter((w) => w === "error")).toHaveLength(1);
+    });
+
+    test("returns empty for short/stop-word-only input", () => {
+      expect(extractKeywords("hi")).toEqual([]);
+      expect(extractKeywords("the a an")).toEqual([]);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // renderSupportingRecall
+  // ─────────────────────────────────────────────────────────────────
+
+  describe("renderSupportingRecall", () => {
+    test("renders bullets in <supporting_recall> tag", () => {
+      const bullets: RecallBullet[] = [
+        {
+          text: "User prefers REST APIs",
+          source: "observation",
+          sourceId: "obs-1",
+          conversationTitle: "API Discussion",
+        },
+        {
+          text: "Deployed to production last week",
+          source: "episode",
+          sourceId: "ep-1",
+        },
+      ];
+
+      const result = renderSupportingRecall(bullets);
+      expect(result).toContain("<supporting_recall>");
+      expect(result).toContain("</supporting_recall>");
+      expect(result).toContain(
+        "- User prefers REST APIs (from: API Discussion)",
+      );
+      expect(result).toContain("- Deployed to production last week");
+      // No provenance for second bullet (no conversationTitle)
+      expect(result).not.toContain("(from: undefined)");
+      expect(result).not.toContain("(from: null)");
+    });
+
+    test("returns empty string for empty bullets", () => {
+      expect(renderSupportingRecall([])).toBe("");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Explicit artifact recall
+  // ─────────────────────────────────────────────────────────────────
+
+  describe("explicit artifact recall", () => {
+    test("recalls observations when user references past discussion", () => {
+      const convId = uuid();
+      const msgId = uuid();
+      createConversation(convId, "Authentication Redesign");
+      createMessage(msgId, convId);
+
+      insertObservation({
+        conversationId: convId,
+        messageId: msgId,
+        role: "user",
+        content:
+          "User wants to migrate authentication from JWT to session tokens",
+        scopeId: "default",
+      });
+
+      const result = buildArchiveRecall(
+        "default",
+        "Do you remember what we discussed about authentication?",
+      );
+
+      expect(result.trigger).toBe("explicit_past_reference");
+      expect(result.bullets.length).toBeGreaterThan(0);
+      expect(result.text).toContain("<supporting_recall>");
+      expect(result.text).toContain("authentication");
+    });
+
+    test("recalls episodes when user references past work", () => {
+      const convId = uuid();
+      createConversation(convId, "Database Migration Sprint");
+
+      insertCompactionEpisode({
+        scopeId: "default",
+        conversationId: convId,
+        title: "PostgreSQL Migration Planning",
+        summary:
+          "Discussed migrating from MySQL to PostgreSQL, decided on a phased approach starting with read replicas",
+        tokenEstimate: 25,
+        startAt: Date.now() - 86_400_000,
+        endAt: Date.now() - 43_200_000,
+      });
+
+      const result = buildArchiveRecall(
+        "default",
+        "What did we talk about regarding the PostgreSQL migration?",
+      );
+
+      expect(result.trigger).toBe("explicit_past_reference");
+      expect(result.bullets.length).toBeGreaterThan(0);
+      expect(result.text).toContain("<supporting_recall>");
+      expect(result.text).toContain("PostgreSQL");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Analogy/debugging-shaped recall
+  // ─────────────────────────────────────────────────────────────────
+
+  describe("analogy-shaped recall", () => {
+    test("recalls when user reports a recurring issue", () => {
+      const convId = uuid();
+      const msgId = uuid();
+      createConversation(convId, "Debugging Session");
+      createMessage(msgId, convId);
+
+      insertObservation({
+        conversationId: convId,
+        messageId: msgId,
+        role: "user",
+        content:
+          "Connection timeout error when calling the payment gateway service",
+        scopeId: "default",
+      });
+
+      const result = buildArchiveRecall(
+        "default",
+        "I keep getting a timeout error with the payment service",
+      );
+
+      expect(result.trigger).toBe("analogy_debug");
+      expect(result.bullets.length).toBeGreaterThan(0);
+      expect(result.text).toContain("<supporting_recall>");
+      expect(result.text).toContain("timeout");
+    });
+
+    test("recalls similar past episodes for analogy queries", () => {
+      const convId = uuid();
+      createConversation(convId, "Infrastructure Issues");
+
+      insertCompactionEpisode({
+        scopeId: "default",
+        conversationId: convId,
+        title: "Redis Connection Pool Exhaustion",
+        summary:
+          "Debugged Redis connection pool exhaustion caused by missing connection.release() calls in the retry handler",
+        tokenEstimate: 30,
+        startAt: Date.now() - 172_800_000,
+        endAt: Date.now() - 86_400_000,
+      });
+
+      const result = buildArchiveRecall(
+        "default",
+        "This is similar to the Redis connection issue we had",
+      );
+
+      expect(result.trigger).toBe("analogy_debug");
+      expect(result.bullets.length).toBeGreaterThan(0);
+      expect(result.text).toContain("Redis");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Empty result omission
+  // ─────────────────────────────────────────────────────────────────
+
+  describe("empty result omission", () => {
+    test("returns empty text when no archive content exists", () => {
+      const result = buildArchiveRecall(
+        "default",
+        "Do you remember what we discussed about quantum computing?",
+      );
+
+      expect(result.trigger).toBe("explicit_past_reference");
+      expect(result.bullets).toHaveLength(0);
+      expect(result.text).toBe("");
+    });
+
+    test("returns empty text for ordinary turns with no matches", () => {
+      const result = buildArchiveRecall(
+        "default",
+        "Write a hello world program in Python",
+      );
+
+      expect(result.trigger).toBe("none");
+      expect(result.bullets).toHaveLength(0);
+      expect(result.text).toBe("");
+    });
+
+    test("does not emit <supporting_recall> when trigger fires but no data matches", () => {
+      // Seed with unrelated data
+      const convId = uuid();
+      const msgId = uuid();
+      createConversation(convId, "Cooking Tips");
+      createMessage(msgId, convId);
+
+      insertObservation({
+        conversationId: convId,
+        messageId: msgId,
+        role: "user",
+        content: "User enjoys Italian cooking with fresh basil",
+        scopeId: "default",
+      });
+
+      // Ask about something completely unrelated
+      const result = buildArchiveRecall(
+        "default",
+        "Do you remember what we discussed about Kubernetes deployments?",
+      );
+
+      expect(result.trigger).toBe("explicit_past_reference");
+      expect(result.bullets).toHaveLength(0);
+      expect(result.text).toBe("");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Prefetch behavior
+  // ─────────────────────────────────────────────────────────────────
+
+  describe("prefetch", () => {
+    test("returns hits from episodes and observations", () => {
+      const convId = uuid();
+      const msgId = uuid();
+      createConversation(convId);
+      createMessage(msgId, convId);
+
+      insertObservation({
+        conversationId: convId,
+        messageId: msgId,
+        role: "user",
+        content: "User prefers TypeScript over JavaScript",
+        scopeId: "default",
+      });
+
+      insertCompactionEpisode({
+        scopeId: "default",
+        conversationId: convId,
+        title: "TypeScript Configuration",
+        summary: "Set up strict TypeScript config with path aliases",
+        tokenEstimate: 15,
+        startAt: Date.now() - 3600_000,
+        endAt: Date.now() - 1800_000,
+      });
+
+      const hits = prefetchArchive("default", "TypeScript configuration setup");
+      expect(hits.length).toBeGreaterThan(0);
+      expect(hits.some((h) => h.source === "episode")).toBe(true);
+      expect(hits.some((h) => h.source === "observation")).toBe(true);
+    });
+
+    test("returns empty for no matches", () => {
+      const hits = prefetchArchive("default", "xyzzy nonexistent topic");
+      expect(hits).toHaveLength(0);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Bullet cap and deduplication
+  // ─────────────────────────────────────────────────────────────────
+
+  describe("bullet cap and dedup", () => {
+    test("returns at most 3 bullets", () => {
+      const convId = uuid();
+      createConversation(convId);
+
+      // Insert 5 distinct observations
+      for (let i = 0; i < 5; i++) {
+        const msgId = uuid();
+        createMessage(msgId, convId);
+        insertObservation({
+          conversationId: convId,
+          messageId: msgId,
+          role: "user",
+          content: `Authentication fact number ${i}: uses OAuth2 flow variant ${i}`,
+          scopeId: "default",
+        });
+      }
+
+      const result = buildArchiveRecall(
+        "default",
+        "Do you remember what authentication method we use?",
+      );
+
+      expect(result.trigger).toBe("explicit_past_reference");
+      expect(result.bullets.length).toBeLessThanOrEqual(3);
+    });
+
+    test("deduplicates identical content from different sources", () => {
+      const convId = uuid();
+      const msgId = uuid();
+      createConversation(convId);
+      createMessage(msgId, convId);
+
+      // Insert the same content as both an observation and in an episode
+      const content = "User prefers dark mode for all development tools";
+      insertObservation({
+        conversationId: convId,
+        messageId: msgId,
+        role: "user",
+        content,
+        scopeId: "default",
+      });
+
+      insertCompactionEpisode({
+        scopeId: "default",
+        conversationId: convId,
+        title: "Development Preferences",
+        summary: content,
+        tokenEstimate: 10,
+        startAt: Date.now() - 3600_000,
+        endAt: Date.now() - 1800_000,
+      });
+
+      const result = buildArchiveRecall(
+        "default",
+        "Do you recall my preference for dark mode development tools?",
+      );
+
+      // Should have bullets but content should not be duplicated
+      if (result.bullets.length > 1) {
+        const texts = result.bullets.map((b) => b.text.toLowerCase());
+        // Each bullet text should be distinct
+        const uniqueTexts = new Set(texts);
+        expect(uniqueTexts.size).toBe(texts.length);
+      }
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Scope isolation
+  // ─────────────────────────────────────────────────────────────────
+
+  describe("scope isolation", () => {
+    test("only returns results from the requested scope", () => {
+      const convId = uuid();
+      const msgId = uuid();
+      createConversation(convId);
+      createMessage(msgId, convId);
+
+      insertObservation({
+        conversationId: convId,
+        messageId: msgId,
+        role: "user",
+        content: "Deployment uses Kubernetes with Helm charts",
+        scopeId: "other-scope",
+      });
+
+      const result = buildArchiveRecall(
+        "default",
+        "Do you remember our Kubernetes deployment setup?",
+      );
+
+      // Should trigger but find no results in "default" scope
+      expect(result.trigger).toBe("explicit_past_reference");
+      expect(result.bullets).toHaveLength(0);
+      expect(result.text).toBe("");
+    });
+  });
+});

--- a/assistant/src/memory/archive-recall.ts
+++ b/assistant/src/memory/archive-recall.ts
@@ -1,0 +1,516 @@
+/**
+ * Archive recall: retrieval layer over the simplified memory archive tables
+ * (memory_observations, memory_chunks, memory_episodes).
+ *
+ * Two retrieval paths:
+ *
+ * 1. **Prefetch** — lightweight query run on every turn. Fetches recent
+ *    episodes and observations to detect whether the user's turn references
+ *    past context that the archive can answer.
+ *
+ * 2. **Deeper recall** — triggered when the prefetch surfaces strong hits,
+ *    or when the user's turn contains explicit past-reference or
+ *    analogy/debugging-shaped language. Queries all three archive tables
+ *    and returns up to 3 source-linked bullets wrapped in
+ *    `<supporting_recall>`.
+ *
+ * Empty results produce no output (no `<supporting_recall>` tag).
+ */
+
+import { and, desc, eq, like, or, sql } from "drizzle-orm";
+
+import { getLogger } from "../util/logger.js";
+import { getDb } from "./db.js";
+import { memoryChunks, memoryEpisodes, memoryObservations } from "./schema.js";
+
+const log = getLogger("memory-archive-recall");
+
+// ── Pattern matchers ────────────────────────────────────────────────
+
+/**
+ * Phrases that signal the user is explicitly referencing a past
+ * interaction, artifact, or fact the assistant should recall.
+ */
+const PAST_REFERENCE_PATTERNS = [
+  /\b(?:remember|recall|mentioned|talked about|discussed|said|told you|last time|earlier|before|previously)\b/i,
+  /\bwhat (?:did|was|were)\b.*\b(?:we|i|you)\b/i,
+  /\bdo you (?:know|remember)\b/i,
+];
+
+/**
+ * Phrases that signal an analogy or debugging-shaped query where
+ * historical context would be especially valuable.
+ */
+const ANALOGY_DEBUG_PATTERNS = [
+  /\b(?:similar to|like when|same (?:issue|problem|error|bug)|happened before|recurring|déjà vu)\b/i,
+  /\b(?:last time.*(?:fix|solve|debug|resolve))\b/i,
+  /\b(?:keep (?:getting|seeing|hitting)|again|keeps happening)\b/i,
+];
+
+// ── Turn classification ─────────────────────────────────────────────
+
+export type RecallTrigger =
+  | "explicit_past_reference"
+  | "analogy_debug"
+  | "strong_prefetch"
+  | "none";
+
+/**
+ * Classify whether a user turn warrants deeper archive recall.
+ */
+export function classifyRecallTrigger(
+  userText: string,
+  prefetchHitCount: number,
+): RecallTrigger {
+  if (PAST_REFERENCE_PATTERNS.some((p) => p.test(userText))) {
+    return "explicit_past_reference";
+  }
+  if (ANALOGY_DEBUG_PATTERNS.some((p) => p.test(userText))) {
+    return "analogy_debug";
+  }
+  if (prefetchHitCount >= 2) {
+    return "strong_prefetch";
+  }
+  return "none";
+}
+
+// ── Prefetch ────────────────────────────────────────────────────────
+
+/** A lightweight prefetch hit from the archive tables. */
+export interface PrefetchHit {
+  source: "episode" | "observation" | "chunk";
+  id: string;
+  content: string;
+  createdAt: number;
+  conversationId?: string | null;
+}
+
+/**
+ * Lightweight prefetch over recent episodes and observations for the
+ * given scope. Returns up to `limit` hits ordered by recency. This is
+ * cheap enough to run on every turn.
+ */
+export function prefetchArchive(
+  scopeId: string,
+  userText: string,
+  limit: number = 10,
+): PrefetchHit[] {
+  const db = getDb();
+  const hits: PrefetchHit[] = [];
+
+  // Extract meaningful keywords from user text (words >= 4 chars)
+  const keywords = extractKeywords(userText);
+  if (keywords.length === 0) return hits;
+
+  try {
+    // Query recent episodes whose title or summary contain any keyword
+    const episodeConditions = keywords.map((kw) =>
+      or(
+        like(memoryEpisodes.title, `%${kw}%`),
+        like(memoryEpisodes.summary, `%${kw}%`),
+      ),
+    );
+
+    const episodes = db
+      .select({
+        id: memoryEpisodes.id,
+        title: memoryEpisodes.title,
+        summary: memoryEpisodes.summary,
+        createdAt: memoryEpisodes.createdAt,
+        conversationId: memoryEpisodes.conversationId,
+      })
+      .from(memoryEpisodes)
+      .where(and(eq(memoryEpisodes.scopeId, scopeId), or(...episodeConditions)))
+      .orderBy(desc(memoryEpisodes.createdAt))
+      .limit(limit)
+      .all();
+
+    for (const ep of episodes) {
+      hits.push({
+        source: "episode",
+        id: ep.id,
+        content: `${ep.title}: ${ep.summary}`,
+        createdAt: ep.createdAt,
+        conversationId: ep.conversationId,
+      });
+    }
+
+    // Query recent observations whose content matches any keyword
+    const observationConditions = keywords.map((kw) =>
+      like(memoryObservations.content, `%${kw}%`),
+    );
+
+    const observations = db
+      .select({
+        id: memoryObservations.id,
+        content: memoryObservations.content,
+        createdAt: memoryObservations.createdAt,
+        conversationId: memoryObservations.conversationId,
+      })
+      .from(memoryObservations)
+      .where(
+        and(
+          eq(memoryObservations.scopeId, scopeId),
+          or(...observationConditions),
+        ),
+      )
+      .orderBy(desc(memoryObservations.createdAt))
+      .limit(limit)
+      .all();
+
+    for (const obs of observations) {
+      hits.push({
+        source: "observation",
+        id: obs.id,
+        content: obs.content,
+        createdAt: obs.createdAt,
+        conversationId: obs.conversationId,
+      });
+    }
+  } catch (err) {
+    log.warn({ err }, "Archive prefetch failed");
+  }
+
+  // Sort all hits by recency and cap at limit
+  hits.sort((a, b) => b.createdAt - a.createdAt);
+  return hits.slice(0, limit);
+}
+
+// ── Deeper recall ───────────────────────────────────────────────────
+
+/** A source-linked recall bullet for injection. */
+export interface RecallBullet {
+  /** Human-readable one-line summary. */
+  text: string;
+  /** Which archive table sourced this bullet. */
+  source: "episode" | "observation" | "chunk";
+  /** Row ID in the source table. */
+  sourceId: string;
+  /** Optional conversation title for provenance. */
+  conversationTitle?: string | null;
+}
+
+export interface ArchiveRecallResult {
+  /** The recall trigger that activated deeper recall (or "none"). */
+  trigger: RecallTrigger;
+  /** Up to 3 source-linked bullets. Empty when no relevant results. */
+  bullets: RecallBullet[];
+  /** Rendered `<supporting_recall>` block, or empty string. */
+  text: string;
+  /** Number of prefetch hits examined. */
+  prefetchHitCount: number;
+}
+
+/**
+ * Run archive recall for a user turn.
+ *
+ * 1. Runs a lightweight prefetch over episodes and observations.
+ * 2. Classifies whether deeper recall is warranted.
+ * 3. If triggered, queries all three archive tables and assembles
+ *    up to 3 source-linked bullets.
+ * 4. Returns rendered `<supporting_recall>` or empty string.
+ */
+export function buildArchiveRecall(
+  scopeId: string,
+  userText: string,
+): ArchiveRecallResult {
+  // Step 1: prefetch
+  const prefetchHits = prefetchArchive(scopeId, userText);
+  const prefetchHitCount = prefetchHits.length;
+
+  // Step 2: classify
+  const trigger = classifyRecallTrigger(userText, prefetchHitCount);
+
+  if (trigger === "none") {
+    return {
+      trigger,
+      bullets: [],
+      text: "",
+      prefetchHitCount,
+    };
+  }
+
+  // Step 3: deeper recall
+  const bullets = deeperRecall(scopeId, userText, prefetchHits);
+
+  // Step 4: render
+  const text = renderSupportingRecall(bullets);
+
+  log.debug(
+    {
+      trigger,
+      prefetchHitCount,
+      bulletCount: bullets.length,
+    },
+    "Archive recall completed",
+  );
+
+  return {
+    trigger,
+    bullets,
+    text,
+    prefetchHitCount,
+  };
+}
+
+// ── Deeper recall implementation ────────────────────────────────────
+
+/**
+ * Query all three archive tables for the user's text and assemble
+ * up to 3 source-linked bullets. Prioritizes episodes (narrative
+ * summaries) over observations (raw facts) over chunks (indexed text).
+ */
+function deeperRecall(
+  scopeId: string,
+  userText: string,
+  prefetchHits: PrefetchHit[],
+): RecallBullet[] {
+  const db = getDb();
+  const keywords = extractKeywords(userText);
+  if (keywords.length === 0) return [];
+
+  const bullets: RecallBullet[] = [];
+  const seenContent = new Set<string>();
+  const MAX_BULLETS = 3;
+
+  try {
+    // --- Episodes: highest signal (narrative summaries) ---
+    const episodeConditions = keywords.map((kw) =>
+      or(
+        like(memoryEpisodes.title, `%${kw}%`),
+        like(memoryEpisodes.summary, `%${kw}%`),
+      ),
+    );
+
+    const episodes = db
+      .select({
+        id: memoryEpisodes.id,
+        title: memoryEpisodes.title,
+        summary: memoryEpisodes.summary,
+        conversationId: memoryEpisodes.conversationId,
+      })
+      .from(memoryEpisodes)
+      .where(and(eq(memoryEpisodes.scopeId, scopeId), or(...episodeConditions)))
+      .orderBy(desc(memoryEpisodes.createdAt))
+      .limit(MAX_BULLETS)
+      .all();
+
+    for (const ep of episodes) {
+      if (bullets.length >= MAX_BULLETS) break;
+      const normalized = normalizeForDedup(ep.summary);
+      if (seenContent.has(normalized)) continue;
+      seenContent.add(normalized);
+
+      const convTitle = lookupConversationTitle(db, ep.conversationId);
+      bullets.push({
+        text: `${ep.title} — ${truncate(ep.summary, 200)}`,
+        source: "episode",
+        sourceId: ep.id,
+        conversationTitle: convTitle,
+      });
+    }
+
+    // --- Observations: raw factual statements ---
+    if (bullets.length < MAX_BULLETS) {
+      const observationConditions = keywords.map((kw) =>
+        like(memoryObservations.content, `%${kw}%`),
+      );
+
+      const observations = db
+        .select({
+          id: memoryObservations.id,
+          content: memoryObservations.content,
+          conversationId: memoryObservations.conversationId,
+        })
+        .from(memoryObservations)
+        .where(
+          and(
+            eq(memoryObservations.scopeId, scopeId),
+            or(...observationConditions),
+          ),
+        )
+        .orderBy(desc(memoryObservations.createdAt))
+        .limit(MAX_BULLETS)
+        .all();
+
+      for (const obs of observations) {
+        if (bullets.length >= MAX_BULLETS) break;
+        const normalized = normalizeForDedup(obs.content);
+        if (seenContent.has(normalized)) continue;
+        seenContent.add(normalized);
+
+        const convTitle = lookupConversationTitle(db, obs.conversationId);
+        bullets.push({
+          text: truncate(obs.content, 200),
+          source: "observation",
+          sourceId: obs.id,
+          conversationTitle: convTitle,
+        });
+      }
+    }
+
+    // --- Chunks: indexed text fragments ---
+    if (bullets.length < MAX_BULLETS) {
+      const chunkConditions = keywords.map((kw) =>
+        like(memoryChunks.content, `%${kw}%`),
+      );
+
+      const chunks = db
+        .select({
+          id: memoryChunks.id,
+          content: memoryChunks.content,
+          observationId: memoryChunks.observationId,
+        })
+        .from(memoryChunks)
+        .where(and(eq(memoryChunks.scopeId, scopeId), or(...chunkConditions)))
+        .orderBy(desc(memoryChunks.createdAt))
+        .limit(MAX_BULLETS)
+        .all();
+
+      for (const chunk of chunks) {
+        if (bullets.length >= MAX_BULLETS) break;
+        const normalized = normalizeForDedup(chunk.content);
+        if (seenContent.has(normalized)) continue;
+        seenContent.add(normalized);
+
+        // Look up the observation's conversationId for provenance
+        const obs = db
+          .select({ conversationId: memoryObservations.conversationId })
+          .from(memoryObservations)
+          .where(eq(memoryObservations.id, chunk.observationId))
+          .get();
+
+        const convTitle = obs
+          ? lookupConversationTitle(db, obs.conversationId)
+          : null;
+
+        bullets.push({
+          text: truncate(chunk.content, 200),
+          source: "chunk",
+          sourceId: chunk.id,
+          conversationTitle: convTitle,
+        });
+      }
+    }
+  } catch (err) {
+    log.warn({ err }, "Deeper archive recall failed");
+  }
+
+  // Also incorporate prefetch hits that weren't already captured
+  for (const hit of prefetchHits) {
+    if (bullets.length >= MAX_BULLETS) break;
+    const normalized = normalizeForDedup(hit.content);
+    if (seenContent.has(normalized)) continue;
+    seenContent.add(normalized);
+
+    bullets.push({
+      text: truncate(hit.content, 200),
+      source: hit.source,
+      sourceId: hit.id,
+    });
+  }
+
+  return bullets.slice(0, MAX_BULLETS);
+}
+
+// ── Rendering ───────────────────────────────────────────────────────
+
+/**
+ * Render recall bullets into `<supporting_recall>` XML block.
+ * Returns empty string when there are no bullets.
+ */
+export function renderSupportingRecall(bullets: RecallBullet[]): string {
+  if (bullets.length === 0) return "";
+
+  const lines = bullets.map((b) => {
+    const provenance = b.conversationTitle
+      ? ` (from: ${b.conversationTitle})`
+      : "";
+    return `- ${b.text}${provenance}`;
+  });
+
+  return `<supporting_recall>\n${lines.join("\n")}\n</supporting_recall>`;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Extract meaningful keywords from user text for LIKE-based matching.
+ * Filters out short words (< 4 chars) and common stop words.
+ */
+export function extractKeywords(text: string): string[] {
+  const STOP_WORDS = new Set([
+    "about",
+    "also",
+    "been",
+    "could",
+    "does",
+    "from",
+    "have",
+    "into",
+    "just",
+    "know",
+    "like",
+    "make",
+    "more",
+    "much",
+    "only",
+    "over",
+    "said",
+    "some",
+    "than",
+    "that",
+    "them",
+    "then",
+    "they",
+    "this",
+    "very",
+    "want",
+    "were",
+    "what",
+    "when",
+    "will",
+    "with",
+    "your",
+  ]);
+
+  const words = text
+    .toLowerCase()
+    .replace(/[^\w\s]/g, " ")
+    .split(/\s+/)
+    .filter((w) => w.length >= 4 && !STOP_WORDS.has(w));
+
+  // Deduplicate while preserving order
+  return [...new Set(words)];
+}
+
+/**
+ * Look up a conversation's title for provenance display.
+ */
+function lookupConversationTitle(
+  db: ReturnType<typeof getDb>,
+  conversationId: string,
+): string | null {
+  try {
+    const row = db
+      .select({ title: sql<string | null>`title` })
+      .from(sql`conversations`)
+      .where(sql`id = ${conversationId}`)
+      .get();
+    return row?.title ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 3)}...`;
+}
+
+/**
+ * Normalize text for content deduplication across sources.
+ */
+function normalizeForDedup(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, " ").trim();
+}


### PR DESCRIPTION
## Summary
- Add archive-recall.ts with prefetch and deeper recall paths over archive tables
- Support explicit past-reference, analogy-shaped, and strong-prefetch recall
- Return up to 3 source-linked bullets in <supporting_recall> format
- Add tests for artifact recall, analogy recall, and empty-result omission

Part of plan: simplified-memory-v1.md (PR 21 of 23)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
