### PR TITLE
refactor: centralize platform API access in VellumPlatformClient

### DIFF
--- a/assistant/src/credential-execution/managed-catalog.ts
+++ b/assistant/src/credential-execution/managed-catalog.ts
@@ -11,8 +11,7 @@
 
 import { platformOAuthHandle } from "@vellumai/ces-contracts";
 
-import { getPlatformAssistantId } from "../config/env.js";
-import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
+import { VellumPlatformClient } from "../platform/client.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("managed-catalog");
@@ -79,25 +78,18 @@ export interface FetchManagedCatalogResult {
  * error message that never contains secret material.
  */
 export async function fetchManagedCatalog(): Promise<FetchManagedCatalogResult> {
-  const ctx = await resolveManagedProxyContext();
+  const client = await VellumPlatformClient.create();
 
-  if (!ctx.enabled) {
+  if (!client) {
     return { ok: true, descriptors: [] };
   }
 
-  const assistantId = getPlatformAssistantId();
-  if (!assistantId) {
-    log.warn("PLATFORM_ASSISTANT_ID not set; cannot fetch managed catalog");
-    return { ok: true, descriptors: [] };
-  }
-
-  const url = `${ctx.platformBaseUrl}/v1/assistants/${encodeURIComponent(assistantId)}/oauth/managed/catalog/`;
+  const path = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/managed/catalog/`;
 
   try {
-    const response = await fetch(url, {
+    const response = await client.fetch(path, {
       method: "GET",
       headers: {
-        Authorization: `Api-Key ${ctx.assistantApiKey}`,
         Accept: "application/json",
       },
     });
@@ -139,8 +131,6 @@ export async function fetchManagedCatalog(): Promise<FetchManagedCatalogResult> 
     return { ok: true, descriptors };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    // Ensure the error message does not leak secrets — strip any URL params
-    // that might contain tokens (defensive, since we use Api-Key header).
     const safeMessage = message.replace(
       /Api-Key\s+\S+/gi,
       "Api-Key [REDACTED]",

--- a/assistant/src/credential-execution/managed-catalog.ts
+++ b/assistant/src/credential-execution/managed-catalog.ts
@@ -80,7 +80,7 @@ export interface FetchManagedCatalogResult {
 export async function fetchManagedCatalog(): Promise<FetchManagedCatalogResult> {
   const client = await VellumPlatformClient.create();
 
-  if (!client) {
+  if (!client || !client.platformAssistantId) {
     return { ok: true, descriptors: [] };
   }
 

--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ---------------------------------------------------------------------------
 // Mutable mock state
@@ -8,12 +8,7 @@ let mockProvider: Record<string, unknown> | undefined;
 let mockConnection: Record<string, unknown> | undefined;
 let mockAccessToken: string | undefined;
 let mockConfig: Record<string, unknown> = {};
-let mockManagedProxyCtx = {
-  enabled: false,
-  platformBaseUrl: "",
-  assistantApiKey: "",
-};
-let mockAssistantId = "";
+let mockPlatformClient: Record<string, unknown> | null = null;
 
 // ---------------------------------------------------------------------------
 // Module mocks (must precede imports of the module under test)
@@ -48,12 +43,10 @@ mock.module("../config/loader.js", () => ({
   getConfig: () => mockConfig,
 }));
 
-mock.module("../config/env.js", () => ({
-  getPlatformAssistantId: () => mockAssistantId,
-}));
-
-mock.module("../providers/managed-proxy/context.js", () => ({
-  resolveManagedProxyContext: async () => mockManagedProxyCtx,
+mock.module("../platform/client.js", () => ({
+  VellumPlatformClient: {
+    create: async () => mockPlatformClient,
+  },
 }));
 
 // ---------------------------------------------------------------------------
@@ -67,6 +60,22 @@ import { PlatformOAuthConnection } from "./platform-connection.js";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+function makeMockClient() {
+  return {
+    baseUrl: "https://platform.example.com",
+    assistantApiKey: "sk-test-key",
+    platformAssistantId: "asst-123",
+    fetch: mock(async () => {
+      return new Response(
+        JSON.stringify({
+          results: [{ id: "platform-conn-1", account_label: null }],
+        }),
+        { status: 200 },
+      );
+    }),
+  };
+}
 
 function setupDefaults(): void {
   mockProvider = {
@@ -100,12 +109,7 @@ function setupDefaults(): void {
       "google-oauth": { mode: "managed" },
     },
   };
-  mockManagedProxyCtx = {
-    enabled: true,
-    platformBaseUrl: "https://platform.example.com",
-    assistantApiKey: "sk-test-key",
-  };
-  mockAssistantId = "asst-123";
+  mockPlatformClient = makeMockClient();
 }
 
 // ---------------------------------------------------------------------------
@@ -113,24 +117,8 @@ function setupDefaults(): void {
 // ---------------------------------------------------------------------------
 
 describe("resolveOAuthConnection", () => {
-  let originalFetch: typeof globalThis.fetch;
-
   beforeEach(() => {
     setupDefaults();
-    originalFetch = globalThis.fetch;
-    // Default mock: return a single active connection from the platform
-    globalThis.fetch = mock(async () => {
-      return new Response(
-        JSON.stringify({
-          results: [{ id: "platform-conn-1", account_label: null }],
-        }),
-        { status: 200 },
-      );
-    }) as unknown as typeof globalThis.fetch;
-  });
-
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
   });
 
   test("returns BYOOAuthConnection when provider has no managedServiceConfigKey", async () => {

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -49,9 +49,12 @@ export async function resolveOAuthConnection(
     const services: Services = getConfig().services;
     if (services[managedKey as keyof Services].mode === "managed") {
       const client = await VellumPlatformClient.create();
-      if (!client) {
+      if (!client || !client.platformAssistantId) {
+        const detail = !client
+          ? "missing platform prerequisites"
+          : "missing assistant ID";
         throw new Error(
-          `Platform-managed connection for "${providerKey}" cannot be created: missing platform prerequisites. ` +
+          `Platform-managed connection for "${providerKey}" cannot be created: ${detail}. ` +
             `Log in to the Vellum platform or switch to using your own OAuth app.`,
         );
       }

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -1,7 +1,6 @@
-import { getPlatformAssistantId } from "../config/env.js";
 import { getConfig } from "../config/loader.js";
 import { type Services, ServicesSchema } from "../config/schemas/services.js";
-import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
+import { VellumPlatformClient } from "../platform/client.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import { BYOOAuthConnection } from "./byo-connection.js";
@@ -49,14 +48,18 @@ export async function resolveOAuthConnection(
   if (managedKey && managedKey in ServicesSchema.shape) {
     const services: Services = getConfig().services;
     if (services[managedKey as keyof Services].mode === "managed") {
-      const ctx = await resolveManagedProxyContext();
-      const assistantId = getPlatformAssistantId();
+      const client = await VellumPlatformClient.create();
+      if (!client) {
+        throw new Error(
+          `Platform-managed connection for "${providerKey}" cannot be created: missing platform prerequisites. ` +
+            `Log in to the Vellum platform or switch to using your own OAuth app.`,
+        );
+      }
+
       const providerSlug = providerKey.replace(/^integration:/, "");
 
       const connectionId = await resolvePlatformConnectionId({
-        assistantId,
-        platformBaseUrl: ctx.platformBaseUrl.replace(/\/+$/, ""),
-        apiKey: ctx.assistantApiKey,
+        client,
         provider: providerSlug,
         account,
       });
@@ -66,9 +69,7 @@ export async function resolveOAuthConnection(
         providerKey,
         externalId: providerKey,
         accountInfo: account ?? null,
-        assistantId,
-        platformBaseUrl: ctx.platformBaseUrl,
-        apiKey: ctx.assistantApiKey,
+        client,
         connectionId,
       });
     }
@@ -118,9 +119,7 @@ export async function resolveOAuthConnection(
 // ---------------------------------------------------------------------------
 
 interface ResolvePlatformConnectionIdOptions {
-  assistantId: string;
-  platformBaseUrl: string;
-  apiKey: string;
+  client: VellumPlatformClient;
   provider: string;
   account?: string;
 }
@@ -132,32 +131,17 @@ interface ResolvePlatformConnectionIdOptions {
 async function resolvePlatformConnectionId(
   options: ResolvePlatformConnectionIdOptions,
 ): Promise<string> {
-  const { assistantId, platformBaseUrl, apiKey, provider, account } = options;
+  const { client, provider, account } = options;
 
-  const missing: string[] = [];
-  if (!platformBaseUrl) missing.push("platform base URL");
-  if (!apiKey) missing.push("assistant API key");
-  if (!assistantId) missing.push("assistant ID");
-  if (missing.length > 0) {
-    throw new Error(
-      `Platform-managed connection for "${provider}" cannot be created: missing ${missing.join(", ")}. ` +
-        `Log in to the Vellum platform or switch to using your own OAuth app.`,
-    );
-  }
-
-  const url = new URL(
-    `/v1/assistants/${assistantId}/oauth/connections/`,
-    platformBaseUrl,
-  );
-  url.searchParams.set("provider", provider);
-  url.searchParams.set("status", "ACTIVE");
+  const params = new URLSearchParams();
+  params.set("provider", provider);
+  params.set("status", "ACTIVE");
   if (account) {
-    url.searchParams.set("account_identifier", account);
+    params.set("account_identifier", account);
   }
 
-  const response = await fetch(url.toString(), {
-    headers: { Authorization: `Api-Key ${apiKey}` },
-  });
+  const path = `/v1/assistants/${client.platformAssistantId}/oauth/connections/?${params.toString()}`;
+  const response = await client.fetch(path);
 
   if (!response.ok) {
     log.error(

--- a/assistant/src/oauth/platform-connection.test.ts
+++ b/assistant/src/oauth/platform-connection.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
+import type { VellumPlatformClient } from "../platform/client.js";
 import { BackendError, VellumError } from "../util/errors.js";
 import {
   CredentialRequiredError,
@@ -7,41 +8,53 @@ import {
   ProviderUnreachableError,
 } from "./platform-connection.js";
 
+function makeMockClient(
+  fetchImpl?: typeof globalThis.fetch,
+): VellumPlatformClient {
+  const mockFetchFn =
+    fetchImpl ??
+    (mock(async () => {
+      return new Response(
+        JSON.stringify({ status: 200, headers: {}, body: null }),
+        { status: 200 },
+      );
+    }) as unknown as typeof globalThis.fetch);
+
+  return {
+    baseUrl: "https://platform.example.com",
+    assistantApiKey: "test-api-key",
+    platformAssistantId: "asst-abc",
+    fetch: mock(async (path: string, init?: RequestInit) => {
+      const url = `https://platform.example.com${path}`;
+      const headers = new Headers(init?.headers);
+      headers.set("Authorization", "Api-Key test-api-key");
+      return mockFetchFn(url, { ...init, headers });
+    }),
+  } as unknown as VellumPlatformClient;
+}
+
 const DEFAULT_OPTIONS = {
   id: "conn-1",
   providerKey: "integration:google",
   externalId: "ext-123",
   accountInfo: "user@example.com",
-  assistantId: "asst-abc",
-  platformBaseUrl: "https://platform.example.com",
-  apiKey: "test-api-key",
+  client: makeMockClient(),
   connectionId: "platform-conn-123",
 };
 
 describe("PlatformOAuthConnection", () => {
-  let originalFetch: typeof globalThis.fetch;
-
-  beforeEach(() => {
-    originalFetch = globalThis.fetch;
-  });
-
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
-  });
-
   test("successful proxied request", async () => {
     const upstreamBody = { messages: [{ id: "msg-1", snippet: "Hello" }] };
 
-    globalThis.fetch = mock(
-      async (url: string | URL | Request, init?: RequestInit) => {
-        expect(url).toBe(
+    const client = makeMockClient(
+      mock(async (url: string | URL | Request, init?: RequestInit) => {
+        expect(String(url)).toBe(
           "https://platform.example.com/v1/assistants/asst-abc/external-provider-proxy/platform-conn-123/",
         );
         expect(init?.method).toBe("POST");
-        expect(init?.headers).toEqual({
-          Authorization: "Api-Key test-api-key",
-          "Content-Type": "application/json",
-        });
+        const headers = new Headers(init?.headers);
+        expect(headers.get("Authorization")).toBe("Api-Key test-api-key");
+        expect(headers.get("Content-Type")).toBe("application/json");
 
         const parsed = JSON.parse(init?.body as string);
         expect(parsed).toEqual({
@@ -62,10 +75,13 @@ describe("PlatformOAuthConnection", () => {
           }),
           { status: 200 },
         );
-      },
-    ) as unknown as typeof globalThis.fetch;
+      }) as unknown as typeof globalThis.fetch,
+    );
 
-    const conn = new PlatformOAuthConnection(DEFAULT_OPTIONS);
+    const conn = new PlatformOAuthConnection({
+      ...DEFAULT_OPTIONS,
+      client,
+    });
     const result = await conn.request({
       method: "GET",
       path: "/gmail/v1/users/me/messages",
@@ -78,8 +94,8 @@ describe("PlatformOAuthConnection", () => {
   });
 
   test("forwards baseUrl when provided", async () => {
-    globalThis.fetch = mock(
-      async (_url: string | URL | Request, init?: RequestInit) => {
+    const client = makeMockClient(
+      mock(async (_url: string | URL | Request, init?: RequestInit) => {
         const parsed = JSON.parse(init?.body as string);
         expect(parsed.request.baseUrl).toBe(
           "https://www.googleapis.com/calendar/v3",
@@ -89,10 +105,10 @@ describe("PlatformOAuthConnection", () => {
           JSON.stringify({ status: 200, headers: {}, body: {} }),
           { status: 200 },
         );
-      },
-    ) as unknown as typeof globalThis.fetch;
+      }) as unknown as typeof globalThis.fetch,
+    );
 
-    const conn = new PlatformOAuthConnection(DEFAULT_OPTIONS);
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
     await conn.request({
       method: "GET",
       path: "/calendars/primary/events",
@@ -101,8 +117,8 @@ describe("PlatformOAuthConnection", () => {
   });
 
   test("omits baseUrl from envelope when not provided", async () => {
-    globalThis.fetch = mock(
-      async (_url: string | URL | Request, init?: RequestInit) => {
+    const client = makeMockClient(
+      mock(async (_url: string | URL | Request, init?: RequestInit) => {
         const parsed = JSON.parse(init?.body as string);
         expect("baseUrl" in parsed.request).toBe(false);
 
@@ -110,10 +126,10 @@ describe("PlatformOAuthConnection", () => {
           JSON.stringify({ status: 200, headers: {}, body: null }),
           { status: 200 },
         );
-      },
-    ) as unknown as typeof globalThis.fetch;
+      }) as unknown as typeof globalThis.fetch,
+    );
 
-    const conn = new PlatformOAuthConnection(DEFAULT_OPTIONS);
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
     await conn.request({ method: "GET", path: "/some/path" });
   });
 
@@ -128,22 +144,26 @@ describe("PlatformOAuthConnection", () => {
   });
 
   test("424 response throws CredentialRequiredError", async () => {
-    globalThis.fetch = mock(async () => {
-      return new Response("", { status: 424 });
-    }) as unknown as typeof globalThis.fetch;
+    const client = makeMockClient(
+      mock(
+        async () => new Response("", { status: 424 }),
+      ) as unknown as typeof globalThis.fetch,
+    );
 
-    const conn = new PlatformOAuthConnection(DEFAULT_OPTIONS);
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
     await expect(
       conn.request({ method: "GET", path: "/test" }),
     ).rejects.toThrow(CredentialRequiredError);
   });
 
   test("502 response throws ProviderUnreachableError", async () => {
-    globalThis.fetch = mock(async () => {
-      return new Response("", { status: 502 });
-    }) as unknown as typeof globalThis.fetch;
+    const client = makeMockClient(
+      mock(
+        async () => new Response("", { status: 502 }),
+      ) as unknown as typeof globalThis.fetch,
+    );
 
-    const conn = new PlatformOAuthConnection(DEFAULT_OPTIONS);
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
     await expect(
       conn.request({ method: "GET", path: "/test" }),
     ).rejects.toThrow(ProviderUnreachableError);
@@ -156,35 +176,22 @@ describe("PlatformOAuthConnection", () => {
     );
   });
 
-  test("strips trailing slash from platformBaseUrl to avoid double slashes", async () => {
-    globalThis.fetch = mock(async (url: string | URL | Request) => {
-      expect(String(url)).toBe(
-        "https://platform.example.com/v1/assistants/asst-abc/external-provider-proxy/platform-conn-123/",
-      );
-      return new Response(
-        JSON.stringify({ status: 200, headers: {}, body: null }),
-        { status: 200 },
-      );
-    }) as unknown as typeof globalThis.fetch;
-
-    const conn = new PlatformOAuthConnection({
-      ...DEFAULT_OPTIONS,
-      platformBaseUrl: "https://platform.example.com/",
-    });
-    await conn.request({ method: "GET", path: "/test" });
-  });
-
   test("uses connectionId in proxy URL regardless of providerKey format", async () => {
-    globalThis.fetch = mock(async (url: string | URL | Request) => {
-      expect(String(url)).toContain("/external-provider-proxy/slack-conn-456/");
-      return new Response(
-        JSON.stringify({ status: 200, headers: {}, body: null }),
-        { status: 200 },
-      );
-    }) as unknown as typeof globalThis.fetch;
+    const client = makeMockClient(
+      mock(async (url: string | URL | Request) => {
+        expect(String(url)).toContain(
+          "/external-provider-proxy/slack-conn-456/",
+        );
+        return new Response(
+          JSON.stringify({ status: 200, headers: {}, body: null }),
+          { status: 200 },
+        );
+      }) as unknown as typeof globalThis.fetch,
+    );
 
     const conn = new PlatformOAuthConnection({
       ...DEFAULT_OPTIONS,
+      client,
       providerKey: "integration:slack",
       connectionId: "slack-conn-456",
     });

--- a/assistant/src/oauth/platform-connection.ts
+++ b/assistant/src/oauth/platform-connection.ts
@@ -1,3 +1,4 @@
+import type { VellumPlatformClient } from "../platform/client.js";
 import { BackendError } from "../util/errors.js";
 import type {
   OAuthConnection,
@@ -24,9 +25,7 @@ export interface PlatformOAuthConnectionOptions {
   providerKey: string;
   externalId: string;
   accountInfo: string | null;
-  assistantId: string;
-  platformBaseUrl: string;
-  apiKey: string;
+  client: VellumPlatformClient;
   /** Platform-side connection ID used in the proxy URL path. */
   connectionId: string;
 }
@@ -37,20 +36,13 @@ export class PlatformOAuthConnection implements OAuthConnection {
   readonly externalId: string;
   readonly accountInfo: string | null;
 
-  private readonly assistantId: string;
-  private readonly platformBaseUrl: string;
-  private readonly apiKey: string;
+  private readonly client: VellumPlatformClient;
   private readonly connectionId: string;
 
   constructor(options: PlatformOAuthConnectionOptions) {
-    const missing: string[] = [];
-    if (!options.platformBaseUrl) missing.push("platform base URL");
-    if (!options.apiKey) missing.push("assistant API key");
-    if (!options.assistantId) missing.push("assistant ID");
-    if (!options.connectionId) missing.push("connection ID");
-    if (missing.length > 0) {
+    if (!options.connectionId) {
       throw new BackendError(
-        `Platform-managed connection for "${options.providerKey}" cannot be created: missing ${missing.join(", ")}. ` +
+        `Platform-managed connection for "${options.providerKey}" cannot be created: missing connection ID. ` +
           `Log in to the Vellum platform or switch to using your own OAuth app.`,
       );
     }
@@ -59,14 +51,12 @@ export class PlatformOAuthConnection implements OAuthConnection {
     this.providerKey = options.providerKey;
     this.externalId = options.externalId;
     this.accountInfo = options.accountInfo;
-    this.assistantId = options.assistantId;
-    this.platformBaseUrl = options.platformBaseUrl.replace(/\/+$/, "");
-    this.apiKey = options.apiKey;
+    this.client = options.client;
     this.connectionId = options.connectionId;
   }
 
   async request(req: OAuthConnectionRequest): Promise<OAuthConnectionResponse> {
-    const proxyUrl = `${this.platformBaseUrl}/v1/assistants/${this.assistantId}/external-provider-proxy/${this.connectionId}/`;
+    const proxyPath = `/v1/assistants/${this.client.platformAssistantId}/external-provider-proxy/${this.connectionId}/`;
 
     const body: Record<string, unknown> = {
       request: {
@@ -79,10 +69,9 @@ export class PlatformOAuthConnection implements OAuthConnection {
       },
     };
 
-    const response = await fetch(proxyUrl, {
+    const response = await this.client.fetch(proxyPath, {
       method: "POST",
       headers: {
-        Authorization: `Api-Key ${this.apiKey}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify(body),

--- a/assistant/src/platform/client.test.ts
+++ b/assistant/src/platform/client.test.ts
@@ -70,11 +70,12 @@ describe("VellumPlatformClient", () => {
       expect(client).toBeNull();
     });
 
-    test("returns null when assistant ID is missing", async () => {
+    test("returns client with empty assistantId when assistant ID is missing", async () => {
       mockAssistantId = "";
 
       const client = await VellumPlatformClient.create();
-      expect(client).toBeNull();
+      expect(client).not.toBeNull();
+      expect(client!.platformAssistantId).toBe("");
     });
 
     test("strips trailing slash from platform base URL", async () => {

--- a/assistant/src/platform/client.test.ts
+++ b/assistant/src/platform/client.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mutable mock state
+// ---------------------------------------------------------------------------
+
+let mockManagedProxyCtx = {
+  enabled: false,
+  platformBaseUrl: "",
+  assistantApiKey: "",
+};
+let mockAssistantId = "";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../providers/managed-proxy/context.js", () => ({
+  resolveManagedProxyContext: async () => mockManagedProxyCtx,
+}));
+
+mock.module("../config/env.js", () => ({
+  getPlatformAssistantId: () => mockAssistantId,
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after mocks)
+// ---------------------------------------------------------------------------
+
+import { VellumPlatformClient } from "./client.js";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("VellumPlatformClient", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    mockManagedProxyCtx = {
+      enabled: true,
+      platformBaseUrl: "https://platform.example.com",
+      assistantApiKey: "sk-test-key",
+    };
+    mockAssistantId = "asst-123";
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe("create()", () => {
+    test("returns a client when all prerequisites are met", async () => {
+      const client = await VellumPlatformClient.create();
+      expect(client).not.toBeNull();
+      expect(client!.baseUrl).toBe("https://platform.example.com");
+      expect(client!.assistantApiKey).toBe("sk-test-key");
+      expect(client!.platformAssistantId).toBe("asst-123");
+    });
+
+    test("returns null when managed proxy is not enabled", async () => {
+      mockManagedProxyCtx = {
+        enabled: false,
+        platformBaseUrl: "",
+        assistantApiKey: "",
+      };
+
+      const client = await VellumPlatformClient.create();
+      expect(client).toBeNull();
+    });
+
+    test("returns null when assistant ID is missing", async () => {
+      mockAssistantId = "";
+
+      const client = await VellumPlatformClient.create();
+      expect(client).toBeNull();
+    });
+
+    test("strips trailing slash from platform base URL", async () => {
+      mockManagedProxyCtx.platformBaseUrl = "https://platform.example.com///";
+
+      const client = await VellumPlatformClient.create();
+      expect(client!.baseUrl).toBe("https://platform.example.com");
+    });
+  });
+
+  describe("fetch()", () => {
+    test("prepends base URL to path", async () => {
+      globalThis.fetch = mock(async (url: string | URL | Request) => {
+        expect(String(url)).toBe(
+          "https://platform.example.com/v1/some/endpoint/",
+        );
+        return new Response("ok", { status: 200 });
+      }) as unknown as typeof globalThis.fetch;
+
+      const client = await VellumPlatformClient.create();
+      await client!.fetch("/v1/some/endpoint/");
+    });
+
+    test("injects Api-Key auth header", async () => {
+      globalThis.fetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const headers = new Headers(init?.headers);
+          expect(headers.get("Authorization")).toBe("Api-Key sk-test-key");
+          return new Response("ok", { status: 200 });
+        },
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = await VellumPlatformClient.create();
+      await client!.fetch("/v1/test/");
+    });
+
+    test("preserves caller-provided headers", async () => {
+      globalThis.fetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const headers = new Headers(init?.headers);
+          expect(headers.get("Content-Type")).toBe("application/json");
+          expect(headers.get("Authorization")).toBe("Api-Key sk-test-key");
+          return new Response("ok", { status: 200 });
+        },
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = await VellumPlatformClient.create();
+      await client!.fetch("/v1/test/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    test("passes through request init options", async () => {
+      globalThis.fetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          expect(init?.method).toBe("POST");
+          expect(init?.body).toBe('{"key":"value"}');
+          return new Response("ok", { status: 200 });
+        },
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = await VellumPlatformClient.create();
+      await client!.fetch("/v1/test/", {
+        method: "POST",
+        body: '{"key":"value"}',
+      });
+    });
+  });
+});

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -1,0 +1,70 @@
+/**
+ * Centralized platform API client.
+ *
+ * Owns managed proxy context resolution, prerequisite validation, and
+ * authenticated fetch for all platform API calls that use Api-Key auth.
+ */
+
+import { getPlatformAssistantId } from "../config/env.js";
+import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
+
+export class VellumPlatformClient {
+  private readonly platformBaseUrl: string;
+  private readonly apiKey: string;
+  private readonly assistantId: string;
+
+  private constructor(
+    platformBaseUrl: string,
+    apiKey: string,
+    assistantId: string,
+  ) {
+    this.platformBaseUrl = platformBaseUrl.replace(/\/+$/, "");
+    this.apiKey = apiKey;
+    this.assistantId = assistantId;
+  }
+
+  /**
+   * Create a platform client by resolving managed proxy context and assistant ID.
+   *
+   * Returns `null` when prerequisites are missing (not logged in, no API key, etc.).
+   */
+  static async create(): Promise<VellumPlatformClient | null> {
+    const ctx = await resolveManagedProxyContext();
+    if (!ctx.enabled) return null;
+
+    const assistantId = getPlatformAssistantId();
+    if (!assistantId) return null;
+
+    return new VellumPlatformClient(
+      ctx.platformBaseUrl,
+      ctx.assistantApiKey,
+      assistantId,
+    );
+  }
+
+  /**
+   * Authenticated fetch against the platform API.
+   *
+   * Prepends `platformBaseUrl` to `path` and injects the `Api-Key` auth header.
+   * Callers handle response parsing and domain-specific error mapping.
+   */
+  async fetch(path: string, init?: RequestInit): Promise<Response> {
+    const url = `${this.platformBaseUrl}${path}`;
+    const headers = new Headers(init?.headers);
+    headers.set("Authorization", `Api-Key ${this.apiKey}`);
+
+    return fetch(url, { ...init, headers });
+  }
+
+  get baseUrl(): string {
+    return this.platformBaseUrl;
+  }
+
+  get assistantApiKey(): string {
+    return this.apiKey;
+  }
+
+  get platformAssistantId(): string {
+    return this.assistantId;
+  }
+}

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -24,16 +24,17 @@ export class VellumPlatformClient {
   }
 
   /**
-   * Create a platform client by resolving managed proxy context and assistant ID.
+   * Create a platform client by resolving managed proxy context.
    *
-   * Returns `null` when prerequisites are missing (not logged in, no API key, etc.).
+   * Returns `null` when auth prerequisites are missing (not logged in, no API
+   * key). The assistant ID is resolved but not required — callers that need it
+   * should check `platformAssistantId` themselves.
    */
   static async create(): Promise<VellumPlatformClient | null> {
     const ctx = await resolveManagedProxyContext();
     if (!ctx.enabled) return null;
 
     const assistantId = getPlatformAssistantId();
-    if (!assistantId) return null;
 
     return new VellumPlatformClient(
       ctx.platformBaseUrl,

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -41,14 +41,12 @@ mock.module("../memory/turn-events-store.js", () => ({
   queryUnreportedTurnEvents: mockQueryUnreportedTurnEvents,
 }));
 
-const mockResolveManagedProxyContext = mock(async () => ({
-  enabled: false,
-  platformBaseUrl: "",
-  assistantApiKey: "",
-}));
+let mockPlatformClient: Record<string, unknown> | null = null;
 
-mock.module("../providers/managed-proxy/context.js", () => ({
-  resolveManagedProxyContext: mockResolveManagedProxyContext,
+mock.module("../platform/client.js", () => ({
+  VellumPlatformClient: {
+    create: async () => mockPlatformClient,
+  },
 }));
 
 const mockGetTelemetryPlatformUrl = mock(() => "https://platform.vellum.ai");
@@ -142,7 +140,7 @@ beforeEach(() => {
   mockQueryUnreportedUsageEvents.mockReset();
   mockQueryUnreportedTurnEvents.mockReset();
   mockQueryUnreportedTurnEvents.mockReturnValue([]);
-  mockResolveManagedProxyContext.mockReset();
+  mockPlatformClient = null;
   mockGetTelemetryPlatformUrl.mockReset();
   mockGetTelemetryAppToken.mockReset();
   mockGetDeviceId.mockReset();
@@ -156,11 +154,6 @@ beforeEach(() => {
 
   // Defaults
   mockGetMemoryCheckpoint.mockReturnValue(null);
-  mockResolveManagedProxyContext.mockResolvedValue({
-    enabled: false,
-    platformBaseUrl: "",
-    assistantApiKey: "",
-  });
   mockGetTelemetryPlatformUrl.mockReturnValue("https://platform.vellum.ai");
   mockGetTelemetryAppToken.mockReturnValue("default-test-token");
 
@@ -179,37 +172,31 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("UsageTelemetryReporter", () => {
-  test("authenticated flush uses Api-Key header and proxy URL", async () => {
-    mockResolveManagedProxyContext.mockResolvedValue({
-      enabled: true,
-      platformBaseUrl: "https://test.vellum.ai",
-      assistantApiKey: "test-key",
+  test("authenticated flush uses client.fetch with platform path", async () => {
+    const clientFetchMock = mock(async (_path: string, _init?: RequestInit) => {
+      return new Response('{"accepted":2}', { status: 200 });
     });
+    mockPlatformClient = {
+      baseUrl: "https://test.vellum.ai",
+      assistantApiKey: "test-key",
+      platformAssistantId: "asst-123",
+      fetch: clientFetchMock,
+    };
     const events = [makeUsageEvent(), makeUsageEvent()];
     mockQueryUnreportedUsageEvents.mockReturnValue(events);
-    mockFetch.mockImplementation(() =>
-      Promise.resolve(
-        new Response(`{"accepted":${events.length}}`, { status: 200 }),
-      ),
-    );
 
     const reporter = new UsageTelemetryReporter();
     await reporter.flush();
 
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe("https://test.vellum.ai/v1/telemetry/ingest/");
-    expect((opts.headers as Record<string, string>)["Authorization"]).toBe(
-      "Api-Key test-key",
-    );
+    expect(clientFetchMock).toHaveBeenCalledTimes(1);
+    const [path] = clientFetchMock.mock.calls[0] as [string, RequestInit];
+    expect(path).toBe("/v1/telemetry/ingest/");
+    // globalThis.fetch should NOT have been called directly
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   test("anonymous flush uses X-Telemetry-Token and default URL", async () => {
-    mockResolveManagedProxyContext.mockResolvedValue({
-      enabled: false,
-      platformBaseUrl: "",
-      assistantApiKey: "",
-    });
+    mockPlatformClient = null;
     mockGetTelemetryPlatformUrl.mockReturnValue("https://platform.test.ai");
     mockGetTelemetryAppToken.mockReturnValue("anon-token");
 

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -41,12 +41,14 @@ mock.module("../memory/turn-events-store.js", () => ({
   queryUnreportedTurnEvents: mockQueryUnreportedTurnEvents,
 }));
 
-let mockPlatformClient: Record<string, unknown> | null = null;
+const mockResolveManagedProxyContext = mock(async () => ({
+  enabled: false,
+  platformBaseUrl: "",
+  assistantApiKey: "",
+}));
 
-mock.module("../platform/client.js", () => ({
-  VellumPlatformClient: {
-    create: async () => mockPlatformClient,
-  },
+mock.module("../providers/managed-proxy/context.js", () => ({
+  resolveManagedProxyContext: mockResolveManagedProxyContext,
 }));
 
 const mockGetTelemetryPlatformUrl = mock(() => "https://platform.vellum.ai");
@@ -140,7 +142,7 @@ beforeEach(() => {
   mockQueryUnreportedUsageEvents.mockReset();
   mockQueryUnreportedTurnEvents.mockReset();
   mockQueryUnreportedTurnEvents.mockReturnValue([]);
-  mockPlatformClient = null;
+  mockResolveManagedProxyContext.mockReset();
   mockGetTelemetryPlatformUrl.mockReset();
   mockGetTelemetryAppToken.mockReset();
   mockGetDeviceId.mockReset();
@@ -154,6 +156,11 @@ beforeEach(() => {
 
   // Defaults
   mockGetMemoryCheckpoint.mockReturnValue(null);
+  mockResolveManagedProxyContext.mockResolvedValue({
+    enabled: false,
+    platformBaseUrl: "",
+    assistantApiKey: "",
+  });
   mockGetTelemetryPlatformUrl.mockReturnValue("https://platform.vellum.ai");
   mockGetTelemetryAppToken.mockReturnValue("default-test-token");
 
@@ -172,31 +179,37 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("UsageTelemetryReporter", () => {
-  test("authenticated flush uses client.fetch with platform path", async () => {
-    const clientFetchMock = mock(async (_path: string, _init?: RequestInit) => {
-      return new Response('{"accepted":2}', { status: 200 });
-    });
-    mockPlatformClient = {
-      baseUrl: "https://test.vellum.ai",
+  test("authenticated flush uses Api-Key header and proxy URL", async () => {
+    mockResolveManagedProxyContext.mockResolvedValue({
+      enabled: true,
+      platformBaseUrl: "https://test.vellum.ai",
       assistantApiKey: "test-key",
-      platformAssistantId: "asst-123",
-      fetch: clientFetchMock,
-    };
+    });
     const events = [makeUsageEvent(), makeUsageEvent()];
     mockQueryUnreportedUsageEvents.mockReturnValue(events);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        new Response(`{"accepted":${events.length}}`, { status: 200 }),
+      ),
+    );
 
     const reporter = new UsageTelemetryReporter();
     await reporter.flush();
 
-    expect(clientFetchMock).toHaveBeenCalledTimes(1);
-    const [path] = clientFetchMock.mock.calls[0] as [string, RequestInit];
-    expect(path).toBe("/v1/telemetry/ingest/");
-    // globalThis.fetch should NOT have been called directly
-    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://test.vellum.ai/v1/telemetry/ingest/");
+    expect((opts.headers as Record<string, string>)["Authorization"]).toBe(
+      "Api-Key test-key",
+    );
   });
 
   test("anonymous flush uses X-Telemetry-Token and default URL", async () => {
-    mockPlatformClient = null;
+    mockResolveManagedProxyContext.mockResolvedValue({
+      enabled: false,
+      platformBaseUrl: "",
+      assistantApiKey: "",
+    });
     mockGetTelemetryPlatformUrl.mockReturnValue("https://platform.test.ai");
     mockGetTelemetryAppToken.mockReturnValue("anon-token");
 

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -22,7 +22,7 @@ import {
 import { queryUnreportedLifecycleEvents } from "../memory/lifecycle-events-store.js";
 import { queryUnreportedUsageEvents } from "../memory/llm-usage-store.js";
 import { queryUnreportedTurnEvents } from "../memory/turn-events-store.js";
-import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
+import { VellumPlatformClient } from "../platform/client.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getExternalAssistantId } from "../runtime/auth/external-assistant-id.js";
 import { getDeviceId } from "../util/device-id.js";
@@ -138,11 +138,9 @@ export class UsageTelemetryReporter {
       )
         return;
 
-      // Resolve auth context — skip flush when neither auth mode is viable.
-      // Telemetry only needs URL + API key, not an assistant ID, so we use
-      // resolveManagedProxyContext() directly instead of VellumPlatformClient.
-      const proxyCtx = await resolveManagedProxyContext();
-      if (!proxyCtx.enabled && !getTelemetryAppToken()) {
+      // Resolve auth context — skip flush when neither auth mode is viable
+      const client = await VellumPlatformClient.create();
+      if (!client && !getTelemetryAppToken()) {
         return;
       }
 
@@ -202,15 +200,8 @@ export class UsageTelemetryReporter {
       };
 
       let resp: Response;
-      if (proxyCtx.enabled) {
-        const url = `${proxyCtx.platformBaseUrl}${TELEMETRY_PATH}`;
-        resp = await fetch(url, {
-          ...fetchInit,
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Api-Key ${proxyCtx.assistantApiKey}`,
-          },
-        });
+      if (client) {
+        resp = await client.fetch(TELEMETRY_PATH, fetchInit);
       } else {
         const url = `${getTelemetryPlatformUrl()}${TELEMETRY_PATH}`;
         resp = await fetch(url, {

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -22,7 +22,7 @@ import {
 import { queryUnreportedLifecycleEvents } from "../memory/lifecycle-events-store.js";
 import { queryUnreportedUsageEvents } from "../memory/llm-usage-store.js";
 import { queryUnreportedTurnEvents } from "../memory/turn-events-store.js";
-import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
+import { VellumPlatformClient } from "../platform/client.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getExternalAssistantId } from "../runtime/auth/external-assistant-id.js";
 import { getDeviceId } from "../util/device-id.js";
@@ -139,20 +139,9 @@ export class UsageTelemetryReporter {
         return;
 
       // Resolve auth context — skip flush when neither auth mode is viable
-      const proxyCtx = await resolveManagedProxyContext();
-      if (!proxyCtx.enabled && !getTelemetryAppToken()) {
+      const client = await VellumPlatformClient.create();
+      if (!client && !getTelemetryAppToken()) {
         return;
-      }
-
-      let url: string;
-      let authHeaders: Record<string, string>;
-
-      if (proxyCtx.enabled) {
-        url = `${proxyCtx.platformBaseUrl}${TELEMETRY_PATH}`;
-        authHeaders = { Authorization: `Api-Key ${proxyCtx.assistantApiKey}` };
-      } else {
-        url = `${getTelemetryPlatformUrl()}${TELEMETRY_PATH}`;
-        authHeaders = { "X-Telemetry-Token": getTelemetryAppToken() };
       }
 
       // Build payload
@@ -202,19 +191,32 @@ export class UsageTelemetryReporter {
       };
 
       // Send
-      const resp = await fetch(url, {
+      const fetchInit: RequestInit = {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          ...authHeaders,
         },
         body: JSON.stringify(payload),
-      });
+      };
+
+      let resp: Response;
+      if (client) {
+        resp = await client.fetch(TELEMETRY_PATH, fetchInit);
+      } else {
+        const url = `${getTelemetryPlatformUrl()}${TELEMETRY_PATH}`;
+        resp = await fetch(url, {
+          ...fetchInit,
+          headers: {
+            "Content-Type": "application/json",
+            "X-Telemetry-Token": getTelemetryAppToken(),
+          },
+        });
+      }
 
       if (!resp.ok) {
         await resp.text(); // consume body to release connection
         log.warn(
-          { status: resp.status, url },
+          { status: resp.status },
           "Usage telemetry POST failed — will retry next cycle",
         );
         return;

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -22,7 +22,7 @@ import {
 import { queryUnreportedLifecycleEvents } from "../memory/lifecycle-events-store.js";
 import { queryUnreportedUsageEvents } from "../memory/llm-usage-store.js";
 import { queryUnreportedTurnEvents } from "../memory/turn-events-store.js";
-import { VellumPlatformClient } from "../platform/client.js";
+import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getExternalAssistantId } from "../runtime/auth/external-assistant-id.js";
 import { getDeviceId } from "../util/device-id.js";
@@ -138,9 +138,11 @@ export class UsageTelemetryReporter {
       )
         return;
 
-      // Resolve auth context — skip flush when neither auth mode is viable
-      const client = await VellumPlatformClient.create();
-      if (!client && !getTelemetryAppToken()) {
+      // Resolve auth context — skip flush when neither auth mode is viable.
+      // Telemetry only needs URL + API key, not an assistant ID, so we use
+      // resolveManagedProxyContext() directly instead of VellumPlatformClient.
+      const proxyCtx = await resolveManagedProxyContext();
+      if (!proxyCtx.enabled && !getTelemetryAppToken()) {
         return;
       }
 
@@ -200,8 +202,15 @@ export class UsageTelemetryReporter {
       };
 
       let resp: Response;
-      if (client) {
-        resp = await client.fetch(TELEMETRY_PATH, fetchInit);
+      if (proxyCtx.enabled) {
+        const url = `${proxyCtx.platformBaseUrl}${TELEMETRY_PATH}`;
+        resp = await fetch(url, {
+          ...fetchInit,
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Api-Key ${proxyCtx.assistantApiKey}`,
+          },
+        });
       } else {
         const url = `${getTelemetryPlatformUrl()}${TELEMETRY_PATH}`;
         resp = await fetch(url, {


### PR DESCRIPTION
## Summary
- Introduce `VellumPlatformClient` class (`assistant/src/platform/client.ts`) that owns managed proxy context resolution, prerequisite validation, and authenticated `Api-Key` fetch for platform API calls
- Refactor four call sites (`connection-resolver`, `platform-connection`, `managed-catalog`, `usage-telemetry-reporter`) to use the shared client instead of independently resolving context, constructing URLs, and injecting auth headers
- Remove duplicated prerequisite validation logic from each call site — `VellumPlatformClient.create()` returns `null` when prerequisites are missing

## Test plan
- [x] New unit tests for `VellumPlatformClient` (`client.test.ts`): `create()` returns null when prereqs missing, `fetch()` injects auth header and constructs URL
- [x] Updated `connection-resolver.test.ts` to mock the client instead of raw proxy context
- [x] Updated `platform-connection.test.ts` to use mock clients instead of `globalThis.fetch`
- [x] Updated `usage-telemetry-reporter.test.ts` to mock `VellumPlatformClient` instead of proxy context
- [x] All tests pass, lint/typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
