### PR TITLE
test: fix memory reducer empty-result CI assertions

### DIFF
--- a/assistant/src/__tests__/memory-reducer-types.test.ts
+++ b/assistant/src/__tests__/memory-reducer-types.test.ts
@@ -84,9 +84,12 @@ describe("parseReducerOutput — invalid inputs", () => {
   });
 
   test("returns empty result for object with no recognized arrays", () => {
-    expect(parseReducerOutput(toRaw({ foo: "bar" }))).toBe(
-      EMPTY_REDUCER_RESULT,
-    );
+    expect(parseReducerOutput(toRaw({ foo: "bar" }))).toEqual({
+      timeContexts: [],
+      openLoops: [],
+      archiveObservations: [],
+      archiveEpisodes: [],
+    });
   });
 
   test("returns empty result when all recognized keys are not arrays", () => {
@@ -99,7 +102,12 @@ describe("parseReducerOutput — invalid inputs", () => {
           archiveEpisodes: true,
         }),
       ),
-    ).toBe(EMPTY_REDUCER_RESULT);
+    ).toEqual({
+      timeContexts: [],
+      openLoops: [],
+      archiveObservations: [],
+      archiveEpisodes: [],
+    });
   });
 });
 

--- a/assistant/src/__tests__/memory-reducer.test.ts
+++ b/assistant/src/__tests__/memory-reducer.test.ts
@@ -529,7 +529,13 @@ describe("runReducer — error handling", () => {
 
     const result = await runReducer(makeInput());
 
-    expect(result).toBe(EMPTY_REDUCER_RESULT);
+    expect(result).toEqual({
+      timeContexts: [],
+      openLoops: [],
+      archiveObservations: [],
+      archiveEpisodes: [],
+    });
+    expect(result).not.toBe(EMPTY_REDUCER_RESULT);
   });
 });
 


### PR DESCRIPTION
## Summary
- update memory reducer tests to treat parseable empty objects as valid empty results instead of the EMPTY_REDUCER_RESULT sentinel
- keep sentinel identity checks only for true reducer failures and unparseable output

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23312662779/job/67803779365
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
