### PR TITLE
feat: remove data volume mount from assistant container

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -68,18 +68,17 @@ RUN groupadd --system --gid 1001 assistant && \
     useradd --system --uid 1001 --gid assistant --create-home --shell /bin/bash assistant && \
     echo "assistant ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-# Set up data directory
-RUN mkdir -p /home/assistant/.vellum /data && \
-    chown -R assistant:assistant /home/assistant/.vellum /data && \
-    chmod a+rwx /data
+# Set up assistant home directory for local state (device.json, etc.)
+RUN mkdir -p /home/assistant/.vellum && \
+    chown -R assistant:assistant /home/assistant/.vellum
 
 # Update PATH for assistant user
-ENV PATH="/home/assistant/.bun/bin:/data/bin:${PATH}"
+ENV PATH="/home/assistant/.bun/bin:${PATH}"
 
-# Configure package managers to use /data
-ENV BUN_INSTALL="/data/.bun"
+# Configure package managers to use assistant home
+ENV BUN_INSTALL="/home/assistant/.bun"
 ENV PATH="${BUN_INSTALL}/bin:${PATH}"
-ENV PYTHONUSERBASE="/data/.python"
+ENV PYTHONUSERBASE="/home/assistant/.python"
 ENV PATH="${PYTHONUSERBASE}/bin:${PATH}"
 
 # Ensure the CES bootstrap socket volume is writable by the non-root CES user.
@@ -90,7 +89,6 @@ USER assistant
 EXPOSE 3001
 
 ENV RUNTIME_HTTP_PORT=3001
-ENV BASE_DATA_DIR=/data
 ENV IS_CONTAINERIZED=true
 
 # Copy from builder

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -434,13 +434,15 @@ export function ensureDataDir(): void {
   const wsData = join(workspace, "data");
   const containerized = getIsContainerized();
   const dirs = [
-    // Root-level dirs (runtime / protected)
+    // Root-level dirs (runtime)
     root,
-    join(root, "protected"),
+    // protected, signals, hooks are local-only — skip in containerized mode
+    // (credentials via CES HTTP API, trust via gateway API, no IPC signals)
+    ...(containerized
+      ? []
+      : [join(root, "protected"), join(root, "signals"), join(root, "hooks")]),
     // Workspace dirs
     workspace,
-    // Hooks are a local-only concept — skip in containerized mode
-    ...(containerized ? [] : [join(root, "hooks")]),
     join(workspace, "skills"),
     join(workspace, "embedding-models"),
     join(workspace, "conversations"),

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -488,8 +488,6 @@ export function serviceDockerRunArgs(opts: {
         res.assistantContainer,
         `--network=${res.network}`,
         "-v",
-        `${res.dataVolume}:/data`,
-        "-v",
         `${res.workspaceVolume}:/workspace`,
         "-v",
         `${res.socketVolume}:/run/ces-bootstrap`,


### PR DESCRIPTION
## Summary
- Remove data volume mount (-v dataVolume:/data) from assistant container
- Remove BASE_DATA_DIR=/data env var from assistant container (both Dockerfile and run args)
- Guard ensureDataDir() to skip protected/signals/hooks dirs when containerized
- Clean up Dockerfile: remove /data directory creation, update package manager paths to use /home/assistant
- Ensure /home/assistant/.vellum/ exists in Dockerfile for assistant-local state (device.json, etc.)
- Assistant now uses WORKSPACE_DIR for workspace access, CES HTTP API for credentials, gateway API for trust

Part of plan: docker-volume-security.md (PR 29 of 35)