### PR TITLE
fix: type error in conversation-title-service test

### DIFF
--- a/assistant/src/__tests__/conversation-title-service.test.ts
+++ b/assistant/src/__tests__/conversation-title-service.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-const mockRunBtwSidechain = mock(async () => ({
+const mockRunBtwSidechain = mock(async (_params: Record<string, unknown>) => ({
   text: "Project kickoff",
   hadTextDeltas: true,
   response: {


### PR DESCRIPTION
## Summary
- Add `_params: Record<string, unknown>` to `mockRunBtwSidechain` mock so TypeScript infers a non-empty call tuple, fixing `TS2493` and `TS2352` errors at line 156.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23324770662/job/67843561121
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
