### PR TITLE
Always fetch avatar via HTTP through the gateway for consistency

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -127,16 +127,6 @@ final class AvatarAppearanceManager {
         return Self.workspaceCustomAvatarURL()
     }
 
-    /// Whether the connected assistant has a local workspace directory.
-    /// When false (Docker/remote instances), avatar data must be fetched via HTTP.
-    private var hasLocalWorkspace: Bool {
-        if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
-           let assistant = LockfileAssistant.loadByName(assistantId) {
-            return assistant.workspaceDir != nil
-        }
-        return true
-    }
-
     /// The assistant's display name, loaded once from IDENTITY.md to avoid repeated disk I/O.
     private var assistantName: String = "V"
 
@@ -145,16 +135,9 @@ final class AvatarAppearanceManager {
             IdentityInfo.load()?.name,
             fallback: "V"
         )
-        if hasLocalWorkspace {
-            loadCustomAvatar()
-            loadAvatarComponents()
-            watchAvatarFile()
-            watchTraitsFile()
-        } else {
-            Task { [weak self] in
-                await self?.fetchAvatarViaHTTP()
-                await self?.fetchTraitsViaHTTP()
-            }
+        Task { [weak self] in
+            await self?.fetchAvatarViaHTTP()
+            await self?.fetchTraitsViaHTTP()
         }
         updateDockLabel()
 
@@ -332,7 +315,7 @@ final class AvatarAppearanceManager {
     /// (`proceedToApp`), and after assistant switches.
     /// Invalidates all cached images so SwiftUI views pick up the new avatar,
     /// and re-reads the identity so the dock label reflects the current assistant.
-    /// For Docker/remote instances, fetches via HTTP through the gateway.
+    /// Fetches via HTTP through the gateway for consistency across all instance types.
     func reloadAvatar() {
         assistantName = AssistantDisplayName.resolve(
             IdentityInfo.load()?.name,
@@ -343,14 +326,9 @@ final class AvatarAppearanceManager {
         cachedFallbackName = nil
         cachedFullFallbackAvatar = nil
         cachedFullFallbackName = nil
-        if hasLocalWorkspace {
-            loadCustomAvatar()
-            loadAvatarComponents()
-        } else {
-            Task { [weak self] in
-                await self?.fetchAvatarViaHTTP()
-                await self?.fetchTraitsViaHTTP()
-            }
+        Task { [weak self] in
+            await self?.fetchAvatarViaHTTP()
+            await self?.fetchTraitsViaHTTP()
         }
         updateDockLabel()
     }


### PR DESCRIPTION
## Summary
- Remove `hasLocalWorkspace` branching so all instance types (local, Docker, remote) use HTTP-based avatar fetching through the gateway.
- `start()` and `reloadAvatar()` now always use `fetchAvatarViaHTTP()` / `fetchTraitsViaHTTP()` instead of conditionally reading from local disk.
- File watchers are no longer started in `start()` — the `avatar_updated` SSE event already triggers `reloadAvatar()` for live updates.

## Original prompt
Always fetch avatar via HTTP through the gateway, even for local instances, for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
