### PR TITLE
fix: use modern two-parameter onChange closure form in ChatBubble

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -286,8 +286,8 @@ struct ChatBubble: View {
         }
         .contentShape(Rectangle())
         .onAppear { recomputeInterleavedContentCache() }
-        .onChange(of: message.contentOrder) { _ in recomputeInterleavedContentCache() }
-        .onChange(of: message.textSegments) { _ in recomputeInterleavedContentCache() }
+        .onChange(of: message.contentOrder) { _, _ in recomputeInterleavedContentCache() }
+        .onChange(of: message.textSegments) { _, _ in recomputeInterleavedContentCache() }
         .onHover { hovering in
             isHovered = hovering
         }


### PR DESCRIPTION
## Summary
Replace deprecated single-parameter onChange closures with the modern
two-parameter form to suppress deprecation warnings and match the pattern
used in AssistantProgressView.

Fixes gap identified during plan review for scroll-perf-spike.md.

**Gap:** Deprecated onChange closure form
**What was expected:** Modern two-parameter onChange
**What was found:** Single-parameter deprecated form
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
