### PR TITLE
Fix Swift 6 hang-context concurrency warnings

### DIFF
--- a/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
+++ b/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
@@ -300,6 +300,26 @@ struct ChatTranscriptSnapshot: Codable, Sendable {
     }
 }
 
+/// Background-readable cache for the latest sanitized diagnostics snapshot.
+///
+/// Kept outside `ChatDiagnosticsStore` so background readers do not need to
+/// access the store's `@MainActor` singleton just to read the fallback copy.
+final class LastKnownDiagnosticsCache: @unchecked Sendable {
+    static let shared = LastKnownDiagnosticsCache()
+
+    private let snapshotLock = OSAllocatedUnfairLock<LastKnownDiagnosticsSnapshot?>(initialState: nil)
+
+    private init() {}
+
+    func update(_ snapshot: LastKnownDiagnosticsSnapshot?) {
+        snapshotLock.withLock { $0 = snapshot }
+    }
+
+    func snapshot() -> LastKnownDiagnosticsSnapshot? {
+        snapshotLock.withLock { $0 }
+    }
+}
+
 // MARK: - ChatDiagnosticsStore
 
 /// Shared diagnostics store for the chat transcript.
@@ -535,29 +555,18 @@ final class ChatDiagnosticsStore {
     /// the main actor. This is the fallback data source when the main thread
     /// is wedged and `enrichWithDiagnosticsAsync()` never completes.
     ///
-    /// **Thread safety**: Written only from `@MainActor`; read atomically
-    /// via `nonisolated` accessor through the `NSLock`-guarded getter.
+    /// **Thread safety**: Written only from `@MainActor`; mirrored into
+    /// `LastKnownDiagnosticsCache` for lock-protected background reads.
     private(set) var lastKnownDiagnostics: LastKnownDiagnosticsSnapshot? {
         didSet {
-            _lastKnownLock.lock()
-            _lastKnownBackgroundCopy = lastKnownDiagnostics
-            _lastKnownLock.unlock()
+            LastKnownDiagnosticsCache.shared.update(lastKnownDiagnostics)
         }
     }
-
-    /// Lock protecting the background-readable copy.
-    private let _lastKnownLock = NSLock()
-
-    /// Background-readable copy of `lastKnownDiagnostics`, guarded by `_lastKnownLock`.
-    /// `nonisolated(unsafe)` is safe here because all access is serialized through `_lastKnownLock`.
-    private nonisolated(unsafe) var _lastKnownBackgroundCopy: LastKnownDiagnosticsSnapshot?
 
     /// Returns the last-known diagnostics snapshot from any thread.
     /// This is safe to call from the stall detector's background queue.
     nonisolated func lastKnownDiagnosticsFromBackground() -> LastKnownDiagnosticsSnapshot? {
-        _lastKnownLock.lock()
-        defer { _lastKnownLock.unlock() }
-        return _lastKnownBackgroundCopy
+        LastKnownDiagnosticsCache.shared.snapshot()
     }
 
     /// Rebuilds the last-known diagnostics snapshot from current state.

--- a/clients/macos/vellum-assistant/Logging/HangContextWriter.swift
+++ b/clients/macos/vellum-assistant/Logging/HangContextWriter.swift
@@ -15,6 +15,12 @@ private let log = Logger(
 /// continues. A separate `enrichWithDiagnostics` path attempts a best-effort
 /// main-actor read; if the main thread is wedged it simply won't complete.
 final class HangContextWriter: @unchecked Sendable {
+    private struct WriteState: Sendable {
+        var generation: Int = 0
+        var latestStallStartTime: Date?
+        var latestStallDurationSeconds: Double = 0
+        var latestSamplingSkipped: Bool = false
+    }
 
     /// Protocol for providing diagnostic events from a background queue.
     /// The concrete implementation reads from `ChatDiagnosticsStore` on the main actor.
@@ -44,11 +50,7 @@ final class HangContextWriter: @unchecked Sendable {
 
     // MARK: - Private
 
-    private let lock = NSLock()
-    private var writeGeneration: Int = 0
-    private var latestStallStartTime: Date?
-    private var latestStallDurationSeconds: Double = 0
-    private var latestSamplingSkipped: Bool = false
+    private let writeStateLock = OSAllocatedUnfairLock<WriteState>(initialState: WriteState())
 
     private let encoder: JSONEncoder
 
@@ -91,12 +93,12 @@ final class HangContextWriter: @unchecked Sendable {
         transcriptSnapshots: [ChatTranscriptSnapshot] = [],
         samplingSkipped: Bool = false
     ) {
-        lock.lock()
-        writeGeneration += 1
-        latestStallStartTime = stallStartTime
-        latestStallDurationSeconds = stallDurationSeconds
-        latestSamplingSkipped = samplingSkipped
-        lock.unlock()
+        writeStateLock.withLock { state in
+            state.generation += 1
+            state.latestStallStartTime = stallStartTime
+            state.latestStallDurationSeconds = stallDurationSeconds
+            state.latestSamplingSkipped = samplingSkipped
+        }
 
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
         let pid = ProcessInfo.processInfo.processIdentifier
@@ -150,9 +152,7 @@ final class HangContextWriter: @unchecked Sendable {
         stallDurationSeconds: Double
     ) {
         guard let provider = diagnosticsProvider else { return }
-        lock.lock()
-        let capturedGeneration = writeGeneration
-        lock.unlock()
+        let capturedGeneration = writeStateLock.withLock { $0.generation }
 
         Task.detached(priority: .utility) { [self] in
             let events = await provider.recentEvents()
@@ -161,12 +161,11 @@ final class HangContextWriter: @unchecked Sendable {
 
             // If a newer write occurred (e.g. Stage 2) while we were awaiting
             // diagnostics, use its values so we don't overwrite with stale data.
-            self.lock.lock()
-            let useLatest = self.writeGeneration > capturedGeneration
-            let actualStartTime = useLatest ? (self.latestStallStartTime ?? stallStartTime) : stallStartTime
-            let actualDuration = useLatest ? self.latestStallDurationSeconds : stallDurationSeconds
-            let actualSamplingSkipped = self.latestSamplingSkipped
-            self.lock.unlock()
+            let latestState = self.writeStateLock.withLock { $0 }
+            let useLatest = latestState.generation > capturedGeneration
+            let actualStartTime = useLatest ? (latestState.latestStallStartTime ?? stallStartTime) : stallStartTime
+            let actualDuration = useLatest ? latestState.latestStallDurationSeconds : stallDurationSeconds
+            let actualSamplingSkipped = latestState.latestSamplingSkipped
 
             self.writeHangContextSync(
                 stallStartTime: actualStartTime,
@@ -236,10 +235,10 @@ struct MainActorDiagnosticsProvider: HangContextWriter.DiagnosticsProvider {
     }
 }
 
-/// Production last-known diagnostics provider that reads the lock-guarded
-/// background copy from `ChatDiagnosticsStore`. Safe to call from any thread.
+/// Production last-known diagnostics provider that reads the background-safe
+/// cache mirrored by `ChatDiagnosticsStore`. Safe to call from any thread.
 struct BackgroundDiagnosticsProvider: HangContextWriter.LastKnownDiagnosticsProvider {
     func lastKnownDiagnostics() -> LastKnownDiagnosticsSnapshot? {
-        ChatDiagnosticsStore.shared.lastKnownDiagnosticsFromBackground()
+        LastKnownDiagnosticsCache.shared.snapshot()
     }
 }


### PR DESCRIPTION
## Summary
- replace HangContextWriter state locking with OSAllocatedUnfairLock so detached enrichment no longer uses NSLock from an async context
- mirror last-known diagnostics through a background-safe cache so fallback reads do not cross the ChatDiagnosticsStore @MainActor singleton
- keep hang-context capture behavior intact while clearing the Swift 6 concurrency warnings in the macOS build

## Original prompt
Fix this: VELLUM_NO_WATCH=1 ./build.sh run emitted Swift 6 concurrency warnings in HangContextWriter.swift and ChatDiagnosticsStore.swift
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
