### PR TITLE
fix: strip MIME parameters before extension lookup in Whisper provider

### DIFF
--- a/assistant/src/__tests__/openai-whisper.test.ts
+++ b/assistant/src/__tests__/openai-whisper.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { OpenAIWhisperProvider } from "../providers/speech-to-text/openai-whisper.js";
+
+// ---------------------------------------------------------------------------
+// Mock fetch — capture outgoing FormData so we can assert filenames
+// ---------------------------------------------------------------------------
+
+const originalFetch = globalThis.fetch;
+
+let capturedFormData: FormData | null = null;
+
+function mockFetch(
+  _url: string | URL | Request,
+  init?: RequestInit,
+): Promise<Response> {
+  if (init?.body instanceof FormData) {
+    capturedFormData = init.body;
+  }
+  return Promise.resolve(
+    new Response(JSON.stringify({ text: "hello world" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}
+
+beforeEach(() => {
+  capturedFormData = null;
+  globalThis.fetch = mockFetch as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("OpenAIWhisperProvider", () => {
+  const provider = new OpenAIWhisperProvider("test-api-key");
+  const dummyAudio = Buffer.from("fake-audio-data");
+
+  describe("extensionFromMime (via transcribe filename)", () => {
+    test("plain MIME type resolves to correct extension", async () => {
+      await provider.transcribe(dummyAudio, "audio/ogg");
+      const file = capturedFormData?.get("file") as File;
+      expect(file.name).toBe("audio.ogg");
+    });
+
+    test("MIME type with parameters resolves to correct extension", async () => {
+      await provider.transcribe(dummyAudio, "audio/ogg; codecs=opus");
+      const file = capturedFormData?.get("file") as File;
+      expect(file.name).toBe("audio.ogg");
+    });
+
+    test("MIME type with extra whitespace around parameters", async () => {
+      await provider.transcribe(dummyAudio, "audio/mpeg ; bitrate=128");
+      const file = capturedFormData?.get("file") as File;
+      expect(file.name).toBe("audio.mp3");
+    });
+
+    test("unknown MIME type falls back to .audio", async () => {
+      await provider.transcribe(dummyAudio, "audio/unknown-format");
+      const file = capturedFormData?.get("file") as File;
+      expect(file.name).toBe("audio.audio");
+    });
+
+    test("unknown MIME type with parameters still falls back", async () => {
+      await provider.transcribe(dummyAudio, "audio/unknown; foo=bar");
+      const file = capturedFormData?.get("file") as File;
+      expect(file.name).toBe("audio.audio");
+    });
+
+    test.each([
+      ["audio/wav", "audio.wav"],
+      ["audio/x-wav", "audio.wav"],
+      ["audio/mpeg", "audio.mp3"],
+      ["audio/mp3", "audio.mp3"],
+      ["audio/ogg", "audio.ogg"],
+      ["audio/opus", "audio.opus"],
+      ["audio/webm", "audio.webm"],
+      ["audio/mp4", "audio.m4a"],
+      ["audio/x-m4a", "audio.m4a"],
+      ["audio/flac", "audio.flac"],
+    ])("%s → %s", async (mime, expectedFilename) => {
+      await provider.transcribe(dummyAudio, mime);
+      const file = capturedFormData?.get("file") as File;
+      expect(file.name).toBe(expectedFilename);
+    });
+  });
+});

--- a/assistant/src/providers/speech-to-text/openai-whisper.ts
+++ b/assistant/src/providers/speech-to-text/openai-whisper.ts
@@ -20,7 +20,8 @@ function extensionFromMime(mimeType: string): string {
     "audio/x-m4a": "m4a",
     "audio/flac": "flac",
   };
-  return map[mimeType] ?? "audio";
+  const base = mimeType.split(";")[0].trim().toLowerCase();
+  return map[base] ?? "audio";
 }
 
 export class OpenAIWhisperProvider implements SpeechToTextProvider {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for telegram-voice-messages.md.

**Gap:** MIME type parameters not stripped before extension lookup
**What was expected:** audio/ogg; codecs=opus should resolve to .ogg extension
**What was found:** Exact-match lookup failed for parameterized MIME types, producing wrong filenames

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
