### PR TITLE
refactor: abstract trust store behind interface for file vs gateway backends

### DIFF
--- a/assistant/src/permissions/trust-store-interface.ts
+++ b/assistant/src/permissions/trust-store-interface.ts
@@ -1,0 +1,105 @@
+import type { PolicyContext, TrustRule } from "./types.js";
+
+export interface StarterBundleRule {
+  id: string;
+  tool: string;
+  pattern: string;
+  scope: string;
+  decision: "allow";
+  priority: number;
+}
+
+export interface AcceptStarterBundleResult {
+  accepted: boolean;
+  rulesAdded: number;
+  alreadyAccepted: boolean;
+}
+
+/**
+ * Backend interface for trust rule storage and retrieval.
+ *
+ * The file-based implementation reads/writes `~/.vellum/protected/trust.json`.
+ * A future gateway-backed implementation will proxy these operations through
+ * the gateway HTTP API for containerized deployments.
+ */
+export interface TrustStoreBackend {
+  /** Return a copy of all trust rules (file-based rules + defaults). */
+  getAllRules(): TrustRule[];
+
+  /**
+   * Find the highest-priority rule that matches any of the command candidates.
+   * Rules are pre-sorted by priority descending, so the first match wins.
+   */
+  findHighestPriorityRule(
+    tool: string,
+    commands: string[],
+    scope: string,
+    ctx?: PolicyContext,
+  ): TrustRule | null;
+
+  /** Find the first matching allow rule for a tool/command/scope. */
+  findMatchingRule(
+    tool: string,
+    command: string,
+    scope: string,
+  ): TrustRule | null;
+
+  /** Find the first matching deny rule for a tool/command/scope. */
+  findDenyRule(
+    tool: string,
+    command: string,
+    scope: string,
+  ): TrustRule | null;
+
+  /** Add a new trust rule and persist it. */
+  addRule(
+    tool: string,
+    pattern: string,
+    scope: string,
+    decision?: "allow" | "deny" | "ask",
+    priority?: number,
+    options?: {
+      allowHighRisk?: boolean;
+      executionTarget?: string;
+    },
+  ): TrustRule;
+
+  /** Update an existing trust rule by ID and persist it. */
+  updateRule(
+    id: string,
+    updates: {
+      tool?: string;
+      pattern?: string;
+      scope?: string;
+      decision?: "allow" | "deny" | "ask";
+      priority?: number;
+    },
+  ): TrustRule;
+
+  /** Remove a trust rule by ID. Returns true if the rule existed. */
+  removeRule(id: string): boolean;
+
+  /** Clear all user-created rules (default rules are re-backfilled). */
+  clearAllRules(): void;
+
+  /** Accept the starter approval bundle, seeding low-risk allow rules. */
+  acceptStarterBundle(): AcceptStarterBundleResult;
+
+  /** Whether the user has previously accepted the starter bundle. */
+  isStarterBundleAccepted(): boolean;
+
+  /** Register a callback to be invoked whenever trust rules change. */
+  onRulesChanged(listener: () => void): void;
+
+  /** Invalidate in-memory caches, forcing a re-read from the backing store. */
+  clearCache(): void;
+
+  /**
+   * Check whether a minimatch pattern matches a candidate string.
+   * Reuses the compiled pattern cache from trust rule evaluation.
+   */
+  patternMatchesCandidate(pattern: string, candidate: string): boolean;
+
+  /** Returns the starter bundle rule definitions. */
+  getStarterBundleRules(): StarterBundleRule[];
+}

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -14,7 +14,15 @@ import { v4 as uuid } from "uuid";
 import { getLogger } from "../util/logger.js";
 import { getRootDir } from "../util/platform.js";
 import { getDefaultRuleTemplates } from "./defaults.js";
+import type {
+  AcceptStarterBundleResult,
+  StarterBundleRule,
+  TrustStoreBackend,
+} from "./trust-store-interface.js";
 import type { PolicyContext, TrustRule } from "./types.js";
+
+export type { AcceptStarterBundleResult, StarterBundleRule } from "./trust-store-interface.js";
+export type { TrustStoreBackend } from "./trust-store-interface.js";
 
 const log = getLogger("trust-store");
 
@@ -592,15 +600,6 @@ export function clearCache(): void {
 // once, reducing prompt noise in strict mode while keeping the action
 // explicitly opt-in.
 
-export interface StarterBundleRule {
-  id: string;
-  tool: string;
-  pattern: string;
-  scope: string;
-  decision: "allow";
-  priority: number;
-}
-
 /**
  * Returns the starter bundle rule definitions.  These cover read-only and
  * information-gathering tools that never mutate the filesystem or execute
@@ -670,12 +669,6 @@ export function isStarterBundleAccepted(): boolean {
   return cachedStarterBundleAccepted === true;
 }
 
-export interface AcceptStarterBundleResult {
-  accepted: boolean;
-  rulesAdded: number;
-  alreadyAccepted: boolean;
-}
-
 /**
  * Seed the trust store with the starter bundle rules.
  *
@@ -719,4 +712,38 @@ export function acceptStarterBundle(): AcceptStarterBundleResult {
   log.info({ rulesAdded: added }, "Starter approval bundle accepted");
 
   return { accepted: true, rulesAdded: added, alreadyAccepted: false };
+}
+
+// ─── Backend interface ──────────────────────────────────────────────────────
+
+/**
+ * File-based trust store backend. Wraps the module-level functions into a
+ * `TrustStoreBackend` so callers can program against the interface.
+ */
+const fileTrustStoreBackend: TrustStoreBackend = {
+  getAllRules,
+  findHighestPriorityRule,
+  findMatchingRule,
+  findDenyRule,
+  addRule,
+  updateRule,
+  removeRule,
+  clearAllRules,
+  acceptStarterBundle,
+  isStarterBundleAccepted,
+  onRulesChanged,
+  clearCache,
+  patternMatchesCandidate,
+  getStarterBundleRules,
+};
+
+/**
+ * Returns the active trust store backend.
+ *
+ * Currently always returns the file-based implementation. A future PR will
+ * add a gateway-backed backend for containerized deployments and switch
+ * based on `getIsContainerized()`.
+ */
+export function getTrustStore(): TrustStoreBackend {
+  return fileTrustStoreBackend;
 }


### PR DESCRIPTION
## Summary
- Extract TrustStoreBackend interface from existing trust store public API
- Existing file-based implementation satisfies the interface
- Export getTrustStore() that returns the file-based backend
- No behavioral change — prepares for gateway-backed backend in containerized mode

Part of plan: docker-volume-security.md (PR 15 of 35)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
