### PR TITLE
fix: gateway trust delete endpoint returns { success } instead of { removed }

### DIFF
--- a/gateway/src/http/routes/trust-rules.ts
+++ b/gateway/src/http/routes/trust-rules.ts
@@ -240,7 +240,7 @@ export function createTrustRulesDeleteHandler() {
           { status: 404 },
         );
       }
-      return Response.json({ removed: true });
+      return Response.json({ success: true });
     } catch (err) {
       log.error({ err }, "Failed to remove trust rule");
       return Response.json({ error: "Internal server error" }, { status: 500 });
@@ -256,7 +256,7 @@ export function createTrustRulesClearHandler() {
   return async (_req: Request): Promise<Response> => {
     try {
       clearRules();
-      return Response.json({ cleared: true });
+      return Response.json({ success: true });
     } catch (err) {
       log.error({ err }, "Failed to clear trust rules");
       return Response.json({ error: "Internal server error" }, { status: 500 });


### PR DESCRIPTION
## Summary
- Gateway trust-rules DELETE endpoint returned `{ removed: true }` but the trust client expected `{ success: true }`, causing every successful delete to be reported as failed.
- Also fixed the clear endpoint which returned `{ cleared: true }` instead of `{ success: true }`.

Closes the "Trust client DELETE expects `{ success }` but gateway returns `{ removed }`" gap.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
