### PR TITLE
refactor: extract shared computeHostId into a single location

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import SwiftUI
 import VellumAssistantShared
 
@@ -324,29 +323,8 @@ struct PairingQRCodeSheet: View {
     }
 
     /// Compute a stable, privacy-safe host identifier.
-    /// SHA-256 of the IOPlatformUUID + an app-specific salt.
+    /// Delegates to the shared `HostIdComputer` implementation.
     static func computeHostId() -> String {
-        let platformUUID = getPlatformUUID() ?? UUID().uuidString
-        let salt = "vellum-assistant-host-id"
-        let input = Data((platformUUID + salt).utf8)
-        let hash = SHA256.hash(data: input)
-        return hash.compactMap { String(format: "%02x", $0) }.joined()
-    }
-
-    /// Read the IOPlatformUUID from the IORegistry (macOS hardware identifier).
-    private static func getPlatformUUID() -> String? {
-        let service = IOServiceGetMatchingService(
-            kIOMainPortDefault,
-            IOServiceMatching("IOPlatformExpertDevice")
-        )
-        guard service != 0 else { return nil }
-        defer { IOObjectRelease(service) }
-
-        let key = kIOPlatformUUIDKey as CFString
-        guard let uuid = IORegistryEntryCreateCFProperty(service, key, kCFAllocatorDefault, 0)?
-            .takeRetainedValue() as? String else {
-            return nil
-        }
-        return uuid
+        return HostIdComputer.computeHostId()
     }
 }

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -1,8 +1,4 @@
 import Foundation
-#if os(macOS)
-import CryptoKit
-import IOKit
-#endif
 
 /// Authenticated HTTP client for gateway and platform proxy requests.
 ///
@@ -517,29 +513,9 @@ public enum GatewayHTTPClient {
 
     #if os(macOS)
     /// Compute a stable device ID from the IOPlatformUUID.
+    /// Delegates to the shared `HostIdComputer` implementation.
     private static func computeMacOSDeviceId() -> String {
-        let platformUUID = getMacOSPlatformUUID() ?? UUID().uuidString
-        let salt = "vellum-assistant-host-id"
-        let input = Data((platformUUID + salt).utf8)
-        let hash = SHA256.hash(data: input)
-        return hash.compactMap { String(format: "%02x", $0) }.joined()
-    }
-
-    /// Read the IOPlatformUUID from the IORegistry (macOS hardware identifier).
-    private static func getMacOSPlatformUUID() -> String? {
-        let service = IOServiceGetMatchingService(
-            kIOMainPortDefault,
-            IOServiceMatching("IOPlatformExpertDevice")
-        )
-        guard service != 0 else { return nil }
-        defer { IOObjectRelease(service) }
-
-        let key = kIOPlatformUUIDKey as CFString
-        guard let uuid = IORegistryEntryCreateCFProperty(service, key, kCFAllocatorDefault, 0)?
-            .takeRetainedValue() as? String else {
-            return nil
-        }
-        return uuid
+        return HostIdComputer.computeHostId()
     }
     #endif
 }

--- a/clients/shared/Utilities/HostIdComputer.swift
+++ b/clients/shared/Utilities/HostIdComputer.swift
@@ -1,0 +1,40 @@
+#if os(macOS)
+import CryptoKit
+import Foundation
+import IOKit
+
+/// Single source of truth for computing a stable, privacy-safe macOS host identifier.
+///
+/// The identifier is a SHA-256 hash of the IOPlatformUUID combined with an
+/// app-specific salt. This produces a deterministic, non-reversible device ID
+/// that stays consistent across app launches.
+public enum HostIdComputer {
+
+    /// Compute a stable host identifier from the IOPlatformUUID.
+    /// Falls back to a random UUID if the platform UUID cannot be read.
+    public static func computeHostId() -> String {
+        let platformUUID = getPlatformUUID() ?? UUID().uuidString
+        let salt = "vellum-assistant-host-id"
+        let input = Data((platformUUID + salt).utf8)
+        let hash = SHA256.hash(data: input)
+        return hash.compactMap { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Read the IOPlatformUUID from the IORegistry (macOS hardware identifier).
+    private static func getPlatformUUID() -> String? {
+        let service = IOServiceGetMatchingService(
+            kIOMainPortDefault,
+            IOServiceMatching("IOPlatformExpertDevice")
+        )
+        guard service != 0 else { return nil }
+        defer { IOObjectRelease(service) }
+
+        let key = kIOPlatformUUIDKey as CFString
+        guard let uuid = IORegistryEntryCreateCFProperty(service, key, kCFAllocatorDefault, 0)?
+            .takeRetainedValue() as? String else {
+            return nil
+        }
+        return uuid
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Extract SHA-256(IOPlatformUUID + salt) host-id computation into a single shared `HostIdComputer` enum in `clients/shared/Utilities/`
- Update `PairingQRCodeSheet.computeHostId()` and `GatewayHTTPClient.computeMacOSDeviceId()` to delegate to the shared implementation
- Remove duplicated `getPlatformUUID` / `getMacOSPlatformUUID` methods and unused `CryptoKit`/`IOKit` imports from both files

Part of plan: sentry-id-alignment.md (PR 4 of 4)

## Test plan
- [ ] Verify pairing QR code still generates correctly (same host-id value)
- [ ] Verify credential refresh flow still produces the same device-id
- [ ] Swift build passes (confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
