### PR TITLE
feat: add random ambient sound trigger on configurable interval

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -370,6 +370,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         applyThemePreference()
         registerBundledFonts()
         AvatarAppearanceManager.shared.start()
+        SoundManager.shared.start()
+        RandomSoundTimer.shared.start()
 
         #if DEBUG
         let skipOnboarding = CommandLine.arguments.contains("--skip-onboarding")
@@ -587,6 +589,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         recordingHUDWindow?.dismiss()
         e2eStatusOverlayWindow?.dismiss()
         debugStateWriter.stop()
+        RandomSoundTimer.shared.stop()
+        SoundManager.shared.stop()
         #if !DEBUG
         keychainBroker?.stop()
         #endif

--- a/clients/macos/vellum-assistant/Features/Sounds/RandomSoundTimer.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/RandomSoundTimer.swift
@@ -1,0 +1,46 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "RandomSoundTimer")
+
+/// Fires a random ambient sound at unpredictable intervals (5-30 minutes).
+/// SoundManager handles the global and per-event enabled checks internally,
+/// so the timer simply calls `play(.random)` on each tick.
+@MainActor
+final class RandomSoundTimer {
+    static let shared = RandomSoundTimer()
+
+    private var timer: Task<Void, Never>?
+
+    /// Launches an async loop that sleeps for a random interval (5-30 min)
+    /// and then plays the `.random` sound event. The loop continues until
+    /// the task is cancelled.
+    func start() {
+        // Cancel any existing timer before starting a new one.
+        timer?.cancel()
+
+        timer = Task {
+            while !Task.isCancelled {
+                let interval = TimeInterval.random(in: 300...1800)
+                log.debug("Next random sound in \(Int(interval))s")
+
+                do {
+                    try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+                } catch {
+                    // Task was cancelled during sleep.
+                    break
+                }
+
+                guard !Task.isCancelled else { break }
+
+                SoundManager.shared.play(.random)
+            }
+        }
+    }
+
+    /// Cancels the recurring timer task.
+    func stop() {
+        timer?.cancel()
+        timer = nil
+    }
+}


### PR DESCRIPTION
## Summary
- Add RandomSoundTimer that fires at random 5-30 minute intervals
- Start timer on app launch, stop on termination
- SoundManager handles enabled/disabled checks internally

Part of plan: custom-sounds-mac.md (PR 7 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
