### PR TITLE
refactor: remove legacy memory item tools and inspection paths

### DIFF
--- a/assistant/src/tools/memory/definitions.ts
+++ b/assistant/src/tools/memory/definitions.ts
@@ -3,7 +3,7 @@ import type { ToolDefinition } from "../../providers/types.js";
 export const memoryRecallDefinition: ToolDefinition = {
   name: "memory_recall",
   description:
-    "Hybrid search across memory (semantic and recency) for specific information. Relevant memories are auto-injected each turn, so only call this when the auto-injected context doesn't contain what you need - e.g. the user references a past session, or you need deeper recall. Be specific in your query for best results. Returns formatted memory context with item IDs for use with memory_manage.",
+    "Search across memory (keyword-based) for specific information. Relevant memories are auto-injected each turn, so only call this when the auto-injected context doesn't contain what you need - e.g. the user references a past session, or you need deeper recall. Be specific in your query for best results.",
   input_schema: {
     type: "object",
     properties: {
@@ -11,58 +11,46 @@ export const memoryRecallDefinition: ToolDefinition = {
         type: "string",
         description: "The search query - be specific and descriptive",
       },
-      scope: {
-        type: "string",
-        enum: ["default", "conversation"],
-        description:
-          'Scope to search - "default" searches all memory, "conversation" restricts to current conversation',
-      },
     },
     required: ["query"],
-  },
-};
-
-const memoryManageProperties = {
-  op: {
-    type: "string" as const,
-    enum: ["save", "update", "delete"],
-    description: "The operation to perform",
-  },
-  memory_id: {
-    type: "string" as const,
-    description: "ID of existing memory item (required for update/delete)",
-  },
-  statement: {
-    type: "string" as const,
-    description:
-      "The fact or preference to remember (required for save/update, 1-2 sentences)",
-  },
-  kind: {
-    type: "string" as const,
-    enum: [
-      "identity",
-      "preference",
-      "project",
-      "decision",
-      "constraint",
-      "event",
-    ],
-    description:
-      'Category of the memory item (required for save). Use "constraint" for mistakes, gotchas, discoveries, and working solutions - write as advice to your future self.',
-  },
-  subject: {
-    type: "string" as const,
-    description: "Short subject/topic label, 2-8 words (optional, save only)",
   },
 };
 
 export const memoryManageDefinition: ToolDefinition = {
   name: "memory_manage",
   description:
-    "Save, update, or delete memory items. Memory does not survive session restarts - if you want to remember something, save it now. Use 'save' for new information worth remembering (facts, preferences, mistakes, discoveries, gotchas), 'update' to correct existing items, 'delete' to remove outdated items. When a user says 'remember this', save immediately. For user profile or personality changes, update workspace files (USER.md, SOUL.md) instead.",
+    "Save observations to memory. Memory does not survive session restarts - if you want to remember something, save it now. Use 'save' for new information worth remembering (facts, preferences, mistakes, discoveries, gotchas). When a user says 'remember this', save immediately. For user profile or personality changes, update workspace files (USER.md, SOUL.md) instead.",
   input_schema: {
     type: "object",
-    properties: memoryManageProperties,
-    required: ["op"],
+    properties: {
+      op: {
+        type: "string" as const,
+        enum: ["save"],
+        description: "The operation to perform",
+      },
+      statement: {
+        type: "string" as const,
+        description:
+          "The fact or preference to remember (required, 1-2 sentences)",
+      },
+      kind: {
+        type: "string" as const,
+        enum: [
+          "identity",
+          "preference",
+          "project",
+          "decision",
+          "constraint",
+          "event",
+        ],
+        description:
+          'Category of the memory observation (required). Use "constraint" for mistakes, gotchas, discoveries, and working solutions - write as advice to your future self.',
+      },
+      subject: {
+        type: "string" as const,
+        description: "Short subject/topic label, 2-8 words (optional)",
+      },
+    },
+    required: ["op", "statement", "kind"],
   },
 };

--- a/assistant/src/tools/memory/handlers.test.ts
+++ b/assistant/src/tools/memory/handlers.test.ts
@@ -1,8 +1,9 @@
 /**
- * Tests for the handleMemoryRecall() tool handler.
+ * Tests for memory tool handlers (simplified-memory only).
  *
- * Covers happy path (multi-source results), empty results, degraded mode
- * (embeddings/Qdrant unavailable), scope filtering, and error handling.
+ * Covers:
+ * - memory_save: input validation, happy path via simplified observation store
+ * - memory_recall: input validation, empty results, result shape, error handling
  */
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -17,7 +18,7 @@ import {
   test,
 } from "bun:test";
 
-const testDir = mkdtempSync(join(tmpdir(), "memory-recall-handler-"));
+const testDir = mkdtempSync(join(tmpdir(), "memory-tool-handler-"));
 
 // ── Module mocks (must precede production imports) ───────────────────
 
@@ -88,20 +89,15 @@ mock.module("../../config/loader.js", () => ({
 
 import { getDb, initializeDb } from "../../memory/db.js";
 import { clearEmbeddingBackendCache } from "../../memory/embedding-backend.js";
-import {
-  conversations,
-  memoryItems,
-  memoryItemSources,
-  messages,
-} from "../../memory/schema.js";
+import { conversations, memoryObservations } from "../../memory/schema.js";
 import type { MemoryRecallToolResult } from "./handlers.js";
-import { handleMemoryRecall } from "./handlers.js";
+import { handleMemoryRecall, handleMemorySave } from "./handlers.js";
 
 function clearTables() {
   const db = getDb();
-  db.run("DELETE FROM memory_item_sources");
-  db.run("DELETE FROM memory_items");
-  db.run("DELETE FROM memory_segments");
+  db.run("DELETE FROM memory_chunks");
+  db.run("DELETE FROM memory_observations");
+  db.run("DELETE FROM memory_episodes");
   db.run("DELETE FROM messages");
   db.run("DELETE FROM conversations");
 }
@@ -129,140 +125,115 @@ function insertConversation(
     .run();
 }
 
-function insertMessage(
-  db: ReturnType<typeof getDb>,
-  id: string,
-  conversationId: string,
-  role: string,
-  text: string,
-  createdAt: number,
-) {
-  db.insert(messages)
-    .values({
-      id,
-      conversationId,
-      role,
-      content: JSON.stringify([{ type: "text", text }]),
-      createdAt,
-    })
-    .run();
-}
-
-function insertItem(
-  db: ReturnType<typeof getDb>,
-  opts: {
-    id: string;
-    kind: string;
-    subject: string;
-    statement: string;
-    status?: string;
-    confidence?: number;
-    importance?: number;
-    firstSeenAt: number;
-    lastSeenAt?: number;
-    scopeId?: string;
-  },
-) {
-  db.insert(memoryItems)
-    .values({
-      id: opts.id,
-      kind: opts.kind,
-      subject: opts.subject,
-      statement: opts.statement,
-      status: opts.status ?? "active",
-      confidence: opts.confidence ?? 0.8,
-      importance: opts.importance ?? 0.6,
-      accessCount: 0,
-      fingerprint: `fp-${opts.id}`,
-      scopeId: opts.scopeId ?? "default",
-      firstSeenAt: opts.firstSeenAt,
-      lastSeenAt: opts.lastSeenAt ?? opts.firstSeenAt,
-      lastUsedAt: null,
-    })
-    .run();
-}
-
-function insertItemSource(
-  db: ReturnType<typeof getDb>,
-  itemId: string,
-  messageId: string,
-  createdAt: number,
-) {
-  db.insert(memoryItemSources)
-    .values({
-      memoryItemId: itemId,
-      messageId,
-      evidence: `evidence for ${itemId}`,
-      createdAt,
-    })
-    .run();
-}
-
 function parseResult(content: string): MemoryRecallToolResult {
   return JSON.parse(content) as MemoryRecallToolResult;
 }
 
-/** Seed with searchable memory items from multiple sources. */
-function seedMemory() {
-  const db = getDb();
-  const now = Date.now();
-  const convId = "conv-recall-test";
-
-  insertConversation(db, convId, now - 60_000);
-  insertMessage(
-    db,
-    "msg-1",
-    convId,
-    "user",
-    "discuss API design",
-    now - 50_000,
-  );
-  insertMessage(
-    db,
-    "msg-2",
-    convId,
-    "assistant",
-    "The API design uses REST endpoints",
-    now - 40_000,
-  );
-
-  insertItem(db, {
-    id: "item-api",
-    kind: "preference",
-    subject: "API design",
-    statement: "User prefers REST over GraphQL for API design",
-    firstSeenAt: now - 30_000,
-    importance: 0.9,
-  });
-  insertItemSource(db, "item-api", "msg-1", now - 30_000);
-
-  insertItem(db, {
-    id: "item-testing",
-    kind: "identity",
-    subject: "testing",
-    statement: "The project uses bun test for unit testing",
-    firstSeenAt: now - 20_000,
-    importance: 0.7,
-  });
-  insertItemSource(db, "item-testing", "msg-2", now - 20_000);
-}
-
 // ── Suite ────────────────────────────────────────────────────────────
 
+beforeAll(() => {
+  initializeDb();
+});
+
+beforeEach(() => {
+  clearTables();
+  clearEmbeddingBackendCache();
+});
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe("handleMemorySave", () => {
+  // ── Input validation ──────────────────────────────────────────────
+
+  test("returns error when statement is missing", async () => {
+    const result = await handleMemorySave(
+      { kind: "preference" },
+      TEST_CONFIG,
+      "conv-1",
+      undefined,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("statement is required");
+  });
+
+  test("returns error when kind is missing", async () => {
+    const result = await handleMemorySave(
+      { statement: "some fact" },
+      TEST_CONFIG,
+      "conv-1",
+      undefined,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("kind is required");
+  });
+
+  test("returns error when kind is invalid", async () => {
+    const result = await handleMemorySave(
+      { statement: "some fact", kind: "bogus" },
+      TEST_CONFIG,
+      "conv-1",
+      undefined,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("kind is required");
+  });
+
+  // ── Happy path ────────────────────────────────────────────────────
+
+  test("saves observation to simplified memory store", async () => {
+    const db = getDb();
+    const convId = "conv-save-test";
+    insertConversation(db, convId, Date.now());
+
+    const result = await handleMemorySave(
+      {
+        statement: "User prefers dark mode",
+        kind: "preference",
+        subject: "UI theme",
+      },
+      TEST_CONFIG,
+      convId,
+      undefined,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Saved to memory");
+    expect(result.content).toContain("preference");
+    expect(result.content).toContain("UI theme");
+
+    // Verify the observation was written to the simplified tables
+    const observations = db.select().from(memoryObservations).all();
+    expect(observations.length).toBe(1);
+    expect(observations[0].content).toContain("preference");
+    expect(observations[0].content).toContain("UI theme");
+    expect(observations[0].content).toContain("User prefers dark mode");
+    expect(observations[0].source).toBe("tool:memory_save");
+  });
+
+  test("infers subject from statement when subject is omitted", async () => {
+    const db = getDb();
+    const convId = "conv-infer-subject";
+    insertConversation(db, convId, Date.now());
+
+    const result = await handleMemorySave(
+      {
+        statement:
+          "The deployment pipeline uses GitHub Actions with self-hosted runners",
+        kind: "project",
+      },
+      TEST_CONFIG,
+      convId,
+      undefined,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Saved to memory");
+  });
+});
+
 describe("handleMemoryRecall", () => {
-  beforeAll(() => {
-    initializeDb();
-  });
-
-  beforeEach(() => {
-    clearTables();
-    clearEmbeddingBackendCache();
-  });
-
-  afterAll(() => {
-    rmSync(testDir, { recursive: true, force: true });
-  });
-
   // ── Input validation ──────────────────────────────────────────────
 
   test("returns error when query is missing", async () => {
@@ -283,29 +254,9 @@ describe("handleMemoryRecall", () => {
     expect(result.content).toContain("query is required");
   });
 
-  // ── Happy path ────────────────────────────────────────────────────
-
-  test("returns valid result shape with Qdrant mocked empty", async () => {
-    seedMemory();
-
-    const result = await handleMemoryRecall(
-      { query: "API design" },
-      TEST_CONFIG,
-    );
-
-    // With Qdrant mocked empty, hybrid search returns nothing.
-    // Recency search also returns nothing (no conversationId passed to handler).
-    // The handler should return a valid result shape with zero results.
-    expect(result.isError).toBe(false);
-    const parsed = parseResult(result.content);
-    expect(typeof parsed.resultCount).toBe("number");
-    expect(typeof parsed.text).toBe("string");
-  });
-
   // ── Empty results ─────────────────────────────────────────────────
 
   test("returns empty result when no memories match", async () => {
-    // No items seeded - tables cleared in beforeEach
     const result = await handleMemoryRecall(
       { query: "quantum physics" },
       TEST_CONFIG,
@@ -319,195 +270,7 @@ describe("handleMemoryRecall", () => {
     expect(parsed.sources.recency).toBe(0);
   });
 
-  // ── Degraded mode ─────────────────────────────────────────────────
-
-  test("returns results with degraded=true when embeddings required but unavailable", async () => {
-    seedMemory();
-
-    // When embeddings are required but no provider is available,
-    // the handler reports degraded=true
-    const degradedConfig: AssistantConfig = {
-      ...TEST_CONFIG,
-      memory: {
-        ...TEST_CONFIG.memory,
-        embeddings: {
-          ...TEST_CONFIG.memory.embeddings,
-          provider: "none" as never,
-          required: true,
-        },
-      },
-    };
-
-    const result = await handleMemoryRecall(
-      { query: "API design" },
-      degradedConfig,
-    );
-
-    expect(result.isError).toBe(false);
-    const parsed = parseResult(result.content);
-    expect(parsed.degraded).toBe(true);
-    expect(parsed.sources.semantic).toBe(0);
-  });
-
-  test("returns results with degraded=false when embeddings optional and unavailable", async () => {
-    seedMemory();
-
-    // When embeddings are not required and no provider is available,
-    // the handler gracefully continues without degradation
-    const optionalEmbeddingsConfig: AssistantConfig = {
-      ...TEST_CONFIG,
-      memory: {
-        ...TEST_CONFIG.memory,
-        embeddings: {
-          ...TEST_CONFIG.memory.embeddings,
-          provider: "none" as never,
-          required: false,
-        },
-      },
-    };
-
-    const result = await handleMemoryRecall(
-      { query: "API design" },
-      optionalEmbeddingsConfig,
-    );
-
-    expect(result.isError).toBe(false);
-    const parsed = parseResult(result.content);
-    // Not degraded because embeddings are optional
-    expect(parsed.degraded).toBe(false);
-    expect(parsed.sources.semantic).toBe(0);
-    // With FTS/direct-item search removed, only Qdrant hybrid search and
-    // recency search remain. Both return empty here (Qdrant mocked,
-    // no conversationId passed). The handler returns a valid empty result.
-    expect(parsed.resultCount).toBe(0);
-  });
-
-  test("gracefully returns empty in degraded mode without embeddings", async () => {
-    seedMemory();
-
-    const degradedConfig: AssistantConfig = {
-      ...TEST_CONFIG,
-      memory: {
-        ...TEST_CONFIG.memory,
-        embeddings: {
-          ...TEST_CONFIG.memory.embeddings,
-          provider: "none" as never,
-          required: false,
-        },
-      },
-    };
-
-    const result = await handleMemoryRecall(
-      { query: "API design" },
-      degradedConfig,
-    );
-
-    expect(result.isError).toBe(false);
-    const parsed = parseResult(result.content);
-    // With FTS removed and Qdrant mocked, no retrieval path finds items.
-    // The handler returns a valid empty result without throwing.
-    expect(typeof parsed.resultCount).toBe("number");
-  });
-
-  // ── Scope filtering ───────────────────────────────────────────────
-
-  test("scope 'conversation' passes scope policy override to retriever", async () => {
-    // Seed a conversation with segments in the target scope and in a different
-    // scope. With scope="conversation", only the target scope's segments should
-    // be returned (fallbackToDefault=false).
-    const db = getDb();
-    const now = Date.now();
-    const convId = "conv-scope-a";
-
-    insertConversation(db, convId, now - 10_000);
-    insertMessage(
-      db,
-      "msg-scope-a",
-      convId,
-      "user",
-      "scoped data for conversation A",
-      now - 5_000,
-    );
-
-    // Insert a segment scoped to this conversation's scope
-    db.run(`
-      INSERT INTO memory_segments (id, message_id, conversation_id, role, segment_index, text, token_estimate, scope_id, created_at, updated_at)
-      VALUES ('seg-scope-a', 'msg-scope-a', '${convId}', 'user', 0, 'Conversation-scoped data for conversation A', 8, '${convId}', ${
-        now - 5_000
-      }, ${now - 5_000})
-    `);
-
-    // Insert an out-of-scope segment that should NOT be returned
-    db.run(`
-      INSERT INTO memory_segments (id, message_id, conversation_id, role, segment_index, text, token_estimate, scope_id, created_at, updated_at)
-      VALUES ('seg-scope-other', 'msg-scope-a', '${convId}', 'user', 1, 'Out-of-scope data from a different scope', 8, 'other-scope', ${
-        now - 5_000
-      }, ${now - 5_000})
-    `);
-
-    const result = await handleMemoryRecall(
-      { query: "data", scope: "conversation" },
-      TEST_CONFIG,
-      convId,
-      convId,
-    );
-
-    expect(result.isError).toBe(false);
-    const parsed = parseResult(result.content);
-    // With conversation scope, only the conversation-scoped segment is returned.
-    // The other-scope segment should be excluded (fallbackToDefault=false).
-    expect(parsed.sources.recency).toBe(1);
-    expect(parsed.text).toContain("Conversation-scoped data");
-    expect(parsed.text).not.toContain("Out-of-scope data");
-  });
-
-  test("default scope handler invocation does not error", async () => {
-    const db = getDb();
-    const now = Date.now();
-
-    insertItem(db, {
-      id: "item-fallback",
-      kind: "identity",
-      subject: "global knowledge",
-      statement: "This global knowledge should be accessible from any scope",
-      firstSeenAt: now - 10_000,
-      scopeId: "default",
-    });
-
-    const result = await handleMemoryRecall(
-      { query: "global knowledge" },
-      TEST_CONFIG,
-      "some-thread-id",
-    );
-
-    expect(result.isError).toBe(false);
-    const parsed = parseResult(result.content);
-    // With Qdrant mocked and no conversation segments, the retriever returns
-    // empty. Handler should still return a valid result shape.
-    expect(typeof parsed.resultCount).toBe("number");
-  });
-
   // ── Result shape ─────────────────────────────────────────────────
-
-  test("result shape matches MemoryRecallToolResult when successful", async () => {
-    seedMemory();
-
-    const result = await handleMemoryRecall(
-      { query: "API design" },
-      TEST_CONFIG,
-    );
-
-    expect(result.isError).toBe(false);
-    const parsed = parseResult(result.content);
-
-    // Verify the result shape has all expected fields
-    expect(typeof parsed.text).toBe("string");
-    expect(typeof parsed.resultCount).toBe("number");
-    expect(typeof parsed.degraded).toBe("boolean");
-    expect(typeof parsed.sources).toBe("object");
-    expect(typeof parsed.sources.semantic).toBe("number");
-    expect(typeof parsed.sources.recency).toBe("number");
-  });
 
   test("empty result shape matches MemoryRecallToolResult", async () => {
     const result = await handleMemoryRecall(
@@ -525,14 +288,69 @@ describe("handleMemoryRecall", () => {
     expect(parsed.sources.recency).toBe(0);
   });
 
+  test("result shape has all expected fields", async () => {
+    const result = await handleMemoryRecall(
+      { query: "any topic" },
+      TEST_CONFIG,
+    );
+
+    expect(result.isError).toBe(false);
+    const parsed = parseResult(result.content);
+
+    expect(typeof parsed.text).toBe("string");
+    expect(typeof parsed.resultCount).toBe("number");
+    expect(typeof parsed.degraded).toBe("boolean");
+    expect(typeof parsed.sources).toBe("object");
+    expect(typeof parsed.sources.semantic).toBe("number");
+    expect(typeof parsed.sources.recency).toBe("number");
+  });
+
+  // ── Recall after save ─────────────────────────────────────────────
+
+  test("recalls observation saved via memory_save", async () => {
+    const db = getDb();
+    const convId = "conv-recall-after-save";
+    insertConversation(db, convId, Date.now());
+
+    // Save a memory
+    const saveResult = await handleMemorySave(
+      {
+        statement:
+          "The project previously used Webpack but migrated to Vite",
+        kind: "project",
+        subject: "build tooling",
+      },
+      TEST_CONFIG,
+      convId,
+      undefined,
+    );
+    expect(saveResult.isError).toBe(false);
+
+    // Recall it — the archive recall path uses keyword matching, so we query
+    // with a term that appears in the saved observation.
+    const recallResult = await handleMemoryRecall(
+      { query: "remember what build tooling was mentioned previously" },
+      TEST_CONFIG,
+      "default",
+    );
+
+    expect(recallResult.isError).toBe(false);
+    const parsed = parseResult(recallResult.content);
+    // The archive recall path requires a recall trigger (explicit past
+    // reference, analogy/debug pattern, or strong prefetch). The query
+    // contains "remember" and "previously" which match PAST_REFERENCE_PATTERNS.
+    expect(parsed.resultCount).toBeGreaterThanOrEqual(1);
+    expect(parsed.text).toContain("build tooling");
+  });
+
   // ── Error handling ────────────────────────────────────────────────
-  // This test must be last: mock.module replaces the retriever for all
+  // This test must be last: mock.module replaces the module for all
   // subsequent imports and cannot be cleanly reverted within the same
   // test file.
 
   test("retrieval failure returns error message, does not throw", async () => {
-    mock.module("../../memory/retriever.js", () => ({
-      buildMemoryRecall: async () => {
+    mock.module("../../memory/archive-recall.js", () => ({
+      buildArchiveRecall: () => {
         throw new Error("Simulated retrieval failure");
       },
     }));

--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -1,13 +1,5 @@
-import { and, eq, ne } from "drizzle-orm";
-import { v4 as uuid } from "uuid";
-
-import type { AssistantConfig } from "../../config/types.js";
 import { buildArchiveRecall } from "../../memory/archive-recall.js";
 import { insertObservation } from "../../memory/archive-store.js";
-import { getDb } from "../../memory/db.js";
-import { computeMemoryFingerprint } from "../../memory/fingerprint.js";
-import { enqueueMemoryJob } from "../../memory/jobs-store.js";
-import { memoryItems } from "../../memory/schema.js";
 import { getLogger } from "../../util/logger.js";
 import { truncate } from "../../util/truncate.js";
 import type { ToolExecutionResult } from "../types.js";
@@ -18,7 +10,7 @@ const log = getLogger("memory-tools");
 
 export async function handleMemorySave(
   args: Record<string, unknown>,
-  config: AssistantConfig,
+  _config: unknown,
   conversationId: string,
   messageId: string | undefined,
   scopeId: string = "default",
@@ -63,311 +55,8 @@ export async function handleMemorySave(
       ? truncate(args.subject.trim(), 80, "")
       : inferSubjectFromStatement(statement.trim());
 
-  // When simplified memory is enabled, save directly to the simplified
-  // observation/chunk tables instead of the legacy memory_items table.
-  if (config.memory.simplified.enabled) {
-    return handleSimplifiedMemorySave(
-      kind,
-      subject,
-      statement.trim(),
-      conversationId,
-      messageId,
-      scopeId,
-    );
-  }
-
   try {
-    const db = getDb();
-    const id = uuid();
-    const now = Date.now();
     const trimmedStatement = truncate(statement.trim(), 500, "");
-
-    const fingerprint = computeMemoryFingerprint(
-      scopeId,
-      kind,
-      subject,
-      trimmedStatement,
-    );
-
-    const existing = db
-      .select()
-      .from(memoryItems)
-      .where(
-        and(
-          eq(memoryItems.fingerprint, fingerprint),
-          eq(memoryItems.scopeId, scopeId),
-        ),
-      )
-      .get();
-
-    if (existing) {
-      db.update(memoryItems)
-        .set({
-          status: "active",
-          importance: 0.8,
-          lastSeenAt: now,
-          verificationState: "user_confirmed",
-        })
-        .where(eq(memoryItems.id, existing.id))
-        .run();
-
-      enqueueMemoryJob("embed_item", { itemId: existing.id });
-      return {
-        content: `Memory already exists (ID: ${existing.id}). Updated and refreshed.`,
-        isError: false,
-      };
-    }
-
-    db.insert(memoryItems)
-      .values({
-        id,
-        kind,
-        subject,
-        statement: trimmedStatement,
-        status: "active",
-        confidence: 0.95, // explicit saves have high confidence
-        importance: 0.8, // explicit saves are high importance
-        fingerprint,
-        verificationState: "user_confirmed",
-        scopeId,
-        firstSeenAt: now,
-        lastSeenAt: now,
-        lastUsedAt: null,
-      })
-      .run();
-
-    enqueueMemoryJob("embed_item", { itemId: id });
-
-    log.debug(
-      { id, kind, subject, conversationId, messageId },
-      "Memory item saved via tool",
-    );
-    return {
-      content: `Saved to memory (ID: ${id}).\nKind: ${kind}\nSubject: ${subject}\nStatement: ${trimmedStatement}`,
-      isError: false,
-    };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    log.error({ err }, "memory_save failed");
-    return { content: `Error: Failed to save memory: ${msg}`, isError: true };
-  }
-}
-
-// ── memory_update ────────────────────────────────────────────────────
-
-export async function handleMemoryUpdate(
-  args: Record<string, unknown>,
-  _config: AssistantConfig,
-  scopeId: string = "default",
-): Promise<ToolExecutionResult> {
-  const rawMemoryId = args.memory_id;
-  if (typeof rawMemoryId !== "string" || rawMemoryId.trim().length === 0) {
-    return {
-      content: "Error: memory_id is required and must be a non-empty string",
-      isError: true,
-    };
-  }
-
-  // Accept both bare IDs and typed IDs (e.g. "item:abc-123" -> "abc-123")
-  const memoryId = stripTypedIdPrefix(rawMemoryId.trim());
-
-  const statement = args.statement;
-  if (typeof statement !== "string" || statement.trim().length === 0) {
-    return {
-      content: "Error: statement is required and must be a non-empty string",
-      isError: true,
-    };
-  }
-
-  try {
-    const db = getDb();
-
-    // Constrain lookup to the current scope so conversations cannot mutate
-    // memory items belonging to a different scope.
-    const existing = db
-      .select()
-      .from(memoryItems)
-      .where(
-        and(eq(memoryItems.id, memoryId), eq(memoryItems.scopeId, scopeId)),
-      )
-      .get();
-
-    if (!existing) {
-      return {
-        content: `Error: Memory item with ID "${memoryId}" not found`,
-        isError: true,
-      };
-    }
-
-    const now = Date.now();
-    const trimmedStatement = truncate(statement.trim(), 500, "");
-
-    const fingerprint = computeMemoryFingerprint(
-      scopeId,
-      existing.kind,
-      existing.subject,
-      trimmedStatement,
-    );
-
-    // Collision detection also constrained to the current scope.
-    const collision = db
-      .select({ id: memoryItems.id })
-      .from(memoryItems)
-      .where(
-        and(
-          eq(memoryItems.fingerprint, fingerprint),
-          eq(memoryItems.scopeId, scopeId),
-          ne(memoryItems.status, "deleted"),
-        ),
-      )
-      .get();
-    if (collision && collision.id !== existing.id) {
-      return {
-        content: `Error: Another memory item (ID: ${collision.id}) already contains this statement. Use memory_recall to find it.`,
-        isError: true,
-      };
-    }
-
-    db.update(memoryItems)
-      .set({
-        statement: trimmedStatement,
-        fingerprint,
-        lastSeenAt: now,
-        importance: 0.8,
-        verificationState: "user_confirmed",
-      })
-      .where(eq(memoryItems.id, existing.id))
-      .run();
-
-    enqueueMemoryJob("embed_item", { itemId: existing.id });
-
-    log.debug(
-      { id: existing.id, kind: existing.kind },
-      "Memory item updated via tool",
-    );
-    return {
-      content: `Updated memory (ID: ${existing.id}).\nKind: ${existing.kind}\nSubject: ${existing.subject}\nNew statement: ${trimmedStatement}`,
-      isError: false,
-    };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    log.error({ err, memoryId }, "memory_update failed");
-    return { content: `Error: Failed to update memory: ${msg}`, isError: true };
-  }
-}
-
-// ── memory_recall ────────────────────────────────────────────────────
-
-export interface MemoryRecallToolResult {
-  text: string;
-  resultCount: number;
-  degraded: boolean;
-  items: Array<{ id: string; type: string; kind: string }>;
-  sources: {
-    semantic: number;
-    recency: number;
-  };
-}
-
-export async function handleMemoryRecall(
-  args: Record<string, unknown>,
-  _config: AssistantConfig,
-  scopeId?: string,
-  _conversationId?: string,
-): Promise<ToolExecutionResult> {
-  const query = args.query;
-  if (typeof query !== "string" || query.trim().length === 0) {
-    return {
-      content: "Error: query is required and must be a non-empty string",
-      isError: true,
-    };
-  }
-
-  return handleSimplifiedMemoryRecall(query.trim(), scopeId ?? "default");
-}
-
-// ── memory_delete ────────────────────────────────────────────────────
-
-export async function handleMemoryDelete(
-  args: Record<string, unknown>,
-  _config: AssistantConfig,
-  scopeId: string = "default",
-): Promise<ToolExecutionResult> {
-  const rawMemoryId = args.memory_id;
-  if (typeof rawMemoryId !== "string" || rawMemoryId.trim().length === 0) {
-    return {
-      content: "Error: memory_id is required and must be a non-empty string",
-      isError: true,
-    };
-  }
-
-  const memoryId = stripTypedIdPrefix(rawMemoryId.trim());
-
-  try {
-    const db = getDb();
-
-    const existing = db
-      .select()
-      .from(memoryItems)
-      .where(
-        and(eq(memoryItems.id, memoryId), eq(memoryItems.scopeId, scopeId)),
-      )
-      .get();
-
-    if (!existing) {
-      return {
-        content: `Error: Memory item with ID "${memoryId}" not found`,
-        isError: true,
-      };
-    }
-
-    if (existing.status === "deleted") {
-      return {
-        content: `Memory item (ID: ${memoryId}) was already deleted.`,
-        isError: false,
-      };
-    }
-
-    db.update(memoryItems)
-      .set({
-        status: "deleted",
-        lastSeenAt: Date.now(),
-      })
-      .where(eq(memoryItems.id, existing.id))
-      .run();
-
-    log.debug(
-      { id: existing.id, kind: existing.kind },
-      "Memory item deleted via tool",
-    );
-    return {
-      content: `Deleted memory (ID: ${existing.id}).\nKind: ${existing.kind}\nSubject: ${existing.subject}\nStatement: ${existing.statement}`,
-      isError: false,
-    };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    log.error({ err, memoryId }, "memory_delete failed");
-    return { content: `Error: Failed to delete memory: ${msg}`, isError: true };
-  }
-}
-
-// ── Simplified memory helpers ────────────────────────────────────────
-
-/**
- * Save a memory item as an observation + chunk in the simplified system.
- * This is used when simplified memory is enabled instead of writing to
- * the legacy memory_items table.
- */
-function handleSimplifiedMemorySave(
-  kind: string,
-  subject: string,
-  statement: string,
-  conversationId: string,
-  messageId: string | undefined,
-  scopeId: string,
-): ToolExecutionResult {
-  try {
-    const trimmedStatement = truncate(statement, 500, "");
     const content = `[${kind}] ${subject}: ${trimmedStatement}`;
 
     const result = insertObservation({
@@ -398,14 +87,45 @@ function handleSimplifiedMemorySave(
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    log.error({ err }, "simplified memory_save failed");
+    log.error({ err }, "memory_save failed");
     return { content: `Error: Failed to save memory: ${msg}`, isError: true };
   }
 }
 
+// ── memory_recall ────────────────────────────────────────────────────
+
+export interface MemoryRecallToolResult {
+  text: string;
+  resultCount: number;
+  degraded: boolean;
+  items: Array<{ id: string; type: string; kind: string }>;
+  sources: {
+    semantic: number;
+    recency: number;
+  };
+}
+
+export async function handleMemoryRecall(
+  args: Record<string, unknown>,
+  _config: unknown,
+  scopeId?: string,
+  _conversationId?: string,
+): Promise<ToolExecutionResult> {
+  const query = args.query;
+  if (typeof query !== "string" || query.trim().length === 0) {
+    return {
+      content: "Error: query is required and must be a non-empty string",
+      isError: true,
+    };
+  }
+
+  return handleSimplifiedMemoryRecall(query.trim(), scopeId ?? "default");
+}
+
+// ── Simplified memory helpers ────────────────────────────────────────
+
 /**
- * Recall memories using the simplified archive recall path instead of
- * the legacy hybrid retriever.
+ * Recall memories using the simplified archive recall path.
  */
 function handleSimplifiedMemoryRecall(
   query: string,
@@ -450,7 +170,7 @@ function handleSimplifiedMemoryRecall(
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    log.error({ err, query }, "simplified memory_recall failed");
+    log.error({ err, query }, "memory_recall failed");
     return {
       content: `Error: Memory recall failed: ${msg}`,
       isError: true,
@@ -464,13 +184,4 @@ function inferSubjectFromStatement(statement: string): string {
   // Take first few words as a subject label
   const words = statement.split(/\s+/).slice(0, 6).join(" ");
   return truncate(words, 80, "");
-}
-
-/**
- * Strip a typed ID prefix (e.g. "item:abc-123" -> "abc-123") so that IDs
- * copied from memory_recall output work in memory_manage update/delete ops.
- */
-function stripTypedIdPrefix(id: string): string {
-  const match = id.match(/^(?:item|segment|summary):(.+)$/);
-  return match ? match[1] : id;
 }

--- a/assistant/src/tools/memory/register.ts
+++ b/assistant/src/tools/memory/register.ts
@@ -6,12 +6,7 @@ import {
   memoryManageDefinition,
   memoryRecallDefinition,
 } from "./definitions.js";
-import {
-  handleMemoryDelete,
-  handleMemoryRecall,
-  handleMemorySave,
-  handleMemoryUpdate,
-} from "./handlers.js";
+import { handleMemoryRecall, handleMemorySave } from "./handlers.js";
 
 // ── memory_manage ────────────────────────────────────────────────────
 
@@ -39,13 +34,9 @@ class MemoryManageTool implements Tool {
           context.requestId,
           context.memoryScopeId,
         );
-      case "update":
-        return handleMemoryUpdate(input, config, context.memoryScopeId);
-      case "delete":
-        return handleMemoryDelete(input, config, context.memoryScopeId);
       default:
         return {
-          content: `Error: unknown op "${input.op}". Must be one of: save, update, delete`,
+          content: `Error: unknown op "${input.op}". Must be: save`,
           isError: true,
         };
     }


### PR DESCRIPTION
## Summary
- Remove memory-item CRUD behavior from tool handlers (handleMemoryUpdate, handleMemoryDelete, and the legacy memoryItems branch in handleMemorySave are deleted)
- handleMemorySave now always writes through the simplified observation store (insertObservation) regardless of config
- Update tool definitions: memoryManageDefinition only exposes "save" op, memoryRecallDefinition no longer references item IDs
- Update tool registrations: MemoryManageTool only handles "save", removed imports of deleted handlers
- Rewrite tool tests to cover only simplified-memory behavior (save validation, observation writes, recall validation, result shape, recall-after-save, error handling)

Note: memory-regressions.test.ts has 3 new TS errors from removed handleMemoryUpdate export — will be cleaned up in PR 8 (final sweep).

Part of plan: legacy-memory-cleanup.md (PR 4 of 8)