### PR TITLE
Fix confirmation bubble compact layout width measurement

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -256,6 +256,7 @@ public struct ToolConfirmationBubble: View {
             .clipped()
         }
         .padding(VSpacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             GeometryReader { geo in
                 RoundedRectangle(cornerRadius: VRadius.md)


### PR DESCRIPTION
## Summary
- Add `.frame(maxWidth: .infinity)` so the confirmation bubble fills the available chat width
- This ensures the GeometryReader measures the container width (stable) rather than the bubble's intrinsic content width (which shrinks in compact mode and gets stuck)
- Addresses review feedback on #19716

Part of LUM-330

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
