### PR TITLE
fix: send X-Confirm-Destructive header in macOS clear-all-conversations

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1294,6 +1294,7 @@ public final class HTTPTransport {
 
         var request = URLRequest(url: url)
         request.httpMethod = "DELETE"
+        request.setValue("clear-all-conversations", forHTTPHeaderField: "X-Confirm-Destructive")
         applyAuth(&request)
 
         do {


### PR DESCRIPTION
## Summary
- Add X-Confirm-Destructive: clear-all-conversations header to the macOS app's DELETE /v1/conversations request
- Required after PR #19755 elevated the endpoint's security requirements

Part of plan: safe-clear-conversations.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
