### PR TITLE
perf: apply drawingGroup() to non-streaming completed message bubbles

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -257,6 +257,20 @@ struct ChatBubble: View {
                 // async task completions (markdown parsing, image decoding) would
                 // trigger full re-compositing of the entire message on every change.
                 .modifier(ConditionalCompositingGroup(isActive: !message.isStreaming && !hasInterleavedContent))
+                // Rasterize completed, non-interactive assistant bubbles via Metal.
+                // drawingGroup() flattens the view subtree into an offscreen render
+                // pass, which is faster for complex static content during scrolling.
+                // Skipped for: streaming messages, user messages, interleaved content,
+                // messages with pending tool calls, and messages still processing —
+                // all of which contain interactive or in-flight elements.
+                .modifier(ConditionalDrawingGroup(isActive: !isUser
+                    && !message.isStreaming
+                    && !hasInterleavedContent
+                    && !isProcessingAfterTools
+                    && activeConfirmationRequestId == nil
+                    && message.toolCalls.allSatisfy(\.isComplete)
+                    && message.inlineSurfaces.isEmpty
+                ))
 
             if !isUser { Spacer(minLength: 0) }
         }
@@ -564,6 +578,23 @@ private struct ConditionalCompositingGroup: ViewModifier {
     func body(content: Content) -> some View {
         if isActive {
             content.compositingGroup()
+        } else {
+            content
+        }
+    }
+}
+
+/// Applies `.drawingGroup()` only when active, rasterizing the view subtree via Metal.
+/// This is faster than compositingGroup for complex static content (completed assistant
+/// messages) because it flattens the entire subtree into a single texture. Must NOT be
+/// applied to views with interactive elements (buttons, toggles) as it prevents SwiftUI
+/// from hit-testing subviews individually.
+private struct ConditionalDrawingGroup: ViewModifier {
+    let isActive: Bool
+
+    func body(content: Content) -> some View {
+        if isActive {
+            content.drawingGroup()
         } else {
             content
         }


### PR DESCRIPTION
## Summary
- Apply .drawingGroup() to completed, non-interactive assistant message bubbles
- Rasterizes static view subtrees via Metal for faster scroll rendering
- Only applies when message is not streaming and has no pending interactions

Part of plan: scroll-perf-spike.md (PR 8 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
