### PR TITLE
fix(memory): re-throw permanent provider errors from `runReducer` instead of swallowing

### DIFF
--- a/assistant/src/__tests__/memory-reducer.test.ts
+++ b/assistant/src/__tests__/memory-reducer.test.ts
@@ -490,12 +490,20 @@ describe("runReducer — error handling", () => {
     expect(mockSendMessage).not.toHaveBeenCalled();
   });
 
-  test("returns EMPTY_REDUCER_RESULT when provider throws", async () => {
-    mockSendMessage.mockRejectedValueOnce(new Error("Provider error"));
+  test("returns EMPTY_REDUCER_RESULT when provider throws a transient error", async () => {
+    const transientError = Object.assign(new Error("Server error"), { status: 500 });
+    mockSendMessage.mockRejectedValueOnce(transientError);
 
     const result = await runReducer(makeInput());
 
     expect(result).toBe(EMPTY_REDUCER_RESULT);
+  });
+
+  test("re-throws permanent provider errors (fatal)", async () => {
+    const fatalError = Object.assign(new Error("prompt too long"), { status: 400 });
+    mockSendMessage.mockRejectedValueOnce(fatalError);
+
+    await expect(runReducer(makeInput())).rejects.toThrow("prompt too long");
   });
 
   test("returns EMPTY_REDUCER_RESULT when provider returns empty text", async () => {

--- a/assistant/src/memory/reducer.ts
+++ b/assistant/src/memory/reducer.ts
@@ -17,6 +17,7 @@ import {
   getConfiguredProvider,
 } from "../providers/provider-send-message.js";
 import { getLogger } from "../util/logger.js";
+import { classifyError } from "./job-utils.js";
 import {
   type ArchiveEpisodeCandidate,
   type ArchiveObservationCandidate,
@@ -147,8 +148,13 @@ export function buildReducerUserMessage(input: ReducerPromptInput): string {
  *
  * Returns {@link EMPTY_REDUCER_RESULT} when:
  * - No provider is configured/available
- * - The provider call fails or times out
+ * - The provider call fails with a transient error (timeouts, 5xx, rate limits)
+ * - The call is aborted via the provided signal
  * - The model output is unparseable
+ *
+ * @throws Re-throws permanent provider errors (4xx client errors such as
+ *         400 "prompt too long", 401, 403) so callers can handle them
+ *         (e.g. force-advancing the dirty tail to break retry loops).
  *
  * @param input  Structured reducer input
  * @param signal Optional external abort signal
@@ -197,9 +203,19 @@ export async function runReducer(
   } catch (err) {
     if (combinedSignal.aborted) {
       log.warn("Memory reducer provider call timed out or was aborted");
-    } else {
-      log.warn({ err }, "Memory reducer provider call failed");
+      return EMPTY_REDUCER_RESULT;
     }
+
+    // Permanent provider errors (400 "prompt too long", 401, 403, etc.)
+    // must not be silently swallowed — re-throw so callers can handle them
+    // (e.g. force-advancing the dirty tail to break retry loops).
+    const category = classifyError(err);
+    if (category === "fatal") {
+      log.error({ err }, "Memory reducer provider call failed with permanent error");
+      throw err;
+    }
+
+    log.warn({ err }, "Memory reducer provider call failed (transient)");
     return EMPTY_REDUCER_RESULT;
   } finally {
     cleanup();


### PR DESCRIPTION
## Summary
- Distinguish between transient (timeouts, 5xx) and permanent (4xx) provider errors in `runReducer()`
- Transient errors still return `EMPTY_REDUCER_RESULT` for retry
- Permanent errors (like 400 'prompt too long') are now re-thrown so callers can handle them appropriately
- Updated JSDoc to document the new error behavior

Part of plan: fix-app-freeze.md (PR 2 of 6)