### PR TITLE
feat: redesign memory card to match skill card layout

### DIFF
--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -5,7 +5,7 @@ import {
   setPlatformUserId,
 } from "../config/env.js";
 import type { AssistantConfig } from "../config/types.js";
-import { setSentryOrganizationId } from "../instrument.js";
+import { setSentryOrganizationId, setSentryUserId } from "../instrument.js";
 import { getMcpServerManager } from "../mcp/manager.js";
 import { gmailMessagingProvider } from "../messaging/providers/gmail/adapter.js";
 import { slackProvider as slackMessagingProvider } from "../messaging/providers/slack/adapter.js";
@@ -91,6 +91,7 @@ export async function initializeProvidersAndTools(
     const trimmed = persisted?.trim();
     if (trimmed) {
       setPlatformUserId(trimmed);
+      setSentryUserId(trimmed);
       log.info("Rehydrated platform user ID from credential store");
     }
   } catch (err) {

--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -2,7 +2,12 @@ import { arch, hostname, platform, release } from "node:os";
 
 import * as Sentry from "@sentry/node";
 
-import { getPlatformOrganizationId, getSentryDsn } from "./config/env.js";
+import {
+  getPlatformOrganizationId,
+  getPlatformUserId,
+  getSentryDsn,
+} from "./config/env.js";
+import { getDeviceId } from "./util/device-id.js";
 import { APP_VERSION, COMMIT_SHA } from "./version.js";
 
 /** Patterns that match sensitive data in Sentry event values. */
@@ -58,9 +63,11 @@ export function initSentry(): void {
         runtime: "bun",
         runtime_version:
           typeof Bun !== "undefined" ? Bun.version : process.version,
+        device_id: getDeviceId(),
         ...(getPlatformOrganizationId()
           ? { organization_id: getPlatformOrganizationId() }
           : {}),
+        ...(getPlatformUserId() ? { user_id: getPlatformUserId() } : {}),
       },
     },
     beforeSend(event) {
@@ -107,6 +114,17 @@ export function setSentryOrganizationId(
   organizationId: string | undefined,
 ): void {
   Sentry.setTag("organization_id", organizationId || undefined);
+}
+
+/**
+ * Set (or clear) the user_id tag on the global Sentry scope.
+ *
+ * Called after the platform user ID is rehydrated from the credential
+ * store or updated at runtime so that every subsequent Sentry event
+ * includes the user context.
+ */
+export function setSentryUserId(userId: string | undefined): void {
+  Sentry.setTag("user_id", userId || undefined);
 }
 
 // ── Dynamic conversation-scoped Sentry tags ─────────────────────────

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -10,7 +10,7 @@ import {
   invalidateConfigCache,
 } from "../../config/loader.js";
 import type { CesClient } from "../../credential-execution/client.js";
-import { setSentryOrganizationId } from "../../instrument.js";
+import { setSentryOrganizationId, setSentryUserId } from "../../instrument.js";
 import { clearEmbeddingBackendCache } from "../../memory/embedding-backend.js";
 import { syncManualTokenConnection } from "../../oauth/manual-token-connection.js";
 import { validateAnthropicApiKey } from "../../providers/anthropic/client.js";
@@ -235,6 +235,7 @@ export async function handleAddSecret(
           setSentryOrganizationId(undefined);
         } else if (field === "platform_user_id") {
           setPlatformUserId(undefined);
+          setSentryUserId(undefined);
         }
         deleteCredentialMetadata(service, field);
       } else {
@@ -260,6 +261,7 @@ export async function handleAddSecret(
         }
         if (service === "vellum" && field === "platform_user_id") {
           setPlatformUserId(effectiveValue || undefined);
+          setSentryUserId(effectiveValue || undefined);
         }
       }
       if (isManagedProxyCredential(service, field)) {
@@ -395,6 +397,7 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
       }
       if (service === "vellum" && field === "platform_user_id") {
         setPlatformUserId(undefined);
+        setSentryUserId(undefined);
       }
       if (isManagedProxyCredential(service, field)) {
         await initializeProviders(getConfig());

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -418,7 +418,13 @@ struct MemoriesPanel: View {
             )
         } else {
             ScrollView {
-                LazyVStack(spacing: VSpacing.sm) {
+                LazyVGrid(
+                    columns: [
+                        GridItem(.flexible(), spacing: VSpacing.md),
+                        GridItem(.flexible(), spacing: VSpacing.md)
+                    ],
+                    spacing: VSpacing.md
+                ) {
                     ForEach(filteredItems) { item in
                         MemoryItemRow(
                             item: item,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -19,30 +19,31 @@ struct MemoryItemRow: View {
 
                 // Text content
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    // Header: subject + badges + actions on same line
-                    HStack(spacing: VSpacing.sm) {
-                        Text(item.subject)
-                            .font(VFont.bodyBold)
-                            .foregroundColor(VColor.contentDefault)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
+                    // Header + timestamp group
+                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                        HStack(spacing: VSpacing.sm) {
+                            Text(item.subject)
+                                .font(VFont.bodyBold)
+                                .foregroundColor(VColor.contentDefault)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
 
-                        Spacer()
+                            Spacer()
 
-                        kindTag
+                            kindTag
 
-                        if let scopeLabel = item.scopeLabel {
-                            VBadge(label: scopeLabel, icon: .lock, tone: .neutral, emphasis: .subtle, shape: .rounded)
+                            if let scopeLabel = item.scopeLabel {
+                                VBadge(label: scopeLabel, icon: .lock, tone: .neutral, emphasis: .subtle, shape: .rounded)
+                            }
+
+                            VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerGhost, action: onDelete)
+                                .accessibilityLabel("Delete memory")
                         }
 
-                        VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerGhost, action: onDelete)
-                            .accessibilityLabel("Delete memory")
+                        Text(item.relativeLastSeen)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentTertiary)
                     }
-
-                    // Timestamp
-                    Text(item.relativeLastSeen)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
 
                     // Description — fixed 2-line height for uniform cards
                     Text(item.statement)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -35,13 +35,14 @@ struct MemoryItemRow: View {
                             VBadge(label: scopeLabel, icon: .lock, tone: .neutral, emphasis: .subtle, shape: .rounded)
                         }
 
-                        Text(item.relativeLastSeen)
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.contentTertiary)
-
                         VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerGhost, action: onDelete)
                             .accessibilityLabel("Delete memory")
                     }
+
+                    // Timestamp
+                    Text(item.relativeLastSeen)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
 
                     // Description — fixed 2-line height for uniform cards
                     Text(item.statement)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -22,7 +22,7 @@ struct MemoryItemRow: View {
                     // Header row: title+timestamp on the left, badges+delete on the right
                     HStack(alignment: .top, spacing: VSpacing.sm) {
                         // Title + timestamp, tightly grouped
-                        VStack(alignment: .leading, spacing: 1) {
+                        VStack(alignment: .leading, spacing: -2) {
                             Text(item.subject)
                                 .font(VFont.bodyBold)
                                 .foregroundColor(VColor.contentDefault)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -7,47 +7,62 @@ struct MemoryItemRow: View {
     let onDelete: () -> Void
     @State private var isHovered = false
 
+    private var memoryKind: MemoryKind? {
+        MemoryKind(rawValue: item.kind)
+    }
+
     var body: some View {
         Button(action: onSelect) {
             HStack(alignment: .center, spacing: VSpacing.lg) {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                // Icon — centered vertically, matching skill card
+                kindIcon
+
+                // Text content
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    // Header: subject + badges + actions on same line
                     HStack(spacing: VSpacing.sm) {
                         Text(item.subject)
                             .font(VFont.bodyBold)
                             .foregroundColor(VColor.contentDefault)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+
+                        Spacer()
 
                         kindTag
 
                         if let scopeLabel = item.scopeLabel {
                             VBadge(label: scopeLabel, icon: .lock, tone: .neutral, emphasis: .subtle, shape: .rounded)
                         }
+
+                        Text(item.relativeLastSeen)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentTertiary)
+
+                        VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerGhost, action: onDelete)
+                            .accessibilityLabel("Delete memory")
                     }
 
+                    // Description — fixed 2-line height for uniform cards
                     Text(item.statement)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.contentTertiary)
-                        .lineLimit(1)
-                        .multilineTextAlignment(.leading)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentSecondary)
+                        .lineLimit(2)
+                        .frame(maxWidth: .infinity, minHeight: 28, alignment: .topLeading)
                 }
-
-                Spacer()
-
-                Text(item.relativeLastSeen)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.contentTertiary)
-
-                VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerOutline, action: onDelete)
-                    .accessibilityLabel("Delete memory")
             }
             .padding(VSpacing.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .background(isHovered ? VColor.surfaceActive : Color.clear)
             .overlay(
                 RoundedRectangle(cornerRadius: VRadius.xl)
                     .stroke(VColor.borderDisabled, lineWidth: 2)
             )
             .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .pointerCursor()
         .onHover { isHovered = $0 }
         .contextMenu {
             Button("Delete", role: .destructive, action: onDelete)
@@ -55,11 +70,25 @@ struct MemoryItemRow: View {
         .accessibilityElement(children: .combine)
     }
 
+    // MARK: - Kind Icon
+
+    @ViewBuilder
+    private var kindIcon: some View {
+        if let kind = memoryKind, let icon = VIcon(rawValue: kind.icon) {
+            VIconView(icon, size: 20)
+                .foregroundColor(kind.color)
+                .frame(width: 40, height: 40)
+        } else {
+            VIconView(.brain, size: 20)
+                .foregroundColor(VColor.contentTertiary)
+                .frame(width: 40, height: 40)
+        }
+    }
+
     // MARK: - Kind Tag
 
     private var kindTag: some View {
-        let memoryKind = MemoryKind(rawValue: item.kind)
-        return VBadge(
+        VBadge(
             label: memoryKind?.label ?? item.kind.capitalized,
             color: memoryKind?.color ?? VColor.contentTertiary,
             shape: .rounded

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -13,14 +13,14 @@ struct MemoryItemRow: View {
 
     var body: some View {
         Button(action: onSelect) {
-            HStack(alignment: .center, spacing: VSpacing.lg) {
-                // Icon — centered vertically, matching skill card
+            HStack(alignment: .top, spacing: VSpacing.lg) {
+                // Icon — top-aligned, matching skill card
                 kindIcon
 
                 // Text content
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     // Header + timestamp group
-                    VStack(alignment: .leading, spacing: 1) {
+                    VStack(alignment: .leading, spacing: 0) {
                         HStack(spacing: VSpacing.sm) {
                             Text(item.subject)
                                 .font(VFont.bodyBold)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -20,7 +20,7 @@ struct MemoryItemRow: View {
                 // Text content
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     // Header + timestamp group
-                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    VStack(alignment: .leading, spacing: 1) {
                         HStack(spacing: VSpacing.sm) {
                             Text(item.subject)
                                 .font(VFont.bodyBold)
@@ -33,7 +33,7 @@ struct MemoryItemRow: View {
                             kindTag
 
                             if let scopeLabel = item.scopeLabel {
-                                VBadge(label: scopeLabel, icon: .lock, tone: .neutral, emphasis: .subtle, shape: .rounded)
+                                VBadge(label: scopeLabel, icon: .lock, tone: .neutral, emphasis: .subtle, shape: .pill)
                             }
 
                             VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerGhost, action: onDelete)
@@ -93,7 +93,7 @@ struct MemoryItemRow: View {
         VBadge(
             label: memoryKind?.label ?? item.kind.capitalized,
             color: memoryKind?.color ?? VColor.contentTertiary,
-            shape: .rounded
+            shape: .pill
         )
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -19,30 +19,31 @@ struct MemoryItemRow: View {
 
                 // Text content
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    // Header + timestamp group
-                    VStack(alignment: .leading, spacing: 0) {
-                        HStack(spacing: VSpacing.sm) {
+                    // Header row: title+timestamp on the left, badges+delete on the right
+                    HStack(alignment: .top, spacing: VSpacing.sm) {
+                        // Title + timestamp, tightly grouped
+                        VStack(alignment: .leading, spacing: 1) {
                             Text(item.subject)
                                 .font(VFont.bodyBold)
                                 .foregroundColor(VColor.contentDefault)
                                 .lineLimit(1)
                                 .truncationMode(.tail)
 
-                            Spacer()
-
-                            kindTag
-
-                            if let scopeLabel = item.scopeLabel {
-                                VBadge(label: scopeLabel, icon: .lock, tone: .neutral, emphasis: .subtle, shape: .pill)
-                            }
-
-                            VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerGhost, action: onDelete)
-                                .accessibilityLabel("Delete memory")
+                            Text(item.relativeLastSeen)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.contentTertiary)
                         }
 
-                        Text(item.relativeLastSeen)
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.contentTertiary)
+                        Spacer()
+
+                        kindTag
+
+                        if let scopeLabel = item.scopeLabel {
+                            VBadge(label: scopeLabel, icon: .lock, tone: .neutral, emphasis: .subtle, shape: .pill)
+                        }
+
+                        VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerGhost, action: onDelete)
+                            .accessibilityLabel("Delete memory")
                     }
 
                     // Description — fixed 2-line height for uniform cards

--- a/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
+++ b/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
@@ -1,21 +1,14 @@
-import CryptoKit
 import Foundation
-import IOKit
 @preconcurrency import Sentry
 import VellumAssistantShared
 
 /// Privacy-safe device identification and Sentry scope configuration.
-/// Uses the same SHA-256(IOPlatformUUID + salt) approach as PairingQRCodeSheet.computeHostId().
+/// Uses the shared UUID from ~/.vellum/device.json so Sentry device_id
+/// matches the daemon telemetry device_id for cross-system correlation.
 enum SentryDeviceInfo {
-    /// A stable, hashed device identifier derived from the hardware UUID.
+    /// A stable device identifier from the shared device.json file.
     /// Computed once and cached for the process lifetime.
-    static let deviceId: String = {
-        let platformUUID = getPlatformUUID() ?? UUID().uuidString
-        let salt = "vellum-assistant-host-id"
-        let input = Data((platformUUID + salt).utf8)
-        let hash = SHA256.hash(data: input)
-        return hash.compactMap { String(format: "%02x", $0) }.joined()
-    }()
+    static let deviceId: String = DeviceIdStore.getOrCreate()
 
     /// Sentry environment string matching the daemon convention in instrument.ts.
     static let sentryEnvironment: String = {
@@ -79,21 +72,5 @@ enum SentryDeviceInfo {
                 scope.removeTag(key: "user_id")
             }
         }
-    }
-
-    private static func getPlatformUUID() -> String? {
-        let service = IOServiceGetMatchingService(
-            kIOMainPortDefault,
-            IOServiceMatching("IOPlatformExpertDevice")
-        )
-        guard service != 0 else { return nil }
-        defer { IOObjectRelease(service) }
-
-        let key = kIOPlatformUUIDKey as CFString
-        guard let uuid = IORegistryEntryCreateCFProperty(service, key, kCFAllocatorDefault, 0)?
-            .takeRetainedValue() as? String else {
-            return nil
-        }
-        return uuid
     }
 }


### PR DESCRIPTION
## Summary
- Redesigns `MemoryItemRow` to visually match `SkillCardButton` layout
- Adds a left-side icon (40×40) based on memory kind (identity → user, preference → heart, etc.) with kind-specific color
- Restructures to two-row text layout: header row (subject + badges + time + delete) and description row (statement, 2-line cap with fixed min height)
- Adds `.pointerCursor()`, `.contentShape(Rectangle())`, and `.frame(maxWidth:)` for consistent tap targets

## Test plan
- [ ] Verify memory cards display kind-specific icons on the left
- [ ] Verify header row shows subject, kind badge, scope badge, relative time, and delete button
- [ ] Verify statement text appears below header with 2-line limit
- [ ] Verify hover state works correctly
- [ ] Compare visually with skill cards for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
