### PR TITLE
fix: rename commit_sha Sentry tag to commit for consistency with daemon

### DIFF
--- a/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
+++ b/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
@@ -45,7 +45,7 @@ enum SentryDeviceInfo {
             }
             scope.setTag(value: ProcessInfo.processInfo.operatingSystemVersionString, key: "os_version")
             if let commitSHA = Bundle.main.infoDictionary?["VellumCommitSHA"] as? String, !commitSHA.isEmpty {
-                scope.setTag(value: commitSHA, key: "commit_sha")
+                scope.setTag(value: commitSHA, key: "commit")
             }
             if let clientVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
                 scope.setTag(value: clientVersion, key: "client_version")


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for clean-up-version-tracking.md.

**Gap:** Inconsistent Sentry tag name for commit SHA
**What was expected:** Consistent tag names across daemon and client
**What was found:** Daemon uses 'commit', client used 'commit_sha'
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
