### PR TITLE
fix: skip x-forwarded-for check in guardian bootstrap when containerized

### DIFF
--- a/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
+++ b/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
@@ -28,6 +28,7 @@ type ServerWithRequestIP = {
   ): { address: string; family: string; port: number } | null;
 };
 import { isHttpAuthDisabled } from "../../config/env.js";
+import { getIsContainerized } from "../../config/env-registry.js";
 
 const log = getLogger("guardian-bootstrap");
 
@@ -86,19 +87,30 @@ export async function handleGuardianBootstrap(
   req: Request,
   server: ServerWithRequestIP,
 ): Promise<Response> {
+  // Reject non-private-network peers (allows loopback, Docker bridge, etc.)
+  const peerIp = server.requestIP(req)?.address;
+  if ((!peerIp || !isPrivateAddress(peerIp)) && !isHttpAuthDisabled()) {
+    return httpError("FORBIDDEN", "Bootstrap endpoint is local-only", 403);
+  }
+
   // Reject requests forwarded from public networks. The gateway sets
   // x-forwarded-for to the real client IP; if that IP is on a private
   // network (loopback, Docker bridge, RFC 1918) the request is still
   // considered local. Only reject when the forwarded IP is public.
+  //
+  // Skip this check when running in a container: the peer IP was already
+  // validated above (Docker bridge network = private), so the request
+  // reached us through a co-located gateway. The x-forwarded-for header
+  // reflects the original external client (e.g. platform proxy) and is
+  // not meaningful for local-only enforcement in this topology.
   const forwarded = req.headers.get("x-forwarded-for");
   const forwardedIp = forwarded ? forwarded.split(",")[0].trim() : null;
-  if (forwardedIp && !isPrivateAddress(forwardedIp) && !isHttpAuthDisabled()) {
-    return httpError("FORBIDDEN", "Bootstrap endpoint is local-only", 403);
-  }
-
-  // Reject non-private-network peers (allows loopback, Docker bridge, etc.)
-  const peerIp = server.requestIP(req)?.address;
-  if ((!peerIp || !isPrivateAddress(peerIp)) && !isHttpAuthDisabled()) {
+  if (
+    forwardedIp &&
+    !isPrivateAddress(forwardedIp) &&
+    !isHttpAuthDisabled() &&
+    !getIsContainerized()
+  ) {
     return httpError("FORBIDDEN", "Bootstrap endpoint is local-only", 403);
   }
 


### PR DESCRIPTION
## Summary
- Guardian bootstrap (`POST /v1/guardian/init`) was failing with 403 in Docker mode because the macOS app connects through the platform proxy, forwarding a public IP in `x-forwarded-for`
- Skip the `x-forwarded-for` check when `IS_CONTAINERIZED=true` — the peer IP check (Docker bridge = private) is sufficient to prove the request came through the co-located gateway
- Reorder checks so peer IP validation runs first (cheap, always reliable), forwarded IP check second (non-containerized only)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
