### PR TITLE
fix: clear embedding backend cache on API key add/update path

### DIFF
--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -182,6 +182,7 @@ export async function handleAddSecret(
           500,
         );
       }
+      clearEmbeddingBackendCache();
       invalidateConfigCache();
       await initializeProviders(getConfig());
       log.info({ provider: name }, "API key updated via HTTP");


### PR DESCRIPTION
## Summary
- Adds missing `clearEmbeddingBackendCache()` call to the API key add/update path in `handleAddSecret`
- Mirrors the existing call in the delete path (`handleDeleteSecret`) added in PR #19567
- Without this, key rotations leave stale cached embedding backends using the old (possibly revoked) key until daemon restart

## Test plan
- [ ] Rotate an API key via POST /v1/secrets and verify embedding calls use the new key immediately
- [ ] Verify key deletion still clears the cache (existing behavior from #19567)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
