### PR TITLE
fix: capture appName before @Sendable closures to silence warning

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -200,6 +200,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             appMenuPatchDelegate?.patchTitles(menu: appMenu)
         }
 
+        // Capture outside @Sendable closures to avoid main-actor isolation warning.
+        let appName = AppDelegate.appName
+
         // Patch the menu bar title right when the user clicks the menu bar.
         if appMenuTrackingObserver == nil {
             appMenuTrackingObserver = NotificationCenter.default.addObserver(
@@ -207,8 +210,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 object: NSApp.mainMenu,
                 queue: .main
             ) { _ in
-                if let item = NSApp.mainMenu?.items.first, item.title != AppDelegate.appName {
-                    item.title = AppDelegate.appName
+                if let item = NSApp.mainMenu?.items.first, item.title != appName {
+                    item.title = appName
                 }
             }
         }
@@ -221,8 +224,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 object: nil,
                 queue: .main
             ) { _ in
-                if let item = NSApp.mainMenu?.items.first, item.title != AppDelegate.appName {
-                    item.title = AppDelegate.appName
+                if let item = NSApp.mainMenu?.items.first, item.title != appName {
+                    item.title = appName
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Capture `AppDelegate.appName` in a local `let` before the `@Sendable` notification observer closures, avoiding the main-actor isolation warning without needing `nonisolated(unsafe)`

## Original prompt
Fix Swift build warning: `main actor-isolated static property 'appName' can not be referenced from a Sendable closure` in `AppDelegate.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
