### PR TITLE
fix: consolidate SoundManager lifecycle in AppDelegate and guard appOpen sound

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -154,6 +154,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     /// finished before the observer was registered.
     var localBootstrapDidComplete = false
 
+    /// Guards `.appOpen` sound so it fires only once per app session,
+    /// even if `proceedToApp()` is called again after assistant switches
+    /// or re-authentication flows.
+    private var hasPlayedAppOpenSound = false
+
     @AppStorage("themePreference") private var themePreference: String = "system"
 
     // MARK: - App Menu Name Patching
@@ -370,8 +375,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         applyThemePreference()
         registerBundledFonts()
         AvatarAppearanceManager.shared.start()
-        SoundManager.shared.start()
-        RandomSoundTimer.shared.start()
 
         #if DEBUG
         let skipOnboarding = CommandLine.arguments.contains("--skip-onboarding")
@@ -476,7 +479,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         setupAutoUpdate()
 
         SoundManager.shared.start()
-        SoundManager.shared.play(.appOpen)
+        RandomSoundTimer.shared.start()
+        if !hasPlayedAppOpenSound {
+            hasPlayedAppOpenSound = true
+            SoundManager.shared.play(.appOpen)
+        }
 
         // Ensure actor credentials are present. On first launch this performs
         // initial bootstrap; on subsequent launches it schedules proactive
@@ -584,7 +591,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         pulseTimer?.invalidate()
         pulseTimer = nil
         voiceInput?.stop()
-        SoundManager.shared.stop()
         ambientAgent.teardown()
         surfaceManager.dismissAll()
         toolConfirmationNotificationService.dismissAll()


### PR DESCRIPTION
## Summary
Fixes 3 gaps identified during plan review for custom-sounds-mac.md.

**Gap A:** Remove duplicate SoundManager.shared.start() — consolidate in proceedToApp()
**Gap B:** Remove duplicate SoundManager.shared.stop() in applicationWillTerminate
**Gap C:** Guard appOpen sound with a flag so it only plays once per app session

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
