### PR TITLE
feat: configure CES security volume for keys.enc and store.key

### DIFF
--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -282,6 +282,7 @@ export function dockerResourceNames(instanceName: string) {
   return {
     assistantContainer: `${instanceName}-assistant`,
     cesContainer: `${instanceName}-credential-executor`,
+    cesSecurityVolume: `${instanceName}-ces-sec`,
     dataVolume: `${instanceName}-data`,
     gatewayContainer: `${instanceName}-gateway`,
     network: `${instanceName}-net`,
@@ -336,7 +337,7 @@ export async function retireDocker(name: string): Promise<void> {
   } catch {
     // network may not exist
   }
-  for (const vol of [res.dataVolume, res.socketVolume, res.workspaceVolume]) {
+  for (const vol of [res.dataVolume, res.socketVolume, res.workspaceVolume, res.cesSecurityVolume]) {
     try {
       await exec("docker", ["volume", "rm", vol]);
     } catch {
@@ -538,6 +539,8 @@ export function serviceDockerRunArgs(opts: {
       `${res.dataVolume}:/data:ro`,
       "-v",
       `${res.workspaceVolume}:/workspace:ro`,
+      "-v",
+      `${res.cesSecurityVolume}:/ces-security`,
       "-e",
       "CES_MODE=managed",
       "-e",
@@ -546,6 +549,8 @@ export function serviceDockerRunArgs(opts: {
       "CES_BOOTSTRAP_SOCKET_DIR=/run/ces-bootstrap",
       "-e",
       "CES_ASSISTANT_DATA_MOUNT=/data",
+      "-e",
+      "CREDENTIAL_SECURITY_DIR=/ces-security",
       imageTags["credential-executor"],
     ],
   };
@@ -886,6 +891,7 @@ export async function hatchDocker(
     await exec("docker", ["volume", "create", res.dataVolume]);
     await exec("docker", ["volume", "create", res.socketVolume]);
     await exec("docker", ["volume", "create", res.workspaceVolume]);
+    await exec("docker", ["volume", "create", res.cesSecurityVolume]);
 
     await startContainers({ gatewayPort, imageTags, instanceName, res }, log);
 

--- a/credential-executor/Dockerfile
+++ b/credential-executor/Dockerfile
@@ -49,6 +49,9 @@ COPY --from=builder --chown=ces:ces /app /app
 # when no PVC volume is mounted (e.g., direct docker run)
 RUN mkdir -p /ces-data && chown ces:ces /ces-data
 
+# Pre-create /ces-security for credential key storage (keys.enc, store.key)
+RUN mkdir -p /ces-security && chown ces:ces /ces-security
+
 USER ces
 
 EXPOSE 8090


### PR DESCRIPTION
## Summary
- Add CES security volume (`<instance>-ces-sec`) to Docker resource names
- Create CES security volume during `hatch` and clean it up during `retire`
- Mount CES security volume at `/ces-security` in CES container
- Set `CREDENTIAL_SECURITY_DIR=/ces-security` env var for CES
- Add `/ces-security` directory with proper `ces:ces` ownership in CES Dockerfile

Part of plan: docker-volume-security.md (PR 19 of 35)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
