### PR TITLE
feat: add required activity field to file tools for human-friendly status

### DIFF
--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -38,8 +38,13 @@ class FileEditTool implements Tool {
             description:
               "Replace all occurrences of old_string instead of requiring a unique match (default: false)",
           },
+          activity: {
+            type: "string",
+            description:
+              "Brief non-technical explanation of what you are doing and why, shown to the user as a status update.",
+          },
         },
-        required: ["path", "old_string", "new_string"],
+        required: ["path", "old_string", "new_string", "activity"],
       },
     };
   }

--- a/assistant/src/tools/filesystem/read.ts
+++ b/assistant/src/tools/filesystem/read.ts
@@ -38,8 +38,13 @@ class FileReadTool implements Tool {
             type: "number",
             description: "Maximum number of lines to read",
           },
+          activity: {
+            type: "string",
+            description:
+              "Brief non-technical explanation of what you are doing and why, shown to the user as a status update.",
+          },
         },
-        required: ["path"],
+        required: ["path", "activity"],
       },
     };
   }

--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -28,8 +28,13 @@ class FileWriteTool implements Tool {
             type: "string",
             description: "The content to write to the file",
           },
+          activity: {
+            type: "string",
+            description:
+              "Brief non-technical explanation of what you are doing and why, shown to the user as a status update.",
+          },
         },
-        required: ["path", "content"],
+        required: ["path", "content", "activity"],
       },
     };
   }


### PR DESCRIPTION
## Summary
- Added required `activity` field to `file_write`, `file_read`, and `file_edit` tool schemas
- The LLM must now provide a brief non-technical description of what it's doing (e.g., "Designing the hero section layout") with every file operation
- The client already extracts `activity` into `reasonDescription` and displays it — no client changes needed

Closes JARVIS-244

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19683" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
