### PR TITLE
M2: Add missing design system components to gallery

### DIFF
--- a/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -309,6 +309,132 @@ struct FeedbackGallerySection: View {
                     onDismiss: {}
                 )
             }
+
+            Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+
+            // MARK: - VBusyIndicator
+            GallerySectionHeader(
+                title: "VBusyIndicator",
+                description: "Pulsing dot indicator for busy/processing state. Respects reduced motion."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.xl) {
+                    // Size variants
+                    HStack(spacing: VSpacing.xxl) {
+                        VStack(spacing: VSpacing.md) {
+                            Text("Small (6)").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                            VBusyIndicator(size: 6)
+                        }
+                        VStack(spacing: VSpacing.md) {
+                            Text("Default (10)").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                            VBusyIndicator()
+                        }
+                        VStack(spacing: VSpacing.md) {
+                            Text("Large (16)").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                            VBusyIndicator(size: 16)
+                        }
+                    }
+
+                    Divider().background(VColor.borderBase)
+
+                    // Color variants
+                    HStack(spacing: VSpacing.xxl) {
+                        VStack(spacing: VSpacing.md) {
+                            Text("Accent").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                            VBusyIndicator(color: VColor.primaryBase)
+                        }
+                        VStack(spacing: VSpacing.md) {
+                            Text("Success").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                            VBusyIndicator(color: VColor.systemPositiveStrong)
+                        }
+                        VStack(spacing: VSpacing.md) {
+                            Text("Error").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                            VBusyIndicator(color: VColor.systemNegativeStrong)
+                        }
+                    }
+                }
+            }
+
+            Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+
+            // MARK: - VSkeletonBone
+            GallerySectionHeader(
+                title: "VSkeletonBone",
+                description: "Skeleton placeholder for loading states. Pairs with .vShimmer() for animation."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.xl) {
+                    // Text line
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Text line").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                        VSkeletonBone(height: 14)
+                    }
+
+                    Divider().background(VColor.borderBase)
+
+                    // Title
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Title").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                        VSkeletonBone(width: 200, height: 20)
+                    }
+
+                    Divider().background(VColor.borderBase)
+
+                    // Avatar
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Avatar").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                        VSkeletonBone(width: 40, height: 40, radius: VRadius.pill)
+                    }
+
+                    Divider().background(VColor.borderBase)
+
+                    // Paragraph
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Paragraph").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                        VStack(alignment: .leading, spacing: VSpacing.sm) {
+                            VSkeletonBone(height: 14)
+                            VSkeletonBone(width: 280, height: 14)
+                            VSkeletonBone(width: 200, height: 14)
+                        }
+                    }
+                }
+            }
+
+            Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+
+            // MARK: - VSkillTypePill
+            GallerySectionHeader(
+                title: "VSkillTypePill",
+                description: "Pill badge indicating skill type or source."
+            )
+
+            VCard {
+                HStack(spacing: VSpacing.lg) {
+                    VSkillTypePill(type: .core)
+                    VSkillTypePill(type: .installed)
+                    VSkillTypePill(type: .created)
+                    VSkillTypePill(type: .extra)
+                }
+            }
+
+            Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+
+            // MARK: - VInfoTooltip
+            GallerySectionHeader(
+                title: "VInfoTooltip",
+                description: "Small info-circle icon with hover tooltip for supplementary information."
+            )
+
+            VCard {
+                HStack(spacing: VSpacing.xs) {
+                    Text("Some setting")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentDefault)
+                    VInfoTooltip("Explanation of this setting.")
+                }
+            }
         }
     }
 }

--- a/clients/shared/DesignSystem/Gallery/Sections/ModifiersGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ModifiersGallerySection.swift
@@ -257,6 +257,59 @@ struct ModifiersGallerySection: View {
                         }
                 }
             }
+
+            Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+
+            // MARK: - .vShimmer()
+            GallerySectionHeader(
+                title: ".vShimmer()",
+                description: "Sweeps a translucent highlight across the view for skeleton loading. Respects reduced motion."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
+                        HStack(spacing: VSpacing.md) {
+                            VSkeletonBone(width: 40, height: 40, radius: VRadius.pill)
+                            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                                VSkeletonBone(width: 120, height: 14)
+                                VSkeletonBone(width: 80, height: 12)
+                            }
+                        }
+                        VSkeletonBone(height: 14)
+                        VSkeletonBone(width: 240, height: 14)
+                        VSkeletonBone(width: 180, height: 14)
+                    }
+                    .vShimmer()
+                }
+            }
+
+            Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+
+            // MARK: - .inlineWidgetCard()
+            GallerySectionHeader(
+                title: ".inlineWidgetCard()",
+                description: "Standard card chrome for inline chat widgets. Applies padding, background, border, and optional hover highlight."
+            )
+
+            VCard {
+                HStack(spacing: VSpacing.lg) {
+                    VStack(spacing: VSpacing.md) {
+                        Text("Non-interactive (default)").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                        Text("Widget content")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.contentDefault)
+                            .inlineWidgetCard()
+                    }
+                    VStack(spacing: VSpacing.md) {
+                        Text("Interactive (hover highlight)").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                        Text("Clickable widget")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.contentDefault)
+                            .inlineWidgetCard(interactive: true)
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Add gallery entries for 4 design system components and 2 modifiers that are actively used in production but were missing from the Component Gallery.

### FeedbackGallerySection additions:
- **VBusyIndicator** — size variants (6pt, 10pt, 16pt) and color variants (accent, success, error)
- **VSkeletonBone** — text line, title, avatar, and paragraph variants
- **VSkillTypePill** — all built-in variants (core, installed, created, extra)
- **VInfoTooltip** — inline usage with a label

### ModifiersGallerySection additions:
- **.vShimmer()** — loading card with skeleton bones demonstrating the shimmer effect
- **.inlineWidgetCard()** — non-interactive (default) and interactive (hover highlight) variants

Part of #19698

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
