### PR TITLE
fix: strip mrkdwn formatting from pasted verification codes

### DIFF
--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -80,13 +80,28 @@ export interface AclResult {
 }
 
 /**
+ * Strip Slack/Telegram mrkdwn formatting wrappers from a raw message.
+ * When users copy-paste a verification code from the desktop app with
+ * rich-text formatting (e.g. bold), Slack preserves it as `*code*` in
+ * the message text, which would otherwise fail the strict bare-code regex.
+ */
+function stripMrkdwnFormatting(text: string): string {
+  // Bold (*…*), italic (_…_), strikethrough (~…~), inline code (`…`)
+  return text.replace(/^[*_~`]+/, "").replace(/[*_~`]+$/, "");
+}
+
+/**
  * Parse a guardian verification code from message content.
  * Accepts a bare code as the entire message: 6-digit numeric OR 64-char hex
  * (hex is retained for compatibility with unbound inbound/bootstrap sessions
  * that intentionally use high-entropy secrets).
+ *
+ * Strips surrounding mrkdwn formatting characters first so that codes
+ * pasted with bold/italic/code formatting are still recognized.
  */
 function parseGuardianVerifyCode(content: string): string | undefined {
-  const bareMatch = content.match(/^([0-9a-fA-F]{64}|\d{6})$/);
+  const stripped = stripMrkdwnFormatting(content);
+  const bareMatch = stripped.match(/^([0-9a-fA-F]{64}|\d{6})$/);
   if (bareMatch) return bareMatch[1];
 
   return undefined;


### PR DESCRIPTION
## Summary
- Strip Slack/Telegram mrkdwn formatting wrappers (`*`, `_`, `~`, `` ` ``) from verification code messages before matching
- Fixes an issue where users copying verification codes from the desktop app and pasting into Slack with bold formatting caused silent verification failure
- The strict `parseGuardianVerifyCode` regex rejected `*848189*` (bold-wrapped) — now strips formatting first

## Original prompt
Strip mrkdwn formatting from verification codes so bold-pasted codes work in Slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
