### PR TITLE
fix: correct tool result fixture typing

### DIFF
--- a/assistant/src/__tests__/simplified-memory-runtime.test.ts
+++ b/assistant/src/__tests__/simplified-memory-runtime.test.ts
@@ -594,7 +594,7 @@ describe("Simplified Memory Runtime", () => {
           {
             type: "tool_result",
             tool_use_id: "tool-1",
-            content: [{ type: "text", text: "tool output" }],
+            content: "tool output",
           },
         ],
       };


### PR DESCRIPTION
## Summary
- fix the simplified memory runtime test fixture to use string tool-result content
- align the fixture with the provider content type expected by TypeScript

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23311692767/job/67800430840
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
