### PR TITLE
feat: wire up sound triggers for task complete, needs input, and task failed

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -216,6 +216,10 @@ extension AppDelegate {
     func setupSecretPromptManager() {
         daemonClient.onSecretRequest = { [weak self] msg in
             self?.secretPromptManager.showPrompt(msg)
+            // Secret/credential prompts require user input — play the needs-input sound.
+            Task { @MainActor in
+                SoundManager.shared.play(.needsInput)
+            }
         }
         secretPromptManager.onResponse = { requestId, value, delivery in
             await InteractionClient().sendSecretResponse(requestId: requestId, value: value, delivery: delivery)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -2237,12 +2237,35 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             }
         }
         .removeDuplicates()
-        .sink { [weak self] state in
+        // Track previous state to detect transitions that trigger sounds.
+        // isFirstEmission prevents sounds from firing on initial subscription
+        // (e.g. a conversation that loads in an error state).
+        .scan((previous: ConversationInteractionState?.none, current: ConversationInteractionState.idle, isFirstEmission: true)) { accumulated, newState in
+            (previous: accumulated.current, current: newState, isFirstEmission: false)
+        }
+        .sink { [weak self] transition in
             guard let self else { return }
+            let state = transition.current
             if state == .idle {
                 self.conversationInteractionStates.removeValue(forKey: conversationId)
             } else {
                 self.conversationInteractionStates[conversationId] = state
+            }
+
+            // Play sounds on discrete state transitions. The .removeDuplicates()
+            // upstream ensures these only fire once per transition, not on every
+            // streaming delta. Skip the first emission to avoid sounds on initial load.
+            guard !transition.isFirstEmission else { return }
+            let previous = transition.previous
+            switch state {
+            case .idle where previous == .processing:
+                SoundManager.shared.play(.taskComplete)
+            case .waitingForInput:
+                SoundManager.shared.play(.needsInput)
+            case .error:
+                SoundManager.shared.play(.taskFailed)
+            default:
+                break
             }
         }
         .store(in: &subs)


### PR DESCRIPTION
## Summary
- Play taskComplete sound when assistant finishes a multi-tool-call task (processing -> idle transition)
- Play needsInput sound on tool confirmation (waitingForInput state) and secret/credential prompts
- Play taskFailed sound on error messages from the daemon (error state transition)
- Uses Combine .scan() to track state transitions, with .removeDuplicates() ensuring sounds fire only on discrete transitions
- Skips first emission to avoid sounds on initial conversation load

Part of plan: custom-sounds-mac.md (PR 5 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
