### PR TITLE
Fix chat messages disappearing during panel resize

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -198,7 +198,7 @@ struct MessageListView: View {
     /// case where pagination stalls without adding/removing messages.
     @State private var anchorTimeoutTask: Task<Void, Never>?
     /// Last container width that triggered a resize scroll handler, used to
-    /// detect meaningful width changes (>20pt) and avoid sub-pixel jitter.
+    /// detect meaningful width changes (>2pt) and avoid sub-pixel jitter.
     @State private var lastHandledContainerWidth: CGFloat = 0
     /// In-flight resize scroll stabilization task; cancelled on each new resize.
     @State private var resizeScrollTask: Task<Void, Never>?

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1453,8 +1453,12 @@ struct MessageListView: View {
                 }
             }
             .onChange(of: containerWidth) {
-                // Ignore sub-pixel jitter and initial zero value
-                guard containerWidth > 0, abs(containerWidth - lastHandledContainerWidth) > 20 else { return }
+                // Ignore sub-pixel jitter and initial zero value.
+                // Use a tight 2pt threshold so scroll suppression activates on
+                // any meaningful width change during divider drag — the previous
+                // 20pt dead-zone let intermediate reflows through without suppression,
+                // causing scroll position desync and disappearing messages.
+                guard containerWidth > 0, abs(containerWidth - lastHandledContainerWidth) > 2 else { return }
                 lastHandledContainerWidth = containerWidth
 
                 // Cancel competing scroll tasks to prevent jitter during resize


### PR DESCRIPTION
## Summary
Fixes chat messages disappearing when dragging the green vertical divider to resize the chat panel. The scroll position would desynchronize because small width changes bypassed the resize suppression dead-zone.

## Changes
- Lower the containerWidth dead-zone threshold from 20pt to 2pt in MessageListView's resize handler
- Ensures scroll suppression activates on any meaningful width change during divider drag
- Prevents text reflow from triggering unsuppressed scroll-to-bottom with stale metrics

## Milestone PRs (merged into feature branch)
- #19732: M1: Lower resize dead-zone to prevent scroll desync

## Project issue
Closes #19730

## Test plan
- [ ] Open a conversation with several messages
- [ ] Open a document panel (side-by-side view)
- [ ] Drag the green vertical divider to shrink the chat
- [ ] Verify messages remain visible during and after resize
- [ ] Drag divider back to widen — messages should still be there
- [ ] Verify normal scroll behavior unaffected (new messages, streaming, manual scroll)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
