### PR TITLE
feat: add getSoundsDir utility and exclude sounds from diagnostic exports

### DIFF
--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -444,6 +444,7 @@ const WORKSPACE_SKIP_DIRS = new Set([
   "embedding-models",
   "data/qdrant",
   "data/attachments",
+  "data/sounds",
   "conversations",
 ]);
 

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -238,6 +238,15 @@ export function getInterfacesDir(): string {
 }
 
 /**
+ * Returns the sounds directory (~/.vellum/workspace/data/sounds).
+ * Custom sound files and sound configuration live here. Sound files
+ * can be large, so this directory is excluded from diagnostic exports.
+ */
+export function getSoundsDir(): string {
+  return join(getWorkspaceDir(), "data", "sounds");
+}
+
+/**
  * Returns the TCP port the daemon should listen on for iOS clients.
  * Hardcoded default: 8765.
  */
@@ -432,6 +441,7 @@ export function ensureDataDir(): void {
     join(wsData, "memory", "knowledge"),
     join(wsData, "apps"),
     join(wsData, "interfaces"),
+    join(wsData, "sounds"),
   ];
   for (const dir of dirs) {
     if (!existsSync(dir)) {


### PR DESCRIPTION
## Summary
- Add `getSoundsDir()` utility returning workspace-scoped sounds directory path
- Ensure sounds directory is created on daemon startup
- Exclude `data/sounds/` from diagnostic log exports

Part of plan: custom-sounds-mac.md (PR 1 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
