### PR TITLE
fix: eagerly initialize DerivedProgressState to prevent first-render flash

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -158,7 +158,45 @@ struct AssistantProgressView: View {
     @State private var isOverflowPopoverShown: Bool = false
     @State private var suppressNextExpand: Bool = false
     @State private var hideInlineChips: Bool = false
-    @State private var derived = DerivedProgressState()
+    @State private var derived: DerivedProgressState
+
+    // MARK: - Init
+
+    init(
+        toolCalls: [ToolCallData],
+        isStreaming: Bool,
+        hasText: Bool,
+        isProcessing: Bool,
+        processingStatusText: String? = nil,
+        streamingCodePreview: String? = nil,
+        streamingCodeToolName: String? = nil,
+        decidedConfirmations: [ToolConfirmationData],
+        onRehydrate: (() -> Void)? = nil,
+        onConfirmationAllow: ((String) -> Void)? = nil,
+        onConfirmationDeny: ((String) -> Void)? = nil,
+        onAlwaysAllow: ((String, String, String, String) -> Void)? = nil,
+        onTemporaryAllow: ((String, String) -> Void)? = nil,
+        activeConfirmationRequestId: String? = nil
+    ) {
+        self.toolCalls = toolCalls
+        self.isStreaming = isStreaming
+        self.hasText = hasText
+        self.isProcessing = isProcessing
+        self.processingStatusText = processingStatusText
+        self.streamingCodePreview = streamingCodePreview
+        self.streamingCodeToolName = streamingCodeToolName
+        self.decidedConfirmations = decidedConfirmations
+        self.onRehydrate = onRehydrate
+        self.onConfirmationAllow = onConfirmationAllow
+        self.onConfirmationDeny = onConfirmationDeny
+        self.onAlwaysAllow = onAlwaysAllow
+        self.onTemporaryAllow = onTemporaryAllow
+        self.activeConfirmationRequestId = activeConfirmationRequestId
+        _derived = State(initialValue: DerivedProgressState.compute(
+            toolCalls: toolCalls,
+            decidedConfirmations: decidedConfirmations
+        ))
+    }
 
     // MARK: - Derived State (reads from cached DerivedProgressState)
 
@@ -358,9 +396,6 @@ struct AssistantProgressView: View {
             }
         }
         .onAppear {
-            // Compute initial derived state
-            derived = DerivedProgressState.compute(toolCalls: toolCalls, decidedConfirmations: decidedConfirmations)
-
             if phase == .processing && processingStartDate == nil {
                 processingStartDate = Date()
             }


### PR DESCRIPTION
## Summary
Compute initial DerivedProgressState in init instead of relying on onAppear.
Prevents first-frame flash where AssistantProgressView shows wrong phase
(e.g. .complete instead of .toolRunning) before onAppear fires.

Fixes gap identified during plan review for scroll-perf-spike.md.

**Gap:** DerivedProgressState defaults cause wrong first render
**What was expected:** Correct phase on first frame
**What was found:** Default values showed wrong state until onAppear
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
