### PR TITLE
Support `vellum sleep` and `vellum wake` for Docker instances

### DIFF
--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -3,6 +3,7 @@ import { join } from "path";
 
 import { resolveTargetAssistant } from "../lib/assistant-config.js";
 import type { AssistantEntry } from "../lib/assistant-config.js";
+import { dockerResourceNames, sleepContainers } from "../lib/docker.js";
 import { isProcessAlive, stopProcessByPidFile } from "../lib/process";
 
 const ACTIVE_CALL_LEASES_FILE = "active-call-leases.json";
@@ -64,9 +65,16 @@ export async function sleep(): Promise<void> {
   const nameArg = args.find((a) => !a.startsWith("-"));
   const entry = resolveTargetAssistant(nameArg);
 
+  if (entry.cloud === "docker") {
+    const res = dockerResourceNames(entry.assistantId);
+    await sleepContainers(res);
+    console.log("Docker containers stopped.");
+    return;
+  }
+
   if (entry.cloud && entry.cloud !== "local") {
     console.error(
-      `Error: 'vellum sleep' only works with local assistants. '${entry.assistantId}' is a ${entry.cloud} instance.`,
+      `Error: 'vellum sleep' only works with local and docker assistants. '${entry.assistantId}' is a ${entry.cloud} instance.`,
     );
     process.exit(1);
   }

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 
 import { resolveTargetAssistant } from "../lib/assistant-config.js";
+import { dockerResourceNames, wakeContainers } from "../lib/docker.js";
 import { isProcessAlive, stopProcessByPidFile } from "../lib/process";
 import {
   isAssistantWatchModeAvailable,
@@ -38,9 +39,17 @@ export async function wake(): Promise<void> {
   const nameArg = args.find((a) => !a.startsWith("-"));
   const entry = resolveTargetAssistant(nameArg);
 
+  if (entry.cloud === "docker") {
+    const res = dockerResourceNames(entry.assistantId);
+    await wakeContainers(res);
+    console.log("Docker containers started.");
+    console.log("Wake complete.");
+    return;
+  }
+
   if (entry.cloud && entry.cloud !== "local") {
     console.error(
-      `Error: 'vellum wake' only works with local assistants. '${entry.assistantId}' is a ${entry.cloud} instance.`,
+      `Error: 'vellum wake' only works with local and docker assistants. '${entry.assistantId}' is a ${entry.cloud} instance.`,
     );
     process.exit(1);
   }

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -569,6 +569,28 @@ export async function stopContainers(
   await removeContainer(res.assistantContainer);
 }
 
+/** Stop containers without removing them (preserves state for `docker start`). */
+export async function sleepContainers(
+  res: ReturnType<typeof dockerResourceNames>,
+): Promise<void> {
+  for (const container of [res.cesContainer, res.gatewayContainer, res.assistantContainer]) {
+    try {
+      await exec("docker", ["stop", container]);
+    } catch {
+      // container may not exist or already stopped
+    }
+  }
+}
+
+/** Start existing stopped containers. */
+export async function wakeContainers(
+  res: ReturnType<typeof dockerResourceNames>,
+): Promise<void> {
+  for (const container of [res.assistantContainer, res.gatewayContainer, res.cesContainer]) {
+    await exec("docker", ["start", container]);
+  }
+}
+
 /**
  * Capture the current image references for running service containers.
  * Returns a complete record of service → immutable image ID (sha256 digest)


### PR DESCRIPTION
## Summary
- Add `sleepContainers` and `wakeContainers` helpers to `cli/src/lib/docker.ts` that use `docker stop` / `docker start` (without removing containers, unlike the existing `stopContainers`)
- Update `sleep.ts` and `wake.ts` to branch on `cloud === "docker"` instead of rejecting non-local instances

## Original prompt
Add Docker support to `vellum sleep` and `vellum wake` so they stop/start Docker containers instead of rejecting them.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
