### PR TITLE
perf: add Equatable conformance to MarkdownSegmentView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -407,6 +407,7 @@ struct ChatBubble: View {
                         codeBackgroundColor: isUser ? VColor.contentDefault.opacity(0.1) : VColor.surfaceActive,
                         hrColor: isUser ? VColor.contentDefault.opacity(0.3) : VColor.borderBase
                     )
+                    .equatable()
                 } else if !message.attachments.isEmpty {
                     Text(attachmentSummary)
                         .font(VFont.caption)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -19,6 +19,7 @@ extension ChatBubble {
             // LazyVStack to use stale height measurements, resulting in
             // content truncation and footer overlap.
             MarkdownSegmentView(segments: segments)
+                .equatable()
         }
         .task(id: "\(segmentText)|\(streaming)") {
             // Only run async parsing for large, non-streaming text with a cache miss

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -6,7 +6,7 @@ import VellumAssistantShared
 /// Reusable view that renders parsed `MarkdownSegment` arrays.
 /// Groups consecutive text-selectable segments (text, headings, lists) into
 /// unified Text views so that text selection can span across paragraphs.
-struct MarkdownSegmentView: View {
+struct MarkdownSegmentView: View, Equatable {
     let segments: [MarkdownSegment]
     var maxContentWidth: CGFloat? = VSpacing.chatBubbleMaxWidth
     var textColor: Color = VColor.contentDefault
@@ -16,6 +16,18 @@ struct MarkdownSegmentView: View {
     var codeTextColor: Color = VColor.systemNegativeStrong
     var codeBackgroundColor: Color = VColor.surfaceActive
     var hrColor: Color = VColor.borderBase
+
+    static func == (lhs: MarkdownSegmentView, rhs: MarkdownSegmentView) -> Bool {
+        lhs.segments == rhs.segments
+            && lhs.maxContentWidth == rhs.maxContentWidth
+            && lhs.textColor == rhs.textColor
+            && lhs.secondaryTextColor == rhs.secondaryTextColor
+            && lhs.mutedTextColor == rhs.mutedTextColor
+            && lhs.tintColor == rhs.tintColor
+            && lhs.codeTextColor == rhs.codeTextColor
+            && lhs.codeBackgroundColor == rhs.codeBackgroundColor
+            && lhs.hrColor == rhs.hrColor
+    }
 
     var body: some View {
         let groups = groupedSegments

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -212,6 +212,7 @@ struct SubagentDetailPanel: View {
         switch event.kind {
         case .text:
             MarkdownSegmentView(segments: parseMarkdownSegments(event.content), maxContentWidth: nil)
+                .equatable()
                 .padding(VSpacing.sm)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(


### PR DESCRIPTION
## Summary
- Add Equatable conformance to MarkdownSegmentView with custom == operator
- Apply .equatable() modifier at call sites to enable SwiftUI render skipping
- Allows SwiftUI to skip re-rendering when markdown segment content hasn't changed

Part of plan: scroll-perf-spike.md (PR 5 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
