### PR TITLE
M1: Add WindowDragArea and apply to title bar spacers

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -428,6 +428,8 @@ struct MainWindowView: View {
                 }
             }
             Spacer()
+                .contentShape(Rectangle())
+                .background(WindowDragArea())
             if windowState.isConversationVisible {
                 ConversationTitleActionsControl(
                     presentation: conversationHeaderPresentation,
@@ -469,6 +471,8 @@ struct MainWindowView: View {
                 })
             }
             Spacer()
+                .contentShape(Rectangle())
+                .background(WindowDragArea())
             if updateManager.isUpdateAvailable {
                 VButton(
                     label: updateManager.isDeferredUpdateReady ? "Restart to update" : "Update",

--- a/clients/macos/vellum-assistant/Features/MainWindow/WindowDragArea.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/WindowDragArea.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// A lightweight `NSViewRepresentable` that enables window dragging from any
+/// SwiftUI region by calling `window?.performDrag(with:)` on mouse-down.
+///
+/// This bypasses the `NonDraggableContainerView` hierarchy (which sets
+/// `mouseDownCanMoveWindow` to `false` on the hosting view) by initiating the
+/// drag directly from the event.
+struct WindowDragArea: NSViewRepresentable {
+    func makeNSView(context: Context) -> DraggableView {
+        DraggableView()
+    }
+
+    func updateNSView(_ nsView: DraggableView, context: Context) {}
+
+    final class DraggableView: NSView {
+        override var mouseDownCanMoveWindow: Bool { true }
+
+        override func mouseDown(with event: NSEvent) {
+            window?.performDrag(with: event)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the title bar drag area being too narrow by making the spacer regions in the title bar draggable.

Creates a `WindowDragArea` `NSViewRepresentable` wrapping a custom `NSView` that calls `window?.performDrag(with:)` on mouse down, bypassing the `NonDraggableContainerView` hierarchy. Applied as `.background()` on both title bar spacers with `.contentShape(Rectangle())` to ensure hit testing.

## Changes
- **New**: `clients/macos/vellum-assistant/Features/MainWindow/WindowDragArea.swift` — draggable NSView wrapper
- **Modified**: `clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift` — apply WindowDragArea to both title bar spacers

## Test plan
- [ ] Launch app, click-hold-drag on empty space between buttons in title bar → window should move
- [ ] Click buttons in title bar (sidebar, search, back/forward, update, temp chat) → should still work normally
- [ ] Verify traffic light buttons still work
- [ ] Double-click on empty title bar space → should not cause issues

Part of LUM-311
Closes #19693
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
