### PR TITLE
perf: cache static NSRegularExpression in ChatMarkdownParser

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -190,12 +190,13 @@ func parseMarkdownSegments(_ text: String) -> [MarkdownSegment] {
     }
 }
 
+/// Pre-compiled regex for matching inline markdown images `![alt](url)`.
+/// Hoisted to a file-level constant so the pattern is compiled once at app launch.
+private let imageRegex = try! NSRegularExpression(pattern: #"!\[([^\]]*)\]\(([^)]+)\)"#)
+
 /// Splits text around `![alt](url)` matches, returning mixed `.text` / `.image` segments.
 func extractImageSegments(from text: String) -> [MarkdownSegment] {
-    let pattern = #"!\[([^\]]*)\]\(([^)]+)\)"#
-    guard let regex = try? NSRegularExpression(pattern: pattern) else {
-        return [.text(text)]
-    }
+    let regex = imageRegex
 
     let nsText = text as NSString
     let matches = regex.matches(in: text, range: NSRange(location: 0, length: nsText.length))


### PR DESCRIPTION
## Summary
- Hoist all NSRegularExpression compilations to static let properties
- Eliminates repeated regex compilation on every markdown parse call

Part of plan: scroll-perf-spike.md (PR 1 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
