### PR TITLE
fix: use app name consistently in macOS menu

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -44,6 +44,28 @@ struct VellumAssistantApp: App {
                     }
                 }
             }
+            // Replace the auto-generated Hide/Quit items so they always
+            // say "Vellum" instead of the bundle display name (which may
+            // be a custom dock label like the assistant's name).
+            CommandGroup(replacing: .appVisibility) {
+                Button("Hide Vellum") {
+                    NSApp.hide(nil)
+                }
+                .keyboardShortcut("h", modifiers: .command)
+                Button("Hide Others") {
+                    NSApp.hideOtherApplications(nil)
+                }
+                .keyboardShortcut("h", modifiers: [.command, .option])
+                Button("Show All") {
+                    NSApp.unhideAllApplications(nil)
+                }
+            }
+            CommandGroup(replacing: .appTermination) {
+                Button("Quit Vellum") {
+                    NSApp.terminate(nil)
+                }
+                .keyboardShortcut("q", modifiers: .command)
+            }
             // Replace the default Settings menu item (which opens the SwiftUI
             // Settings scene window) with one that opens the in-app panel.
             CommandGroup(replacing: .appSettings) {

--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -4,6 +4,7 @@ import VellumAssistantLib
 @main
 struct VellumAssistantApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    private var appName: String { AppDelegate.appName }
 
     var body: some Scene {
         // The Settings scene exists solely to host the .commands menu items
@@ -22,7 +23,7 @@ struct VellumAssistantApp: App {
         }
         .commands {
             CommandGroup(replacing: .appInfo) {
-                Button("About Vellum") {
+                Button("About \(appName)") {
                     appDelegate.showAboutPanel()
                 }
                 Button(appDelegate.updateManager.updateMenuItemTitle) {
@@ -30,11 +31,11 @@ struct VellumAssistantApp: App {
                 }
                 .disabled(!appDelegate.updateManager.updateMenuItemIsEnabled)
                 Divider()
-                Button("Send Logs to Vellum") {
+                Button("Send Logs to \(appName)") {
                     appDelegate.sendLogsToSentry()
                 }
                 Divider()
-                Button("Uninstall Vellum...") {
+                Button("Uninstall \(appName)...") {
                     appDelegate.performUninstall()
                 }
                 if appDelegate.authManager.isAuthenticated {
@@ -48,7 +49,7 @@ struct VellumAssistantApp: App {
             // say "Vellum" instead of the bundle display name (which may
             // be a custom dock label like the assistant's name).
             CommandGroup(replacing: .appVisibility) {
-                Button("Hide Vellum") {
+                Button("Hide \(appName)") {
                     NSApp.hide(nil)
                 }
                 .keyboardShortcut("h", modifiers: .command)
@@ -61,7 +62,7 @@ struct VellumAssistantApp: App {
                 }
             }
             CommandGroup(replacing: .appTermination) {
-                Button("Quit Vellum") {
+                Button("Quit \(appName)") {
                     NSApp.terminate(nil)
                 }
                 .keyboardShortcut("q", modifiers: .command)

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -35,9 +35,14 @@ final class AppMenuPatchDelegate: NSObject, NSMenuDelegate {
         if menu.title != name {
             menu.title = name
         }
-        // Patch any remaining items that still contain the bundle name.
-        for item in menu.items where item.title.contains(bundleDisplayName) {
-            item.title = item.title.replacingOccurrences(of: bundleDisplayName, with: name)
+        // Patch only the system-generated app-name items (About, Hide, Quit).
+        // A blanket replacingOccurrences would break if the bundle name were
+        // a common word like "All" or "Settings".
+        let prefixes = ["About ", "Hide ", "Quit "]
+        for item in menu.items {
+            for prefix in prefixes where item.title == "\(prefix)\(bundleDisplayName)" {
+                item.title = "\(prefix)\(name)"
+            }
         }
     }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -10,6 +10,37 @@ extension Notification.Name {
     static let activateChatSearch = Notification.Name("activateChatSearch")
 }
 
+/// Delegate installed on the app submenu to patch the menu bar title to
+/// "Vellum" right before macOS renders it.  SwiftUI resets the title from
+/// the bundle display name, so we override it in `menuWillOpen`.
+final class AppMenuPatchDelegate: NSObject, NSMenuDelegate {
+    let bundleDisplayName: String
+
+    init(bundleDisplayName: String) {
+        self.bundleDisplayName = bundleDisplayName
+    }
+
+    func menuWillOpen(_ menu: NSMenu) {
+        patchTitles(menu: menu)
+    }
+
+    func patchTitles(menu: NSMenu) {
+        // Patch the parent menu item title (the bold text in the menu bar).
+        if let mainMenu = NSApp.mainMenu,
+           let appMenuItem = mainMenu.items.first,
+           appMenuItem.title != "Vellum" {
+            appMenuItem.title = "Vellum"
+        }
+        if menu.title != "Vellum" {
+            menu.title = "Vellum"
+        }
+        // Patch any remaining items that still contain the bundle name.
+        for item in menu.items where item.title.contains(bundleDisplayName) {
+            item.title = item.title.replacingOccurrences(of: bundleDisplayName, with: "Vellum")
+        }
+    }
+}
+
 extension AppDelegate {
 
     // MARK: - Menu Bar

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -25,18 +25,19 @@ final class AppMenuPatchDelegate: NSObject, NSMenuDelegate {
     }
 
     func patchTitles(menu: NSMenu) {
+        let name = AppDelegate.appName
         // Patch the parent menu item title (the bold text in the menu bar).
         if let mainMenu = NSApp.mainMenu,
            let appMenuItem = mainMenu.items.first,
-           appMenuItem.title != "Vellum" {
-            appMenuItem.title = "Vellum"
+           appMenuItem.title != name {
+            appMenuItem.title = name
         }
-        if menu.title != "Vellum" {
-            menu.title = "Vellum"
+        if menu.title != name {
+            menu.title = name
         }
         // Patch any remaining items that still contain the bundle name.
         for item in menu.items where item.title.contains(bundleDisplayName) {
-            item.title = item.title.replacingOccurrences(of: bundleDisplayName, with: "Vellum")
+            item.title = item.title.replacingOccurrences(of: bundleDisplayName, with: name)
         }
     }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -683,7 +683,7 @@ extension AppDelegate {
         creditsString.append(NSAttributedString(string: archLabel, attributes: archAttributes))
 
         options[.credits] = creditsString
-        options[.applicationName] = "Vellum"
+        options[.applicationName] = Self.appName
 
         NSApp.activate(ignoringOtherApps: true)
         NSApp.orderFrontStandardAboutPanel(options: options)

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -683,6 +683,7 @@ extension AppDelegate {
         creditsString.append(NSAttributedString(string: archLabel, attributes: archAttributes))
 
         options[.credits] = creditsString
+        options[.applicationName] = "Vellum"
 
         NSApp.activate(ignoringOtherApps: true)
         NSApp.orderFrontStandardAboutPanel(options: options)

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -169,6 +169,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     /// macOS renders them.
     private var appMenuPatchDelegate: AppMenuPatchDelegate?
     private var appMenuTrackingObserver: NSObjectProtocol?
+    private var appMenuActivationObserver: NSObjectProtocol?
 
     public func applicationWillFinishLaunching(_ notification: Notification) {
         // Ensure the macOS app menu consistently says "Vellum" (Hide Vellum,
@@ -212,7 +213,29 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             }
         }
 
-        // Apply immediately.
+        // Patch when the app becomes active (reopen from Dock, Cmd+Tab, etc.)
+        // so the title is correct before the user clicks the menu.
+        if appMenuActivationObserver == nil {
+            appMenuActivationObserver = NotificationCenter.default.addObserver(
+                forName: NSApplication.didBecomeActiveNotification,
+                object: nil,
+                queue: .main
+            ) { _ in
+                if let item = NSApp.mainMenu?.items.first, item.title != AppDelegate.appName {
+                    item.title = AppDelegate.appName
+                }
+            }
+        }
+
+        // Apply immediately, and again after a short delay to catch SwiftUI
+        // resetting the title after applicationDidFinishLaunching returns.
+        applyMenuBarTitlePatch()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            self?.applyMenuBarTitlePatch()
+        }
+    }
+
+    private func applyMenuBarTitlePatch() {
         if let item = NSApp.mainMenu?.items.first, item.title != Self.appName {
             item.title = Self.appName
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -151,6 +151,68 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
     @AppStorage("themePreference") private var themePreference: String = "system"
 
+    // MARK: - App Menu Name Patching
+
+    /// The bundle display name from Info.plist (may be a custom dock label).
+    private lazy var bundleDisplayName: String = {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
+            ?? Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String
+            ?? "Vellum"
+    }()
+
+    /// Delegate that patches the app menu items to "Vellum" right before
+    /// macOS renders them.
+    private var appMenuPatchDelegate: AppMenuPatchDelegate?
+    private var appMenuTrackingObserver: NSObjectProtocol?
+
+    public func applicationWillFinishLaunching(_ notification: Notification) {
+        // Ensure the macOS app menu consistently says "Vellum" (Hide Vellum,
+        // Quit Vellum, etc.) regardless of the executable name — which may
+        // differ between production builds (renamed to "Vellum" by build.sh)
+        // and development builds (SPM target name).  The bundle display name
+        // may be a custom dock label (e.g. an assistant name), so we patch
+        // both the process name and the main menu items.
+        ProcessInfo.processInfo.processName = "Vellum"
+    }
+
+    /// Installs observers that patch the app menu bar title and items to
+    /// "Vellum".  The menu bar title is patched via didBeginTracking (fires
+    /// when the user clicks the menu bar, before rendering) and the submenu
+    /// items are patched via a delegate.
+    func patchAppMenuTitles() {
+        guard bundleDisplayName != "Vellum" else { return }
+
+        if appMenuPatchDelegate == nil {
+            appMenuPatchDelegate = AppMenuPatchDelegate(
+                bundleDisplayName: bundleDisplayName
+            )
+        }
+
+        // Patch submenu items via delegate.
+        if let appMenu = NSApp.mainMenu?.items.first?.submenu {
+            appMenu.delegate = appMenuPatchDelegate
+            appMenuPatchDelegate?.patchTitles(menu: appMenu)
+        }
+
+        // Patch the menu bar title right when the user clicks the menu bar.
+        if appMenuTrackingObserver == nil {
+            appMenuTrackingObserver = NotificationCenter.default.addObserver(
+                forName: NSMenu.didBeginTrackingNotification,
+                object: NSApp.mainMenu,
+                queue: .main
+            ) { _ in
+                if let item = NSApp.mainMenu?.items.first, item.title != "Vellum" {
+                    item.title = "Vellum"
+                }
+            }
+        }
+
+        // Apply immediately.
+        if let item = NSApp.mainMenu?.items.first, item.title != "Vellum" {
+            item.title = "Vellum"
+        }
+    }
+
     public func applicationDidFinishLaunching(_ notification: Notification) {
         // ── Single-instance guard ──────────────────────────────────────
         // If another copy of this app is already running (e.g. Sparkle
@@ -291,6 +353,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
         // Set up menu bar and hotkeys early so they work regardless of auth state.
         setupMenuBar()
+        patchAppMenuTitles()
         setupHotKey()
 
         // Install CLI symlinks early so they are available before the daemon
@@ -364,6 +427,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         AvatarAppearanceManager.shared.reloadAvatar()
         setupMenuBar()
         setupFileMenu()
+        patchAppMenuTitles()
         registerNavigationMonitor()
         registerZoomMonitor()
         setupHotKey()

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -562,6 +562,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         if let observer = avatarChangeObserver {
             NotificationCenter.default.removeObserver(observer)
         }
+        if let observer = appMenuTrackingObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        if let observer = appMenuActivationObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
         statusIconCancellable?.cancel()
         conversationBadgeCancellable?.cancel()
         NSApp.dockTile.badgeLabel = nil

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -12,6 +12,11 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 
 @MainActor
 public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
+    /// The canonical product name shown in menus and the About panel.
+    /// Use this instead of hardcoding "Vellum" so the name is defined
+    /// in one place.
+    public static let appName = "Vellum"
+
     /// Shared reference — `NSApp.delegate as? AppDelegate` fails under
     /// SwiftUI's `@NSApplicationDelegateAdaptor` because SwiftUI wraps
     /// the delegate.  Use `AppDelegate.shared` instead.
@@ -157,7 +162,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     private lazy var bundleDisplayName: String = {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
             ?? Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String
-            ?? "Vellum"
+            ?? Self.appName
     }()
 
     /// Delegate that patches the app menu items to "Vellum" right before
@@ -172,7 +177,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         // and development builds (SPM target name).  The bundle display name
         // may be a custom dock label (e.g. an assistant name), so we patch
         // both the process name and the main menu items.
-        ProcessInfo.processInfo.processName = "Vellum"
+        ProcessInfo.processInfo.processName = Self.appName
     }
 
     /// Installs observers that patch the app menu bar title and items to
@@ -180,7 +185,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     /// when the user clicks the menu bar, before rendering) and the submenu
     /// items are patched via a delegate.
     func patchAppMenuTitles() {
-        guard bundleDisplayName != "Vellum" else { return }
+        guard bundleDisplayName != Self.appName else { return }
 
         if appMenuPatchDelegate == nil {
             appMenuPatchDelegate = AppMenuPatchDelegate(
@@ -201,15 +206,15 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 object: NSApp.mainMenu,
                 queue: .main
             ) { _ in
-                if let item = NSApp.mainMenu?.items.first, item.title != "Vellum" {
-                    item.title = "Vellum"
+                if let item = NSApp.mainMenu?.items.first, item.title != AppDelegate.appName {
+                    item.title = AppDelegate.appName
                 }
             }
         }
 
         // Apply immediately.
-        if let item = NSApp.mainMenu?.items.first, item.title != "Vellum" {
-            item.title = "Vellum"
+        if let item = NSApp.mainMenu?.items.first, item.title != Self.appName {
+            item.title = Self.appName
         }
     }
 


### PR DESCRIPTION
## Summary
- Set `ProcessInfo.processName` to "Vellum" in `applicationWillFinishLaunching` for standard menu items
- Override `.appVisibility` and `.appTermination` SwiftUI command groups to hardcode "Hide Vellum" and "Quit Vellum"
- Add `AppMenuPatchDelegate` with `menuWillOpen` and `didBeginTrackingNotification` to fix the bold menu bar title (SwiftUI resets it from the bundle display name, which may be a custom dock label)
- Pass `.applicationName = "Vellum"` to the About panel

## Original prompt
--safe https://linear.app/vellum/issue/LUM-308/use-app-name-consistently-in-macos-menu change everything in App menu to say Vellum

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
