### PR TITLE
fix: use rawRun for parameterized lifecycle_events INSERT

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1317,7 +1317,7 @@ export function clearAll(): { conversations: number; messages: number } {
 
   // Record audit event — lifecycle_events is NOT deleted by clearAll(),
   // so this survives the wipe and provides a permanent trail.
-  rawExec(
+  rawRun(
     `INSERT INTO lifecycle_events (id, event_name, created_at) VALUES (?, ?, ?)`,
     uuid(),
     "conversations_clear_all",


### PR DESCRIPTION
## Summary
- `rawExec()` only accepts a single SQL string with no parameter bindings
- The `clearAll()` lifecycle_events INSERT was calling `rawExec(sql, ...params)` with 4 arguments, causing TypeScript error TS2554
- Switched to `rawRun()` which supports parameterized queries via `...params: SqlParam[]`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23317981440/job/67822330115
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
