### PR TITLE
refactor: stop enqueueing legacy memory jobs

### DIFF
--- a/assistant/src/__tests__/memory-chunk-dual-write.test.ts
+++ b/assistant/src/__tests__/memory-chunk-dual-write.test.ts
@@ -1,14 +1,13 @@
 /**
- * Tests for the chunk dual-write path in the memory indexer.
+ * Tests for the chunk write path in the memory indexer.
  *
- * The indexer now writes both legacy memory_segments AND archive
- * memory_chunks using the same segmentation boundaries. These tests
- * verify:
+ * The indexer writes archive memory_chunks (legacy memory_segments are no
+ * longer produced). These tests verify:
  *
- * 1. Chunks are created alongside segments with matching boundaries.
+ * 1. Chunks are created with correct boundaries and content.
  * 2. Unchanged chunk content does not enqueue duplicate embed_chunk jobs.
  * 3. Changed chunk content enqueues an embed_chunk job.
- * 4. The legacy memory_segments path remains intact.
+ * 4. Legacy embed_segment and extract_items jobs are no longer enqueued.
  */
 
 import { mkdtempSync, rmSync } from "node:fs";
@@ -77,7 +76,6 @@ import {
   memoryChunks,
   memoryJobs,
   memoryObservations,
-  memorySegments,
   messages,
 } from "../memory/schema.js";
 
@@ -135,15 +133,15 @@ function seedConversationAndMessage(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Test suite: chunk dual-write alongside legacy segments
+// Test suite: chunk writes (legacy segment production removed)
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("chunk dual-write from the memory indexer", () => {
+describe("chunk writes from the memory indexer", () => {
   beforeEach(() => {
     resetTables();
   });
 
-  test("indexing a message creates chunks alongside segments with matching boundaries", async () => {
+  test("indexing a message creates observation and chunks", async () => {
     const conversationId = "conv-dual-write-basic";
     const messageId = "msg-dual-write-basic";
     const text =
@@ -167,22 +165,14 @@ describe("chunk dual-write from the memory indexer", () => {
 
     const db = getDb();
 
-    // Verify segments were created (legacy path)
-    const segments = db
-      .select()
-      .from(memorySegments)
-      .where(eq(memorySegments.messageId, messageId))
-      .all();
-    expect(segments.length).toBeGreaterThanOrEqual(1);
-
-    // Verify chunks were created (dual-write path)
+    // Verify chunks were created
     const observationId = `obs:${messageId}`;
     const chunks = db
       .select()
       .from(memoryChunks)
       .where(eq(memoryChunks.observationId, observationId))
       .all();
-    expect(chunks.length).toBe(segments.length);
+    expect(chunks.length).toBeGreaterThanOrEqual(1);
 
     // Verify the observation was created
     const observation = db
@@ -195,14 +185,13 @@ describe("chunk dual-write from the memory indexer", () => {
     expect(observation!.messageId).toBe(messageId);
     expect(observation!.role).toBe("user");
 
-    // Verify chunk content matches segment content (same boundaries)
-    for (let i = 0; i < segments.length; i++) {
+    // Verify chunk content is populated
+    for (let i = 0; i < chunks.length; i++) {
       const chunkId = `chunk:${messageId}:${i}`;
       const chunk = chunks.find((c) => c.id === chunkId);
       expect(chunk).toBeDefined();
-      expect(chunk!.content).toBe(segments[i].text);
-      expect(chunk!.tokenEstimate).toBe(segments[i].tokenEstimate);
-      expect(chunk!.scopeId).toBe(segments[i].scopeId);
+      expect(chunk!.content.length).toBeGreaterThan(0);
+      expect(chunk!.tokenEstimate).toBeGreaterThan(0);
     }
   });
 
@@ -314,16 +303,16 @@ describe("chunk dual-write from the memory indexer", () => {
     expect(jobsAfterSecond.length).toBeGreaterThan(firstChunkJobCount);
   });
 
-  test("legacy memory_segments path remains intact", async () => {
-    const conversationId = "conv-legacy-compat";
-    const messageId = "msg-legacy-compat";
+  test("legacy jobs are no longer enqueued", async () => {
+    const conversationId = "conv-no-legacy-jobs";
+    const messageId = "msg-no-legacy-jobs";
     const text =
       "I always prefer concise code reviews and I work in a distributed team.";
 
     seedConversationAndMessage(conversationId, messageId, text);
 
     const config = TEST_CONFIG.memory;
-    const result = await indexMessageNow(
+    await indexMessageNow(
       {
         messageId,
         conversationId,
@@ -336,32 +325,40 @@ describe("chunk dual-write from the memory indexer", () => {
 
     const db = getDb();
 
-    // Legacy segments must be present and correctly formed
-    const segments = db
-      .select()
-      .from(memorySegments)
-      .where(eq(memorySegments.messageId, messageId))
-      .all();
-    expect(segments.length).toBe(result.indexedSegments);
-
-    for (const seg of segments) {
-      expect(seg.id.startsWith(messageId + ":")).toBe(true);
-      expect(seg.conversationId).toBe(conversationId);
-      expect(seg.role).toBe("user");
-      expect(seg.text.length).toBeGreaterThan(0);
-      expect(seg.contentHash).toBeTruthy();
-    }
-
-    // Legacy embed_segment jobs must be enqueued
+    // No legacy embed_segment jobs
     const segmentJobs = db
       .select()
       .from(memoryJobs)
       .where(eq(memoryJobs.type, "embed_segment"))
       .all();
-    expect(segmentJobs.length).toBeGreaterThanOrEqual(1);
+    expect(segmentJobs).toHaveLength(0);
+
+    // No legacy extract_items jobs
+    const extractJobs = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.type, "extract_items"))
+      .all();
+    expect(extractJobs).toHaveLength(0);
+
+    // No legacy build_conversation_summary jobs
+    const summaryJobs = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.type, "build_conversation_summary"))
+      .all();
+    expect(summaryJobs).toHaveLength(0);
+
+    // embed_chunk jobs ARE still enqueued (new archive path)
+    const chunkJobs = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.type, "embed_chunk"))
+      .all();
+    expect(chunkJobs.length).toBeGreaterThanOrEqual(1);
   });
 
-  test("repeated indexing produces exactly one chunk per segment boundary", async () => {
+  test("repeated indexing produces stable chunk count with unique IDs", async () => {
     const conversationId = "conv-chunk-dedup";
     const messageId = "msg-chunk-dedup";
     const text =
@@ -372,8 +369,31 @@ describe("chunk dual-write from the memory indexer", () => {
     const config = TEST_CONFIG.memory;
     const content = JSON.stringify([{ type: "text", text }]);
 
-    // Index the same message multiple times
-    for (let i = 0; i < 5; i++) {
+    // Index the same message once to get the baseline chunk count
+    const firstResult = await indexMessageNow(
+      {
+        messageId,
+        conversationId,
+        role: "user",
+        content,
+        createdAt: Date.now(),
+      },
+      config,
+    );
+
+    const db = getDb();
+    const observationId = `obs:${messageId}`;
+
+    const chunksAfterFirst = db
+      .select()
+      .from(memoryChunks)
+      .where(eq(memoryChunks.observationId, observationId))
+      .all();
+    const baselineChunkCount = chunksAfterFirst.length;
+    expect(baselineChunkCount).toBe(firstResult.indexedSegments);
+
+    // Index the same message multiple more times
+    for (let i = 0; i < 4; i++) {
       await indexMessageNow(
         {
           messageId,
@@ -386,22 +406,13 @@ describe("chunk dual-write from the memory indexer", () => {
       );
     }
 
-    const db = getDb();
-    const observationId = `obs:${messageId}`;
-
-    // Verify no duplicate chunks — one chunk per segment boundary
+    // Verify no duplicate chunks — count stays the same
     const chunks = db
       .select()
       .from(memoryChunks)
       .where(eq(memoryChunks.observationId, observationId))
       .all();
-    const segments = db
-      .select()
-      .from(memorySegments)
-      .where(eq(memorySegments.messageId, messageId))
-      .all();
-
-    expect(chunks.length).toBe(segments.length);
+    expect(chunks.length).toBe(baselineChunkCount);
 
     // Verify chunk IDs are unique
     const chunkIds = chunks.map((c) => c.id);

--- a/assistant/src/__tests__/memory-observation-dual-write.test.ts
+++ b/assistant/src/__tests__/memory-observation-dual-write.test.ts
@@ -93,7 +93,7 @@ import { eq } from "drizzle-orm";
 import { getChunkByObservationId } from "../memory/archive-store.js";
 import { addMessage, createConversation } from "../memory/conversation-crud.js";
 import { getDb, initializeDb, rawAll, resetDb } from "../memory/db.js";
-import { memoryObservations, memorySegments } from "../memory/schema.js";
+import { memoryObservations } from "../memory/schema.js";
 
 function removeTestDbFiles(): void {
   rmSync(dbPath, { force: true });
@@ -258,49 +258,46 @@ describe("memory observation dual-write from addMessage", () => {
     });
   });
 
-  // ── Legacy indexing unchanged ───────────────────────────────────
+  // ── Legacy jobs are no longer produced ──────────────────────────
 
-  describe("legacy indexing continues alongside dual-write", () => {
-    test("legacy memory_segments are still created for text messages", async () => {
-      const conv = createConversation("test-conv");
-      await addMessage(conv.id, "user", "A fact worth remembering for memory");
-
-      // Legacy segments should exist
-      const db = getDb();
-      const segments = db
-        .select()
-        .from(memorySegments)
-        .where(eq(memorySegments.conversationId, conv.id))
-        .all();
-      expect(segments.length).toBeGreaterThanOrEqual(1);
-
-      // Observation should also exist
-      const observations = getObservationsByConversation(conv.id);
-      expect(observations).toHaveLength(1);
-    });
-
-    test("legacy extract_items jobs are still enqueued for user messages", async () => {
+  describe("legacy jobs are no longer produced", () => {
+    test("no extract_items jobs are enqueued for user messages", async () => {
       const conv = createConversation("test-conv");
       await addMessage(conv.id, "user", "The user lives in San Francisco");
 
       const extractJobs = getJobsByType("extract_items");
-      expect(extractJobs.length).toBeGreaterThanOrEqual(1);
+      expect(extractJobs).toHaveLength(0);
     });
 
-    test("skipping indexing skips both legacy and observation writes", async () => {
+    test("no embed_segment jobs are enqueued for text messages", async () => {
+      const conv = createConversation("test-conv");
+      await addMessage(conv.id, "user", "A fact worth remembering for memory");
+
+      const embedSegmentJobs = getJobsByType("embed_segment");
+      expect(embedSegmentJobs).toHaveLength(0);
+    });
+
+    test("no build_conversation_summary jobs are enqueued", async () => {
+      const conv = createConversation("test-conv");
+      await addMessage(conv.id, "user", "Some message content");
+
+      const summaryJobs = getJobsByType("build_conversation_summary");
+      expect(summaryJobs).toHaveLength(0);
+    });
+
+    test("observations are still created (new archive write path)", async () => {
+      const conv = createConversation("test-conv");
+      await addMessage(conv.id, "user", "A fact worth remembering for memory");
+
+      const observations = getObservationsByConversation(conv.id);
+      expect(observations).toHaveLength(1);
+    });
+
+    test("skipping indexing skips observation writes", async () => {
       const conv = createConversation("test-conv");
       await addMessage(conv.id, "user", "No indexing please", undefined, {
         skipIndexing: true,
       });
-
-      // No legacy segments
-      const db = getDb();
-      const segments = db
-        .select()
-        .from(memorySegments)
-        .where(eq(memorySegments.conversationId, conv.id))
-        .all();
-      expect(segments).toHaveLength(0);
 
       // No observations
       const observations = getObservationsByConversation(conv.id);

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -1,9 +1,7 @@
-import { createHash } from "crypto";
 import { desc, eq } from "drizzle-orm";
 
 import { getConfig } from "../config/loader.js";
 import type { MemoryConfig } from "../config/types.js";
-import type { TrustClass } from "../runtime/actor-trust-resolver.js";
 import { getLogger } from "../util/logger.js";
 import { computeChunkContentHash } from "./archive-store.js";
 import { getDb } from "./db.js";
@@ -13,7 +11,11 @@ import {
   extractMediaBlockMeta,
   extractTextFromStoredMessageContent,
 } from "./message-content.js";
-import { memoryChunks, memoryObservations, memorySegments } from "./schema.js";
+import {
+  memoryChunks,
+  memoryObservations,
+  memorySegments,
+} from "./schema.js";
 import { segmentText } from "./segmenter.js";
 
 const log = getLogger("memory-indexer");
@@ -26,13 +28,16 @@ export interface IndexMessageInput {
   createdAt: number;
   scopeId?: string;
   /**
-   * Trust class of the actor who produced this message, captured at
-   * persist time. When `'guardian'` or `undefined` (legacy), extraction
-   * jobs run. Otherwise, the message is segmented and embedded but no
-   * profile mutations are triggered.
+   * @deprecated No longer used for job gating — legacy extraction jobs
+   * have been removed. Kept for backwards-compatible call-site signatures
+   * until callers are updated.
    */
-  provenanceTrustClass?: TrustClass;
-  /** When true, the message was auto-sent by the client (e.g. wake-up greeting) and should not trigger memory extraction. */
+  provenanceTrustClass?: unknown;
+  /**
+   * @deprecated No longer used for job gating — legacy extraction jobs
+   * have been removed. Kept for backwards-compatible call-site signatures
+   * until callers are updated.
+   */
   automated?: boolean;
 }
 
@@ -47,12 +52,6 @@ export async function indexMessageNow(
 ): Promise<IndexMessageResult> {
   if (!config.enabled) return { indexedSegments: 0, enqueuedJobs: 0 };
 
-  // Provenance-based trust gating: only guardian and legacy (undefined) actors
-  // are trusted for extraction.
-  const isTrustedActor =
-    input.provenanceTrustClass === "guardian" ||
-    input.provenanceTrustClass === undefined;
-
   const text = extractTextFromStoredMessageContent(input.content);
   const hasText = text.length > 0;
   const candidateMediaMeta = extractMediaBlockMeta(input.content).filter(
@@ -60,14 +59,10 @@ export async function indexMessageNow(
   );
   const hasMedia = candidateMediaMeta.length > 0;
   if (!hasText && !hasMedia) {
-    enqueueMemoryJob("build_conversation_summary", {
-      conversationId: input.conversationId,
-    });
-    return { indexedSegments: 0, enqueuedJobs: 1 };
+    return { indexedSegments: 0, enqueuedJobs: 0 };
   }
 
   const db = getDb();
-  const now = Date.now();
   const segments = hasText
     ? segmentText(
         text,
@@ -75,9 +70,6 @@ export async function indexMessageNow(
         config.segmentation.overlapTokens,
       )
     : [];
-  const shouldExtract =
-    input.role === "user" ||
-    (input.role === "assistant" && config.extraction.extractFromAssistant);
   // Check if the message has any image blocks before probing the backend.
   // extractMediaBlockMeta is synchronous and lightweight — it detects image
   // blocks without decoding base64 data into Buffers, avoiding CPU/memory
@@ -90,58 +82,12 @@ export async function indexMessageNow(
       ? candidateMediaMeta
       : [];
 
-  // Wrap all segment inserts and job enqueues in a single transaction so they
-  // either all succeed or all roll back, preventing partial/orphaned state.
-  let skippedEmbedJobs = 0;
+  // Wrap all observation/chunk inserts and job enqueues in a single
+  // transaction so they either all succeed or all roll back.
   let skippedChunkEmbedJobs = 0;
   const scopeId = input.scopeId ?? "default";
   db.transaction((tx) => {
-    // ── Legacy segment path (kept intact for parallel validation) ───
-    for (const segment of segments) {
-      const segmentId = buildSegmentId(input.messageId, segment.segmentIndex);
-      const hash = createHash("sha256").update(segment.text).digest("hex");
-
-      // Check if this segment already exists with the same content hash
-      const existing = tx
-        .select({ contentHash: memorySegments.contentHash })
-        .from(memorySegments)
-        .where(eq(memorySegments.id, segmentId))
-        .get();
-
-      tx.insert(memorySegments)
-        .values({
-          id: segmentId,
-          messageId: input.messageId,
-          conversationId: input.conversationId,
-          role: input.role,
-          segmentIndex: segment.segmentIndex,
-          text: segment.text,
-          tokenEstimate: segment.tokenEstimate,
-          scopeId,
-          contentHash: hash,
-          createdAt: input.createdAt,
-          updatedAt: now,
-        })
-        .onConflictDoUpdate({
-          target: memorySegments.id,
-          set: {
-            text: segment.text,
-            tokenEstimate: segment.tokenEstimate,
-            scopeId,
-            contentHash: hash,
-            updatedAt: now,
-          },
-        })
-        .run();
-
-      if (existing?.contentHash === hash) {
-        skippedEmbedJobs++;
-      } else {
-        enqueueMemoryJob("embed_segment", { segmentId }, Date.now(), tx);
-      }
-    }
-
-    // ── Archive chunk dual-write (mirrors segment boundaries) ──────
+    // ── Archive observation + chunk writes ─────────────────────────
     // Create a single observation per message, then create one chunk per
     // segment using the same segmentation boundaries. Chunks are
     // deduplicated by (scopeId, contentHash) via onConflictDoNothing so
@@ -210,28 +156,7 @@ export async function indexMessageNow(
         tx,
       );
     }
-
-    if (shouldExtract && isTrustedActor && !input.automated) {
-      enqueueMemoryJob(
-        "extract_items",
-        { messageId: input.messageId, scopeId },
-        Date.now(),
-        tx,
-      );
-    }
-    enqueueMemoryJob(
-      "build_conversation_summary",
-      { conversationId: input.conversationId },
-      Date.now(),
-      tx,
-    );
   });
-
-  if (skippedEmbedJobs > 0) {
-    log.debug(
-      `Skipped ${skippedEmbedJobs}/${segments.length} embed_segment jobs (content unchanged)`,
-    );
-  }
 
   if (skippedChunkEmbedJobs > 0) {
     log.debug(
@@ -239,24 +164,8 @@ export async function indexMessageNow(
     );
   }
 
-  if (!isTrustedActor && shouldExtract) {
-    log.info(
-      `Skipping extraction jobs for untrusted actor (trustClass=${input.provenanceTrustClass})`,
-    );
-  }
-
-  if (input.automated && shouldExtract) {
-    log.info("Skipping extraction jobs for automated message");
-  }
-
-  const extractionGated = !isTrustedActor || !!input.automated;
-  const segmentEmbedJobs = segments.length - skippedEmbedJobs;
   const chunkEmbedJobs = segments.length - skippedChunkEmbedJobs;
-  const enqueuedJobs =
-    segmentEmbedJobs +
-    chunkEmbedJobs +
-    mediaBlocks.length +
-    (shouldExtract && !extractionGated ? 2 : 1);
+  const enqueuedJobs = chunkEmbedJobs + mediaBlocks.length;
   return {
     indexedSegments: segments.length,
     enqueuedJobs,
@@ -283,10 +192,6 @@ export function getRecentSegmentsForConversation(
     .orderBy(desc(memorySegments.createdAt))
     .limit(limit)
     .all();
-}
-
-function buildSegmentId(messageId: string, segmentIndex: number): string {
-  return `${messageId}:${segmentIndex}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Stop enqueueing legacy extract_items, embed_segment, and build_conversation_summary jobs from the indexer
- Remove legacy memory-summary side effects from the conversation agent loop
- Update dual-write tests to assert legacy jobs are no longer produced

Part of plan: legacy-memory-cleanup.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
