### PR TITLE
fix(memory): force-advance dirty tail in reduceBeforeSwitch on permanent failure

### DIFF
--- a/assistant/src/memory/reducer-scheduler.ts
+++ b/assistant/src/memory/reducer-scheduler.ts
@@ -24,6 +24,7 @@ import { getDb } from "./db.js";
 import { type ReducerPromptInput, runReducer } from "./reducer.js";
 import {
   applyReducerResult,
+  forceAdvanceDirtyTail,
   getActiveOpenLoops,
   getActiveTimeContexts,
 } from "./reducer-store.js";
@@ -233,9 +234,20 @@ export async function reduceBeforeSwitch(
 
     return dirtyConversationId;
   } catch (err) {
+    // runReducer only throws on fatal/permanent errors (e.g. 400 "prompt
+    // too long"). Force-advance the dirty tail so every subsequent
+    // conversation switch doesn't waste an API call hitting the same
+    // permanent error.
+    const lastMessage = unreducedMessages[unreducedMessages.length - 1];
+    forceAdvanceDirtyTail(dirtyConversationId, lastMessage.id);
     log.warn(
-      { err, conversationId: dirtyConversationId },
-      "Pre-switch memory reduction failed — continuing with switch",
+      {
+        err,
+        conversationId: dirtyConversationId,
+        skippedMessages: unreducedMessages.length,
+        reducedThroughMessageId: lastMessage.id,
+      },
+      "Pre-switch memory reduction failed permanently — force-advanced dirty tail",
     );
     return null;
   }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-app-freeze.md.

**Gap:** reduceBeforeSwitch silently swallows fatal errors without force-advancing dirty tail
**What was expected:** All callers of runReducer() should handle fatal errors by force-advancing the dirty tail
**What was found:** reducer-scheduler.ts catches all errors and returns null, wasting API calls on each conversation switch

- In the catch block of `reduceBeforeSwitch`, call `forceAdvanceDirtyTail(conversationId, lastMessageId)` before returning `null`
- This mirrors the pattern used in `reduceConversationMemoryJob` handler
- Since `runReducer` already classifies errors internally (only throws on fatal, returns EMPTY_REDUCER_RESULT for transient), no additional `classifyError` check is needed in the catch block
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
