### PR TITLE
fix: handle non-finite AnchorMinYKey values to fix scroll-to-bottom button

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1147,25 +1147,29 @@ struct MessageListView: View {
                     // The anchor was deallocated by the LazyVStack (no child reports
                     // a finite value, so the preference reduces to its .infinity default).
                     // Mark the anchor as off-screen so the "Scroll to latest" button can appear.
+                    // Also reset lastMinY to .infinity so the button condition
+                    // (!isNearBottom && !isVisible && lastMinY > viewportHeight + 20) is satisfied.
+                    // .infinity is safe: updateViewport() guards isFinite, evaluate() treats
+                    // it as a skip for the dead-zone check, and verify() returns .geometryUnavailable.
                     if anchorTracker.isVisible {
                         anchorTracker.isVisible = false
                         log.debug("Anchor preference non-finite — marking anchor invisible (deallocated by LazyVStack)")
                     }
+                    anchorTracker.lastMinY = .infinity
                     return
                 case .rejectDeadZone:
                     return
                 case .accept(let accepted):
-                    break  // fall through to existing handler
+                    os_signpost(.begin, log: PerfSignposts.log, name: "anchorMinYPreferenceChange")
+                    recordScrollLoopEvent(.anchorPreferenceChange)
+                    anchorTracker.update(minY: accepted, viewportHeight: scrollViewportHeight)
+                    if !hasFreshAnchorMeasurement { hasFreshAnchorMeasurement = true }
+                    scheduleTranscriptSnapshot()
+                    // Geometry tracking only — no per-frame scrollTo calls here.
+                    // All bottom-follow work is handled by the ChatBottomPinCoordinator
+                    // via bounded staged retries, not inline on every anchor change.
+                    os_signpost(.end, log: PerfSignposts.log, name: "anchorMinYPreferenceChange")
                 }
-                os_signpost(.begin, log: PerfSignposts.log, name: "anchorMinYPreferenceChange")
-                recordScrollLoopEvent(.anchorPreferenceChange)
-                anchorTracker.update(minY: accepted, viewportHeight: scrollViewportHeight)
-                if !hasFreshAnchorMeasurement { hasFreshAnchorMeasurement = true }
-                scheduleTranscriptSnapshot()
-                // Geometry tracking only — no per-frame scrollTo calls here.
-                // All bottom-follow work is handled by the ChatBottomPinCoordinator
-                // via bounded staged retries, not inline on every anchor change.
-                os_signpost(.end, log: PerfSignposts.log, name: "anchorMinYPreferenceChange")
             }
             .transaction { $0.disablesAnimations = true }
             .onPreferenceChange(ConversationTailAnchorYKey.self) { anchorY in

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1142,7 +1142,21 @@ struct MessageListView: View {
                     newValue: minY,
                     previous: anchorTracker.lastMinY
                 )
-                guard case .accept(let accepted) = decision else { return }
+                switch decision {
+                case .rejectNonFinite:
+                    // The anchor was deallocated by the LazyVStack (no child reports
+                    // a finite value, so the preference reduces to its .infinity default).
+                    // Mark the anchor as off-screen so the "Scroll to latest" button can appear.
+                    if anchorTracker.isVisible {
+                        anchorTracker.isVisible = false
+                        log.debug("Anchor preference non-finite — marking anchor invisible (deallocated by LazyVStack)")
+                    }
+                    return
+                case .rejectDeadZone:
+                    return
+                case .accept(let accepted):
+                    break  // fall through to existing handler
+                }
                 os_signpost(.begin, log: PerfSignposts.log, name: "anchorMinYPreferenceChange")
                 recordScrollLoopEvent(.anchorPreferenceChange)
                 anchorTracker.update(minY: accepted, viewportHeight: scrollViewportHeight)


### PR DESCRIPTION
## Summary
- When LazyVStack deallocates the scroll-bottom-anchor, the AnchorMinYKey preference fires with `.infinity`. Previously this was silently rejected by `PreferenceGeometryFilter.evaluate()`, leaving `anchorTracker.isVisible` stuck at `true` and preventing the "Scroll to latest" button from appearing.
- Now the `.rejectNonFinite` case explicitly sets `anchorTracker.isVisible = false` instead of returning early, allowing the scroll-to-bottom button to appear when the anchor is deallocated.
- Added a debug log statement for diagnostics when this case is hit.

## Test plan
- [ ] Scroll up in a long conversation so the bottom anchor leaves the LazyVStack viewport
- [ ] Verify the "Scroll to latest" button appears when the anchor is deallocated
- [ ] Verify normal scrolling behavior is unaffected (dead-zone rejections still return early, accepted values still update as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
