### PR TITLE
Fix title bar drag area — make spacers draggable for window move

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -428,6 +428,8 @@ struct MainWindowView: View {
                 }
             }
             Spacer()
+                .contentShape(Rectangle())
+                .background(WindowDragArea())
             if windowState.isConversationVisible {
                 ConversationTitleActionsControl(
                     presentation: conversationHeaderPresentation,
@@ -469,6 +471,8 @@ struct MainWindowView: View {
                 })
             }
             Spacer()
+                .contentShape(Rectangle())
+                .background(WindowDragArea())
             if updateManager.isUpdateAvailable {
                 VButton(
                     label: updateManager.isDeferredUpdateReady ? "Restart to update" : "Update",

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -427,9 +427,8 @@ struct MainWindowView: View {
                     .opacity(windowState.navigationHistory.canGoForward ? 1 : 0.35)
                 }
             }
-            Spacer()
-                .contentShape(Rectangle())
-                .background(WindowDragArea())
+            WindowDragArea()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             if windowState.isConversationVisible {
                 ConversationTitleActionsControl(
                     presentation: conversationHeaderPresentation,
@@ -470,9 +469,8 @@ struct MainWindowView: View {
                     }
                 })
             }
-            Spacer()
-                .contentShape(Rectangle())
-                .background(WindowDragArea())
+            WindowDragArea()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             if updateManager.isUpdateAvailable {
                 VButton(
                     label: updateManager.isDeferredUpdateReady ? "Restart to update" : "Update",

--- a/clients/macos/vellum-assistant/Features/MainWindow/WindowDragArea.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/WindowDragArea.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// A lightweight `NSViewRepresentable` that enables window dragging from any
+/// SwiftUI region by calling `window?.performDrag(with:)` on mouse-down.
+///
+/// This bypasses the `NonDraggableContainerView` hierarchy (which sets
+/// `mouseDownCanMoveWindow` to `false` on the hosting view) by initiating the
+/// drag directly from the event.
+struct WindowDragArea: NSViewRepresentable {
+    func makeNSView(context: Context) -> DraggableView {
+        DraggableView()
+    }
+
+    func updateNSView(_ nsView: DraggableView, context: Context) {}
+
+    final class DraggableView: NSView {
+        override var mouseDownCanMoveWindow: Bool { true }
+
+        override func mouseDown(with event: NSEvent) {
+            window?.performDrag(with: event)
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/WindowDragArea.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/WindowDragArea.swift
@@ -17,7 +17,11 @@ struct WindowDragArea: NSViewRepresentable {
         override var mouseDownCanMoveWindow: Bool { true }
 
         override func mouseDown(with event: NSEvent) {
-            window?.performDrag(with: event)
+            if event.clickCount == 2 {
+                window?.zoom(nil)
+            } else {
+                window?.performDrag(with: event)
+            }
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/WindowDragArea.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/WindowDragArea.swift
@@ -18,7 +18,10 @@ struct WindowDragArea: NSViewRepresentable {
 
         override func mouseDown(with event: NSEvent) {
             if event.clickCount == 2 {
-                window?.zoom(nil)
+                // Let the event propagate to TitleBarZoomableWindow.mouseUp
+                // which respects the AppleActionOnDoubleClick system preference
+                // (Minimize / None / Maximize) and handles custom zoom restore.
+                super.mouseDown(with: event)
             } else {
                 window?.performDrag(with: event)
             }


### PR DESCRIPTION
## Summary
Fixes the macOS title bar drag area being too narrow. Users reported that the title bar was "very picky" about where to click to drag and move the window. The root cause was that the two `Spacer()` elements in the title bar HStack had no drag handling, and the hosting view was wrapped in `NonDraggableContainerView`.

## Changes
- **New**: `WindowDragArea` NSViewRepresentable — wraps a custom NSView that calls `window?.performDrag(with:)` on mouseDown, bypassing the `NonDraggableContainerView` hierarchy
- **Modified**: Both title bar spacers now have `.contentShape(Rectangle()).background(WindowDragArea())` for hit testing and drag handling

## Milestone PRs (merged into feature branch)
- #19703: M1: Add WindowDragArea and apply to title bar spacers

## Project issue
Closes #19692

## Test plan
- [ ] Launch app, click-hold-drag on empty space between buttons in title bar → window should move
- [ ] Click buttons in title bar (sidebar, search, back/forward, update, temp chat) → should still work normally
- [ ] Verify traffic light buttons still work
- [ ] Double-click on empty title bar space → should not cause issues

Closes LUM-311
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19708" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
