### PR TITLE
feat: add copy button to markdown code blocks

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -55,26 +55,34 @@ struct MarkdownSegmentView: View {
                         .padding(.top, level == 1 ? 4 : 2)
 
                 case .codeBlock(let language, let code):
-                    VStack(alignment: .leading, spacing: 0) {
-                        if let language, !language.isEmpty {
-                            Text(language)
-                                .font(.system(size: scaledCodeLabelSize, weight: .medium))
-                                .foregroundColor(mutedTextColor)
-                                .padding(.horizontal, VSpacing.sm)
-                                .padding(.top, VSpacing.xs)
+                    ZStack(alignment: .topTrailing) {
+                        VStack(alignment: .leading, spacing: 0) {
+                            if let language, !language.isEmpty {
+                                Text(language)
+                                    .font(.system(size: scaledCodeLabelSize, weight: .medium))
+                                    .foregroundColor(mutedTextColor)
+                                    .padding(.horizontal, VSpacing.sm)
+                                    .padding(.top, VSpacing.xs)
+                            }
+                            ScrollView(.horizontal, showsIndicators: false) {
+                                Text(code)
+                                    .font(.custom("DMMono-Regular", size: 13))
+                                    .foregroundColor(textColor)
+                                    .textSelection(.enabled)
+                                    .fixedSize(horizontal: true, vertical: true)
+                                    .padding(VSpacing.sm)
+                            }
                         }
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            Text(code)
-                                .font(.custom("DMMono-Regular", size: 13))
-                                .foregroundColor(textColor)
-                                .textSelection(.enabled)
-                                .fixedSize(horizontal: true, vertical: true)
-                                .padding(VSpacing.sm)
+                        .optionalMaxWidth(maxContentWidth)
+                        .background(codeBackgroundColor)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+
+                        VButton(label: "Copy code", iconOnly: VIcon.copy.rawValue, style: .ghost, iconSize: 20, iconColor: mutedTextColor) {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(code, forType: .string)
                         }
+                        .padding(VSpacing.xs)
                     }
-                    .optionalMaxWidth(maxContentWidth)
-                    .background(codeBackgroundColor)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
 
                 case .table(let headers, let rows):
                     MarkdownTableView(headers: headers, rows: rows, maxWidth: maxContentWidth ?? .infinity)


### PR DESCRIPTION
## Summary
- Adds a copy-to-clipboard button to fenced code blocks in chat messages
- Reuses the existing `VButton` + `NSPasteboard` pattern from `AssistantProgressView`
- Button appears in the top-right corner of code blocks, matching tool output styling

## Test plan
- [ ] Verify the copy button appears on code blocks in assistant messages
- [ ] Click the button and confirm clipboard contains the code text
- [ ] Ensure text selection within code blocks still works
- [ ] Check that code blocks without a language label render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
