### PR TITLE
fix: add GATEWAY_INTERNAL_URL env var to assistant Docker container

### DIFF
--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -500,6 +500,8 @@ export function serviceDockerRunArgs(opts: {
         "WORKSPACE_DIR=/workspace",
         "-e",
         `CES_CREDENTIAL_URL=http://${res.cesContainer}:8090`,
+        "-e",
+        `GATEWAY_INTERNAL_URL=http://${res.gatewayContainer}:${GATEWAY_INTERNAL_PORT}`,
       ];
       if (cesServiceToken) {
         args.push("-e", `CES_SERVICE_TOKEN=${cesServiceToken}`);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for docker-volume-security.md.

**Gap:** Missing GATEWAY_INTERNAL_URL env var
**What was expected:** Assistant can reach gateway for trust rule API calls
**What was found:** Fallback to localhost:7830 doesn't work across Docker containers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
