### PR TITLE
refactor: remove legacy runtime memory fallback

### DIFF
--- a/assistant/src/__tests__/simplified-memory-runtime.test.ts
+++ b/assistant/src/__tests__/simplified-memory-runtime.test.ts
@@ -1,11 +1,10 @@
 /**
- * Tests for the simplified memory runtime injection path in
- * conversation-memory.ts.
+ * Tests for the memory runtime injection path in conversation-memory.ts.
  *
  * Covers:
  * - Brief-only turns (no archive recall trigger)
  * - Brief-plus-recall turns (archive recall fires)
- * - Disabled-flag fallback (legacy path used when flag is off)
+ * - Gate checks (untrusted actors, tool-result-only turns)
  */
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -55,10 +54,6 @@ let testConfig: AssistantConfig = {
   memory: {
     ...DEFAULT_CONFIG.memory,
     enabled: true,
-    simplified: {
-      ...DEFAULT_CONFIG.memory.simplified,
-      enabled: true,
-    },
   },
 };
 
@@ -70,18 +65,9 @@ mock.module("../config/loader.js", () => ({
   invalidateConfigCache: () => {},
 }));
 
-// Stub out the legacy retriever to ensure the simplified path does not
-// call into the heavy V2 hybrid pipeline. If the legacy path is used
-// unexpectedly, the test will fail with a clear error.
-//
-// We provide the real `injectMemoryRecallAsUserBlock` inline since
-// it's a pure function used by both the legacy and simplified paths.
+// Provide `injectMemoryRecallAsUserBlock` inline — it's a pure function
+// used by the memory injection path.
 mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: () => {
-    throw new Error(
-      "buildMemoryRecall should not be called in simplified mode",
-    );
-  },
   injectMemoryRecallAsUserBlock: (
     msgs: import("../providers/types.js").Message[],
     memoryRecallText: string,
@@ -101,24 +87,6 @@ mock.module("../memory/retriever.js", () => ({
       },
     ];
   },
-}));
-
-// Stub out modules used only by the legacy pipeline (budget, token
-// estimator, query builder) so they never execute in simplified mode.
-mock.module("../memory/query-builder.js", () => ({
-  buildMemoryQuery: () => {
-    throw new Error("buildMemoryQuery should not be called in simplified mode");
-  },
-}));
-mock.module("../memory/retrieval-budget.js", () => ({
-  computeRecallBudget: () => {
-    throw new Error(
-      "computeRecallBudget should not be called in simplified mode",
-    );
-  },
-}));
-mock.module("../context/token-estimator.js", () => ({
-  estimatePromptTokens: () => 0,
 }));
 
 // ── Now import the module under test ────────────────────────────────
@@ -256,7 +224,7 @@ const DAY = 24 * HOUR;
 
 // ── Setup / Teardown ────────────────────────────────────────────────
 
-describe("Simplified Memory Runtime", () => {
+describe("Memory Runtime", () => {
   const events: ServerMessage[] = [];
   const onEvent = (msg: ServerMessage) => events.push(msg);
   const abortController = new AbortController();
@@ -270,16 +238,12 @@ describe("Simplified Memory Runtime", () => {
     resetDb();
     removeTestDbFiles();
     initializeDb();
-    // Reset config to simplified-enabled for each test
+    // Reset config for each test
     testConfig = {
       ...DEFAULT_CONFIG,
       memory: {
         ...DEFAULT_CONFIG.memory,
         enabled: true,
-        simplified: {
-          ...DEFAULT_CONFIG.memory.simplified,
-          enabled: true,
-        },
       },
     };
   });
@@ -496,62 +460,10 @@ describe("Simplified Memory Runtime", () => {
     });
   });
 
-  // ── Disabled-flag fallback ──────────────────────────────────────
-
-  describe("disabled-flag fallback", () => {
-    test("falls back to legacy path when memory.simplified.enabled is false", async () => {
-      // Disable the simplified flag
-      testConfig = {
-        ...DEFAULT_CONFIG,
-        memory: {
-          ...DEFAULT_CONFIG.memory,
-          enabled: true,
-          simplified: {
-            ...DEFAULT_CONFIG.memory.simplified,
-            enabled: false,
-          },
-        },
-      };
-
-      // The legacy retriever mock throws, so we need to unmock it for
-      // this test. Instead, we verify the flag gating by checking the
-      // code path via the mock that throws — if the simplified path is
-      // correctly bypassed, the legacy path will be invoked.
-      const ctx = buildCtx({
-        messages: [makeUserMessage("Hello there")],
-      });
-      const msgId = uuid();
-
-      // The legacy path calls buildMemoryRecall which we mocked to throw.
-      // This confirms the code took the legacy path, not the simplified one.
-      let hitLegacyPath = false;
-      try {
-        await prepareMemoryContext(
-          ctx,
-          "Hello there",
-          msgId,
-          abortController.signal,
-          onEvent,
-        );
-      } catch (err) {
-        if (
-          err instanceof Error &&
-          err.message.includes("should not be called in simplified mode")
-        ) {
-          hitLegacyPath = true;
-        } else {
-          throw err;
-        }
-      }
-
-      expect(hitLegacyPath).toBe(true);
-    });
-  });
-
   // ── Gate checks ─────────────────────────────────────────────────
 
   describe("gate checks", () => {
-    test("skips memory for untrusted actors in simplified mode", async () => {
+    test("skips memory for untrusted actors", async () => {
       const now = Date.now();
       insertTimeContext({
         id: "tc-1",
@@ -579,7 +491,7 @@ describe("Simplified Memory Runtime", () => {
       expect(result.recall.enabled).toBe(false);
     });
 
-    test("skips memory for tool-result-only turns in simplified mode", async () => {
+    test("skips memory for tool-result-only turns", async () => {
       const now = Date.now();
       insertTimeContext({
         id: "tc-1",

--- a/assistant/src/config/schemas/memory-simplified.ts
+++ b/assistant/src/config/schemas/memory-simplified.ts
@@ -72,7 +72,11 @@ export const MemorySimplifiedConfigSchema = z
         error: "memory.simplified.enabled must be a boolean",
       })
       .default(true)
-      .describe("Whether the simplified memory system is enabled"),
+      .describe(
+        "Legacy toggle — the simplified memory system is now always active. " +
+          "This field is retained for backwards compatibility and will be " +
+          "removed in a future release.",
+      ),
     brief: MemorySimplifiedBriefConfigSchema.default(
       MemorySimplifiedBriefConfigSchema.parse({}),
     ),
@@ -84,7 +88,7 @@ export const MemorySimplifiedConfigSchema = z
     ),
   })
   .describe(
-    "Simplified two-layer memory system — a brief plus archive recall, replacing the legacy item/tier/staleness model",
+    "Simplified two-layer memory system — a brief plus archive recall",
   );
 
 export type MemorySimplifiedConfig = z.infer<

--- a/assistant/src/daemon/conversation-memory.ts
+++ b/assistant/src/daemon/conversation-memory.ts
@@ -1,17 +1,9 @@
-import { getConfig } from "../config/loader.js";
-import { estimatePromptTokens } from "../context/token-estimator.js";
 import { buildArchiveRecall } from "../memory/archive-recall.js";
 import { compileMemoryBrief } from "../memory/brief.js";
 import { getDb } from "../memory/db.js";
-import { buildMemoryQuery } from "../memory/query-builder.js";
-import { computeRecallBudget } from "../memory/retrieval-budget.js";
-import {
-  buildMemoryRecall,
-  injectMemoryRecallAsUserBlock,
-} from "../memory/retriever.js";
-import type { ScopePolicyOverride } from "../memory/search/types.js";
+import { injectMemoryRecallAsUserBlock } from "../memory/retriever.js";
+import type { MemoryRecallResult as SearchRecallResult } from "../memory/search/types.js";
 import type { Message } from "../providers/types.js";
-import type { Provider } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 import type { ServerMessage } from "./message-protocol.js";
 
@@ -19,14 +11,14 @@ const log = getLogger("conversation-memory");
 
 export interface MemoryRecallResult {
   runMessages: Message[];
-  recall: Awaited<ReturnType<typeof buildMemoryRecall>>;
+  recall: SearchRecallResult;
 }
 
 export interface MemoryPrepareContext {
   conversationId: string;
   messages: Message[];
   systemPrompt: string;
-  provider: Provider;
+  provider: { name: string };
   scopeId: string;
   includeDefaultFallback: boolean;
   trustClass: "guardian" | "trusted_contact" | "unknown";
@@ -70,20 +62,21 @@ export function needsMemory(messages: Message[], content: string): boolean {
 }
 
 /**
- * Build memory recall for a single agent loop turn using the V2 hybrid
- * pipeline. Returns the augmented run messages and metadata for
+ * Build memory context for a single agent loop turn. Compiles the
+ * `<memory_brief>` block and conditionally appends `<supporting_recall>`
+ * from the archive. Returns the augmented run messages and metadata for
  * downstream event emission.
  *
  * Memory context is injected as a text content block prepended to the
  * last user message (same pattern as workspace/temporal injections).
- * Stripping is handled by `stripUserTextBlocksByPrefix` matching the
- * `<memory_context __injected>` prefix in `RUNTIME_INJECTION_PREFIXES`.
+ * Stripping is handled by `RUNTIME_INJECTION_PREFIXES` which includes
+ * `<memory_brief>`.
  */
 export async function prepareMemoryContext(
   ctx: MemoryPrepareContext,
   content: string,
   userMessageId: string,
-  abortSignal: AbortSignal,
+  _abortSignal: AbortSignal,
   onEvent: (msg: ServerMessage) => void,
 ): Promise<MemoryRecallResult> {
   // Provenance-based trust gating: untrusted actors skip all memory operations
@@ -106,7 +99,7 @@ export async function prepareMemoryContext(
       topCandidates: [],
       tier1Count: 0,
       tier2Count: 0,
-    } as Awaited<ReturnType<typeof buildMemoryRecall>>,
+    },
   });
 
   if (!isTrustedActor) {
@@ -119,144 +112,22 @@ export async function prepareMemoryContext(
     return noopResult();
   }
 
-  const runtimeConfig = getConfig();
-
-  // ── Simplified memory path ──────────────────────────────────────────
-  // When `memory.simplified.enabled` is true, inject the brief and
-  // optional archive recall instead of the legacy hybrid pipeline.
-  if (runtimeConfig.memory?.simplified?.enabled) {
-    return prepareSimplifiedMemoryContext(ctx, content, userMessageId, onEvent);
-  }
-
-  // ── Legacy memory path (fallback) ──────────────────────────────────
-  // Memory recall via the V2 hybrid pipeline
-  const recallQuery = buildMemoryQuery(content, ctx.messages);
-  const dynamicBudgetConfig = runtimeConfig.memory?.retrieval?.dynamicBudget;
-  const recallBudget = dynamicBudgetConfig?.enabled
-    ? computeRecallBudget({
-        estimatedPromptTokens: estimatePromptTokens(
-          ctx.messages,
-          ctx.systemPrompt,
-          { providerName: ctx.provider.name },
-        ),
-        maxInputTokens: runtimeConfig.contextWindow.maxInputTokens,
-        targetHeadroomTokens: dynamicBudgetConfig.targetHeadroomTokens,
-        minInjectTokens: dynamicBudgetConfig.minInjectTokens,
-        maxInjectTokens: dynamicBudgetConfig.maxInjectTokens,
-      })
-    : undefined;
-  // Build scope policy override for non-default scopes so retrieval
-  // honours the conversation's memory policy regardless of the global config.
-  const scopePolicyOverride: ScopePolicyOverride | undefined =
-    ctx.scopeId !== "default"
-      ? { scopeId: ctx.scopeId, fallbackToDefault: ctx.includeDefaultFallback }
-      : undefined;
-
-  const recall = await buildMemoryRecall(
-    recallQuery,
-    ctx.conversationId,
-    runtimeConfig,
-    {
-      excludeMessageIds: [userMessageId],
-      signal: abortSignal,
-      maxInjectTokensOverride: recallBudget,
-      scopeId: ctx.scopeId,
-      scopePolicyOverride,
-    },
-  );
-  onEvent({
-    type: "memory_status",
-    enabled: recall.enabled,
-    degraded: recall.degraded,
-    degradation: recall.degradation
-      ? {
-          semanticUnavailable: recall.degradation.semanticUnavailable,
-          reason: recall.degradation.reason,
-          fallbackSources: [...recall.degradation.fallbackSources],
-        }
-      : undefined,
-    reason: recall.reason,
-    provider: recall.provider,
-    model: recall.model,
-  });
-
-  // Inject recall as a text block prepended to the last user message.
-  // When injection text is empty, skip injection entirely.
-  let runMessages = ctx.messages;
-  if (recall.injectedText.length > 0) {
-    const userTail = ctx.messages[ctx.messages.length - 1];
-    if (userTail && userTail.role === "user") {
-      runMessages = injectMemoryRecallAsUserBlock(
-        ctx.messages,
-        recall.injectedText,
-      );
-      onEvent({
-        type: "memory_recalled",
-        provider: recall.provider ?? "unknown",
-        model: recall.model ?? "unknown",
-        degradation: recall.degradation
-          ? {
-              semanticUnavailable: recall.degradation.semanticUnavailable,
-              reason: recall.degradation.reason,
-              fallbackSources: [...recall.degradation.fallbackSources],
-            }
-          : undefined,
-        semanticHits: recall.semanticHits,
-        recencyHits: recall.recencyHits,
-        tier1Count: recall.tier1Count ?? 0,
-        tier2Count: recall.tier2Count ?? 0,
-        hybridSearchLatencyMs: recall.hybridSearchMs ?? 0,
-        sparseVectorUsed: recall.sparseVectorUsed ?? false,
-        mergedCount: recall.mergedCount,
-        selectedCount: recall.selectedCount,
-        injectedTokens: recall.injectedTokens,
-        latencyMs: recall.latencyMs,
-        topCandidates: recall.topCandidates,
-      });
-    }
-  }
-
-  return {
-    runMessages,
-    recall,
-  };
-}
-
-// ── Simplified memory injection ─────────────────────────────────────────
-
-/**
- * Build simplified memory context for a turn: compiles the `<memory_brief>`
- * block and conditionally appends `<supporting_recall>` from the archive.
- *
- * Non-empty blocks are injected as text content blocks prepended to the
- * last user message, following the same injection pattern as the legacy
- * pipeline. Stripping is handled by `RUNTIME_INJECTION_PREFIXES` which
- * already includes `<memory_brief>`.
- */
-function prepareSimplifiedMemoryContext(
-  ctx: MemoryPrepareContext,
-  content: string,
-  userMessageId: string,
-  onEvent: (msg: ServerMessage) => void,
-): MemoryRecallResult {
   const start = Date.now();
 
-  // Build a no-op recall result matching the legacy shape.
-  const noopRecall = (): Awaited<ReturnType<typeof buildMemoryRecall>> =>
-    ({
-      enabled: true,
-      degraded: false,
-      injectedText: "",
-      semanticHits: 0,
-      recencyHits: 0,
-      mergedCount: 0,
-      selectedCount: 0,
-      injectedTokens: 0,
-      latencyMs: 0,
-      topCandidates: [],
-      tier1Count: 0,
-      tier2Count: 0,
-    }) as Awaited<ReturnType<typeof buildMemoryRecall>>;
+  const emptyRecall = (): SearchRecallResult => ({
+    enabled: true,
+    degraded: false,
+    injectedText: "",
+    semanticHits: 0,
+    recencyHits: 0,
+    mergedCount: 0,
+    selectedCount: 0,
+    injectedTokens: 0,
+    latencyMs: 0,
+    topCandidates: [],
+    tier1Count: 0,
+    tier2Count: 0,
+  });
 
   try {
     const db = getDb();
@@ -278,7 +149,7 @@ function prepareSimplifiedMemoryContext(
 
     const latencyMs = Date.now() - start;
 
-    // Emit memory status for the simplified path
+    // Emit memory status
     onEvent({
       type: "memory_status",
       enabled: true,
@@ -301,24 +172,24 @@ function prepareSimplifiedMemoryContext(
           recallBullets: archiveResult.bullets.length,
           latencyMs,
         },
-        "Simplified memory injection completed",
+        "Memory injection completed",
       );
     }
 
     return {
       runMessages,
       recall: {
-        ...noopRecall(),
+        ...emptyRecall(),
         injectedText: blocks.length > 0 ? blocks.join("\n\n") : "",
         latencyMs,
       },
     };
   } catch (err) {
-    log.warn({ err }, "Simplified memory injection failed, returning no-op");
+    log.warn({ err }, "Memory injection failed, returning no-op");
     return {
       runMessages: ctx.messages,
       recall: {
-        ...noopRecall(),
+        ...emptyRecall(),
         latencyMs: Date.now() - start,
       },
     };


### PR DESCRIPTION
## Summary
- Remove the memory.simplified.enabled fallback branch so the runtime unconditionally uses the simplified memory path
- Remove the rollback toggle from the memory-simplified config schema
- Update runtime tests to reflect the unconditional simplified-memory path

Part of plan: legacy-memory-cleanup.md (PR 1 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
