### PR TITLE
fix: eagerly initialize interleaved content cache to prevent first-render flash

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -51,10 +51,94 @@ struct ChatBubble: View {
     @State private var mediaEmbedIntents: [MediaEmbedIntent] = []
     // Cached interleaved content state — updated via .onChange(of:) to avoid
     // recomputing O(n) grouping on every body evaluation.
-    @State var cachedHasInterleavedContent: Bool = false
-    @State var cachedContentGroups: [ContentGroup] = []
+    // Eagerly initialized in init() to prevent first-frame flash where the
+    // wrong layout path renders before .onAppear fires.
+    @State var cachedHasInterleavedContent: Bool
+    @State var cachedContentGroups: [ContentGroup]
     /// Set of stableIds for tool-call groups that have non-empty text after them.
-    @State var cachedToolGroupsWithTrailingText: Set<String> = []
+    @State var cachedToolGroupsWithTrailingText: Set<String>
+
+    init(
+        message: ChatMessage,
+        decidedConfirmation: ToolConfirmationData?,
+        onSurfaceAction: @escaping (String, String, [String: AnyCodable]?) -> Void,
+        onDismissDocumentWidget: @escaping (String) -> Void,
+        dismissedDocumentSurfaceIds: Set<String>,
+        onReportMessage: ((String?) -> Void)? = nil,
+        onForkFromMessage: ((String) -> Void)? = nil,
+        showInspectButton: Bool = false,
+        onInspectMessage: ((String?) -> Void)? = nil,
+        onSurfaceRefetch: ((String, String) -> Void)? = nil,
+        onRehydrate: (() -> Void)? = nil,
+        mediaEmbedSettings: MediaEmbedResolverSettings? = nil,
+        resolveHttpPort: @escaping (() -> Int?) = { nil },
+        onConfirmationAllow: ((String) -> Void)? = nil,
+        onConfirmationDeny: ((String) -> Void)? = nil,
+        onAlwaysAllow: ((String, String, String, String) -> Void)? = nil,
+        onTemporaryAllow: ((String, String) -> Void)? = nil,
+        activeConfirmationRequestId: String? = nil,
+        onRetryFailedMessage: ((UUID) -> Void)? = nil,
+        onRetryConversationError: (() -> Void)? = nil,
+        isLatestAssistantMessage: Bool = false,
+        isProcessingAfterTools: Bool = false,
+        processingStatusText: String? = nil,
+        activeSurfaceId: String? = nil
+    ) {
+        self.message = message
+        self.decidedConfirmation = decidedConfirmation
+        self.onSurfaceAction = onSurfaceAction
+        self.onDismissDocumentWidget = onDismissDocumentWidget
+        self.dismissedDocumentSurfaceIds = dismissedDocumentSurfaceIds
+        self.onReportMessage = onReportMessage
+        self.onForkFromMessage = onForkFromMessage
+        self.showInspectButton = showInspectButton
+        self.onInspectMessage = onInspectMessage
+        self.onSurfaceRefetch = onSurfaceRefetch
+        self.onRehydrate = onRehydrate
+        self.mediaEmbedSettings = mediaEmbedSettings
+        self.resolveHttpPort = resolveHttpPort
+        self.onConfirmationAllow = onConfirmationAllow
+        self.onConfirmationDeny = onConfirmationDeny
+        self.onAlwaysAllow = onAlwaysAllow
+        self.onTemporaryAllow = onTemporaryAllow
+        self.activeConfirmationRequestId = activeConfirmationRequestId
+        self.onRetryFailedMessage = onRetryFailedMessage
+        self.onRetryConversationError = onRetryConversationError
+        self.isLatestAssistantMessage = isLatestAssistantMessage
+        self.isProcessingAfterTools = isProcessingAfterTools
+        self.processingStatusText = processingStatusText
+        self.activeSurfaceId = activeSurfaceId
+
+        // Eagerly compute interleaved content cache so the first body
+        // evaluation uses the correct layout path (no flash).
+        let interleaved = Self.computeHasInterleavedContent(message.contentOrder)
+        _cachedHasInterleavedContent = State(initialValue: interleaved)
+
+        if interleaved {
+            let groups = Self.computeContentGroupsStatic(
+                contentOrder: message.contentOrder,
+                hasInterleavedContent: interleaved
+            )
+            _cachedContentGroups = State(initialValue: groups)
+
+            var trailingTextIds = Set<String>()
+            for group in groups {
+                guard case .toolCalls(let indices) = group else { continue }
+                if Self.computeHasTextAfterToolGroupStatic(
+                    toolIndices: indices,
+                    contentOrder: message.contentOrder,
+                    textSegments: message.textSegments,
+                    hasText: !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ) {
+                    trailingTextIds.insert(group.stableId)
+                }
+            }
+            _cachedToolGroupsWithTrailingText = State(initialValue: trailingTextIds)
+        } else {
+            _cachedContentGroups = State(initialValue: [])
+            _cachedToolGroupsWithTrailingText = State(initialValue: [])
+        }
+    }
     /// Injected from the parent instead of observing the shared singleton directly.
     /// This avoids every ChatBubble in the list re-rendering whenever the overlay
     /// manager publishes any change (the "thundering herd" problem).

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -51,7 +51,10 @@ extension ChatBubble {
             return
         }
 
-        let groups = computeContentGroups()
+        let groups = Self.computeContentGroupsStatic(
+            contentOrder: message.contentOrder,
+            hasInterleavedContent: interleaved
+        )
         cachedContentGroups = groups
 
         // Pre-compute which tool-call groups have trailing text so that
@@ -60,7 +63,12 @@ extension ChatBubble {
         var trailingTextIds = Set<String>()
         for group in groups {
             guard case .toolCalls(let indices) = group else { continue }
-            if computeHasTextAfterToolGroup(indices) {
+            if Self.computeHasTextAfterToolGroupStatic(
+                toolIndices: indices,
+                contentOrder: message.contentOrder,
+                textSegments: message.textSegments,
+                hasText: hasText
+            ) {
                 trailingTextIds.insert(group.stableId)
             }
         }
@@ -83,9 +91,14 @@ extension ChatBubble {
         return false
     }
 
-    private func computeContentGroups() -> [ContentGroup] {
+    /// Static version of content group computation, callable from init() before
+    /// self is fully initialized. The instance method delegates to this.
+    static func computeContentGroupsStatic(
+        contentOrder: [ContentBlockRef],
+        hasInterleavedContent: Bool
+    ) -> [ContentGroup] {
         var groups: [ContentGroup] = []
-        for ref in message.contentOrder {
+        for ref in contentOrder {
             switch ref {
             case .text(let i):
                 if case .texts(let indices) = groups.last {
@@ -106,7 +119,12 @@ extension ChatBubble {
 
         // When tool calls render inline (visible progress views), they must
         // break text runs just like surfaces do — skip coalescing entirely.
-        guard !shouldRenderToolProgressInline else { return groups }
+        // Replicate shouldRenderToolProgressInline logic inline:
+        let shouldRenderInline = hasInterleavedContent && contentOrder.contains(where: {
+            if case .toolCall = $0 { return true }
+            return false
+        })
+        guard !shouldRenderInline else { return groups }
 
         // Post-process: coalesce text groups that are only separated by tool call
         // groups so that the user can drag-select across text that spans a tool
@@ -153,23 +171,28 @@ extension ChatBubble {
         return coalesced
     }
 
-    /// Returns true when there is non-empty text content after a tool-call group.
-    /// Used during cache recomputation to pre-compute trailing text status.
-    private func computeHasTextAfterToolGroup(_ toolIndices: [Int]) -> Bool {
+    /// Static version of trailing text detection, callable from init() before
+    /// self is fully initialized. The instance method delegates to this.
+    static func computeHasTextAfterToolGroupStatic(
+        toolIndices: [Int],
+        contentOrder: [ContentBlockRef],
+        textSegments: [String],
+        hasText: Bool
+    ) -> Bool {
         let indexSet = Set(toolIndices)
-        guard let lastToolRefIndex = message.contentOrder.lastIndex(where: {
+        guard let lastToolRefIndex = contentOrder.lastIndex(where: {
             if case .toolCall(let i) = $0 { return indexSet.contains(i) }
             return false
         }) else {
             return hasText
         }
-        let start = message.contentOrder.index(after: lastToolRefIndex)
-        guard start < message.contentOrder.endIndex else { return false }
-        for ref in message.contentOrder[start...] {
+        let start = contentOrder.index(after: lastToolRefIndex)
+        guard start < contentOrder.endIndex else { return false }
+        for ref in contentOrder[start...] {
             guard case .text(let textIndex) = ref,
                   textIndex >= 0,
-                  textIndex < message.textSegments.count else { continue }
-            if !message.textSegments[textIndex].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                  textIndex < textSegments.count else { continue }
+            if !textSegments[textIndex].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 return true
             }
         }


### PR DESCRIPTION
## Summary
Initialize @State cached interleaved content values eagerly in init instead of
relying on onAppear. Prevents first-frame flash where messages with interleaved
content (text + tool calls) briefly render via the wrong layout path.

Fixes gap identified during plan review for scroll-perf-spike.md.

**Gap:** First-render flash for interleaved content
**What was expected:** Correct layout on first frame
**What was found:** @State defaults caused wrong path until onAppear fired
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
