### PR TITLE
fix: backup restore fails silently for large .vbundle files

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -208,8 +208,8 @@ const log = getLogger("runtime-http");
 const DEFAULT_PORT = 7821;
 const DEFAULT_HOSTNAME = "127.0.0.1";
 
-/** Global hard cap on request body size (150 MB — accommodates base64-encoded 100 MB attachments). */
-const MAX_REQUEST_BODY_BYTES = 150 * 1024 * 1024;
+/** Global hard cap on request body size (512 MB — accommodates large .vbundle backup imports). */
+const MAX_REQUEST_BODY_BYTES = 512 * 1024 * 1024;
 
 export class RuntimeHttpServer {
   private server: ReturnType<typeof Bun.serve> | null = null;

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -227,10 +227,11 @@ struct AssistantBackupsSection: View {
                 filename = "export-\(formatter.string(from: Date())).vbundle"
             }
 
-            // Show save panel
+            // Show save panel — don't set allowedContentTypes since the filename
+            // already includes .vbundle; setting it causes NSSavePanel to append
+            // a duplicate extension (.vbundle.vbundle).
             let panel = NSSavePanel()
             panel.nameFieldStringValue = filename
-            panel.allowedContentTypes = [.init(filenameExtension: "vbundle") ?? .data]
             panel.canCreateDirectories = true
 
             let panelResult = await panel.beginSheetModal(for: NSApp.keyWindow ?? NSApp.mainWindow ?? NSApp.windows.first!)
@@ -406,6 +407,8 @@ extension AssistantBackupsSection {
                 } else {
                     errorMessage = "Import completed with warnings. Check assistant logs for details."
                 }
+            } else if httpResponse.statusCode == 413 {
+                errorMessage = "Backup file is too large. Please upgrade the assistant to restore this backup."
             } else {
                 errorMessage = "Import failed (HTTP \(httpResponse.statusCode))"
             }


### PR DESCRIPTION
## Summary
- Raise daemon `MAX_REQUEST_BODY_BYTES` from 150 MB to 512 MB so large `.vbundle` backup imports are accepted
- Fix NSSavePanel export creating files with double `.vbundle.vbundle` extension by removing redundant `allowedContentTypes`
- Add specific HTTP 413 error message in the macOS client for better UX

## Original prompt
When I restore from backup nothing happens. I have a backup from a few hours ago in my Downloads folder
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
