### PR TITLE
fix: move notification sound after authorization check

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -233,13 +233,6 @@ extension AppDelegate {
         deepLinkMetadata: [String: AnyCodable]?,
         deliveryId: String? = nil
     ) {
-        // Play the custom notification sound in addition to the system notification sound.
-        // The system sound (`UNNotificationSound.default`) plays when the banner appears,
-        // while this custom sound plays immediately when the notification is posted.
-        // Both are kept so users get the system banner sound even if custom sounds are disabled,
-        // and the custom sound provides the configurable audio feedback from SoundManager.
-        SoundManager.shared.play(.notification)
-
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body
@@ -281,6 +274,12 @@ extension AppDelegate {
                 )
                 return
             }
+
+            // Play the custom notification sound only after confirming authorization.
+            // The system sound (`UNNotificationSound.default`) plays when the banner appears,
+            // while this custom sound provides the configurable audio feedback from SoundManager.
+            // Both are kept so users get the system banner sound even if custom sounds are disabled.
+            SoundManager.shared.play(.notification)
 
             do {
                 try await UNUserNotificationCenter.current().add(request)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for custom-sounds-mac.md.

**Gap:** Notification sound plays before authorization check
**What was expected:** Sound only plays after confirming notification authorization
**What was found:** Sound fires unconditionally before checkNotificationAuthorization()

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
