### PR TITLE
fix: add path traversal and extension validation to previewSound(for:)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
@@ -102,6 +102,37 @@ final class SoundManager {
         }
     }
 
+    // MARK: - Sound Resolution
+
+    /// Validates a custom sound filename (extension check + path traversal guard) and returns
+    /// the resolved file URL if it passes. Returns `nil` if the filename has an unsupported
+    /// extension, attempts path traversal outside the sounds directory, or does not exist on disk.
+    private func resolveCustomSoundURL(filename: String) -> URL? {
+        // Validate the file extension is supported.
+        let ext = (filename as NSString).pathExtension.lowercased()
+        guard supportedSoundExtensions.contains(ext) else {
+            log.warning("Unsupported sound file extension '\(ext)' for '\(filename)', rejecting")
+            return nil
+        }
+
+        let fileURL = soundsDirectoryURL.appendingPathComponent(filename)
+
+        // Guard against path traversal: ensure the resolved path stays within the sounds directory.
+        let resolvedPath = fileURL.standardizedFileURL.path
+        let safeDirPath = soundsDirectoryURL.standardizedFileURL.path
+        guard resolvedPath.hasPrefix(safeDirPath + "/") || resolvedPath == safeDirPath else {
+            log.warning("Sound filename '\(filename)' resolves outside the sounds directory, ignoring")
+            return nil
+        }
+
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            log.warning("Sound file not found at '\(fileURL.path)'")
+            return nil
+        }
+
+        return fileURL
+    }
+
     // MARK: - Playback
 
     /// Plays the sound associated with the given event, respecting global and per-event toggles.
@@ -114,31 +145,7 @@ final class SoundManager {
         let sound: NSSound
 
         if let filename = eventConfig.sound {
-            // Validate the file extension is supported.
-            let ext = (filename as NSString).pathExtension.lowercased()
-            guard supportedSoundExtensions.contains(ext) else {
-                log.warning("Unsupported sound file extension '\(ext)' for '\(filename)', falling back to default")
-                sound = defaultBlipSound()
-                sound.volume = config.volume
-                sound.play()
-                return
-            }
-
-            let fileURL = soundsDirectoryURL.appendingPathComponent(filename)
-
-            // Guard against path traversal: ensure the resolved path stays within the sounds directory.
-            let resolvedPath = fileURL.standardizedFileURL.path
-            let safeDirPath = soundsDirectoryURL.standardizedFileURL.path
-            guard resolvedPath.hasPrefix(safeDirPath + "/") || resolvedPath == safeDirPath else {
-                log.warning("Sound filename '\(filename)' resolves outside the sounds directory, ignoring")
-                sound = defaultBlipSound()
-                sound.volume = config.volume
-                sound.play()
-                return
-            }
-
-            guard FileManager.default.fileExists(atPath: fileURL.path) else {
-                log.warning("Sound file not found at '\(fileURL.path)', falling back to default")
+            guard let fileURL = resolveCustomSoundURL(filename: filename) else {
                 sound = defaultBlipSound()
                 sound.volume = config.volume
                 sound.play()
@@ -177,8 +184,7 @@ final class SoundManager {
             return
         }
 
-        let fileURL = soundsDirectoryURL.appendingPathComponent(filename)
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+        guard let fileURL = resolveCustomSoundURL(filename: filename) else {
             previewDefaultBlip()
             return
         }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review round 2 for custom-sounds-mac.md.

**Gap:** previewSound(for:) missing path traversal and extension validation guards
**What was expected:** Same validation as play() — extension check + path traversal guard
**Fix:** Extracted validation into resolveCustomSoundURL() helper used by both methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
