### PR TITLE
feat: log clear-all-conversations to lifecycle_events table

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1315,6 +1315,15 @@ export function clearAll(): { conversations: number; messages: number } {
   rawExec("DELETE FROM messages");
   rawExec("DELETE FROM conversations");
 
+  // Record audit event — lifecycle_events is NOT deleted by clearAll(),
+  // so this survives the wipe and provides a permanent trail.
+  rawExec(
+    `INSERT INTO lifecycle_events (id, event_name, created_at) VALUES (?, ?, ?)`,
+    uuid(),
+    "conversations_clear_all",
+    Date.now(),
+  );
+
   // Rebuild corrupted FTS tables and restore triggers after all base-table
   // DELETEs have completed. Dropping the virtual table clears the corruption,
   // and recreating it + triggers means subsequent writes maintain FTS


### PR DESCRIPTION
## Summary
- Add audit log entry to lifecycle_events when clearAll() is called
- lifecycle_events survives clearAll() deletion, providing permanent evidence of mass conversation deletion
- Uses existing rawExec pattern consistent with the rest of clearAll()

Part of plan: safe-clear-conversations.md (PR 1 of 4)