### PR TITLE
fix: add missing cesPort to migration test fixture

### DIFF
--- a/cli/src/__tests__/assistant-config.test.ts
+++ b/cli/src/__tests__/assistant-config.test.ts
@@ -328,6 +328,7 @@ describe("migrateLegacyEntry", () => {
         daemonPort: 8000,
         gatewayPort: 8001,
         qdrantPort: 8002,
+        cesPort: 8090,
         pidFile: "/my/path/.vellum/vellum.pid",
       },
     };


### PR DESCRIPTION
## Summary
- The `migrateLegacyEntry > does not overwrite existing resources fields` test was failing because its "complete" resources fixture was missing `cesPort`, which was recently added to `LocalInstanceResources`
- The migration backfill logic for `cesPort` triggered, returning `mutated = true` instead of the expected `false`
- Added `cesPort: 8090` to the test fixture so it's truly complete

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23322305138/job/67836013068
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
