### PR TITLE
Add serviceGroupVersion and containerInfo fields to AssistantEntry

### DIFF
--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -34,6 +34,21 @@ export interface LocalInstanceResources {
   [key: string]: unknown;
 }
 
+/** Docker image metadata for the service group. Enables rollback to known-good digests. */
+export interface ContainerInfo {
+  assistantImage: string;
+  gatewayImage: string;
+  cesImage: string;
+  /** sha256 digest of the assistant image at time of hatch/upgrade */
+  assistantDigest?: string;
+  /** sha256 digest of the gateway image at time of hatch/upgrade */
+  gatewayDigest?: string;
+  /** sha256 digest of the CES image at time of hatch/upgrade */
+  cesDigest?: string;
+  /** Docker network name for the service group */
+  networkName?: string;
+}
+
 export interface AssistantEntry {
   assistantId: string;
   runtimeUrl: string;
@@ -56,6 +71,10 @@ export interface AssistantEntry {
   resources?: LocalInstanceResources;
   /** PID of the file watcher process for docker instances hatched with --watch. */
   watcherPid?: number;
+  /** Last-known version of the service group, populated at hatch and updated by health checks. */
+  serviceGroupVersion?: string;
+  /** Docker image metadata for rollback. Only present for docker topology entries. */
+  containerInfo?: ContainerInfo;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
- Add ContainerInfo interface for Docker image metadata (tags, digests, network)
- Add optional serviceGroupVersion field to AssistantEntry
- Add optional containerInfo field to AssistantEntry
- Purely additive type definitions; no behavioral changes

Part of plan: lockfile-service-group-topology.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
