### PR TITLE
feat: wire up sound triggers for app open, new conversation, and message sent

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -473,6 +473,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         setupNotifications()
         setupAutoUpdate()
 
+        SoundManager.shared.start()
+        SoundManager.shared.play(.appOpen)
+
         // Ensure actor credentials are present. On first launch this performs
         // initial bootstrap; on subsequent launches it schedules proactive
         // refresh when the access token nears expiry.
@@ -579,6 +582,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         pulseTimer?.invalidate()
         pulseTimer = nil
         voiceInput?.stop()
+        SoundManager.shared.stop()
         ambientAgent.teardown()
         surfaceManager.dismissAll()
         toolConfirmationNotificationService.dismissAll()

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -318,6 +318,7 @@ struct ComposerView: View {
         } else if canSend {
             sendPath = "normalSend"
             onSend()
+            SoundManager.shared.play(.messageSent)
         } else if hasPendingConfirmation
                     && inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             sendPath = "pendingConfirmationApproval"

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -344,6 +344,8 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         // Enter draft mode — conversation only appears in sidebar when the user sends
         // their first message (via promoteDraft triggered by onUserMessageSent).
         enterDraftMode()
+
+        SoundManager.shared.play(.newConversation)
     }
 
     /// Opens a conversation for interaction, optionally creating a new one and/or sending a message.


### PR DESCRIPTION
## Summary
- Play sound on app launch (appOpen event) via SoundManager in AppDelegate.proceedToApp
- Play sound when creating a new conversation (newConversation event) in ConversationManager.createConversation
- Play sound when sending a message (messageSent event) in ComposerView.performSendAction
- Properly tear down SoundManager file watcher on app termination

Part of plan: custom-sounds-mac.md (PR 4 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
