### PR TITLE
fix: filter time_contexts by scopeId in SQL instead of in-memory

### DIFF
--- a/assistant/src/memory/brief-time.ts
+++ b/assistant/src/memory/brief-time.ts
@@ -4,7 +4,7 @@
  * schedule jobs, sorts them by urgency bucket, and caps the output.
  */
 
-import { and, gte, lte } from "drizzle-orm";
+import { and, eq, gte, lte } from "drizzle-orm";
 
 import { getDueSoonSchedules } from "../schedule/schedule-store.js";
 import type { BriefEntry } from "./brief-formatting.js";
@@ -69,18 +69,19 @@ function collectTimeContexts(
   now: number,
   out: Candidate[],
 ): void {
-  // Active time contexts: activeFrom <= now AND activeUntil >= now
+  // Active time contexts: scopeId match AND activeFrom <= now AND activeUntil >= now
+  // Uses idx_time_contexts_scope_active_until composite index
   const rows = db
     .select()
     .from(timeContexts)
     .where(
       and(
+        eq(timeContexts.scopeId, scopeId),
         lte(timeContexts.activeFrom, now),
         gte(timeContexts.activeUntil, now),
       ),
     )
-    .all()
-    .filter((r) => r.scopeId === scopeId);
+    .all();
 
   for (const row of rows) {
     const remaining = row.activeUntil - now;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for simplified-memory-v1.md.

**Gap:** collectTimeContexts does not filter by scopeId in SQL
**What was expected:** SQL WHERE should include scopeId to use the composite index
**What was found:** All scopes fetched then filtered in JavaScript
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
