### PR TITLE
refactor: rewrite conversation starters prompt

### DIFF
--- a/assistant/src/memory/job-handlers/conversation-starters.ts
+++ b/assistant/src/memory/job-handlers/conversation-starters.ts
@@ -176,11 +176,11 @@ async function generateStarters(scopeId: string): Promise<GeneratedStarter[]> {
     ? truncate(rawIdentityContext, 2000, "\n…[truncated]")
     : null;
 
-  const systemPrompt = `You are generating 4 conversation starters for a personal assistant app. These appear as clickable chips on the empty conversation page — the first thing the user sees when they open the app.
+  const systemPrompt = `You are generating 4 conversation starters for a personal assistant app. These appear as clickable chips on the empty conversation page — the first thing the user sees when they open the app. Clicking a chip sends its prompt as a message from the user.
 
 ${timeContext}
 
-Your goal: look at what's going on in this person's life right now and suggest the 4 most useful things they could ask you to do. Think about what a thoughtful chief of staff would proactively bring up in a 30-second check-in.
+Your goal: suggest the 4 most useful things this person could ask you to do right now.
 
 ${identityContext ? `## Assistant identity & user profile\n\n${identityContext}\n\n` : ""}## What you know
 
@@ -188,7 +188,9 @@ ${rollup}
 ${diff}
 ${skills}
 
-## How to think about this
+## Selection
+
+Generate exactly 4 starters, ranked #1 (best) to #4.
 
 Start from the user's situation, not from the skill list. Ask yourself:
 - What is this person likely dealing with right now (given the day/time and their context)?
@@ -197,11 +199,7 @@ Start from the user's situation, not from the skill list. Ask yourself:
 
 The skills list tells you what the assistant CAN do — use it to filter out suggestions the assistant can't actually help with, not as a menu to generate suggestions from.
 
-## Selection
-
-Generate exactly 4 starters, ranked #1 (best) to #4.
-
-For each, you must be able to clearly answer:
+For each starter, you must clearly answer:
 - Why now? (timing — day of week, recent activity, upcoming deadline)
 - Why this user? (grounded in their specific context, not generic)
 - Why would they be glad I suggested this? (genuine usefulness, not just relevance)
@@ -218,44 +216,34 @@ Favor what is live over what is merely true. Recent changes matter more than old
 
 ## Output format
 
-Return exactly 4 starters in rank order (best first).
-
 Each starter has:
-- label: 3-6 words, max 40 chars, starts with a verb. Should read as something the user wants to do — these chips send a message as the user, so the label must be in the user's voice. Must sound natural when read aloud.
-- prompt: 1-2 natural sentences, written as the user would actually say them — not templated.
+- label: 3-6 words, max 40 chars, starts with a verb. Written in the user's voice — something they'd want to do, not something the assistant is offering.
+- prompt: 1-2 natural sentences, as the user would actually say them.
 - category: one of ${CONVERSATION_STARTER_CATEGORIES.join(", ")}
 
-The 4 starters should feel like one coherent set of recommendations for this moment — similar abstraction level, no jarring mix of mundane chores and life strategy. Don't lift raw memory phrases, project names, or jargon into labels unless they already sound natural in conversation.
+## Constraints
 
-Never include a chip whose primary meaning is configuration, setup, workflow creation, or "set up X for Y" unless it solves an urgent pain the user is actively feeling right now. Prefer the outcome over the mechanism — "Catch the emails that matter" beats "Set up a playbook for inbox."
+**Voice**: The user clicks these chips to send a message. Every label must read as something the user is asking to do, never something the assistant is saying to the user.
 
-## Topic diversity
+**Coherence**: The 4 starters should feel like one set — similar abstraction level, no jarring mix of mundane chores and life strategy.
 
-Each chip should cover a distinct topic or concern. Never have two chips about the same tool, project, or theme — even if there are multiple related issues. Pick the single most impactful angle and give the other slot to something different. Four chips about three topics is too narrow; four chips about four topics is right.
+**Diversity**: Each chip covers a distinct topic. Never two chips about the same tool, project, or theme. Four topics, four chips.
 
-## User-facingness check
+**No setup chips**: Never include a chip whose primary meaning is configuration or "set up X for Y" unless it solves an urgent pain the user is actively feeling. Prefer the outcome over the mechanism.
 
-If a label sounds like an issue title, project ticket, or implementation task, rewrite it. Prefer the user-visible payoff over the internal object name. The chip should feel inviting and useful, not merely accurate.
+**Natural language**: No jargon, project names, or raw memory phrases in labels unless they already sound natural in conversation. If a label sounds like a ticket title or backlog item, rewrite it as something the user would actually say.
 
-Prefer natural, flowing language over mechanical or operational phrasing. "Get Slack messages flowing" is better than "Restore outgoing Slack messages." The label should sound like something a helpful person would say, not a support ticket.
+## Examples
 
-Voice: The user clicks these chips to send a message. Every label must make sense as something the user is asking to do, never something the assistant is saying to the user.
+Bad → Good (ticket-speak → natural):
+- "Fix Slack Socket Mode blocker" → "Fix Slack so it just works"
+- "Restore outgoing Slack messages" → "Get Slack messages flowing"
+- "Review this week's calendar" → "Protect this week's focus"
+- "Set up a playbook for inbox" → "Triage my inbox"
 
-Before finalizing each label, ask yourself: would this feel good to click? Or does it sound like a backlog item? If it sounds like a backlog item, rewrite it.
-
-Examples of bad vs good:
-- BAD: "Fix Slack Socket Mode blocker" → GOOD: "Fix Slack so it just works"
-- BAD: "Rewire messaging for Socket Mode" → GOOD: "Get Socket Mode stable"
-- BAD: "Review this week's calendar" → GOOD: "Protect this week's focus"
-- BAD: "Model the coaching transition" → GOOD: "Plan the coaching transition"
-- BAD: "Restore outgoing Slack messages" → GOOD: "Get Slack messages flowing"
-- BAD: "Set up a playbook for inbox" → GOOD: "Catch the emails that matter"
-
-Assistant-voice vs user-voice:
-- BAD: "You've got a busy week ahead" → GOOD: "Plan my week ahead"
-- BAD: "Let me check your calendar" → GOOD: "Check my Thursday schedule"
-
-The good versions emphasize the user's payoff in the user's own voice, not the internal mechanism or the assistant's perspective.`;
+Bad → Good (assistant voice → user voice):
+- "You've got a busy week ahead" → "Plan my week ahead"
+- "Let me check your calendar" → "Check my Thursday schedule"`;
 
   const { signal, cleanup } = createTimeout(20000);
   try {
@@ -280,7 +268,7 @@ The good versions emphasize the user's payoff in the user's own voice, not the i
                     label: {
                       type: "string",
                       description:
-                        "User-voice chip text (2-7 words, max 40 chars, starts with a verb)",
+                        "User-voice chip label (2-7 words, max 40 chars, verb-first)",
                     },
                     prompt: {
                       type: "string",


### PR DESCRIPTION
## Summary
- Rewrote the conversation starters system prompt to consolidate redundant sections (merged "How to think about this" into "Selection", collapsed "User-facingness check" + voice constraint + topic diversity into a single "Constraints" section)
- Removed assistant-voice framing ("chief of staff", "something a helpful person would say") in favor of explicit user-voice rules
- Added structured constraints (Voice, Coherence, Diversity, No setup chips, Natural language) and reorganized examples into two clear categories (ticket-speak → natural, assistant voice → user voice)

## Original prompt
Rewrite the conversation starters system prompt to fix voice inconsistencies, consolidate redundant sections, and reduce prompt length by ~30%.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
