### PR TITLE
Stop syncing ElevenLabs key to daemon since it is never consumed

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -29,7 +29,6 @@ export const API_KEY_PROVIDERS = [
   "fireworks",
   "openrouter",
   "brave",
-  "elevenlabs",
   "perplexity",
 ] as const;
 

--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -40,7 +40,6 @@ enum APIKeyManager {
     static let allSyncableProviders = [
         "anthropic",
         "brave",
-        "elevenlabs",
         "fireworks",
         "gemini",
         "openai",
@@ -53,6 +52,7 @@ enum APIKeyManager {
         for provider in allSyncableProviders {
             if getKey(for: provider) != nil { return true }
         }
+        if getKey(for: "elevenlabs") != nil { return true }
         return false
     }
 
@@ -66,6 +66,8 @@ enum APIKeyManager {
         for provider in allSyncableProviders {
             migrateProviderFromUserDefaults(provider)
         }
+        // ElevenLabs is stored locally only (not synced to daemon)
+        migrateProviderFromUserDefaults("elevenlabs")
     }
 
     /// Migrate a single provider's key from UserDefaults to credential storage.

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -791,16 +791,12 @@ public final class SettingsStore: ObservableObject {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         APIKeyManager.setKey(trimmed, for: "elevenlabs")
-        removeDeletionTombstone(type: "api_key", name: "elevenlabs")
-        syncKeyToDaemon(provider: "elevenlabs", value: trimmed)
         hasElevenLabsKey = true
         maskedElevenLabsKey = Self.maskKey(trimmed)
     }
 
     func clearElevenLabsKey() {
         APIKeyManager.deleteKey(for: "elevenlabs")
-        addDeletionTombstone(type: "api_key", name: "elevenlabs")
-        deleteKeyFromDaemon(provider: "elevenlabs")
         hasElevenLabsKey = false
         maskedElevenLabsKey = ""
     }


### PR DESCRIPTION
## Summary
- Removes `elevenlabs` from `API_KEY_PROVIDERS` (daemon) and `allSyncableProviders` (macOS client) since the daemon never reads the ElevenLabs API key (TTS goes through Twilio ConversationRelay)
- Drops `syncKeyToDaemon` / `deleteKeyFromDaemon` calls from `saveElevenLabsKey` / `clearElevenLabsKey` — key is still stored locally for UI display
- Preserves ElevenLabs in `hasAnyKey()` and `migrateFromUserDefaults()` since it is still stored locally

## Original prompt
Remove the daemon sync calls from saveElevenLabsKey and clearElevenLabsKey in SettingsStore.swift since the daemon never reads the ElevenLabs key (TTS goes through Twilio ConversationRelay). Also remove elevenlabs from allSyncableProviders in APIKeyManager.swift and from API_KEY_PROVIDERS in loader.ts since there is no point syncing a key the daemon does not consume.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
