### PR TITLE
feat: support WORKSPACE_DIR env var in gateway config resolution

### DIFF
--- a/gateway/src/config-file-cache.ts
+++ b/gateway/src/config-file-cache.ts
@@ -8,7 +8,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { getRootDir } from "./credential-reader.js";
+import { getWorkspaceDir } from "./credential-reader.js";
 
 const DEFAULT_TTL_MS = 1000;
 
@@ -55,7 +55,7 @@ export class ConfigFileCache {
 
   constructor(opts?: { ttlMs?: number }) {
     this.ttlMs = opts?.ttlMs ?? DEFAULT_TTL_MS;
-    this.configPath = join(getRootDir(), "workspace", "config.json");
+    this.configPath = join(getWorkspaceDir(), "config.json");
   }
 
   /** Read the config file if the cached snapshot is stale or force is set. */

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { getLogger, type LogFileConfig } from "./logger.js";
-import { getRootDir } from "./credential-reader.js";
+import { getWorkspaceDir } from "./credential-reader.js";
 
 const log = getLogger("config");
 
@@ -43,7 +43,7 @@ type RoutingEntry = {
  */
 function readWorkspaceConfig(): Record<string, unknown> {
   try {
-    const configPath = join(getRootDir(), "workspace", "config.json");
+    const configPath = join(getWorkspaceDir(), "config.json");
     if (!existsSync(configPath)) return {};
     const raw = readFileSync(configPath, "utf-8");
     const data = JSON.parse(raw);

--- a/gateway/src/credential-reader.ts
+++ b/gateway/src/credential-reader.ts
@@ -137,18 +137,25 @@ export function getRootDir(): string {
   );
 }
 
+/**
+ * Returns the workspace root for user-facing state.
+ *
+ * When the WORKSPACE_DIR env var is set, returns that value (used in
+ * containerized deployments where the workspace is a separate volume).
+ * Otherwise falls back to ~/.vellum/workspace.
+ */
+export function getWorkspaceDir(): string {
+  const override = process.env.WORKSPACE_DIR?.trim();
+  if (override) return override;
+  return join(getRootDir(), "workspace");
+}
+
 export function getEncryptedStorePath(): string {
   return join(getRootDir(), "protected", "keys.enc");
 }
 
 export function getMetadataPath(): string {
-  return join(
-    getRootDir(),
-    "workspace",
-    "data",
-    "credentials",
-    "metadata.json",
-  );
+  return join(getWorkspaceDir(), "data", "credentials", "metadata.json");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add WORKSPACE_DIR env var support to gateway config, credential-reader, and credential-watcher
- When set, config.json and metadata.json are resolved from WORKSPACE_DIR instead of BASE_DATA_DIR
- Existing behavior unchanged when WORKSPACE_DIR is unset

Part of plan: docker-volume-security.md (PR 7 of 35)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19846" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
