### PR TITLE
fix: stabilize flaky ChatBottomPinCoordinator retry test on CI

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
@@ -354,8 +354,11 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
 
         coordinator.requestPin(reason: .initialRestore, conversationId: convId)
 
-        // Allow the retry loop to run.
-        try await Task.sleep(nanoseconds: 300_000_000)
+        // Poll until the session completes (robust against slow CI scheduling).
+        let deadline = CFAbsoluteTimeGetCurrent() + 1.0
+        while coordinator.activeSession != nil, CFAbsoluteTimeGetCurrent() < deadline {
+            try await Task.sleep(nanoseconds: 10_000_000) // 10ms
+        }
 
         // Should have stopped after success (3 attempts), not continued to maxRetries.
         XCTAssertGreaterThanOrEqual(callCount, 3)


### PR DESCRIPTION
## Summary
- Replace fixed 300ms `Task.sleep` in `testRetryLoopStopsOnSuccess` with a poll loop that waits for the active session to complete
- The fixed sleep raced with MainActor scheduling on slow CI runners — only 2 of 3 expected retry attempts completed within the window
- Poll loop checks every 10ms with a 1s deadline, eliminating the timing dependency

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23318034563/job/67822526945
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
