### PR TITLE
feat: support WORKSPACE_DIR env var for explicit workspace path

### DIFF
--- a/assistant/src/config/env-registry.ts
+++ b/assistant/src/config/env-registry.ts
@@ -54,6 +54,15 @@ export function getIsContainerized(): boolean {
   return flag("IS_CONTAINERIZED");
 }
 
+/**
+ * WORKSPACE_DIR — string, default: undefined
+ * When set, overrides the default workspace directory. Used in containerized
+ * deployments where the workspace is a separate volume.
+ */
+export function getWorkspaceDirOverride(): string | undefined {
+  return str("WORKSPACE_DIR");
+}
+
 // ── Known env var names ──────────────────────────────────────────────────────
 
 /**

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -8,7 +8,11 @@ import {
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { getBaseDataDir, getIsContainerized } from "../config/env-registry.js";
+import {
+  getBaseDataDir,
+  getIsContainerized,
+  getWorkspaceDirOverride,
+} from "../config/env-registry.js";
 
 export function isMacOS(): boolean {
   return process.platform === "darwin";
@@ -365,13 +369,19 @@ export function getSignalsDir(): string {
 // Currently not used by call-sites; wired in later PRs.
 
 /**
- * Returns ~/.vellum/workspace — the workspace root for user-facing state.
+ * Returns the workspace root for user-facing state.
+ *
+ * When the WORKSPACE_DIR env var is set, returns that value (used in
+ * containerized deployments where the workspace is a separate volume).
+ * Otherwise falls back to ~/.vellum/workspace.
  *
  * WARNING: The entire workspace directory is included in diagnostic log exports
  * ("Send logs to Vellum"). Do not store secrets, API keys, or sensitive
  * credentials here — use the credential store or ~/.vellum/protected/ instead.
  */
 export function getWorkspaceDir(): string {
+  const override = getWorkspaceDirOverride();
+  if (override) return override;
   return join(getRootDir(), "workspace");
 }
 


### PR DESCRIPTION
## Summary
- Add `WORKSPACE_DIR` env var support to override workspace directory path
- When set, `getWorkspaceDir()` returns the `WORKSPACE_DIR` value instead of `~/.vellum/workspace`
- All downstream paths (`getDataDir`, `getDbPath`, etc.) correctly derive from the new workspace dir

Part of plan: docker-volume-security.md (PR 6 of 35)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19839" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
