### PR TITLE
fix: sort imports in conversation-clear-safety.test.ts

### DIFF
--- a/assistant/src/__tests__/conversation-clear-safety.test.ts
+++ b/assistant/src/__tests__/conversation-clear-safety.test.ts
@@ -42,8 +42,6 @@ mock.module("../config/env.js", () => ({
   hasUngatedHttpAuthDisabled: () => false,
 }));
 
-import { enforcePolicy, getPolicy } from "../runtime/auth/route-policy.js";
-import type { AuthContext, Scope } from "../runtime/auth/types.js";
 import {
   addMessage,
   clearAll,
@@ -51,6 +49,8 @@ import {
   getConversation,
 } from "../memory/conversation-crud.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { enforcePolicy, getPolicy } from "../runtime/auth/route-policy.js";
+import type { AuthContext, Scope } from "../runtime/auth/types.js";
 import { conversationManagementRouteDefinitions } from "../runtime/routes/conversation-management-routes.js";
 
 initializeDb();


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `conversation-clear-safety.test.ts` by sorting imports alphabetically by module path

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23318139286/job/67822856931
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
