### PR TITLE
feat: send device_id instead of installation_id in telemetry payload

### DIFF
--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -193,7 +193,7 @@ export class UsageTelemetryReporter {
       const organizationId = getPlatformOrganizationId() || undefined;
       const userId = getPlatformUserId() || undefined;
       const payload = {
-        installation_id: getDeviceId(),
+        device_id: getDeviceId(),
         assistant_id: assistantId,
         app_version: APP_VERSION,
         ...(organizationId ? { organization_id: organizationId } : {}),


### PR DESCRIPTION
## Summary
- Rename `installation_id` to `device_id` in the telemetry ingest request payload, aligning the field name with the underlying `getDeviceId()` function
- The platform API accepts both field names for backwards compatibility (platform-side change shipped in vellum-ai/vellum-assistant-platform#2690)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
