### PR TITLE
fix: update memory-recall-quality and memory-upsert-concurrency tests

### DIFF
--- a/assistant/src/__tests__/memory-recall-quality.test.ts
+++ b/assistant/src/__tests__/memory-recall-quality.test.ts
@@ -198,7 +198,7 @@ describe("Memory Recall Quality (Simplified Archive)", () => {
 
     test("analogy/debugging patterns trigger recall", () => {
       expect(
-        classifyRecallTrigger("this is similar to that bug before", 0),
+        classifyRecallTrigger("this is similar to that known bug", 0),
       ).toBe("analogy_debug");
       expect(classifyRecallTrigger("I keep getting this error", 0)).toBe(
         "analogy_debug",

--- a/assistant/src/__tests__/memory-upsert-concurrency.test.ts
+++ b/assistant/src/__tests__/memory-upsert-concurrency.test.ts
@@ -21,7 +21,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { eq } from "drizzle-orm";
+import { eq, like } from "drizzle-orm";
 
 const testDir = mkdtempSync(join(tmpdir(), "memory-upsert-concurrency-"));
 
@@ -79,8 +79,8 @@ import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { indexMessageNow } from "../memory/indexer.js";
 import {
   conversations,
+  memoryChunks,
   memoryItems,
-  memorySegments,
   messages,
 } from "../memory/schema.js";
 
@@ -101,6 +101,8 @@ function resetTables() {
   db.run("DELETE FROM memory_item_sources");
   db.run("DELETE FROM memory_embeddings");
   db.run("DELETE FROM memory_items");
+  db.run("DELETE FROM memory_chunks");
+  db.run("DELETE FROM memory_observations");
   db.run("DELETE FROM memory_segments");
   db.run("DELETE FROM memory_jobs");
   db.run("DELETE FROM messages");
@@ -186,21 +188,21 @@ describe("segment UPSERT atomicity under repeated indexer invocations", () => {
       ),
     );
 
-    const segments = db
+    const chunks = db
       .select()
-      .from(memorySegments)
-      .where(eq(memorySegments.messageId, messageId))
+      .from(memoryChunks)
+      .where(like(memoryChunks.id, `chunk:${messageId}:%`))
       .all();
 
-    // Each physical segment (identified by segmentId = messageId + segmentIndex)
+    // Each physical chunk (identified by chunkId = chunk:messageId:segmentIndex)
     // must appear exactly once regardless of how many indexer calls ran.
     const idCounts = new Map<string, number>();
-    for (const seg of segments) {
-      idCounts.set(seg.id, (idCounts.get(seg.id) ?? 0) + 1);
+    for (const chunk of chunks) {
+      idCounts.set(chunk.id, (idCounts.get(chunk.id) ?? 0) + 1);
     }
-    for (const [segId, count] of idCounts) {
+    for (const [chunkId, count] of idCounts) {
       expect(count).toBe(1);
-      expect(segId.startsWith(messageId)).toBe(true);
+      expect(chunkId.startsWith(`chunk:${messageId}:`)).toBe(true);
     }
   });
 
@@ -273,24 +275,22 @@ describe("segment UPSERT atomicity under repeated indexer invocations", () => {
       }),
     );
 
-    // Every segment must reference its own message and no segment may appear
+    // Every chunk must reference its own message and no chunk may appear
     // for the wrong messageId.
     for (let i = 0; i < MSG_COUNT; i++) {
       const msgId = `msg-distinct-${i}`;
-      const segs = db
+      const chunks = db
         .select()
-        .from(memorySegments)
-        .where(eq(memorySegments.messageId, msgId))
+        .from(memoryChunks)
+        .where(like(memoryChunks.id, `chunk:${msgId}:%`))
         .all();
 
-      // At least one segment must have been written.
-      expect(segs.length).toBeGreaterThanOrEqual(1);
+      // At least one chunk must have been written.
+      expect(chunks.length).toBeGreaterThanOrEqual(1);
 
-      // Segment IDs must be of the form `${msgId}:${index}`.
-      for (const seg of segs) {
-        expect(seg.id.startsWith(msgId + ":")).toBe(true);
-        expect(seg.messageId).toBe(msgId);
-        expect(seg.conversationId).toBe(conversationId);
+      // Chunk IDs must be of the form `chunk:${msgId}:${index}`.
+      for (const chunk of chunks) {
+        expect(chunk.id.startsWith(`chunk:${msgId}:`)).toBe(true);
       }
     }
   });
@@ -320,10 +320,10 @@ describe("segment UPSERT atomicity under repeated indexer invocations", () => {
     );
 
     const db = getDb();
-    const segmentsAfterFirst = db
+    const chunksAfterFirst = db
       .select()
-      .from(memorySegments)
-      .where(eq(memorySegments.messageId, messageId))
+      .from(memoryChunks)
+      .where(like(memoryChunks.id, `chunk:${messageId}:%`))
       .all();
 
     // Re-index twice more with the same payload.
@@ -348,22 +348,22 @@ describe("segment UPSERT atomicity under repeated indexer invocations", () => {
       config,
     );
 
-    const segmentsAfterRehash = db
+    const chunksAfterRehash = db
       .select()
-      .from(memorySegments)
-      .where(eq(memorySegments.messageId, messageId))
+      .from(memoryChunks)
+      .where(like(memoryChunks.id, `chunk:${messageId}:%`))
       .all();
 
-    // Segment count must not have grown.
-    expect(segmentsAfterRehash.length).toBe(segmentsAfterFirst.length);
+    // Chunk count must not have grown.
+    expect(chunksAfterRehash.length).toBe(chunksAfterFirst.length);
 
     // Content hashes must match between first and subsequent indexings.
-    const firstById = new Map(segmentsAfterFirst.map((s) => [s.id, s]));
-    for (const seg of segmentsAfterRehash) {
-      const original = firstById.get(seg.id);
+    const firstById = new Map(chunksAfterFirst.map((s) => [s.id, s]));
+    for (const chunk of chunksAfterRehash) {
+      const original = firstById.get(chunk.id);
       expect(original).toBeDefined();
-      expect(seg.contentHash).toBe(original!.contentHash);
-      expect(seg.text).toBe(original!.text);
+      expect(chunk.contentHash).toBe(original!.contentHash);
+      expect(chunk.content).toBe(original!.content);
     }
 
     // The indexer must have reported the correct segment count both times.
@@ -417,14 +417,14 @@ describe("segment UPSERT atomicity under repeated indexer invocations", () => {
     ]);
 
     const db = getDb();
-    const segments = db
+    const chunks = db
       .select()
-      .from(memorySegments)
-      .where(eq(memorySegments.messageId, messageId))
+      .from(memoryChunks)
+      .where(like(memoryChunks.id, `chunk:${messageId}:%`))
       .all();
 
-    // No duplicate segment IDs — each logical segment must appear at most once.
-    const ids = segments.map((s) => s.id);
+    // No duplicate chunk IDs — each logical chunk must appear at most once.
+    const ids = chunks.map((s) => s.id);
     const uniqueIds = new Set(ids);
     expect(uniqueIds.size).toBe(ids.length);
   });
@@ -511,25 +511,25 @@ describe("memory segment job atomicity under repeated indexer invocations", () =
       ).flat(),
     );
 
-    // For every message, count distinct segment IDs — there must be no
+    // For every message, count distinct chunk IDs — there must be no
     // duplicates regardless of how many indexer calls ran.
     for (let i = 0; i < MSG_COUNT; i++) {
       const msgId = `msg-atomicity-${i}`;
-      const segs = db
+      const chunks = db
         .select()
-        .from(memorySegments)
-        .where(eq(memorySegments.messageId, msgId))
+        .from(memoryChunks)
+        .where(like(memoryChunks.id, `chunk:${msgId}:%`))
         .all();
 
-      const segIds = segs.map((s) => s.id);
-      const uniqueSegIds = new Set(segIds);
-      expect(uniqueSegIds.size).toBe(segIds.length);
+      const chunkIds = chunks.map((s) => s.id);
+      const uniqueChunkIds = new Set(chunkIds);
+      expect(uniqueChunkIds.size).toBe(chunkIds.length);
     }
   });
 
-  test("indexer result counts are consistent with actual stored segment counts", async () => {
+  test("indexer result counts are consistent with actual stored chunk counts", async () => {
     // The IndexMessageResult.indexedSegments value returned by indexMessageNow
-    // must always match the number of rows stored in memory_segments for that
+    // must always match the number of rows stored in memory_chunks for that
     // message.  Under repeated indexing the stored count stays stable while
     // every result reports the same logical segment count.
     const conversationId = "conv-count-consistency";
@@ -563,10 +563,10 @@ describe("memory segment job atomicity under repeated indexer invocations", () =
     );
 
     const db = getDb();
-    const storedSegments = db
+    const storedChunks = db
       .select()
-      .from(memorySegments)
-      .where(eq(memorySegments.messageId, messageId))
+      .from(memoryChunks)
+      .where(like(memoryChunks.id, `chunk:${messageId}:%`))
       .all();
 
     // All runs must agree on the segment count.
@@ -576,7 +576,7 @@ describe("memory segment job atomicity under repeated indexer invocations", () =
     }
 
     // Stored count must equal the reported logical count.
-    expect(storedSegments.length).toBe(firstCount);
+    expect(storedChunks.length).toBe(firstCount);
   });
 });
 


### PR DESCRIPTION
## Summary
- Fix `memory-recall-quality` trigger classification test that matched both `PAST_REFERENCE_PATTERNS` ("before") and `ANALOGY_DEBUG_PATTERNS` ("similar to") — changed test string to avoid ambiguous match
- Fix `memory-upsert-concurrency` tests to query `memoryChunks` (with `chunk:${messageId}:` ID prefix) instead of `memorySegments`, since the indexer now writes to the archive schema

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23325261385/job/67845006608

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19938" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
