### PR TITLE
fix: simplify MessageCellView equality check to prevent blank screen in long chats

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1689,7 +1689,6 @@ private struct MessageCellView: View, Equatable {
             && lhs.selectedModel == rhs.selectedModel
             && lhs.configuredProviders == rhs.configuredProviders
             && lhs.providerCatalog.count == rhs.providerCatalog.count
-            && zip(lhs.providerCatalog, rhs.providerCatalog).allSatisfy({ $0.id == $1.id && $0.displayName == $1.displayName && $0.models.count == $1.models.count && zip($0.models, $1.models).allSatisfy({ $0.id == $1.id && $0.displayName == $1.displayName }) })
     }
 
     let message: ChatMessage


### PR DESCRIPTION
## Summary
- Removed expensive nested `providerCatalog` deep comparison from `MessageCellView`'s `Equatable` conformance
- The old check did O(n) work per cell per render pass — comparing every provider's `id`, `displayName`, and all their models' `id` and `displayName`
- In long conversations (100+ messages), this caused SwiftUI layout timeouts during scrolling, resulting in cells rendering at zero height (blank screen)
- Scrolling up/down "fixed" it because it narrowed the layout scope to only visible cells
- Now just compares `providerCatalog.count` — the catalog rarely changes mid-conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
