### PR TITLE
fix: only play newConversation sound on user-initiated conversation creation

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -308,6 +308,7 @@ extension AppDelegate {
         window.actions = [
             CommandPaletteAction(id: "new-conversation", icon: VIcon.squarePen.rawValue, label: "New Conversation", shortcutHint: "\u{2318}N") { [weak self] in
                 self?.mainWindow?.conversationManager.createConversation()
+                SoundManager.shared.play(.newConversation)
                 if let id = self?.mainWindow?.conversationManager.activeConversationId {
                     self?.mainWindow?.windowState.selection = .conversation(id)
                 }
@@ -467,6 +468,7 @@ extension AppDelegate {
         ensureMainWindowExists()
         guard let mainWindow else { return }
         mainWindow.conversationManager.createConversation()
+        SoundManager.shared.play(.newConversation)
         if let conversationId = mainWindow.conversationManager.activeConversationId {
             mainWindow.windowState.selection = .conversation(conversationId)
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -380,6 +380,7 @@ extension AppDelegate {
         guard !isBootstrapping else { return }
         showMainWindow()
         mainWindow?.conversationManager.createConversation()
+        SoundManager.shared.play(.newConversation)
         if let id = mainWindow?.conversationManager.activeConversationId {
             mainWindow?.windowState.selection = .conversation(id)
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -610,6 +610,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     public func createNewConversation() {
         showMainWindow()
         mainWindow?.conversationManager.createConversation()
+        SoundManager.shared.play(.newConversation)
     }
 
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -344,8 +344,6 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         // Enter draft mode — conversation only appears in sidebar when the user sends
         // their first message (via promoteDraft triggered by onUserMessageSent).
         enterDraftMode()
-
-        SoundManager.shared.play(.newConversation)
     }
 
     /// Opens a conversation for interaction, optionally creating a new one and/or sending a message.

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -19,6 +19,7 @@ extension MainWindowView {
 
     func startNewConversation() {
         conversationManager.createConversation()
+        SoundManager.shared.play(.newConversation)
         if let id = conversationManager.activeConversationId {
             windowState.selection = .conversation(id)
         } else {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for custom-sounds-mac.md.

**Gap:** newConversation sound fires on programmatic conversation creation
**What was expected:** Sound only plays when user explicitly creates a new conversation
**What was found:** Sound plays unconditionally including during startup/restoration

Moved `SoundManager.shared.play(.newConversation)` out of `ConversationManager.createConversation()` and into the 5 user-initiated call sites:
- Sidebar "New Conversation" button
- Command palette "New Conversation" action
- Quick input submit
- Menu bar "New Chat"
- `AppDelegate.createNewConversation()`

Programmatic paths (ConversationRestorer, ensureActiveConversation, openConversation fallback, resolveConversationId) no longer trigger the sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
