### PR TITLE
Add voice and audio message support to Telegram normalization

### DIFF
--- a/gateway/src/telegram/normalize.test.ts
+++ b/gateway/src/telegram/normalize.test.ts
@@ -63,3 +63,125 @@ describe("normalizeTelegramUpdate — callback_query DM-only guard", () => {
     expect(result).toBeNull();
   });
 });
+
+function makeVoicePayload(overrides?: {
+  chatType?: string;
+  fromId?: number | null;
+  caption?: string;
+}) {
+  return {
+    update_id: 200,
+    message: {
+      message_id: 20,
+      chat: { id: 42, type: overrides?.chatType ?? "private" },
+      from:
+        overrides?.fromId === null
+          ? undefined
+          : { id: overrides?.fromId ?? 42, first_name: "Alice" },
+      ...(overrides?.caption ? { caption: overrides.caption } : {}),
+      voice: {
+        file_id: "voice-file-id-123",
+        file_unique_id: "voice-unique-123",
+        duration: 5,
+        mime_type: "audio/ogg",
+        file_size: 12345,
+      },
+    },
+  };
+}
+
+function makeAudioPayload(overrides?: {
+  chatType?: string;
+  fromId?: number | null;
+  caption?: string;
+}) {
+  return {
+    update_id: 300,
+    message: {
+      message_id: 30,
+      chat: { id: 42, type: overrides?.chatType ?? "private" },
+      from:
+        overrides?.fromId === null
+          ? undefined
+          : { id: overrides?.fromId ?? 42, first_name: "Alice" },
+      ...(overrides?.caption ? { caption: overrides.caption } : {}),
+      audio: {
+        file_id: "audio-file-id-456",
+        file_unique_id: "audio-unique-456",
+        duration: 180,
+        performer: "Artist",
+        title: "Song Title",
+        file_name: "song.mp3",
+        mime_type: "audio/mpeg",
+        file_size: 5000000,
+      },
+    },
+  };
+}
+
+describe("normalizeTelegramUpdate — voice messages", () => {
+  it("voice message produces an audio attachment with empty content", () => {
+    const result = normalizeTelegramUpdate(makeVoicePayload());
+    expect(result).not.toBeNull();
+    expect(result!.message.content).toBe("");
+    expect(result!.message.attachments).toEqual([
+      {
+        type: "audio",
+        fileId: "voice-file-id-123",
+        mimeType: "audio/ogg",
+        fileSize: 12345,
+      },
+    ]);
+  });
+
+  it("voice message from non-private chat is rejected", () => {
+    const result = normalizeTelegramUpdate(
+      makeVoicePayload({ chatType: "group" }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("voice message with missing sender is rejected", () => {
+    const result = normalizeTelegramUpdate(makeVoicePayload({ fromId: null }));
+    expect(result).toBeNull();
+  });
+});
+
+describe("normalizeTelegramUpdate — audio messages", () => {
+  it("audio message with caption produces audio attachment and caption as content", () => {
+    const result = normalizeTelegramUpdate(
+      makeAudioPayload({ caption: "Check out this song" }),
+    );
+    expect(result).not.toBeNull();
+    expect(result!.message.content).toBe("Check out this song");
+    expect(result!.message.attachments).toEqual([
+      {
+        type: "audio",
+        fileId: "audio-file-id-456",
+        fileName: "song.mp3",
+        mimeType: "audio/mpeg",
+        fileSize: 5000000,
+      },
+    ]);
+  });
+
+  it("audio message without caption has empty content", () => {
+    const result = normalizeTelegramUpdate(makeAudioPayload());
+    expect(result).not.toBeNull();
+    expect(result!.message.content).toBe("");
+    expect(result!.message.attachments).toHaveLength(1);
+    expect(result!.message.attachments![0].type).toBe("audio");
+  });
+
+  it("audio message from non-private chat is rejected", () => {
+    const result = normalizeTelegramUpdate(
+      makeAudioPayload({ chatType: "supergroup" }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("audio message with missing sender is rejected", () => {
+    const result = normalizeTelegramUpdate(makeAudioPayload({ fromId: null }));
+    expect(result).toBeNull();
+  });
+});

--- a/gateway/src/telegram/normalize.ts
+++ b/gateway/src/telegram/normalize.ts
@@ -16,6 +16,25 @@ interface TelegramDocument {
   file_size?: number;
 }
 
+interface TelegramVoice {
+  file_id: string;
+  file_unique_id: string;
+  duration: number;
+  mime_type?: string;
+  file_size?: number;
+}
+
+interface TelegramAudio {
+  file_id: string;
+  file_unique_id: string;
+  duration: number;
+  performer?: string;
+  title?: string;
+  file_name?: string;
+  mime_type?: string;
+  file_size?: number;
+}
+
 interface TelegramMessage {
   message_id?: number;
   text?: string;
@@ -31,6 +50,8 @@ interface TelegramMessage {
   };
   photo?: TelegramPhotoSize[];
   document?: TelegramDocument;
+  voice?: TelegramVoice;
+  audio?: TelegramAudio;
 }
 
 interface TelegramCallbackQuery {
@@ -134,7 +155,13 @@ export function normalizeTelegramUpdate(
   const isEdit = !update.message && !!update.edited_message;
   const message = update.message ?? update.edited_message;
 
-  const hasContent = !!(message?.text || message?.photo || message?.document);
+  const hasContent = !!(
+    message?.text ||
+    message?.photo ||
+    message?.document ||
+    message?.voice ||
+    message?.audio
+  );
   if (!hasContent || !message?.chat?.id || updateId == null) {
     return null;
   }
@@ -159,7 +186,7 @@ export function normalizeTelegramUpdate(
   const content = message.text || message.caption || "";
 
   const attachments: {
-    type: "photo" | "document";
+    type: "photo" | "document" | "audio";
     fileId: string;
     fileName?: string;
     mimeType?: string;
@@ -181,6 +208,23 @@ export function normalizeTelegramUpdate(
       fileName: message.document.file_name,
       mimeType: message.document.mime_type,
       fileSize: message.document.file_size,
+    });
+  }
+  if (message.voice) {
+    attachments.push({
+      type: "audio",
+      fileId: message.voice.file_id,
+      mimeType: message.voice.mime_type,
+      fileSize: message.voice.file_size,
+    });
+  }
+  if (message.audio) {
+    attachments.push({
+      type: "audio",
+      fileId: message.audio.file_id,
+      fileName: message.audio.file_name,
+      mimeType: message.audio.mime_type,
+      fileSize: message.audio.file_size,
     });
   }
 


### PR DESCRIPTION
## Summary
- Add TelegramVoice and TelegramAudio interfaces and handle voice/audio in normalizeTelegramUpdate
- Voice messages normalize to audio attachments with empty content; audio messages preserve caption
- Add comprehensive tests for voice and audio message handling

Part of plan: telegram-voice-messages.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
