### PR TITLE
feat: add device_id and user_id tags to daemon Sentry scope

### DIFF
--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -5,7 +5,7 @@ import {
   setPlatformUserId,
 } from "../config/env.js";
 import type { AssistantConfig } from "../config/types.js";
-import { setSentryOrganizationId } from "../instrument.js";
+import { setSentryOrganizationId, setSentryUserId } from "../instrument.js";
 import { getMcpServerManager } from "../mcp/manager.js";
 import { gmailMessagingProvider } from "../messaging/providers/gmail/adapter.js";
 import { slackProvider as slackMessagingProvider } from "../messaging/providers/slack/adapter.js";
@@ -91,6 +91,7 @@ export async function initializeProvidersAndTools(
     const trimmed = persisted?.trim();
     if (trimmed) {
       setPlatformUserId(trimmed);
+      setSentryUserId(trimmed);
       log.info("Rehydrated platform user ID from credential store");
     }
   } catch (err) {

--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -2,7 +2,12 @@ import { arch, hostname, platform, release } from "node:os";
 
 import * as Sentry from "@sentry/node";
 
-import { getPlatformOrganizationId, getSentryDsn } from "./config/env.js";
+import {
+  getPlatformOrganizationId,
+  getPlatformUserId,
+  getSentryDsn,
+} from "./config/env.js";
+import { getDeviceId } from "./util/device-id.js";
 import { APP_VERSION, COMMIT_SHA } from "./version.js";
 
 /** Patterns that match sensitive data in Sentry event values. */
@@ -58,9 +63,11 @@ export function initSentry(): void {
         runtime: "bun",
         runtime_version:
           typeof Bun !== "undefined" ? Bun.version : process.version,
+        device_id: getDeviceId(),
         ...(getPlatformOrganizationId()
           ? { organization_id: getPlatformOrganizationId() }
           : {}),
+        ...(getPlatformUserId() ? { user_id: getPlatformUserId() } : {}),
       },
     },
     beforeSend(event) {
@@ -107,6 +114,17 @@ export function setSentryOrganizationId(
   organizationId: string | undefined,
 ): void {
   Sentry.setTag("organization_id", organizationId || undefined);
+}
+
+/**
+ * Set (or clear) the user_id tag on the global Sentry scope.
+ *
+ * Called after the platform user ID is rehydrated from the credential
+ * store or updated at runtime so that every subsequent Sentry event
+ * includes the user context.
+ */
+export function setSentryUserId(userId: string | undefined): void {
+  Sentry.setTag("user_id", userId || undefined);
 }
 
 // ── Dynamic conversation-scoped Sentry tags ─────────────────────────

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -10,7 +10,7 @@ import {
   invalidateConfigCache,
 } from "../../config/loader.js";
 import type { CesClient } from "../../credential-execution/client.js";
-import { setSentryOrganizationId } from "../../instrument.js";
+import { setSentryOrganizationId, setSentryUserId } from "../../instrument.js";
 import { clearEmbeddingBackendCache } from "../../memory/embedding-backend.js";
 import { syncManualTokenConnection } from "../../oauth/manual-token-connection.js";
 import { validateAnthropicApiKey } from "../../providers/anthropic/client.js";
@@ -235,6 +235,7 @@ export async function handleAddSecret(
           setSentryOrganizationId(undefined);
         } else if (field === "platform_user_id") {
           setPlatformUserId(undefined);
+          setSentryUserId(undefined);
         }
         deleteCredentialMetadata(service, field);
       } else {
@@ -260,6 +261,7 @@ export async function handleAddSecret(
         }
         if (service === "vellum" && field === "platform_user_id") {
           setPlatformUserId(effectiveValue || undefined);
+          setSentryUserId(effectiveValue || undefined);
         }
       }
       if (isManagedProxyCredential(service, field)) {
@@ -395,6 +397,7 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
       }
       if (service === "vellum" && field === "platform_user_id") {
         setPlatformUserId(undefined);
+        setSentryUserId(undefined);
       }
       if (isManagedProxyCredential(service, field)) {
         await initializeProviders(getConfig());


### PR DESCRIPTION
## Summary
- Add device_id (from ~/.vellum/device.json) to daemon Sentry initial scope tags
- Add user_id tag to daemon Sentry scope (initial + runtime updates)
- Add setSentryUserId() function mirroring setSentryOrganizationId()

Part of plan: sentry-id-alignment.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
