### PR TITLE
chore: remove debug breadcrumbs from backup restore

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -244,14 +244,16 @@ struct AssistantBackupsSection: View {
 
     private func selectAndRestoreLocalBackup() {
         clearMessages()
+
         let panel = NSOpenPanel()
         panel.allowedContentTypes = [.init(filenameExtension: "vbundle") ?? .data]
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
 
         panel.begin { result in
-            guard result == .OK, let url = panel.url else { return }
             Task { @MainActor in
+                guard result == .OK, let url = panel.url else { return }
+
                 // Use NSAlert instead of SwiftUI .alert — SwiftUI alerts on
                 // inner views are swallowed when the parent has its own .alert
                 // modifiers (SettingsDeveloperTab has several).


### PR DESCRIPTION
## Summary
- Remove diagnostic `successMessage` breadcrumbs added during debugging of the restore confirmation dialog fix