### PR TITLE
fix: remove drawingGroup() that breaks text selection on completed messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -267,20 +267,6 @@ struct ChatBubble: View {
                 // async task completions (markdown parsing, image decoding) would
                 // trigger full re-compositing of the entire message on every change.
                 .modifier(ConditionalCompositingGroup(isActive: !message.isStreaming && !cachedHasInterleavedContent))
-                // Rasterize completed, non-interactive assistant bubbles via Metal.
-                // drawingGroup() flattens the view subtree into an offscreen render
-                // pass, which is faster for complex static content during scrolling.
-                // Skipped for: streaming messages, user messages, interleaved content,
-                // messages with pending tool calls, and messages still processing —
-                // all of which contain interactive or in-flight elements.
-                .modifier(ConditionalDrawingGroup(isActive: !isUser
-                    && !message.isStreaming
-                    && !cachedHasInterleavedContent
-                    && !isProcessingAfterTools
-                    && activeConfirmationRequestId == nil
-                    && message.toolCalls.allSatisfy(\.isComplete)
-                    && message.inlineSurfaces.isEmpty
-                ))
 
             if !isUser { Spacer(minLength: 0) }
         }
@@ -594,23 +580,6 @@ private struct ConditionalCompositingGroup: ViewModifier {
     func body(content: Content) -> some View {
         if isActive {
             content.compositingGroup()
-        } else {
-            content
-        }
-    }
-}
-
-/// Applies `.drawingGroup()` only when active, rasterizing the view subtree via Metal.
-/// This is faster than compositingGroup for complex static content (completed assistant
-/// messages) because it flattens the entire subtree into a single texture. Must NOT be
-/// applied to views with interactive elements (buttons, toggles) as it prevents SwiftUI
-/// from hit-testing subviews individually.
-private struct ConditionalDrawingGroup: ViewModifier {
-    let isActive: Bool
-
-    func body(content: Content) -> some View {
-        if isActive {
-            content.drawingGroup()
         } else {
             content
         }


### PR DESCRIPTION
## Summary
Removes the ConditionalDrawingGroup modifier added in PR 8. drawingGroup() rasterizes
the view subtree via Metal, which breaks macOS text selection on completed assistant
messages. The existing ConditionalCompositingGroup is retained as a safer alternative.

Fixes gap identified during plan review for scroll-perf-spike.md.

**Gap:** drawingGroup() breaks text selection
**What was expected:** Non-interactive content only
**What was found:** Applied to messages with .textSelection(.enabled)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
