### PR TITLE
fix: remove invalid @stylistic/max-len eslint-disable comment

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -206,7 +206,7 @@ import {
   sweepStaleItems,
 } from "../memory/jobs-worker.js";
 // @ts-expect-error — deleted module, stubbed via mock.module above
-import { buildMemoryRecall, escapeXmlTags, formatAbsoluteTime, formatRelativeTime, injectMemoryRecallAsUserBlock } from "../memory/retriever.js"; // eslint-disable-line @stylistic/max-len
+import { buildMemoryRecall, escapeXmlTags, formatAbsoluteTime, formatRelativeTime, injectMemoryRecallAsUserBlock } from "../memory/retriever.js";
 import {
   conversations,
   memoryEmbeddings,


### PR DESCRIPTION
## Summary
- Remove `eslint-disable-line @stylistic/max-len` from `memory-regressions.test.ts` — the `@stylistic/max-len` rule is not installed, causing a lint error ("Definition for rule '@stylistic/max-len' was not found")

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23325473491/job/67845653129