### PR TITLE
fix: sync coordinator follow state after callback setup

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -828,6 +828,13 @@ struct MessageListView: View {
         bottomPinCoordinator.onFollowStateChanged = { isFollowing in
             isNearBottom = isFollowing
         }
+
+        // If detach() was called before this callback was wired up (e.g. a
+        // scroll-wheel event fired between makeNSView and onAppear), sync
+        // isNearBottom now so it isn't stuck at true permanently.
+        if !bottomPinCoordinator.isFollowingBottom {
+            isNearBottom = false
+        }
     }
 
     private var shouldAnchorThinkingToConfirmationChip: Bool {


### PR DESCRIPTION
## Summary
- After setting `onFollowStateChanged` in `configureBottomPinCoordinator`, check if the coordinator is already detached and sync `isNearBottom = false`
- This handles the race condition where a scroll-up event fires between `makeNSView` (which installs the NSEvent monitor) and `onAppear` (which sets the callbacks)
- Without this fix, `detach()` called during that window sets `isFollowingBottom = false` on the coordinator but `isNearBottom` stays `true` because the callback was nil

## Test plan
- [ ] Verify that rapidly scrolling up immediately after a chat view appears correctly shows the scroll-to-bottom button
- [ ] Verify normal scroll-to-bottom behavior still works when no race condition occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
