### PR TITLE
Add tooltips to voice and dictation mode buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -542,7 +542,7 @@ VStreamingWaveform(
                             (onDictateToggle ?? onMicrophoneToggle)()
                         }
                     )
-                    .vTooltip("Send")
+                    .vTooltip("Done")
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -529,6 +529,7 @@ VStreamingWaveform(
                             (onDictateToggle ?? onMicrophoneToggle)()
                         }
                     )
+                    .vTooltip("Cancel")
 
                     // Accept: stop dictation and keep transcribed text
                     VButton(
@@ -541,6 +542,7 @@ VStreamingWaveform(
                             (onDictateToggle ?? onMicrophoneToggle)()
                         }
                     )
+                    .vTooltip("Send")
                 }
             }
         }
@@ -582,6 +584,7 @@ VStreamingWaveform(
                         action: { manager.toggleListening() }
                     )
                     .disabled(manager.state == .processing)
+                    .vTooltip(manager.state == .listening ? "Mute" : "Unmute")
 
                     VButton(
                         label: "End voice mode",
@@ -590,6 +593,7 @@ VStreamingWaveform(
                         iconSize: composerActionButtonSize,
                         action: { onEndVoiceMode?() }
                     )
+                    .vTooltip("Cancel Live Voice")
                 }
             }
             .padding(.vertical, VSpacing.md)


### PR DESCRIPTION
## Summary
Adds .vTooltip() hover tooltips to the voice mode and dictation mode buttons in the composer for better discoverability.

## Changes
- Dictation mode: "Cancel" on X button, "Send" on green check button
- Voice mode: "Mute"/"Unmute" on mic button, "Cancel Live Voice" on end call button

## Milestone PRs (merged into feature branch)
- #19737: M1: Add tooltips to voice and dictation mode buttons

## Project issue
Closes #19736

## Test plan
- [ ] Start dictation → hover over X button → tooltip shows "Cancel"
- [ ] Hover over green check → tooltip shows "Send"
- [ ] Start live voice → hover over mic → tooltip shows "Mute"
- [ ] Hover over red phone button → tooltip shows "Cancel Live Voice"

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
