### PR TITLE
feat: load actor-token-signing-key from GATEWAY_SECURITY_DIR

### DIFF
--- a/gateway/src/auth/token-service.ts
+++ b/gateway/src/auth/token-service.ts
@@ -2,7 +2,8 @@
  * JWT token service for the gateway's auth system.
  *
  * Mirrors the assistant's token-service but manages its own signing key
- * using the same loadOrCreateSigningKey pattern, reading from
+ * using the same loadOrCreateSigningKey pattern. When GATEWAY_SECURITY_DIR
+ * is set the key is read from that directory; otherwise falls back to
  * ~/.vellum/protected/actor-token-signing-key.
  */
 
@@ -32,6 +33,10 @@ const log = getLogger("auth-token-service");
 let signingKey: Buffer | null = null;
 
 function getSigningKeyPath(): string {
+  const securityDir = process.env.GATEWAY_SECURITY_DIR;
+  if (securityDir) {
+    return join(securityDir, "actor-token-signing-key");
+  }
   return join(getRootDir(), "protected", "actor-token-signing-key");
 }
 


### PR DESCRIPTION
## Summary
- Resolve actor-token-signing-key path from GATEWAY_SECURITY_DIR when set
- Falls back to existing path (protected/) when env var not set
- Signing key now lives on the gateway-owned security volume in Docker

Part of plan: docker-volume-security.md (PR 13 of 35)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
