### PR TITLE
Fix legacy memory_save regression tests

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -540,13 +540,23 @@ describe("Memory regressions", () => {
 
   test("memory_save sets verificationState to user_confirmed", async () => {
     const { handleMemorySave } = await import("../tools/memory/handlers.js");
+    const legacyConfig = {
+      ...DEFAULT_CONFIG,
+      memory: {
+        ...DEFAULT_CONFIG.memory,
+        simplified: {
+          ...DEFAULT_CONFIG.memory.simplified,
+          enabled: false,
+        },
+      },
+    };
 
     const result = await handleMemorySave(
       {
         statement: "User explicitly saved this preference",
         kind: "preference",
       },
-      DEFAULT_CONFIG,
+      legacyConfig,
       "conv-verify-save",
       "msg-verify-save",
     );
@@ -563,13 +573,23 @@ describe("Memory regressions", () => {
 
   test("memory_save in different scopes creates separate items", async () => {
     const { handleMemorySave } = await import("../tools/memory/handlers.js");
+    const legacyConfig = {
+      ...DEFAULT_CONFIG,
+      memory: {
+        ...DEFAULT_CONFIG.memory,
+        simplified: {
+          ...DEFAULT_CONFIG.memory.simplified,
+          enabled: false,
+        },
+      },
+    };
 
     const sharedArgs = { statement: "I prefer dark mode", kind: "preference" };
 
     // Save in the default scope
     const r1 = await handleMemorySave(
       sharedArgs,
-      DEFAULT_CONFIG,
+      legacyConfig,
       "conv-scope-1",
       "msg-scope-1",
       "default",
@@ -580,7 +600,7 @@ describe("Memory regressions", () => {
     // Save the identical statement in a private scope
     const r2 = await handleMemorySave(
       sharedArgs,
-      DEFAULT_CONFIG,
+      legacyConfig,
       "conv-scope-2",
       "msg-scope-2",
       "private-abc",
@@ -604,7 +624,7 @@ describe("Memory regressions", () => {
     // Saving the same statement again in default scope should dedup (not create a third)
     const r3 = await handleMemorySave(
       sharedArgs,
-      DEFAULT_CONFIG,
+      legacyConfig,
       "conv-scope-3",
       "msg-scope-3",
       "default",


### PR DESCRIPTION
## Summary
- opt the legacy memory_save regression tests into simplified-memory disabled mode
- keep verificationState and cross-scope dedupe assertions pointed at the intended memory_items codepath

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23312230359/job/67802283180
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
