### PR TITLE
M1: Add tooltips to voice and dictation mode buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -529,6 +529,7 @@ VStreamingWaveform(
                             (onDictateToggle ?? onMicrophoneToggle)()
                         }
                     )
+                    .vTooltip("Cancel")
 
                     // Accept: stop dictation and keep transcribed text
                     VButton(
@@ -541,6 +542,7 @@ VStreamingWaveform(
                             (onDictateToggle ?? onMicrophoneToggle)()
                         }
                     )
+                    .vTooltip("Send")
                 }
             }
         }
@@ -582,6 +584,7 @@ VStreamingWaveform(
                         action: { manager.toggleListening() }
                     )
                     .disabled(manager.state == .processing)
+                    .vTooltip(manager.state == .listening ? "Mute" : "Unmute")
 
                     VButton(
                         label: "End voice mode",
@@ -590,6 +593,7 @@ VStreamingWaveform(
                         iconSize: composerActionButtonSize,
                         action: { onEndVoiceMode?() }
                     )
+                    .vTooltip("Cancel Live Voice")
                 }
             }
             .padding(.vertical, VSpacing.md)


### PR DESCRIPTION
Part of #19736.

- Add .vTooltip("Cancel") to dictation cancel button (X)
- Add .vTooltip("Send") to dictation accept button (green check)
- Add .vTooltip("Mute"/"Unmute") to voice mode mic button
- Add .vTooltip("Cancel Live Voice") to voice mode end button
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19737" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
