### PR TITLE
Fix confirmation bubble layout in narrow views (LUM-330)

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -17,6 +17,7 @@ public struct ToolConfirmationBubble: View {
 
     @State private var showDiff = false
     @State private var showTechnicalDetails = false
+    @State private var useCompactConfirmationLayout = false
     @State private var keyboardModel: ToolConfirmationKeyboardModel?
     @AppStorage("hasSeenCommandExplanation") private var hasSeenCommandExplanation = false
     @AppStorage("preferredAllowAction") private var preferredAllowAction: String = "allow_10m"
@@ -199,30 +200,18 @@ public struct ToolConfirmationBubble: View {
     private var pendingContent: some View {
         let actions = topLevelActions
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            // Title + action buttons inline
-            HStack(alignment: .top, spacing: VSpacing.sm) {
-                Text(confirmation.humanDescription)
-                    .font(VFont.bodyBold)
-                    .foregroundColor(VColor.contentDefault)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                Spacer(minLength: VSpacing.md)
-
-                HStack(spacing: VSpacing.sm) {
-                    allowSplitButton
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.md)
-                                .strokeBorder(VColor.primaryBase, lineWidth: isPrimaryAllowKeyboardSelected ? 2 : 0)
-                        )
-
-                    VButton(label: "Deny", style: .danger, size: .compact) {
-                        markCommandExplanationSeen()
-                        onDeny()
-                    }
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.md)
-                            .strokeBorder(VColor.systemNegativeStrong, lineWidth: keyboardModel?.selectedAction == .dontAllow ? 2 : 0)
-                    )
+            // Adaptive layout: horizontal when wide, vertical when narrow
+            if useCompactConfirmationLayout {
+                confirmationDescription
+                HStack {
+                    Spacer()
+                    confirmationActions
+                }
+            } else {
+                HStack(alignment: .top, spacing: VSpacing.sm) {
+                    confirmationDescription
+                    Spacer(minLength: VSpacing.md)
+                    confirmationActions
                 }
             }
 
@@ -268,12 +257,18 @@ public struct ToolConfirmationBubble: View {
         }
         .padding(VSpacing.md)
         .background(
-            RoundedRectangle(cornerRadius: VRadius.md)
-                .fill(VColor.surfaceOverlay)
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(VColor.borderBase, lineWidth: 0.5)
-                )
+            GeometryReader { geo in
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(VColor.surfaceOverlay)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.borderBase, lineWidth: 0.5)
+                    )
+                    .onAppear { useCompactConfirmationLayout = geo.size.width < 450 }
+                    .onChange(of: geo.size.width) { _, width in
+                        useCompactConfirmationLayout = width < 450
+                    }
+            }
         )
         .onAppear {
             if isKeyboardActive {
@@ -454,6 +449,32 @@ public struct ToolConfirmationBubble: View {
                (hasAllow10m && primary != "allow_10m") ||
                (hasAllowConversation && primary != "allow_conversation") ||
                hasAlwaysAllow
+    }
+
+    private var confirmationDescription: some View {
+        Text(confirmation.humanDescription)
+            .font(VFont.bodyBold)
+            .foregroundColor(VColor.contentDefault)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var confirmationActions: some View {
+        HStack(spacing: VSpacing.sm) {
+            allowSplitButton
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .strokeBorder(VColor.primaryBase, lineWidth: isPrimaryAllowKeyboardSelected ? 2 : 0)
+                )
+
+            VButton(label: "Deny", style: .danger, size: .compact) {
+                markCommandExplanationSeen()
+                onDeny()
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .strokeBorder(VColor.systemNegativeStrong, lineWidth: keyboardModel?.selectedAction == .dontAllow ? 2 : 0)
+            )
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
Fixes the tool confirmation bubble (permissions card) layout that looks cramped and unreadable in narrow/shrunk window views. Uses a GeometryReader to adaptively switch between horizontal and vertical layouts based on available width.

## Changes
- Extract `confirmationDescription` and `confirmationActions` into reusable computed properties
- Use GeometryReader to measure container width and switch layouts at 450pt threshold
- Wide (>= 450pt): original horizontal layout (text + buttons on same row)
- Narrow (< 450pt): vertical layout (text on top, buttons right-aligned below)
- Updates live on window resize

## Milestone PRs (merged into feature branch)
- #19713: M1: Stack confirmation bubble layout vertically (LUM-330)

## Project issue
Closes #19711
Closes LUM-330

## Test plan
- [ ] Trigger a tool confirmation at full window width — should show horizontal layout
- [ ] Shrink window below ~450pt — should switch to vertical layout
- [ ] Expand window back — should switch back to horizontal
- [ ] Verify buttons still work in both layouts (Allow, Deny, Show details)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
