### PR TITLE
fix: sort dirty conversations descending to find most recently updated

### DIFF
--- a/assistant/src/__tests__/conversation-switch-memory-reduction.test.ts
+++ b/assistant/src/__tests__/conversation-switch-memory-reduction.test.ts
@@ -214,9 +214,8 @@ describe("findMostRecentDirtyConversation", () => {
     insertConversation("conv-target", { updatedAt: NOW + 1000 });
 
     const result = findMostRecentDirtyConversation("conv-target");
-    // Should return the oldest dirty conversation first (ordered by updatedAt ASC)
-    // since we want to reduce the least-recently-updated dirty conversation
-    expect(result).toBe("conv-old");
+    // Should return the most recently updated dirty conversation (ordered by updatedAt DESC)
+    expect(result).toBe("conv-recent");
   });
 
   test("excludes the target conversation", () => {
@@ -389,8 +388,8 @@ describe("reduceBeforeSwitch — new conversation", () => {
 });
 
 describe("reduceBeforeSwitch — most recent dirty selection", () => {
-  test("selects the earliest-updated dirty conversation when multiple exist", async () => {
-    // Two dirty conversations — conv-older is less recently updated
+  test("selects the most recently updated dirty conversation when multiple exist", async () => {
+    // Two dirty conversations — conv-newer is more recently updated
     insertConversation("conv-older", {
       dirtyTailMessageId: "msg-older",
       updatedAt: NOW - 10_000,
@@ -420,13 +419,13 @@ describe("reduceBeforeSwitch — most recent dirty selection", () => {
     mockReducerResult = makeReducerResult();
 
     // Even though two are dirty, we only reduce one per switch.
-    // The function picks the earliest (by updatedAt ASC).
+    // The function picks the most recently updated (by updatedAt DESC).
     const result = await reduceBeforeSwitch("conv-target");
 
-    // Should pick the oldest dirty conversation
-    expect(result).toBe("conv-older");
+    // Should pick the most recently updated dirty conversation
+    expect(result).toBe("conv-newer");
     expect(reducerCallCount).toBe(1);
-    expect(lastReducerInput?.conversationId).toBe("conv-older");
+    expect(lastReducerInput?.conversationId).toBe("conv-newer");
   });
 });
 

--- a/assistant/src/memory/reducer-scheduler.ts
+++ b/assistant/src/memory/reducer-scheduler.ts
@@ -16,7 +16,7 @@
  * If no eligible dirty conversation exists, the function returns immediately.
  */
 
-import { and, asc, eq, gte, isNotNull, ne } from "drizzle-orm";
+import { and, asc, desc, eq, gte, isNotNull, ne } from "drizzle-orm";
 
 import { getLogger } from "../util/logger.js";
 import { type ConversationRow, getConversation } from "./conversation-crud.js";
@@ -58,7 +58,7 @@ export function findMostRecentDirtyConversation(
         ne(conversations.id, excludeConversationId),
       ),
     )
-    .orderBy(conversations.updatedAt)
+    .orderBy(desc(conversations.updatedAt))
     .limit(1)
     .get();
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for simplified-memory-v1.md.

**Gap:** findMostRecentDirtyConversation sorts ascending (oldest first)
**What was expected:** Most recently updated dirty conversation should be found
**What was found:** Missing desc() in orderBy returned oldest instead of most recent
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
