### PR TITLE
fix: add missing mock.module stubs for deleted memory modules in context-memory-e2e test

### DIFF
--- a/assistant/src/__tests__/context-memory-e2e.test.ts
+++ b/assistant/src/__tests__/context-memory-e2e.test.ts
@@ -57,6 +57,15 @@ const emptyRecall = {
 mock.module("../memory/inject.js", () => ({
   injectMemoryRecallAsUserBlock: (msgs: unknown[]) => msgs,
 }));
+mock.module("../memory/query-builder.js", () => ({
+  buildMemoryQuery: (text: string) => text,
+}));
+mock.module("../memory/retrieval-budget.js", () => ({
+  computeRecallBudget: () => 4000,
+}));
+mock.module("../memory/retriever.js", () => ({
+  buildMemoryRecall: async () => emptyRecall,
+}));
 
 import { DEFAULT_CONFIG } from "../config/defaults.js";
 import { estimatePromptTokens } from "../context/token-estimator.js";


### PR DESCRIPTION
## Summary
- `context-memory-e2e.test.ts` had `@ts-expect-error` imports for three deleted legacy memory modules (`query-builder.js`, `retrieval-budget.js`, `retriever.js`) but was missing the corresponding `mock.module()` calls needed for Bun's runtime module resolution
- Added mock stubs matching the pattern already used in `memory-regressions.test.ts` and `memory-context-benchmark.benchmark.test.ts`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23325434744/job/67845535615
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19928" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
