### PR TITLE
fix: remove Uint8Array cast in restore command to fix type error

### DIFF
--- a/cli/src/commands/restore.ts
+++ b/cli/src/commands/restore.ts
@@ -141,7 +141,7 @@ export async function restore(): Promise<void> {
   }
 
   // Read the .vbundle file
-  const bundleData = readFileSync(fromPath) as unknown as Uint8Array;
+  const bundleData = readFileSync(fromPath);
   const sizeMB = (bundleData.byteLength / (1024 * 1024)).toFixed(2);
   console.log(`Reading ${fromPath} (${sizeMB} MB)...`);
 


### PR DESCRIPTION
## Summary
- Remove the `as unknown as Uint8Array` cast from `readFileSync()` in `cli/src/commands/restore.ts`
- `readFileSync` returns `Buffer` which is already valid as `BodyInit` for `fetch()` and has `.byteLength` — the cast was unnecessary and caused TS2769 type errors

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23322191745/job/67835671356