### PR TITLE
feat: remove data volume mount from CES container

### DIFF
--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -567,8 +567,6 @@ export function serviceDockerRunArgs(opts: {
       "-v",
       `${res.socketVolume}:/run/ces-bootstrap`,
       "-v",
-      `${res.dataVolume}:/data:ro`,
-      "-v",
       `${res.workspaceVolume}:/workspace:ro`,
       "-v",
       `${res.cesSecurityVolume}:/ces-security`,
@@ -578,8 +576,6 @@ export function serviceDockerRunArgs(opts: {
       "WORKSPACE_DIR=/workspace",
       "-e",
       "CES_BOOTSTRAP_SOCKET_DIR=/run/ces-bootstrap",
-      "-e",
-      "CES_ASSISTANT_DATA_MOUNT=/data",
       "-e",
       "CREDENTIAL_SECURITY_DIR=/ces-security",
       ...(cesServiceToken


### PR DESCRIPTION
## Summary
- Remove data volume mount (`-v ${dataVolume}:/data:ro`) from CES container
- Remove `CES_ASSISTANT_DATA_MOUNT` env var (no longer needed — security dir resolved via `CREDENTIAL_SECURITY_DIR`)
- CES now uses its own security volume for keys.enc and store.key
- Workspace volume remains mounted read-only at `/workspace`

Part of plan: docker-volume-security.md (PR 31 of 35)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
