### PR TITLE
test: add tests for DELETE /v1/conversations scope and header requirements

### DIFF
--- a/assistant/src/__tests__/conversation-clear-safety.test.ts
+++ b/assistant/src/__tests__/conversation-clear-safety.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Safety tests for DELETE /v1/conversations (clear all conversations).
+ *
+ * Covers:
+ * - Route policy requires `settings.write` scope (not just `chat.write`)
+ * - Missing X-Confirm-Destructive header returns 400 with explanatory message
+ * - Wrong header value returns 400
+ * - Correct scope + header clears data and returns 204
+ * - lifecycle_events contains `conversations_clear_all` audit entry after clear
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "conv-clear-safety-test-"));
+
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Auth is NOT disabled — we need enforcePolicy to actually check scopes.
+let authDisabled = false;
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => authDisabled,
+  hasUngatedHttpAuthDisabled: () => false,
+}));
+
+import { enforcePolicy, getPolicy } from "../runtime/auth/route-policy.js";
+import type { AuthContext, Scope } from "../runtime/auth/types.js";
+import {
+  addMessage,
+  clearAll,
+  createConversation,
+  getConversation,
+} from "../memory/conversation-crud.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { conversationManagementRouteDefinitions } from "../runtime/routes/conversation-management-routes.js";
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+/** Build a synthetic AuthContext for testing. */
+function buildAuthContext(overrides?: {
+  principalType?: AuthContext["principalType"];
+  scopes?: Scope[];
+}): AuthContext {
+  return {
+    subject: "actor:self:test-principal",
+    principalType: overrides?.principalType ?? "actor",
+    assistantId: "self",
+    actorPrincipalId: "test-principal",
+    scopeProfile: "actor_client_v1",
+    scopes: new Set(
+      overrides?.scopes ?? [
+        "chat.read",
+        "chat.write",
+        "approval.read",
+        "approval.write",
+      ],
+    ),
+    policyEpoch: 1,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Route policy tests (scope check — enforcePolicy level)
+// ---------------------------------------------------------------------------
+
+describe("DELETE /v1/conversations — route policy", () => {
+  test("conversations:DELETE requires settings.write scope", () => {
+    authDisabled = false;
+    const policy = getPolicy("conversations:DELETE");
+    expect(policy).toBeDefined();
+    expect(policy!.requiredScopes).toContain("settings.write");
+  });
+
+  test("chat.write-only token is rejected with 403", () => {
+    authDisabled = false;
+    const ctx = buildAuthContext({
+      scopes: ["chat.read", "chat.write"],
+    });
+    const result = enforcePolicy("conversations:DELETE", ctx);
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  test("settings.write token is allowed through policy", () => {
+    authDisabled = false;
+    const ctx = buildAuthContext({
+      scopes: ["settings.write"],
+    });
+    const result = enforcePolicy("conversations:DELETE", ctx);
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Route handler tests (header check + happy path)
+// ---------------------------------------------------------------------------
+
+describe("DELETE /v1/conversations — route handler", () => {
+  /** Get the DELETE conversations handler from the route definitions. */
+  function getDeleteHandler() {
+    let clearCalled = false;
+    const routes = conversationManagementRouteDefinitions({
+      switchConversation: async () => null,
+      renameConversation: () => true,
+      clearAllConversations: () => {
+        clearCalled = true;
+        return clearAll().conversations;
+      },
+      cancelGeneration: () => true,
+      destroyConversation: () => {},
+      undoLastMessage: async () => null,
+      regenerateResponse: async () => null,
+    });
+
+    const deleteRoute = routes.find(
+      (r) => r.endpoint === "conversations" && r.method === "DELETE",
+    );
+    if (!deleteRoute) throw new Error("DELETE conversations route not found");
+    return { handler: deleteRoute.handler, wasClearCalled: () => clearCalled };
+  }
+
+  test("missing X-Confirm-Destructive header returns 400 with explanatory message", async () => {
+    const { handler } = getDeleteHandler();
+    const req = new Request("http://localhost/v1/conversations", {
+      method: "DELETE",
+    });
+    const response = await handler({
+      req,
+      url: new URL(req.url),
+      server: {} as never,
+      authContext: buildAuthContext({ scopes: ["settings.write"] }),
+      params: {},
+    });
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as {
+      error: { code: string; message: string };
+    };
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("X-Confirm-Destructive");
+    expect(body.error.message).toContain("clear-all-conversations");
+  });
+
+  test("wrong X-Confirm-Destructive header value returns 400", async () => {
+    const { handler } = getDeleteHandler();
+    const req = new Request("http://localhost/v1/conversations", {
+      method: "DELETE",
+      headers: { "X-Confirm-Destructive": "wrong-value" },
+    });
+    const response = await handler({
+      req,
+      url: new URL(req.url),
+      server: {} as never,
+      authContext: buildAuthContext({ scopes: ["settings.write"] }),
+      params: {},
+    });
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as {
+      error: { code: string; message: string };
+    };
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  test("correct scope + header clears data and returns 204", async () => {
+    // Seed a conversation so we can verify it gets cleared
+    const conv = createConversation("safety-test-conv");
+    await addMessage(conv.id, "user", "hello from safety test");
+    expect(getConversation(conv.id)).not.toBeNull();
+
+    const { handler, wasClearCalled } = getDeleteHandler();
+    const req = new Request("http://localhost/v1/conversations", {
+      method: "DELETE",
+      headers: { "X-Confirm-Destructive": "clear-all-conversations" },
+    });
+    const response = await handler({
+      req,
+      url: new URL(req.url),
+      server: {} as never,
+      authContext: buildAuthContext({ scopes: ["settings.write"] }),
+      params: {},
+    });
+    expect(response.status).toBe(204);
+    expect(wasClearCalled()).toBe(true);
+
+    // Conversation should be gone
+    expect(getConversation(conv.id)).toBeNull();
+  });
+
+  test("lifecycle_events contains conversations_clear_all after successful clear", async () => {
+    const { handler } = getDeleteHandler();
+    const req = new Request("http://localhost/v1/conversations", {
+      method: "DELETE",
+      headers: { "X-Confirm-Destructive": "clear-all-conversations" },
+    });
+    await handler({
+      req,
+      url: new URL(req.url),
+      server: {} as never,
+      authContext: buildAuthContext({ scopes: ["settings.write"] }),
+      params: {},
+    });
+
+    // Query lifecycle_events table directly
+    const raw = (
+      getDb() as unknown as {
+        $client: import("bun:sqlite").Database;
+      }
+    ).$client;
+    const rows = raw
+      .query(
+        "SELECT event_name FROM lifecycle_events WHERE event_name = 'conversations_clear_all'",
+      )
+      .all() as Array<{ event_name: string }>;
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    expect(rows[0].event_name).toBe("conversations_clear_all");
+  });
+});

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1317,7 +1317,7 @@ export function clearAll(): { conversations: number; messages: number } {
 
   // Record audit event — lifecycle_events is NOT deleted by clearAll(),
   // so this survives the wipe and provides a permanent trail.
-  rawExec(
+  rawRun(
     `INSERT INTO lifecycle_events (id, event_name, created_at) VALUES (?, ?, ?)`,
     uuid(),
     "conversations_clear_all",


### PR DESCRIPTION
## Summary
- Test that chat.write-only tokens are rejected (403) by the elevated scope requirement
- Test that missing/wrong X-Confirm-Destructive header returns 400 with explanatory message
- Test that correct scope + header succeeds (204) and creates lifecycle_events audit entry
- Fix rawExec -> rawRun bug in clearAll lifecycle_events INSERT (rawExec ignores bind params)
- Verifies the safeguards from PRs #19754 and #19755

Part of plan: safe-clear-conversations.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
