### PR TITLE
fix: use distinct policyKey for clear-all to avoid elevating single-conversation delete

### DIFF
--- a/assistant/src/__tests__/conversation-clear-safety.test.ts
+++ b/assistant/src/__tests__/conversation-clear-safety.test.ts
@@ -92,27 +92,42 @@ function buildAuthContext(overrides?: {
 // ---------------------------------------------------------------------------
 
 describe("DELETE /v1/conversations — route policy", () => {
-  test("conversations:DELETE requires settings.write scope", () => {
+  test("conversations/clear-all requires settings.write scope", () => {
     authDisabled = false;
-    const policy = getPolicy("conversations:DELETE");
+    const policy = getPolicy("conversations/clear-all");
     expect(policy).toBeDefined();
     expect(policy!.requiredScopes).toContain("settings.write");
   });
 
-  test("chat.write-only token is rejected with 403", () => {
+  test("chat.write-only token is rejected with 403 for clear-all", () => {
     authDisabled = false;
     const ctx = buildAuthContext({
       scopes: ["chat.read", "chat.write"],
     });
-    const result = enforcePolicy("conversations:DELETE", ctx);
+    const result = enforcePolicy("conversations/clear-all", ctx);
     expect(result).not.toBeNull();
     expect(result!.status).toBe(403);
   });
 
-  test("settings.write token is allowed through policy", () => {
+  test("settings.write token is allowed through clear-all policy", () => {
     authDisabled = false;
     const ctx = buildAuthContext({
       scopes: ["settings.write"],
+    });
+    const result = enforcePolicy("conversations/clear-all", ctx);
+    expect(result).toBeNull();
+  });
+
+  test("single-conversation DELETE (conversations:DELETE) only requires chat.write", () => {
+    authDisabled = false;
+    const policy = getPolicy("conversations:DELETE");
+    expect(policy).toBeDefined();
+    expect(policy!.requiredScopes).toContain("chat.write");
+    expect(policy!.requiredScopes).not.toContain("settings.write");
+
+    // A chat.write token should pass the single-conversation delete policy
+    const ctx = buildAuthContext({
+      scopes: ["chat.read", "chat.write"],
     });
     const result = enforcePolicy("conversations:DELETE", ctx);
     expect(result).toBeNull();

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -348,6 +348,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "config/embeddings:PUT", scopes: ["settings.write"] },
 
   // Conversation management
+  { endpoint: "conversations:DELETE", scopes: ["chat.write"] },
   { endpoint: "conversations/wipe", scopes: ["chat.write"] },
   { endpoint: "conversations/reorder", scopes: ["chat.write"] },
 
@@ -470,8 +471,10 @@ for (const { endpoint, scopes } of ACTOR_ENDPOINTS) {
   });
 }
 
-// Clear-all conversations: elevated to settings.write (destructive bulk operation)
-registerPolicy("conversations:DELETE", {
+// Clear-all conversations: elevated to settings.write (destructive bulk operation).
+// Uses a distinct key so the single-conversation DELETE (conversations:DELETE)
+// retains the lower chat.write scope.
+registerPolicy("conversations/clear-all", {
   requiredScopes: ["settings.write"],
   allowedPrincipalTypes: ["actor", "svc_gateway", "svc_daemon", "local"],
 });

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -226,7 +226,7 @@ export function conversationManagementRouteDefinitions(
     {
       endpoint: "conversations",
       method: "DELETE",
-      policyKey: "conversations",
+      policyKey: "conversations/clear-all",
       handler: ({ req }) => {
         const confirm = req.headers.get("x-confirm-destructive");
         if (confirm !== "clear-all-conversations") {


### PR DESCRIPTION
## Summary
Fixes collateral scope elevation found during self-review: the single-conversation
DELETE endpoint was unintentionally elevated to settings.write because it shared
policyKey with the clear-all route.

- Give clear-all its own policyKey (conversations/clear-all) with settings.write
- Restore conversations:DELETE in ACTOR_ENDPOINTS with chat.write for single-delete
- Update tests to use the new policy key
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
