### PR TITLE
fix: resolve type-check errors from deleted legacy memory retrieval modules

### DIFF
--- a/assistant/src/__tests__/context-memory-e2e.test.ts
+++ b/assistant/src/__tests__/context-memory-e2e.test.ts
@@ -62,8 +62,11 @@ import { DEFAULT_CONFIG } from "../config/defaults.js";
 import { estimatePromptTokens } from "../context/token-estimator.js";
 import { ContextWindowManager } from "../context/window-manager.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
+// @ts-expect-error — deleted module, stubbed via mock.module above
 import { buildMemoryQuery } from "../memory/query-builder.js";
+// @ts-expect-error — deleted module, stubbed via mock.module above
 import { computeRecallBudget } from "../memory/retrieval-budget.js";
+// @ts-expect-error — deleted module, stubbed via mock.module above
 import { buildMemoryRecall } from "../memory/retriever.js";
 import {
   conversations,

--- a/assistant/src/__tests__/memory-context-benchmark.benchmark.test.ts
+++ b/assistant/src/__tests__/memory-context-benchmark.benchmark.test.ts
@@ -95,7 +95,9 @@ import { DEFAULT_CONFIG } from "../config/defaults.js";
 import { estimatePromptTokens } from "../context/token-estimator.js";
 import { ContextWindowManager } from "../context/window-manager.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
+// @ts-expect-error — deleted module, stubbed via mock.module above
 import { computeRecallBudget } from "../memory/retrieval-budget.js";
+// @ts-expect-error — deleted module, stubbed via mock.module above
 import { buildMemoryRecall } from "../memory/retriever.js";
 import { conversations, memorySegments, messages } from "../memory/schema.js";
 import type { Message, Provider } from "../providers/types.js";

--- a/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
+++ b/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
@@ -173,7 +173,11 @@ describe("Memory lifecycle E2E (simplified path)", () => {
         conversationId,
         title: "Kubernetes Setup",
         summary: "Deployed Kubernetes cluster on AWS EKS with 3 worker nodes",
+        tokenEstimate: 12,
+        startAt: now,
+        endAt: now,
         createdAt: now,
+        updatedAt: now,
       })
       .run();
 

--- a/assistant/src/__tests__/memory-recall-quality.test.ts
+++ b/assistant/src/__tests__/memory-recall-quality.test.ts
@@ -150,7 +150,11 @@ function insertEpisode(
       conversationId: opts.conversationId,
       title: opts.title,
       summary: opts.summary,
+      tokenEstimate: Math.ceil(opts.summary.length / 4),
+      startAt: opts.createdAt,
+      endAt: opts.createdAt,
       createdAt: opts.createdAt,
+      updatedAt: opts.createdAt,
     })
     .run();
 }

--- a/assistant/src/__tests__/memory-regressions.experimental.test.ts
+++ b/assistant/src/__tests__/memory-regressions.experimental.test.ts
@@ -94,6 +94,7 @@ import {
   resetStaleSweepThrottle,
   runMemoryJobsOnce,
 } from "../memory/jobs-worker.js";
+// @ts-expect-error — deleted module, stubbed via mock.module above
 import { buildMemoryRecall } from "../memory/retriever.js";
 import {
   conversations,
@@ -283,14 +284,14 @@ describe("Memory regressions (experimental)", () => {
       },
     ];
 
-    const recall = await withMockOllamaQueryEmbedding(() =>
+    const recall = (await withMockOllamaQueryEmbedding(() =>
       buildMemoryRecall(
         "timezone",
         "conv-semantic-exclude",
         semanticRecallConfig(),
         { excludeMessageIds: ["msg-semantic-current"] },
       ),
-    );
+    )) as { semanticHits: number; injectedText: string };
     expect(recall.semanticHits).toBe(1);
     expect(recall.injectedText).toContain("User timezone is PST");
     expect(recall.injectedText).not.toContain("(current turn)");
@@ -388,13 +389,13 @@ describe("Memory regressions (experimental)", () => {
       },
     ];
 
-    const recall = await withMockOllamaQueryEmbedding(() =>
+    const recall = (await withMockOllamaQueryEmbedding(() =>
       buildMemoryRecall(
         "timezone",
         "conv-semantic-evidence",
         semanticRecallConfig(),
       ),
-    );
+    )) as { semanticHits: number; injectedText: string };
     expect(recall.semanticHits).toBe(1);
     expect(recall.injectedText).toContain("User timezone is PST");
     expect(recall.injectedText).not.toContain("Stale orphan fact");
@@ -486,11 +487,11 @@ describe("Memory regressions (experimental)", () => {
       },
     ];
 
-    const recall = await withMockOllamaQueryEmbedding(() =>
+    const recall = (await withMockOllamaQueryEmbedding(() =>
       buildMemoryRecall("summary", conversationId, semanticRecallConfig(), {
         excludeMessageIds: ["msg-semantic-summary-excluded"],
       }),
-    );
+    )) as { semanticHits: number; injectedText: string };
     // Both summaries are returned from Qdrant and both pass post-filtering.
     // Verify the pipeline completes successfully with semantic hits.
     expect(recall.semanticHits).toBe(2);

--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -205,13 +205,8 @@ import {
   runMemoryJobsOnce,
   sweepStaleItems,
 } from "../memory/jobs-worker.js";
-import {
-  buildMemoryRecall,
-  escapeXmlTags,
-  formatAbsoluteTime,
-  formatRelativeTime,
-  injectMemoryRecallAsUserBlock,
-} from "../memory/retriever.js";
+// @ts-expect-error — deleted module, stubbed via mock.module above
+import { buildMemoryRecall, escapeXmlTags, formatAbsoluteTime, formatRelativeTime, injectMemoryRecallAsUserBlock } from "../memory/retriever.js"; // eslint-disable-line @stylistic/max-len
 import {
   conversations,
   memoryEmbeddings,
@@ -2958,7 +2953,7 @@ describe("Memory regressions", () => {
         scopePolicyOverride: undefined,
       },
     );
-    const stdCandidateKeys = stdRecall.topCandidates.map((c) => c.key);
+    const stdCandidateKeys = stdRecall.topCandidates.map((c: { key: string }) => c.key);
     const hasZephyrInStandard = privateItemKeys.some((k) =>
       stdCandidateKeys.includes(k),
     );

--- a/assistant/src/__tests__/memory-retrieval.benchmark.test.ts
+++ b/assistant/src/__tests__/memory-retrieval.benchmark.test.ts
@@ -92,6 +92,7 @@ mock.module("../memory/retriever.js", () => ({
 import { DEFAULT_CONFIG } from "../config/defaults.js";
 import type { AssistantConfig } from "../config/types.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
+// @ts-expect-error — deleted module, stubbed via mock.module above
 import { buildMemoryRecall } from "../memory/retriever.js";
 import { conversations, memorySegments, messages } from "../memory/schema.js";
 


### PR DESCRIPTION
## Summary
- Replace `queryMemoryForCli` import in `admin.ts` with `buildArchiveRecall` from the new archive recall system
- Add `@ts-expect-error` directives on imports of deleted modules (`retriever.js`, `query-builder.js`, `retrieval-budget.js`) that are stubbed via `mock.module()` in test files
- Add missing required fields (`tokenEstimate`, `updatedAt`, `startAt`, `endAt`) to `memoryEpisodes` and `memoryChunks` inserts in test helpers
- Add type assertions for `recall` results from mocked `buildMemoryRecall` to fix `unknown` type errors

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23325261385/job/67845006605
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19922" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
