### PR TITLE
feat: add SoundManager with file-based config and FSEvents watcher

### DIFF
--- a/clients/macos/vellum-assistant/Features/Sounds/SoundEvent.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/SoundEvent.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Represents the distinct sound events that can be configured and triggered throughout the app.
+enum SoundEvent: String, CaseIterable, Codable {
+    case appOpen = "app_open"
+    case taskComplete = "task_complete"
+    case needsInput = "needs_input"
+    case taskFailed = "task_failed"
+    case notification = "notification"
+    case newConversation = "new_conversation"
+    case messageSent = "message_sent"
+    case characterPoke = "character_poke"
+    case random = "random"
+
+    /// Human-readable label for display in the Settings UI.
+    var displayName: String {
+        switch self {
+        case .appOpen: return "App Open"
+        case .taskComplete: return "Task Complete"
+        case .needsInput: return "Needs Input"
+        case .taskFailed: return "Task Failed"
+        case .notification: return "Notification"
+        case .newConversation: return "New Conversation"
+        case .messageSent: return "Message Sent"
+        case .characterPoke: return "Character Poke"
+        case .random: return "Random"
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
@@ -1,0 +1,307 @@
+import AppKit
+import Foundation
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "SoundManager")
+
+/// Supported audio file extensions for custom sounds.
+private let supportedSoundExtensions: Set<String> = ["aiff", "wav", "mp3", "m4a", "caf"]
+
+/// Manages sound playback for configurable app events. Configuration is persisted
+/// to `~/.vellum/workspace/data/sounds/config.json` and watched via FSEvents so
+/// external changes (e.g. the assistant writing config) are picked up automatically.
+///
+/// Follows the same `@MainActor @Observable` singleton + FSEvents file-watcher pattern
+/// as `AvatarAppearanceManager`.
+@MainActor @Observable
+final class SoundManager {
+    static let shared = SoundManager()
+
+    /// Current sound configuration, loaded from disk.
+    private(set) var config: SoundsConfig = .defaultConfig
+
+    /// Cache of loaded NSSound instances keyed by filename to avoid repeated disk loads.
+    @ObservationIgnored private var soundCache: [String: NSSound] = [:]
+
+    @ObservationIgnored private var fileMonitor: DispatchSourceFileSystemObject?
+
+    // MARK: - Sounds Directory Path
+
+    /// Resolve the sounds directory for the currently connected assistant.
+    /// Mirrors the pattern used by `AvatarAppearanceManager.customAvatarURL`.
+    private var soundsDirectoryURL: URL {
+        if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
+           let assistant = LockfileAssistant.loadByName(assistantId),
+           let workspace = assistant.workspaceDir {
+            return URL(fileURLWithPath: workspace)
+                .appendingPathComponent("data/sounds")
+        }
+        return Self.defaultSoundsDirectoryURL()
+    }
+
+    /// Default sounds directory when no connected assistant is resolved.
+    nonisolated static func defaultSoundsDirectoryURL(homeDirectory: String = NSHomeDirectory()) -> URL {
+        URL(fileURLWithPath: homeDirectory)
+            .appendingPathComponent(".vellum/workspace/data/sounds")
+    }
+
+    /// URL of the config.json file within the sounds directory.
+    private var configFileURL: URL {
+        soundsDirectoryURL.appendingPathComponent("config.json")
+    }
+
+    // MARK: - Lifecycle
+
+    func start() {
+        loadConfig()
+        watchConfigFile()
+    }
+
+    func stop() {
+        fileMonitor?.cancel()
+        fileMonitor = nil
+    }
+
+    // MARK: - Config Loading & Saving
+
+    /// Reads and decodes config.json from the sounds directory. Falls back to
+    /// `SoundsConfig.defaultConfig` if the file doesn't exist or is malformed.
+    func loadConfig() {
+        let url = configFileURL
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            config = .defaultConfig
+            return
+        }
+
+        do {
+            let data = try Data(contentsOf: url)
+            let decoded = try JSONDecoder().decode(SoundsConfig.self, from: data)
+            config = decoded
+        } catch {
+            log.warning("Failed to parse sounds config, using defaults: \(error.localizedDescription)")
+            config = .defaultConfig
+        }
+    }
+
+    /// Encodes and writes the config to disk with pretty-printing.
+    /// Called by the Settings UI when the user changes settings.
+    func saveConfig(_ newConfig: SoundsConfig) {
+        config = newConfig
+        let url = configFileURL
+        let dir = url.deletingLastPathComponent()
+
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(newConfig)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            log.error("Failed to save sounds config: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Playback
+
+    /// Plays the sound associated with the given event, respecting global and per-event toggles.
+    func play(_ event: SoundEvent) {
+        guard config.globalEnabled else { return }
+
+        let eventConfig = config.config(for: event)
+        guard eventConfig.enabled else { return }
+
+        let sound: NSSound
+
+        if let filename = eventConfig.sound {
+            // Validate the file extension is supported.
+            let ext = (filename as NSString).pathExtension.lowercased()
+            guard supportedSoundExtensions.contains(ext) else {
+                log.warning("Unsupported sound file extension '\(ext)' for '\(filename)', falling back to default")
+                sound = defaultBlipSound()
+                sound.volume = config.volume
+                sound.play()
+                return
+            }
+
+            let fileURL = soundsDirectoryURL.appendingPathComponent(filename)
+            guard FileManager.default.fileExists(atPath: fileURL.path) else {
+                log.warning("Sound file not found at '\(fileURL.path)', falling back to default")
+                sound = defaultBlipSound()
+                sound.volume = config.volume
+                sound.play()
+                return
+            }
+
+            // Use cached sound or load from disk.
+            if let cached = soundCache[filename] {
+                sound = cached
+            } else if let loaded = NSSound(contentsOf: fileURL, byReference: true) {
+                soundCache[filename] = loaded
+                sound = loaded
+            } else {
+                log.warning("Failed to load sound file '\(filename)', falling back to default")
+                sound = defaultBlipSound()
+                sound.volume = config.volume
+                sound.play()
+                return
+            }
+        } else {
+            // No custom sound set — use default blip.
+            sound = defaultBlipSound()
+        }
+
+        sound.volume = config.volume
+        sound.play()
+    }
+
+    /// Returns the default blip sound (macOS system sound "Tink").
+    private func defaultBlipSound() -> NSSound {
+        if let cached = soundCache["__default_blip__"] {
+            return cached
+        }
+
+        let blip = NSSound(named: "Tink") ?? NSSound()
+        soundCache["__default_blip__"] = blip
+        return blip
+    }
+
+    // MARK: - Cache
+
+    /// Resets the sound cache, forcing sounds to be reloaded from disk on next play.
+    func clearCache() {
+        soundCache.removeAll()
+    }
+
+    // MARK: - Available Sounds
+
+    /// Lists audio files in the sounds directory, returning tuples of (label, filename).
+    /// Label is the filename with the extension removed. Filters to supported extensions.
+    /// This powers the Settings UI dropdown for sound selection.
+    func availableSounds() -> [(label: String, filename: String)] {
+        let dirURL = soundsDirectoryURL
+        guard let contents = try? FileManager.default.contentsOfDirectory(
+            at: dirURL,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+
+        return contents.compactMap { url in
+            let ext = url.pathExtension.lowercased()
+            guard supportedSoundExtensions.contains(ext) else { return nil }
+            let filename = url.lastPathComponent
+            let label = (filename as NSString).deletingPathExtension
+            return (label: label, filename: filename)
+        }
+        .sorted { $0.label.localizedCaseInsensitiveCompare($1.label) == .orderedAscending }
+    }
+
+    // MARK: - FSEvents File Watcher
+
+    /// Watch config.json for external changes. Follows the same pattern as
+    /// `AvatarAppearanceManager.watchAvatarFile()`.
+    private func watchConfigFile() {
+        fileMonitor?.cancel()
+        fileMonitor = nil
+
+        let path = configFileURL.path
+        let fd = open(path, O_EVTONLY)
+
+        if fd < 0 {
+            // File doesn't exist yet — watch the parent directory instead.
+            watchSoundsDirectory()
+            return
+        }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .delete, .rename],
+            queue: .global(qos: .utility)
+        )
+
+        source.setEventHandler { [weak self] in
+            let flags = source.data
+            Task { @MainActor [weak self] in
+                self?.loadConfig()
+                self?.clearCache()
+                if flags.contains(.delete) || flags.contains(.rename) {
+                    // File was deleted or renamed — re-establish the watcher
+                    // (may fall back to directory watching if file is gone).
+                    self?.watchConfigFile()
+                }
+            }
+        }
+
+        source.setCancelHandler {
+            close(fd)
+        }
+
+        fileMonitor = source
+        source.resume()
+    }
+
+    /// Watch the sounds directory for file creation when config.json doesn't exist yet.
+    /// Follows the same fallback pattern as `AvatarAppearanceManager.watchAvatarDirectory()`.
+    private func watchSoundsDirectory() {
+        let dirPath = (configFileURL.path as NSString).deletingLastPathComponent
+        let fd = open(dirPath, O_EVTONLY)
+        guard fd >= 0 else {
+            // Directory doesn't exist either — try creating it and watching.
+            let dirURL = soundsDirectoryURL
+            try? FileManager.default.createDirectory(at: dirURL, withIntermediateDirectories: true)
+            let retryFd = open(dirURL.path, O_EVTONLY)
+            guard retryFd >= 0 else { return }
+
+            let retrySource = DispatchSource.makeFileSystemObjectSource(
+                fileDescriptor: retryFd,
+                eventMask: .write,
+                queue: .global(qos: .utility)
+            )
+
+            retrySource.setEventHandler { [weak self] in
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    if FileManager.default.fileExists(atPath: self.configFileURL.path) {
+                        self.loadConfig()
+                        self.clearCache()
+                        self.watchConfigFile()
+                    }
+                }
+            }
+
+            retrySource.setCancelHandler {
+                close(retryFd)
+            }
+
+            fileMonitor = retrySource
+            retrySource.resume()
+            return
+        }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: .write,
+            queue: .global(qos: .utility)
+        )
+
+        source.setEventHandler { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                if FileManager.default.fileExists(atPath: self.configFileURL.path) {
+                    self.loadConfig()
+                    self.clearCache()
+                    self.watchConfigFile()
+                }
+            }
+        }
+
+        source.setCancelHandler {
+            close(fd)
+        }
+
+        fileMonitor = source
+        source.resume()
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Sounds/SoundsConfig.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/SoundsConfig.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Per-event sound configuration. `sound` is a filename in the sounds directory
+/// (e.g., "Gentle Ding.aiff"); nil means use the default blip.
+/// Display label is the filename minus its extension.
+struct SoundEventConfig: Codable, Equatable {
+    var enabled: Bool
+    var sound: String?
+}
+
+/// Top-level sound configuration persisted as JSON.
+/// Keys in `events` are `SoundEvent` raw values.
+struct SoundsConfig: Codable, Equatable {
+    var globalEnabled: Bool
+    var volume: Float
+    var events: [String: SoundEventConfig]
+
+    /// Default configuration: all events disabled, no custom sounds, volume at 70%.
+    static var defaultConfig: SoundsConfig {
+        var events: [String: SoundEventConfig] = [:]
+        for event in SoundEvent.allCases {
+            events[event.rawValue] = SoundEventConfig(enabled: false, sound: nil)
+        }
+        return SoundsConfig(
+            globalEnabled: false,
+            volume: 0.7,
+            events: events
+        )
+    }
+
+    /// Returns the configuration for a specific event, falling back to disabled with default sound
+    /// if the event is not present in the dictionary.
+    func config(for event: SoundEvent) -> SoundEventConfig {
+        events[event.rawValue] ?? SoundEventConfig(enabled: false, sound: nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Add SoundEvent enum with 9 configurable sound events
- Add SoundsConfig model with per-event toggles and sound file selection
- Add SoundManager with file-based config, FSEvents watcher, and sound playback

Part of plan: custom-sounds-mac.md (PR 2 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
