### PR TITLE
fix: trust client sends 'commands' query param to match gateway API

### DIFF
--- a/assistant/src/permissions/trust-client.ts
+++ b/assistant/src/permissions/trust-client.ts
@@ -253,7 +253,7 @@ export async function findMatchingRule(
 ): Promise<TrustRule | null> {
   const params = new URLSearchParams({
     tool,
-    candidates: candidates.join(","),
+    commands: candidates.join(","),
     scope,
   });
   const data = await request<{ rule: TrustRule | null }>(


### PR DESCRIPTION
## Summary
Fixes gap: trust client sent 'candidates' but gateway expects 'commands' query param.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
