### PR TITLE
refactor: skip signal file IPC when IS_CONTAINERIZED

### DIFF
--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -12,6 +12,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
+import { getIsContainerized } from "../config/env-registry.js";
 import { getConfig, invalidateConfigCache } from "../config/loader.js";
 import { clearEmbeddingBackendCache } from "../memory/embedding-backend.js";
 import { clearCache as clearTrustCache } from "../permissions/trust-store.js";
@@ -209,7 +210,9 @@ export class ConfigWatcher {
       );
     }
 
-    this.startSignalsWatcher();
+    if (!getIsContainerized()) {
+      this.startSignalsWatcher();
+    }
     this.startSkillsWatchers(onConversationEvict);
   }
 

--- a/assistant/src/signals/bash.ts
+++ b/assistant/src/signals/bash.ts
@@ -20,6 +20,7 @@ import { spawn } from "node:child_process";
 import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { getIsContainerized } from "../config/env-registry.js";
 import { getLogger } from "../util/logger.js";
 import { getSignalsDir, getWorkspaceDir } from "../util/platform.js";
 
@@ -65,6 +66,8 @@ function writeResult(requestId: string, result: BashSignalResult): void {
  * when a matching signal file is created or modified.
  */
 export function handleBashSignal(filename: string): void {
+  if (getIsContainerized()) return;
+
   if (!isDebugMode()) {
     log.warn(
       { filename },

--- a/assistant/src/signals/cancel.ts
+++ b/assistant/src/signals/cancel.ts
@@ -13,6 +13,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { getIsContainerized } from "../config/env-registry.js";
 import { getLogger } from "../util/logger.js";
 import { getSignalsDir } from "../util/platform.js";
 
@@ -39,6 +40,8 @@ export function registerCancelCallback(cb: CancelCallback): void {
  * Called by ConfigWatcher when the signal file is written or modified.
  */
 export function handleCancelSignal(): void {
+  if (getIsContainerized()) return;
+
   try {
     const content = readFileSync(join(getSignalsDir(), "cancel"), "utf-8");
     const parsed = JSON.parse(content) as { conversationId?: string };

--- a/assistant/src/signals/confirm.ts
+++ b/assistant/src/signals/confirm.ts
@@ -10,6 +10,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { getIsContainerized } from "../config/env-registry.js";
 import type { UserDecision } from "../permissions/types.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { getLogger } from "../util/logger.js";
@@ -37,6 +38,8 @@ function isUserDecision(value: string): value is UserDecision {
  * Called by ConfigWatcher when the signal file is written or modified.
  */
 export function handleConfirmationSignal(): void {
+  if (getIsContainerized()) return;
+
   try {
     const content = readFileSync(join(getSignalsDir(), "confirm"), "utf-8");
     const parsed = JSON.parse(content) as {

--- a/assistant/src/signals/conversation-undo.ts
+++ b/assistant/src/signals/conversation-undo.ts
@@ -16,6 +16,7 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { getIsContainerized } from "../config/env-registry.js";
 import { getLogger } from "../util/logger.js";
 import { getSignalsDir } from "../util/platform.js";
 
@@ -46,6 +47,8 @@ export function registerConversationUndoCallback(cb: UndoCallback): void {
  * file is written.
  */
 export async function handleConversationUndoSignal(): Promise<void> {
+  if (getIsContainerized()) return;
+
   const resultPath = join(getSignalsDir(), "conversation-undo.result");
 
   const writeResult = (

--- a/assistant/src/signals/event-stream.ts
+++ b/assistant/src/signals/event-stream.ts
@@ -24,6 +24,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
+import { getIsContainerized } from "../config/env-registry.js";
 import type { AssistantEvent } from "../runtime/assistant-event.js";
 import { getSignalsDir } from "../util/platform.js";
 
@@ -86,6 +87,8 @@ export function appendEventToStream(
   conversationId: string,
   event: AssistantEvent,
 ): void {
+  if (getIsContainerized()) return;
+
   const dirs = getSubscriberDirs(conversationId);
   if (dirs.length === 0) return;
 
@@ -130,6 +133,10 @@ export function watchEventStream(
   conversationId: string,
   callback: (event: AssistantEvent) => void,
 ): EventStreamWatcher {
+  if (getIsContainerized()) {
+    return { dispose() {} };
+  }
+
   const parentDir = eventsDir();
   mkdirSync(parentDir, { recursive: true });
   const subDir = join(parentDir, `${conversationId}.${process.pid}`);

--- a/assistant/src/signals/shotgun.ts
+++ b/assistant/src/signals/shotgun.ts
@@ -15,6 +15,7 @@ import crypto from "node:crypto";
 import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { getIsContainerized } from "../config/env-registry.js";
 import {
   fireWatchCompletionNotifier,
   fireWatchStartNotifier,
@@ -54,6 +55,8 @@ function writeResult(requestId: string, result: ShotgunResult): void {
  * when a matching signal file is created or modified.
  */
 export function handleShotgunSignal(filename: string): void {
+  if (getIsContainerized()) return;
+
   const signalPath = join(getSignalsDir(), filename);
   let raw: string;
   try {

--- a/assistant/src/signals/trust-rule.ts
+++ b/assistant/src/signals/trust-rule.ts
@@ -12,6 +12,7 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { getIsContainerized } from "../config/env-registry.js";
 import { addRule } from "../permissions/trust-store.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { getTool } from "../tools/registry.js";
@@ -27,6 +28,8 @@ const VALID_TRUST_DECISIONS: ReadonlySet<string> = new Set(["allow", "deny"]);
  * Called by ConfigWatcher when the signal file is written or modified.
  */
 export function handleTrustRuleSignal(): void {
+  if (getIsContainerized()) return;
+
   const resultPath = join(getSignalsDir(), "trust-rule.result");
 
   const writeError = (requestId: string | undefined, error: string): void => {


### PR DESCRIPTION
## Summary
- Skip signals directory creation and file watchers when IS_CONTAINERIZED
- Add early-return guards in signal handlers when containerized
- File-based IPC only used by local CLI; Docker instances use HTTP via gateway

Part of plan: docker-volume-security.md (PR 3 of 35)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
