### PR TITLE
feat: backfill simplified memory and enable it by default

### DIFF
--- a/assistant/docs/architecture/memory.md
+++ b/assistant/docs/architecture/memory.md
@@ -2,6 +2,111 @@
 
 Assistant memory and context-injection architecture details.
 
+## Simplified Memory System (Default)
+
+The simplified memory system replaces the legacy item/tier/staleness model with a two-layer architecture: a **brief** (time-relevant context + open loops) plus **archive recall** (observations, chunks, episodes). It is enabled by default via `memory.simplified.enabled: true`.
+
+### Architecture Overview
+
+```mermaid
+graph TB
+    subgraph "Write Path (Simplified)"
+        MSG["Incoming Message"] --> REDUCER["Memory Reducer<br/>(LLM-backed, delayed)"]
+        REDUCER --> TC["time_contexts<br/>(brief state)"]
+        REDUCER --> OL["open_loops<br/>(brief state)"]
+        REDUCER --> OBS_R["Archive Observations<br/>(reducer output)"]
+        REDUCER --> EP_R["Archive Episodes<br/>(reducer output)"]
+
+        MSG --> INDEXER["Dual-Write Indexer"]
+        INDEXER --> OBS["memory_observations"]
+        INDEXER --> CHK["memory_chunks<br/>(content-hash deduped)"]
+
+        COMPACT["Context Compaction"] --> EP["memory_episodes"]
+    end
+
+    subgraph "Read Path (Simplified)"
+        TURN["User Turn"] --> BRIEF["Memory Brief Compiler"]
+        BRIEF --> TC
+        BRIEF --> OL
+        BRIEF --> BRIEF_OUT["&lt;memory_brief&gt;<br/>Time contexts + Open loops"]
+
+        TURN --> RECALL_GATE["Archive Recall Gate<br/>(keyword + pattern match)"]
+        RECALL_GATE --> PREFETCH["Prefetch<br/>(episodes + observations)"]
+        RECALL_GATE --> DEEP["Deeper Recall<br/>(episodes + observations + chunks)"]
+        DEEP --> RECALL_OUT["&lt;supporting_recall&gt;<br/>Source-linked bullets"]
+
+        BRIEF_OUT --> INJECT["Runtime Injection<br/>(prepend to user message)"]
+        RECALL_OUT --> INJECT
+    end
+
+    subgraph "Memory Tools (Simplified)"
+        SAVE["memory_save"] --> OBS
+        RECALL_TOOL["memory_recall"] --> RECALL_GATE
+    end
+```
+
+### Tables
+
+| Table                 | Purpose                                         | Write source                                            |
+| --------------------- | ----------------------------------------------- | ------------------------------------------------------- |
+| `time_contexts`       | Bounded temporal windows for the brief          | Reducer                                                 |
+| `open_loops`          | Unresolved follow-up items for the brief        | Reducer                                                 |
+| `memory_observations` | Raw factual statements from conversation turns  | Indexer dual-write, reducer, memory_save tool, backfill |
+| `memory_chunks`       | Deduplicated content units for embedding/recall | Derived from observations, content-hash deduped         |
+| `memory_episodes`     | Narrative summaries of interaction spans        | Compaction, reducer, backfill                           |
+
+### Reducer
+
+The memory reducer is a provider-backed (LLM) background process that analyzes unreduced conversation turns and produces structured CRUD operations for brief-state tables and archive candidates. It runs on a delay after conversation idle or switch, scheduled via the `reduce_conversation_memory` job. The reducer is side-effect-free; results are applied transactionally via `applyReducerResult`.
+
+### Brief
+
+The memory brief is compiled fresh on every turn from active `time_contexts` and `open_loops`. It is rendered as `<memory_brief>` XML and injected as a text block prepended to the user message. Empty sections are omitted.
+
+### Archive Recall
+
+Archive recall runs when the user's turn triggers a recall gate (past-reference language, analogy/debugging patterns, or strong prefetch hits). It queries episodes, observations, and chunks via keyword matching and returns up to 3 source-linked bullets in `<supporting_recall>`. No recall tag is emitted when results are empty.
+
+### Backfill
+
+Existing users have legacy data in `memory_segments`, `memory_summaries`, and `memory_items`. The `backfill_simplified_memory` job migrates this data into the simplified tables:
+
+- `memory_segments` -> `memory_observations` + `memory_chunks`
+- `memory_summaries` -> `memory_episodes`
+- Active, high-confidence `memory_items` -> `memory_observations` + `memory_chunks`, with unambiguous items also mapped to `time_contexts` or `open_loops`
+
+The backfill is idempotent (content-hash dedup + checkpoint tracking), processes in batches of 200, and self-enqueues continuation jobs for large datasets.
+
+### Rollback Posture
+
+The legacy memory system remains fully available as a short-lived rollback path:
+
+- **Legacy tables are preserved**: `memory_segments`, `memory_items`, `memory_summaries`, and `memory_item_sources` remain in the schema and continue to receive writes from the legacy indexer/extraction pipeline.
+- **Flag-gated**: Setting `memory.simplified.enabled: false` reverts to the legacy item/tier/staleness model for both read and write paths.
+- **Memory tools**: `memory_save` and `memory_recall` check the flag at call time and route to the appropriate path (simplified observations or legacy items).
+- **No data loss**: The backfill copies data without deleting legacy rows. Both systems can coexist.
+
+### Key Files
+
+| File                                                              | Role                                             |
+| ----------------------------------------------------------------- | ------------------------------------------------ |
+| `assistant/src/config/schemas/memory-simplified.ts`               | Config schema with `enabled: true` default       |
+| `assistant/src/memory/reducer.ts`                                 | Provider-backed reducer (LLM call + parse)       |
+| `assistant/src/memory/reducer-store.ts`                           | Transactional result application                 |
+| `assistant/src/memory/reducer-scheduler.ts`                       | Idle-delay and conversation-switch scheduling    |
+| `assistant/src/memory/archive-store.ts`                           | Observation/chunk/episode write helpers          |
+| `assistant/src/memory/archive-recall.ts`                          | Prefetch + deeper recall over archive tables     |
+| `assistant/src/memory/brief.ts`                                   | Brief composer (time contexts + open loops)      |
+| `assistant/src/memory/job-handlers/backfill-simplified-memory.ts` | Legacy data migration handler                    |
+| `assistant/src/tools/memory/handlers.ts`                          | Memory tool handlers (simplified/legacy routing) |
+| `assistant/src/__tests__/simplified-memory-e2e.test.ts`           | End-to-end test suite                            |
+
+---
+
+## Legacy Memory System — Daemon Data Flow
+
+> **Note**: The legacy system below is retained as rollback support. New installations use the simplified system by default.
+
 ## Memory System — Daemon Data Flow
 
 ```mermaid

--- a/assistant/src/__tests__/memory-simplified-config.test.ts
+++ b/assistant/src/__tests__/memory-simplified-config.test.ts
@@ -83,7 +83,7 @@ describe("MemorySimplifiedConfigSchema", () => {
   test("parses empty object with all defaults", () => {
     const result = MemorySimplifiedConfigSchema.parse({});
     expect(result).toEqual({
-      enabled: false,
+      enabled: true,
       brief: { maxTokens: 4000 },
       reducer: { idleDelayMs: 30_000, switchWaitMs: 5_000 },
       archiveRecall: { maxSnippets: 10 },
@@ -175,7 +175,7 @@ describe("AssistantConfigSchema memory.simplified", () => {
   test("empty config exposes memory.simplified with defaults", () => {
     const result = AssistantConfigSchema.parse({});
     expect(result.memory.simplified).toEqual({
-      enabled: false,
+      enabled: true,
       brief: { maxTokens: 4000 },
       reducer: { idleDelayMs: 30_000, switchWaitMs: 5_000 },
       archiveRecall: { maxSnippets: 10 },
@@ -248,7 +248,7 @@ describe("loadConfig with memory.simplified", () => {
     writeConfig({});
     const config = loadConfig();
     expect(config.memory.simplified).toEqual({
-      enabled: false,
+      enabled: true,
       brief: { maxTokens: 4000 },
       reducer: { idleDelayMs: 30_000, switchWaitMs: 5_000 },
       archiveRecall: { maxSnippets: 10 },
@@ -258,7 +258,7 @@ describe("loadConfig with memory.simplified", () => {
   test("no config file loads cleanly with simplified defaults", () => {
     const config = loadConfig();
     expect(config.memory.simplified).toEqual({
-      enabled: false,
+      enabled: true,
       brief: { maxTokens: 4000 },
       reducer: { idleDelayMs: 30_000, switchWaitMs: 5_000 },
       archiveRecall: { maxSnippets: 10 },

--- a/assistant/src/__tests__/simplified-memory-e2e.test.ts
+++ b/assistant/src/__tests__/simplified-memory-e2e.test.ts
@@ -1,0 +1,666 @@
+/**
+ * End-to-end tests for the simplified memory system.
+ *
+ * Covers the must-have scenarios:
+ * 1. Backfill: legacy segments, summaries, and items migrate to simplified tables
+ * 2. Simplified memory is enabled by default after backfill
+ * 3. Memory tools use simplified path when enabled
+ * 4. Legacy tables remain available as rollback support
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "simplified-memory-e2e-test-"));
+const dbPath = join(testDir, "test.db");
+
+// ── Platform mock (must come before any module imports) ──────────────
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  getRootDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => dbPath,
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  truncateForLog: (value: string) => value,
+}));
+
+// Stub the Qdrant and embedding backends since we don't need vectors
+mock.module("../memory/qdrant-client.js", () => ({
+  getQdrantClient: () => ({
+    searchWithFilter: async () => [],
+    hybridSearch: async () => [],
+    upsertPoints: async () => {},
+    deletePoints: async () => {},
+    upsert: async () => {},
+  }),
+  initQdrantClient: () => {},
+}));
+
+mock.module("../memory/embedding-backend.js", () => ({
+  getMemoryBackendStatus: async () => ({
+    provider: null,
+    reason: "test-stub",
+  }),
+  embedWithBackend: async () => ({
+    vectors: [[]],
+    provider: "test",
+    model: "test",
+  }),
+  generateSparseEmbedding: () => undefined,
+  selectEmbeddingBackend: async () => null,
+}));
+
+mock.module("../memory/qdrant-circuit-breaker.js", () => ({
+  withQdrantBreaker: async (fn: () => Promise<unknown>) => fn(),
+  QdrantCircuitOpenError: class extends Error {},
+}));
+
+// ── Configurable config mock ────────────────────────────────────────
+
+import { DEFAULT_CONFIG } from "../config/defaults.js";
+import type { AssistantConfig } from "../config/types.js";
+
+let testConfig: AssistantConfig = {
+  ...DEFAULT_CONFIG,
+  memory: {
+    ...DEFAULT_CONFIG.memory,
+    enabled: true,
+    simplified: {
+      ...DEFAULT_CONFIG.memory.simplified,
+      enabled: true,
+    },
+  },
+};
+
+mock.module("../config/loader.js", () => ({
+  loadConfig: () => testConfig,
+  getConfig: () => testConfig,
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+// ── Now import modules under test ────────────────────────────────────
+
+import { v4 as uuid } from "uuid";
+
+import { insertObservation } from "../memory/archive-store.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { getSqlite } from "../memory/db-connection.js";
+import { backfillSimplifiedMemoryJob } from "../memory/job-handlers/backfill-simplified-memory.js";
+import type { MemoryJob } from "../memory/jobs-store.js";
+import { conversations, memoryItems, messages } from "../memory/schema.js";
+import {
+  handleMemoryRecall,
+  handleMemorySave,
+} from "../tools/memory/handlers.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function removeTestDbFiles(): void {
+  rmSync(dbPath, { force: true });
+  rmSync(`${dbPath}-shm`, { force: true });
+  rmSync(`${dbPath}-wal`, { force: true });
+}
+
+function getRawDb(): import("bun:sqlite").Database {
+  return getSqlite();
+}
+
+function makeJob(overrides: Partial<MemoryJob> = {}): MemoryJob {
+  return {
+    id: uuid(),
+    type: "backfill_simplified_memory",
+    payload: {},
+    status: "running",
+    attempts: 0,
+    deferrals: 0,
+    runAfter: 0,
+    lastError: null,
+    startedAt: Date.now(),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function createConversation(id: string, title: string | null = null): void {
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversations)
+    .values({
+      id,
+      title,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+let segmentIndexCounter = 0;
+
+function insertLegacySegment(opts: {
+  id: string;
+  messageId: string;
+  conversationId: string;
+  role: string;
+  text: string;
+  scopeId?: string;
+  segmentIndex?: number;
+}): void {
+  const now = Date.now();
+  const idx = opts.segmentIndex ?? segmentIndexCounter++;
+  getRawDb().run(
+    `INSERT INTO memory_segments (id, message_id, conversation_id, role, segment_index, text, token_estimate, scope_id, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      opts.id,
+      opts.messageId,
+      opts.conversationId,
+      opts.role,
+      idx,
+      opts.text,
+      Math.ceil(opts.text.length / 4),
+      opts.scopeId ?? "default",
+      now,
+      now,
+    ],
+  );
+}
+
+function insertLegacySummary(opts: {
+  id: string;
+  scope: string;
+  scopeKey: string;
+  summary: string;
+  scopeId?: string;
+  startAt?: number;
+  endAt?: number;
+}): void {
+  const now = Date.now();
+  getRawDb().run(
+    `INSERT INTO memory_summaries (id, scope, scope_key, summary, token_estimate, version, scope_id, start_at, end_at, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?)`,
+    [
+      opts.id,
+      opts.scope,
+      opts.scopeKey,
+      opts.summary,
+      Math.ceil(opts.summary.length / 4),
+      opts.scopeId ?? "default",
+      opts.startAt ?? now - 3600000,
+      opts.endAt ?? now,
+      now,
+      now,
+    ],
+  );
+}
+
+function insertLegacyItem(opts: {
+  id: string;
+  kind: string;
+  subject: string;
+  statement: string;
+  scopeId?: string;
+  confidence?: number;
+  status?: string;
+  validFrom?: number | null;
+  invalidAt?: number | null;
+}): void {
+  const now = Date.now();
+  getRawDb().run(
+    `INSERT INTO memory_items (id, kind, subject, statement, status, confidence, importance, fingerprint, verification_state, scope_id, first_seen_at, last_seen_at)
+     VALUES (?, ?, ?, ?, ?, ?, 0.8, ?, 'assistant_inferred', ?, ?, ?)`,
+    [
+      opts.id,
+      opts.kind,
+      opts.subject,
+      opts.statement,
+      opts.status ?? "active",
+      opts.confidence ?? 0.9,
+      `fp-${opts.id}`,
+      opts.scopeId ?? "default",
+      now,
+      now,
+    ],
+  );
+  // Set validFrom/invalidAt if provided
+  if (opts.validFrom != null || opts.invalidAt != null) {
+    getRawDb().run(
+      `UPDATE memory_items SET valid_from = ?, invalid_at = ? WHERE id = ?`,
+      [opts.validFrom ?? null, opts.invalidAt ?? null, opts.id],
+    );
+  }
+}
+
+function insertMessage(
+  id: string,
+  conversationId: string,
+  role: string = "user",
+  content: string = "test message",
+): void {
+  const db = getDb();
+  const now = Date.now();
+  db.insert(messages)
+    .values({
+      id,
+      conversationId,
+      role,
+      content,
+      createdAt: now,
+    })
+    .run();
+}
+
+function countRows(table: string): number {
+  const result = getRawDb()
+    .query<{ c: number }, []>(`SELECT COUNT(*) as c FROM ${table}`)
+    .get();
+  return result?.c ?? 0;
+}
+
+// ── Setup / Teardown ────────────────────────────────────────────────
+
+describe("Simplified Memory E2E", () => {
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    segmentIndexCounter = 0;
+    resetDb();
+    removeTestDbFiles();
+    initializeDb();
+    testConfig = {
+      ...DEFAULT_CONFIG,
+      memory: {
+        ...DEFAULT_CONFIG.memory,
+        enabled: true,
+        simplified: {
+          ...DEFAULT_CONFIG.memory.simplified,
+          enabled: true,
+        },
+      },
+    };
+  });
+
+  afterAll(() => {
+    resetDb();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  // ── 1. Backfill tests ──────────────────────────────────────────────
+
+  describe("backfill: legacy data migration", () => {
+    test("migrates legacy segments to observations and chunks", async () => {
+      const convId = uuid();
+      createConversation(convId);
+      const msgId = uuid();
+      insertMessage(msgId, convId, "user", "I like TypeScript");
+
+      insertLegacySegment({
+        id: "seg-1",
+        messageId: msgId,
+        conversationId: convId,
+        role: "user",
+        text: "I like TypeScript and prefer it over JavaScript",
+      });
+      insertLegacySegment({
+        id: "seg-2",
+        messageId: msgId,
+        conversationId: convId,
+        role: "user",
+        text: "My favorite editor is VS Code",
+      });
+
+      expect(countRows("memory_segments")).toBe(2);
+      expect(countRows("memory_observations")).toBe(0);
+
+      await backfillSimplifiedMemoryJob(makeJob());
+
+      // Segments should have been migrated to observations
+      expect(countRows("memory_observations")).toBeGreaterThanOrEqual(2);
+      // Chunks should have been created for each observation
+      expect(countRows("memory_chunks")).toBeGreaterThanOrEqual(2);
+      // Original segments remain untouched
+      expect(countRows("memory_segments")).toBe(2);
+    });
+
+    test("migrates legacy summaries to episodes", async () => {
+      const convId = uuid();
+      createConversation(convId);
+
+      insertLegacySummary({
+        id: "sum-1",
+        scope: "conversation",
+        scopeKey: convId,
+        summary: "User discussed TypeScript preferences and project setup",
+      });
+
+      expect(countRows("memory_summaries")).toBe(1);
+      expect(countRows("memory_episodes")).toBe(0);
+
+      await backfillSimplifiedMemoryJob(makeJob());
+
+      expect(countRows("memory_episodes")).toBeGreaterThanOrEqual(1);
+      // Original summaries remain untouched
+      expect(countRows("memory_summaries")).toBe(1);
+    });
+
+    test("migrates active legacy items to observations", async () => {
+      insertLegacyItem({
+        id: "item-1",
+        kind: "preference",
+        subject: "Editor",
+        statement: "Prefers VS Code with vim keybindings",
+      });
+      insertLegacyItem({
+        id: "item-2",
+        kind: "identity",
+        subject: "Name",
+        statement: "User's name is Alice",
+      });
+      // Low-confidence item should be skipped
+      insertLegacyItem({
+        id: "item-3",
+        kind: "event",
+        subject: "Meeting",
+        statement: "Had a meeting yesterday",
+        confidence: 0.3,
+      });
+
+      expect(countRows("memory_items")).toBe(3);
+      expect(countRows("memory_observations")).toBe(0);
+
+      await backfillSimplifiedMemoryJob(makeJob());
+
+      // Only the 2 active, high-confidence items should be migrated
+      expect(countRows("memory_observations")).toBeGreaterThanOrEqual(2);
+      // Original items remain untouched
+      expect(countRows("memory_items")).toBe(3);
+    });
+
+    test("backfill is idempotent — running twice does not duplicate", async () => {
+      const convId = uuid();
+      createConversation(convId);
+      const msgId = uuid();
+      insertMessage(msgId, convId, "user", "Hello");
+
+      insertLegacySegment({
+        id: "seg-idem-1",
+        messageId: msgId,
+        conversationId: convId,
+        role: "user",
+        text: "This is an idempotency test segment",
+      });
+
+      await backfillSimplifiedMemoryJob(makeJob());
+      const firstRunObservations = countRows("memory_observations");
+
+      // Run again — should not create duplicates because content-hash dedup
+      // and checkpoint tracking prevent it
+      await backfillSimplifiedMemoryJob(makeJob());
+      const secondRunObservations = countRows("memory_observations");
+
+      expect(secondRunObservations).toBe(firstRunObservations);
+    });
+
+    test("backfill skips non-conversation summaries", async () => {
+      insertLegacySummary({
+        id: "sum-skip-1",
+        scope: "weekly",
+        scopeKey: "2024-W01",
+        summary: "A weekly summary that does not link to a conversation",
+      });
+
+      await backfillSimplifiedMemoryJob(makeJob());
+
+      // Non-conversation summaries should be skipped (no episode created)
+      // The summary has scope "weekly" with a non-conversation-id scope_key
+      // so it should be skipped by the extractConversationId check.
+      // (Weekly summaries have no valid conversation to link to.)
+      expect(countRows("memory_episodes")).toBe(0);
+    });
+  });
+
+  // ── 2. Default flag state ─────────────────────────────────────────
+
+  describe("simplified memory enabled by default", () => {
+    test("config defaults to simplified.enabled = true", () => {
+      expect(testConfig.memory.simplified.enabled).toBe(true);
+    });
+
+    test("can be disabled for rollback via config override", () => {
+      testConfig = {
+        ...testConfig,
+        memory: {
+          ...testConfig.memory,
+          simplified: {
+            ...testConfig.memory.simplified,
+            enabled: false,
+          },
+        },
+      };
+      expect(testConfig.memory.simplified.enabled).toBe(false);
+    });
+  });
+
+  // ── 3. Memory tools use simplified path ────────────────────────────
+
+  describe("memory tools use simplified system when enabled", () => {
+    test("memory_save writes to observations when simplified is enabled", async () => {
+      const convId = uuid();
+      createConversation(convId);
+
+      const result = await handleMemorySave(
+        {
+          statement: "User prefers dark mode",
+          kind: "preference",
+          subject: "UI theme",
+        },
+        testConfig,
+        convId,
+        undefined,
+        "default",
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("Saved to memory");
+
+      // Should have written to observations, not memory_items
+      expect(countRows("memory_observations")).toBeGreaterThanOrEqual(1);
+    });
+
+    test("memory_save writes to memory_items when simplified is disabled", async () => {
+      testConfig = {
+        ...testConfig,
+        memory: {
+          ...testConfig.memory,
+          simplified: {
+            ...testConfig.memory.simplified,
+            enabled: false,
+          },
+        },
+      };
+
+      const convId = uuid();
+      createConversation(convId);
+
+      const result = await handleMemorySave(
+        {
+          statement: "User prefers light mode",
+          kind: "preference",
+          subject: "UI theme",
+        },
+        testConfig,
+        convId,
+        undefined,
+        "default",
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("Saved to memory");
+
+      // Should have written to legacy memory_items
+      expect(countRows("memory_items")).toBeGreaterThanOrEqual(1);
+    });
+
+    test("memory_recall uses archive recall when simplified is enabled", async () => {
+      // Insert some archive data that the recall can find
+      const convId = uuid();
+      createConversation(convId);
+
+      insertObservation({
+        conversationId: convId,
+        role: "user",
+        content:
+          "User mentioned that their favorite programming language is TypeScript",
+        scopeId: "default",
+        modality: "text",
+        source: "test",
+      });
+
+      const result = await handleMemoryRecall(
+        { query: "programming language TypeScript" },
+        testConfig,
+        "default",
+        convId,
+      );
+
+      expect(result.isError).toBe(false);
+      // The result should be valid JSON
+      const parsed = JSON.parse(result.content);
+      expect(parsed).toBeDefined();
+      expect(typeof parsed.text).toBe("string");
+      expect(typeof parsed.resultCount).toBe("number");
+    });
+  });
+
+  // ── 4. Legacy tables remain available ──────────────────────────────
+
+  describe("legacy tables remain for rollback", () => {
+    test("legacy memory_items table still exists and is writable", () => {
+      const db = getDb();
+      const now = Date.now();
+
+      // Write to the legacy table should succeed
+      db.insert(memoryItems)
+        .values({
+          id: uuid(),
+          kind: "preference",
+          subject: "Test",
+          statement: "Test statement",
+          status: "active",
+          confidence: 0.9,
+          importance: 0.8,
+          fingerprint: `fp-${uuid()}`,
+          verificationState: "assistant_inferred",
+          scopeId: "default",
+          firstSeenAt: now,
+          lastSeenAt: now,
+        })
+        .run();
+
+      expect(countRows("memory_items")).toBe(1);
+    });
+
+    test("legacy memory_segments table still exists and is writable", () => {
+      const convId = uuid();
+      createConversation(convId);
+      const msgId = uuid();
+      insertMessage(msgId, convId, "user", "test");
+
+      insertLegacySegment({
+        id: uuid(),
+        messageId: msgId,
+        conversationId: convId,
+        role: "user",
+        text: "Test legacy segment",
+      });
+
+      expect(countRows("memory_segments")).toBe(1);
+    });
+
+    test("legacy memory_summaries table still exists and is writable", () => {
+      const convId = uuid();
+      createConversation(convId);
+
+      insertLegacySummary({
+        id: uuid(),
+        scope: "conversation",
+        scopeKey: convId,
+        summary: "Test legacy summary",
+      });
+
+      expect(countRows("memory_summaries")).toBe(1);
+    });
+
+    test("switching to legacy mode by disabling simplified flag works", async () => {
+      // First save with simplified enabled
+      const convId = uuid();
+      createConversation(convId);
+
+      await handleMemorySave(
+        {
+          statement: "User likes coffee",
+          kind: "preference",
+          subject: "Beverage",
+        },
+        testConfig,
+        convId,
+        undefined,
+        "default",
+      );
+
+      const simplifiedObs = countRows("memory_observations");
+      expect(simplifiedObs).toBeGreaterThanOrEqual(1);
+
+      // Now disable simplified and save — should go to legacy table
+      testConfig = {
+        ...testConfig,
+        memory: {
+          ...testConfig.memory,
+          simplified: {
+            ...testConfig.memory.simplified,
+            enabled: false,
+          },
+        },
+      };
+
+      await handleMemorySave(
+        {
+          statement: "User likes tea",
+          kind: "preference",
+          subject: "Beverage",
+        },
+        testConfig,
+        convId,
+        undefined,
+        "default",
+      );
+
+      expect(countRows("memory_items")).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/assistant/src/config/schemas/memory-simplified.ts
+++ b/assistant/src/config/schemas/memory-simplified.ts
@@ -71,7 +71,7 @@ export const MemorySimplifiedConfigSchema = z
       .boolean({
         error: "memory.simplified.enabled must be a boolean",
       })
-      .default(false)
+      .default(true)
       .describe("Whether the simplified memory system is enabled"),
     brief: MemorySimplifiedBriefConfigSchema.default(
       MemorySimplifiedBriefConfigSchema.parse({}),

--- a/assistant/src/memory/job-handlers/backfill-simplified-memory.ts
+++ b/assistant/src/memory/job-handlers/backfill-simplified-memory.ts
@@ -1,0 +1,462 @@
+/**
+ * Backfill job handler: migrates legacy memory rows into the simplified memory
+ * system without deleting the old tables.
+ *
+ * Migration mapping:
+ *   - `memory_segments` -> `memory_chunks` (via `memory_observations`)
+ *   - `memory_summaries` -> `memory_episodes`
+ *   - Active/high-confidence `memory_items` -> `memory_observations`,
+ *     plus `time_contexts` or `open_loops` when the mapping is unambiguous.
+ *
+ * The handler is idempotent: content-hash deduplication on chunks and
+ * checkpoint tracking prevent double-writes on re-runs.
+ */
+
+import { eq } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import { estimateTextTokens } from "../../context/token-estimator.js";
+import { getLogger } from "../../util/logger.js";
+import {
+  computeChunkContentHash,
+  insertObservation,
+} from "../archive-store.js";
+import { getMemoryCheckpoint, setMemoryCheckpoint } from "../checkpoints.js";
+import { getDb, rawAll } from "../db.js";
+import type { MemoryJob } from "../jobs-store.js";
+import { enqueueMemoryJob } from "../jobs-store.js";
+import {
+  conversations,
+  memoryChunks,
+  memoryEpisodes,
+  memoryObservations,
+  openLoops,
+  timeContexts,
+} from "../schema.js";
+
+const log = getLogger("backfill-simplified-memory");
+
+/** Checkpoint keys for tracking backfill progress. */
+const CHECKPOINT_SEGMENTS = "simplified_backfill:segments:last_id";
+const CHECKPOINT_SUMMARIES = "simplified_backfill:summaries:last_id";
+const CHECKPOINT_ITEMS = "simplified_backfill:items:last_id";
+const CHECKPOINT_COMPLETE = "simplified_backfill:complete";
+
+/** Batch size for each migration pass. */
+const BATCH_SIZE = 200;
+
+// ── Legacy row types ──────────────────────────────────────────────────
+
+interface LegacySegment {
+  id: string;
+  message_id: string;
+  conversation_id: string;
+  role: string;
+  text: string;
+  token_estimate: number;
+  scope_id: string;
+  content_hash: string | null;
+  created_at: number;
+}
+
+interface LegacySummary {
+  id: string;
+  scope: string;
+  scope_key: string;
+  summary: string;
+  token_estimate: number;
+  scope_id: string;
+  start_at: number;
+  end_at: number;
+  created_at: number;
+}
+
+interface LegacyItem {
+  id: string;
+  kind: string;
+  subject: string;
+  statement: string;
+  status: string;
+  confidence: number;
+  scope_id: string;
+  first_seen_at: number;
+  last_seen_at: number;
+  valid_from: number | null;
+  invalid_at: number | null;
+}
+
+// ── Entry point ───────────────────────────────────────────────────────
+
+export async function backfillSimplifiedMemoryJob(
+  job: MemoryJob,
+): Promise<void> {
+  const force = job.payload.force === true;
+
+  if (!force) {
+    const complete = getMemoryCheckpoint(CHECKPOINT_COMPLETE);
+    if (complete === "true") {
+      log.debug("Simplified memory backfill already complete, skipping");
+      return;
+    }
+  }
+
+  if (force) {
+    // Reset all checkpoints so the backfill restarts from scratch
+    setMemoryCheckpoint(CHECKPOINT_SEGMENTS, "");
+    setMemoryCheckpoint(CHECKPOINT_SUMMARIES, "");
+    setMemoryCheckpoint(CHECKPOINT_ITEMS, "");
+    setMemoryCheckpoint(CHECKPOINT_COMPLETE, "false");
+  }
+
+  let hasMore = false;
+
+  // ── Phase 1: memory_segments -> memory_observations + memory_chunks
+  hasMore = migrateSegments();
+  if (hasMore) {
+    enqueueMemoryJob("backfill_simplified_memory", {});
+    return;
+  }
+
+  // ── Phase 2: memory_summaries -> memory_episodes
+  hasMore = migrateSummaries();
+  if (hasMore) {
+    enqueueMemoryJob("backfill_simplified_memory", {});
+    return;
+  }
+
+  // ── Phase 3: active memory_items -> memory_observations (+ brief-state)
+  hasMore = migrateItems();
+  if (hasMore) {
+    enqueueMemoryJob("backfill_simplified_memory", {});
+    return;
+  }
+
+  // All phases complete
+  setMemoryCheckpoint(CHECKPOINT_COMPLETE, "true");
+  log.info("Simplified memory backfill completed");
+}
+
+// ── Phase 1: Segments ─────────────────────────────────────────────────
+
+function migrateSegments(): boolean {
+  const lastId = getMemoryCheckpoint(CHECKPOINT_SEGMENTS) ?? "";
+
+  const segments = rawAll<LegacySegment>(
+    `SELECT id, message_id, conversation_id, role, text, token_estimate,
+            scope_id, content_hash, created_at
+     FROM memory_segments
+     WHERE id > ?
+     ORDER BY id ASC
+     LIMIT ?`,
+    lastId,
+    BATCH_SIZE,
+  );
+
+  if (segments.length === 0) return false;
+
+  for (const seg of segments) {
+    try {
+      // Insert as an observation — insertObservation handles chunk dedup
+      insertObservation({
+        conversationId: seg.conversation_id,
+        messageId: seg.message_id,
+        role: seg.role,
+        content: seg.text,
+        scopeId: seg.scope_id,
+        modality: "text",
+        source: "backfill:segment",
+      });
+    } catch (err) {
+      // Log and continue — individual failures should not block the batch
+      log.warn(
+        { err, segmentId: seg.id },
+        "Failed to migrate segment, skipping",
+      );
+    }
+  }
+
+  const lastSegment = segments[segments.length - 1];
+  setMemoryCheckpoint(CHECKPOINT_SEGMENTS, lastSegment.id);
+
+  log.debug(
+    { migrated: segments.length, lastId: lastSegment.id },
+    "Migrated segment batch",
+  );
+
+  return segments.length === BATCH_SIZE;
+}
+
+// ── Phase 2: Summaries ────────────────────────────────────────────────
+
+function migrateSummaries(): boolean {
+  const lastId = getMemoryCheckpoint(CHECKPOINT_SUMMARIES) ?? "";
+
+  const summaries = rawAll<LegacySummary>(
+    `SELECT id, scope, scope_key, summary, token_estimate, scope_id,
+            start_at, end_at, created_at
+     FROM memory_summaries
+     WHERE id > ?
+     ORDER BY id ASC
+     LIMIT ?`,
+    lastId,
+    BATCH_SIZE,
+  );
+
+  if (summaries.length === 0) return false;
+
+  const db = getDb();
+  const now = Date.now();
+
+  for (const sum of summaries) {
+    try {
+      // Derive a conversation ID from the scope_key if it looks like a conversation summary.
+      // scope_key format: "conversation:<conversationId>" or "<scope>:<key>"
+      const conversationId = extractConversationId(sum.scope, sum.scope_key);
+      if (!conversationId) {
+        log.debug(
+          { summaryId: sum.id, scope: sum.scope, scopeKey: sum.scope_key },
+          "Skipping non-conversation summary",
+        );
+        continue;
+      }
+
+      const episodeId = uuid();
+      const title = buildEpisodeTitle(sum.scope, sum.scope_key);
+
+      db.insert(memoryEpisodes)
+        .values({
+          id: episodeId,
+          scopeId: sum.scope_id,
+          conversationId,
+          title,
+          summary: sum.summary,
+          tokenEstimate: sum.token_estimate,
+          source: "backfill:summary",
+          startAt: sum.start_at,
+          endAt: sum.end_at,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .onConflictDoNothing()
+        .run();
+
+      // Enqueue embedding for the new episode
+      enqueueMemoryJob("embed_episode", { episodeId });
+    } catch (err) {
+      log.warn(
+        { err, summaryId: sum.id },
+        "Failed to migrate summary, skipping",
+      );
+    }
+  }
+
+  const lastSummary = summaries[summaries.length - 1];
+  setMemoryCheckpoint(CHECKPOINT_SUMMARIES, lastSummary.id);
+
+  log.debug(
+    { migrated: summaries.length, lastId: lastSummary.id },
+    "Migrated summary batch",
+  );
+
+  return summaries.length === BATCH_SIZE;
+}
+
+// ── Phase 3: Items ────────────────────────────────────────────────────
+
+/** Sentinel conversation ID for legacy items that have no conversation linkage. */
+const LEGACY_SENTINEL_CONVERSATION_ID = "__legacy_backfill__";
+
+/**
+ * Ensure the legacy sentinel conversation row exists. This is needed because
+ * memory_observations has a FK constraint on conversation_id.
+ */
+function ensureLegacySentinelConversation(): void {
+  const db = getDb();
+  const existing = db
+    .select({ id: conversations.id })
+    .from(conversations)
+    .where(eq(conversations.id, LEGACY_SENTINEL_CONVERSATION_ID))
+    .get();
+  if (existing) return;
+
+  const now = Date.now();
+  db.insert(conversations)
+    .values({
+      id: LEGACY_SENTINEL_CONVERSATION_ID,
+      title: "[Legacy Memory Backfill]",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function migrateItems(): boolean {
+  const lastId = getMemoryCheckpoint(CHECKPOINT_ITEMS) ?? "";
+
+  const items = rawAll<LegacyItem>(
+    `SELECT id, kind, subject, statement, status, confidence, scope_id,
+            first_seen_at, last_seen_at, valid_from, invalid_at
+     FROM memory_items
+     WHERE id > ?
+       AND status = 'active'
+       AND confidence >= 0.5
+       AND invalid_at IS NULL
+     ORDER BY id ASC
+     LIMIT ?`,
+    lastId,
+    BATCH_SIZE,
+  );
+
+  if (items.length === 0) return false;
+
+  // Ensure the sentinel conversation exists for items without conversation linkage
+  ensureLegacySentinelConversation();
+
+  const db = getDb();
+  const now = Date.now();
+
+  for (const item of items) {
+    try {
+      // Every active item becomes an observation
+      const observationId = uuid();
+      const observationContent = `[${item.kind}] ${item.subject}: ${item.statement}`;
+
+      db.insert(memoryObservations)
+        .values({
+          id: observationId,
+          scopeId: item.scope_id,
+          conversationId: LEGACY_SENTINEL_CONVERSATION_ID,
+          role: "user",
+          content: observationContent,
+          modality: "text",
+          source: "backfill:item",
+          createdAt: now,
+        })
+        .run();
+
+      // Create a chunk for the observation (with dedup)
+      const contentHash = computeChunkContentHash(
+        item.scope_id,
+        observationContent,
+      );
+      const chunkId = uuid();
+      const tokenEstimate = estimateTextTokens(observationContent);
+
+      db.insert(memoryChunks)
+        .values({
+          id: chunkId,
+          scopeId: item.scope_id,
+          observationId,
+          content: observationContent,
+          tokenEstimate,
+          contentHash,
+          createdAt: now,
+        })
+        .onConflictDoNothing({
+          target: [memoryChunks.scopeId, memoryChunks.contentHash],
+        })
+        .run();
+
+      // Enqueue embedding for the observation's chunk
+      enqueueMemoryJob("embed_chunk", { chunkId, scopeId: item.scope_id });
+
+      // ── Brief-state: map unambiguous items to time_contexts or open_loops
+      mapItemToBriefState(item, now);
+    } catch (err) {
+      log.warn({ err, itemId: item.id }, "Failed to migrate item, skipping");
+    }
+  }
+
+  const lastItem = items[items.length - 1];
+  setMemoryCheckpoint(CHECKPOINT_ITEMS, lastItem.id);
+
+  log.debug(
+    { migrated: items.length, lastId: lastItem.id },
+    "Migrated item batch",
+  );
+
+  return items.length === BATCH_SIZE;
+}
+
+// ── Brief-state mapping ───────────────────────────────────────────────
+
+/**
+ * Map a legacy memory item to `time_contexts` or `open_loops` when the
+ * mapping is unambiguous.
+ *
+ * - Items with `valid_from` and a future `invalid_at` -> time_context
+ * - `event` kind items with future timestamps -> open_loop
+ */
+function mapItemToBriefState(item: LegacyItem, now: number): void {
+  const db = getDb();
+
+  // Time-bounded items -> time_contexts
+  if (
+    item.valid_from != null &&
+    item.invalid_at != null &&
+    item.invalid_at > now
+  ) {
+    db.insert(timeContexts)
+      .values({
+        id: uuid(),
+        scopeId: item.scope_id,
+        summary: `${item.subject}: ${item.statement}`,
+        source: "backfill:item",
+        activeFrom: item.valid_from,
+        activeUntil: item.invalid_at,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return;
+  }
+
+  // Event items with future last_seen_at -> open_loops
+  if (item.kind === "event" && item.last_seen_at > now) {
+    db.insert(openLoops)
+      .values({
+        id: uuid(),
+        scopeId: item.scope_id,
+        summary: `${item.subject}: ${item.statement}`,
+        source: "backfill:item",
+        status: "open",
+        dueAt: item.last_seen_at,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Extract a conversation ID from the summary's scope and scope_key.
+ * Returns null for non-conversation summaries.
+ */
+function extractConversationId(scope: string, scopeKey: string): string | null {
+  // Conversation summaries use scope "conversation" with scope_key as the ID
+  if (scope === "conversation") return scopeKey;
+
+  // Some summaries use "conversation:<id>" as scope_key
+  const match = scopeKey.match(/^conversation:(.+)$/);
+  if (match) return match[1];
+
+  return null;
+}
+
+/**
+ * Build a human-readable episode title from the summary's scope metadata.
+ */
+function buildEpisodeTitle(scope: string, scopeKey: string): string {
+  if (scope === "conversation") {
+    return `Conversation summary`;
+  }
+  if (scope === "weekly") {
+    return `Weekly summary (${scopeKey})`;
+  }
+  if (scope === "monthly") {
+    return `Monthly summary (${scopeKey})`;
+  }
+  return `${scope} summary`;
+}

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -31,6 +31,7 @@ export type MemoryJobType =
   | "embed_attachment"
   | "generate_conversation_starters"
   | "reduce_conversation_memory"
+  | "backfill_simplified_memory"
   | "generate_capability_cards" // legacy compat — silently dropped by worker (capability cards removed)
   | "generate_thread_starters"; // legacy compat — silently dropped by worker (renamed to generate_conversation_starters)
 

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -3,6 +3,7 @@ import type { AssistantConfig } from "../config/types.js";
 import { getLogger } from "../util/logger.js";
 import { rawRun } from "./db.js";
 import { backfillJob } from "./job-handlers/backfill.js";
+import { backfillSimplifiedMemoryJob } from "./job-handlers/backfill-simplified-memory.js";
 import {
   cleanupStaleSupersededItemsJob,
   pruneOldConversationsJob,
@@ -322,6 +323,9 @@ async function processJob(
       return;
     case "reduce_conversation_memory":
       await reduceConversationMemoryJob(job);
+      return;
+    case "backfill_simplified_memory":
+      await backfillSimplifiedMemoryJob(job);
       return;
     case "generate_conversation_starters":
       await generateConversationStartersJob(job);

--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -2,6 +2,8 @@ import { and, eq, ne } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import type { AssistantConfig } from "../../config/types.js";
+import { buildArchiveRecall } from "../../memory/archive-recall.js";
+import { insertObservation } from "../../memory/archive-store.js";
 import { getDb } from "../../memory/db.js";
 import { computeMemoryFingerprint } from "../../memory/fingerprint.js";
 import { enqueueMemoryJob } from "../../memory/jobs-store.js";
@@ -18,7 +20,7 @@ const log = getLogger("memory-tools");
 
 export async function handleMemorySave(
   args: Record<string, unknown>,
-  _config: AssistantConfig,
+  config: AssistantConfig,
   conversationId: string,
   messageId: string | undefined,
   scopeId: string = "default",
@@ -62,6 +64,19 @@ export async function handleMemorySave(
     typeof args.subject === "string" && args.subject.trim().length > 0
       ? truncate(args.subject.trim(), 80, "")
       : inferSubjectFromStatement(statement.trim());
+
+  // When simplified memory is enabled, save directly to the simplified
+  // observation/chunk tables instead of the legacy memory_items table.
+  if (config.memory.simplified.enabled) {
+    return handleSimplifiedMemorySave(
+      kind,
+      subject,
+      statement.trim(),
+      conversationId,
+      messageId,
+      scopeId,
+    );
+  }
 
   try {
     const db = getDb();
@@ -275,6 +290,12 @@ export async function handleMemoryRecall(
       ? args.scope.trim()
       : "default";
 
+  // When simplified memory is enabled, use the archive recall path
+  // instead of the legacy hybrid retriever.
+  if (config.memory.simplified.enabled) {
+    return handleSimplifiedMemoryRecall(query.trim(), scopeId ?? "default");
+  }
+
   // Scope policy: "conversation" means strict (only that scope),
   // anything else allows fallback to the default scope.
   const scopePolicyOverride: ScopePolicyOverride | undefined = scopeId
@@ -408,6 +429,113 @@ export async function handleMemoryDelete(
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err, memoryId }, "memory_delete failed");
     return { content: `Error: Failed to delete memory: ${msg}`, isError: true };
+  }
+}
+
+// ── Simplified memory helpers ────────────────────────────────────────
+
+/**
+ * Save a memory item as an observation + chunk in the simplified system.
+ * This is used when simplified memory is enabled instead of writing to
+ * the legacy memory_items table.
+ */
+function handleSimplifiedMemorySave(
+  kind: string,
+  subject: string,
+  statement: string,
+  conversationId: string,
+  messageId: string | undefined,
+  scopeId: string,
+): ToolExecutionResult {
+  try {
+    const trimmedStatement = truncate(statement, 500, "");
+    const content = `[${kind}] ${subject}: ${trimmedStatement}`;
+
+    const result = insertObservation({
+      conversationId,
+      messageId: messageId ?? null,
+      role: "user",
+      content,
+      scopeId,
+      modality: "text",
+      source: "tool:memory_save",
+    });
+
+    log.debug(
+      {
+        observationId: result.observationId,
+        chunkId: result.chunkId,
+        kind,
+        subject,
+        conversationId,
+        messageId,
+      },
+      "Memory saved via simplified system",
+    );
+
+    return {
+      content: `Saved to memory (ID: ${result.observationId}).\nKind: ${kind}\nSubject: ${subject}\nStatement: ${trimmedStatement}`,
+      isError: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err }, "simplified memory_save failed");
+    return { content: `Error: Failed to save memory: ${msg}`, isError: true };
+  }
+}
+
+/**
+ * Recall memories using the simplified archive recall path instead of
+ * the legacy hybrid retriever.
+ */
+function handleSimplifiedMemoryRecall(
+  query: string,
+  scopeId: string,
+): ToolExecutionResult {
+  try {
+    const recallResult = buildArchiveRecall(scopeId, query);
+
+    if (recallResult.bullets.length === 0) {
+      return {
+        content: JSON.stringify({
+          text: "No matching memories found.",
+          resultCount: 0,
+          degraded: false,
+          items: [],
+          sources: { semantic: 0, recency: 0 },
+        }),
+        isError: false,
+      };
+    }
+
+    const items = recallResult.bullets.map((b) => ({
+      id: b.sourceId,
+      type: b.source,
+      kind: b.source,
+    }));
+
+    const result = {
+      text: recallResult.text,
+      resultCount: recallResult.bullets.length,
+      degraded: false,
+      items,
+      sources: {
+        semantic: recallResult.prefetchHitCount,
+        recency: 0,
+      },
+    };
+
+    return {
+      content: JSON.stringify(result),
+      isError: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err, query }, "simplified memory_recall failed");
+    return {
+      content: `Error: Memory recall failed: ${msg}`,
+      isError: true,
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
- Add backfill job handler migrating legacy segments/summaries/items to simplified tables
- Update memory tools to use simplified system when enabled
- Flip memory.simplified.enabled default to true
- Add e2e test suite and architecture documentation

Part of plan: simplified-memory-v1.md (PR 23 of 23)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
