### PR TITLE
feat: reduce prior dirty conversation before switching context

### DIFF
--- a/assistant/src/__tests__/conversation-switch-memory-reduction.test.ts
+++ b/assistant/src/__tests__/conversation-switch-memory-reduction.test.ts
@@ -1,0 +1,475 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Test directory & platform mocks ───────────────────────────────
+
+const testDir = mkdtempSync(
+  join(tmpdir(), "conversation-switch-memory-reduction-test-"),
+);
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  getRootDir: () => testDir,
+  getWorkspaceDir: () => join(testDir, "workspace"),
+  getConversationsDir: () => join(testDir, "workspace", "conversations"),
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ── Config mock ───────────────────────────────────────────────────
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    memory: {
+      simplified: {
+        reducer: {
+          idleDelayMs: 30_000,
+          switchWaitMs: 5_000,
+        },
+      },
+    },
+  }),
+  loadConfig: () => ({
+    memory: {
+      simplified: {
+        reducer: {
+          idleDelayMs: 30_000,
+          switchWaitMs: 5_000,
+        },
+      },
+    },
+  }),
+}));
+
+// ── Suppress disk-view side effects ──────────────────────────────
+
+mock.module("../memory/conversation-disk-view.js", () => ({
+  initConversationDir: () => {},
+  removeConversationDir: () => {},
+  syncMessageToDisk: () => {},
+  updateMetaFile: () => {},
+}));
+
+// ── Suppress indexer side effects ────────────────────────────────
+
+mock.module("../memory/indexer.js", () => ({
+  indexMessageNow: async () => {},
+}));
+
+// ── Suppress attention side effects ──────────────────────────────
+
+mock.module("../memory/conversation-attention-store.js", () => ({
+  projectAssistantMessage: () => {},
+  seedForkedConversationAttention: () => {},
+}));
+
+// ── Mock the reducer ──────────────────────────────────────────────
+
+import type { ReducerPromptInput } from "../memory/reducer.js";
+import type { ReducerResult } from "../memory/reducer-types.js";
+import { EMPTY_REDUCER_RESULT } from "../memory/reducer-types.js";
+
+let mockReducerResult: ReducerResult = EMPTY_REDUCER_RESULT;
+let lastReducerInput: ReducerPromptInput | null = null;
+let reducerCallCount = 0;
+
+mock.module("../memory/reducer.js", () => ({
+  runReducer: async (input: ReducerPromptInput) => {
+    lastReducerInput = input;
+    reducerCallCount++;
+    return mockReducerResult;
+  },
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────
+
+import { initializeDb, resetDb } from "../memory/db.js";
+import { getSqlite } from "../memory/db-connection.js";
+import { resetTestTables } from "../memory/raw-query.js";
+import {
+  findMostRecentDirtyConversation,
+  reduceBeforeSwitch,
+} from "../memory/reducer-scheduler.js";
+
+initializeDb();
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+const NOW = 1_700_000_000_000;
+const SCOPE = "default";
+
+function insertConversation(
+  id: string,
+  opts?: {
+    dirtyTailMessageId?: string | null;
+    updatedAt?: number;
+    memoryScopeId?: string;
+    contextSummary?: string;
+  },
+): void {
+  const raw = getSqlite();
+  raw.run(
+    `INSERT INTO conversations (id, title, created_at, updated_at, conversation_type, source, memory_scope_id, is_auto_title,
+       memory_dirty_tail_since_message_id, context_summary)
+     VALUES (?, 'Test', ?, ?, 'standard', 'user', ?, 1, ?, ?)`,
+    [
+      id,
+      NOW,
+      opts?.updatedAt ?? NOW,
+      opts?.memoryScopeId ?? SCOPE,
+      opts?.dirtyTailMessageId ?? null,
+      opts?.contextSummary ?? null,
+    ],
+  );
+}
+
+function insertMessage(opts: {
+  id: string;
+  conversationId: string;
+  role?: string;
+  content?: string;
+  createdAt?: number;
+}): void {
+  const raw = getSqlite();
+  raw.run(
+    `INSERT INTO messages (id, conversation_id, role, content, created_at)
+     VALUES (?, ?, ?, ?, ?)`,
+    [
+      opts.id,
+      opts.conversationId,
+      opts.role ?? "user",
+      opts.content ?? "test message",
+      opts.createdAt ?? NOW,
+    ],
+  );
+}
+
+function getRawConversation(conversationId: string): Record<string, unknown> {
+  const raw = getSqlite();
+  return raw
+    .query(`SELECT * FROM conversations WHERE id = ?`)
+    .get(conversationId) as Record<string, unknown>;
+}
+
+function makeReducerResult(overrides?: Partial<ReducerResult>): ReducerResult {
+  return {
+    timeContexts: [],
+    openLoops: [],
+    archiveObservations: [],
+    archiveEpisodes: [],
+    ...overrides,
+  };
+}
+
+// ── Teardown ──────────────────────────────────────────────────────
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+beforeEach(() => {
+  resetTestTables(
+    "messages",
+    "conversations",
+    "memory_jobs",
+    "time_contexts",
+    "open_loops",
+  );
+  mockReducerResult = EMPTY_REDUCER_RESULT;
+  lastReducerInput = null;
+  reducerCallCount = 0;
+});
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+describe("findMostRecentDirtyConversation", () => {
+  test("returns the most recently updated dirty conversation", () => {
+    insertConversation("conv-old", {
+      dirtyTailMessageId: "msg-old",
+      updatedAt: NOW - 5000,
+    });
+    insertConversation("conv-recent", {
+      dirtyTailMessageId: "msg-recent",
+      updatedAt: NOW,
+    });
+    insertConversation("conv-target", { updatedAt: NOW + 1000 });
+
+    const result = findMostRecentDirtyConversation("conv-target");
+    // Should return the oldest dirty conversation first (ordered by updatedAt ASC)
+    // since we want to reduce the least-recently-updated dirty conversation
+    expect(result).toBe("conv-old");
+  });
+
+  test("excludes the target conversation", () => {
+    insertConversation("conv-dirty", {
+      dirtyTailMessageId: "msg-1",
+      updatedAt: NOW,
+    });
+
+    const result = findMostRecentDirtyConversation("conv-dirty");
+    expect(result).toBeNull();
+  });
+
+  test("returns null when no dirty conversations exist", () => {
+    insertConversation("conv-clean", { updatedAt: NOW });
+
+    const result = findMostRecentDirtyConversation("conv-target");
+    expect(result).toBeNull();
+  });
+
+  test("returns null when only dirty conversation is the target", () => {
+    insertConversation("conv-target", {
+      dirtyTailMessageId: "msg-1",
+      updatedAt: NOW,
+    });
+    insertConversation("conv-clean", { updatedAt: NOW + 1000 });
+
+    const result = findMostRecentDirtyConversation("conv-target");
+    expect(result).toBeNull();
+  });
+});
+
+describe("reduceBeforeSwitch — conversation switch", () => {
+  test("reduces the dirty conversation before switching", async () => {
+    // Previous conversation with dirty messages
+    insertConversation("conv-prev", {
+      dirtyTailMessageId: "msg-1",
+      updatedAt: NOW,
+    });
+    insertMessage({
+      id: "msg-1",
+      conversationId: "conv-prev",
+      role: "user",
+      content: "Hello",
+      createdAt: NOW,
+    });
+    insertMessage({
+      id: "msg-2",
+      conversationId: "conv-prev",
+      role: "assistant",
+      content: "Hi there!",
+      createdAt: NOW + 1000,
+    });
+
+    // Target conversation
+    insertConversation("conv-target", { updatedAt: NOW + 5000 });
+
+    mockReducerResult = makeReducerResult({
+      openLoops: [
+        {
+          action: "create",
+          summary: "User greeted the assistant",
+          source: "conversation",
+        },
+      ],
+    });
+
+    const result = await reduceBeforeSwitch("conv-target");
+
+    // Should have reduced conv-prev
+    expect(result).toBe("conv-prev");
+    expect(reducerCallCount).toBe(1);
+
+    // Checkpoint should be advanced
+    const conv = getRawConversation("conv-prev");
+    expect(conv.memory_reduced_through_message_id).toBe("msg-2");
+    expect(conv.memory_dirty_tail_since_message_id).toBeNull();
+  });
+
+  test("skips when no eligible dirty conversation exists", async () => {
+    insertConversation("conv-clean", { updatedAt: NOW });
+    insertConversation("conv-target", { updatedAt: NOW + 1000 });
+
+    const result = await reduceBeforeSwitch("conv-target");
+
+    expect(result).toBeNull();
+    expect(reducerCallCount).toBe(0);
+  });
+
+  test("skips when the only dirty conversation is the target", async () => {
+    insertConversation("conv-target", {
+      dirtyTailMessageId: "msg-1",
+      updatedAt: NOW,
+    });
+    insertMessage({ id: "msg-1", conversationId: "conv-target" });
+
+    const result = await reduceBeforeSwitch("conv-target");
+
+    expect(result).toBeNull();
+    expect(reducerCallCount).toBe(0);
+  });
+
+  test("does not advance checkpoint when reducer returns empty result", async () => {
+    insertConversation("conv-prev", {
+      dirtyTailMessageId: "msg-1",
+      updatedAt: NOW,
+    });
+    insertMessage({
+      id: "msg-1",
+      conversationId: "conv-prev",
+      role: "user",
+      content: "Hello",
+      createdAt: NOW,
+    });
+    insertConversation("conv-target", { updatedAt: NOW + 5000 });
+
+    mockReducerResult = EMPTY_REDUCER_RESULT;
+
+    const result = await reduceBeforeSwitch("conv-target");
+
+    // Returns null because empty result means nothing was reduced
+    expect(result).toBeNull();
+
+    // Checkpoint should NOT advance
+    const conv = getRawConversation("conv-prev");
+    expect(conv.memory_reduced_through_message_id).toBeNull();
+    expect(conv.memory_dirty_tail_since_message_id).toBe("msg-1");
+  });
+});
+
+describe("reduceBeforeSwitch — new conversation", () => {
+  test("reduces the previous dirty conversation when starting a new one", async () => {
+    insertConversation("conv-prev", {
+      dirtyTailMessageId: "msg-1",
+      updatedAt: NOW,
+    });
+    insertMessage({
+      id: "msg-1",
+      conversationId: "conv-prev",
+      role: "user",
+      content: "Some prior work",
+      createdAt: NOW,
+    });
+
+    // The new conversation ID (just created)
+    const newConvId = "conv-new";
+    insertConversation(newConvId, { updatedAt: NOW + 5000 });
+
+    mockReducerResult = makeReducerResult({
+      timeContexts: [
+        {
+          action: "create",
+          summary: "Prior work in progress",
+          source: "conversation",
+          activeFrom: NOW,
+          activeUntil: NOW + 7 * 24 * 60 * 60 * 1000,
+        },
+      ],
+    });
+
+    const result = await reduceBeforeSwitch(newConvId);
+
+    expect(result).toBe("conv-prev");
+    expect(reducerCallCount).toBe(1);
+
+    // Verify the previous conversation's checkpoint was advanced
+    const conv = getRawConversation("conv-prev");
+    expect(conv.memory_reduced_through_message_id).toBe("msg-1");
+    expect(conv.memory_dirty_tail_since_message_id).toBeNull();
+  });
+});
+
+describe("reduceBeforeSwitch — most recent dirty selection", () => {
+  test("selects the earliest-updated dirty conversation when multiple exist", async () => {
+    // Two dirty conversations — conv-older is less recently updated
+    insertConversation("conv-older", {
+      dirtyTailMessageId: "msg-older",
+      updatedAt: NOW - 10_000,
+    });
+    insertMessage({
+      id: "msg-older",
+      conversationId: "conv-older",
+      role: "user",
+      content: "Older conversation",
+      createdAt: NOW - 10_000,
+    });
+
+    insertConversation("conv-newer", {
+      dirtyTailMessageId: "msg-newer",
+      updatedAt: NOW,
+    });
+    insertMessage({
+      id: "msg-newer",
+      conversationId: "conv-newer",
+      role: "user",
+      content: "Newer conversation",
+      createdAt: NOW,
+    });
+
+    insertConversation("conv-target", { updatedAt: NOW + 5000 });
+
+    mockReducerResult = makeReducerResult();
+
+    // Even though two are dirty, we only reduce one per switch.
+    // The function picks the earliest (by updatedAt ASC).
+    const result = await reduceBeforeSwitch("conv-target");
+
+    // Should pick the oldest dirty conversation
+    expect(result).toBe("conv-older");
+    expect(reducerCallCount).toBe(1);
+    expect(lastReducerInput?.conversationId).toBe("conv-older");
+  });
+});
+
+describe("reduceBeforeSwitch — error handling", () => {
+  test("returns null and continues when reducer throws", async () => {
+    insertConversation("conv-prev", {
+      dirtyTailMessageId: "msg-1",
+      updatedAt: NOW,
+    });
+    insertMessage({
+      id: "msg-1",
+      conversationId: "conv-prev",
+      role: "user",
+      content: "Hello",
+      createdAt: NOW,
+    });
+    insertConversation("conv-target", { updatedAt: NOW + 5000 });
+
+    // Override mock to throw
+    mock.module("../memory/reducer.js", () => ({
+      runReducer: async () => {
+        reducerCallCount++;
+        throw new Error("Provider timeout");
+      },
+    }));
+
+    const result = await reduceBeforeSwitch("conv-target");
+
+    // Should return null (graceful failure, don't block the switch)
+    expect(result).toBeNull();
+
+    // Checkpoint should NOT advance
+    const conv = getRawConversation("conv-prev");
+    expect(conv.memory_reduced_through_message_id).toBeNull();
+    expect(conv.memory_dirty_tail_since_message_id).toBe("msg-1");
+
+    // Restore normal mock for subsequent tests
+    mock.module("../memory/reducer.js", () => ({
+      runReducer: async (input: ReducerPromptInput) => {
+        lastReducerInput = input;
+        reducerCallCount++;
+        return mockReducerResult;
+      },
+    }));
+  });
+});

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -23,6 +23,7 @@ import {
   queueGenerateConversationTitle,
   UNTITLED_FALLBACK,
 } from "../../memory/conversation-title-service.js";
+import { reduceBeforeSwitch } from "../../memory/reducer-scheduler.js";
 import * as pendingInteractions from "../../runtime/pending-interactions.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import { truncate } from "../../util/truncate.js";
@@ -233,6 +234,12 @@ export async function handleConversationCreate(
     conversationType: normalizeConversationType(conversation.conversationType),
   });
 
+  // Reduce the previous dirty conversation before processing the initial
+  // message so its memory is fresh for the next read.
+  if (msg.initialMessage) {
+    await reduceBeforeSwitch(conversation.id);
+  }
+
   // Auto-send the initial message if provided, kick-starting the skill.
   if (msg.initialMessage) {
     // Queue title generation eagerly — some processMessage paths (guardian
@@ -342,6 +349,10 @@ export async function switchConversation(
   if (!conversation) {
     return null;
   }
+
+  // Reduce the previous dirty conversation before switching so its memory
+  // is fresh for the next read.
+  await reduceBeforeSwitch(conversationId);
 
   // If the target conversation is headless-locked (actively executing a task run),
   // skip rebinding so tool confirmations stay suppressed.

--- a/assistant/src/memory/reducer-scheduler.ts
+++ b/assistant/src/memory/reducer-scheduler.ts
@@ -1,0 +1,242 @@
+/**
+ * Reducer scheduler — synchronous pre-switch/create reduction of the most
+ * recently updated dirty conversation.
+ *
+ * When the user switches conversations or starts a new one, we want the
+ * *previous* conversation's memory to be reduced before the next memory
+ * read. This module exposes {@link reduceBeforeSwitch} which:
+ *
+ *   1. Finds the single most recently updated dirty conversation (excluding
+ *      the target conversation).
+ *   2. Runs the same reduction pipeline the background job uses (load
+ *      unreduced messages, call {@link runReducer}, apply via
+ *      {@link applyReducerResult}).
+ *   3. Awaits the result so the caller can proceed knowing memory is fresh.
+ *
+ * If no eligible dirty conversation exists, the function returns immediately.
+ */
+
+import { and, asc, eq, gte, isNotNull, ne } from "drizzle-orm";
+
+import { getLogger } from "../util/logger.js";
+import { type ConversationRow, getConversation } from "./conversation-crud.js";
+import { getDb } from "./db.js";
+import { type ReducerPromptInput, runReducer } from "./reducer.js";
+import {
+  applyReducerResult,
+  getActiveOpenLoops,
+  getActiveTimeContexts,
+} from "./reducer-store.js";
+import { EMPTY_REDUCER_RESULT } from "./reducer-types.js";
+import { conversations, messages } from "./schema.js";
+
+const log = getLogger("reducer-scheduler");
+
+// ── Internal helpers ────────────────────────────────────────────────
+
+interface MessageRow {
+  id: string;
+  role: string;
+  content: string;
+  createdAt: number;
+}
+
+/**
+ * Find the single most recently updated dirty conversation, excluding
+ * the target conversation. Returns the conversation ID or null if none.
+ */
+export function findMostRecentDirtyConversation(
+  excludeConversationId: string,
+): string | null {
+  const db = getDb();
+  const row = db
+    .select({ id: conversations.id })
+    .from(conversations)
+    .where(
+      and(
+        isNotNull(conversations.memoryDirtyTailSinceMessageId),
+        ne(conversations.id, excludeConversationId),
+      ),
+    )
+    .orderBy(conversations.updatedAt)
+    .limit(1)
+    .get();
+
+  return row?.id ?? null;
+}
+
+/**
+ * Load messages from `dirtyTailMessageId` onward (inclusive), ordered by
+ * createdAt ascending.
+ */
+function loadUnreducedMessages(
+  conversationId: string,
+  dirtyTailMessageId: string,
+): MessageRow[] {
+  const db = getDb();
+
+  const tailMessage = db
+    .select({ createdAt: messages.createdAt })
+    .from(messages)
+    .where(eq(messages.id, dirtyTailMessageId))
+    .get();
+
+  if (!tailMessage) {
+    return [];
+  }
+
+  return db
+    .select({
+      id: messages.id,
+      role: messages.role,
+      content: messages.content,
+      createdAt: messages.createdAt,
+    })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, conversationId),
+        gte(messages.createdAt, tailMessage.createdAt),
+      ),
+    )
+    .orderBy(asc(messages.createdAt))
+    .all();
+}
+
+/**
+ * Build the `newMessages` array for the reducer input, optionally
+ * prepending the conversation's contextSummary as a synthetic system message.
+ */
+function buildNewMessages(
+  conversation: ConversationRow,
+  unreducedMessages: MessageRow[],
+): Array<{ role: string; content: string }> {
+  const result: Array<{ role: string; content: string }> = [];
+
+  if (conversation.contextSummary) {
+    result.push({
+      role: "system",
+      content: `[Prior context summary] ${conversation.contextSummary}`,
+    });
+  }
+
+  for (const msg of unreducedMessages) {
+    result.push({ role: msg.role, content: msg.content });
+  }
+
+  return result;
+}
+
+// ── Public API ──────────────────────────────────────────────────────
+
+/**
+ * Reduce the most recently updated dirty conversation (excluding
+ * `targetConversationId`) before a conversation switch or create.
+ *
+ * This runs the full reduction pipeline synchronously (awaiting the
+ * provider call) so the caller can proceed knowing memory is fresh.
+ *
+ * Returns the conversation ID that was reduced, or null if none were eligible.
+ */
+export async function reduceBeforeSwitch(
+  targetConversationId: string,
+): Promise<string | null> {
+  const dirtyConversationId =
+    findMostRecentDirtyConversation(targetConversationId);
+
+  if (!dirtyConversationId) {
+    return null;
+  }
+
+  const conversation = getConversation(dirtyConversationId);
+  if (!conversation) {
+    return null;
+  }
+
+  const dirtyTailMessageId = conversation.memoryDirtyTailSinceMessageId;
+  if (!dirtyTailMessageId) {
+    return null;
+  }
+
+  // ── Load unreduced messages ──────────────────────────────────
+  const unreducedMessages = loadUnreducedMessages(
+    dirtyConversationId,
+    dirtyTailMessageId,
+  );
+
+  if (unreducedMessages.length === 0) {
+    log.debug(
+      { conversationId: dirtyConversationId, dirtyTailMessageId },
+      "No messages found from dirty tail — nothing to reduce on switch",
+    );
+    return null;
+  }
+
+  // ── Load active brief-state context ──────────────────────────
+  const scopeId = conversation.memoryScopeId;
+  const now = Date.now();
+
+  const existingTimeContexts = getActiveTimeContexts(scopeId, now);
+  const existingOpenLoops = getActiveOpenLoops(scopeId);
+
+  // ── Build reducer input ──────────────────────────────────────
+  const newMessages = buildNewMessages(conversation, unreducedMessages);
+
+  const reducerInput: ReducerPromptInput = {
+    conversationId: dirtyConversationId,
+    newMessages,
+    existingTimeContexts: existingTimeContexts.map((tc) => ({
+      id: tc.id,
+      summary: tc.summary,
+    })),
+    existingOpenLoops: existingOpenLoops.map((ol) => ({
+      id: ol.id,
+      summary: ol.summary,
+      status: ol.status,
+    })),
+    nowMs: now,
+    scopeId,
+  };
+
+  // ── Run the reducer ──────────────────────────────────────────
+  try {
+    const result = await runReducer(reducerInput);
+
+    if (result === EMPTY_REDUCER_RESULT) {
+      log.debug(
+        { conversationId: dirtyConversationId },
+        "Reducer returned empty result on switch — not advancing checkpoint",
+      );
+      return null;
+    }
+
+    // ── Apply result transactionally ───────────────────────────
+    const lastMessage = unreducedMessages[unreducedMessages.length - 1];
+    applyReducerResult({
+      result,
+      conversationId: dirtyConversationId,
+      scopeId,
+      reducedThroughMessageId: lastMessage.id,
+      now,
+    });
+
+    log.info(
+      {
+        conversationId: dirtyConversationId,
+        reducedThroughMessageId: lastMessage.id,
+        messageCount: unreducedMessages.length,
+        timeContextOps: result.timeContexts.length,
+        openLoopOps: result.openLoops.length,
+      },
+      "Pre-switch memory reduction completed",
+    );
+
+    return dirtyConversationId;
+  } catch (err) {
+    log.warn(
+      { err, conversationId: dirtyConversationId },
+      "Pre-switch memory reduction failed — continuing with switch",
+    );
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Add reducer-scheduler.ts with synchronous helper to reduce most recent dirty conversation
- Wire into conversation switch and create handlers
- Skip when no eligible dirty conversation or target is already the dirty one
- Add tests for switch, create, most-recent selection, and no-op behavior

Part of plan: simplified-memory-v1.md (PR 17 of 23)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
