### PR TITLE
fix: add <supporting_recall> to runtime injection strip list

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -962,6 +962,7 @@ const RUNTIME_INJECTION_PREFIXES = [
   "<interface_turn_context>",
   "<turn_context>",
   "<memory_brief>",
+  "<supporting_recall>",
   "<memory_context __injected>",
   "<memory_context>", // backward-compat: strip legacy blocks from pre-__injected history
   "<voice_call_control>",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for simplified-memory-v1.md.

**Gap:** <supporting_recall> not in runtime injection strip list
**What was expected:** <supporting_recall> blocks should be stripped from prior turns
**What was found:** Only <memory_brief> was in the strip list, causing recall-only blocks to accumulate
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19691" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
