### PR TITLE
feat: add quiet mode for scheduled job completion notifications

### DIFF
--- a/assistant/src/__tests__/db-schedule-syntax-migration.test.ts
+++ b/assistant/src/__tests__/db-schedule-syntax-migration.test.ts
@@ -41,6 +41,7 @@ describe("schedule_syntax column migration", () => {
         routing_intent TEXT NOT NULL DEFAULT 'all_channels',
         routing_hints_json TEXT NOT NULL DEFAULT '{}',
         status TEXT NOT NULL DEFAULT 'active',
+        quiet INTEGER NOT NULL DEFAULT 0,
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
       )
@@ -96,6 +97,7 @@ describe("schedule_syntax column migration", () => {
         routing_intent TEXT NOT NULL DEFAULT 'all_channels',
         routing_hints_json TEXT NOT NULL DEFAULT '{}',
         status TEXT NOT NULL DEFAULT 'active',
+        quiet INTEGER NOT NULL DEFAULT 0,
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
       )
@@ -145,6 +147,7 @@ describe("schedule_syntax column migration", () => {
         routing_intent TEXT NOT NULL DEFAULT 'all_channels',
         routing_hints_json TEXT NOT NULL DEFAULT '{}',
         status TEXT NOT NULL DEFAULT 'active',
+        quiet INTEGER NOT NULL DEFAULT 0,
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
       )

--- a/assistant/src/config/bundled-skills/schedule/TOOLS.json
+++ b/assistant/src/config/bundled-skills/schedule/TOOLS.json
@@ -52,6 +52,10 @@
             "type": "object",
             "description": "Additional routing metadata (e.g. preferred channel identifiers)"
           },
+          "quiet": {
+            "type": "boolean",
+            "description": "When true, suppress completion notifications for this schedule. The job still runs and produces output, but no notification or conversation message is sent on completion. Useful for high-frequency recurring jobs that report findings separately. Defaults to false."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -138,6 +142,10 @@
           "routing_hints": {
             "type": "object",
             "description": "Additional routing metadata (e.g. preferred channel identifiers)"
+          },
+          "quiet": {
+            "type": "boolean",
+            "description": "When true, suppress completion notifications for this schedule. Useful for high-frequency jobs that report findings separately."
           },
           "activity": {
             "type": "string",

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -111,6 +111,7 @@ import {
   migrateRenameVerificationTable,
   migrateRenameVoiceToPhone,
   migrateScheduleOneShotRouting,
+  migrateScheduleQuietFlag,
   migrateSchemaIndexesAndColumns,
   migrateUsageDashboardIndexes,
   migrateVoiceInviteColumns,
@@ -495,6 +496,9 @@ export function initializeDb(): void {
 
   // 87. Add memory reducer checkpoint columns to conversations
   migrateMemoryReducerCheckpoints(database);
+
+  // 88. Add quiet flag to schedule jobs
+  migrateScheduleQuietFlag(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/188-schedule-quiet-flag.ts
+++ b/assistant/src/memory/migrations/188-schedule-quiet-flag.ts
@@ -1,0 +1,13 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateScheduleQuietFlag(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  try {
+    raw.exec(
+      `ALTER TABLE cron_jobs ADD COLUMN quiet INTEGER NOT NULL DEFAULT 0`,
+    );
+  } catch {
+    // Column already exists — nothing to do.
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -129,6 +129,7 @@ export { migrateLlmRequestLogProvider } from "./184-llm-request-log-provider.js"
 export { migrateMemoryBriefState } from "./185-memory-brief-state.js";
 export { migrateMemoryArchiveTables } from "./186-memory-archive.js";
 export { migrateMemoryReducerCheckpoints } from "./187-memory-reducer-checkpoints.js";
+export { migrateScheduleQuietFlag } from "./188-schedule-quiet-flag.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -24,6 +24,7 @@ export const cronJobs = sqliteTable("cron_jobs", {
   routingIntent: text("routing_intent").notNull().default("all_channels"), // 'single_channel' | 'multi_channel' | 'all_channels'
   routingHintsJson: text("routing_hints_json").notNull().default("{}"),
   status: text("status").notNull().default("active"), // 'active' | 'firing' | 'fired' | 'cancelled'
+  quiet: integer("quiet", { mode: "boolean" }).notNull().default(false), // suppress completion notifications
   createdAt: integer("created_at").notNull(),
   updatedAt: integer("updated_at").notNull(),
 });

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -35,6 +35,7 @@ export interface ScheduleJob {
   mode: ScheduleMode;
   routingIntent: RoutingIntent;
   routingHints: Record<string, unknown>;
+  quiet: boolean;
   status: ScheduleStatus;
   createdAt: number;
   updatedAt: number;
@@ -91,6 +92,7 @@ export function createSchedule(params: {
   mode?: ScheduleMode;
   routingIntent?: RoutingIntent;
   routingHints?: Record<string, unknown>;
+  quiet?: boolean;
 }): ScheduleJob {
   const expression = params.expression ?? params.cronExpression ?? null;
   const isOneShot = expression == null;
@@ -118,6 +120,7 @@ export function createSchedule(params: {
   const mode = params.mode ?? "execute";
   const routingIntent = params.routingIntent ?? "all_channels";
   const routingHints = params.routingHints ?? {};
+  const quiet = params.quiet ?? false;
 
   let nextRunAt: number;
   if (isOneShot) {
@@ -144,6 +147,7 @@ export function createSchedule(params: {
     mode,
     routingIntent,
     routingHintsJson: JSON.stringify(routingHints),
+    quiet,
     status: "active" as ScheduleStatus,
     createdAt: now,
     updatedAt: now,
@@ -236,6 +240,7 @@ export function updateSchedule(
     mode?: ScheduleMode;
     routingIntent?: RoutingIntent;
     routingHints?: Record<string, unknown>;
+    quiet?: boolean;
   },
 ): ScheduleJob | null {
   const db = getDb();
@@ -290,6 +295,7 @@ export function updateSchedule(
     set.routingIntent = updates.routingIntent;
   if (updates.routingHints !== undefined)
     set.routingHintsJson = JSON.stringify(updates.routingHints);
+  if (updates.quiet !== undefined) set.quiet = updates.quiet;
 
   // Recompute nextRunAt if schedule timing may have changed (only for recurring)
   if (
@@ -771,6 +777,7 @@ function parseJobRow(row: typeof scheduleJobs.$inferSelect): ScheduleJob {
     mode: (row.mode ?? "execute") as ScheduleMode,
     routingIntent: (row.routingIntent ?? "all_channels") as RoutingIntent,
     routingHints: safeParseJson(row.routingHintsJson),
+    quiet: row.quiet ?? false,
     status: (row.status ?? "active") as ScheduleStatus,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -206,7 +206,9 @@ async function runScheduleOnce(
           if (isOneShot) failOneShot(job.id);
         } else {
           completeScheduleRun(runId, { status: "ok" });
-          notifySchedule({ id: job.id, name: job.name });
+          if (!job.quiet) {
+            notifySchedule({ id: job.id, name: job.name });
+          }
           if (isOneShot) completeOneShot(job.id);
         }
         processed += 1;
@@ -278,7 +280,9 @@ async function runScheduleOnce(
         trustClass: "guardian",
       });
       completeScheduleRun(runId, { status: "ok" });
-      notifySchedule({ id: job.id, name: job.name });
+      if (!job.quiet) {
+        notifySchedule({ id: job.id, name: job.name });
+      }
       if (isOneShot) completeOneShot(job.id);
       processed += 1;
     } catch (err) {

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -41,6 +41,7 @@ export async function executeScheduleCreate(
   const routingHints = input.routing_hints as
     | Record<string, unknown>
     | undefined;
+  const quiet = (input.quiet as boolean) ?? false;
 
   if (!name || typeof name !== "string") {
     return {
@@ -112,6 +113,7 @@ export async function executeScheduleCreate(
         mode,
         routingIntent: routingIntent as RoutingIntent | undefined,
         routingHints,
+        quiet,
       });
 
       const fireDate = formatLocalDate(job.nextRunAt);
@@ -187,6 +189,7 @@ export async function executeScheduleCreate(
       mode,
       routingIntent: routingIntent as RoutingIntent | undefined,
       routingHints,
+      quiet,
     });
 
     const scheduleDescription =

--- a/assistant/src/tools/schedule/list.ts
+++ b/assistant/src/tools/schedule/list.ts
@@ -62,7 +62,11 @@ export async function executeScheduleList(
       );
     }
 
-    lines.push(`  Enabled: ${job.enabled}`, `  Message: ${job.message}`);
+    lines.push(
+      `  Enabled: ${job.enabled}`,
+      `  Quiet: ${job.quiet}`,
+      `  Message: ${job.message}`,
+    );
 
     if (!oneShot) {
       lines.push(`  Next run: ${formatLocalDate(job.nextRunAt)}`);

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -97,6 +97,11 @@ export async function executeScheduleUpdate(
     updates.routingHints = input.routing_hints;
   }
 
+  // Quiet mode
+  if (input.quiet !== undefined) {
+    updates.quiet = input.quiet;
+  }
+
   // Auto-detect syntax when expression changes without explicit syntax
   if (input.expression !== undefined || input.syntax !== undefined) {
     const resolved = normalizeScheduleSyntax({
@@ -159,6 +164,7 @@ export async function executeScheduleUpdate(
         mode?: ScheduleMode;
         routingIntent?: RoutingIntent;
         routingHints?: Record<string, unknown>;
+        quiet?: boolean;
       },
     );
 


### PR DESCRIPTION
## Summary
- Add a `quiet` flag to schedules that suppresses completion notifications when set to true
- Jobs still run and produce output, but no notification or conversation message is sent on success
- Useful for high-frequency recurring jobs (e.g. Slack scan every 15 min) that report findings separately

## Changes
- Add `quiet` column to `cron_jobs` table (migration 188)
- Gate `notifySchedule` calls in scheduler on `!job.quiet`
- Expose `quiet` in `schedule_create` and `schedule_update` tool schemas
- Show `quiet` status in `schedule_list` detail view

## Test plan
- [ ] Create a schedule with `quiet: true` — verify no completion notification
- [ ] Create a schedule with `quiet: false` (default) — verify notification still fires
- [ ] Update existing schedule to set `quiet: true` — verify notification stops
- [ ] `schedule_list` detail view shows `Quiet: true/false`

JARVIS-264

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
