### PR TITLE
fix: play messageSent sound on button-tap sends, not just keyboard

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -433,7 +433,7 @@ struct ComposerView: View {
                     iconSize: composerActionButtonSize
                 ) {
                     composerFocus = true
-                    onSend()
+                    performSendAction()
                 }
                 .vTooltip("Type a message to send")
             } else if !hasPendingConfirmation {
@@ -457,7 +457,7 @@ struct ComposerView: View {
                     iconSize: composerActionButtonSize
                 ) {
                     composerFocus = true
-                    onSend()
+                    performSendAction()
                 }
                 .vTooltip(canSend ? "Send" : "Type a message to send")
             } else {
@@ -488,7 +488,7 @@ struct ComposerView: View {
                     iconSize: composerActionButtonSize
                 ) {
                     composerFocus = true
-                    onSend()
+                    performSendAction()
                 }
             }
         }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review round 3 for custom-sounds-mac.md.

**Gap:** messageSent sound only plays on keyboard send (Cmd+Enter), not button clicks
**Fix:** Changed all three send-button tap handlers in `ComposerView.swift` to call `performSendAction()` instead of `onSend()` directly, ensuring the `.messageSent` sound plays on every send path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
