### PR TITLE
feat(memory): add `forceAdvanceDirtyTail` helper for permanent reducer failures

### DIFF
--- a/assistant/src/memory/reducer-store.ts
+++ b/assistant/src/memory/reducer-store.ts
@@ -251,6 +251,31 @@ export function applyReducerResult(params: ApplyReducerResultParams): void {
   });
 }
 
+// ── Force-advance (permanent failure bail-out) ───────────────────────
+
+/**
+ * Unconditionally advance the reducer checkpoint and clear the dirty tail
+ * marker without applying any reducer result.
+ *
+ * Used when the reducer encounters a permanent provider error (e.g. prompt
+ * too long) and retrying would loop forever. This lets the conversation
+ * move past the problematic window so future turns are not blocked.
+ */
+export function forceAdvanceDirtyTail(
+  conversationId: string,
+  reducedThroughMessageId: string,
+): void {
+  const db = getDb();
+  db.update(conversations)
+    .set({
+      memoryReducedThroughMessageId: reducedThroughMessageId,
+      memoryDirtyTailSinceMessageId: null,
+      memoryLastReducedAt: Date.now(),
+    })
+    .where(eq(conversations.id, conversationId))
+    .run();
+}
+
 // ── Internal helpers ─────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary
- Add `forceAdvanceDirtyTail()` exported function to `reducer-store.ts` that unconditionally advances the reducer checkpoint and clears the dirty tail marker
- Used by downstream PR to break infinite reducer retry loops when the provider returns a permanent error (e.g. prompt too long)

Part of plan: fix-app-freeze.md (PR 1 of 6)