### PR TITLE
fix: correct isFirstEmission guard in sound triggers and use instance-aware path for preview

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -2238,11 +2238,12 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         }
         .removeDuplicates()
         // Track previous state to detect transitions that trigger sounds.
-        // isFirstEmission prevents sounds from firing on initial subscription
+        // .dropFirst() prevents sounds from firing on initial subscription
         // (e.g. a conversation that loads in an error state).
-        .scan((previous: ConversationInteractionState?.none, current: ConversationInteractionState.idle, isFirstEmission: true)) { accumulated, newState in
-            (previous: accumulated.current, current: newState, isFirstEmission: false)
+        .scan((previous: ConversationInteractionState?.none, current: ConversationInteractionState.idle)) { accumulated, newState in
+            (previous: accumulated.current, current: newState)
         }
+        .dropFirst()
         .sink { [weak self] transition in
             guard let self else { return }
             let state = transition.current
@@ -2254,8 +2255,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
 
             // Play sounds on discrete state transitions. The .removeDuplicates()
             // upstream ensures these only fire once per transition, not on every
-            // streaming delta. Skip the first emission to avoid sounds on initial load.
-            guard !transition.isFirstEmission else { return }
+            // streaming delta.
             let previous = transition.previous
             switch state {
             case .idle where previous == .processing:

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsSoundsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsSoundsTab.swift
@@ -169,36 +169,12 @@ struct SettingsSoundsTab: View {
 
     /// Preview the default blip at the current volume, bypassing enabled checks.
     private func previewDefaultBlip() {
-        let blip = NSSound(named: "Tink") ?? NSSound()
-        blip.volume = soundManager.config.volume
-        blip.play()
+        soundManager.previewDefaultBlip()
     }
 
-    /// Preview the sound configured for a specific event. Loads the sound file
-    /// directly and plays it at the current volume, bypassing enabled checks.
+    /// Preview the sound configured for a specific event, delegating to
+    /// SoundManager which uses the instance-aware sounds directory.
     private func previewSound(for event: SoundEvent, eventConfig: SoundEventConfig) {
-        guard let filename = eventConfig.sound, !filename.isEmpty else {
-            previewDefaultBlip()
-            return
-        }
-
-        // Try to locate the sound file by scanning available sounds for a match.
-        // availableSounds() reads from SoundManager's resolved sounds directory.
-        let available = soundManager.availableSounds()
-        guard available.contains(where: { $0.filename == filename }) else {
-            previewDefaultBlip()
-            return
-        }
-
-        // The sound file exists in the sounds directory. Load via the default
-        // URL helper — for standard setups this resolves to the same directory.
-        let dirURL = SoundManager.defaultSoundsDirectoryURL()
-        let fileURL = dirURL.appendingPathComponent(filename)
-        if let sound = NSSound(contentsOf: fileURL, byReference: true) {
-            sound.volume = soundManager.config.volume
-            sound.play()
-        } else {
-            previewDefaultBlip()
-        }
+        soundManager.previewSound(for: event)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
@@ -155,6 +155,37 @@ final class SoundManager {
         sound.play()
     }
 
+    /// Preview the sound configured for a specific event at the current volume,
+    /// bypassing enabled checks. Uses the instance-aware `soundsDirectoryURL` so
+    /// previews resolve correctly for non-default assistant instances.
+    func previewSound(for event: SoundEvent) {
+        let eventConfig = config.config(for: event)
+        guard let filename = eventConfig.sound, !filename.isEmpty else {
+            previewDefaultBlip()
+            return
+        }
+
+        let fileURL = soundsDirectoryURL.appendingPathComponent(filename)
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            previewDefaultBlip()
+            return
+        }
+
+        if let sound = NSSound(contentsOf: fileURL, byReference: true) {
+            sound.volume = config.volume
+            sound.play()
+        } else {
+            previewDefaultBlip()
+        }
+    }
+
+    /// Preview the default blip at the current volume, bypassing enabled checks.
+    func previewDefaultBlip() {
+        let blip = NSSound(named: "Tink") ?? NSSound()
+        blip.volume = config.volume
+        blip.play()
+    }
+
     /// Returns the default blip sound (macOS system sound "Tink").
     private func defaultBlipSound() -> NSSound {
         if let cached = soundCache["__default_blip__"] {


### PR DESCRIPTION
## Summary
Fixes 2 gaps identified during plan review for custom-sounds-mac.md.

**Gap A:** isFirstEmission guard broken — Combine .scan never emits the seed value
**Gap B:** Settings preview uses hardcoded default directory, breaking multi-instance path invariant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
