### PR TITLE
feat: add optional `resolveConnection` to MessagingProvider for custom credential resolution

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/shared.ts
@@ -136,6 +136,7 @@ export async function getProviderConnection(
   provider: MessagingProvider,
   account?: string,
 ): Promise<OAuthConnection | string> {
+  if (provider.resolveConnection) return provider.resolveConnection(account);
   if (await provider.isConnected?.()) return "";
   return resolveOAuthConnection(provider.credentialService, { account });
 }

--- a/assistant/src/messaging/provider.ts
+++ b/assistant/src/messaging/provider.ts
@@ -89,6 +89,15 @@ export interface MessagingProvider {
    */
   isConnected?(): Promise<boolean>;
 
+  /**
+   * Custom credential resolution for providers with non-standard credential
+   * paths (e.g. Slack Socket Mode stores tokens under "slack_channel" rather
+   * than the OAuth provider key). When present, getProviderConnection() calls
+   * this instead of resolveOAuthConnection(), giving the provider full control
+   * over credential lookup including fallback strategies.
+   */
+  resolveConnection?(account?: string): Promise<OAuthConnection | string>;
+
   /** Platform-specific capabilities for tool routing (e.g. 'reactions', 'threads', 'labels'). */
   capabilities: Set<string>;
 }


### PR DESCRIPTION
## Summary
- Add optional `resolveConnection?(account?: string)` method to the `MessagingProvider` interface
- Update `getProviderConnection()` to check `resolveConnection` before `isConnected` before `resolveOAuthConnection`
- Backwards compatible: all existing adapters continue to work unchanged

Part of JARVIS-270

Part of plan: slack-msg-token-fix.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
