### PR TITLE
refactor: store embed-worker.pid in assistant-local path when containerized

### DIFF
--- a/assistant/src/memory/embedding-local.ts
+++ b/assistant/src/memory/embedding-local.ts
@@ -1,6 +1,7 @@
 import { existsSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { getIsContainerized } from "../config/env-registry.js";
 import { getLogger } from "../util/logger.js";
 import { getEmbeddingModelsDir, getRootDir } from "../util/platform.js";
 import { PromiseGuard } from "../util/promise-guard.js";
@@ -353,12 +354,17 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
 
   private static readonly PID_FILENAME = "embed-worker.pid";
 
+  /** PID files are process-local state — store in /tmp when containerized to keep shared volumes clean. */
+  private getPidFilePath(): string {
+    if (getIsContainerized()) {
+      return join("/tmp", LocalEmbeddingBackend.PID_FILENAME);
+    }
+    return join(getRootDir(), LocalEmbeddingBackend.PID_FILENAME);
+  }
+
   private writePidFile(pid: number): void {
     try {
-      writeFileSync(
-        join(getRootDir(), LocalEmbeddingBackend.PID_FILENAME),
-        String(pid),
-      );
+      writeFileSync(this.getPidFilePath(), String(pid));
     } catch {
       // Best-effort — doesn't affect functionality
     }
@@ -366,7 +372,7 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
 
   private removePidFile(): void {
     try {
-      unlinkSync(join(getRootDir(), LocalEmbeddingBackend.PID_FILENAME));
+      unlinkSync(this.getPidFilePath());
     } catch {
       // Best-effort
     }


### PR DESCRIPTION
## Summary
- Move embed-worker.pid to /tmp when IS_CONTAINERIZED
- PID files are process-local state and don't belong on shared volumes
- No change for local (non-Docker) installs

Part of plan: docker-volume-security.md (PR 27 of 35)