### PR TITLE
Use VellumCommitSHA as Sentry dist on macOS client instead of CFBundleVersion

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -318,10 +318,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         if sendDiagnostics {
             let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
             let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
+            let commitSHA = Bundle.main.infoDictionary?["VellumCommitSHA"] as? String
             SentrySDK.start { options in
                 options.dsn = MetricKitManager.macosDSN
                 options.releaseName = "vellum-macos@\(appVersion)"
-                options.dist = buildNumber
+                options.dist = commitSHA ?? buildNumber
                 options.environment = SentryDeviceInfo.sentryEnvironment
                 options.debug = false
                 options.tracesSampleRate = 0.1

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -97,10 +97,11 @@ import os
             if needsStart {
                 let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
                 let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
+                let commitSHA = Bundle.main.infoDictionary?["VellumCommitSHA"] as? String
                 SentrySDK.start { options in
                     options.dsn = targetDSN
                     options.releaseName = "vellum-macos@\(version)"
-                    options.dist = build
+                    options.dist = commitSHA ?? build
                     options.environment = SentryDeviceInfo.sentryEnvironment
                     options.sendDefaultPii = false
                     options.enableCrashHandler = false
@@ -225,10 +226,11 @@ import os
         guard sendDiagnostics else { return }
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
         let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
+        let commitSHA = Bundle.main.infoDictionary?["VellumCommitSHA"] as? String
         SentrySDK.start { options in
             options.dsn = macosDSN
             options.releaseName = "vellum-macos@\(version)"
-            options.dist = build
+            options.dist = commitSHA ?? build
             options.environment = SentryDeviceInfo.sentryEnvironment
             options.debug = false
             options.tracesSampleRate = 0.1


### PR DESCRIPTION
## Summary
- Prefer VellumCommitSHA (git SHA stamped at CI build time) over CFBundleVersion for Sentry dist on macOS client
- Falls back to CFBundleVersion for local dev builds where VellumCommitSHA is not set
- Applied consistently across AppDelegate and MetricKitManager Sentry init sites

Part of plan: clean-up-version-tracking.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
