### PR TITLE
fix: use shared device.json UUID for macOS Sentry device_id tag

### DIFF
--- a/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
+++ b/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
@@ -1,21 +1,14 @@
-import CryptoKit
 import Foundation
-import IOKit
 @preconcurrency import Sentry
 import VellumAssistantShared
 
 /// Privacy-safe device identification and Sentry scope configuration.
-/// Uses the same SHA-256(IOPlatformUUID + salt) approach as PairingQRCodeSheet.computeHostId().
+/// Uses the shared UUID from ~/.vellum/device.json so Sentry device_id
+/// matches the daemon telemetry device_id for cross-system correlation.
 enum SentryDeviceInfo {
-    /// A stable, hashed device identifier derived from the hardware UUID.
+    /// A stable device identifier from the shared device.json file.
     /// Computed once and cached for the process lifetime.
-    static let deviceId: String = {
-        let platformUUID = getPlatformUUID() ?? UUID().uuidString
-        let salt = "vellum-assistant-host-id"
-        let input = Data((platformUUID + salt).utf8)
-        let hash = SHA256.hash(data: input)
-        return hash.compactMap { String(format: "%02x", $0) }.joined()
-    }()
+    static let deviceId: String = DeviceIdStore.getOrCreate()
 
     /// Sentry environment string matching the daemon convention in instrument.ts.
     static let sentryEnvironment: String = {
@@ -79,21 +72,5 @@ enum SentryDeviceInfo {
                 scope.removeTag(key: "user_id")
             }
         }
-    }
-
-    private static func getPlatformUUID() -> String? {
-        let service = IOServiceGetMatchingService(
-            kIOMainPortDefault,
-            IOServiceMatching("IOPlatformExpertDevice")
-        )
-        guard service != 0 else { return nil }
-        defer { IOObjectRelease(service) }
-
-        let key = kIOPlatformUUIDKey as CFString
-        guard let uuid = IORegistryEntryCreateCFProperty(service, key, kCFAllocatorDefault, 0)?
-            .takeRetainedValue() as? String else {
-            return nil
-        }
-        return uuid
     }
 }


### PR DESCRIPTION
## Summary
- Replace SHA-256(hardware UUID) device_id with shared UUID from ~/.vellum/device.json
- Remove unused CryptoKit/IOKit imports and getPlatformUUID() from SentryDeviceInfo
- macOS Sentry device_id now matches daemon telemetry device_id for cross-system correlation

Part of plan: sentry-id-alignment.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
