### PR TITLE
feat: redesign memory card to match skill card layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -418,7 +418,13 @@ struct MemoriesPanel: View {
             )
         } else {
             ScrollView {
-                LazyVStack(spacing: VSpacing.sm) {
+                LazyVGrid(
+                    columns: [
+                        GridItem(.flexible(), spacing: VSpacing.md),
+                        GridItem(.flexible(), spacing: VSpacing.md)
+                    ],
+                    spacing: VSpacing.md
+                ) {
                     ForEach(filteredItems) { item in
                         MemoryItemRow(
                             item: item,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -13,11 +13,7 @@ struct MemoryItemRow: View {
 
     var body: some View {
         Button(action: onSelect) {
-            HStack(alignment: .center, spacing: VSpacing.lg) {
-                // Kind icon
-                kindIcon
-
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
                     // Header row: badges + delete aligned to top
                     HStack(alignment: .center, spacing: VSpacing.sm) {
                         // Title + timestamp tightly grouped on the left
@@ -52,7 +48,6 @@ struct MemoryItemRow: View {
                         .foregroundColor(VColor.contentSecondary)
                         .lineLimit(2)
                         .frame(maxWidth: .infinity, minHeight: 28, alignment: .topLeading)
-                }
             }
             .padding(VSpacing.lg)
             .background(isHovered ? VColor.surfaceActive : Color.clear)
@@ -70,23 +65,6 @@ struct MemoryItemRow: View {
             Button("Delete", role: .destructive, action: onDelete)
         }
         .accessibilityElement(children: .combine)
-    }
-
-    // MARK: - Kind Icon
-
-    @ViewBuilder
-    private var kindIcon: some View {
-        if let kind = memoryKind, let icon = VIcon(rawValue: kind.icon) {
-            VIconView(icon, size: 20)
-                .foregroundColor(kind.color)
-                .frame(width: 40, height: 40)
-                .accessibilityHidden(true)
-        } else {
-            VIconView(.brain, size: 20)
-                .foregroundColor(VColor.contentTertiary)
-                .frame(width: 40, height: 40)
-                .accessibilityHidden(true)
-        }
     }
 
     // MARK: - Kind Tag

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -46,11 +46,12 @@ struct MemoryItemRow: View {
                             .accessibilityLabel("Delete memory")
                     }
 
+                    // Description — fixed 2-line height for uniform cards
                     Text(item.statement)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.contentTertiary)
-                        .lineLimit(1)
-                        .multilineTextAlignment(.leading)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentSecondary)
+                        .lineLimit(2)
+                        .frame(maxWidth: .infinity, minHeight: 28, alignment: .topLeading)
                 }
             }
             .padding(VSpacing.lg)
@@ -79,10 +80,12 @@ struct MemoryItemRow: View {
             VIconView(icon, size: 20)
                 .foregroundColor(kind.color)
                 .frame(width: 40, height: 40)
+                .accessibilityHidden(true)
         } else {
             VIconView(.brain, size: 20)
                 .foregroundColor(VColor.contentTertiary)
                 .frame(width: 40, height: 40)
+                .accessibilityHidden(true)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -7,20 +7,43 @@ struct MemoryItemRow: View {
     let onDelete: () -> Void
     @State private var isHovered = false
 
+    private var memoryKind: MemoryKind? {
+        MemoryKind(rawValue: item.kind)
+    }
+
     var body: some View {
         Button(action: onSelect) {
             HStack(alignment: .center, spacing: VSpacing.lg) {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    HStack(spacing: VSpacing.sm) {
-                        Text(item.subject)
-                            .font(VFont.bodyBold)
-                            .foregroundColor(VColor.contentDefault)
+                // Kind icon
+                kindIcon
+
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    // Header row: badges + delete aligned to top
+                    HStack(alignment: .center, spacing: VSpacing.sm) {
+                        // Title + timestamp tightly grouped on the left
+                        VStack(alignment: .leading, spacing: 0) {
+                            Text(item.subject)
+                                .font(VFont.bodyBold)
+                                .foregroundColor(VColor.contentDefault)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+
+                            Text(item.relativeLastSeen)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.contentTertiary)
+                                .padding(.top, -1)
+                        }
+
+                        Spacer()
 
                         kindTag
 
                         if let scopeLabel = item.scopeLabel {
-                            VBadge(label: scopeLabel, icon: .lock, tone: .neutral, emphasis: .subtle, shape: .rounded)
+                            VBadge(label: scopeLabel, icon: .lock, tone: .neutral, emphasis: .subtle, shape: .pill)
                         }
+
+                        VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerGhost, action: onDelete)
+                            .accessibilityLabel("Delete memory")
                     }
 
                     Text(item.statement)
@@ -29,15 +52,6 @@ struct MemoryItemRow: View {
                         .lineLimit(1)
                         .multilineTextAlignment(.leading)
                 }
-
-                Spacer()
-
-                Text(item.relativeLastSeen)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.contentTertiary)
-
-                VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerOutline, action: onDelete)
-                    .accessibilityLabel("Delete memory")
             }
             .padding(VSpacing.lg)
             .background(isHovered ? VColor.surfaceActive : Color.clear)
@@ -46,8 +60,10 @@ struct MemoryItemRow: View {
                     .stroke(VColor.borderDisabled, lineWidth: 2)
             )
             .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .pointerCursor()
         .onHover { isHovered = $0 }
         .contextMenu {
             Button("Delete", role: .destructive, action: onDelete)
@@ -55,14 +71,28 @@ struct MemoryItemRow: View {
         .accessibilityElement(children: .combine)
     }
 
+    // MARK: - Kind Icon
+
+    @ViewBuilder
+    private var kindIcon: some View {
+        if let kind = memoryKind, let icon = VIcon(rawValue: kind.icon) {
+            VIconView(icon, size: 20)
+                .foregroundColor(kind.color)
+                .frame(width: 40, height: 40)
+        } else {
+            VIconView(.brain, size: 20)
+                .foregroundColor(VColor.contentTertiary)
+                .frame(width: 40, height: 40)
+        }
+    }
+
     // MARK: - Kind Tag
 
     private var kindTag: some View {
-        let memoryKind = MemoryKind(rawValue: item.kind)
-        return VBadge(
+        VBadge(
             label: memoryKind?.label ?? item.kind.capitalized,
             color: memoryKind?.color ?? VColor.contentTertiary,
-            shape: .rounded
+            shape: .pill
         )
     }
 }


### PR DESCRIPTION
## Summary
- Add left-side kind icon (40×40) colored by memory type with brain fallback
- Move delete button into header row (top-right, matching skill card pattern)
- Place timestamp directly under title with minimal gap (-1pt padding)
- Switch badges from rounded to pill shape
- Display memories in 2-column grid layout (LazyVGrid)
- Add pointerCursor and contentShape for better interaction

## Test plan
- [ ] Verify memory cards show kind-specific icons (user, heart, folder, etc.)
- [ ] Verify delete button appears in header row, vertically centered
- [ ] Verify timestamp sits tight under title
- [ ] Verify 2-column grid layout
- [ ] Verify hover state and click targets work correctly
- [ ] Compare visually with skill cards for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
