### PR TITLE
feat: add trust rule CRUD endpoints to gateway

### DIFF
--- a/gateway/bun.lock
+++ b/gateway/bun.lock
@@ -6,11 +6,14 @@
       "name": "vellum-gateway",
       "dependencies": {
         "file-type": "^21.3.0",
+        "minimatch": "^10.2.4",
         "pino": "^9.6.0",
         "pino-pretty": "^13.1.3",
+        "uuid": "^13.0.0",
       },
       "devDependencies": {
         "@types/bun": "^1.2.4",
+        "@types/uuid": "^11.0.0",
         "eslint": "^10.0.0",
         "knip": "^5.83.1",
         "prettier": "^3.8.1",
@@ -117,6 +120,8 @@
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
+
+    "@types/uuid": ["@types/uuid@11.0.0", "", { "dependencies": { "uuid": "*" } }, "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.56.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.56.0", "@typescript-eslint/type-utils": "8.56.0", "@typescript-eslint/utils": "8.56.0", "@typescript-eslint/visitor-keys": "8.56.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.56.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw=="],
 
@@ -262,7 +267,7 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
-    "minimatch": ["minimatch@10.2.0", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w=="],
+    "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
@@ -362,6 +367,8 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
+    "uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
+
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -376,9 +383,13 @@
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
+    "@eslint/config-array/minimatch": ["minimatch@10.2.0", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w=="],
+
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "eslint/minimatch": ["minimatch@10.2.0", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -23,11 +23,14 @@
   },
   "dependencies": {
     "file-type": "^21.3.0",
+    "minimatch": "^10.2.4",
     "pino": "^9.6.0",
-    "pino-pretty": "^13.1.3"
+    "pino-pretty": "^13.1.3",
+    "uuid": "^13.0.0"
   },
   "devDependencies": {
     "@types/bun": "^1.2.4",
+    "@types/uuid": "^11.0.0",
     "eslint": "^10.0.0",
     "knip": "^5.83.1",
     "prettier": "^3.8.1",

--- a/gateway/src/http/routes/trust-rules.ts
+++ b/gateway/src/http/routes/trust-rules.ts
@@ -1,0 +1,338 @@
+/**
+ * Trust rule CRUD endpoints for the gateway.
+ *
+ * All endpoints require "edge" auth. The assistant daemon will call these
+ * endpoints instead of reading trust.json directly once the migration is
+ * complete (PR 14-16 in the docker-volume-security plan).
+ */
+
+import { getLogger } from "../../logger.js";
+import {
+  addRule,
+  updateRule,
+  removeRule,
+  clearRules,
+  getAllRules,
+  findMatchingRule,
+  findHighestPriorityRule,
+  acceptStarterBundle,
+  type TrustDecision,
+} from "../../trust-store.js";
+
+const log = getLogger("trust-rules");
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+function isValidDecision(value: unknown): value is TrustDecision {
+  return value === "allow" || value === "deny" || value === "ask";
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/trust-rules — list all rules
+// ---------------------------------------------------------------------------
+
+export function createTrustRulesListHandler() {
+  return async (_req: Request): Promise<Response> => {
+    try {
+      const rules = getAllRules();
+      return Response.json({ rules });
+    } catch (err) {
+      log.error({ err }, "Failed to list trust rules");
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/trust-rules — add rule
+// ---------------------------------------------------------------------------
+
+export function createTrustRulesAddHandler() {
+  return async (req: Request): Promise<Response> => {
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return Response.json(
+        { error: "Request body must be valid JSON" },
+        { status: 400 },
+      );
+    }
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return Response.json(
+        { error: "Request body must be a JSON object" },
+        { status: 400 },
+      );
+    }
+
+    const { tool, pattern, scope, decision, priority, allowHighRisk, executionTarget } =
+      body as Record<string, unknown>;
+
+    if (typeof tool !== "string" || !tool) {
+      return Response.json(
+        { error: '"tool" must be a non-empty string' },
+        { status: 400 },
+      );
+    }
+    if (typeof pattern !== "string" || !pattern) {
+      return Response.json(
+        { error: '"pattern" must be a non-empty string' },
+        { status: 400 },
+      );
+    }
+    if (typeof scope !== "string" || !scope) {
+      return Response.json(
+        { error: '"scope" must be a non-empty string' },
+        { status: 400 },
+      );
+    }
+    if (decision !== undefined && !isValidDecision(decision)) {
+      return Response.json(
+        { error: '"decision" must be one of: allow, deny, ask' },
+        { status: 400 },
+      );
+    }
+    if (priority !== undefined && (typeof priority !== "number" || !Number.isFinite(priority))) {
+      return Response.json(
+        { error: '"priority" must be a finite number' },
+        { status: 400 },
+      );
+    }
+    if (allowHighRisk !== undefined && typeof allowHighRisk !== "boolean") {
+      return Response.json(
+        { error: '"allowHighRisk" must be a boolean' },
+        { status: 400 },
+      );
+    }
+    if (executionTarget !== undefined && typeof executionTarget !== "string") {
+      return Response.json(
+        { error: '"executionTarget" must be a string' },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const rule = addRule(
+        tool,
+        pattern,
+        scope,
+        (decision as TrustDecision) ?? "allow",
+        (priority as number) ?? 100,
+        {
+          allowHighRisk: allowHighRisk as boolean | undefined,
+          executionTarget: executionTarget as string | undefined,
+        },
+      );
+      return Response.json({ rule }, { status: 201 });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Internal server error";
+      log.error({ err }, "Failed to add trust rule");
+      return Response.json({ error: message }, { status: 400 });
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PATCH /v1/trust-rules/:id — update rule
+// ---------------------------------------------------------------------------
+
+export function createTrustRulesUpdateHandler() {
+  return async (req: Request, ruleId: string): Promise<Response> => {
+    if (!ruleId) {
+      return Response.json(
+        { error: "Rule ID is required" },
+        { status: 400 },
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return Response.json(
+        { error: "Request body must be valid JSON" },
+        { status: 400 },
+      );
+    }
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return Response.json(
+        { error: "Request body must be a JSON object" },
+        { status: 400 },
+      );
+    }
+
+    const { tool, pattern, scope, decision, priority } =
+      body as Record<string, unknown>;
+
+    if (tool !== undefined && (typeof tool !== "string" || !tool)) {
+      return Response.json(
+        { error: '"tool" must be a non-empty string' },
+        { status: 400 },
+      );
+    }
+    if (pattern !== undefined && (typeof pattern !== "string" || !pattern)) {
+      return Response.json(
+        { error: '"pattern" must be a non-empty string' },
+        { status: 400 },
+      );
+    }
+    if (scope !== undefined && (typeof scope !== "string" || !scope)) {
+      return Response.json(
+        { error: '"scope" must be a non-empty string' },
+        { status: 400 },
+      );
+    }
+    if (decision !== undefined && !isValidDecision(decision)) {
+      return Response.json(
+        { error: '"decision" must be one of: allow, deny, ask' },
+        { status: 400 },
+      );
+    }
+    if (priority !== undefined && (typeof priority !== "number" || !Number.isFinite(priority))) {
+      return Response.json(
+        { error: '"priority" must be a finite number' },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const rule = updateRule(ruleId, {
+        tool: tool as string | undefined,
+        pattern: pattern as string | undefined,
+        scope: scope as string | undefined,
+        decision: decision as TrustDecision | undefined,
+        priority: priority as number | undefined,
+      });
+      return Response.json({ rule });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Internal server error";
+      if (message.includes("not found")) {
+        return Response.json({ error: message }, { status: 404 });
+      }
+      log.error({ err }, "Failed to update trust rule");
+      return Response.json({ error: message }, { status: 400 });
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /v1/trust-rules/:id — remove rule
+// ---------------------------------------------------------------------------
+
+export function createTrustRulesDeleteHandler() {
+  return async (_req: Request, ruleId: string): Promise<Response> => {
+    if (!ruleId) {
+      return Response.json(
+        { error: "Rule ID is required" },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const removed = removeRule(ruleId);
+      if (!removed) {
+        return Response.json(
+          { error: `Trust rule not found: ${ruleId}` },
+          { status: 404 },
+        );
+      }
+      return Response.json({ removed: true });
+    } catch (err) {
+      log.error({ err }, "Failed to remove trust rule");
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/trust-rules/clear — clear all user rules
+// ---------------------------------------------------------------------------
+
+export function createTrustRulesClearHandler() {
+  return async (_req: Request): Promise<Response> => {
+    try {
+      clearRules();
+      return Response.json({ cleared: true });
+    } catch (err) {
+      log.error({ err }, "Failed to clear trust rules");
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/trust-rules/match — query matching rule
+// ---------------------------------------------------------------------------
+
+export function createTrustRulesMatchHandler() {
+  return async (req: Request): Promise<Response> => {
+    const url = new URL(req.url);
+    const tool = url.searchParams.get("tool");
+    const pattern = url.searchParams.get("pattern");
+    const scope = url.searchParams.get("scope");
+    const commandsParam = url.searchParams.get("commands");
+
+    if (!tool) {
+      return Response.json(
+        { error: '"tool" query parameter is required' },
+        { status: 400 },
+      );
+    }
+    if (!scope) {
+      return Response.json(
+        { error: '"scope" query parameter is required' },
+        { status: 400 },
+      );
+    }
+
+    try {
+      // Support two modes:
+      // 1. Single pattern match: ?tool=X&pattern=Y&scope=Z
+      // 2. Multi-command highest priority: ?tool=X&commands=Y,Z&scope=S
+      if (commandsParam) {
+        const commands = commandsParam.split(",").filter(Boolean);
+        if (commands.length === 0) {
+          return Response.json(
+            { error: '"commands" must contain at least one command' },
+            { status: 400 },
+          );
+        }
+        const rule = findHighestPriorityRule(tool, commands, scope);
+        return Response.json({ rule: rule ?? null });
+      }
+
+      if (!pattern) {
+        return Response.json(
+          { error: '"pattern" or "commands" query parameter is required' },
+          { status: 400 },
+        );
+      }
+
+      const rule = findMatchingRule(tool, pattern, scope);
+      return Response.json({ rule: rule ?? null });
+    } catch (err) {
+      log.error({ err }, "Failed to find matching trust rule");
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/trust-rules/starter-bundle — accept starter bundle
+// ---------------------------------------------------------------------------
+
+export function createTrustRulesStarterBundleHandler() {
+  return async (_req: Request): Promise<Response> => {
+    try {
+      const result = acceptStarterBundle();
+      return Response.json(result);
+    } catch (err) {
+      log.error({ err }, "Failed to accept starter bundle");
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -54,6 +54,15 @@ import { createOAuthAppsProxyHandler } from "./http/routes/oauth-apps-proxy.js";
 import { createChannelReadinessProxyHandler } from "./http/routes/channel-readiness-proxy.js";
 import { createRuntimeHealthProxyHandler } from "./http/routes/runtime-health-proxy.js";
 import { createBrainGraphProxyHandler } from "./http/routes/brain-graph-proxy.js";
+import {
+  createTrustRulesListHandler,
+  createTrustRulesAddHandler,
+  createTrustRulesUpdateHandler,
+  createTrustRulesDeleteHandler,
+  createTrustRulesClearHandler,
+  createTrustRulesMatchHandler,
+  createTrustRulesStarterBundleHandler,
+} from "./http/routes/trust-rules.js";
 import { getLogger, initLogger } from "./logger.js";
 import { CircuitBreakerOpenError } from "./runtime/client.js";
 import { buildSchema } from "./schema.js";
@@ -274,6 +283,13 @@ async function main() {
   const handleFeatureFlagsGet = createFeatureFlagsGetHandler();
   const handleFeatureFlagsPatch = createFeatureFlagsPatchHandler();
   const handlePrivacyConfigPatch = createPrivacyConfigPatchHandler();
+  const handleTrustRulesList = createTrustRulesListHandler();
+  const handleTrustRulesAdd = createTrustRulesAddHandler();
+  const handleTrustRulesUpdate = createTrustRulesUpdateHandler();
+  const handleTrustRulesDelete = createTrustRulesDeleteHandler();
+  const handleTrustRulesClear = createTrustRulesClearHandler();
+  const handleTrustRulesMatch = createTrustRulesMatchHandler();
+  const handleTrustRulesStarterBundle = createTrustRulesStarterBundleHandler();
 
   const handleRuntimeProxy = config.runtimeProxyEnabled
     ? createRuntimeProxyHandler(config)
@@ -803,6 +819,50 @@ async function main() {
       auth: "edge-scoped",
       scope: "settings.write",
       handler: (req) => handlePrivacyConfigPatch(req),
+    },
+
+    // ── Trust rules ──
+    {
+      path: "/v1/trust-rules/clear",
+      method: "POST",
+      auth: "edge",
+      handler: (req) => handleTrustRulesClear(req),
+    },
+    {
+      path: "/v1/trust-rules/match",
+      method: "GET",
+      auth: "edge",
+      handler: (req) => handleTrustRulesMatch(req),
+    },
+    {
+      path: "/v1/trust-rules/starter-bundle",
+      method: "POST",
+      auth: "edge",
+      handler: (req) => handleTrustRulesStarterBundle(req),
+    },
+    {
+      path: "/v1/trust-rules",
+      method: "GET",
+      auth: "edge",
+      handler: (req) => handleTrustRulesList(req),
+    },
+    {
+      path: "/v1/trust-rules",
+      method: "POST",
+      auth: "edge",
+      handler: (req) => handleTrustRulesAdd(req),
+    },
+    {
+      path: /^\/v1\/trust-rules\/([^/]+)$/,
+      method: "PATCH",
+      auth: "edge",
+      handler: (req, params) => handleTrustRulesUpdate(req, params[0]),
+    },
+    {
+      path: /^\/v1\/trust-rules\/([^/]+)$/,
+      method: "DELETE",
+      auth: "edge",
+      handler: (req, params) => handleTrustRulesDelete(req, params[0]),
     },
   ];
 

--- a/gateway/src/trust-store.ts
+++ b/gateway/src/trust-store.ts
@@ -1,0 +1,518 @@
+/**
+ * Gateway-side trust store — file-backed persistence of trust rules.
+ *
+ * Ported from `assistant/src/permissions/trust-store.ts` so that the gateway
+ * can own trust rule CRUD and expose it via HTTP API.  The assistant daemon
+ * will later use the gateway's HTTP API instead of reading trust.json directly.
+ */
+
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+import { Minimatch } from "minimatch";
+import { v4 as uuid } from "uuid";
+
+import { getLogger } from "./logger.js";
+import { getRootDir } from "./credential-reader.js";
+
+const log = getLogger("trust-store");
+
+const TRUST_FILE_VERSION = 3;
+
+// ---------------------------------------------------------------------------
+// Types — duplicated from ces-contracts to avoid adding a package dep for now.
+// These match the TrustRule / TrustFileData / TrustDecision shapes exactly.
+// ---------------------------------------------------------------------------
+
+export type TrustDecision = "allow" | "deny" | "ask";
+
+export interface TrustRule {
+  id: string;
+  tool: string;
+  pattern: string;
+  scope: string;
+  decision: TrustDecision;
+  priority: number;
+  createdAt: number;
+  executionTarget?: string;
+  allowHighRisk?: boolean;
+}
+
+interface TrustFileData {
+  version: number;
+  rules: TrustRule[];
+  starterBundleAccepted?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Starter bundle definitions
+// ---------------------------------------------------------------------------
+
+export interface StarterBundleRule {
+  id: string;
+  tool: string;
+  pattern: string;
+  scope: string;
+  decision: "allow";
+  priority: number;
+}
+
+function getStarterBundleRules(): StarterBundleRule[] {
+  return [
+    {
+      id: "starter:allow-file_read",
+      tool: "file_read",
+      pattern: "**",
+      scope: "everywhere",
+      decision: "allow",
+      priority: 90,
+    },
+    {
+      id: "starter:allow-glob",
+      tool: "glob",
+      pattern: "**",
+      scope: "everywhere",
+      decision: "allow",
+      priority: 90,
+    },
+    {
+      id: "starter:allow-grep",
+      tool: "grep",
+      pattern: "**",
+      scope: "everywhere",
+      decision: "allow",
+      priority: 90,
+    },
+    {
+      id: "starter:allow-list_directory",
+      tool: "list_directory",
+      pattern: "**",
+      scope: "everywhere",
+      decision: "allow",
+      priority: 90,
+    },
+    {
+      id: "starter:allow-web_search",
+      tool: "web_search",
+      pattern: "**",
+      scope: "everywhere",
+      decision: "allow",
+      priority: 90,
+    },
+    {
+      id: "starter:allow-web_fetch",
+      tool: "web_fetch",
+      pattern: "**",
+      scope: "everywhere",
+      decision: "allow",
+      priority: 90,
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Pattern compilation cache
+// ---------------------------------------------------------------------------
+
+const compiledPatterns = new Map<string, Minimatch>();
+const invalidPatterns = new Set<string>();
+
+function getCompiledPattern(pattern: string): Minimatch | null {
+  if (invalidPatterns.has(pattern)) return null;
+  let compiled = compiledPatterns.get(pattern);
+  if (!compiled) {
+    if (typeof pattern !== "string") {
+      log.warn({ pattern }, "Cannot compile non-string pattern");
+      invalidPatterns.add(pattern as string);
+      return null;
+    }
+    try {
+      compiled = new Minimatch(pattern);
+      compiledPatterns.set(pattern, compiled);
+    } catch (err) {
+      log.warn({ pattern, err }, "Failed to compile pattern");
+      invalidPatterns.add(pattern);
+      return null;
+    }
+  }
+  return compiled;
+}
+
+function rebuildPatternCache(rules: TrustRule[]): void {
+  compiledPatterns.clear();
+  invalidPatterns.clear();
+  for (const rule of rules) {
+    if (typeof rule.pattern !== "string") {
+      log.warn(
+        { ruleId: rule.id, pattern: rule.pattern },
+        "Skipping rule with non-string pattern during cache rebuild",
+      );
+      continue;
+    }
+    if (!compiledPatterns.has(rule.pattern)) {
+      try {
+        compiledPatterns.set(rule.pattern, new Minimatch(rule.pattern));
+      } catch (err) {
+        log.warn(
+          { ruleId: rule.id, pattern: rule.pattern, err },
+          "Skipping rule with invalid pattern during cache rebuild",
+        );
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// File path
+// ---------------------------------------------------------------------------
+
+function getTrustPath(): string {
+  const securityDir = process.env.GATEWAY_SECURITY_DIR;
+  if (securityDir) {
+    return join(securityDir, "trust.json");
+  }
+  return join(getRootDir(), "protected", "trust.json");
+}
+
+// ---------------------------------------------------------------------------
+// Rule ordering
+// ---------------------------------------------------------------------------
+
+/**
+ * Sort comparator: highest priority first. At the same priority, deny rules
+ * come before allow rules for safety (deny wins ties).
+ */
+function ruleOrder(a: TrustRule, b: TrustRule): number {
+  if (b.priority !== a.priority) return b.priority - a.priority;
+  if (a.decision !== b.decision) {
+    const order = { deny: 0, ask: 1, allow: 2 };
+    return (order[a.decision] ?? 2) - (order[b.decision] ?? 2);
+  }
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Scope matching
+// ---------------------------------------------------------------------------
+
+function matchesScope(ruleScope: string, workingDir: string): boolean {
+  if (ruleScope === "everywhere") return true;
+  const prefix = ruleScope.replace(/\*$/, "").replace(/\/+$/, "");
+  const dir = workingDir.replace(/\/+$/, "");
+  return dir === prefix || dir.startsWith(prefix + "/");
+}
+
+// ---------------------------------------------------------------------------
+// Disk I/O
+// ---------------------------------------------------------------------------
+
+let cachedRules: TrustRule[] | null = null;
+let cachedStarterBundleAccepted: boolean | null = null;
+
+function loadFromDisk(): TrustRule[] {
+  const path = getTrustPath();
+  let rules: TrustRule[] = [];
+
+  if (existsSync(path)) {
+    try {
+      const raw = readFileSync(path, "utf-8");
+      const data = JSON.parse(raw) as TrustFileData;
+
+      const rawRules = Array.isArray(data.rules) ? data.rules : [];
+      cachedStarterBundleAccepted = data.starterBundleAccepted === true;
+
+      // Strip __internal: rules that may have been hand-edited in
+      const sanitizedRules = rawRules.filter((r) => {
+        if (typeof r.tool === "string" && r.tool.startsWith("__internal:")) {
+          log.warn(
+            { ruleId: r.id, tool: r.tool },
+            "Stripping __internal: rule from trust file on load",
+          );
+          return false;
+        }
+        return true;
+      });
+
+      if (
+        data.version === TRUST_FILE_VERSION ||
+        data.version === 1 ||
+        data.version === 2
+      ) {
+        rules = sanitizedRules;
+
+        // Strip legacy principal-scoped fields
+        for (const rule of rules) {
+          const r = rule as unknown as Record<string, unknown>;
+          if (
+            "principalKind" in r ||
+            "principalId" in r ||
+            "principalVersion" in r
+          ) {
+            delete r.principalKind;
+            delete r.principalId;
+            delete r.principalVersion;
+          }
+        }
+      } else {
+        log.warn(
+          { version: data.version },
+          "Unknown trust file version, returning empty rules",
+        );
+        return [];
+      }
+    } catch (err) {
+      log.error({ err }, "Failed to load trust file");
+    }
+  }
+
+  rules.sort(ruleOrder);
+  return rules;
+}
+
+function saveToDisk(rules: TrustRule[]): void {
+  const path = getTrustPath();
+  const dir = dirname(path);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const data: TrustFileData = { version: TRUST_FILE_VERSION, rules };
+  if (cachedStarterBundleAccepted) {
+    data.starterBundleAccepted = true;
+  }
+  const tmpPath = path + ".tmp." + process.pid;
+  writeFileSync(tmpPath, JSON.stringify(data, null, 2), { mode: 0o600 });
+  renameSync(tmpPath, path);
+  chmodSync(path, 0o600);
+}
+
+function getRules(): TrustRule[] {
+  if (cachedRules == null) {
+    cachedRules = loadFromDisk();
+    rebuildPatternCache(cachedRules);
+  }
+  return cachedRules;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function loadRules(): TrustRule[] {
+  return getRules();
+}
+
+export function saveRules(rules: TrustRule[]): void {
+  rules.sort(ruleOrder);
+  cachedRules = rules;
+  rebuildPatternCache(rules);
+  saveToDisk(rules);
+}
+
+export function getAllRules(): TrustRule[] {
+  return [...getRules()];
+}
+
+export function addRule(
+  tool: string,
+  pattern: string,
+  scope: string,
+  decision: TrustDecision = "allow",
+  priority: number = 100,
+  options?: {
+    allowHighRisk?: boolean;
+    executionTarget?: string;
+  },
+): TrustRule {
+  if (tool.startsWith("__internal:"))
+    throw new Error(`Cannot create internal pseudo-rule via addRule: ${tool}`);
+
+  // Re-read from disk to avoid lost updates
+  cachedRules = null;
+  const rules = [...getRules()];
+  const rule: TrustRule = {
+    id: uuid(),
+    tool,
+    pattern,
+    scope,
+    decision,
+    priority,
+    createdAt: Date.now(),
+  };
+  if (options?.allowHighRisk != null) {
+    rule.allowHighRisk = options.allowHighRisk;
+  }
+  if (options?.executionTarget != null) {
+    rule.executionTarget = options.executionTarget;
+  }
+  rules.push(rule);
+  rules.sort(ruleOrder);
+  cachedRules = rules;
+  rebuildPatternCache(rules);
+  saveToDisk(rules);
+  log.info({ rule }, "Added trust rule");
+  return rule;
+}
+
+export function updateRule(
+  id: string,
+  updates: {
+    tool?: string;
+    pattern?: string;
+    scope?: string;
+    decision?: TrustDecision;
+    priority?: number;
+  },
+): TrustRule {
+  if (updates.tool?.startsWith("__internal:"))
+    throw new Error(
+      `Cannot update tool to internal pseudo-rule: ${updates.tool}`,
+    );
+
+  // Re-read from disk to avoid lost updates
+  cachedRules = null;
+  const rules = [...getRules()];
+  const index = rules.findIndex((r) => r.id === id);
+  if (index === -1) throw new Error(`Trust rule not found: ${id}`);
+  const rule = { ...rules[index] };
+  if (updates.tool != null) rule.tool = updates.tool;
+  if (updates.pattern != null) rule.pattern = updates.pattern;
+  if (updates.scope != null) rule.scope = updates.scope;
+  if (updates.decision != null) rule.decision = updates.decision;
+  if (updates.priority != null) rule.priority = updates.priority;
+  rules[index] = rule;
+  rules.sort(ruleOrder);
+  cachedRules = rules;
+  rebuildPatternCache(rules);
+  saveToDisk(rules);
+  log.info({ rule }, "Updated trust rule");
+  return rule;
+}
+
+export function removeRule(id: string): boolean {
+  // Re-read from disk to avoid lost updates
+  cachedRules = null;
+  const rules = [...getRules()];
+  const index = rules.findIndex((r) => r.id === id);
+  if (index === -1) return false;
+  rules.splice(index, 1);
+  cachedRules = rules;
+  rebuildPatternCache(rules);
+  saveToDisk(rules);
+  log.info({ id }, "Removed trust rule");
+  return true;
+}
+
+export function clearRules(): void {
+  cachedStarterBundleAccepted = false;
+  cachedRules = [];
+  rebuildPatternCache([]);
+  saveToDisk([]);
+  log.info("Cleared all trust rules");
+}
+
+export function findMatchingRule(
+  tool: string,
+  command: string,
+  scope: string,
+): TrustRule | null {
+  const rules = getRules();
+  for (const rule of rules) {
+    if (rule.tool !== tool) continue;
+    const compiled = getCompiledPattern(rule.pattern);
+    if (!compiled || !compiled.match(command)) continue;
+    if (!matchesScope(rule.scope, scope)) continue;
+    return rule;
+  }
+  return null;
+}
+
+/**
+ * Find the highest-priority rule that matches any of the command candidates.
+ * Rules are pre-sorted by priority descending, so the first match wins.
+ */
+export function findHighestPriorityRule(
+  tool: string,
+  commands: string[],
+  scope: string,
+): TrustRule | null {
+  const rules = getRules();
+  for (const rule of rules) {
+    if (rule.tool !== tool) continue;
+    if (!matchesScope(rule.scope, scope)) continue;
+    const compiled = getCompiledPattern(rule.pattern);
+    if (!compiled) continue;
+    for (const command of commands) {
+      if (compiled.match(command)) {
+        return rule;
+      }
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Starter bundle
+// ---------------------------------------------------------------------------
+
+export interface AcceptStarterBundleResult {
+  accepted: boolean;
+  rulesAdded: number;
+  alreadyAccepted: boolean;
+}
+
+export function isStarterBundleAccepted(): boolean {
+  getRules();
+  return cachedStarterBundleAccepted === true;
+}
+
+export function acceptStarterBundle(): AcceptStarterBundleResult {
+  // Re-read from disk to avoid lost updates
+  cachedRules = null;
+  cachedStarterBundleAccepted = null;
+  const rules = [...getRules()];
+
+  if (cachedStarterBundleAccepted === true) {
+    return { accepted: true, rulesAdded: 0, alreadyAccepted: true };
+  }
+
+  const existingIds = new Set(rules.map((r) => r.id));
+  let added = 0;
+
+  for (const template of getStarterBundleRules()) {
+    if (existingIds.has(template.id)) continue;
+    rules.push({
+      id: template.id,
+      tool: template.tool,
+      pattern: template.pattern,
+      scope: template.scope,
+      decision: template.decision,
+      priority: template.priority,
+      createdAt: Date.now(),
+    });
+    added++;
+  }
+
+  cachedStarterBundleAccepted = true;
+  rules.sort(ruleOrder);
+  cachedRules = rules;
+  rebuildPatternCache(rules);
+  saveToDisk(rules);
+  log.info({ rulesAdded: added }, "Starter approval bundle accepted");
+
+  return { accepted: true, rulesAdded: added, alreadyAccepted: false };
+}
+
+/** Reset cached state (useful for tests). */
+export function clearCache(): void {
+  cachedRules = null;
+  cachedStarterBundleAccepted = null;
+  compiledPatterns.clear();
+  invalidPatterns.clear();
+}


### PR DESCRIPTION
## Summary
- Create gateway trust store (`gateway/src/trust-store.ts`) with file-backed persistence and rule matching logic ported from the assistant daemon
- Add trust rule CRUD HTTP endpoints in `gateway/src/http/routes/trust-rules.ts` (list, add, update, delete, clear, match, starter-bundle)
- Register all routes in gateway before catch-all proxy with edge auth
- Uses configurable trust.json path via `GATEWAY_SECURITY_DIR` env var, falling back to `~/.vellum/protected/trust.json`
- Atomic write pattern (temp file + rename, mode 0o600) for safe persistence
- Added `minimatch` and `uuid` as gateway dependencies

Part of plan: docker-volume-security.md (PR 11 of 35)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19853" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
