### PR TITLE
Use red color for failure build alerts

### DIFF
--- a/.github/actions/send-build-alert/action.yml
+++ b/.github/actions/send-build-alert/action.yml
@@ -38,7 +38,7 @@ runs:
             ;;
           failure)
             ICON=":kimk-cryingggggggg:"
-            COLOR="#884EA0"
+            COLOR="#E74C3C"
             ;;
           cancelled)
             ICON=":meow_meltshoe:"


### PR DESCRIPTION
## Summary
- Change the Slack build alert color for `failure` status from purple (`#884EA0`) to red (`#E74C3C`)
- Keeps `cancelled` status as purple (`#A569BD`) so the two are visually distinct

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19690" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
