### PR TITLE
fix: add path traversal guard to SoundManager sound file resolution

### DIFF
--- a/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
@@ -125,6 +125,18 @@ final class SoundManager {
             }
 
             let fileURL = soundsDirectoryURL.appendingPathComponent(filename)
+
+            // Guard against path traversal: ensure the resolved path stays within the sounds directory.
+            let resolvedPath = fileURL.standardizedFileURL.path
+            let safeDirPath = soundsDirectoryURL.standardizedFileURL.path
+            guard resolvedPath.hasPrefix(safeDirPath + "/") || resolvedPath == safeDirPath else {
+                log.warning("Sound filename '\(filename)' resolves outside the sounds directory, ignoring")
+                sound = defaultBlipSound()
+                sound.volume = config.volume
+                sound.play()
+                return
+            }
+
             guard FileManager.default.fileExists(atPath: fileURL.path) else {
                 log.warning("Sound file not found at '\(fileURL.path)', falling back to default")
                 sound = defaultBlipSound()


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for custom-sounds-mac.md.

**Gap:** Path traversal via unsanitized sound filename
**What was expected:** Sound filenames from config.json should be validated to prevent path traversal
**What was found:** Filenames passed directly to appendingPathComponent without sanitizing .. components

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
