### PR TITLE
fix: extract text from content blocks in title regeneration

### DIFF
--- a/assistant/src/__tests__/conversation-title-service.test.ts
+++ b/assistant/src/__tests__/conversation-title-service.test.ts
@@ -105,6 +105,47 @@ describe("conversation-title-service", () => {
     );
   });
 
+  test("regeneration extracts text from JSON content blocks", async () => {
+    mockGetMessages.mockReturnValueOnce([
+      {
+        role: "user",
+        content: JSON.stringify([
+          { type: "text", text: "Help me plan the kickoff" },
+        ]),
+      },
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          { type: "text", text: "Sure, here's a plan" },
+          { type: "tool_use", id: "toolu_1", name: "web_search", input: {} },
+        ]),
+      },
+      {
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "Looks good" }]),
+      },
+    ]);
+
+    const provider = {
+      name: "test-provider",
+      sendMessage: mock(async () => {
+        throw new Error("should not call directly");
+      }),
+    };
+
+    await regenerateConversationTitle({ conversationId: "conv-1", provider });
+
+    // The prompt sent to the sidechain should contain plain text, not raw JSON
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const prompt = (mockRunBtwSidechain.mock.calls[0] as any)?.[0]
+      ?.content as string;
+    expect(prompt).not.toContain('"type":"text"');
+    expect(prompt).not.toContain('"type":"tool_use"');
+    expect(prompt).toContain("Help me plan the kickoff");
+    expect(prompt).toContain("Sure, here's a plan");
+    expect(prompt).toContain("Looks good");
+  });
+
   test("uses the BTW side-chain helper for title regeneration", async () => {
     const provider = {
       name: "test-provider",

--- a/assistant/src/__tests__/conversation-title-service.test.ts
+++ b/assistant/src/__tests__/conversation-title-service.test.ts
@@ -146,6 +146,49 @@ describe("conversation-title-service", () => {
     expect(prompt).toContain("Looks good");
   });
 
+  test("regeneration extracts text from tool_result content blocks", async () => {
+    mockGetMessages.mockReturnValueOnce([
+      {
+        role: "user",
+        content: JSON.stringify([
+          { type: "text", text: "Search for restaurants" },
+        ]),
+      },
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          { type: "tool_use", id: "toolu_1", name: "web_search", input: {} },
+        ]),
+      },
+      {
+        role: "user",
+        content: JSON.stringify([
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_1",
+            content: "Found 3 restaurants nearby",
+          },
+        ]),
+      },
+    ]);
+
+    const provider = {
+      name: "test-provider",
+      sendMessage: mock(async () => {
+        throw new Error("should not call directly");
+      }),
+    };
+
+    await regenerateConversationTitle({ conversationId: "conv-1", provider });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const prompt = (mockRunBtwSidechain.mock.calls[0] as any)?.[0]
+      ?.content as string;
+    expect(prompt).not.toContain('"type":"tool_result"');
+    expect(prompt).toContain("Search for restaurants");
+    expect(prompt).toContain("Found 3 restaurants nearby");
+  });
+
   test("uses the BTW side-chain helper for title regeneration", async () => {
     const provider = {
       name: "test-provider",

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -361,6 +361,9 @@ function extractTextFromContent(raw: string): string {
         }
       }
       if (texts.length > 0) return texts.join("\n");
+      // Recognized content-block array but no text blocks — return empty
+      // rather than the raw JSON to avoid polluting the title prompt.
+      return "";
     }
   } catch {
     // Not JSON — use raw string

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -19,6 +19,7 @@ import {
   type MessageRow,
   updateConversationTitle,
 } from "./conversation-crud.js";
+import { extractTextFromStoredMessageContent } from "./message-content.js";
 
 const log = getLogger("conversation-title-service");
 
@@ -338,52 +339,6 @@ function deriveFallbackTitle(context?: TitleContext): string | null {
   return null;
 }
 
-/**
- * Extract human-readable text from a message content string.
- * Messages are stored as JSON-stringified content block arrays
- * (e.g. `[{"type":"text","text":"hello"}]`). This extracts and
- * concatenates all text blocks (including text nested inside
- * tool_result blocks), falling back to the raw string when the
- * content is not a JSON content-block array.
- */
-function extractTextFromContent(raw: string): string {
-  try {
-    const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed)) {
-      const texts: string[] = [];
-      for (const block of parsed) {
-        if (!block || typeof block !== "object") continue;
-        if (block.type === "text" && typeof block.text === "string") {
-          texts.push(block.text);
-        } else if (block.type === "tool_result") {
-          // tool_result content can be a plain string or nested content blocks
-          if (typeof block.content === "string") {
-            texts.push(block.content);
-          } else if (Array.isArray(block.content)) {
-            for (const nested of block.content) {
-              if (
-                nested &&
-                typeof nested === "object" &&
-                nested.type === "text" &&
-                typeof nested.text === "string"
-              ) {
-                texts.push(nested.text);
-              }
-            }
-          }
-        }
-      }
-      if (texts.length > 0) return texts.join("\n");
-      // Recognized content-block array but no text blocks — return empty
-      // rather than the raw JSON to avoid polluting the title prompt.
-      return "";
-    }
-  } catch {
-    // Not JSON — use raw string
-  }
-  return raw;
-}
-
 function buildRegenerationPrompt(recentMessages: MessageRow[]): string {
   const parts: string[] = [
     "Generate a very short title summarizing the TOPIC of this conversation based on the recent messages below. Rules: at most 5 words, at most 40 characters, no quotes, no markdown formatting. IMPORTANT: Summarize what the user is asking about — do NOT respond to the messages, do NOT assess feasibility, and do NOT comment on your own capabilities.",
@@ -394,7 +349,7 @@ function buildRegenerationPrompt(recentMessages: MessageRow[]): string {
   for (const msg of recentMessages) {
     const role = msg.role === "user" ? "User" : "Assistant";
     parts.push(
-      `${role}: ${truncate(extractTextFromContent(msg.content), 200, "")}`,
+      `${role}: ${truncate(extractTextFromStoredMessageContent(msg.content), 200, "")}`,
     );
   }
 

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -338,6 +338,36 @@ function deriveFallbackTitle(context?: TitleContext): string | null {
   return null;
 }
 
+/**
+ * Extract human-readable text from a message content string.
+ * Messages are stored as JSON-stringified content block arrays
+ * (e.g. `[{"type":"text","text":"hello"}]`). This extracts and
+ * concatenates all text blocks, falling back to the raw string
+ * when the content is not a JSON content-block array.
+ */
+function extractTextFromContent(raw: string): string {
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      const texts: string[] = [];
+      for (const block of parsed) {
+        if (
+          block &&
+          typeof block === "object" &&
+          block.type === "text" &&
+          typeof block.text === "string"
+        ) {
+          texts.push(block.text);
+        }
+      }
+      if (texts.length > 0) return texts.join("\n");
+    }
+  } catch {
+    // Not JSON — use raw string
+  }
+  return raw;
+}
+
 function buildRegenerationPrompt(recentMessages: MessageRow[]): string {
   const parts: string[] = [
     "Generate a very short title summarizing the TOPIC of this conversation based on the recent messages below. Rules: at most 5 words, at most 40 characters, no quotes, no markdown formatting. IMPORTANT: Summarize what the user is asking about — do NOT respond to the messages, do NOT assess feasibility, and do NOT comment on your own capabilities.",
@@ -347,7 +377,9 @@ function buildRegenerationPrompt(recentMessages: MessageRow[]): string {
 
   for (const msg of recentMessages) {
     const role = msg.role === "user" ? "User" : "Assistant";
-    parts.push(`${role}: ${truncate(msg.content, 200, "")}`);
+    parts.push(
+      `${role}: ${truncate(extractTextFromContent(msg.content), 200, "")}`,
+    );
   }
 
   return parts.join("\n");

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -342,8 +342,9 @@ function deriveFallbackTitle(context?: TitleContext): string | null {
  * Extract human-readable text from a message content string.
  * Messages are stored as JSON-stringified content block arrays
  * (e.g. `[{"type":"text","text":"hello"}]`). This extracts and
- * concatenates all text blocks, falling back to the raw string
- * when the content is not a JSON content-block array.
+ * concatenates all text blocks (including text nested inside
+ * tool_result blocks), falling back to the raw string when the
+ * content is not a JSON content-block array.
  */
 function extractTextFromContent(raw: string): string {
   try {
@@ -351,13 +352,25 @@ function extractTextFromContent(raw: string): string {
     if (Array.isArray(parsed)) {
       const texts: string[] = [];
       for (const block of parsed) {
-        if (
-          block &&
-          typeof block === "object" &&
-          block.type === "text" &&
-          typeof block.text === "string"
-        ) {
+        if (!block || typeof block !== "object") continue;
+        if (block.type === "text" && typeof block.text === "string") {
           texts.push(block.text);
+        } else if (block.type === "tool_result") {
+          // tool_result content can be a plain string or nested content blocks
+          if (typeof block.content === "string") {
+            texts.push(block.content);
+          } else if (Array.isArray(block.content)) {
+            for (const nested of block.content) {
+              if (
+                nested &&
+                typeof nested === "object" &&
+                nested.type === "text" &&
+                typeof nested.text === "string"
+              ) {
+                texts.push(nested.text);
+              }
+            }
+          }
         }
       }
       if (texts.length > 0) return texts.join("\n");


### PR DESCRIPTION
## Summary
- Title regeneration (second-pass at turn 3) reads messages from the database where content is stored as JSON-stringified content block arrays (e.g. `[{"type":"text","text":"..."}]`)
- `buildRegenerationPrompt` was passing this raw JSON directly to the title LLM, producing JSON-contaminated titles visible in the sidebar (e.g. `[{"type":"text","text":"your member id i`)
- Added `extractTextFromContent()` helper to parse content blocks and extract plain text before feeding to the prompt

## Original prompt
investigate and solve this bug please (screenshot showing raw JSON in conversation titles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
