### PR TITLE
Add unbind button for voice input hotkey

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -19,6 +19,7 @@ struct SettingsAppearanceTab: View {
     @State private var debouncedTimezoneSearchText: String = ""
     @State private var isTimezoneDropdownOpen: Bool = false
     @State private var timezoneSearchDebounceTask: Task<Void, Never>?
+    @AppStorage("activationKey") private var activationKey: String = "fn"
     @FocusState private var isTimezoneSearchFocused: Bool
 
     var body: some View {
@@ -246,7 +247,23 @@ struct SettingsAppearanceTab: View {
 
                 SettingsDivider()
 
-                ShortcutRow(label: "Start voice input", shortcut: PTTActivator.fromStored().kind != .none ? "Hold \(PTTActivator.fromStored().displayName)" : "Disabled")
+                HStack {
+                    Text("Start voice input")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentSecondary)
+                    Spacer()
+                    // Read activationKey to establish SwiftUI dependency tracking
+                    let activator = { _ = activationKey; return PTTActivator.fromStored() }()
+                    VShortcutTag(activator.kind != .none ? "Hold \(activator.displayName)" : "Disabled")
+                    if activator.kind != .none {
+                        VButton(label: "Unbind", style: .outlined) {
+                            PTTActivator.off.store()
+                            activationKey = "none"
+                            NotificationCenter.default.post(name: .activationKeyChanged, object: nil)
+                        }
+                    }
+                }
+                .padding(.vertical, VSpacing.md)
 
                 SettingsDivider()
 


### PR DESCRIPTION
## Summary
- Replace the read-only `ShortcutRow` for "Start voice input" with an interactive row that shows an "Unbind" button when a hotkey is bound
- Clicking Unbind sets `PTTActivator.off`, updates `@AppStorage`, and posts `.activationKeyChanged` notification so `VoiceInputManager` stops monitoring
- The row now shows "Disabled" when unbound, matching the existing pattern for other configurable shortcuts

## Original prompt
I want to be able to unbind this fn to talk hotkey