### PR TITLE
fix: guard leaseGuardianToken against connection errors in backup/restore

### DIFF
--- a/cli/src/commands/backup.ts
+++ b/cli/src/commands/backup.ts
@@ -79,8 +79,20 @@ export async function backup(): Promise<void> {
   ) {
     accessToken = tokenData.accessToken;
   } else {
-    const freshToken = await leaseGuardianToken(entry.runtimeUrl, name);
-    accessToken = freshToken.accessToken;
+    try {
+      const freshToken = await leaseGuardianToken(entry.runtimeUrl, entry.assistantId);
+      accessToken = freshToken.accessToken;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("ECONNREFUSED") || msg.includes("fetch failed")) {
+        console.error(
+          `Error: Could not connect to assistant '${name}'. Is it running?`,
+        );
+        console.error(`Try: vellum wake ${name}`);
+        process.exit(1);
+      }
+      throw err;
+    }
   }
 
   // Call the export endpoint

--- a/cli/src/commands/restore.ts
+++ b/cli/src/commands/restore.ts
@@ -64,6 +64,7 @@ function parseArgs(argv: string[]): {
 async function getAccessToken(
   runtimeUrl: string,
   assistantId: string,
+  displayName: string,
 ): Promise<string> {
   const tokenData = loadGuardianToken(assistantId);
 
@@ -74,8 +75,20 @@ async function getAccessToken(
     return tokenData.accessToken;
   }
 
-  const freshToken = await leaseGuardianToken(runtimeUrl, assistantId);
-  return freshToken.accessToken;
+  try {
+    const freshToken = await leaseGuardianToken(runtimeUrl, assistantId);
+    return freshToken.accessToken;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("ECONNREFUSED") || msg.includes("fetch failed")) {
+      console.error(
+        `Error: Could not connect to assistant '${displayName}'. Is it running?`,
+      );
+      console.error(`Try: vellum wake ${displayName}`);
+      process.exit(1);
+    }
+    throw err;
+  }
 }
 
 interface PreflightFileEntry {
@@ -146,7 +159,7 @@ export async function restore(): Promise<void> {
   console.log(`Reading ${fromPath} (${sizeMB} MB)...`);
 
   // Obtain auth token
-  const accessToken = await getAccessToken(entry.runtimeUrl, name);
+  const accessToken = await getAccessToken(entry.runtimeUrl, entry.assistantId, name);
 
   if (dryRun) {
     // Preflight check


### PR DESCRIPTION
## Summary
- Wrap leaseGuardianToken calls in both backup.ts and restore.ts with try/catch for connection-refused errors
- Normalize backup.ts to use entry.assistantId consistently (matching restore.ts pattern)

Fixes gaps from backup-restore-cli.md plan review round 2.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
