### PR TITLE
Fix scroll-to-bottom button not appearing consistently

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -828,6 +828,13 @@ struct MessageListView: View {
         bottomPinCoordinator.onFollowStateChanged = { isFollowing in
             isNearBottom = isFollowing
         }
+
+        // If detach() was called before this callback was wired up (e.g. a
+        // scroll-wheel event fired between makeNSView and onAppear), sync
+        // isNearBottom now so it isn't stuck at true permanently.
+        if !bottomPinCoordinator.isFollowingBottom {
+            isNearBottom = false
+        }
     }
 
     private var shouldAnchorThinkingToConfirmationChip: Bool {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1142,16 +1142,34 @@ struct MessageListView: View {
                     newValue: minY,
                     previous: anchorTracker.lastMinY
                 )
-                guard case .accept(let accepted) = decision else { return }
-                os_signpost(.begin, log: PerfSignposts.log, name: "anchorMinYPreferenceChange")
-                recordScrollLoopEvent(.anchorPreferenceChange)
-                anchorTracker.update(minY: accepted, viewportHeight: scrollViewportHeight)
-                if !hasFreshAnchorMeasurement { hasFreshAnchorMeasurement = true }
-                scheduleTranscriptSnapshot()
-                // Geometry tracking only — no per-frame scrollTo calls here.
-                // All bottom-follow work is handled by the ChatBottomPinCoordinator
-                // via bounded staged retries, not inline on every anchor change.
-                os_signpost(.end, log: PerfSignposts.log, name: "anchorMinYPreferenceChange")
+                switch decision {
+                case .rejectNonFinite:
+                    // The anchor was deallocated by the LazyVStack (no child reports
+                    // a finite value, so the preference reduces to its .infinity default).
+                    // Mark the anchor as off-screen so the "Scroll to latest" button can appear.
+                    // Also reset lastMinY to .infinity so the button condition
+                    // (!isNearBottom && !isVisible && lastMinY > viewportHeight + 20) is satisfied.
+                    // .infinity is safe: updateViewport() guards isFinite, evaluate() treats
+                    // it as a skip for the dead-zone check, and verify() returns .geometryUnavailable.
+                    if anchorTracker.isVisible {
+                        anchorTracker.isVisible = false
+                        log.debug("Anchor preference non-finite — marking anchor invisible (deallocated by LazyVStack)")
+                    }
+                    anchorTracker.lastMinY = .infinity
+                    return
+                case .rejectDeadZone:
+                    return
+                case .accept(let accepted):
+                    os_signpost(.begin, log: PerfSignposts.log, name: "anchorMinYPreferenceChange")
+                    recordScrollLoopEvent(.anchorPreferenceChange)
+                    anchorTracker.update(minY: accepted, viewportHeight: scrollViewportHeight)
+                    if !hasFreshAnchorMeasurement { hasFreshAnchorMeasurement = true }
+                    scheduleTranscriptSnapshot()
+                    // Geometry tracking only — no per-frame scrollTo calls here.
+                    // All bottom-follow work is handled by the ChatBottomPinCoordinator
+                    // via bounded staged retries, not inline on every anchor change.
+                    os_signpost(.end, log: PerfSignposts.log, name: "anchorMinYPreferenceChange")
+                }
             }
             .transaction { $0.disablesAnimations = true }
             .onPreferenceChange(ConversationTailAnchorYKey.self) { anchorY in


### PR DESCRIPTION
## Summary
Fixes the "Scroll to latest" button not appearing consistently when scrolling up in conversations (both forked and regular). The root cause was twofold: the macOS `PreferenceGeometryFilter` silently rejected `.infinity` values from `AnchorMinYKey` when the LazyVStack deallocated the scroll anchor, and a race condition where the `bottomPinCoordinator.onFollowStateChanged` callback could be nil during view remount.

## Changes
- **Handle non-finite AnchorMinYKey values**: When the LazyVStack deallocates the `scroll-bottom-anchor`, the preference fires with `.infinity`. Previously this was silently rejected, leaving `anchorTracker.isVisible` stuck at `true` and `lastMinY` frozen. Now the `.rejectNonFinite` case explicitly sets `isVisible = false` and `lastMinY = .infinity` so the button can appear.
- **Sync coordinator state after callback setup**: After setting `onFollowStateChanged` in `configureBottomPinCoordinator`, check if the coordinator is already detached and sync `isNearBottom = false`. This handles the race where a scroll event fires between `makeNSView` and `onAppear`.

## Milestone PRs (merged into feature branch)
- #19750: fix: handle non-finite AnchorMinYKey values to fix scroll-to-bottom button
- #19756: fix: sync coordinator follow state after callback setup

## Project issue
Closes #19747

## Test plan
- [ ] Open a forked conversation, scroll up — "Scroll to latest" button should appear
- [ ] Open a regular conversation with history, scroll up — button should appear
- [ ] Fast-scroll (quick trackpad swipe) up in a long conversation — button should appear
- [ ] Click "Scroll to latest" — should scroll to bottom and button should disappear
- [ ] Scroll back down to bottom manually — button should disappear
- [ ] Short conversations (all content fits on screen) — button should NOT appear
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
