### PR TITLE
M1: Stack confirmation bubble layout vertically (LUM-330)

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -17,6 +17,7 @@ public struct ToolConfirmationBubble: View {
 
     @State private var showDiff = false
     @State private var showTechnicalDetails = false
+    @State private var useCompactConfirmationLayout = false
     @State private var keyboardModel: ToolConfirmationKeyboardModel?
     @AppStorage("hasSeenCommandExplanation") private var hasSeenCommandExplanation = false
     @AppStorage("preferredAllowAction") private var preferredAllowAction: String = "allow_10m"
@@ -199,23 +200,18 @@ public struct ToolConfirmationBubble: View {
     private var pendingContent: some View {
         let actions = topLevelActions
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            // Adaptive layout: horizontal when there's room, vertical when narrow
-            ViewThatFits(in: .horizontal) {
-                // Wide: description + buttons on same row
-                HStack(alignment: .top, spacing: VSpacing.sm) {
-                    confirmationDescription
-                        .frame(minWidth: 200)
-                    Spacer(minLength: VSpacing.md)
+            // Adaptive layout: horizontal when wide, vertical when narrow
+            if useCompactConfirmationLayout {
+                confirmationDescription
+                HStack {
+                    Spacer()
                     confirmationActions
                 }
-
-                // Narrow: description on top, buttons right-aligned below
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
+            } else {
+                HStack(alignment: .top, spacing: VSpacing.sm) {
                     confirmationDescription
-                    HStack {
-                        Spacer()
-                        confirmationActions
-                    }
+                    Spacer(minLength: VSpacing.md)
+                    confirmationActions
                 }
             }
 
@@ -261,12 +257,18 @@ public struct ToolConfirmationBubble: View {
         }
         .padding(VSpacing.md)
         .background(
-            RoundedRectangle(cornerRadius: VRadius.md)
-                .fill(VColor.surfaceOverlay)
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(VColor.borderBase, lineWidth: 0.5)
-                )
+            GeometryReader { geo in
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(VColor.surfaceOverlay)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.borderBase, lineWidth: 0.5)
+                    )
+                    .onAppear { useCompactConfirmationLayout = geo.size.width < 450 }
+                    .onChange(of: geo.size.width) { _, width in
+                        useCompactConfirmationLayout = width < 450
+                    }
+            }
         )
         .onAppear {
             if isKeyboardActive {

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -199,31 +199,30 @@ public struct ToolConfirmationBubble: View {
     private var pendingContent: some View {
         let actions = topLevelActions
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            // Title + action buttons inline
-            HStack(alignment: .top, spacing: VSpacing.sm) {
-                Text(confirmation.humanDescription)
-                    .font(VFont.bodyBold)
-                    .foregroundColor(VColor.contentDefault)
-                    .fixedSize(horizontal: false, vertical: true)
+            // Description text (full width)
+            Text(confirmation.humanDescription)
+                .font(VFont.bodyBold)
+                .foregroundColor(VColor.contentDefault)
+                .fixedSize(horizontal: false, vertical: true)
 
-                Spacer(minLength: VSpacing.md)
+            // Action buttons (right-aligned)
+            HStack(spacing: VSpacing.sm) {
+                Spacer()
 
-                HStack(spacing: VSpacing.sm) {
-                    allowSplitButton
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .strokeBorder(VColor.primaryBase, lineWidth: isPrimaryAllowKeyboardSelected ? 2 : 0)
-                        )
-
-                    VButton(label: "Deny", style: .danger, size: .compact) {
-                        markCommandExplanationSeen()
-                        onDeny()
-                    }
+                allowSplitButton
                     .overlay(
                         RoundedRectangle(cornerRadius: VRadius.md)
-                            .strokeBorder(VColor.systemNegativeStrong, lineWidth: keyboardModel?.selectedAction == .dontAllow ? 2 : 0)
+                            .strokeBorder(VColor.primaryBase, lineWidth: isPrimaryAllowKeyboardSelected ? 2 : 0)
                     )
+
+                VButton(label: "Deny", style: .danger, size: .compact) {
+                    markCommandExplanationSeen()
+                    onDeny()
                 }
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .strokeBorder(VColor.systemNegativeStrong, lineWidth: keyboardModel?.selectedAction == .dontAllow ? 2 : 0)
+                )
             }
 
             // First-time educational banner for command confirmations

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -199,30 +199,24 @@ public struct ToolConfirmationBubble: View {
     private var pendingContent: some View {
         let actions = topLevelActions
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            // Description text (full width)
-            Text(confirmation.humanDescription)
-                .font(VFont.bodyBold)
-                .foregroundColor(VColor.contentDefault)
-                .fixedSize(horizontal: false, vertical: true)
-
-            // Action buttons (right-aligned)
-            HStack(spacing: VSpacing.sm) {
-                Spacer()
-
-                allowSplitButton
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.md)
-                            .strokeBorder(VColor.primaryBase, lineWidth: isPrimaryAllowKeyboardSelected ? 2 : 0)
-                    )
-
-                VButton(label: "Deny", style: .danger, size: .compact) {
-                    markCommandExplanationSeen()
-                    onDeny()
+            // Adaptive layout: horizontal when there's room, vertical when narrow
+            ViewThatFits(in: .horizontal) {
+                // Wide: description + buttons on same row
+                HStack(alignment: .top, spacing: VSpacing.sm) {
+                    confirmationDescription
+                        .frame(minWidth: 200)
+                    Spacer(minLength: VSpacing.md)
+                    confirmationActions
                 }
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .strokeBorder(VColor.systemNegativeStrong, lineWidth: keyboardModel?.selectedAction == .dontAllow ? 2 : 0)
-                )
+
+                // Narrow: description on top, buttons right-aligned below
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    confirmationDescription
+                    HStack {
+                        Spacer()
+                        confirmationActions
+                    }
+                }
             }
 
             // First-time educational banner for command confirmations
@@ -453,6 +447,32 @@ public struct ToolConfirmationBubble: View {
                (hasAllow10m && primary != "allow_10m") ||
                (hasAllowConversation && primary != "allow_conversation") ||
                hasAlwaysAllow
+    }
+
+    private var confirmationDescription: some View {
+        Text(confirmation.humanDescription)
+            .font(VFont.bodyBold)
+            .foregroundColor(VColor.contentDefault)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var confirmationActions: some View {
+        HStack(spacing: VSpacing.sm) {
+            allowSplitButton
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .strokeBorder(VColor.primaryBase, lineWidth: isPrimaryAllowKeyboardSelected ? 2 : 0)
+                )
+
+            VButton(label: "Deny", style: .danger, size: .compact) {
+                markCommandExplanationSeen()
+                onDeny()
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .strokeBorder(VColor.systemNegativeStrong, lineWidth: keyboardModel?.selectedAction == .dontAllow ? 2 : 0)
+            )
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
Part of #19711. Fixes #19712. Closes LUM-330.

- Change `pendingContent` layout from horizontal HStack (text + buttons same row) to vertical VStack (text on top, buttons right-aligned below)
- Description text now gets full card width, wraps naturally at any window size
- Buttons are right-aligned on their own row, matching macOS permission dialog conventions
- Fixes cramped/unreadable layout in narrow/shrunk window views
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
