### PR TITLE
fix: resolve lint errors in ces-credential-client and logger

### DIFF
--- a/assistant/src/security/ces-credential-client.ts
+++ b/assistant/src/security/ces-credential-client.ts
@@ -15,8 +15,8 @@
  * Base URL: `CES_CREDENTIAL_URL` env var (e.g. `http://ces-container:8090`).
  */
 
-import type { CredentialBackend, DeleteResult } from "./credential-backend.js";
 import { getLogger } from "../util/logger.js";
+import type { CredentialBackend, DeleteResult } from "./credential-backend.js";
 
 const log = getLogger("ces-credential-client");
 

--- a/assistant/src/util/logger.ts
+++ b/assistant/src/util/logger.ts
@@ -87,7 +87,6 @@ function resolveLogDir(config: LogFileConfig): string | undefined {
         // Config has a host-specific path that can't be created inside the
         // container (e.g. /Users/…). Fall back to the default log directory.
         const fallback = join(getLogPath(), "..");
-        // eslint-disable-next-line no-console
         console.warn(
           `[logger] Configured logFile.dir "${config.dir}" cannot be created ` +
             `in container (${(err as Error).message}). Falling back to "${fallback}".`,


### PR DESCRIPTION
## Summary
- Fix import sort order in `ces-credential-client.ts` (simple-import-sort/imports)
- Remove unused eslint-disable directive in `logger.ts` (no-console rule no longer triggers)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23322621970/job/67836958404
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19878" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
