### PR TITLE
Add tests for cesPort migration in assistant-config

### DIFF
--- a/cli/src/__tests__/assistant-config.test.ts
+++ b/cli/src/__tests__/assistant-config.test.ts
@@ -238,6 +238,7 @@ describe("migrateLegacyEntry", () => {
     expect(resources.daemonPort).toBe(7821);
     expect(resources.gatewayPort).toBe(7830);
     expect(resources.qdrantPort).toBe(6333);
+    expect(resources.cesPort).toBe(8090);
     expect(resources.pidFile).toContain("vellum.pid");
   });
 
@@ -310,6 +311,7 @@ describe("migrateLegacyEntry", () => {
     expect(resources.daemonPort).toBe(7821);
     expect(resources.gatewayPort).toBe(7830);
     expect(resources.qdrantPort).toBe(6333);
+    expect(resources.cesPort).toBe(8090);
     expect(resources.pidFile).toBe("/custom/path/.vellum/vellum.pid");
   });
 
@@ -328,7 +330,7 @@ describe("migrateLegacyEntry", () => {
         daemonPort: 8000,
         gatewayPort: 8001,
         qdrantPort: 8002,
-        cesPort: 8090,
+        cesPort: 8003,
         pidFile: "/my/path/.vellum/vellum.pid",
       },
     };
@@ -344,6 +346,7 @@ describe("migrateLegacyEntry", () => {
     expect(resources.daemonPort).toBe(8000);
     expect(resources.gatewayPort).toBe(8001);
     expect(resources.qdrantPort).toBe(8002);
+    expect(resources.cesPort).toBe(8003);
   });
 
   test("baseDataDir does not overwrite existing resources.instanceDir", () => {
@@ -377,6 +380,48 @@ describe("migrateLegacyEntry", () => {
     // AND the existing instanceDir should be preserved
     const resources = entry.resources as Record<string, unknown>;
     expect(resources.instanceDir).toBe("/new/path");
+  });
+
+  test("backfills cesPort with default 8090", () => {
+    // GIVEN a local entry with resources that has no cesPort
+    const entry: Record<string, unknown> = {
+      assistantId: "no-ces-port",
+      runtimeUrl: "http://localhost:7830",
+      cloud: "local",
+      resources: {
+        instanceDir: "/custom/path",
+        daemonPort: 7821,
+        gatewayPort: 7830,
+        qdrantPort: 6333,
+        pidFile: "/custom/path/.vellum/vellum.pid",
+      },
+    };
+    // WHEN we migrate the entry
+    const changed = migrateLegacyEntry(entry);
+    // THEN cesPort should be backfilled
+    expect(changed).toBe(true);
+    const resources = entry.resources as Record<string, unknown>;
+    expect(resources.cesPort).toBe(8090);
+  });
+
+  test("does not overwrite existing cesPort", () => {
+    const entry: Record<string, unknown> = {
+      assistantId: "has-ces-port",
+      runtimeUrl: "http://localhost:7830",
+      cloud: "local",
+      resources: {
+        instanceDir: "/my/path",
+        daemonPort: 8000,
+        gatewayPort: 8001,
+        qdrantPort: 8002,
+        cesPort: 9090,
+        pidFile: "/my/path/.vellum/vellum.pid",
+      },
+    };
+    const changed = migrateLegacyEntry(entry);
+    expect(changed).toBe(false);
+    const resources = entry.resources as Record<string, unknown>;
+    expect(resources.cesPort).toBe(9090);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add test confirming cesPort is backfilled to 8090 for entries missing it
- Add test confirming existing cesPort values are preserved
- Update existing migration tests to verify cesPort is included

Part of plan: lockfile-service-group-topology.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
