### PR TITLE
feat: wire up sound triggers for notifications and character poke

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -233,6 +233,13 @@ extension AppDelegate {
         deepLinkMetadata: [String: AnyCodable]?,
         deliveryId: String? = nil
     ) {
+        // Play the custom notification sound in addition to the system notification sound.
+        // The system sound (`UNNotificationSound.default`) plays when the banner appears,
+        // while this custom sound plays immediately when the notification is posted.
+        // Both are kept so users get the system banner sound even if custom sounds are disabled,
+        // and the custom sound provides the configurable audio feedback from SoundManager.
+        SoundManager.shared.play(.notification)
+
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body

--- a/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
@@ -501,6 +501,11 @@ class AvatarLayerView: NSView {
         guard animationsActive, configPokeEnabled else { return }
         guard let rootLayer = layer else { return }
 
+        // Play the character poke sound immediately on click, before starting the
+        // wobble animation. NSSound.play() is non-blocking so it won't delay the
+        // animation start — both fire in the same run-loop tick.
+        SoundManager.shared.play(.characterPoke)
+
         // Remove any in-progress poke animation (enables interruptible rapid clicks)
         rootLayer.removeAnimation(forKey: "poke")
 


### PR DESCRIPTION
## Summary
- Play notification sound when app posts a local notification (in addition to system notification sound)
- Play characterPoke sound when user clicks the avatar (alongside existing wobble animation)
- Both play alongside existing behaviors — system notification sound and wobble animation remain unchanged

Part of plan: custom-sounds-mac.md (PR 6 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
