### PR TITLE
Remove 'Fork from here' text from message overflow menu

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -346,15 +346,10 @@ struct ChatBubble: View {
                 Button {
                     onForkFromMessage(daemonMessageId)
                 } label: {
-                    Label {
-                        Text("Fork from here")
-                            .font(VFont.caption)
-                    } icon: {
-                        VIconView(.gitBranch, size: 11)
-                    }
-                    .foregroundColor(VColor.contentTertiary)
-                    .frame(height: 24)
-                    .contentShape(Rectangle())
+                    VIconView(.gitBranch, size: 11)
+                        .foregroundColor(VColor.contentTertiary)
+                        .frame(width: 24, height: 24)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .pointerCursor()


### PR DESCRIPTION
## Summary
- Removed the "Fork from here" label text from the message hover overflow menu, keeping just the git-branch icon to match the style of adjacent icon-only buttons (copy, report, inspect)

## Original prompt
get rid of the "Fork from here" text (keep the icon)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
