### PR TITLE
fix: resolve lint errors in memory test files

### DIFF
--- a/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
+++ b/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
@@ -61,12 +61,12 @@ mock.module("../config/loader.js", () => ({
 
 import { v4 as uuid } from "uuid";
 
+import { stripUserTextBlocksByPrefix } from "../daemon/conversation-runtime-assembly.js";
 import { buildArchiveRecall } from "../memory/archive-recall.js";
 import { insertObservation } from "../memory/archive-store.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { injectMemoryRecallAsUserBlock } from "../memory/inject.js";
 import { memoryEpisodes, memoryObservations } from "../memory/schema.js";
-import { stripUserTextBlocksByPrefix } from "../daemon/conversation-runtime-assembly.js";
 import type { Message } from "../providers/types.js";
 
 describe("Memory lifecycle E2E (simplified path)", () => {

--- a/assistant/src/__tests__/memory-recall-quality.test.ts
+++ b/assistant/src/__tests__/memory-recall-quality.test.ts
@@ -65,7 +65,6 @@ import {
 } from "../memory/archive-recall.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import {
-  memoryChunks,
   memoryEpisodes,
   memoryObservations,
 } from "../memory/schema.js";
@@ -132,28 +131,6 @@ function insertObservation(
     .run();
 }
 
-function insertChunk(
-  db: ReturnType<typeof getDb>,
-  opts: {
-    id: string;
-    scopeId: string;
-    observationId: string;
-    content: string;
-    contentHash: string;
-    createdAt: number;
-  },
-) {
-  db.insert(memoryChunks)
-    .values({
-      id: opts.id,
-      scopeId: opts.scopeId,
-      observationId: opts.observationId,
-      content: opts.content,
-      contentHash: opts.contentHash,
-      createdAt: opts.createdAt,
-    })
-    .run();
-}
 
 function insertEpisode(
   db: ReturnType<typeof getDb>,


### PR DESCRIPTION
## Summary
- Fixed import sort order in `memory-lifecycle-e2e.test.ts` (`simple-import-sort/imports`)
- Removed unused `insertChunk` function and `memoryChunks` import in `memory-recall-quality.test.ts` (`@typescript-eslint/no-unused-vars`)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23325261385/job/67845006621
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
