### PR TITLE
fix: clean up Qdrant vectors for archive types on conversation deletion

### DIFF
--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -375,6 +375,24 @@ Examples:
           targetId: summaryId,
         });
       }
+      for (const obsId of result.deletedObservationIds) {
+        enqueueMemoryJob("delete_qdrant_vectors", {
+          targetType: "observation",
+          targetId: obsId,
+        });
+      }
+      for (const chunkId of result.deletedChunkIds) {
+        enqueueMemoryJob("delete_qdrant_vectors", {
+          targetType: "chunk",
+          targetId: chunkId,
+        });
+      }
+      for (const episodeId of result.deletedEpisodeIds) {
+        enqueueMemoryJob("delete_qdrant_vectors", {
+          targetType: "episode",
+          targetId: episodeId,
+        });
+      }
 
       log.info(
         `Wiped conversation "${conversation.title ?? "Untitled"}". ` +

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -207,16 +207,40 @@ export async function runDaemon(): Promise<void> {
           targetId: summaryId,
         });
       }
+      for (const obsId of deletedMemory.deletedObservationIds) {
+        enqueueMemoryJob("delete_qdrant_vectors", {
+          targetType: "observation",
+          targetId: obsId,
+        });
+      }
+      for (const chunkId of deletedMemory.deletedChunkIds) {
+        enqueueMemoryJob("delete_qdrant_vectors", {
+          targetType: "chunk",
+          targetId: chunkId,
+        });
+      }
+      for (const episodeId of deletedMemory.deletedEpisodeIds) {
+        enqueueMemoryJob("delete_qdrant_vectors", {
+          targetType: "episode",
+          targetId: episodeId,
+        });
+      }
       if (
         deletedMemory.segmentIds.length > 0 ||
         deletedMemory.orphanedItemIds.length > 0 ||
-        deletedMemory.deletedSummaryIds.length > 0
+        deletedMemory.deletedSummaryIds.length > 0 ||
+        deletedMemory.deletedObservationIds.length > 0 ||
+        deletedMemory.deletedChunkIds.length > 0 ||
+        deletedMemory.deletedEpisodeIds.length > 0
       ) {
         log.info(
           {
             segments: deletedMemory.segmentIds.length,
             orphanedItems: deletedMemory.orphanedItemIds.length,
             deletedSummaries: deletedMemory.deletedSummaryIds.length,
+            deletedObservations: deletedMemory.deletedObservationIds.length,
+            deletedChunks: deletedMemory.deletedChunkIds.length,
+            deletedEpisodes: deletedMemory.deletedEpisodeIds.length,
           },
           "Enqueued Qdrant vector cleanup jobs for purged private conversations",
         );

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -47,9 +47,12 @@ import {
   conversations,
   conversationStarters,
   llmRequestLogs,
+  memoryChunks,
   memoryEmbeddings,
+  memoryEpisodes,
   memoryItems,
   memoryItemSources,
+  memoryObservations,
   memorySegments,
   memorySummaries,
   messageAttachments,
@@ -552,6 +555,9 @@ export function deleteConversation(id: string): DeletedMemoryIds {
     segmentIds: [],
     orphanedItemIds: [],
     deletedSummaryIds: [],
+    deletedObservationIds: [],
+    deletedChunkIds: [],
+    deletedEpisodeIds: [],
   };
 
   // Capture createdAt before the transaction deletes the row — needed to
@@ -711,6 +717,69 @@ export function deleteConversation(id: string): DeletedMemoryIds {
         .where(eq(timeContexts.scopeId, memoryScopeId))
         .run();
       tx.delete(openLoops).where(eq(openLoops.scopeId, memoryScopeId)).run();
+    }
+
+    // Collect archive table IDs before the cascade delete removes them.
+    // Observations and episodes reference conversations with ON DELETE CASCADE,
+    // and chunks cascade from observations.
+    const observationRows = tx
+      .select({ id: memoryObservations.id })
+      .from(memoryObservations)
+      .where(eq(memoryObservations.conversationId, id))
+      .all();
+    const observationIds = observationRows.map((r) => r.id);
+
+    if (observationIds.length > 0) {
+      // Collect chunk IDs before observations cascade-delete them.
+      const chunkRows = tx
+        .select({ id: memoryChunks.id })
+        .from(memoryChunks)
+        .where(inArray(memoryChunks.observationId, observationIds))
+        .all();
+      const chunkIds = chunkRows.map((r) => r.id);
+
+      // Clean up embeddings for chunks.
+      if (chunkIds.length > 0) {
+        tx.delete(memoryEmbeddings)
+          .where(
+            and(
+              eq(memoryEmbeddings.targetType, "chunk"),
+              inArray(memoryEmbeddings.targetId, chunkIds),
+            ),
+          )
+          .run();
+        result.deletedChunkIds.push(...chunkIds);
+      }
+
+      // Clean up embeddings for observations.
+      tx.delete(memoryEmbeddings)
+        .where(
+          and(
+            eq(memoryEmbeddings.targetType, "observation"),
+            inArray(memoryEmbeddings.targetId, observationIds),
+          ),
+        )
+        .run();
+      result.deletedObservationIds.push(...observationIds);
+    }
+
+    const episodeRows = tx
+      .select({ id: memoryEpisodes.id })
+      .from(memoryEpisodes)
+      .where(eq(memoryEpisodes.conversationId, id))
+      .all();
+    const episodeIds = episodeRows.map((r) => r.id);
+
+    if (episodeIds.length > 0) {
+      tx.delete(memoryEmbeddings)
+        .where(
+          and(
+            eq(memoryEmbeddings.targetType, "episode"),
+            inArray(memoryEmbeddings.targetId, episodeIds),
+          ),
+        )
+        .run();
+      result.deletedEpisodeIds.push(...episodeIds);
     }
 
     tx.delete(conversations).where(eq(conversations.id, id)).run();
@@ -936,6 +1005,9 @@ export function purgePrivateConversations(): {
         segmentIds: [],
         orphanedItemIds: [],
         deletedSummaryIds: [],
+        deletedObservationIds: [],
+        deletedChunkIds: [],
+        deletedEpisodeIds: [],
       },
     };
   }
@@ -943,12 +1015,18 @@ export function purgePrivateConversations(): {
   const allSegmentIds: string[] = [];
   const allOrphanedItemIds: string[] = [];
   const allDeletedSummaryIds: string[] = [];
+  const allDeletedObservationIds: string[] = [];
+  const allDeletedChunkIds: string[] = [];
+  const allDeletedEpisodeIds: string[] = [];
 
   for (const conv of privateConvs) {
     const deleted = deleteConversation(conv.id);
     allSegmentIds.push(...deleted.segmentIds);
     allOrphanedItemIds.push(...deleted.orphanedItemIds);
     allDeletedSummaryIds.push(...deleted.deletedSummaryIds);
+    allDeletedObservationIds.push(...deleted.deletedObservationIds);
+    allDeletedChunkIds.push(...deleted.deletedChunkIds);
+    allDeletedEpisodeIds.push(...deleted.deletedEpisodeIds);
   }
 
   return {
@@ -957,6 +1035,9 @@ export function purgePrivateConversations(): {
       segmentIds: allSegmentIds,
       orphanedItemIds: allOrphanedItemIds,
       deletedSummaryIds: allDeletedSummaryIds,
+      deletedObservationIds: allDeletedObservationIds,
+      deletedChunkIds: allDeletedChunkIds,
+      deletedEpisodeIds: allDeletedEpisodeIds,
     },
   };
 }
@@ -1341,6 +1422,9 @@ export interface DeletedMemoryIds {
   segmentIds: string[];
   orphanedItemIds: string[];
   deletedSummaryIds: string[];
+  deletedObservationIds: string[];
+  deletedChunkIds: string[];
+  deletedEpisodeIds: string[];
 }
 
 export interface WipeConversationResult extends DeletedMemoryIds {
@@ -1414,6 +1498,9 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
     segmentIds: [],
     orphanedItemIds: [],
     deletedSummaryIds: [],
+    deletedObservationIds: [],
+    deletedChunkIds: [],
+    deletedEpisodeIds: [],
   };
 
   // Collect attachment IDs linked to this message before cascade-delete

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -266,6 +266,24 @@ export function conversationManagementRouteDefinitions(
             targetId: summaryId,
           });
         }
+        for (const obsId of result.deletedObservationIds) {
+          enqueueMemoryJob("delete_qdrant_vectors", {
+            targetType: "observation",
+            targetId: obsId,
+          });
+        }
+        for (const chunkId of result.deletedChunkIds) {
+          enqueueMemoryJob("delete_qdrant_vectors", {
+            targetType: "chunk",
+            targetId: chunkId,
+          });
+        }
+        for (const episodeId of result.deletedEpisodeIds) {
+          enqueueMemoryJob("delete_qdrant_vectors", {
+            targetType: "episode",
+            targetId: episodeId,
+          });
+        }
         log.info(
           {
             conversationId: resolvedId,
@@ -320,6 +338,24 @@ export function conversationManagementRouteDefinitions(
           enqueueMemoryJob("delete_qdrant_vectors", {
             targetType: "summary",
             targetId: summaryId,
+          });
+        }
+        for (const obsId of deleted.deletedObservationIds) {
+          enqueueMemoryJob("delete_qdrant_vectors", {
+            targetType: "observation",
+            targetId: obsId,
+          });
+        }
+        for (const chunkId of deleted.deletedChunkIds) {
+          enqueueMemoryJob("delete_qdrant_vectors", {
+            targetType: "chunk",
+            targetId: chunkId,
+          });
+        }
+        for (const episodeId of deleted.deletedEpisodeIds) {
+          enqueueMemoryJob("delete_qdrant_vectors", {
+            targetType: "episode",
+            targetId: episodeId,
           });
         }
         log.info({ conversationId: resolvedId }, "Deleted conversation");


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for simplified-memory-v1.md.

**Gap:** No Qdrant vector cleanup for new archive target types
**What was expected:** Observation/chunk/episode vectors cleaned up on conversation deletion
**What was found:** Only legacy segment/item/summary vectors were cleaned up
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
