### PR TITLE
feat: resolve platform connection ID via List Connections endpoint

### DIFF
--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ---------------------------------------------------------------------------
 // Mutable mock state
@@ -113,8 +113,24 @@ function setupDefaults(): void {
 // ---------------------------------------------------------------------------
 
 describe("resolveOAuthConnection", () => {
+  let originalFetch: typeof globalThis.fetch;
+
   beforeEach(() => {
     setupDefaults();
+    originalFetch = globalThis.fetch;
+    // Default mock: return a single active connection from the platform
+    globalThis.fetch = mock(async () => {
+      return new Response(
+        JSON.stringify({
+          results: [{ id: "platform-conn-1", account_label: null }],
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
   });
 
   test("returns BYOOAuthConnection when provider has no managedServiceConfigKey", async () => {

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -3,10 +3,13 @@ import { getConfig } from "../config/loader.js";
 import { type Services, ServicesSchema } from "../config/schemas/services.js";
 import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getLogger } from "../util/logger.js";
 import { BYOOAuthConnection } from "./byo-connection.js";
 import type { OAuthConnection } from "./connection.js";
 import { getActiveConnection, getProvider } from "./oauth-store.js";
 import { PlatformOAuthConnection } from "./platform-connection.js";
+
+const log = getLogger("connection-resolver");
 
 export interface ResolveOAuthConnectionOptions {
   /** OAuth app client ID — narrows to a specific app when multiple BYO apps
@@ -48,6 +51,16 @@ export async function resolveOAuthConnection(
     if (services[managedKey as keyof Services].mode === "managed") {
       const ctx = await resolveManagedProxyContext();
       const assistantId = getPlatformAssistantId();
+      const providerSlug = providerKey.replace(/^integration:/, "");
+
+      const connectionId = await resolvePlatformConnectionId({
+        assistantId,
+        platformBaseUrl: ctx.platformBaseUrl.replace(/\/+$/, ""),
+        apiKey: ctx.assistantApiKey,
+        provider: providerSlug,
+        account,
+      });
+
       return new PlatformOAuthConnection({
         id: providerKey,
         providerKey,
@@ -56,6 +69,7 @@ export async function resolveOAuthConnection(
         assistantId,
         platformBaseUrl: ctx.platformBaseUrl,
         apiKey: ctx.assistantApiKey,
+        connectionId,
       });
     }
   }
@@ -97,4 +111,65 @@ export async function resolveOAuthConnection(
     baseUrl,
     accountInfo: conn.accountInfo,
   });
+}
+
+// ---------------------------------------------------------------------------
+// Platform connection ID resolution
+// ---------------------------------------------------------------------------
+
+interface ResolvePlatformConnectionIdOptions {
+  assistantId: string;
+  platformBaseUrl: string;
+  apiKey: string;
+  provider: string;
+  account?: string;
+}
+
+/**
+ * Fetch the platform-side connection ID for a managed provider by calling
+ * the List Connections endpoint.
+ */
+async function resolvePlatformConnectionId(
+  options: ResolvePlatformConnectionIdOptions,
+): Promise<string> {
+  const { assistantId, platformBaseUrl, apiKey, provider, account } = options;
+
+  const url = new URL(
+    `/v1/assistants/${assistantId}/oauth/connections/`,
+    platformBaseUrl,
+  );
+  url.searchParams.set("provider", provider);
+  url.searchParams.set("status", "ACTIVE");
+  if (account) {
+    url.searchParams.set("account_identifier", account);
+  }
+
+  const response = await fetch(url.toString(), {
+    headers: { Authorization: `Api-Key ${apiKey}` },
+  });
+
+  if (!response.ok) {
+    log.error(
+      { status: response.status, provider },
+      "Failed to list platform OAuth connections",
+    );
+    throw new Error(
+      `Failed to resolve platform connection for "${provider}": HTTP ${response.status}`,
+    );
+  }
+
+  const body = (await response.json()) as {
+    results?: Array<{ id: string; account_label?: string }>;
+  };
+  const connections = body.results ?? [];
+
+  if (connections.length === 0) {
+    throw new Error(
+      `No active platform OAuth connection found for provider "${provider}"` +
+        (account ? ` with account "${account}"` : "") +
+        ". Connect the service on the Vellum platform first.",
+    );
+  }
+
+  return connections[0].id;
 }

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -182,5 +182,17 @@ async function resolvePlatformConnectionId(
     );
   }
 
+  if (connections.length > 1 && !account) {
+    log.warn(
+      {
+        provider,
+        count: connections.length,
+        selectedId: connections[0].id,
+      },
+      "Multiple active platform connections found; using the most recently created. " +
+        "Pass an account option to select a specific connection.",
+    );
+  }
+
   return connections[0].id;
 }

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -51,6 +51,22 @@ export async function resolveOAuthConnection(
     if (services[managedKey as keyof Services].mode === "managed") {
       const ctx = await resolveManagedProxyContext();
       const assistantId = getPlatformAssistantId();
+
+      // Validate prerequisites before making network calls so that
+      // partially configured installs get the same clear error that
+      // PlatformOAuthConnection would produce, rather than an opaque
+      // fetch failure from resolvePlatformConnectionId().
+      const missing: string[] = [];
+      if (!ctx.platformBaseUrl) missing.push("platform base URL");
+      if (!ctx.assistantApiKey) missing.push("assistant API key");
+      if (!assistantId) missing.push("assistant ID");
+      if (missing.length > 0) {
+        throw new Error(
+          `Platform-managed connection for "${providerKey}" cannot be created: missing ${missing.join(", ")}. ` +
+            `Log in to the Vellum platform or switch to using your own OAuth app.`,
+        );
+      }
+
       const providerSlug = providerKey.replace(/^integration:/, "");
 
       const connectionId = await resolvePlatformConnectionId({

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -51,22 +51,6 @@ export async function resolveOAuthConnection(
     if (services[managedKey as keyof Services].mode === "managed") {
       const ctx = await resolveManagedProxyContext();
       const assistantId = getPlatformAssistantId();
-
-      // Validate prerequisites before making network calls so that
-      // partially configured installs get the same clear error that
-      // PlatformOAuthConnection would produce, rather than an opaque
-      // fetch failure from resolvePlatformConnectionId().
-      const missing: string[] = [];
-      if (!ctx.platformBaseUrl) missing.push("platform base URL");
-      if (!ctx.assistantApiKey) missing.push("assistant API key");
-      if (!assistantId) missing.push("assistant ID");
-      if (missing.length > 0) {
-        throw new Error(
-          `Platform-managed connection for "${providerKey}" cannot be created: missing ${missing.join(", ")}. ` +
-            `Log in to the Vellum platform or switch to using your own OAuth app.`,
-        );
-      }
-
       const providerSlug = providerKey.replace(/^integration:/, "");
 
       const connectionId = await resolvePlatformConnectionId({
@@ -149,6 +133,17 @@ async function resolvePlatformConnectionId(
   options: ResolvePlatformConnectionIdOptions,
 ): Promise<string> {
   const { assistantId, platformBaseUrl, apiKey, provider, account } = options;
+
+  const missing: string[] = [];
+  if (!platformBaseUrl) missing.push("platform base URL");
+  if (!apiKey) missing.push("assistant API key");
+  if (!assistantId) missing.push("assistant ID");
+  if (missing.length > 0) {
+    throw new Error(
+      `Platform-managed connection for "${provider}" cannot be created: missing ${missing.join(", ")}. ` +
+        `Log in to the Vellum platform or switch to using your own OAuth app.`,
+    );
+  }
 
   const url = new URL(
     `/v1/assistants/${assistantId}/oauth/connections/`,

--- a/assistant/src/oauth/platform-connection.test.ts
+++ b/assistant/src/oauth/platform-connection.test.ts
@@ -15,6 +15,7 @@ const DEFAULT_OPTIONS = {
   assistantId: "asst-abc",
   platformBaseUrl: "https://platform.example.com",
   apiKey: "test-api-key",
+  connectionId: "platform-conn-123",
 };
 
 describe("PlatformOAuthConnection", () => {
@@ -34,7 +35,7 @@ describe("PlatformOAuthConnection", () => {
     globalThis.fetch = mock(
       async (url: string | URL | Request, init?: RequestInit) => {
         expect(url).toBe(
-          "https://platform.example.com/v1/assistants/asst-abc/external-provider-proxy/google/",
+          "https://platform.example.com/v1/assistants/asst-abc/external-provider-proxy/platform-conn-123/",
         );
         expect(init?.method).toBe("POST");
         expect(init?.headers).toEqual({
@@ -158,7 +159,7 @@ describe("PlatformOAuthConnection", () => {
   test("strips trailing slash from platformBaseUrl to avoid double slashes", async () => {
     globalThis.fetch = mock(async (url: string | URL | Request) => {
       expect(String(url)).toBe(
-        "https://platform.example.com/v1/assistants/asst-abc/external-provider-proxy/google/",
+        "https://platform.example.com/v1/assistants/asst-abc/external-provider-proxy/platform-conn-123/",
       );
       return new Response(
         JSON.stringify({ status: 200, headers: {}, body: null }),
@@ -173,9 +174,9 @@ describe("PlatformOAuthConnection", () => {
     await conn.request({ method: "GET", path: "/test" });
   });
 
-  test("strips integration: prefix from providerKey for slug", async () => {
+  test("uses connectionId in proxy URL regardless of providerKey format", async () => {
     globalThis.fetch = mock(async (url: string | URL | Request) => {
-      expect(String(url)).toContain("/external-provider-proxy/slack/");
+      expect(String(url)).toContain("/external-provider-proxy/slack-conn-456/");
       return new Response(
         JSON.stringify({ status: 200, headers: {}, body: null }),
         { status: 200 },
@@ -185,6 +186,7 @@ describe("PlatformOAuthConnection", () => {
     const conn = new PlatformOAuthConnection({
       ...DEFAULT_OPTIONS,
       providerKey: "integration:slack",
+      connectionId: "slack-conn-456",
     });
     await conn.request({ method: "GET", path: "/test" });
   });

--- a/assistant/src/oauth/platform-connection.ts
+++ b/assistant/src/oauth/platform-connection.ts
@@ -27,6 +27,8 @@ export interface PlatformOAuthConnectionOptions {
   assistantId: string;
   platformBaseUrl: string;
   apiKey: string;
+  /** Platform-side connection ID used in the proxy URL path. */
+  connectionId: string;
 }
 
 export class PlatformOAuthConnection implements OAuthConnection {
@@ -38,12 +40,14 @@ export class PlatformOAuthConnection implements OAuthConnection {
   private readonly assistantId: string;
   private readonly platformBaseUrl: string;
   private readonly apiKey: string;
+  private readonly connectionId: string;
 
   constructor(options: PlatformOAuthConnectionOptions) {
     const missing: string[] = [];
     if (!options.platformBaseUrl) missing.push("platform base URL");
     if (!options.apiKey) missing.push("assistant API key");
     if (!options.assistantId) missing.push("assistant ID");
+    if (!options.connectionId) missing.push("connection ID");
     if (missing.length > 0) {
       throw new BackendError(
         `Platform-managed connection for "${options.providerKey}" cannot be created: missing ${missing.join(", ")}. ` +
@@ -58,11 +62,11 @@ export class PlatformOAuthConnection implements OAuthConnection {
     this.assistantId = options.assistantId;
     this.platformBaseUrl = options.platformBaseUrl.replace(/\/+$/, "");
     this.apiKey = options.apiKey;
+    this.connectionId = options.connectionId;
   }
 
   async request(req: OAuthConnectionRequest): Promise<OAuthConnectionResponse> {
-    const providerSlug = this.providerKey.replace(/^integration:/, "");
-    const proxyUrl = `${this.platformBaseUrl}/v1/assistants/${this.assistantId}/external-provider-proxy/${providerSlug}/`;
+    const proxyUrl = `${this.platformBaseUrl}/v1/assistants/${this.assistantId}/external-provider-proxy/${this.connectionId}/`;
 
     const body: Record<string, unknown> = {
       request: {


### PR DESCRIPTION
## Summary
- Update `PlatformOAuthConnection` to use a platform `connection_id` in the proxy URL instead of deriving a provider slug from `providerKey`
- Add `resolvePlatformConnectionId()` in `connection-resolver.ts` that calls `GET /v1/assistants/{id}/oauth/connections/?provider={slug}&status=ACTIVE` to fetch the connection ID at resolution time
- Supports filtering by `account_identifier` when an account option is provided

## Test plan
- [x] Existing `platform-connection.test.ts` tests updated and passing (17 tests)
- [x] Existing `connection-resolver.test.ts` tests updated with fetch mock and passing
- [x] Pre-push hooks pass (type-check, lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
