### PR TITLE
fix: migrate HTTPDaemonClient to shared HostIdComputer

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1,10 +1,5 @@
 import Foundation
 import os
-import CryptoKit
-#if os(macOS)
-import IOKit
-#endif
-
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "HTTPTransport")
 
 // MARK: - AssistantEvent Envelope
@@ -1650,31 +1645,9 @@ public final class HTTPTransport {
     // MARK: - macOS Device ID
 
     #if os(macOS)
-    /// Compute a stable device ID matching PairingQRCodeSheet.computeHostId().
-    /// SHA-256 of the IOPlatformUUID + an app-specific salt.
+    /// Compute a stable device ID via the shared HostIdComputer.
     private static func computeMacOSDeviceId() -> String {
-        let platformUUID = getMacOSPlatformUUID() ?? UUID().uuidString
-        let salt = "vellum-assistant-host-id"
-        let input = Data((platformUUID + salt).utf8)
-        let hash = SHA256.hash(data: input)
-        return hash.compactMap { String(format: "%02x", $0) }.joined()
-    }
-
-    /// Read the IOPlatformUUID from the IORegistry (macOS hardware identifier).
-    private static func getMacOSPlatformUUID() -> String? {
-        let service = IOServiceGetMatchingService(
-            kIOMainPortDefault,
-            IOServiceMatching("IOPlatformExpertDevice")
-        )
-        guard service != 0 else { return nil }
-        defer { IOObjectRelease(service) }
-
-        let key = kIOPlatformUUIDKey as CFString
-        guard let uuid = IORegistryEntryCreateCFProperty(service, key, kCFAllocatorDefault, 0)?
-            .takeRetainedValue() as? String else {
-            return nil
-        }
-        return uuid
+        return HostIdComputer.computeHostId()
     }
     #endif
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for sentry-id-alignment.md.

**Gap:** HTTPDaemonClient still has duplicated host-id computation
**What was expected:** All SHA-256 host-id logic consolidated into HostIdComputer
**What was found:** HTTPDaemonClient had its own inline copy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
