### PR TITLE
fix: route local assistant health checks through target gateway's readyz endpoint

### DIFF
--- a/clients/shared/Network/HealthCheckClient.swift
+++ b/clients/shared/Network/HealthCheckClient.swift
@@ -3,12 +3,11 @@ import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "HealthCheckClient")
 
-/// Checks assistant reachability via the authenticated gateway healthz endpoint.
+/// Checks assistant reachability.
 ///
-/// All requests go through `GatewayHTTPClient` which handles URL resolution,
-/// authentication, and routing for both local and remote assistants.
-/// Uses `GET /v1/assistants/{id}/healthz` which verifies gateway connectivity,
-/// daemon availability, and JWT validity.
+/// Local assistants are checked by hitting their own gateway's `/readyz` endpoint
+/// directly (unauthenticated). Remote/managed assistants route through
+/// `GatewayHTTPClient` which handles URL resolution, authentication, and 401 retry.
 @MainActor
 public enum HealthCheckClient {
 
@@ -26,16 +25,48 @@ public enum HealthCheckClient {
     }
 
     #if os(macOS)
-    /// Check whether a specific assistant is reachable via the connected gateway.
+    /// Resolves the health check URL for a local assistant.
+    /// Returns `nil` when the gateway port cannot be determined from the lockfile.
+    static func localHealthCheckURL(for assistant: LockfileAssistant) -> URL? {
+        guard let port = assistant.gatewayPort else { return nil }
+        return URL(string: "http://127.0.0.1:\(port)/readyz")
+    }
+
+    /// Check whether a specific assistant is reachable.
+    ///
+    /// Local assistants are checked by hitting their own gateway's `/readyz` endpoint
+    /// directly (unauthenticated). Remote/managed assistants route through
+    /// `GatewayHTTPClient` with full 401 retry and credential refresh behavior.
     public static func isReachable(for assistant: LockfileAssistant, timeout: TimeInterval = 3) async -> Bool {
-        do {
-            let response = try await GatewayHTTPClient.get(
-                path: "assistants/\(assistant.assistantId)/healthz",
-                timeout: timeout
-            )
-            return response.isSuccess
-        } catch {
-            return false
+        return await isReachable(for: assistant, timeout: timeout, session: .shared)
+    }
+
+    /// Internal entry point — accepts a `URLSession` for test injection.
+    static func isReachable(for assistant: LockfileAssistant, timeout: TimeInterval = 3, session: URLSession) async -> Bool {
+        if assistant.isRemote {
+            do {
+                let response = try await GatewayHTTPClient.get(
+                    path: "assistants/\(assistant.assistantId)/healthz",
+                    timeout: timeout
+                )
+                return response.isSuccess
+            } catch {
+                return false
+            }
+        } else {
+            guard let url = localHealthCheckURL(for: assistant) else { return false }
+            var request = URLRequest(url: url)
+            request.httpMethod = "GET"
+            request.timeoutInterval = timeout
+            do {
+                let (_, response) = try await session.data(for: request)
+                if let httpResponse = response as? HTTPURLResponse {
+                    return (200..<300).contains(httpResponse.statusCode)
+                }
+                return false
+            } catch {
+                return false
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Local assistant health checks now hit the target assistant's own gateway `/readyz` endpoint directly instead of routing through `GatewayHTTPClient` (which always used the connected assistant's gateway)
- Uses `assistant.gatewayPort` only — no env-var fallback that could target the wrong gateway
- Added injectable `URLSession` parameter for testability (PR 2 adds tests)

Part of plan: multi-asst-health-check.md (PR 1 of 2)

Closes JARVIS-269

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
