### PR TITLE
fix: remove unused buildConversationTitleMap in memories-routes

### DIFF
--- a/assistant/src/runtime/routes/memories-routes.ts
+++ b/assistant/src/runtime/routes/memories-routes.ts
@@ -64,34 +64,6 @@ function isValidSortField(value: string): value is SortField {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Batch-fetch conversation titles for a set of conversation IDs.
- * Returns a Map from conversation ID to title (or null).
- */
-function buildConversationTitleMap(
-  db: ReturnType<typeof getDb>,
-  conversationIds: string[],
-): Map<string, string | null> {
-  const uniqueIds = [...new Set(conversationIds)];
-  if (uniqueIds.length === 0) return new Map();
-
-  const rows = db
-    .select({ id: conversations.id, title: conversations.title })
-    .from(conversations)
-    .where(inArray(conversations.id, uniqueIds))
-    .all();
-
-  const map = new Map<string, string | null>();
-  for (const row of rows) {
-    map.set(row.id, row.title);
-  }
-  return map;
-}
-
-// ---------------------------------------------------------------------------
 // GET /v1/memories
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Remove unused `buildConversationTitleMap` helper function from `memories-routes.ts` that was causing a lint error (`@typescript-eslint/no-unused-vars`)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23323913698/job/67840953551
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
