### PR TITLE
feat: configure gateway security volume for trust.json and signing key

### DIFF
--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -285,6 +285,7 @@ export function dockerResourceNames(instanceName: string) {
     cesSecurityVolume: `${instanceName}-ces-sec`,
     dataVolume: `${instanceName}-data`,
     gatewayContainer: `${instanceName}-gateway`,
+    gatewaySecurityVolume: `${instanceName}-gateway-sec`,
     network: `${instanceName}-net`,
     socketVolume: `${instanceName}-socket`,
     workspaceVolume: `${instanceName}-workspace`,
@@ -342,6 +343,7 @@ export async function retireDocker(name: string): Promise<void> {
     res.socketVolume,
     res.workspaceVolume,
     res.cesSecurityVolume,
+    res.gatewaySecurityVolume,
   ]) {
     try {
       await exec("docker", ["volume", "rm", vol]);
@@ -518,10 +520,14 @@ export function serviceDockerRunArgs(opts: {
       `${res.dataVolume}:/data`,
       "-v",
       `${res.workspaceVolume}:/workspace`,
+      "-v",
+      `${res.gatewaySecurityVolume}:/gateway-security`,
       "-e",
       "BASE_DATA_DIR=/data",
       "-e",
       "WORKSPACE_DIR=/workspace",
+      "-e",
+      "GATEWAY_SECURITY_DIR=/gateway-security",
       "-e",
       `GATEWAY_PORT=${GATEWAY_INTERNAL_PORT}`,
       "-e",
@@ -905,6 +911,7 @@ export async function hatchDocker(
     await exec("docker", ["volume", "create", res.socketVolume]);
     await exec("docker", ["volume", "create", res.workspaceVolume]);
     await exec("docker", ["volume", "create", res.cesSecurityVolume]);
+    await exec("docker", ["volume", "create", res.gatewaySecurityVolume]);
 
     await startContainers({ gatewayPort, imageTags, instanceName, res }, log);
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -30,6 +30,8 @@ RUN groupadd --system --gid 1001 gateway && \
 
 COPY --from=builder --chown=gateway:gateway /app /app
 
+RUN mkdir -p /gateway-security && chown gateway:gateway /gateway-security
+
 USER gateway
 
 EXPOSE 7830

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { getLogger, type LogFileConfig } from "./logger.js";
-import { getWorkspaceDir } from "./credential-reader.js";
+import { getRootDir, getWorkspaceDir } from "./credential-reader.js";
 
 const log = getLogger("config");
 
@@ -52,6 +52,19 @@ function readWorkspaceConfig(): Record<string, unknown> {
   } catch {
     return {};
   }
+}
+
+/**
+ * Directory containing gateway security files (trust.json, actor-token-signing-key).
+ *
+ * In Docker, this is a dedicated volume mounted at /gateway-security via the
+ * GATEWAY_SECURITY_DIR env var. In local (non-Docker) mode, falls back to
+ * ~/.vellum/protected/ for backwards compatibility.
+ */
+export function getGatewaySecurityDir(): string {
+  const override = process.env.GATEWAY_SECURITY_DIR?.trim();
+  if (override) return override;
+  return join(getRootDir(), "protected");
 }
 
 function parseRoutingEntries(raw: unknown): RoutingEntry[] {


### PR DESCRIPTION
## Summary
- Add gateway security volume to Docker resource names and volume creation
- Mount at /gateway-security in gateway container with GATEWAY_SECURITY_DIR env var
- Export GATEWAY_SECURITY_DIR from gateway config for use by trust store and token service
- Add /gateway-security directory with proper ownership in gateway Dockerfile

Part of plan: docker-volume-security.md (PR 12 of 35)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
