### PR TITLE
fix: run container as non-root assistant user

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -92,7 +92,7 @@ ENV LD_LIBRARY_PATH="/data/usr/lib:/data/usr/lib/x86_64-linux-gnu:/data/usr/lib/
 # Ensure the CES bootstrap socket volume is writable by the non-root CES user.
 RUN mkdir -p /run/ces-bootstrap && chmod 777 /run/ces-bootstrap
 
-USER root
+USER assistant
 
 EXPOSE 3001
 


### PR DESCRIPTION
## Summary
- Switch Dockerfile runtime user from `root` to `assistant` for improved container security