### PR TITLE
feat: require settings.write scope and confirmation header for DELETE /v1/conversations

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -129,7 +129,6 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "btw", scopes: ["chat.write"] },
   { endpoint: "conversations", scopes: ["chat.read"] },
   { endpoint: "conversations:POST", scopes: ["chat.write"] },
-  { endpoint: "conversations:DELETE", scopes: ["chat.write"] },
   { endpoint: "conversations/fork", scopes: ["chat.write"] },
   { endpoint: "conversations/switch", scopes: ["chat.write"] },
   { endpoint: "conversations/name", scopes: ["chat.write"] },
@@ -470,6 +469,12 @@ for (const { endpoint, scopes } of ACTOR_ENDPOINTS) {
     allowedPrincipalTypes: ["actor", "svc_gateway", "svc_daemon", "local"],
   });
 }
+
+// Clear-all conversations: elevated to settings.write (destructive bulk operation)
+registerPolicy("conversations:DELETE", {
+  requiredScopes: ["settings.write"],
+  allowedPrincipalTypes: ["actor", "svc_gateway", "svc_daemon", "local"],
+});
 
 // Channel inbound: gateway-only
 registerPolicy("channels/inbound", {

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -227,7 +227,16 @@ export function conversationManagementRouteDefinitions(
       endpoint: "conversations",
       method: "DELETE",
       policyKey: "conversations",
-      handler: () => {
+      handler: ({ req }) => {
+        const confirm = req.headers.get("x-confirm-destructive");
+        if (confirm !== "clear-all-conversations") {
+          return httpError(
+            "BAD_REQUEST",
+            "DELETE /v1/conversations permanently deletes ALL conversations, messages, and memory. " +
+              "To confirm, set header X-Confirm-Destructive: clear-all-conversations",
+            400,
+          );
+        }
         deps.clearAllConversations();
         return new Response(null, { status: 204 });
       },


### PR DESCRIPTION
## Summary
- Elevate DELETE /v1/conversations from chat.write to settings.write scope — blocks agents with only chat-level tokens
- Add X-Confirm-Destructive header requirement as defense-in-depth against automated callers
- Scope elevation is the primary gate; header is secondary defense

Part of plan: safe-clear-conversations.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
