### PR TITLE
Add DEFAULT_CES_PORT constant and cesPort field to LocalInstanceResources

### DIFF
--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 
 import {
   DAEMON_INTERNAL_ASSISTANT_ID,
+  DEFAULT_CES_PORT,
   DEFAULT_DAEMON_PORT,
   DEFAULT_GATEWAY_PORT,
   DEFAULT_QDRANT_PORT,
@@ -29,6 +30,8 @@ export interface LocalInstanceResources {
   gatewayPort: number;
   /** HTTP port for the Qdrant vector store */
   qdrantPort: number;
+  /** HTTP port for the CES (Claude Extension Server) */
+  cesPort: number;
   /** Absolute path to the daemon PID file */
   pidFile: string;
   [key: string]: unknown;
@@ -166,6 +169,7 @@ export function migrateLegacyEntry(raw: Record<string, unknown>): boolean {
       daemonPort: DEFAULT_DAEMON_PORT,
       gatewayPort,
       qdrantPort: DEFAULT_QDRANT_PORT,
+      cesPort: DEFAULT_CES_PORT,
       pidFile: join(instanceDir, ".vellum", "vellum.pid"),
     };
     mutated = true;
@@ -196,6 +200,10 @@ export function migrateLegacyEntry(raw: Record<string, unknown>): boolean {
     }
     if (typeof res.qdrantPort !== "number") {
       res.qdrantPort = DEFAULT_QDRANT_PORT;
+      mutated = true;
+    }
+    if (typeof res.cesPort !== "number") {
+      res.cesPort = DEFAULT_CES_PORT;
       mutated = true;
     }
     if (typeof res.pidFile !== "string") {
@@ -373,6 +381,7 @@ export async function allocateLocalResources(
       daemonPort: DEFAULT_DAEMON_PORT,
       gatewayPort: DEFAULT_GATEWAY_PORT,
       qdrantPort: DEFAULT_QDRANT_PORT,
+      cesPort: DEFAULT_CES_PORT,
       pidFile: join(vellumDir, "vellum.pid"),
     };
   }
@@ -423,6 +432,7 @@ export async function allocateLocalResources(
     daemonPort,
     gatewayPort,
     qdrantPort,
+    cesPort: DEFAULT_CES_PORT,
     pidFile: join(instanceDir, ".vellum", "vellum.pid"),
   };
 }

--- a/cli/src/lib/constants.ts
+++ b/cli/src/lib/constants.ts
@@ -16,6 +16,7 @@ export const GATEWAY_PORT = process.env.GATEWAY_PORT
 export const DEFAULT_DAEMON_PORT = 7821;
 export const DEFAULT_GATEWAY_PORT = 7830;
 export const DEFAULT_QDRANT_PORT = 6333;
+export const DEFAULT_CES_PORT = 8090;
 
 /**
  * Environment variable names for provider API keys, keyed by provider ID.


### PR DESCRIPTION
## Summary
- Add DEFAULT_CES_PORT (8090) constant to cli/src/lib/constants.ts
- Add cesPort field to LocalInstanceResources interface
- Backfill cesPort via one-time migration in migrateLegacyEntry
- Include cesPort in allocateLocalResources

Part of plan: lockfile-service-group-topology.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
