### PR TITLE
Add speech-to-text provider abstraction with OpenAI Whisper backend

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -254,6 +254,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "config/bundled-skills/slack/tools/shared.ts", // Slack skill bot token lookup
       "daemon/conversation-process.ts", // masked provider key display
       "daemon/handlers/config-model.ts", // masked provider key display
+      "providers/speech-to-text/resolve.ts", // STT provider API key lookup
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/providers/speech-to-text/openai-whisper.test.ts
+++ b/assistant/src/providers/speech-to-text/openai-whisper.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { OpenAIWhisperProvider } from "./openai-whisper.js";
+
+const TEST_API_KEY = "sk-test-key-for-unit-tests";
+
+describe("OpenAIWhisperProvider", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("successful transcription returns text", async () => {
+    globalThis.fetch = (async (
+      _url: string | URL | Request,
+      _init?: RequestInit,
+    ) => {
+      return new Response(JSON.stringify({ text: "  Hello, world!  " }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const provider = new OpenAIWhisperProvider(TEST_API_KEY);
+    const result = await provider.transcribe(
+      Buffer.from("fake-audio"),
+      "audio/ogg",
+    );
+
+    expect(result).toEqual({ text: "Hello, world!" });
+  });
+
+  test("API error throws with status and partial body", async () => {
+    const errorBody = JSON.stringify({
+      error: {
+        message: "Invalid API key provided",
+        type: "invalid_request_error",
+      },
+    });
+
+    globalThis.fetch = (async (
+      _url: string | URL | Request,
+      _init?: RequestInit,
+    ) => {
+      return new Response(errorBody, {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const provider = new OpenAIWhisperProvider(TEST_API_KEY);
+
+    await expect(
+      provider.transcribe(Buffer.from("fake-audio"), "audio/wav"),
+    ).rejects.toThrow("Whisper API error (401)");
+  });
+
+  test("sends correct FormData structure (model=whisper-1, file blob with correct MIME)", async () => {
+    let capturedBody: FormData | undefined;
+    let capturedHeaders: HeadersInit | undefined;
+
+    globalThis.fetch = (async (
+      url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      capturedBody = init?.body as FormData;
+      capturedHeaders = init?.headers;
+      expect(url).toBe("https://api.openai.com/v1/audio/transcriptions");
+      expect(init?.method).toBe("POST");
+
+      return new Response(JSON.stringify({ text: "transcribed" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const provider = new OpenAIWhisperProvider(TEST_API_KEY);
+    await provider.transcribe(Buffer.from("fake-audio"), "audio/mpeg");
+
+    // Verify authorization header
+    expect(capturedHeaders).toEqual({
+      Authorization: `Bearer ${TEST_API_KEY}`,
+    });
+
+    // Verify FormData contents
+    expect(capturedBody).toBeInstanceOf(FormData);
+    const model = capturedBody!.get("model");
+    expect(model).toBe("whisper-1");
+
+    const file = capturedBody!.get("file");
+    expect(file).toBeInstanceOf(Blob);
+    expect((file as Blob).type).toBe("audio/mpeg");
+  });
+
+  test("returns empty text when API returns empty text field", async () => {
+    globalThis.fetch = (async () => {
+      return new Response(JSON.stringify({ text: "" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const provider = new OpenAIWhisperProvider(TEST_API_KEY);
+    const result = await provider.transcribe(
+      Buffer.from("silence"),
+      "audio/wav",
+    );
+
+    expect(result).toEqual({ text: "" });
+  });
+
+  test("returns empty text when API response has no text property", async () => {
+    globalThis.fetch = (async () => {
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const provider = new OpenAIWhisperProvider(TEST_API_KEY);
+    const result = await provider.transcribe(
+      Buffer.from("silence"),
+      "audio/wav",
+    );
+
+    expect(result).toEqual({ text: "" });
+  });
+
+  test("error body is truncated to 300 characters", async () => {
+    const longBody = "x".repeat(500);
+
+    globalThis.fetch = (async () => {
+      return new Response(longBody, { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const provider = new OpenAIWhisperProvider(TEST_API_KEY);
+
+    try {
+      await provider.transcribe(Buffer.from("audio"), "audio/wav");
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toContain("Whisper API error (500)");
+      // The body portion should be at most 300 chars
+      const bodyPart = msg.replace("Whisper API error (500): ", "");
+      expect(bodyPart.length).toBeLessThanOrEqual(300);
+    }
+  });
+});

--- a/assistant/src/providers/speech-to-text/openai-whisper.test.ts
+++ b/assistant/src/providers/speech-to-text/openai-whisper.test.ts
@@ -1,4 +1,18 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module mocks (must precede dynamic imports)
+// ---------------------------------------------------------------------------
+
+let mockOpenAIKey: string | undefined;
+
+mock.module("../../security/secure-keys.js", () => ({
+  getProviderKeyAsync: async (provider: string) =>
+    provider === "openai" ? mockOpenAIKey : undefined,
+}));
+
+// Dynamic import so the mock is in effect when resolve.ts loads.
+const { resolveSpeechToTextProvider } = await import("./resolve.js");
 
 import { OpenAIWhisperProvider } from "./openai-whisper.js";
 
@@ -150,5 +164,27 @@ describe("OpenAIWhisperProvider", () => {
       const bodyPart = msg.replace("Whisper API error (500): ", "");
       expect(bodyPart.length).toBeLessThanOrEqual(300);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveSpeechToTextProvider
+// ---------------------------------------------------------------------------
+
+describe("resolveSpeechToTextProvider", () => {
+  beforeEach(() => {
+    mockOpenAIKey = undefined;
+  });
+
+  test("returns null when no OpenAI key is configured", async () => {
+    mockOpenAIKey = undefined;
+    const provider = await resolveSpeechToTextProvider();
+    expect(provider).toBeNull();
+  });
+
+  test("returns an OpenAIWhisperProvider when key exists", async () => {
+    mockOpenAIKey = "sk-real-key";
+    const provider = await resolveSpeechToTextProvider();
+    expect(provider).toBeInstanceOf(OpenAIWhisperProvider);
   });
 });

--- a/assistant/src/providers/speech-to-text/openai-whisper.ts
+++ b/assistant/src/providers/speech-to-text/openai-whisper.ts
@@ -1,0 +1,67 @@
+import type { SpeechToTextProvider, SpeechToTextResult } from "./types.js";
+
+const WHISPER_API_URL = "https://api.openai.com/v1/audio/transcriptions";
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+/**
+ * Derive a filename extension from a MIME type so the Whisper API can detect
+ * the audio format. Falls back to "audio" when the MIME type is unrecognised.
+ */
+function extensionFromMime(mimeType: string): string {
+  const map: Record<string, string> = {
+    "audio/wav": "wav",
+    "audio/x-wav": "wav",
+    "audio/mpeg": "mp3",
+    "audio/mp3": "mp3",
+    "audio/ogg": "ogg",
+    "audio/opus": "opus",
+    "audio/webm": "webm",
+    "audio/mp4": "m4a",
+    "audio/x-m4a": "m4a",
+    "audio/flac": "flac",
+  };
+  return map[mimeType] ?? "audio";
+}
+
+export class OpenAIWhisperProvider implements SpeechToTextProvider {
+  private readonly apiKey: string;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  async transcribe(
+    audio: Buffer,
+    mimeType: string,
+    signal?: AbortSignal,
+  ): Promise<SpeechToTextResult> {
+    const ext = extensionFromMime(mimeType);
+
+    const formData = new FormData();
+    formData.append(
+      "file",
+      new Blob([new Uint8Array(audio)], { type: mimeType }),
+      `audio.${ext}`,
+    );
+    formData.append("model", "whisper-1");
+
+    const effectiveSignal = signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+
+    const response = await fetch(WHISPER_API_URL, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${this.apiKey}` },
+      body: formData,
+      signal: effectiveSignal,
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(
+        `Whisper API error (${response.status}): ${body.slice(0, 300)}`,
+      );
+    }
+
+    const result = (await response.json()) as { text?: string };
+    return { text: result.text?.trim() ?? "" };
+  }
+}

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -1,0 +1,9 @@
+import { getProviderKeyAsync } from "../../security/secure-keys.js";
+import { OpenAIWhisperProvider } from "./openai-whisper.js";
+import type { SpeechToTextProvider } from "./types.js";
+
+export async function resolveSpeechToTextProvider(): Promise<SpeechToTextProvider | null> {
+  const apiKey = await getProviderKeyAsync("openai");
+  if (!apiKey) return null;
+  return new OpenAIWhisperProvider(apiKey);
+}

--- a/assistant/src/providers/speech-to-text/types.ts
+++ b/assistant/src/providers/speech-to-text/types.ts
@@ -1,0 +1,17 @@
+export interface SpeechToTextResult {
+  text: string;
+}
+
+export interface SpeechToTextProvider {
+  /**
+   * Transcribe audio from a Buffer.
+   * @param audio - Raw audio data (WAV, OGG, MP3, etc.)
+   * @param mimeType - MIME type of the audio data
+   * @param signal - Optional abort signal for cancellation
+   */
+  transcribe(
+    audio: Buffer,
+    mimeType: string,
+    signal?: AbortSignal,
+  ): Promise<SpeechToTextResult>;
+}


### PR DESCRIPTION
## Summary
- Define generic SpeechToTextProvider interface decoupled from any specific backend
- Implement OpenAIWhisperProvider using the Whisper API for voice message transcription
- Add resolveSpeechToTextProvider factory that resolves credentials via the existing secure key store

Part of plan: telegram-voice-messages.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19817" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
