### PR TITLE
fix: sweep time_contexts and open_loops on private conversation deletion

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -54,6 +54,8 @@ import {
   memorySummaries,
   messageAttachments,
   messages,
+  openLoops,
+  timeContexts,
   toolInvocations,
 } from "./schema.js";
 import { cancelPendingJobsForConversation } from "./task-memory-cleanup.js";
@@ -703,6 +705,12 @@ export function deleteConversation(id: string): DeletedMemoryIds {
       tx.delete(conversationStarters)
         .where(eq(conversationStarters.scopeId, memoryScopeId))
         .run();
+
+      // Sweep brief-state tables scoped to this private conversation.
+      tx.delete(timeContexts)
+        .where(eq(timeContexts.scopeId, memoryScopeId))
+        .run();
+      tx.delete(openLoops).where(eq(openLoops.scopeId, memoryScopeId)).run();
     }
 
     tx.delete(conversations).where(eq(conversations.id, id)).run();


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for simplified-memory-v1.md.

**Gap:** Private-scope deletion does not sweep time_contexts or open_loops
**What was expected:** Brief-state rows cleaned up with private scope
**What was found:** Only legacy memoryItems/memorySummaries/conversationStarters were swept
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
