### PR TITLE
fix(clients): cancel sendingWatchdogTask in ChatViewModel deinit

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -3110,6 +3110,7 @@ public final class ChatViewModel: ObservableObject {
         reconnectDebounceTask?.cancel()
         btwTask?.cancel()
         greetingTask?.cancel()
+        sendingWatchdogTask?.cancel()
         memoryPressureSource?.cancel()
         if let observer = reconnectObserver {
             NotificationCenter.default.removeObserver(observer)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-app-freeze.md.

**Gap:** sendingWatchdogTask not cancelled in deinit
**What was expected:** All task properties should be cancelled in deinit for consistency
**What was found:** Every other Task property is cancelled in deinit except the new sendingWatchdogTask
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
