### PR TITLE
feat: add credential CRUD HTTP endpoints to CES managed service

### DIFF
--- a/credential-executor/src/http/credential-routes.ts
+++ b/credential-executor/src/http/credential-routes.ts
@@ -1,0 +1,199 @@
+/**
+ * Credential CRUD HTTP endpoints for the CES managed service.
+ *
+ * Exposes credential management over HTTP so the assistant and gateway
+ * can access credentials via the network instead of reading keys.enc
+ * directly from a shared volume.
+ *
+ * Endpoints:
+ * - `GET  /v1/credentials`           — list credential account names
+ * - `GET  /v1/credentials/:account`  — get a credential value
+ * - `POST /v1/credentials/:account`  — set a credential value
+ * - `DELETE /v1/credentials/:account` — delete a credential
+ *
+ * Auth: All endpoints require a `CES_SERVICE_TOKEN` bearer token in the
+ * `Authorization` header. Both the CES and its callers share this token
+ * via the environment.
+ */
+
+import type { SecureKeyBackend } from "@vellumai/credential-storage";
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate the Authorization header against the configured service token.
+ * Returns an error Response if auth fails, or null if auth succeeds.
+ */
+function checkAuth(req: Request, serviceToken: string): Response | null {
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader) {
+    return new Response(
+      JSON.stringify({ error: "Missing Authorization header" }),
+      { status: 401, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const parts = authHeader.split(" ");
+  if (parts.length !== 2 || parts[0]!.toLowerCase() !== "bearer") {
+    return new Response(
+      JSON.stringify({ error: "Invalid Authorization header format. Expected: Bearer <token>" }),
+      { status: 401, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  if (parts[1] !== serviceToken) {
+    return new Response(
+      JSON.stringify({ error: "Invalid service token" }),
+      { status: 403, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Route handler
+// ---------------------------------------------------------------------------
+
+export interface CredentialRouteDeps {
+  /** The secure key backend to wrap. */
+  backend: SecureKeyBackend;
+  /** Service token for authenticating requests. */
+  serviceToken: string;
+}
+
+const CREDENTIAL_PATH_PREFIX = "/v1/credentials";
+
+/**
+ * Try to handle a credential CRUD request. Returns a Response if the
+ * request matches a credential route, or null if it doesn't match
+ * (allowing the caller to fall through to other routes).
+ */
+export async function handleCredentialRoute(
+  req: Request,
+  deps: CredentialRouteDeps,
+): Promise<Response | null> {
+  const url = new URL(req.url);
+  const { pathname } = url;
+
+  // Only handle /v1/credentials paths
+  if (!pathname.startsWith(CREDENTIAL_PATH_PREFIX)) {
+    return null;
+  }
+
+  // Auth check
+  const authError = checkAuth(req, deps.serviceToken);
+  if (authError) return authError;
+
+  const { backend } = deps;
+
+  // Extract account from path: /v1/credentials/:account
+  const accountSegment = pathname.slice(CREDENTIAL_PATH_PREFIX.length);
+
+  // GET /v1/credentials — list all credential account names
+  if (accountSegment === "" || accountSegment === "/") {
+    if (req.method !== "GET") {
+      return new Response(
+        JSON.stringify({ error: "Method not allowed" }),
+        { status: 405, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const accounts = await backend.list();
+    return new Response(
+      JSON.stringify({ accounts }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  // Remaining routes require /:account
+  if (!accountSegment.startsWith("/")) {
+    return null; // Not a credential route
+  }
+
+  const account = decodeURIComponent(accountSegment.slice(1));
+  if (!account) {
+    return new Response(
+      JSON.stringify({ error: "Account name is required" }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  switch (req.method) {
+    // GET /v1/credentials/:account — get credential value
+    case "GET": {
+      const value = await backend.get(account);
+      if (value === undefined) {
+        return new Response(
+          JSON.stringify({ error: "Credential not found", account }),
+          { status: 404, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(
+        JSON.stringify({ account, value }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    // POST /v1/credentials/:account — set credential value
+    case "POST": {
+      let body: { value?: string };
+      try {
+        body = await req.json();
+      } catch {
+        return new Response(
+          JSON.stringify({ error: "Invalid JSON body" }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (typeof body.value !== "string") {
+        return new Response(
+          JSON.stringify({ error: "Body must contain a 'value' string field" }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      const ok = await backend.set(account, body.value);
+      if (!ok) {
+        return new Response(
+          JSON.stringify({ error: "Failed to set credential", account }),
+          { status: 500, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(
+        JSON.stringify({ ok: true, account }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    // DELETE /v1/credentials/:account — delete credential
+    case "DELETE": {
+      const result = await backend.delete(account);
+      if (result === "not-found") {
+        return new Response(
+          JSON.stringify({ error: "Credential not found", account }),
+          { status: 404, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (result === "error") {
+        return new Response(
+          JSON.stringify({ error: "Failed to delete credential", account }),
+          { status: 500, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(
+        JSON.stringify({ ok: true, account }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    default:
+      return new Response(
+        JSON.stringify({ error: "Method not allowed" }),
+        { status: 405, headers: { "Content-Type": "application/json" } },
+      );
+  }
+}

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -57,6 +57,8 @@ import { materializeManagedToken } from "./materializers/managed-platform.js";
 import { HandleType, parseHandle } from "@vellumai/ces-contracts";
 import { buildLazyGetters, type ApiKeyRef } from "./managed-lazy-getters.js";
 import { MANAGED_LOCAL_STATIC_REJECTION_ERROR } from "./managed-errors.js";
+import { createLocalSecureKeyBackend } from "./materializers/local-secure-key-backend.js";
+import { handleCredentialRoute, type CredentialRouteDeps } from "./http/credential-routes.js";
 
 // ---------------------------------------------------------------------------
 // Logging (managed always logs to stderr)
@@ -324,10 +326,14 @@ function buildHandlers(sessionIdRef: SessionIdRef, apiKeyRef: ApiKeyRef): RpcHan
 
 let rpcConnected = false;
 
-function startHealthServer(port: number, signal: AbortSignal): ReturnType<typeof Bun.serve> {
+function startHealthServer(
+  port: number,
+  signal: AbortSignal,
+  credentialDeps: CredentialRouteDeps | null,
+): ReturnType<typeof Bun.serve> {
   const server = Bun.serve({
     port,
-    fetch(req) {
+    async fetch(req) {
       const url = new URL(req.url);
       if (url.pathname === "/healthz") {
         return new Response(
@@ -350,6 +356,13 @@ function startHealthServer(port: number, signal: AbortSignal): ReturnType<typeof
           },
         );
       }
+
+      // Credential CRUD routes (only if service token is configured)
+      if (credentialDeps) {
+        const credentialResponse = await handleCredentialRoute(req, credentialDeps);
+        if (credentialResponse) return credentialResponse;
+      }
+
       return new Response("Not Found", { status: 404 });
     },
   });
@@ -480,9 +493,29 @@ async function main(): Promise<void> {
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);
 
+  // Set up credential CRUD routes if a service token is configured.
+  // The assistant and gateway use CES_SERVICE_TOKEN to authenticate
+  // credential management requests over HTTP.
+  const serviceToken = process.env["CES_SERVICE_TOKEN"] ?? "";
+  let credentialDeps: CredentialRouteDeps | null = null;
+
+  if (serviceToken) {
+    const assistantDataMount =
+      process.env["CES_ASSISTANT_DATA_MOUNT"] ?? "/assistant-data-ro";
+    const vellumRoot = join(assistantDataMount, ".vellum");
+    const backend = createLocalSecureKeyBackend(vellumRoot);
+    credentialDeps = { backend, serviceToken };
+    log("Credential CRUD routes enabled (CES_SERVICE_TOKEN configured)");
+  } else {
+    warn(
+      "CES_SERVICE_TOKEN not set — credential CRUD HTTP routes are disabled. " +
+        "Set CES_SERVICE_TOKEN to enable credential management over HTTP.",
+    );
+  }
+
   // Start health server on dedicated port
   const healthPort = getHealthPort();
-  const healthServer = startHealthServer(healthPort, controller.signal);
+  const healthServer = startHealthServer(healthPort, controller.signal, credentialDeps);
   log(`Health server listening on port ${healthPort}`);
 
   // Wait for exactly one assistant connection on the bootstrap socket


### PR DESCRIPTION
## Summary
- Add credential CRUD HTTP endpoints to the CES health server (port 8090)
- Endpoints: GET /v1/credentials (list), GET/POST/DELETE /v1/credentials/:account
- Auth via CES_SERVICE_TOKEN bearer token in Authorization header
- Wraps existing LocalSecureKeyBackend methods (get, set, delete, list)
- Credential routes only enabled when CES_SERVICE_TOKEN env var is set

Part of plan: docker-volume-security.md (PR 20 of 35)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19866" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
