### PR TITLE
fix: add @MainActor to AppMenuPatchDelegate.patchTitles

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -24,7 +24,7 @@ final class AppMenuPatchDelegate: NSObject, NSMenuDelegate {
         patchTitles(menu: menu)
     }
 
-    func patchTitles(menu: NSMenu) {
+    @MainActor func patchTitles(menu: NSMenu) {
         let name = AppDelegate.appName
         // Patch the parent menu item title (the bold text in the menu bar).
         if let mainMenu = NSApp.mainMenu,


### PR DESCRIPTION
## Summary
- Add `@MainActor` annotation to `AppMenuPatchDelegate.patchTitles(menu:)` to fix Swift 6 concurrency warning when accessing `AppDelegate.appName` from a non-isolated context.

## Original prompt
Fix Swift compiler warning: main actor-isolated static property 'appName' cannot be referenced from a nonisolated context in `AppDelegate+MenuBar.swift:28`.