### PR TITLE
fix: tolerate partial reducer config mocks in memory scheduling

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1536,8 +1536,7 @@ export function scheduleReducerJob(
   conversationId: string,
   runAfter?: number,
 ): void {
-  const config = getConfig();
-  const idleDelayMs = config.memory.simplified.reducer.idleDelayMs;
+  const idleDelayMs = getReducerIdleDelayMs();
   const scheduledAt = runAfter ?? Date.now() + idleDelayMs;
 
   const existing = rawGet<{ id: string; status: string }>(
@@ -1579,8 +1578,7 @@ export function scheduleReducerJob(
  * Returns the number of jobs enqueued.
  */
 export function sweepStaleReducerJobs(): number {
-  const config = getConfig();
-  const idleDelayMs = config.memory.simplified.reducer.idleDelayMs;
+  const idleDelayMs = getReducerIdleDelayMs();
   const cutoff = Date.now() - idleDelayMs;
 
   // Find dirty conversations whose latest message is older than the idle
@@ -1607,6 +1605,21 @@ export function sweepStaleReducerJobs(): number {
   }
 
   return stale.length;
+}
+
+function getReducerIdleDelayMs(): number {
+  // Some test suites mock getConfig() with partial objects; fall back to the
+  // schema default so reducer scheduling stays stable outside full config load.
+  const config = getConfig() as {
+    memory?: {
+      simplified?: {
+        reducer?: {
+          idleDelayMs?: number;
+        };
+      };
+    };
+  };
+  return config.memory?.simplified?.reducer?.idleDelayMs ?? 30_000;
 }
 
 export function setConversationOriginChannelIfUnset(


### PR DESCRIPTION
## Summary
- make reducer scheduling fall back to the default idle delay when tests mock `getConfig()` with only partial memory config
- keep `scheduleReducerJob()` and `sweepStaleReducerJobs()` behavior unchanged for fully-loaded configs while avoiding crashes in disk-view tests

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23311107705/job/67798379719
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
