### PR TITLE
perf: replace String(describing:) cache keys with stable hash in MarkdownSegmentView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -307,23 +307,25 @@ struct MarkdownTableView: View {
     // MARK: - Table Cell AttributedString Cache
 
     /// Simple LRU cache for table cell inline markdown AttributedString results.
-    /// Keyed by the cell text content.
+    /// Keyed by the cell text content. Uses a Dictionary for O(1) lookups with
+    /// an access-time counter for LRU eviction.
     private static let cellCacheLimit = 200
 
-    /// Ordered dictionary acting as an LRU cache: most-recently-used entries are at the end.
-    @MainActor private static var cellCache: [(key: String, value: AttributedString)] = []
+    /// Dictionary-based LRU cache: O(1) lookups, evicts least-recently-used
+    /// entry when the cache exceeds `cellCacheLimit`.
+    @MainActor private static var cellCache: [String: (value: AttributedString, accessTime: Int)] = [:]
+    @MainActor private static var cellCacheLruCounter: Int = 0
 
     @MainActor static func clearCellAttributedStringCache() {
         cellCache.removeAll()
+        cellCacheLruCounter = 0
     }
 
     @MainActor private static func cachedAttributedString(for text: String) -> AttributedString {
-        let key = text
-
-        // Check if already cached — if so, move to end (most-recently-used)
-        if let idx = cellCache.firstIndex(where: { $0.key == key }) {
-            let entry = cellCache.remove(at: idx)
-            cellCache.append(entry)
+        // O(1) lookup
+        if let entry = cellCache[text] {
+            cellCacheLruCounter += 1
+            cellCache[text] = (entry.value, cellCacheLruCounter)
             return entry.value
         }
 
@@ -334,11 +336,14 @@ struct MarkdownTableView: View {
         let attributed = (try? AttributedString(markdown: text, options: options))
             ?? AttributedString(text)
 
-        // Evict oldest entries if over limit
+        // Evict least-recently-used entry if over limit
         if cellCache.count >= cellCacheLimit {
-            cellCache.removeFirst()
+            if let lruKey = cellCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
+                cellCache.removeValue(forKey: lruKey)
+            }
         }
-        cellCache.append((key: key, value: attributed))
+        cellCacheLruCounter += 1
+        cellCache[text] = (attributed, cellCacheLruCounter)
 
         return attributed
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -110,12 +110,35 @@ struct MarkdownSegmentView: View {
         case horizontalRule
     }
 
+    /// Cache for `computeGroupedSegments` results, keyed by the hash of the
+    /// input segments array. Avoids recomputing the grouping on every body
+    /// evaluation when segments haven't changed.
+    @MainActor private static var groupedSegmentsCache: [Int: [SegmentGroup]] = [:]
+    private static let groupedSegmentsCacheLimit = 200
+
     /// Groups consecutive text-selectable segments together so they render
     /// as a single Text view, enabling cross-paragraph text selection.
-    /// `computeGroupedSegments` is a pure O(segment-count) switch/append walk
-    /// with no string operations, so it is cheap enough to call on every body
-    /// evaluation without a separate cache.
-    private var groupedSegments: [SegmentGroup] { computeGroupedSegments() }
+    private var groupedSegments: [SegmentGroup] {
+        var hasher = Hasher()
+        for segment in segments {
+            hasher.combine(segment)
+        }
+        let key = hasher.finalize()
+
+        if let cached = Self.groupedSegmentsCache[key] {
+            return cached
+        }
+
+        let result = computeGroupedSegments()
+
+        // Evict oldest entry if over limit (simple eviction — no LRU needed
+        // since this cache is small and entries are cheap).
+        if Self.groupedSegmentsCache.count >= Self.groupedSegmentsCacheLimit {
+            Self.groupedSegmentsCache.removeValue(forKey: Self.groupedSegmentsCache.keys.first!)
+        }
+        Self.groupedSegmentsCache[key] = result
+        return result
+    }
 
     private func computeGroupedSegments() -> [SegmentGroup] {
         os_signpost(.begin, log: PerfSignposts.log, name: "markdownGroupSegments")
@@ -161,11 +184,11 @@ struct MarkdownSegmentView: View {
     // MARK: - Combined AttributedString
 
     /// Cache for expensive `buildCombinedAttributedString` results.
-    /// Keyed by a hash of the segment descriptions so identical segment
-    /// arrays return the cached value instead of re-parsing markdown and
-    /// re-creating `AttributedString` on every SwiftUI body evaluation.
-    /// Each entry stores (value, accessTime, estimatedBytes) for LRU eviction
-    /// and byte-budget enforcement.
+    /// Keyed by a combined hash of the segment values and style colors so
+    /// identical segment arrays return the cached value instead of re-parsing
+    /// markdown and re-creating `AttributedString` on every SwiftUI body
+    /// evaluation. Each entry stores (value, accessTime, estimatedBytes) for
+    /// LRU eviction and byte-budget enforcement.
     @MainActor private static var attributedStringCache: [Int: (value: AttributedString, accessTime: Int, estimatedBytes: Int)] = [:]
     @MainActor private static var lruCounter: Int = 0
     private static let attributedStringCacheLimit = 200
@@ -181,6 +204,7 @@ struct MarkdownSegmentView: View {
     static func clearAttributedStringCache() {
         attributedStringCache.removeAll()
         estimatedCacheBytes = 0
+        groupedSegmentsCache.removeAll()
         MarkdownTableView.clearCellAttributedStringCache()
     }
 
@@ -218,7 +242,7 @@ struct MarkdownSegmentView: View {
         // prefix coloring) so different visual contexts don't share entries.
         var hasher = Hasher()
         for segment in segments {
-            hasher.combine(String(describing: segment))
+            hasher.combine(segment)
         }
         hasher.combine(secondaryTextColor.description)
         hasher.combine(textColor.description)


### PR DESCRIPTION
## Summary
- Replace expensive `String(describing:)` cache keys with direct `Hasher.combine(segment)` using `MarkdownSegment`'s native `Hashable` conformance
- Cache `groupedSegments` in a static dictionary to avoid recomputation on every body evaluation
- Convert `MarkdownTableView` cell cache from O(n) array-based LRU to O(1) dictionary-based LRU

Part of plan: scroll-perf-spike.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
