### PR TITLE
refactor: extract TrustRule types to ces-contracts for cross-package use

### DIFF
--- a/packages/ces-contracts/src/index.ts
+++ b/packages/ces-contracts/src/index.ts
@@ -145,3 +145,4 @@ export * from "./handles.js";
 export * from "./grants.js";
 export * from "./rpc.js";
 export * from "./rendering.js";
+export * from "./trust-rules.js";

--- a/packages/ces-contracts/src/trust-rules.ts
+++ b/packages/ces-contracts/src/trust-rules.ts
@@ -1,0 +1,42 @@
+/**
+ * Trust rule types shared between the assistant daemon and the gateway.
+ *
+ * These are extracted from `assistant/src/permissions/types.ts` and
+ * `assistant/src/permissions/trust-store.ts` so that both packages can
+ * reference a single canonical definition.
+ */
+
+// ---------------------------------------------------------------------------
+// Trust decision
+// ---------------------------------------------------------------------------
+
+/** The possible decisions a trust rule can make. */
+export type TrustDecision = "allow" | "deny" | "ask";
+
+// ---------------------------------------------------------------------------
+// Trust rule
+// ---------------------------------------------------------------------------
+
+export interface TrustRule {
+  id: string;
+  tool: string;
+  pattern: string;
+  scope: string;
+  decision: TrustDecision;
+  priority: number;
+  createdAt: number;
+  executionTarget?: string;
+  allowHighRisk?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Trust file (on-disk shape)
+// ---------------------------------------------------------------------------
+
+/** Shape of the `trust.json` file persisted to disk. */
+export interface TrustFileData {
+  version: number;
+  rules: TrustRule[];
+  /** Set to true when the user explicitly accepts the starter approval bundle. */
+  starterBundleAccepted?: boolean;
+}


### PR DESCRIPTION
## Summary
- Extract TrustRule, TrustDecision, and TrustFileData types to packages/ces-contracts
- Both assistant and gateway can now share these types
- Enables gateway to own trust rules in containerized mode

Part of plan: docker-volume-security.md (PR 10 of 35)