### PR TITLE
feat: use gateway trust API when IS_CONTAINERIZED

### DIFF
--- a/assistant/src/permissions/trust-client.ts
+++ b/assistant/src/permissions/trust-client.ts
@@ -4,6 +4,10 @@
  * Provides CRUD operations over trust rules stored in the gateway,
  * replacing direct filesystem access to trust.json when the assistant
  * runs in a containerized environment.
+ *
+ * Both async and synchronous variants are exported. The sync variants
+ * use `Bun.spawnSync` + `curl` to make blocking HTTP calls — acceptable
+ * for user-initiated write operations that are infrequent.
  */
 
 import type { TrustRule } from "@vellumai/ces-contracts";
@@ -88,6 +92,88 @@ async function request<T>(
   }
 
   return (await response.json()) as T;
+}
+
+/**
+ * Synchronous HTTP request via `Bun.spawnSync` + `curl`.
+ *
+ * Used by the gateway trust store adapter for write operations that must
+ * return synchronously to satisfy the `TrustStoreBackend` interface.
+ * Write operations are user-initiated and infrequent, so blocking is acceptable.
+ */
+function requestSync<T>(method: string, path: string, body?: unknown): T {
+  const url = `${getBaseUrl()}${path}`;
+  const headers = authHeaders();
+  const args: string[] = [
+    "curl",
+    "-s",
+    "-S",
+    "-X",
+    method,
+    "--max-time",
+    String(Math.ceil(REQUEST_TIMEOUT_MS / 1000)),
+    "-H",
+    `Authorization: ${headers.Authorization}`,
+    "-H",
+    "Content-Type: application/json",
+    "-w",
+    "\n%{http_code}",
+  ];
+  if (body !== undefined) {
+    args.push("-d", JSON.stringify(body));
+  }
+  args.push(url);
+
+  const proc = Bun.spawnSync(args, {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  if (proc.exitCode !== 0) {
+    const stderr = proc.stderr.toString().trim();
+    log.error(
+      { exitCode: proc.exitCode, stderr, method, path },
+      "Trust rule sync request failed (curl)",
+    );
+    throw new Error(
+      `Trust rule sync request failed: ${method} ${path}: curl exit ${proc.exitCode}: ${stderr}`,
+    );
+  }
+
+  const output = proc.stdout.toString().trim();
+  // curl -w "\n%{http_code}" appends the HTTP status code on the last line
+  const lastNewline = output.lastIndexOf("\n");
+  const responseBody = lastNewline >= 0 ? output.slice(0, lastNewline) : "";
+  const statusCode = parseInt(
+    lastNewline >= 0 ? output.slice(lastNewline + 1) : output,
+    10,
+  );
+
+  if (statusCode < 200 || statusCode >= 300) {
+    log.error(
+      { status: statusCode, body: responseBody, method, path },
+      "Trust rule sync request failed",
+    );
+    throw new Error(
+      `Trust rule sync request failed (${statusCode}): ${method} ${path}: ${responseBody}`,
+    );
+  }
+
+  if (!responseBody) {
+    return {} as T;
+  }
+
+  try {
+    return JSON.parse(responseBody) as T;
+  } catch (err) {
+    log.error(
+      { err, responseBody, method, path },
+      "Failed to parse sync response JSON",
+    );
+    throw new Error(
+      `Trust rule sync request: failed to parse response: ${method} ${path}`,
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -180,6 +266,77 @@ export async function findMatchingRule(
 /** Accept the starter approval bundle, seeding common low-risk allow rules. */
 export async function acceptStarterBundle(): Promise<AcceptStarterBundleResult> {
   return request<AcceptStarterBundleResult>(
+    "POST",
+    "/v1/trust-rules/starter-bundle",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Synchronous API — used by the gateway trust store adapter
+// ---------------------------------------------------------------------------
+
+/** Fetch all trust rules from the gateway (synchronous). */
+export function getAllRulesSync(): TrustRule[] {
+  const data = requestSync<{ rules: TrustRule[] }>("GET", "/v1/trust-rules");
+  return data.rules;
+}
+
+/** Create a new trust rule (synchronous). */
+export function addRuleSync(params: {
+  tool: string;
+  pattern: string;
+  scope: string;
+  decision?: TrustRule["decision"];
+  priority?: number;
+  allowHighRisk?: boolean;
+  executionTarget?: string;
+}): TrustRule {
+  const data = requestSync<{ rule: TrustRule }>(
+    "POST",
+    "/v1/trust-rules",
+    params,
+  );
+  return data.rule;
+}
+
+/** Update an existing trust rule by ID (synchronous). */
+export function updateRuleSync(
+  id: string,
+  updates: {
+    tool?: string;
+    pattern?: string;
+    scope?: string;
+    decision?: TrustRule["decision"];
+    priority?: number;
+    allowHighRisk?: boolean;
+    executionTarget?: string;
+  },
+): TrustRule {
+  const data = requestSync<{ rule: TrustRule }>(
+    "PATCH",
+    `/v1/trust-rules/${encodeURIComponent(id)}`,
+    updates,
+  );
+  return data.rule;
+}
+
+/** Remove a trust rule by ID (synchronous). Returns true if deleted. */
+export function removeRuleSync(id: string): boolean {
+  const data = requestSync<{ success: boolean }>(
+    "DELETE",
+    `/v1/trust-rules/${encodeURIComponent(id)}`,
+  );
+  return data.success;
+}
+
+/** Clear all user trust rules (synchronous). */
+export function clearRulesSync(): void {
+  requestSync<{ success: boolean }>("POST", "/v1/trust-rules/clear");
+}
+
+/** Accept the starter approval bundle (synchronous). */
+export function acceptStarterBundleSync(): AcceptStarterBundleResult {
+  return requestSync<AcceptStarterBundleResult>(
     "POST",
     "/v1/trust-rules/starter-bundle",
   );

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -11,9 +11,11 @@ import { dirname, join } from "node:path";
 import { Minimatch } from "minimatch";
 import { v4 as uuid } from "uuid";
 
+import { getIsContainerized } from "../config/env-registry.js";
 import { getLogger } from "../util/logger.js";
 import { getRootDir } from "../util/platform.js";
 import { getDefaultRuleTemplates } from "./defaults.js";
+import * as trustClient from "./trust-client.js";
 import type {
   AcceptStarterBundleResult,
   StarterBundleRule,
@@ -737,13 +739,379 @@ const fileTrustStoreBackend: TrustStoreBackend = {
   getStarterBundleRules,
 };
 
+// ─── Gateway-backed trust store adapter ─────────────────────────────────────
+//
+// When the daemon runs in a container (IS_CONTAINERIZED=true), trust rules
+// are stored in the gateway — not on the local filesystem. This adapter
+// wraps the async gateway HTTP client into the synchronous TrustStoreBackend
+// interface using an in-memory cache.
+//
+// Read operations serve from the cache. Write operations call the gateway
+// synchronously (via curl), then update the cache from the response.
+// A background timer refreshes the cache every CACHE_TTL_MS.
+
+const CACHE_TTL_MS = 5_000;
+
+/**
+ * Gateway-backed trust store that caches rules in memory and refreshes
+ * on a TTL. Satisfies the synchronous TrustStoreBackend interface by
+ * reading from cache and writing via synchronous HTTP calls.
+ */
+class GatewayTrustStoreAdapter implements TrustStoreBackend {
+  private rules: TrustRule[] = [];
+  private starterBundleAccepted = false;
+  private initialized = false;
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+  private readonly listeners: Array<() => void> = [];
+
+  /** Pattern cache — mirrors the file-based store's approach. */
+  private readonly gwCompiledPatterns = new Map<string, Minimatch>();
+  private readonly gwInvalidPatterns = new Set<string>();
+
+  // ── Initialization ──────────────────────────────────────────────────────
+
+  /**
+   * Ensure the cache is populated. Blocks synchronously on the first call
+   * by fetching rules from the gateway via the sync client. Subsequent
+   * calls are no-ops because the background refresh timer keeps the cache
+   * current.
+   */
+  private ensureInitialized(): void {
+    if (this.initialized) return;
+    try {
+      this.rules = trustClient.getAllRulesSync();
+      this.rules.sort(ruleOrder);
+      this.rebuildPatternCache();
+      // Infer starterBundleAccepted from the fetched rules — if any starter
+      // rule IDs are present, the bundle was accepted.
+      const starterIds = new Set(
+        getStarterBundleRules().map((r) => r.id),
+      );
+      this.starterBundleAccepted = this.rules.some((r) =>
+        starterIds.has(r.id),
+      );
+    } catch (err) {
+      log.error(
+        { err },
+        "Failed to load trust rules from gateway; using empty rule set",
+      );
+      this.rules = [];
+    }
+    this.initialized = true;
+    this.startRefreshTimer();
+  }
+
+  private startRefreshTimer(): void {
+    if (this.refreshTimer != null) return;
+    this.refreshTimer = setInterval(() => {
+      this.refreshCache();
+    }, CACHE_TTL_MS);
+    // Unref so the timer doesn't prevent the process from exiting.
+    if (this.refreshTimer && typeof this.refreshTimer === "object" && "unref" in this.refreshTimer) {
+      (this.refreshTimer as NodeJS.Timeout).unref();
+    }
+  }
+
+  private refreshCache(): void {
+    try {
+      const fresh = trustClient.getAllRulesSync();
+      fresh.sort(ruleOrder);
+      const oldJson = JSON.stringify(this.rules);
+      this.rules = fresh;
+      this.rebuildPatternCache();
+      // Detect starter bundle acceptance
+      const starterIds = new Set(
+        getStarterBundleRules().map((r) => r.id),
+      );
+      this.starterBundleAccepted = this.rules.some((r) =>
+        starterIds.has(r.id),
+      );
+      if (JSON.stringify(fresh) !== oldJson) {
+        this.notifyListeners();
+      }
+    } catch (err) {
+      log.warn(
+        { err },
+        "Failed to refresh trust rules from gateway; using stale cache",
+      );
+    }
+  }
+
+  private rebuildPatternCache(): void {
+    this.gwCompiledPatterns.clear();
+    this.gwInvalidPatterns.clear();
+    for (const rule of this.rules) {
+      if (typeof rule.pattern !== "string") continue;
+      if (!this.gwCompiledPatterns.has(rule.pattern)) {
+        try {
+          this.gwCompiledPatterns.set(
+            rule.pattern,
+            new Minimatch(rule.pattern),
+          );
+        } catch {
+          // skip invalid patterns
+        }
+      }
+    }
+  }
+
+  private getCompiledPattern(pattern: string): Minimatch | null {
+    if (this.gwInvalidPatterns.has(pattern)) return null;
+    let compiled = this.gwCompiledPatterns.get(pattern);
+    if (!compiled) {
+      try {
+        compiled = new Minimatch(pattern);
+        this.gwCompiledPatterns.set(pattern, compiled);
+      } catch {
+        this.gwInvalidPatterns.add(pattern);
+        return null;
+      }
+    }
+    return compiled;
+  }
+
+  private notifyListeners(): void {
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+
+  // ── TrustStoreBackend implementation ────────────────────────────────────
+
+  getAllRules(): TrustRule[] {
+    this.ensureInitialized();
+    return [...this.rules];
+  }
+
+  findHighestPriorityRule(
+    tool: string,
+    commands: string[],
+    scope: string,
+    ctx?: PolicyContext,
+  ): TrustRule | null {
+    this.ensureInitialized();
+    const ephemeral = ctx?.ephemeralRules ?? [];
+    const allRules =
+      ephemeral.length > 0
+        ? [...ephemeral, ...this.rules].sort(ruleOrder)
+        : this.rules;
+
+    for (const rule of allRules) {
+      if (rule.tool !== tool) continue;
+      if (!matchesScope(rule.scope, scope)) continue;
+      if (!matchesExecutionTarget(rule, ctx)) continue;
+      const compiled = this.getCompiledPattern(rule.pattern);
+      if (!compiled) continue;
+      for (const command of commands) {
+        if (compiled.match(command)) {
+          return rule;
+        }
+      }
+    }
+    return null;
+  }
+
+  findMatchingRule(
+    tool: string,
+    command: string,
+    scope: string,
+  ): TrustRule | null {
+    this.ensureInitialized();
+    for (const rule of this.rules) {
+      if (rule.tool !== tool) continue;
+      if (rule.decision !== "allow") continue;
+      const compiled = this.getCompiledPattern(rule.pattern);
+      if (!compiled || !compiled.match(command)) continue;
+      if (!matchesScope(rule.scope, scope)) continue;
+      return rule;
+    }
+    return null;
+  }
+
+  findDenyRule(
+    tool: string,
+    command: string,
+    scope: string,
+  ): TrustRule | null {
+    this.ensureInitialized();
+    for (const rule of this.rules) {
+      if (rule.tool !== tool) continue;
+      if (rule.decision !== "deny") continue;
+      const compiled = this.getCompiledPattern(rule.pattern);
+      if (!compiled || !compiled.match(command)) continue;
+      if (!matchesScope(rule.scope, scope)) continue;
+      return rule;
+    }
+    return null;
+  }
+
+  addRule(
+    tool: string,
+    pattern: string,
+    scope: string,
+    decision: "allow" | "deny" | "ask" = "allow",
+    priority: number = 100,
+    options?: {
+      allowHighRisk?: boolean;
+      executionTarget?: string;
+    },
+  ): TrustRule {
+    if (tool.startsWith("__internal:"))
+      throw new Error(
+        `Cannot create internal pseudo-rule via addRule: ${tool}`,
+      );
+    this.ensureInitialized();
+    const rule = trustClient.addRuleSync({
+      tool,
+      pattern,
+      scope,
+      decision,
+      priority,
+      allowHighRisk: options?.allowHighRisk,
+      executionTarget: options?.executionTarget,
+    });
+    // Update local cache
+    this.rules = [...this.rules, rule].sort(ruleOrder);
+    this.rebuildPatternCache();
+    this.notifyListeners();
+    log.info({ rule }, "Added trust rule via gateway");
+    return rule;
+  }
+
+  updateRule(
+    id: string,
+    updates: {
+      tool?: string;
+      pattern?: string;
+      scope?: string;
+      decision?: "allow" | "deny" | "ask";
+      priority?: number;
+    },
+  ): TrustRule {
+    if (updates.tool?.startsWith("__internal:"))
+      throw new Error(
+        `Cannot update tool to internal pseudo-rule: ${updates.tool}`,
+      );
+    this.ensureInitialized();
+    const rule = trustClient.updateRuleSync(id, updates);
+    // Update local cache
+    const idx = this.rules.findIndex((r) => r.id === id);
+    if (idx >= 0) {
+      this.rules[idx] = rule;
+    } else {
+      this.rules.push(rule);
+    }
+    this.rules = [...this.rules].sort(ruleOrder);
+    this.rebuildPatternCache();
+    this.notifyListeners();
+    log.info({ rule }, "Updated trust rule via gateway");
+    return rule;
+  }
+
+  removeRule(id: string): boolean {
+    this.ensureInitialized();
+    const success = trustClient.removeRuleSync(id);
+    if (success) {
+      this.rules = this.rules.filter((r) => r.id !== id);
+      this.rebuildPatternCache();
+      this.notifyListeners();
+      log.info({ id }, "Removed trust rule via gateway");
+    }
+    return success;
+  }
+
+  clearAllRules(): void {
+    this.ensureInitialized();
+    trustClient.clearRulesSync();
+    this.starterBundleAccepted = false;
+    // Re-fetch to get the default rules the gateway preserves
+    try {
+      this.rules = trustClient.getAllRulesSync();
+      this.rules.sort(ruleOrder);
+    } catch {
+      this.rules = [];
+    }
+    this.rebuildPatternCache();
+    this.notifyListeners();
+    log.info("Cleared all user trust rules via gateway");
+  }
+
+  acceptStarterBundle(): AcceptStarterBundleResult {
+    this.ensureInitialized();
+    const result = trustClient.acceptStarterBundleSync();
+    this.starterBundleAccepted = true;
+    // Refresh cache to include the newly added starter rules
+    try {
+      this.rules = trustClient.getAllRulesSync();
+      this.rules.sort(ruleOrder);
+    } catch {
+      // Keep stale cache
+    }
+    this.rebuildPatternCache();
+    this.notifyListeners();
+    log.info(
+      { rulesAdded: result.rulesAdded },
+      "Starter approval bundle accepted via gateway",
+    );
+    return { ...result, alreadyAccepted: result.rulesAdded === 0 };
+  }
+
+  isStarterBundleAccepted(): boolean {
+    this.ensureInitialized();
+    return this.starterBundleAccepted;
+  }
+
+  onRulesChanged(listener: () => void): void {
+    this.listeners.push(listener);
+  }
+
+  clearCache(): void {
+    this.initialized = false;
+    this.rules = [];
+    this.starterBundleAccepted = false;
+    this.gwCompiledPatterns.clear();
+    this.gwInvalidPatterns.clear();
+    if (this.refreshTimer != null) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+
+  patternMatchesCandidate(pattern: string, candidate: string): boolean {
+    const compiled = this.getCompiledPattern(pattern);
+    if (!compiled) return false;
+    return compiled.match(candidate);
+  }
+
+  getStarterBundleRules(): StarterBundleRule[] {
+    // Starter bundle definitions are static — same regardless of backend.
+    return getStarterBundleRules();
+  }
+}
+
+/** Singleton gateway adapter instance (lazily created). */
+let gatewayTrustStoreBackend: GatewayTrustStoreAdapter | null = null;
+
+function getGatewayTrustStore(): GatewayTrustStoreAdapter {
+  if (!gatewayTrustStoreBackend) {
+    gatewayTrustStoreBackend = new GatewayTrustStoreAdapter();
+  }
+  return gatewayTrustStoreBackend;
+}
+
 /**
  * Returns the active trust store backend.
  *
- * Currently always returns the file-based implementation. A future PR will
- * add a gateway-backed backend for containerized deployments and switch
- * based on `getIsContainerized()`.
+ * When `IS_CONTAINERIZED=true`, returns a gateway-backed adapter that
+ * proxies all trust operations through the gateway HTTP API. The daemon
+ * never reads or writes `protected/trust.json` directly in Docker.
+ *
+ * When `IS_CONTAINERIZED=false`, returns the file-based implementation
+ * (no change from previous behavior).
  */
 export function getTrustStore(): TrustStoreBackend {
+  if (getIsContainerized()) {
+    return getGatewayTrustStore();
+  }
   return fileTrustStoreBackend;
 }


### PR DESCRIPTION
## Summary
- `getTrustStore()` returns gateway-backed trust client when `IS_CONTAINERIZED=true`
- `GatewayTrustStoreAdapter` wraps the async gateway HTTP client into the sync `TrustStoreBackend` interface using an in-memory cache
- Sync HTTP requests via `Bun.spawnSync` + `curl` for write operations (infrequent, user-initiated)
- TTL-based cache refresh every 5s for read operations with background timer (unref'd to avoid blocking process exit)
- Listener notification on cache changes for dependent cache invalidation
- No change for local (non-Docker) installs — file-based backend unchanged

Part of plan: docker-volume-security.md (PR 16 of 35)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
