### PR TITLE
perf: deduplicate surface filters in ChatBubble and cache content grouping

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -49,6 +49,12 @@ struct ChatBubble: View {
     @State private var showCopyConfirmation = false
     @State private var copyConfirmationTimer: DispatchWorkItem?
     @State private var mediaEmbedIntents: [MediaEmbedIntent] = []
+    // Cached interleaved content state — updated via .onChange(of:) to avoid
+    // recomputing O(n) grouping on every body evaluation.
+    @State var cachedHasInterleavedContent: Bool = false
+    @State var cachedContentGroups: [ContentGroup] = []
+    /// Set of stableIds for tool-call groups that have non-empty text after them.
+    @State var cachedToolGroupsWithTrailingText: Set<String> = []
     /// Injected from the parent instead of observing the shared singleton directly.
     /// This avoids every ChatBubble in the list re-rendering whenever the overlay
     /// manager publishes any change (the "thundering herd" problem).
@@ -154,6 +160,11 @@ struct ChatBubble: View {
         return formatter.string(from: message.timestamp)
     }
 
+    /// Surfaces not currently shown in the floating overlay, computed once per body evaluation.
+    private var visibleInlineSurfaces: [InlineSurfaceData] {
+        message.inlineSurfaces.filter { $0.id != activeSurfaceId }
+    }
+
     /// Whether the text/attachment bubble should be rendered.
     /// Tool calls for assistant messages render outside the bubble as separate chips,
     /// so only show the bubble when there's actual text or attachment content.
@@ -167,11 +178,10 @@ struct ChatBubble: View {
     /// that should not appear above the rendered dynamic UI surface.
     private var shouldShowBubble: Bool {
         if isUser { return true }
-        // Filter out the surface shown in the floating overlay
-        let visibleSurfaces = message.inlineSurfaces.filter { $0.id != activeSurfaceId }
-        if !visibleSurfaces.isEmpty {
+        let surfaces = visibleInlineSurfaces
+        if !surfaces.isEmpty {
             // Show bubble text when all visible surfaces are completed (collapsed to chips)
-            let allCompleted = visibleSurfaces.allSatisfy { $0.completionState != nil }
+            let allCompleted = surfaces.allSatisfy { $0.completionState != nil }
             if !allCompleted { return false }
         }
         return hasText || !message.attachments.isEmpty
@@ -185,7 +195,7 @@ struct ChatBubble: View {
             if isUser { Spacer(minLength: 0) }
 
             VStack(alignment: isUser ? .trailing : .leading, spacing: VSpacing.sm) {
-                    if !isUser && hasInterleavedContent {
+                    if !isUser && cachedHasInterleavedContent {
                         interleavedContent
                     } else {
                         if message.isError && hasText {
@@ -200,8 +210,8 @@ struct ChatBubble: View {
 
                         // Inline surfaces render below the bubble as full-width cards
                         // Skip surfaces that are currently shown in the floating overlay
-                        if !message.inlineSurfaces.isEmpty {
-                            ForEach(message.inlineSurfaces.filter { $0.id != activeSurfaceId }) { surface in
+                        if !visibleInlineSurfaces.isEmpty {
+                            ForEach(visibleInlineSurfaces) { surface in
                                 InlineSurfaceRouter(surface: surface, onAction: onSurfaceAction, onRefetch: onSurfaceRefetch)
                             }
                         }
@@ -212,7 +222,7 @@ struct ChatBubble: View {
                         }
                     }
 
-                    if !hasInterleavedContent {
+                    if !cachedHasInterleavedContent {
                         attachmentWarningBanners(message.attachmentWarnings)
                     }
 
@@ -256,11 +266,14 @@ struct ChatBubble: View {
                 // where the complex view hierarchy makes re-compositing expensive —
                 // async task completions (markdown parsing, image decoding) would
                 // trigger full re-compositing of the entire message on every change.
-                .modifier(ConditionalCompositingGroup(isActive: !message.isStreaming && !hasInterleavedContent))
+                .modifier(ConditionalCompositingGroup(isActive: !message.isStreaming && !cachedHasInterleavedContent))
 
             if !isUser { Spacer(minLength: 0) }
         }
         .contentShape(Rectangle())
+        .onAppear { recomputeInterleavedContentCache() }
+        .onChange(of: message.contentOrder) { _ in recomputeInterleavedContentCache() }
+        .onChange(of: message.textSegments) { _ in recomputeInterleavedContentCache() }
         .onHover { hovering in
             isHovered = hovering
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -8,27 +8,11 @@ extension ChatBubble {
     /// instead of in the trailing status area.
     var shouldRenderToolProgressInline: Bool {
         // Tool calls are never hidden; always consider inline rendering.
-        guard hasInterleavedContent else { return false }
+        guard cachedHasInterleavedContent else { return false }
         return message.contentOrder.contains(where: {
             if case .toolCall = $0 { return true }
             return false
         })
-    }
-
-    /// Whether this message has meaningful interleaved content (multiple block types).
-    var hasInterleavedContent: Bool {
-        // Use interleaved path when contentOrder has more than one distinct block type
-        guard message.contentOrder.count > 1 else { return false }
-        var hasTextBlock = false
-        var hasNonText = false
-        for ref in message.contentOrder {
-            switch ref {
-            case .text: hasTextBlock = true
-            case .toolCall, .surface: hasNonText = true
-            }
-            if hasTextBlock && hasNonText { return true }
-        }
-        return false
     }
 
     /// Groups consecutive tool call refs for rendering.
@@ -53,7 +37,53 @@ extension ChatBubble {
         }
     }
 
-    func groupContentBlocks() -> [ContentGroup] {
+    // MARK: - Cache Recomputation
+
+    /// Recomputes all cached interleaved content state. Called from `.onAppear`
+    /// and `.onChange(of: message.contentOrder)` / `.onChange(of: message.textSegments)`.
+    func recomputeInterleavedContentCache() {
+        let interleaved = Self.computeHasInterleavedContent(message.contentOrder)
+        cachedHasInterleavedContent = interleaved
+
+        guard interleaved else {
+            cachedContentGroups = []
+            cachedToolGroupsWithTrailingText = []
+            return
+        }
+
+        let groups = computeContentGroups()
+        cachedContentGroups = groups
+
+        // Pre-compute which tool-call groups have trailing text so that
+        // `interleavedContent` can look up the set instead of scanning
+        // contentOrder per group during body evaluation.
+        var trailingTextIds = Set<String>()
+        for group in groups {
+            guard case .toolCalls(let indices) = group else { continue }
+            if computeHasTextAfterToolGroup(indices) {
+                trailingTextIds.insert(group.stableId)
+            }
+        }
+        cachedToolGroupsWithTrailingText = trailingTextIds
+    }
+
+    /// Whether this message has meaningful interleaved content (multiple block types).
+    private static func computeHasInterleavedContent(_ contentOrder: [ContentBlockRef]) -> Bool {
+        // Use interleaved path when contentOrder has more than one distinct block type
+        guard contentOrder.count > 1 else { return false }
+        var hasTextBlock = false
+        var hasNonText = false
+        for ref in contentOrder {
+            switch ref {
+            case .text: hasTextBlock = true
+            case .toolCall, .surface: hasNonText = true
+            }
+            if hasTextBlock && hasNonText { return true }
+        }
+        return false
+    }
+
+    private func computeContentGroups() -> [ContentGroup] {
         var groups: [ContentGroup] = []
         for ref in message.contentOrder {
             switch ref {
@@ -124,9 +154,8 @@ extension ChatBubble {
     }
 
     /// Returns true when there is non-empty text content after a tool-call group.
-    /// Used to decide whether the inline progress block should remain in
-    /// an active "thinking/processing" phase while the model continues.
-    private func hasTextAfterToolGroup(_ toolIndices: [Int]) -> Bool {
+    /// Used during cache recomputation to pre-compute trailing text status.
+    private func computeHasTextAfterToolGroup(_ toolIndices: [Int]) -> Bool {
         let indexSet = Set(toolIndices)
         guard let lastToolRefIndex = message.contentOrder.lastIndex(where: {
             if case .toolCall(let i) = $0 { return indexSet.contains(i) }
@@ -148,7 +177,7 @@ extension ChatBubble {
     }
 
     @ViewBuilder
-    private func inlineToolProgress(toolIndices: [Int], isLatestGroup: Bool) -> some View {
+    private func inlineToolProgress(toolIndices: [Int], isLatestGroup: Bool, hasTrailingText: Bool) -> some View {
         let groupedToolCalls: [ToolCallData] = toolIndices.compactMap { idx -> ToolCallData? in
             guard idx < message.toolCalls.count else { return nil }
             return message.toolCalls[idx]
@@ -185,7 +214,7 @@ extension ChatBubble {
             AssistantProgressView(
                 toolCalls: groupedToolCalls,
                 isStreaming: isLatestGroup ? message.isStreaming : false,
-                hasText: hasTextAfterToolGroup(toolIndices),
+                hasText: hasTrailingText,
                 isProcessing: isLatestGroup && isProcessingAfterTools,
                 processingStatusText: isLatestGroup && isProcessingAfterTools ? processingStatusText : nil,
                 streamingCodePreview: isLatestGroup ? message.streamingCodePreview : nil,
@@ -207,7 +236,7 @@ extension ChatBubble {
 
     @ViewBuilder
     var interleavedContent: some View {
-        let groups = groupContentBlocks()
+        let groups = cachedContentGroups
         let latestToolGroup: [Int]? = groups.reversed().compactMap { group in
             guard case .toolCalls(let indices) = group else { return nil }
             return indices
@@ -233,7 +262,11 @@ extension ChatBubble {
                 }
             case .toolCalls(let indices):
                 if shouldRenderToolProgressInline {
-                    inlineToolProgress(toolIndices: indices, isLatestGroup: indices == latestToolGroup)
+                    inlineToolProgress(
+                        toolIndices: indices,
+                        isLatestGroup: indices == latestToolGroup,
+                        hasTrailingText: cachedToolGroupsWithTrailingText.contains(group.stableId)
+                    )
                 } else {
                     // Tool calls are rendered by trailingStatus below the message
                     EmptyView()


### PR DESCRIPTION
## Summary
- Compute filtered surfaces once in ChatBubble body instead of twice
- Cache interleaved content grouping and hasInterleavedContent flag
- Pre-compute trailing text indices during content grouping

Part of plan: scroll-perf-spike.md (PR 4 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
