### PR TITLE
fix: remove dangling retriever.js import breaking binary build

### DIFF
--- a/assistant/src/__tests__/context-memory-e2e.test.ts
+++ b/assistant/src/__tests__/context-memory-e2e.test.ts
@@ -54,16 +54,8 @@ const emptyRecall = {
   latencyMs: 0,
   topCandidates: [],
 };
-mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: async () => emptyRecall,
-  queryMemoryForCli: async () => emptyRecall,
+mock.module("../memory/inject.js", () => ({
   injectMemoryRecallAsUserBlock: (msgs: unknown[]) => msgs,
-}));
-mock.module("../memory/query-builder.js", () => ({
-  buildMemoryQuery: (userRequest: string) => userRequest,
-}));
-mock.module("../memory/retrieval-budget.js", () => ({
-  computeRecallBudget: () => 4000,
 }));
 
 import { DEFAULT_CONFIG } from "../config/defaults.js";

--- a/assistant/src/cli/commands/memory.ts
+++ b/assistant/src/cli/commands/memory.ts
@@ -2,12 +2,10 @@ import type { Command } from "commander";
 
 import {
   getMemorySystemStatus,
-  queryMemory,
   requestMemoryBackfill,
   requestMemoryCleanup,
   requestMemoryRebuildIndex,
 } from "../../memory/admin.js";
-import { listConversations } from "../../memory/conversation-queries.js";
 import { initializeDb } from "../db.js";
 import { log } from "../logger.js";
 
@@ -31,7 +29,6 @@ Key concepts:
 
 Examples:
   $ assistant memory status
-  $ assistant memory query "What is the project deadline?"
   $ assistant memory backfill`,
   );
 
@@ -142,56 +139,6 @@ Examples:
       log.info(
         `Queued cleanup_stale_superseded_items job: ${jobs.staleSupersededItemsJobId}`,
       );
-    });
-
-  memory
-    .command("query <text>")
-    .description(
-      "Run a memory recall query and print the injected memory payload",
-    )
-    .option("-c, --conversation <id>", "Optional conversation ID")
-    .addHelpText(
-      "after",
-      `
-Arguments:
-  text   The recall query string used to search memory (e.g. "What is the
-         project deadline?"). Matched against indexed segments using the full
-         recall pipeline: semantic (dense + sparse vector similarity) and recency
-         (time-weighted).
-
-Runs the complete memory recall pipeline and displays hit counts for each
-retrieval strategy, the total injected token count, query latency, and the
-assembled memory text that would be injected into context.
-
-The optional --conversation flag provides a conversation ID for
-context-aware recall. If omitted, the most recent conversation is used.
-
-Examples:
-  $ assistant memory query "What is the project deadline?"
-  $ assistant memory query "preferred communication style" --conversation conv_abc123
-  $ assistant memory query "API rate limits"`,
-    )
-    .action(async (text: string, opts?: { conversation?: string }) => {
-      initializeDb();
-      let conversationId = opts?.conversation;
-      if (!conversationId) {
-        const latest = listConversations(1)[0];
-        conversationId = latest?.id ?? "";
-      }
-      const result = await queryMemory(text, conversationId ?? "");
-      if (result.degraded) {
-        log.info(`Memory degraded: ${result.reason ?? "unknown reason"}`);
-      }
-      log.info(`Semantic hits: ${result.semanticHits}`);
-      log.info(`Recency hits: ${result.recencyHits}`);
-      log.info(`Injected tokens: ${result.injectedTokens}`);
-      log.info(`Latency: ${result.latencyMs}ms`);
-      if (result.injectedText.length > 0) {
-        log.info("");
-        log.info(result.injectedText);
-      } else {
-        log.info("No memory injected.");
-      }
     });
 
   memory

--- a/assistant/src/memory/admin.ts
+++ b/assistant/src/memory/admin.ts
@@ -7,7 +7,6 @@ import {
   enqueueCleanupStaleSupersededItemsJob,
   getMemoryJobCounts,
 } from "./jobs-store.js";
-import { queryMemoryForCli } from "./retriever.js";
 
 const log = getLogger("memory-admin");
 
@@ -101,8 +100,4 @@ export function requestMemoryCleanup(retentionMs?: number): {
     "Queued memory cleanup jobs",
   );
   return { staleSupersededItemsJobId };
-}
-
-export async function queryMemory(query: string, conversationId: string) {
-  return queryMemoryForCli(query, conversationId, getConfig());
 }


### PR DESCRIPTION
## Summary
- Remove dangling `import { queryMemoryForCli } from "./retriever.js"` in `admin.ts` left behind by #19914
- Remove the dead `queryMemory` wrapper and the CLI `memory query` subcommand that depended on it
- Clean up stale test mock for the deleted `retriever.js` module in `context-memory-e2e.test.ts`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23325261389/job/67845020112
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
