### PR TITLE
fix: harden DB migrations against missing columns and crash recovery

### DIFF
--- a/assistant/src/memory/migrations/036-normalize-phone-identities.ts
+++ b/assistant/src/memory/migrations/036-normalize-phone-identities.ts
@@ -79,9 +79,27 @@ export function migrateNormalizePhoneIdentities(database: DrizzleDb): void {
       .get(table);
     const orderBy = hasUpdatedAt ? "updated_at DESC, rowid DESC" : "rowid DESC";
 
-    const selectColumns = [`id`, column];
+    // Filter uniqueKeyScope to only include peer columns that actually exist in the table.
+    // If a peer column is missing, its unique index can't exist either, so no collision risk.
+    let effectiveScope = uniqueKeyScope;
     if (uniqueKeyScope) {
-      for (const peer of uniqueKeyScope.peerColumns) {
+      const validPeers = uniqueKeyScope.peerColumns.filter(
+        (col) =>
+          !!raw
+            .query(`SELECT 1 FROM pragma_table_info(?) WHERE name = ?`)
+            .get(table, col),
+      );
+      effectiveScope =
+        validPeers.length === uniqueKeyScope.peerColumns.length
+          ? uniqueKeyScope
+          : validPeers.length > 0
+            ? { ...uniqueKeyScope, peerColumns: validPeers }
+            : undefined;
+    }
+
+    const selectColumns = [`id`, column];
+    if (effectiveScope) {
+      for (const peer of effectiveScope.peerColumns) {
         if (!selectColumns.includes(peer)) selectColumns.push(peer);
       }
     }
@@ -104,14 +122,14 @@ export function migrateNormalizePhoneIdentities(database: DrizzleDb): void {
       if (!original) continue;
       const normalized = normalizePhoneNumber(original);
       if (normalized && normalized !== original) {
-        if (uniqueKeyScope) {
+        if (effectiveScope) {
           // Check if another row already has the normalized value within the same unique-key scope
-          const peerConditions = uniqueKeyScope.peerColumns
+          const peerConditions = effectiveScope.peerColumns
             .map((col) => `${col} = ?`)
             .join(" AND ");
-          const peerValues = uniqueKeyScope.peerColumns.map((col) => row[col]);
-          const whereExtra = uniqueKeyScope.whereClause
-            ? ` AND (${uniqueKeyScope.whereClause})`
+          const peerValues = effectiveScope.peerColumns.map((col) => row[col]);
+          const whereExtra = effectiveScope.whereClause
+            ? ` AND (${effectiveScope.whereClause})`
             : "";
           const existing = raw
             .query(
@@ -154,9 +172,26 @@ export function migrateNormalizePhoneIdentities(database: DrizzleDb): void {
       .get(table);
     const orderBy = hasUpdatedAt ? "updated_at DESC, rowid DESC" : "rowid DESC";
 
-    const selectColumns = [`id`, column];
+    // Filter uniqueKeyScope to only include peer columns that actually exist in the table.
+    let effectiveScope = uniqueKeyScope;
     if (uniqueKeyScope) {
-      for (const peer of uniqueKeyScope.peerColumns) {
+      const validPeers = uniqueKeyScope.peerColumns.filter(
+        (col) =>
+          !!raw
+            .query(`SELECT 1 FROM pragma_table_info(?) WHERE name = ?`)
+            .get(table, col),
+      );
+      effectiveScope =
+        validPeers.length === uniqueKeyScope.peerColumns.length
+          ? uniqueKeyScope
+          : validPeers.length > 0
+            ? { ...uniqueKeyScope, peerColumns: validPeers }
+            : undefined;
+    }
+
+    const selectColumns = [`id`, column];
+    if (effectiveScope) {
+      for (const peer of effectiveScope.peerColumns) {
         if (!selectColumns.includes(peer)) selectColumns.push(peer);
       }
     }
@@ -179,13 +214,13 @@ export function migrateNormalizePhoneIdentities(database: DrizzleDb): void {
       if (!original) continue;
       const normalized = normalizePhoneNumber(original);
       if (normalized && normalized !== original) {
-        if (uniqueKeyScope) {
-          const peerConditions = uniqueKeyScope.peerColumns
+        if (effectiveScope) {
+          const peerConditions = effectiveScope.peerColumns
             .map((col) => `${col} = ?`)
             .join(" AND ");
-          const peerValues = uniqueKeyScope.peerColumns.map((col) => row[col]);
-          const whereExtra = uniqueKeyScope.whereClause
-            ? ` AND (${uniqueKeyScope.whereClause})`
+          const peerValues = effectiveScope.peerColumns.map((col) => row[col]);
+          const whereExtra = effectiveScope.whereClause
+            ? ` AND (${effectiveScope.whereClause})`
             : "";
           const existing = raw
             .query(

--- a/assistant/src/memory/migrations/135-backfill-contact-interaction-stats.ts
+++ b/assistant/src/memory/migrations/135-backfill-contact-interaction-stats.ts
@@ -1,4 +1,4 @@
-import type { DrizzleDb } from "../db-connection.js";
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
 /**
@@ -7,6 +7,14 @@ import { withCrashRecovery } from "./validate-migration-state.js";
  * existing data, so it stays at 0 and accumulates going forward.
  */
 export function migrateBackfillContactInteractionStats(db: DrizzleDb): void {
+  const raw = getSqliteFrom(db);
+  const colExists = raw
+    .query(
+      `SELECT 1 FROM pragma_table_info('contacts') WHERE name = 'last_interaction'`,
+    )
+    .get();
+  if (!colExists) return;
+
   withCrashRecovery(db, "backfill_contact_interaction_stats", () => {
     db.run(/*sql*/ `
       UPDATE contacts

--- a/assistant/src/memory/migrations/141-rename-verification-table.ts
+++ b/assistant/src/memory/migrations/141-rename-verification-table.ts
@@ -18,6 +18,14 @@ export function migrateRenameVerificationTable(database: DrizzleDb): void {
       .get();
     if (!oldTableExists) return;
 
+    // If the new table already exists, the rename would collide — skip
+    const newTableExists = raw
+      .query(
+        `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'channel_verification_sessions'`,
+      )
+      .get();
+    if (newTableExists) return;
+
     // Rename the physical table
     raw.exec(
       /*sql*/ `ALTER TABLE channel_guardian_verification_challenges RENAME TO channel_verification_sessions`,

--- a/assistant/src/memory/migrations/142-rename-verification-session-id-column.ts
+++ b/assistant/src/memory/migrations/142-rename-verification-session-id-column.ts
@@ -15,14 +15,19 @@ export function migrateRenameVerificationSessionIdColumn(
     () => {
       const raw = getSqliteFrom(database);
 
-      // Check the old column exists before attempting the rename
+      // Check the old column exists and the new column doesn't before attempting the rename.
+      // Both checks are needed for crash recovery: if the rename succeeded but the checkpoint
+      // didn't commit, the old column is gone and the new one already exists.
       const columns = raw
         .query(`PRAGMA table_info(call_sessions)`)
         .all() as Array<{ name: string }>;
       const hasOldColumn = columns.some(
         (c) => c.name === "guardian_verification_session_id",
       );
-      if (!hasOldColumn) return;
+      const hasNewColumn = columns.some(
+        (c) => c.name === "verification_session_id",
+      );
+      if (!hasOldColumn || hasNewColumn) return;
 
       raw.exec(
         /*sql*/ `ALTER TABLE call_sessions RENAME COLUMN guardian_verification_session_id TO verification_session_id`,

--- a/assistant/src/memory/migrations/174-rename-thread-starters-table.ts
+++ b/assistant/src/memory/migrations/174-rename-thread-starters-table.ts
@@ -21,6 +21,14 @@ export function migrateRenameThreadStartersTable(database: DrizzleDb): void {
         .get();
       if (!oldTableExists) return;
 
+      // If the new table already exists (crash recovery), skip the rename
+      const newTableExists = raw
+        .query(
+          `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'conversation_starters'`,
+        )
+        .get();
+      if (newTableExists) return;
+
       // Rename the physical table
       raw.exec(
         /*sql*/ `ALTER TABLE thread_starters RENAME TO conversation_starters`,


### PR DESCRIPTION
## Summary
- Add column/table existence guards to 5 DB migrations that crash when the expected schema state doesn't match (missing columns, tables already renamed)
- Fixes crash-recovery scenarios where a migration succeeded (e.g. table renamed) but the checkpoint didn't commit, causing the migration to re-run and fail with "duplicate column/table" errors
- Specifically fixes daemon startup crash with `SQLiteError: no such column: assistant_id` in migration 036

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
