### PR TITLE
perf: lower async markdown parsing threshold from 2000 to 500 chars

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -42,7 +42,7 @@ struct ChatBubble: View {
     /// Status text from the assistant activity state, forwarded for inline display.
     var processingStatusText: String?
     @State private var isHovered = false
-    /// Stores async-parsed segments for large messages (>2000 chars) that missed the
+    /// Stores async-parsed segments for large messages (>500 chars) that missed the
     /// synchronous cache. Keyed by text content so multiple segments can be in flight.
     @State var asyncSegments: [String: [MarkdownSegment]] = [:]
 
@@ -500,8 +500,10 @@ struct ChatBubble: View {
     }
 
     /// Length threshold above which a segment cache miss triggers async parsing
-    /// instead of blocking the main thread.
-    static let asyncParseThreshold = 2000
+    /// instead of blocking the main thread. Set to 500 so that most assistant
+    /// messages (routinely 1000+ chars) are parsed off the main thread on cache
+    /// miss, reducing scroll jank from synchronous markdown parsing.
+    static let asyncParseThreshold = 500
 
     // MARK: - LRU Caches
     //

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -5,7 +5,7 @@ import VellumAssistantShared
 
 extension ChatBubble {
     /// Render a single text segment as a styled bubble, with table and image support.
-    /// For large messages (>2000 chars) with a segment cache miss, renders plain text
+    /// For large messages (>500 chars) with a segment cache miss, renders plain text
     /// immediately and parses rich formatting asynchronously to avoid blocking scroll.
     @ViewBuilder
     func textBubble(for segmentText: String) -> some View {


### PR DESCRIPTION
## Summary
- Lower async markdown parsing threshold from 2000 to 500 characters
- Ensures most assistant messages are parsed off the main thread
- Reduces scroll jank from synchronous markdown parsing on cache miss

Part of plan: scroll-perf-spike.md (PR 6 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
