### PR TITLE
refactor: skip hooks discovery and execution when IS_CONTAINERIZED

### DIFF
--- a/assistant/src/hooks/manager.ts
+++ b/assistant/src/hooks/manager.ts
@@ -1,5 +1,6 @@
 import { type FSWatcher, watch } from "node:fs";
 
+import { getIsContainerized } from "../config/env-registry.js";
 import { Debouncer } from "../util/debounce.js";
 import { pathExists } from "../util/fs.js";
 import { getLogger } from "../util/logger.js";
@@ -32,6 +33,10 @@ export class HookManager {
   private readonly debouncer = new Debouncer(500);
 
   initialize(): void {
+    if (getIsContainerized()) {
+      log.info("Hooks disabled in containerized mode");
+      return;
+    }
     this.hooks = discoverHooks();
     this.buildEventIndex();
     const enabled = this.hooks.filter((h) => h.enabled).length;
@@ -107,6 +112,7 @@ export class HookManager {
   }
 
   reload(): void {
+    if (getIsContainerized()) return;
     this.hooks = discoverHooks();
     this.buildEventIndex();
     const enabled = this.hooks.filter((h) => h.enabled).length;
@@ -114,6 +120,7 @@ export class HookManager {
   }
 
   watch(): void {
+    if (getIsContainerized()) return;
     const hooksDir = getHooksDir();
     if (!pathExists(hooksDir)) return;
 

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -8,7 +8,7 @@ import {
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { getBaseDataDir } from "../config/env-registry.js";
+import { getBaseDataDir, getIsContainerized } from "../config/env-registry.js";
 
 export function isMacOS(): boolean {
   return process.platform === "darwin";
@@ -422,13 +422,15 @@ export function ensureDataDir(): void {
   const root = getRootDir();
   const workspace = getWorkspaceDir();
   const wsData = join(workspace, "data");
+  const containerized = getIsContainerized();
   const dirs = [
     // Root-level dirs (runtime / protected)
     root,
     join(root, "protected"),
     // Workspace dirs
     workspace,
-    join(root, "hooks"),
+    // Hooks are a local-only concept — skip in containerized mode
+    ...(containerized ? [] : [join(root, "hooks")]),
     join(workspace, "skills"),
     join(workspace, "embedding-models"),
     join(workspace, "conversations"),


### PR DESCRIPTION
## Summary
- Skip hook discovery, file watching, and execution when IS_CONTAINERIZED
- Skip hooks/ directory creation when containerized
- Hooks are a local-only concept; Docker instances don't use them

Part of plan: docker-volume-security.md (PR 4 of 35)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
