### PR TITLE
fix: pass COMMIT_SHA to build.sh release in CI so VellumCommitSHA plist key is written

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -930,6 +930,7 @@ jobs:
         run: |
           DISPLAY_VERSION="${{ steps.version.outputs.display_version }}" \
           BUILD_VERSION="${{ steps.version.outputs.build_version }}" \
+          COMMIT_SHA="${{ github.sha }}" \
           SU_PUBLIC_ED_KEY="${{ secrets.SPARKLE_ED_PUBLIC_KEY }}" \
           SIGN_IDENTITY="Developer ID Application" \
           RELEASE_ARCH_FLAGS="--arch arm64" \
@@ -1316,6 +1317,7 @@ jobs:
         run: |
           DISPLAY_VERSION="${{ steps.version.outputs.display_version }}" \
           BUILD_VERSION="${{ steps.version.outputs.build_version }}" \
+          COMMIT_SHA="${{ github.sha }}" \
           SU_PUBLIC_ED_KEY="${{ secrets.SPARKLE_ED_PUBLIC_KEY }}" \
           SIGN_IDENTITY="Developer ID Application" \
           RELEASE_ARCH_FLAGS="--arch x86_64" \


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for clean-up-version-tracking.md.

**Gap:** COMMIT_SHA not passed to build.sh release in CI
**What was expected:** CI-built macOS apps should have VellumCommitSHA in their Info.plist
**What was found:** COMMIT_SHA was only passed to build.sh binaries, not build.sh release, so the plist key was never written
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
