### PR TITLE
Fix design token guard: use VColor.auxBlack in tooltip shadow

### DIFF
--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -197,7 +197,7 @@ private struct VTooltipContent: View {
             .padding(.vertical, VSpacing.xs)
             .background(VColor.surfaceLift)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-            .shadow(color: .black.opacity(0.12), radius: 4, y: 2)
+            .shadow(color: VColor.auxBlack.opacity(0.12), radius: 4, y: 2)
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace raw `.black` with `VColor.auxBlack` in `NativeTooltipModifier.swift` to pass the design token guard CI check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
