### PR TITLE
refactor: move guardian-init.lock to gateway security volume

### DIFF
--- a/gateway/src/http/routes/channel-verification-session-proxy.ts
+++ b/gateway/src/http/routes/channel-verification-session-proxy.ts
@@ -150,7 +150,8 @@ export function createChannelVerificationSessionProxyHandler(
       req: Request,
       clientIp?: string,
     ): Promise<Response> {
-      const lockPath = join(getRootDir(), "guardian-init.lock");
+      const lockDir = process.env.GATEWAY_SECURITY_DIR || getRootDir();
+      const lockPath = join(lockDir, "guardian-init.lock");
       if (existsSync(lockPath) || guardianInitInFlight) {
         log.warn("Guardian init rejected — already bootstrapped");
         return Response.json(


### PR DESCRIPTION
## Summary
- Resolve guardian-init.lock path from GATEWAY_SECURITY_DIR when set
- Falls back to existing path when env var not set
- Lock file is gateway-owned state and belongs on the gateway security volume

Part of plan: docker-volume-security.md (PR 28 of 35)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
