### PR TITLE
Add commit_sha and client_version Sentry tags on macOS client

### DIFF
--- a/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
+++ b/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
@@ -44,6 +44,12 @@ enum SentryDeviceInfo {
                 scope.removeTag(key: "organization_id")
             }
             scope.setTag(value: ProcessInfo.processInfo.operatingSystemVersionString, key: "os_version")
+            if let commitSHA = Bundle.main.infoDictionary?["VellumCommitSHA"] as? String, !commitSHA.isEmpty {
+                scope.setTag(value: commitSHA, key: "commit_sha")
+            }
+            if let clientVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+                scope.setTag(value: clientVersion, key: "client_version")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Add commit_sha Sentry tag on macOS client so errors are filterable by exact commit (when built in CI)
- Add client_version Sentry tag for consistency with daemon's tag naming
- Both tags set in the centralized SentryDeviceInfo.configureSentryScope()

Part of plan: clean-up-version-tracking.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
