### PR TITLE
M1: Hide inline permission chips at narrow widths (LUM-330)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -43,6 +43,7 @@ struct AssistantProgressView: View {
     @State private var processingStartDate: Date?
     @State private var isOverflowPopoverShown: Bool = false
     @State private var suppressNextExpand: Bool = false
+    @State private var hideInlineChips: Bool = false
 
     // MARK: - Derived State
 
@@ -352,8 +353,8 @@ struct AssistantProgressView: View {
                 // Headline text with cross-fade
                 headlineLabel
 
-                // Inline permission chips (collapsed only, max 2 + overflow)
-                if !isExpanded {
+                // Inline permission chips (collapsed only, hidden at narrow widths)
+                if !isExpanded && !hideInlineChips {
                     inlinePermissionChips
                 }
 
@@ -377,6 +378,13 @@ struct AssistantProgressView: View {
         .buttonStyle(.plain)
         .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.xs)
+        .background(GeometryReader { geo in
+            Color.clear
+                .onAppear { hideInlineChips = geo.size.width < 350 }
+                .onChange(of: geo.size.width) { _, width in
+                    hideInlineChips = width < 350
+                }
+        })
     }
 
     // MARK: - Status Icon


### PR DESCRIPTION
Part of #19720. Fixes #19721. Part of LUM-330.

- Add `hideInlineChips` state driven by GeometryReader width measurement on the header row
- Hide `inlinePermissionChips` when width < 350pt
- Chips remain visible at normal/wide widths — no behavior change for standard window sizes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
