### PR TITLE
Pre-select Bug Report as default log reporting option (LUM-336)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -458,7 +458,7 @@ extension AppDelegate {
         }
     }
 
-    func showLogReportWindow(scope: LogExportScope = .global, reason: LogReportReason? = nil) {
+    func showLogReportWindow(scope: LogExportScope = .global, reason: LogReportReason? = .bugReport) {
         // If the window is already showing, just bring it forward.
         if let existing = logReportWindow, existing.isVisible {
             existing.makeKeyAndOrderFront(nil)


### PR DESCRIPTION
## Summary
- Pre-selects "Bug Report" as the default reason when opening the Send Logs form, so users don't have to manually pick a category before submitting
- When a specific reason is passed (e.g. `.connectionIssue`), that reason is still used instead

## Original prompt
--safe https://linear.app/vellum/issue/LUM-336/pre-select-a-log-reporting-option pre-select but report by default
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
