### PR TITLE
fix: restore avatar appearance after backup restore

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -399,6 +399,8 @@ extension AssistantBackupsSection {
                         AppDelegate.shared?.vellumCli.stop(name: assistantName)
                         try? await Task.sleep(nanoseconds: 500_000_000)
                         try? await AppDelegate.shared?.vellumCli.wake(name: assistantName)
+                        // Reload avatar after restart so the restored avatar is displayed
+                        AvatarAppearanceManager.shared.reloadAvatar()
                     }
                 } else {
                     errorMessage = "Import completed with warnings. Check assistant logs for details."


### PR DESCRIPTION
## Summary
- Call `AvatarAppearanceManager.shared.reloadAvatar()` after the daemon restarts post-restore so the avatar from the backup is displayed instead of the stale cached one

## Original prompt
Restoring the assistant should also restore the avatar