### PR TITLE
fix: CES uses WORKSPACE_DIR for workspace resolution when set

### DIFF
--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -129,9 +129,14 @@ function buildHandlers(sessionIdRef: SessionIdRef, apiKeyRef: ApiKeyRef): RpcHan
   }
 
   // -- Workspace root for command execution cwd ------------------------------
-  const assistantDataMount =
-    process.env["CES_ASSISTANT_DATA_MOUNT"] ?? "/assistant-data-ro";
-  const mountedVellumRoot = join(assistantDataMount, ".vellum");
+  // Prefer WORKSPACE_DIR when set (new Docker layout mounts workspace at
+  // /workspace). Fall back to the legacy path derived from the assistant
+  // data mount for backwards compatibility.
+  const defaultWorkspaceDir = process.env["WORKSPACE_DIR"] ?? (() => {
+    const assistantDataMount =
+      process.env["CES_ASSISTANT_DATA_MOUNT"] ?? "/assistant-data-ro";
+    return join(join(assistantDataMount, ".vellum"), "workspace");
+  })();
 
   // -- Build handler registry ------------------------------------------------
   // NOTE: local_static credential handles are NOT supported in managed mode.
@@ -243,7 +248,7 @@ function buildHandlers(sessionIdRef: SessionIdRef, apiKeyRef: ApiKeyRef): RpcHan
       cesMode: "managed",
       egressHooks: buildCesEgressHooks(),
     },
-    defaultWorkspaceDir: join(mountedVellumRoot, "workspace"),
+    defaultWorkspaceDir,
   });
 
   // Register manage_secure_command_tool handler


### PR DESCRIPTION
## Summary
Fixes gap: CES defaultWorkspaceDir resolved to non-existent /assistant-data-ro/.vellum/workspace.
Now uses WORKSPACE_DIR env var when set, falling back to existing logic.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19893" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
