### PR TITLE
Fix avatar loading for Docker/remote instances via HTTP gateway fetch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -127,6 +127,16 @@ final class AvatarAppearanceManager {
         return Self.workspaceCustomAvatarURL()
     }
 
+    /// Whether the connected assistant has a local workspace directory.
+    /// When false (Docker/remote instances), avatar data must be fetched via HTTP.
+    private var hasLocalWorkspace: Bool {
+        if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
+           let assistant = LockfileAssistant.loadByName(assistantId) {
+            return assistant.workspaceDir != nil
+        }
+        return true
+    }
+
     /// The assistant's display name, loaded once from IDENTITY.md to avoid repeated disk I/O.
     private var assistantName: String = "V"
 
@@ -135,10 +145,17 @@ final class AvatarAppearanceManager {
             IdentityInfo.load()?.name,
             fallback: "V"
         )
-        loadCustomAvatar()
-        loadAvatarComponents()
-        watchAvatarFile()
-        watchTraitsFile()
+        if hasLocalWorkspace {
+            loadCustomAvatar()
+            loadAvatarComponents()
+            watchAvatarFile()
+            watchTraitsFile()
+        } else {
+            Task { [weak self] in
+                await self?.fetchAvatarViaHTTP()
+                await self?.fetchTraitsViaHTTP()
+            }
+        }
         updateDockLabel()
 
         // Fire-and-forget: fetch character component definitions from the
@@ -188,6 +205,64 @@ final class AvatarAppearanceManager {
         let port = assistant.resolvedDaemonPort()
         if let response = await AvatarComponentService.fetch(port: port) {
             AvatarComponentStore.shared.load(response)
+        }
+    }
+
+    // MARK: - Remote Avatar Fetch (Docker/remote instances)
+
+    /// Fetches the avatar image via HTTP through the gateway for Docker/remote instances.
+    private func fetchAvatarViaHTTP() async {
+        do {
+            let response = try await GatewayHTTPClient.get(
+                path: "assistants/{assistantId}/workspace/file/content",
+                params: ["path": "data/avatar/avatar-image.png"],
+                timeout: 10
+            )
+            guard response.isSuccess, !response.data.isEmpty else {
+                customAvatarImage = nil
+                cachedChatAvatar = nil
+                updateDockIcon()
+                return
+            }
+            cachedChatAvatar = nil
+            customAvatarImage = NSImage(data: response.data)
+            updateDockIcon()
+        } catch {
+            log.warning("Failed to fetch avatar via HTTP: \(error.localizedDescription)")
+            customAvatarImage = nil
+            cachedChatAvatar = nil
+            updateDockIcon()
+        }
+    }
+
+    /// Fetches character-traits.json via HTTP through the gateway for Docker/remote instances.
+    private func fetchTraitsViaHTTP() async {
+        do {
+            let response = try await GatewayHTTPClient.get(
+                path: "assistants/{assistantId}/workspace/file/content",
+                params: ["path": "data/avatar/character-traits.json"],
+                timeout: 10
+            )
+            guard response.isSuccess, !response.data.isEmpty else {
+                characterBodyShape = nil
+                characterEyeStyle = nil
+                characterColor = nil
+                cachedFallbackAvatar = nil
+                cachedFullFallbackAvatar = nil
+                updateDockIcon()
+                return
+            }
+            guard let components = try? JSONDecoder().decode(AvatarComponents.self, from: response.data) else {
+                return
+            }
+            characterBodyShape = AvatarBodyShape(rawValue: components.bodyShape)
+            characterEyeStyle = AvatarEyeStyle(rawValue: components.eyeStyle)
+            characterColor = AvatarColor(rawValue: components.color)
+            cachedFallbackAvatar = nil
+            cachedFullFallbackAvatar = nil
+            updateDockIcon()
+        } catch {
+            log.warning("Failed to fetch character traits via HTTP: \(error.localizedDescription)")
         }
     }
 
@@ -251,12 +326,13 @@ final class AvatarAppearanceManager {
         updateDockIcon()
     }
 
-    /// Reloads the custom avatar from disk and refreshes the assistant name.
+    /// Reloads the custom avatar and refreshes the assistant name.
     /// Called when the daemon notifies that the avatar image has been
     /// regenerated (via `avatar_updated` event), after reconnection
     /// (`proceedToApp`), and after assistant switches.
     /// Invalidates all cached images so SwiftUI views pick up the new avatar,
     /// and re-reads the identity so the dock label reflects the current assistant.
+    /// For Docker/remote instances, fetches via HTTP through the gateway.
     func reloadAvatar() {
         assistantName = AssistantDisplayName.resolve(
             IdentityInfo.load()?.name,
@@ -267,8 +343,15 @@ final class AvatarAppearanceManager {
         cachedFallbackName = nil
         cachedFullFallbackAvatar = nil
         cachedFullFallbackName = nil
-        loadCustomAvatar()
-        loadAvatarComponents()
+        if hasLocalWorkspace {
+            loadCustomAvatar()
+            loadAvatarComponents()
+        } else {
+            Task { [weak self] in
+                await self?.fetchAvatarViaHTTP()
+                await self?.fetchTraitsViaHTTP()
+            }
+        }
         updateDockLabel()
     }
 


### PR DESCRIPTION
## Summary
- Docker/remote instances store workspace files in container volumes not accessible on the host. The macOS app's `AvatarAppearanceManager` tried to read `avatar-image.png` from a local disk path that doesn't exist for these instances.
- Added `hasLocalWorkspace` check: when the connected assistant has no local workspace directory (Docker/remote), fetch avatar image and character traits via HTTP through the gateway using the existing `workspace/file/content` endpoint.
- `reloadAvatar()` (triggered by `avatar_updated` SSE events) also uses HTTP fetch for remote instances, so avatar updates propagate correctly.

## Original prompt
Fix AvatarAppearanceManager to fetch avatar via HTTP through the gateway for Docker/remote instances instead of reading from local disk paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
