### PR TITLE
fix: propagate CES_SERVICE_TOKEN through upgrade path

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from "crypto";
+
 import cliPkg from "../../package.json";
 
 import {
@@ -260,10 +262,18 @@ async function upgradeDocker(
     // use default
   }
 
+  // Extract CES_SERVICE_TOKEN from the captured env so it can be passed via
+  // the dedicated cesServiceToken parameter (which propagates it to all three
+  // containers). If the old instance predates CES_SERVICE_TOKEN, generate a
+  // fresh one so gateway and CES can authenticate.
+  const cesServiceToken =
+    capturedEnv["CES_SERVICE_TOKEN"] || randomBytes(32).toString("hex");
+
   // Build the set of extra env vars to replay on the new assistant container.
   // Captured env vars serve as the base; keys already managed by
   // serviceDockerRunArgs are excluded to avoid duplicates.
   const envKeysSetByRunArgs = new Set([
+    "CES_SERVICE_TOKEN",
     "VELLUM_ASSISTANT_NAME",
     "RUNTIME_HTTP_HOST",
     "PATH",
@@ -290,6 +300,7 @@ async function upgradeDocker(
   console.log("🚀 Starting upgraded containers...");
   await startContainers(
     {
+      cesServiceToken,
       extraAssistantEnv,
       gatewayPort,
       imageTags,
@@ -333,6 +344,7 @@ async function upgradeDocker(
 
         await startContainers(
           {
+            cesServiceToken,
             extraAssistantEnv,
             gatewayPort,
             imageTags: previousImageRefs,


### PR DESCRIPTION
## Summary
Fixes gap: after `vellum upgrade`, gateway and CES containers lacked `CES_SERVICE_TOKEN`.

- Extracts `CES_SERVICE_TOKEN` from captured container env before building `extraAssistantEnv`
- Passes it via the dedicated `cesServiceToken` parameter to `startContainers()`, which propagates it to all three containers (assistant, gateway, CES)
- Generates a fresh token if upgrading from a pre-token instance
- Adds `CES_SERVICE_TOKEN` to the exclusion set so it isn't duplicated via `extraAssistantEnv`
- Also passes the token through the rollback path

## Test plan
- [ ] `vellum upgrade` on an existing instance preserves `CES_SERVICE_TOKEN` across all three containers
- [ ] `vellum upgrade` on a pre-CES-token instance generates a new token for all containers
- [ ] Rollback path also receives the token

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
