### PR TITLE
fix: advance reducer checkpoint on valid-but-empty model output

### DIFF
--- a/assistant/src/memory/job-handlers/reduce-conversation-memory.ts
+++ b/assistant/src/memory/job-handlers/reduce-conversation-memory.ts
@@ -14,8 +14,10 @@
  *   5. Calls `runReducer` with the assembled input.
  *   6. Applies the result transactionally via `applyReducerResult`.
  *
- * If the reducer fails or returns an empty result, the checkpoint is NOT
- * advanced — the dirty tail stays in place so the next run retries.
+ * If the reducer fails or returns the {@link EMPTY_REDUCER_RESULT} sentinel
+ * (unparseable output), the checkpoint is NOT advanced — the dirty tail stays
+ * in place so the next run retries. A valid-but-empty model response (e.g.
+ * `{}`) returns a normal empty result that advances the checkpoint normally.
  */
 
 import { and, asc, eq, gte } from "drizzle-orm";

--- a/assistant/src/memory/reducer-types.ts
+++ b/assistant/src/memory/reducer-types.ts
@@ -86,8 +86,15 @@ export interface ReducerResult {
 }
 
 /**
- * An empty result used as fallback when the reducer output is invalid or
- * unparseable. Guarantees no side-effects on the DB.
+ * Sentinel empty result returned when the reducer output is **unparseable**
+ * (not valid JSON, not a JSON object, provider failure, etc.).
+ *
+ * Callers use identity comparison (`=== EMPTY_REDUCER_RESULT`) to detect
+ * true parse failures and skip checkpoint advancement so the job can retry.
+ *
+ * A valid-but-empty model response (e.g. `{}`) returns a normal
+ * `ReducerResult` with all empty arrays — NOT this sentinel — so the
+ * checkpoint advances and the dirty tail is cleared.
  */
 export const EMPTY_REDUCER_RESULT: Readonly<ReducerResult> = Object.freeze({
   timeContexts: Object.freeze([]) as unknown as TimeContextOp[],

--- a/assistant/src/memory/reducer.ts
+++ b/assistant/src/memory/reducer.ts
@@ -5,7 +5,7 @@
  *   1. ReducerPromptInput — structured input for the provider call
  *   2. runReducer — send the transcript span to the LLM and return a typed result
  *   3. parseReducerOutput — raw string -> validated ReducerResult
- *   4. Fallback to EMPTY_REDUCER_RESULT on any invalid output
+ *   4. Fallback to EMPTY_REDUCER_RESULT on unparseable output (parse failures only)
  *
  * The reducer is intentionally side-effect-free: it never writes to the
  * database. Callers are responsible for applying the returned ReducerResult.
@@ -373,13 +373,19 @@ function validateArchiveEpisode(raw: unknown): ArchiveEpisodeCandidate | null {
 /**
  * Parse raw model output into a validated ReducerResult.
  *
- * On any structural error (non-JSON, missing top-level keys, wrong types)
- * the function returns EMPTY_REDUCER_RESULT rather than throwing. Individual
- * invalid operations within an otherwise valid structure are silently dropped
- * to preserve the rest of the result.
+ * On any structural error (non-JSON, not a JSON object) the function returns
+ * {@link EMPTY_REDUCER_RESULT} rather than throwing — callers use identity
+ * comparison (`=== EMPTY_REDUCER_RESULT`) to detect true parse failures and
+ * skip checkpoint advancement.
  *
- * However, if **all four** top-level arrays are absent or not arrays, the
- * entire output is treated as invalid and returns the empty result.
+ * A valid JSON object with no recognized top-level arrays (e.g. `{}`) is
+ * treated as a **valid-but-empty** response — the model simply had nothing
+ * to extract. In this case a normal `ReducerResult` with all empty arrays
+ * is returned so that callers advance the checkpoint and clear the dirty
+ * tail, avoiding an infinite retry loop.
+ *
+ * Individual invalid operations within an otherwise valid structure are
+ * silently dropped to preserve the rest of the result.
  */
 export function parseReducerOutput(raw: string): ReducerResult {
   let parsed: unknown;
@@ -399,22 +405,30 @@ export function parseReducerOutput(raw: string): ReducerResult {
 
   const obj = parsed as Record<string, unknown>;
 
-  // Check that at least one top-level array key exists
+  // Check which top-level array keys are present
   const hasTimeContexts = Array.isArray(obj.timeContexts);
   const hasOpenLoops = Array.isArray(obj.openLoops);
   const hasArchiveObservations = Array.isArray(obj.archiveObservations);
   const hasArchiveEpisodes = Array.isArray(obj.archiveEpisodes);
 
+  // A valid JSON object with no recognized arrays (e.g. `{}`) means the
+  // model had nothing to extract — return a normal (non-sentinel) empty
+  // result so the checkpoint advances.
   if (
     !hasTimeContexts &&
     !hasOpenLoops &&
     !hasArchiveObservations &&
     !hasArchiveEpisodes
   ) {
-    log.warn(
-      "reducer output has no recognized top-level arrays — falling back to empty result",
+    log.debug(
+      "reducer output is valid JSON with no extractions — advancing with empty result",
     );
-    return EMPTY_REDUCER_RESULT;
+    return {
+      timeContexts: [],
+      openLoops: [],
+      archiveObservations: [],
+      archiveEpisodes: [],
+    };
   }
 
   const timeContexts: TimeContextOp[] = [];


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for simplified-memory-v1.md.

**Gap:** Empty reducer output causes infinite retry loop
**What was expected:** Valid empty output should advance checkpoint and clear dirty tail
**What was found:** EMPTY_REDUCER_RESULT was returned for both parse failures and valid empty outputs, preventing checkpoint advancement
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
