### PR TITLE
Add assistant_version tag to daemon Sentry scope for consistency

### DIFF
--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -51,6 +51,7 @@ export function initSentry(): void {
     initialScope: {
       tags: {
         commit: COMMIT_SHA,
+        assistant_version: APP_VERSION,
         os_platform: platform(),
         os_release: release(),
         os_arch: arch(),


### PR DESCRIPTION
## Summary
- Add assistant_version tag to daemon Sentry scope so events are filterable by the same version name used in telemetry
- Existing commit tag unchanged (backward compatible)

Part of plan: clean-up-version-tracking.md (PR 3 of 3)