### PR TITLE
Hide inline permission chips in narrow views (LUM-330)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -43,6 +43,7 @@ struct AssistantProgressView: View {
     @State private var processingStartDate: Date?
     @State private var isOverflowPopoverShown: Bool = false
     @State private var suppressNextExpand: Bool = false
+    @State private var hideInlineChips: Bool = false
 
     // MARK: - Derived State
 
@@ -352,8 +353,8 @@ struct AssistantProgressView: View {
                 // Headline text with cross-fade
                 headlineLabel
 
-                // Inline permission chips (collapsed only, max 2 + overflow)
-                if !isExpanded {
+                // Inline permission chips (collapsed only, hidden at narrow widths)
+                if !isExpanded && !hideInlineChips {
                     inlinePermissionChips
                 }
 
@@ -377,6 +378,13 @@ struct AssistantProgressView: View {
         .buttonStyle(.plain)
         .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.xs)
+        .background(GeometryReader { geo in
+            Color.clear
+                .onAppear { hideInlineChips = geo.size.width < 350 }
+                .onChange(of: geo.size.width) { _, width in
+                    hideInlineChips = width < 350
+                }
+        })
     }
 
     // MARK: - Status Icon

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -378,6 +378,7 @@ struct AssistantProgressView: View {
         .buttonStyle(.plain)
         .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.xs)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(GeometryReader { geo in
             Color.clear
                 .onAppear { hideInlineChips = geo.size.width < 350 }


### PR DESCRIPTION
## Summary
Hides the inline permission badge chips in the AssistantProgressView header row when the chat window is too narrow, preventing text truncation and badge overflow.

## Changes
- Add GeometryReader width measurement on the header row
- Hide `inlinePermissionChips` when width < 350pt
- Chips remain visible at normal/wide widths

## Milestone PRs (merged into feature branch)
- #19722: M1: Hide inline permission chips at narrow widths

## Project issue
Closes #19720
Part of LUM-330

## Test plan
- [ ] Trigger a tool confirmation and let it complete (so chips appear in collapsed header)
- [ ] At normal width: chips visible alongside "Completed N steps"
- [ ] Shrink window below ~350pt: chips hidden, only "Completed..." text + timer visible
- [ ] Expand back: chips reappear

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
