### PR TITLE
feat: add Swift models for simplified memory observations and episodes

### DIFF
--- a/clients/shared/Features/Memory/SimplifiedMemoryPayloads.swift
+++ b/clients/shared/Features/Memory/SimplifiedMemoryPayloads.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// A single observation from the simplified memory system.
+public struct MemoryObservationPayload: Codable, Identifiable, Hashable, Sendable {
+    public let id: String
+    public let scopeId: String
+    public let conversationId: String
+    public let conversationTitle: String?
+    public let role: String
+    public let content: String
+    public let modality: String
+    public let source: String?
+    public let createdAt: Int  // epoch ms
+
+    public var createdDate: Date {
+        Date(timeIntervalSince1970: Double(createdAt) / 1000.0)
+    }
+
+    public var relativeCreatedAt: String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        return formatter.localizedString(for: createdDate, relativeTo: Date())
+    }
+}
+
+/// A narrative episode summary from the simplified memory system.
+public struct MemoryEpisodePayload: Codable, Identifiable, Hashable, Sendable {
+    public let id: String
+    public let scopeId: String
+    public let conversationId: String
+    public let conversationTitle: String?
+    public let title: String
+    public let summary: String
+    public let source: String?
+    public let startAt: Int   // epoch ms
+    public let endAt: Int     // epoch ms
+    public let createdAt: Int // epoch ms
+
+    public var startDate: Date {
+        Date(timeIntervalSince1970: Double(startAt) / 1000.0)
+    }
+    public var endDate: Date {
+        Date(timeIntervalSince1970: Double(endAt) / 1000.0)
+    }
+    public var createdDate: Date {
+        Date(timeIntervalSince1970: Double(createdAt) / 1000.0)
+    }
+}
+
+/// A bounded time context from the assistant's brief.
+public struct MemoryTimeContextPayload: Codable, Identifiable, Hashable, Sendable {
+    public let id: String
+    public let summary: String
+    public let source: String
+    public let activeFrom: Int
+    public let activeUntil: Int
+    public let createdAt: Int
+
+    public var activeFromDate: Date {
+        Date(timeIntervalSince1970: Double(activeFrom) / 1000.0)
+    }
+    public var activeUntilDate: Date {
+        Date(timeIntervalSince1970: Double(activeUntil) / 1000.0)
+    }
+}
+
+/// An unresolved open loop tracked by the assistant.
+public struct MemoryOpenLoopPayload: Codable, Identifiable, Hashable, Sendable {
+    public let id: String
+    public let summary: String
+    public let status: String
+    public let source: String
+    public let dueAt: Int?
+    public let createdAt: Int
+
+    public var dueDate: Date? {
+        guard let ms = dueAt else { return nil }
+        return Date(timeIntervalSince1970: Double(ms) / 1000.0)
+    }
+}
+
+/// Response shape for GET /v1/memories.
+public struct MemoriesListResponse: Codable, Sendable {
+    public let observations: PaginatedSection<MemoryObservationPayload>
+    public let episodes: PaginatedSection<MemoryEpisodePayload>
+    public let timeContexts: PaginatedSection<MemoryTimeContextPayload>
+    public let openLoops: PaginatedSection<MemoryOpenLoopPayload>
+}
+
+/// A paginated section with items and total count.
+public struct PaginatedSection<T: Codable & Sendable>: Codable, Sendable {
+    public let items: [T]
+    public let total: Int
+}


### PR DESCRIPTION
## Summary
- Add MemoryObservationPayload, MemoryEpisodePayload, MemoryTimeContextPayload, MemoryOpenLoopPayload models
- Add MemoriesListResponse and PaginatedSection response types
- All models include date helper computed properties for epoch ms conversion

Part of plan: simp-mem-ui.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19897" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
