### PR TITLE
feat: migrate trust.json from data volume to gateway security volume

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -13,6 +13,7 @@ import {
   DOCKER_READY_TIMEOUT_MS,
   GATEWAY_INTERNAL_PORT,
   dockerResourceNames,
+  migrateGatewaySecurityFiles,
   startContainers,
   stopContainers,
 } from "../lib/docker";
@@ -278,6 +279,9 @@ async function upgradeDocker(
       extraAssistantEnv[key] = value;
     }
   }
+
+  console.log("🔄 Migrating security files to gateway volume...");
+  await migrateGatewaySecurityFiles(res, (msg) => console.log(msg));
 
   console.log("🚀 Starting upgraded containers...");
   await startContainers(

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -567,6 +567,61 @@ export function serviceDockerRunArgs(opts: {
   };
 }
 
+/**
+ * Migrate trust.json and actor-token-signing-key from the data volume
+ * (old location: /data/.vellum/protected/) to the gateway security volume
+ * (new location: /gateway-security/).
+ *
+ * Uses a temporary busybox container that mounts both volumes. The migration
+ * is idempotent: it only copies a file when the source exists on the data
+ * volume and the destination does not yet exist on the gateway security volume.
+ */
+export async function migrateGatewaySecurityFiles(
+  res: ReturnType<typeof dockerResourceNames>,
+  log: (msg: string) => void,
+): Promise<void> {
+  const migrationContainer = `${res.gatewayContainer}-migration`;
+  const filesToMigrate = ["trust.json", "actor-token-signing-key"];
+
+  // Remove any leftover migration container from a previous interrupted run.
+  try {
+    await exec("docker", ["rm", "-f", migrationContainer]);
+  } catch {
+    // container may not exist
+  }
+
+  for (const fileName of filesToMigrate) {
+    const src = `/data/.vellum/protected/${fileName}`;
+    const dst = `/gateway-security/${fileName}`;
+
+    try {
+      // Run a busybox container that checks source exists and destination
+      // does not, then copies. The shell exits 0 whether or not a copy
+      // happens, so the migration is always safe to re-run.
+      await exec("docker", [
+        "run",
+        "--rm",
+        "--name",
+        migrationContainer,
+        "-v",
+        `${res.dataVolume}:/data:ro`,
+        "-v",
+        `${res.gatewaySecurityVolume}:/gateway-security`,
+        "busybox",
+        "sh",
+        "-c",
+        `if [ -f "${src}" ] && [ ! -f "${dst}" ]; then cp "${src}" "${dst}" && echo "migrated"; else echo "skipped"; fi`,
+      ]);
+      log(`   ${fileName}: checked`);
+    } catch (err) {
+      // Non-fatal — log and continue. The gateway will create fresh files
+      // if they don't exist.
+      const message = err instanceof Error ? err.message : String(err);
+      log(`   ${fileName}: migration failed (${message}), continuing...`);
+    }
+  }
+}
+
 /** The order in which services must be started. */
 export const SERVICE_START_ORDER: ServiceName[] = [
   "assistant",
@@ -912,6 +967,9 @@ export async function hatchDocker(
     await exec("docker", ["volume", "create", res.workspaceVolume]);
     await exec("docker", ["volume", "create", res.cesSecurityVolume]);
     await exec("docker", ["volume", "create", res.gatewaySecurityVolume]);
+
+    log("🔄 Migrating security files to gateway volume...");
+    await migrateGatewaySecurityFiles(res, log);
 
     await startContainers({ gatewayPort, imageTags, instanceName, res }, log);
 


### PR DESCRIPTION
## Summary
- Add migration step to Docker startup that copies trust.json and actor-token-signing-key from data volume to gateway security volume
- Uses temporary busybox container to perform the copy
- Idempotent: only copies if source exists and destination doesn't
- Preserves existing trust rules and signing key for upgraded instances

Part of plan: docker-volume-security.md (PR 17 of 35)