### PR TITLE
fix: silence appName Sendable closure warning

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -15,7 +15,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     /// The canonical product name shown in menus and the About panel.
     /// Use this instead of hardcoding "Vellum" so the name is defined
     /// in one place.
-    public static let appName = "Vellum"
+    nonisolated(unsafe) public static let appName = "Vellum"
 
     /// Shared reference — `NSApp.delegate as? AppDelegate` fails under
     /// SwiftUI's `@NSApplicationDelegateAdaptor` because SwiftUI wraps


### PR DESCRIPTION
## Summary
- Mark `AppDelegate.appName` as `nonisolated(unsafe)` to silence the Swift concurrency warning about accessing a main-actor-isolated static property from a Sendable closure
- Safe because `appName` is an immutable `static let` initialized with a string literal — no data race possible

## Original prompt
Fix main actor-isolated static property 'appName' can not be referenced from a Sendable closure warning in AppDelegate.swift