### PR TITLE
fix: resolve unused variable lint error in context-memory-e2e test

### DIFF
--- a/assistant/src/__tests__/context-memory-e2e.test.ts
+++ b/assistant/src/__tests__/context-memory-e2e.test.ts
@@ -42,7 +42,7 @@ mock.module("../memory/qdrant-client.js", () => ({
 }));
 
 // Stub deleted legacy modules so imports resolve (full cleanup in follow-up PR)
-const emptyRecall = {
+const _emptyRecall = {
   enabled: true,
   degraded: false,
   injectedText: "",


### PR DESCRIPTION
## Summary
- Prefix `emptyRecall` with `_` in `context-memory-e2e.test.ts` to fix `@typescript-eslint/no-unused-vars` lint error

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23325434744/job/67845535603