### PR TITLE
Align telemetry IDs across all reporting systems

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -20,7 +20,7 @@ import { loadConfig } from "../config/loader.js";
 import { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { getHookManager } from "../hooks/manager.js";
 import { installTemplates } from "../hooks/templates.js";
-import { closeSentry, initSentry } from "../instrument.js";
+import { closeSentry, initSentry, setSentryDeviceId } from "../instrument.js";
 import { disableLogfire, initLogfire } from "../logfire.js";
 import { getMcpServerManager } from "../mcp/manager.js";
 import * as attachmentsStore from "../memory/attachments-store.js";
@@ -65,6 +65,7 @@ import { RuntimeHttpServer } from "../runtime/http-server.js";
 import { startScheduler } from "../schedule/scheduler.js";
 import { seedCatalogSkillMemories } from "../skills/skill-memory.js";
 import { UsageTelemetryReporter } from "../telemetry/usage-telemetry-reporter.js";
+import { getDeviceId } from "../util/device-id.js";
 import { getLogger, initLogger } from "../util/logger.js";
 import {
   ensureDataDir,
@@ -178,6 +179,11 @@ export async function runDaemon(): Promise<void> {
 
     await runWorkspaceMigrations(getWorkspaceDir(), WORKSPACE_MIGRATIONS);
     log.info("Daemon startup: workspace migrations complete");
+
+    // Now that workspace migrations have run (including 003-seed-device-id
+    // which may copy the legacy installationId into device.json), it is safe
+    // to read the device ID and set the Sentry tag.
+    setSentryDeviceId(getDeviceId());
 
     // Purge private (temporary) conversations from the previous daemon run.
     // These are ephemeral by design and should not survive daemon restarts.

--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -5,7 +5,7 @@ import {
   setPlatformUserId,
 } from "../config/env.js";
 import type { AssistantConfig } from "../config/types.js";
-import { setSentryOrganizationId } from "../instrument.js";
+import { setSentryOrganizationId, setSentryUserId } from "../instrument.js";
 import { getMcpServerManager } from "../mcp/manager.js";
 import { gmailMessagingProvider } from "../messaging/providers/gmail/adapter.js";
 import { slackProvider as slackMessagingProvider } from "../messaging/providers/slack/adapter.js";
@@ -91,6 +91,7 @@ export async function initializeProvidersAndTools(
     const trimmed = persisted?.trim();
     if (trimmed) {
       setPlatformUserId(trimmed);
+      setSentryUserId(trimmed);
       log.info("Rehydrated platform user ID from credential store");
     }
   } catch (err) {

--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -63,6 +63,10 @@ export function initSentry(): void {
         runtime: "bun",
         runtime_version:
           typeof Bun !== "undefined" ? Bun.version : process.version,
+        // device_id is read from ~/.vellum/device.json (shared with the macOS client).
+        // This may create device.json before macOS migrates a legacy UserDefaults ID,
+        // but the daemon already calls getDeviceId() elsewhere (e.g. telemetry reporter),
+        // so this doesn't introduce a new race.
         device_id: getDeviceId(),
         ...(getPlatformOrganizationId()
           ? { organization_id: getPlatformOrganizationId() }

--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -7,7 +7,6 @@ import {
   getPlatformUserId,
   getSentryDsn,
 } from "./config/env.js";
-import { getDeviceId } from "./util/device-id.js";
 import { APP_VERSION, COMMIT_SHA } from "./version.js";
 
 /** Patterns that match sensitive data in Sentry event values. */
@@ -63,11 +62,10 @@ export function initSentry(): void {
         runtime: "bun",
         runtime_version:
           typeof Bun !== "undefined" ? Bun.version : process.version,
-        // device_id is read from ~/.vellum/device.json (shared with the macOS client).
-        // This may create device.json before macOS migrates a legacy UserDefaults ID,
-        // but the daemon already calls getDeviceId() elsewhere (e.g. telemetry reporter),
-        // so this doesn't introduce a new race.
-        device_id: getDeviceId(),
+        // NOTE: device_id is NOT set here. It is deferred to setSentryDeviceId()
+        // which is called after workspace migrations run, so that migration
+        // 003-seed-device-id can copy the legacy installationId into device.json
+        // before getDeviceId() eagerly creates a new random UUID.
         ...(getPlatformOrganizationId()
           ? { organization_id: getPlatformOrganizationId() }
           : {}),
@@ -129,6 +127,17 @@ export function setSentryOrganizationId(
  */
 export function setSentryUserId(userId: string | undefined): void {
   Sentry.setTag("user_id", userId || undefined);
+}
+
+/**
+ * Set the device_id tag on the global Sentry scope.
+ *
+ * Called after workspace migrations complete so that migration
+ * 003-seed-device-id has a chance to copy the legacy installationId
+ * into device.json before getDeviceId() is invoked.
+ */
+export function setSentryDeviceId(deviceId: string): void {
+  Sentry.setTag("device_id", deviceId);
 }
 
 // ── Dynamic conversation-scoped Sentry tags ─────────────────────────

--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -2,7 +2,12 @@ import { arch, hostname, platform, release } from "node:os";
 
 import * as Sentry from "@sentry/node";
 
-import { getPlatformOrganizationId, getSentryDsn } from "./config/env.js";
+import {
+  getPlatformOrganizationId,
+  getPlatformUserId,
+  getSentryDsn,
+} from "./config/env.js";
+import { getDeviceId } from "./util/device-id.js";
 import { APP_VERSION, COMMIT_SHA } from "./version.js";
 
 /** Patterns that match sensitive data in Sentry event values. */
@@ -58,9 +63,11 @@ export function initSentry(): void {
         runtime: "bun",
         runtime_version:
           typeof Bun !== "undefined" ? Bun.version : process.version,
+        device_id: getDeviceId(),
         ...(getPlatformOrganizationId()
           ? { organization_id: getPlatformOrganizationId() }
           : {}),
+        ...(getPlatformUserId() ? { user_id: getPlatformUserId() } : {}),
       },
     },
     beforeSend(event) {
@@ -107,6 +114,17 @@ export function setSentryOrganizationId(
   organizationId: string | undefined,
 ): void {
   Sentry.setTag("organization_id", organizationId || undefined);
+}
+
+/**
+ * Set (or clear) the user_id tag on the global Sentry scope.
+ *
+ * Called after the platform user ID is rehydrated from the credential
+ * store or updated at runtime so that every subsequent Sentry event
+ * includes the user context.
+ */
+export function setSentryUserId(userId: string | undefined): void {
+  Sentry.setTag("user_id", userId || undefined);
 }
 
 // ── Dynamic conversation-scoped Sentry tags ─────────────────────────

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -10,7 +10,7 @@ import {
   invalidateConfigCache,
 } from "../../config/loader.js";
 import type { CesClient } from "../../credential-execution/client.js";
-import { setSentryOrganizationId } from "../../instrument.js";
+import { setSentryOrganizationId, setSentryUserId } from "../../instrument.js";
 import { clearEmbeddingBackendCache } from "../../memory/embedding-backend.js";
 import { syncManualTokenConnection } from "../../oauth/manual-token-connection.js";
 import { validateAnthropicApiKey } from "../../providers/anthropic/client.js";
@@ -235,6 +235,7 @@ export async function handleAddSecret(
           setSentryOrganizationId(undefined);
         } else if (field === "platform_user_id") {
           setPlatformUserId(undefined);
+          setSentryUserId(undefined);
         }
         deleteCredentialMetadata(service, field);
       } else {
@@ -260,6 +261,7 @@ export async function handleAddSecret(
         }
         if (service === "vellum" && field === "platform_user_id") {
           setPlatformUserId(effectiveValue || undefined);
+          setSentryUserId(effectiveValue || undefined);
         }
       }
       if (isManagedProxyCredential(service, field)) {
@@ -395,6 +397,7 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
       }
       if (service === "vellum" && field === "platform_user_id") {
         setPlatformUserId(undefined);
+        setSentryUserId(undefined);
       }
       if (isManagedProxyCredential(service, field)) {
         await initializeProviders(getConfig());

--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import SwiftUI
 import VellumAssistantShared
 
@@ -324,29 +323,8 @@ struct PairingQRCodeSheet: View {
     }
 
     /// Compute a stable, privacy-safe host identifier.
-    /// SHA-256 of the IOPlatformUUID + an app-specific salt.
+    /// Delegates to the shared `HostIdComputer` implementation.
     static func computeHostId() -> String {
-        let platformUUID = getPlatformUUID() ?? UUID().uuidString
-        let salt = "vellum-assistant-host-id"
-        let input = Data((platformUUID + salt).utf8)
-        let hash = SHA256.hash(data: input)
-        return hash.compactMap { String(format: "%02x", $0) }.joined()
-    }
-
-    /// Read the IOPlatformUUID from the IORegistry (macOS hardware identifier).
-    private static func getPlatformUUID() -> String? {
-        let service = IOServiceGetMatchingService(
-            kIOMainPortDefault,
-            IOServiceMatching("IOPlatformExpertDevice")
-        )
-        guard service != 0 else { return nil }
-        defer { IOObjectRelease(service) }
-
-        let key = kIOPlatformUUIDKey as CFString
-        guard let uuid = IORegistryEntryCreateCFProperty(service, key, kCFAllocatorDefault, 0)?
-            .takeRetainedValue() as? String else {
-            return nil
-        }
-        return uuid
+        return HostIdComputer.computeHostId()
     }
 }

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -286,6 +286,11 @@ enum LogExporter {
                 // so log exports correlate with daemon Sentry events and telemetry.
                 "device_id": SentryDeviceInfo.deviceId,
             ]
+            // user_id mirrors the Sentry user tag set by SentryDeviceInfo.updateUserTag
+            // so log exports can be correlated with authenticated Sentry events.
+            if let userId = AppDelegate.shared?.authManager.currentUser?.id {
+                metadata["user_id"] = userId
+            }
             if !formData.name.isEmpty {
                 metadata["name"] = formData.name
             }

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -282,6 +282,8 @@ enum LogExporter {
             var metadata: [String: Any] = [
                 "reason": formData.reason.rawValue,
                 "message": formData.message,
+                // device_id intentionally matches ~/.vellum/device.json UUID
+                // so log exports correlate with daemon Sentry events and telemetry.
                 "device_id": SentryDeviceInfo.deviceId,
             ]
             if !formData.name.isEmpty {

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -288,7 +288,7 @@ enum LogExporter {
             ]
             // user_id mirrors the Sentry user tag set by SentryDeviceInfo.updateUserTag
             // so log exports can be correlated with authenticated Sentry events.
-            if let userId = AppDelegate.shared?.authManager.currentUser?.id {
+            if let userId = await MainActor.run(body: { AppDelegate.shared?.authManager.currentUser?.id }) {
                 metadata["user_id"] = userId
             }
             if !formData.name.isEmpty {

--- a/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
+++ b/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
@@ -1,21 +1,14 @@
-import CryptoKit
 import Foundation
-import IOKit
 @preconcurrency import Sentry
 import VellumAssistantShared
 
 /// Privacy-safe device identification and Sentry scope configuration.
-/// Uses the same SHA-256(IOPlatformUUID + salt) approach as PairingQRCodeSheet.computeHostId().
+/// Uses the shared UUID from ~/.vellum/device.json so Sentry device_id
+/// matches the daemon telemetry device_id for cross-system correlation.
 enum SentryDeviceInfo {
-    /// A stable, hashed device identifier derived from the hardware UUID.
+    /// A stable device identifier from the shared device.json file.
     /// Computed once and cached for the process lifetime.
-    static let deviceId: String = {
-        let platformUUID = getPlatformUUID() ?? UUID().uuidString
-        let salt = "vellum-assistant-host-id"
-        let input = Data((platformUUID + salt).utf8)
-        let hash = SHA256.hash(data: input)
-        return hash.compactMap { String(format: "%02x", $0) }.joined()
-    }()
+    static let deviceId: String = DeviceIdStore.getOrCreate()
 
     /// Sentry environment string matching the daemon convention in instrument.ts.
     static let sentryEnvironment: String = {
@@ -79,21 +72,5 @@ enum SentryDeviceInfo {
                 scope.removeTag(key: "user_id")
             }
         }
-    }
-
-    private static func getPlatformUUID() -> String? {
-        let service = IOServiceGetMatchingService(
-            kIOMainPortDefault,
-            IOServiceMatching("IOPlatformExpertDevice")
-        )
-        guard service != 0 else { return nil }
-        defer { IOObjectRelease(service) }
-
-        let key = kIOPlatformUUIDKey as CFString
-        guard let uuid = IORegistryEntryCreateCFProperty(service, key, kCFAllocatorDefault, 0)?
-            .takeRetainedValue() as? String else {
-            return nil
-        }
-        return uuid
     }
 }

--- a/clients/shared/App/Auth/DeviceIdStore.swift
+++ b/clients/shared/App/Auth/DeviceIdStore.swift
@@ -124,9 +124,13 @@ public enum DeviceIdStore {
         guard !withInstallId.isEmpty else { return nil }
 
         // Sort by hatchedAt descending to pick the most recent.
+        // Use a formatter with fractional seconds since CLI writes
+        // timestamps via `new Date().toISOString()` (e.g. "...00.000Z").
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         let sorted = withInstallId.sorted { a, b in
-            let dateA = (a["hatchedAt"] as? String).flatMap { ISO8601DateFormatter().date(from: $0) } ?? .distantPast
-            let dateB = (b["hatchedAt"] as? String).flatMap { ISO8601DateFormatter().date(from: $0) } ?? .distantPast
+            let dateA = (a["hatchedAt"] as? String).flatMap { formatter.date(from: $0) } ?? .distantPast
+            let dateB = (b["hatchedAt"] as? String).flatMap { formatter.date(from: $0) } ?? .distantPast
             return dateA > dateB
         }
 

--- a/clients/shared/App/Auth/DeviceIdStore.swift
+++ b/clients/shared/App/Auth/DeviceIdStore.swift
@@ -49,6 +49,10 @@ public enum DeviceIdStore {
            !legacyId.isEmpty {
             deviceId = legacyId
             migratingFromLegacy = true
+        } else if let lockfileId = Self.installationIdFromLockfile() {
+            // 2b. Migrate from lockfile installationId (mirrors daemon 003-seed-device-id).
+            deviceId = lockfileId
+            migratingFromLegacy = false
         } else {
             // 3. No existing ID anywhere — generate a fresh one.
             deviceId = UUID().uuidString.lowercased()
@@ -82,5 +86,50 @@ public enum DeviceIdStore {
 
         cached = deviceId
         return deviceId
+    }
+
+    // MARK: - Lockfile Migration
+
+    /// Reads the most recent `installationId` from the legacy lockfile,
+    /// mirroring the daemon's `003-seed-device-id` migration so the same
+    /// legacy ID is preserved regardless of whether macOS or daemon starts first.
+    private static func installationIdFromLockfile() -> String? {
+        let home = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+        let candidates = [
+            home.appendingPathComponent(".vellum.lock.json"),
+            home.appendingPathComponent(".vellum.lockfile.json"),
+        ]
+
+        var lockJSON: [String: Any]?
+        for candidate in candidates {
+            guard let data = try? Data(contentsOf: candidate),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                continue
+            }
+            lockJSON = json
+            break
+        }
+        guard let lockJSON else { return nil }
+
+        guard let assistants = lockJSON["assistants"] as? [[String: Any]],
+              !assistants.isEmpty else {
+            return nil
+        }
+
+        // Filter to entries with a non-empty installationId.
+        let withInstallId = assistants.filter { entry in
+            guard let id = entry["installationId"] as? String, !id.isEmpty else { return false }
+            return true
+        }
+        guard !withInstallId.isEmpty else { return nil }
+
+        // Sort by hatchedAt descending to pick the most recent.
+        let sorted = withInstallId.sorted { a, b in
+            let dateA = (a["hatchedAt"] as? String).flatMap { ISO8601DateFormatter().date(from: $0) } ?? .distantPast
+            let dateB = (b["hatchedAt"] as? String).flatMap { ISO8601DateFormatter().date(from: $0) } ?? .distantPast
+            return dateA > dateB
+        }
+
+        return sorted.first?["installationId"] as? String
     }
 }

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -1,8 +1,4 @@
 import Foundation
-#if os(macOS)
-import CryptoKit
-import IOKit
-#endif
 
 /// Authenticated HTTP client for gateway and platform proxy requests.
 ///
@@ -517,29 +513,9 @@ public enum GatewayHTTPClient {
 
     #if os(macOS)
     /// Compute a stable device ID from the IOPlatformUUID.
+    /// Delegates to the shared `HostIdComputer` implementation.
     private static func computeMacOSDeviceId() -> String {
-        let platformUUID = getMacOSPlatformUUID() ?? UUID().uuidString
-        let salt = "vellum-assistant-host-id"
-        let input = Data((platformUUID + salt).utf8)
-        let hash = SHA256.hash(data: input)
-        return hash.compactMap { String(format: "%02x", $0) }.joined()
-    }
-
-    /// Read the IOPlatformUUID from the IORegistry (macOS hardware identifier).
-    private static func getMacOSPlatformUUID() -> String? {
-        let service = IOServiceGetMatchingService(
-            kIOMainPortDefault,
-            IOServiceMatching("IOPlatformExpertDevice")
-        )
-        guard service != 0 else { return nil }
-        defer { IOObjectRelease(service) }
-
-        let key = kIOPlatformUUIDKey as CFString
-        guard let uuid = IORegistryEntryCreateCFProperty(service, key, kCFAllocatorDefault, 0)?
-            .takeRetainedValue() as? String else {
-            return nil
-        }
-        return uuid
+        return HostIdComputer.computeHostId()
     }
     #endif
 }

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1,10 +1,5 @@
 import Foundation
 import os
-import CryptoKit
-#if os(macOS)
-import IOKit
-#endif
-
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "HTTPTransport")
 
 // MARK: - AssistantEvent Envelope
@@ -1650,31 +1645,9 @@ public final class HTTPTransport {
     // MARK: - macOS Device ID
 
     #if os(macOS)
-    /// Compute a stable device ID matching PairingQRCodeSheet.computeHostId().
-    /// SHA-256 of the IOPlatformUUID + an app-specific salt.
+    /// Compute a stable device ID via the shared HostIdComputer.
     private static func computeMacOSDeviceId() -> String {
-        let platformUUID = getMacOSPlatformUUID() ?? UUID().uuidString
-        let salt = "vellum-assistant-host-id"
-        let input = Data((platformUUID + salt).utf8)
-        let hash = SHA256.hash(data: input)
-        return hash.compactMap { String(format: "%02x", $0) }.joined()
-    }
-
-    /// Read the IOPlatformUUID from the IORegistry (macOS hardware identifier).
-    private static func getMacOSPlatformUUID() -> String? {
-        let service = IOServiceGetMatchingService(
-            kIOMainPortDefault,
-            IOServiceMatching("IOPlatformExpertDevice")
-        )
-        guard service != 0 else { return nil }
-        defer { IOObjectRelease(service) }
-
-        let key = kIOPlatformUUIDKey as CFString
-        guard let uuid = IORegistryEntryCreateCFProperty(service, key, kCFAllocatorDefault, 0)?
-            .takeRetainedValue() as? String else {
-            return nil
-        }
-        return uuid
+        return HostIdComputer.computeHostId()
     }
     #endif
 

--- a/clients/shared/Utilities/HostIdComputer.swift
+++ b/clients/shared/Utilities/HostIdComputer.swift
@@ -1,0 +1,40 @@
+#if os(macOS)
+import CryptoKit
+import Foundation
+import IOKit
+
+/// Single source of truth for computing a stable, privacy-safe macOS host identifier.
+///
+/// The identifier is a SHA-256 hash of the IOPlatformUUID combined with an
+/// app-specific salt. This produces a deterministic, non-reversible device ID
+/// that stays consistent across app launches.
+public enum HostIdComputer {
+
+    /// Compute a stable host identifier from the IOPlatformUUID.
+    /// Falls back to a random UUID if the platform UUID cannot be read.
+    public static func computeHostId() -> String {
+        let platformUUID = getPlatformUUID() ?? UUID().uuidString
+        let salt = "vellum-assistant-host-id"
+        let input = Data((platformUUID + salt).utf8)
+        let hash = SHA256.hash(data: input)
+        return hash.compactMap { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Read the IOPlatformUUID from the IORegistry (macOS hardware identifier).
+    private static func getPlatformUUID() -> String? {
+        let service = IOServiceGetMatchingService(
+            kIOMainPortDefault,
+            IOServiceMatching("IOPlatformExpertDevice")
+        )
+        guard service != 0 else { return nil }
+        defer { IOObjectRelease(service) }
+
+        let key = kIOPlatformUUIDKey as CFString
+        guard let uuid = IORegistryEntryCreateCFProperty(service, key, kCFAllocatorDefault, 0)?
+            .takeRetainedValue() as? String else {
+            return nil
+        }
+        return uuid
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
Unifies device_id and user_id across Sentry, telemetry payloads, and log export metadata so events from the same machine/user can be correlated across the macOS client and daemon.

**Before:** macOS Sentry used SHA-256(hardware UUID) as device_id, daemon Sentry had no device_id or user_id tags at all, and the daemon telemetry reporter used a different UUID from ~/.vellum/device.json. Cross-system correlation was impossible.

**After:** All systems use the shared UUID from ~/.vellum/device.json as device_id. The SHA-256 hardware hash is preserved as a "host ID" for pairing/auth only, consolidated into a single HostIdComputer utility.

## PRs merged into feature branch
- #19761: feat: add device_id and user_id tags to daemon Sentry scope
- #19760: fix: use shared device.json UUID for macOS Sentry device_id tag
- #19769: fix: use shared device UUID in log export metadata
- #19768: refactor: extract shared computeHostId into a single location
- #19774: fix: migrate HTTPDaemonClient to shared HostIdComputer

## Self-review result
PASS after 1 fix round (HTTPDaemonClient was missed in initial consolidation)

Part of plan: sentry-id-alignment.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
