### PR TITLE
Rename app_version to assistant_version in telemetry payload

### DIFF
--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -375,9 +375,9 @@ describe("UsageTelemetryReporter", () => {
       (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
     );
 
-    // Top-level: installation_id, app_version, and events array (no turn_events key)
+    // Top-level: installation_id, assistant_version, and events array (no turn_events key)
     expect(body.installation_id).toBe("test-device-id");
-    expect(body.app_version).toBe("1.2.3-test");
+    expect(body.assistant_version).toBe("1.2.3-test");
     expect(Array.isArray(body.events)).toBe(true);
     expect(body.events.length).toBe(1);
     expect(body.turn_events).toBeUndefined();

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -195,7 +195,7 @@ export class UsageTelemetryReporter {
       const payload = {
         device_id: getDeviceId(),
         assistant_id: assistantId,
-        app_version: APP_VERSION,
+        assistant_version: APP_VERSION,
         ...(organizationId ? { organization_id: organizationId } : {}),
         ...(userId ? { user_id: userId } : {}),
         events: typedEvents,


### PR DESCRIPTION
## Summary
- Rename `app_version` to `assistant_version` in the telemetry ingest payload to better reflect what it represents (the daemon/assistant version, not the macOS client version)
- Prepares for adding a separate `client_version` field later for macOS client version tracking

## Original prompt
the changes for both repos