### PR TITLE
fix: use dedicated system prompt for conversation title generation

### DIFF
--- a/assistant/src/__tests__/conversation-title-service.test.ts
+++ b/assistant/src/__tests__/conversation-title-service.test.ts
@@ -93,6 +93,8 @@ describe("conversation-title-service", () => {
     expect(mockRunBtwSidechain).toHaveBeenCalledWith(
       expect.objectContaining({
         provider,
+        systemPrompt: expect.stringContaining("conversation titles"),
+        tools: [],
         maxTokens: 37,
         modelIntent: "latency-optimized",
         timeoutMs: 10_000,
@@ -123,6 +125,8 @@ describe("conversation-title-service", () => {
     expect(mockRunBtwSidechain).toHaveBeenCalledWith(
       expect.objectContaining({
         provider,
+        systemPrompt: expect.stringContaining("conversation titles"),
+        tools: [],
         maxTokens: 37,
         modelIntent: "latency-optimized",
         timeoutMs: 10_000,
@@ -133,5 +137,30 @@ describe("conversation-title-service", () => {
       "Project kickoff",
       1,
     );
+  });
+
+  test("title prompt content does not contain generation instructions", async () => {
+    const provider = {
+      name: "test-provider",
+      sendMessage: mock(async () => {
+        throw new Error("provider.sendMessage should not be called directly");
+      }),
+    };
+
+    await generateAndPersistConversationTitle({
+      conversationId: "conv-1",
+      provider,
+      userMessage: "Help me plan the kickoff",
+    });
+
+    const call = mockRunBtwSidechain.mock.calls[0]![0] as {
+      content: string;
+      systemPrompt: string;
+    };
+    // Instructions should be in systemPrompt, not in content
+    expect(call.content).not.toContain("Generate a very short title");
+    expect(call.content).not.toContain("do NOT respond");
+    expect(call.systemPrompt).toContain("Do NOT respond");
+    expect(call.systemPrompt).toContain("Maximum 5 words");
   });
 });

--- a/assistant/src/config/schemas/platform.ts
+++ b/assistant/src/config/schemas/platform.ts
@@ -43,7 +43,7 @@ export const DaemonConfigSchema = z
       .number({ error: "daemon.titleGenerationMaxTokens must be a number" })
       .int("daemon.titleGenerationMaxTokens must be an integer")
       .positive("daemon.titleGenerationMaxTokens must be a positive integer")
-      .default(30)
+      .default(50)
       .describe(
         "Maximum number of tokens for auto-generated conversation titles",
       ),

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -133,6 +133,8 @@ export async function generateAndPersistConversationTitle(
   const result = await runBtwSidechain({
     content: prompt,
     provider,
+    systemPrompt: buildTitleSystemPrompt(),
+    tools: [],
     maxTokens: config.daemon.titleGenerationMaxTokens,
     modelIntent: "latency-optimized",
     signal,
@@ -236,6 +238,8 @@ export async function regenerateConversationTitle(
   const result = await runBtwSidechain({
     content: prompt,
     provider,
+    systemPrompt: buildTitleSystemPrompt(),
+    tools: [],
     maxTokens: config.daemon.titleGenerationMaxTokens,
     modelIntent: "latency-optimized",
     signal,
@@ -277,14 +281,30 @@ export function queueRegenerateConversationTitle(
 
 // ── Internal helpers ─────────────────────────────────────────────────
 
+/**
+ * Dedicated system prompt for title generation. Replaces the default
+ * assistant system prompt that btw-sidechain would otherwise inject,
+ * which caused the model to respond to the conversation content instead
+ * of titling it.
+ */
+function buildTitleSystemPrompt(): string {
+  return [
+    "You generate short conversation titles. Output ONLY the title text — no explanation, no quotes, no markdown, no preamble.",
+    "",
+    "Rules:",
+    "- Maximum 5 words and 40 characters",
+    "- Summarize the TOPIC the user is asking about",
+    "- Do NOT respond to the conversation content",
+    "- Do NOT assess feasibility or comment on capabilities",
+  ].join("\n");
+}
+
 function buildTitlePrompt(
   context?: TitleContext,
   userMessage?: string,
   assistantResponse?: string,
 ): string {
-  const parts: string[] = [
-    "Generate a very short title summarizing the TOPIC of this conversation. Rules: at most 5 words, at most 40 characters, no quotes, no markdown formatting. IMPORTANT: Summarize what the user is asking about — do NOT respond to the message, do NOT assess feasibility, and do NOT comment on your own capabilities.",
-  ];
+  const parts: string[] = [];
 
   if (context) {
     const hints: string[] = [];
@@ -295,12 +315,12 @@ function buildTitlePrompt(
     if (context.metadataHints?.length)
       hints.push(`Hints: ${context.metadataHints.join(", ")}`);
     if (hints.length > 0) {
-      parts.push("", "Metadata:", ...hints);
+      parts.push("Metadata:", ...hints, "");
     }
   }
 
   if (userMessage) {
-    parts.push("", `User: ${truncate(userMessage, 200, "")}`);
+    parts.push(`User: ${truncate(userMessage, 200, "")}`);
   }
   if (assistantResponse) {
     parts.push(`Assistant: ${truncate(assistantResponse, 200, "")}`);
@@ -339,11 +359,7 @@ function deriveFallbackTitle(context?: TitleContext): string | null {
 }
 
 function buildRegenerationPrompt(recentMessages: MessageRow[]): string {
-  const parts: string[] = [
-    "Generate a very short title summarizing the TOPIC of this conversation based on the recent messages below. Rules: at most 5 words, at most 40 characters, no quotes, no markdown formatting. IMPORTANT: Summarize what the user is asking about — do NOT respond to the messages, do NOT assess feasibility, and do NOT comment on your own capabilities.",
-    "",
-    "Recent messages:",
-  ];
+  const parts: string[] = ["Recent messages:"];
 
   for (const msg of recentMessages) {
     const role = msg.role === "user" ? "User" : "Assistant";


### PR DESCRIPTION
## Summary
- **Root cause**: `runBtwSidechain()` was injecting the full assistant system prompt (via default fallback) into title generation calls, causing the model to respond to conversation content instead of titling it
- Added a dedicated `buildTitleSystemPrompt()` with focused title-generation instructions, separated from the conversation content in the user message
- Pass `tools: []` to avoid sending the full tool catalog on title generation calls
- Bumped default `titleGenerationMaxTokens` from 30 to 50 for tokenization breathing room

## Original prompt
Fix conversation title generation — titles were nonsensical (e.g. "I need the topic as") because the model echoed user messages instead of generating titles. Take inspiration from other working autogenerated text (starters, notifications, memory reducer) which all use dedicated system prompts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
