### PR TITLE
refactor: remove legacy memory schema usage and purge old embedding targets

### DIFF
--- a/assistant/src/__tests__/db-drop-legacy-memory-system.test.ts
+++ b/assistant/src/__tests__/db-drop-legacy-memory-system.test.ts
@@ -1,0 +1,466 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+const testDir = mkdtempSync(join(tmpdir(), "drop-legacy-memory-"));
+const dbPath = join(testDir, "test.db");
+const originalBunTest = process.env.BUN_TEST;
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => dbPath,
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { initializeDb, resetDb } from "../memory/db.js";
+import { getSqliteFrom } from "../memory/db-connection.js";
+import { migrateDropLegacyMemorySystem } from "../memory/migrations/189-drop-legacy-memory-system.js";
+import * as schema from "../memory/schema.js";
+
+const LEGACY_TABLES = [
+  "memory_items",
+  "memory_item_sources",
+  "memory_segments",
+  "memory_summaries",
+] as const;
+
+const SIMPLIFIED_TABLES = [
+  "memory_observations",
+  "memory_chunks",
+  "memory_episodes",
+] as const;
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}
+
+function tableExists(raw: Database, tableName: string): boolean {
+  const row = raw
+    .query(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?`)
+    .get(tableName);
+  return row != null;
+}
+
+function removeTestDbFiles(): void {
+  rmSync(dbPath, { force: true });
+  rmSync(`${dbPath}-shm`, { force: true });
+  rmSync(`${dbPath}-wal`, { force: true });
+}
+
+/** Bootstrap prerequisite tables and legacy memory tables for upgrade tests. */
+function bootstrapPrerequisiteTables(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS conversations (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS messages (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      created_at INTEGER NOT NULL
+    )
+  `);
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_embeddings (
+      id TEXT PRIMARY KEY,
+      target_type TEXT NOT NULL,
+      target_id TEXT NOT NULL,
+      provider TEXT NOT NULL,
+      model TEXT NOT NULL,
+      dimensions INTEGER NOT NULL,
+      vector_json TEXT,
+      vector_blob BLOB,
+      content_hash TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  raw.exec(/*sql*/ `
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_embeddings_target_provider_model
+    ON memory_embeddings(target_type, target_id, provider, model)
+  `);
+}
+
+function createLegacyTables(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_segments (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      role TEXT NOT NULL,
+      segment_index INTEGER NOT NULL,
+      text TEXT NOT NULL,
+      token_estimate INTEGER NOT NULL,
+      scope_id TEXT NOT NULL DEFAULT 'default',
+      content_hash TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_segments_scope_id ON memory_segments(scope_id)
+  `);
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_items (
+      id TEXT PRIMARY KEY,
+      kind TEXT NOT NULL,
+      subject TEXT NOT NULL,
+      statement TEXT NOT NULL,
+      status TEXT NOT NULL,
+      confidence REAL NOT NULL,
+      fingerprint TEXT NOT NULL,
+      scope_id TEXT NOT NULL DEFAULT 'default',
+      first_seen_at INTEGER NOT NULL,
+      last_seen_at INTEGER NOT NULL
+    )
+  `);
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_items_scope_id ON memory_items(scope_id)
+  `);
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_items_fingerprint ON memory_items(fingerprint)
+  `);
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_item_sources (
+      memory_item_id TEXT NOT NULL REFERENCES memory_items(id) ON DELETE CASCADE,
+      message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+      evidence TEXT,
+      created_at INTEGER NOT NULL
+    )
+  `);
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_item_sources_memory_item_id ON memory_item_sources(memory_item_id)
+  `);
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_summaries (
+      id TEXT PRIMARY KEY,
+      scope TEXT NOT NULL,
+      scope_key TEXT NOT NULL,
+      summary TEXT NOT NULL,
+      token_estimate INTEGER NOT NULL,
+      version INTEGER NOT NULL DEFAULT 1,
+      scope_id TEXT NOT NULL DEFAULT 'default',
+      start_at INTEGER NOT NULL,
+      end_at INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_summaries_scope_id ON memory_summaries(scope_id)
+  `);
+  raw.exec(/*sql*/ `
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_summaries_scope_scope_key ON memory_summaries(scope, scope_key)
+  `);
+}
+
+function createSimplifiedMemoryTables(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_observations (
+      id TEXT PRIMARY KEY,
+      scope_id TEXT NOT NULL DEFAULT 'default',
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      message_id TEXT,
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      modality TEXT NOT NULL DEFAULT 'text',
+      source TEXT,
+      created_at INTEGER NOT NULL
+    )
+  `);
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_chunks (
+      id TEXT PRIMARY KEY,
+      scope_id TEXT NOT NULL DEFAULT 'default',
+      observation_id TEXT NOT NULL REFERENCES memory_observations(id) ON DELETE CASCADE,
+      content TEXT NOT NULL,
+      token_estimate INTEGER NOT NULL,
+      content_hash TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `);
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_episodes (
+      id TEXT PRIMARY KEY,
+      scope_id TEXT NOT NULL DEFAULT 'default',
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      summary TEXT NOT NULL,
+      token_estimate INTEGER NOT NULL,
+      source TEXT,
+      start_at INTEGER NOT NULL,
+      end_at INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+}
+
+describe("drop legacy memory system migration (189)", () => {
+  beforeEach(() => {
+    process.env.BUN_TEST = "0";
+    resetDb();
+    removeTestDbFiles();
+  });
+
+  afterEach(() => {
+    resetDb();
+    removeTestDbFiles();
+  });
+
+  afterAll(() => {
+    if (originalBunTest === undefined) {
+      delete process.env.BUN_TEST;
+    } else {
+      process.env.BUN_TEST = originalBunTest;
+    }
+    resetDb();
+    removeTestDbFiles();
+    try {
+      rmSync(testDir, { recursive: true });
+    } catch {
+      /* best effort */
+    }
+  });
+
+  // ---------- Fresh init ----------
+
+  test("fresh DB initialization does not create legacy tables", () => {
+    initializeDb();
+
+    const raw = new Database(dbPath);
+    for (const table of LEGACY_TABLES) {
+      expect(tableExists(raw, table)).toBe(false);
+    }
+    raw.close();
+  });
+
+  test("fresh DB initialization preserves simplified-memory tables", () => {
+    initializeDb();
+
+    const raw = new Database(dbPath);
+    for (const table of SIMPLIFIED_TABLES) {
+      expect(tableExists(raw, table)).toBe(true);
+    }
+    raw.close();
+  });
+
+  // ---------- Upgrade (migration on a pre-existing DB with legacy tables) ----------
+
+  test("migration drops legacy tables on an upgraded database", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+
+    bootstrapPrerequisiteTables(raw);
+    createLegacyTables(raw);
+
+    // Verify legacy tables exist before migration
+    for (const table of LEGACY_TABLES) {
+      expect(tableExists(raw, table)).toBe(true);
+    }
+
+    migrateDropLegacyMemorySystem(db);
+
+    // All legacy tables should be gone
+    for (const table of LEGACY_TABLES) {
+      expect(tableExists(raw, table)).toBe(false);
+    }
+
+    raw.close();
+  });
+
+  test("migration purges legacy embedding target types", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    const now = Date.now();
+
+    bootstrapPrerequisiteTables(raw);
+    createLegacyTables(raw);
+
+    // Insert embeddings for legacy target types
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_embeddings (id, target_type, target_id, provider, model, dimensions, created_at, updated_at)
+      VALUES ('emb-item-1', 'item', 'item-1', 'test', 'test-model', 384, ${now}, ${now})
+    `);
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_embeddings (id, target_type, target_id, provider, model, dimensions, created_at, updated_at)
+      VALUES ('emb-seg-1', 'segment', 'seg-1', 'test', 'test-model', 384, ${now}, ${now})
+    `);
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_embeddings (id, target_type, target_id, provider, model, dimensions, created_at, updated_at)
+      VALUES ('emb-sum-1', 'summary', 'sum-1', 'test', 'test-model', 384, ${now}, ${now})
+    `);
+
+    // Insert an embedding for a non-legacy target type (should be preserved)
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_embeddings (id, target_type, target_id, provider, model, dimensions, created_at, updated_at)
+      VALUES ('emb-chunk-1', 'chunk', 'chunk-1', 'test', 'test-model', 384, ${now}, ${now})
+    `);
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_embeddings (id, target_type, target_id, provider, model, dimensions, created_at, updated_at)
+      VALUES ('emb-obs-1', 'observation', 'obs-1', 'test', 'test-model', 384, ${now}, ${now})
+    `);
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_embeddings (id, target_type, target_id, provider, model, dimensions, created_at, updated_at)
+      VALUES ('emb-ep-1', 'episode', 'ep-1', 'test', 'test-model', 384, ${now}, ${now})
+    `);
+
+    migrateDropLegacyMemorySystem(db);
+
+    // Legacy embeddings should be deleted
+    const legacyCount = raw
+      .query(
+        `SELECT COUNT(*) AS c FROM memory_embeddings WHERE target_type IN ('item', 'segment', 'summary')`,
+      )
+      .get() as { c: number };
+    expect(legacyCount.c).toBe(0);
+
+    // Non-legacy embeddings should be preserved
+    const nonLegacyCount = raw
+      .query(
+        `SELECT COUNT(*) AS c FROM memory_embeddings WHERE target_type IN ('chunk', 'observation', 'episode')`,
+      )
+      .get() as { c: number };
+    expect(nonLegacyCount.c).toBe(3);
+
+    raw.close();
+  });
+
+  // ---------- Re-run safety ----------
+
+  test("re-running the migration is safe (idempotent)", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+
+    bootstrapPrerequisiteTables(raw);
+    createLegacyTables(raw);
+
+    // First run
+    migrateDropLegacyMemorySystem(db);
+
+    // Second run should not throw
+    expect(() => migrateDropLegacyMemorySystem(db)).not.toThrow();
+
+    // Tables should still be gone
+    for (const table of LEGACY_TABLES) {
+      expect(tableExists(raw, table)).toBe(false);
+    }
+
+    raw.close();
+  });
+
+  test("re-run on a DB that never had legacy tables is safe", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+
+    bootstrapPrerequisiteTables(raw);
+    // No legacy tables created
+
+    expect(() => migrateDropLegacyMemorySystem(db)).not.toThrow();
+
+    raw.close();
+  });
+
+  // ---------- Simplified-memory table preservation ----------
+
+  test("migration preserves simplified-memory tables and their data", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    const now = Date.now();
+
+    bootstrapPrerequisiteTables(raw);
+    createLegacyTables(raw);
+    createSimplifiedMemoryTables(raw);
+
+    // Insert test data into simplified-memory tables
+    raw.exec(/*sql*/ `
+      INSERT INTO conversations (id, created_at, updated_at)
+      VALUES ('conv-1', ${now}, ${now})
+    `);
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_observations (id, scope_id, conversation_id, role, content, modality, created_at)
+      VALUES ('obs-1', 'default', 'conv-1', 'user', 'The sky is blue', 'text', ${now})
+    `);
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_chunks (id, scope_id, observation_id, content, token_estimate, content_hash, created_at)
+      VALUES ('chunk-1', 'default', 'obs-1', 'The sky is blue', 5, 'abc123', ${now})
+    `);
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_episodes (id, scope_id, conversation_id, title, summary, token_estimate, source, start_at, end_at, created_at, updated_at)
+      VALUES ('ep-1', 'default', 'conv-1', 'Sky color', 'User mentioned sky is blue', 8, 'vellum', ${now}, ${now}, ${now}, ${now})
+    `);
+
+    migrateDropLegacyMemorySystem(db);
+
+    // Simplified-memory tables should still exist
+    for (const table of SIMPLIFIED_TABLES) {
+      expect(tableExists(raw, table)).toBe(true);
+    }
+
+    // Data should be preserved
+    const obs = raw
+      .query(`SELECT id, content FROM memory_observations WHERE id = 'obs-1'`)
+      .get() as { id: string; content: string } | null;
+    expect(obs).toEqual({ id: "obs-1", content: "The sky is blue" });
+
+    const chunk = raw
+      .query(
+        `SELECT id, content_hash FROM memory_chunks WHERE id = 'chunk-1'`,
+      )
+      .get() as { id: string; content_hash: string } | null;
+    expect(chunk).toEqual({ id: "chunk-1", content_hash: "abc123" });
+
+    const ep = raw
+      .query(`SELECT id, title FROM memory_episodes WHERE id = 'ep-1'`)
+      .get() as { id: string; title: string } | null;
+    expect(ep).toEqual({ id: "ep-1", title: "Sky color" });
+
+    raw.close();
+  });
+
+  // ---------- Memory embeddings table preserved ----------
+
+  test("migration preserves memory_embeddings table itself", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+
+    bootstrapPrerequisiteTables(raw);
+    createLegacyTables(raw);
+
+    migrateDropLegacyMemorySystem(db);
+
+    expect(tableExists(raw, "memory_embeddings")).toBe(true);
+
+    raw.close();
+  });
+});

--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -357,24 +357,6 @@ Examples:
       const result = wipeConversation(conversation.id);
 
       // Enqueue Qdrant cleanup
-      for (const segId of result.segmentIds) {
-        enqueueMemoryJob("delete_qdrant_vectors", {
-          targetType: "segment",
-          targetId: segId,
-        });
-      }
-      for (const itemId of result.orphanedItemIds) {
-        enqueueMemoryJob("delete_qdrant_vectors", {
-          targetType: "item",
-          targetId: itemId,
-        });
-      }
-      for (const summaryId of result.deletedSummaryIds) {
-        enqueueMemoryJob("delete_qdrant_vectors", {
-          targetType: "summary",
-          targetId: summaryId,
-        });
-      }
       for (const obsId of result.deletedObservationIds) {
         enqueueMemoryJob("delete_qdrant_vectors", {
           targetType: "observation",
@@ -396,9 +378,7 @@ Examples:
 
       log.info(
         `Wiped conversation "${conversation.title ?? "Untitled"}". ` +
-          `Restored ${result.unsupersededItemIds.length} memory items, ` +
-          `deleted ${result.deletedSummaryIds.length} summaries, ` +
-          `cancelled ${result.cancelledJobCount} jobs.`,
+          `Cancelled ${result.cancelledJobCount} jobs.`,
       );
     });
 }

--- a/assistant/src/cli/commands/memory.ts
+++ b/assistant/src/cli/commands/memory.ts
@@ -2,7 +2,6 @@ import type { Command } from "commander";
 
 import {
   getMemorySystemStatus,
-  queryMemory,
   requestMemoryBackfill,
   requestMemoryRebuildIndex,
 } from "../../memory/admin.js";
@@ -65,9 +64,9 @@ Examples:
       } else {
         log.info("Embedding backend: none");
       }
-      log.info(`Segments: ${status.counts.segments.toLocaleString()}`);
-      log.info(`Items: ${status.counts.items.toLocaleString()}`);
-      log.info(`Summaries: ${status.counts.summaries.toLocaleString()}`);
+      log.info(`Observations: ${status.counts.observations.toLocaleString()}`);
+      log.info(`Chunks: ${status.counts.chunks.toLocaleString()}`);
+      log.info(`Episodes: ${status.counts.episodes.toLocaleString()}`);
       log.info(`Embeddings: ${status.counts.embeddings.toLocaleString()}`);
       log.info("Jobs:");
       for (const [key, value] of Object.entries(status.jobs)) {
@@ -134,20 +133,14 @@ Examples:
         const latest = listConversations(1)[0];
         conversationId = latest?.id ?? "";
       }
-      const result = await queryMemory(text, conversationId ?? "");
-      if (result.degraded) {
-        log.info(`Memory degraded: ${result.reason ?? "unknown reason"}`);
-      }
-      log.info(`Semantic hits: ${result.semanticHits}`);
-      log.info(`Recency hits: ${result.recencyHits}`);
-      log.info(`Injected tokens: ${result.injectedTokens}`);
-      log.info(`Latency: ${result.latencyMs}ms`);
-      if (result.injectedText.length > 0) {
-        log.info("");
-        log.info(result.injectedText);
-      } else {
-        log.info("No memory injected.");
-      }
+      // Legacy memory query pipeline has been retired. The simplified memory
+      // system uses a different recall path via the conversation reducer.
+      void conversationId;
+      void text;
+      log.info(
+        "The `memory query` command is no longer available. " +
+          "The legacy item-based memory system has been retired.",
+      );
     });
 
   memory

--- a/assistant/src/daemon/conversation-history.ts
+++ b/assistant/src/daemon/conversation-history.ts
@@ -9,9 +9,6 @@ import {
   updateMessageContent,
 } from "../memory/conversation-crud.js";
 import { isLastUserMessageToolResult } from "../memory/conversation-queries.js";
-import { enqueueMemoryJob } from "../memory/jobs-store.js";
-import { withQdrantBreaker } from "../memory/qdrant-circuit-breaker.js";
-import { getQdrantClient } from "../memory/qdrant-client.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 import type { ServerMessage } from "./message-protocol.js";
@@ -66,69 +63,9 @@ export function findLastUndoableUserMessageIndex(messages: Message[]): number {
 
 // ── Qdrant Vector Cleanup ────────────────────────────────────────────
 
-/**
- * Delete Qdrant vector entries for the given segment and item IDs.
- * Individual deletion failures are logged and enqueued as retry jobs
- * to prevent silently orphaned vectors.
- */
-export async function cleanupQdrantVectors(
-  conversationId: string,
-  segmentIds: string[],
-  orphanedItemIds: string[],
-): Promise<void> {
-  let qdrant: ReturnType<typeof getQdrantClient>;
-  try {
-    qdrant = getQdrantClient();
-  } catch {
-    return; // Qdrant not initialized — nothing to clean up.
-  }
-
-  if (segmentIds.length === 0 && orphanedItemIds.length === 0) return;
-
-  const targets: Array<{ targetType: string; targetId: string }> = [];
-  for (const segId of segmentIds) {
-    targets.push({ targetType: "segment", targetId: segId });
-  }
-  for (const itemId of orphanedItemIds) {
-    targets.push({ targetType: "item", targetId: itemId });
-  }
-
-  const results = await Promise.allSettled(
-    targets.map((t) =>
-      withQdrantBreaker(() => qdrant.deleteByTarget(t.targetType, t.targetId)),
-    ),
-  );
-
-  let succeeded = 0;
-  let failed = 0;
-  for (let i = 0; i < results.length; i++) {
-    const result = results[i];
-    if (result.status === "fulfilled") {
-      succeeded++;
-    } else {
-      failed++;
-      const { targetType, targetId } = targets[i];
-      log.warn(
-        { err: result.reason, targetType, targetId, conversationId },
-        "Qdrant vector deletion failed, enqueuing retry job",
-      );
-      enqueueMemoryJob("delete_qdrant_vectors", { targetType, targetId });
-    }
-  }
-
-  if (succeeded > 0) {
-    log.info(
-      {
-        conversationId,
-        succeeded,
-        failed,
-        segments: segmentIds.length,
-        items: orphanedItemIds.length,
-      },
-      "Cleaned up Qdrant vectors after regenerate",
-    );
-  }
-}
+// Legacy cleanupQdrantVectors removed — segment/item tables have been dropped.
+// Qdrant vector cleanup for simplified-memory (observations, chunks, episodes)
+// is handled by the delete_qdrant_vectors job queue in lifecycle.ts and routes.
 
 // ── Consolidation ────────────────────────────────────────────────────
 
@@ -183,29 +120,10 @@ export function consolidateAssistantMessages(
   // Only consolidate if there are multiple assistant messages
   if (messagesToConsolidate.length <= 1) {
     let didMutate = false;
-    // Still delete internal tool_result messages even if only one assistant message,
-    // and collect IDs for vector cleanup
-    const allSegmentIds: string[] = [];
-    const allOrphanedItemIds: string[] = [];
+    // Still delete internal tool_result messages even if only one assistant message.
     for (const id of messagesToDelete) {
-      const deleted = deleteMessageById(id);
+      deleteMessageById(id);
       didMutate = true;
-      allSegmentIds.push(...deleted.segmentIds);
-      allOrphanedItemIds.push(...deleted.orphanedItemIds);
-    }
-
-    // Clean up Qdrant vectors (fire-and-forget)
-    if (allSegmentIds.length > 0 || allOrphanedItemIds.length > 0) {
-      cleanupQdrantVectors(
-        conversationId,
-        allSegmentIds,
-        allOrphanedItemIds,
-      ).catch((err) => {
-        log.warn(
-          { err, conversationId },
-          "Qdrant cleanup after consolidation failed (non-fatal)",
-        );
-      });
     }
     return didMutate;
   }
@@ -315,33 +233,12 @@ export function consolidateAssistantMessages(
     }
   }
 
-  // Delete the other assistant messages and internal tool_result messages,
-  // and collect IDs for vector cleanup
-  const allSegmentIds: string[] = [];
-  const allOrphanedItemIds: string[] = [];
+  // Delete the other assistant messages and internal tool_result messages.
   for (let i = 1; i < messagesToConsolidate.length; i++) {
-    const deleted = deleteMessageById(messagesToConsolidate[i].id);
-    allSegmentIds.push(...deleted.segmentIds);
-    allOrphanedItemIds.push(...deleted.orphanedItemIds);
+    deleteMessageById(messagesToConsolidate[i].id);
   }
   for (const id of messagesToDelete) {
-    const deleted = deleteMessageById(id);
-    allSegmentIds.push(...deleted.segmentIds);
-    allOrphanedItemIds.push(...deleted.orphanedItemIds);
-  }
-
-  // Clean up Qdrant vectors (fire-and-forget)
-  if (allSegmentIds.length > 0 || allOrphanedItemIds.length > 0) {
-    cleanupQdrantVectors(
-      conversationId,
-      allSegmentIds,
-      allOrphanedItemIds,
-    ).catch((err) => {
-      log.warn(
-        { err, conversationId },
-        "Qdrant cleanup after consolidation failed (non-fatal)",
-      );
-    });
+    deleteMessageById(id);
   }
 
   log.info(
@@ -533,26 +430,10 @@ export async function regenerate(
   // Everything after the user message needs to be deleted.
   const messagesToDelete = dbMessages.slice(dbUserMsgIdx + 1);
 
-  // Delete each message via deleteMessageById and collect IDs for Qdrant cleanup.
-  const allSegmentIds: string[] = [];
-  const allOrphanedItemIds: string[] = [];
+  // Delete each message.
   for (const msg of messagesToDelete) {
-    const deleted = deleteMessageById(msg.id);
-    allSegmentIds.push(...deleted.segmentIds);
-    allOrphanedItemIds.push(...deleted.orphanedItemIds);
+    deleteMessageById(msg.id);
   }
-
-  // Clean up Qdrant vectors (fire-and-forget).
-  cleanupQdrantVectors(
-    conversation.conversationId,
-    allSegmentIds,
-    allOrphanedItemIds,
-  ).catch((err) => {
-    log.warn(
-      { err, conversationId: conversation.conversationId },
-      "Qdrant cleanup after regenerate failed (non-fatal)",
-    );
-  });
 
   // Re-extract the user message content for the agent loop.
   // Use all content blocks (text, image, file) so attachments are

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -195,24 +195,6 @@ export async function runDaemon(): Promise<void> {
       );
       // Qdrant may not be ready at startup, so enqueue vector cleanup jobs
       // rather than attempting direct deletion.
-      for (const segId of deletedMemory.segmentIds) {
-        enqueueMemoryJob("delete_qdrant_vectors", {
-          targetType: "segment",
-          targetId: segId,
-        });
-      }
-      for (const itemId of deletedMemory.orphanedItemIds) {
-        enqueueMemoryJob("delete_qdrant_vectors", {
-          targetType: "item",
-          targetId: itemId,
-        });
-      }
-      for (const summaryId of deletedMemory.deletedSummaryIds) {
-        enqueueMemoryJob("delete_qdrant_vectors", {
-          targetType: "summary",
-          targetId: summaryId,
-        });
-      }
       for (const obsId of deletedMemory.deletedObservationIds) {
         enqueueMemoryJob("delete_qdrant_vectors", {
           targetType: "observation",
@@ -232,18 +214,12 @@ export async function runDaemon(): Promise<void> {
         });
       }
       if (
-        deletedMemory.segmentIds.length > 0 ||
-        deletedMemory.orphanedItemIds.length > 0 ||
-        deletedMemory.deletedSummaryIds.length > 0 ||
         deletedMemory.deletedObservationIds.length > 0 ||
         deletedMemory.deletedChunkIds.length > 0 ||
         deletedMemory.deletedEpisodeIds.length > 0
       ) {
         log.info(
           {
-            segments: deletedMemory.segmentIds.length,
-            orphanedItems: deletedMemory.orphanedItemIds.length,
-            deletedSummaries: deletedMemory.deletedSummaryIds.length,
             deletedObservations: deletedMemory.deletedObservationIds.length,
             deletedChunks: deletedMemory.deletedChunkIds.length,
             deletedEpisodes: deletedMemory.deletedEpisodeIds.length,

--- a/assistant/src/memory/admin.ts
+++ b/assistant/src/memory/admin.ts
@@ -4,7 +4,6 @@ import { rawGet } from "./db.js";
 import { getMemoryBackendStatus } from "./embedding-backend.js";
 import { enqueueBackfillJob, enqueueRebuildIndexJob } from "./indexer.js";
 import { getMemoryJobCounts } from "./jobs-store.js";
-import { queryMemoryForCli } from "./retriever.js";
 
 const log = getLogger("memory-admin");
 
@@ -15,9 +14,9 @@ export interface MemorySystemStatus {
   provider: string | null;
   model: string | null;
   counts: {
-    segments: number;
-    items: number;
-    summaries: number;
+    observations: number;
+    chunks: number;
+    episodes: number;
     embeddings: number;
   };
   jobs: Record<string, number>;
@@ -27,9 +26,9 @@ export async function getMemorySystemStatus(): Promise<MemorySystemStatus> {
   const config = getConfig();
   const backend = await getMemoryBackendStatus(config);
   const counts = {
-    segments: countTable("memory_segments"),
-    items: countTable("memory_items"),
-    summaries: countTable("memory_summaries"),
+    observations: countTable("memory_observations"),
+    chunks: countTable("memory_chunks"),
+    episodes: countTable("memory_episodes"),
     embeddings: countTable("memory_embeddings"),
   };
   return {
@@ -57,8 +56,4 @@ export function requestMemoryRebuildIndex(): string {
   const id = enqueueRebuildIndexJob();
   log.info({ jobId: id }, "Queued memory index rebuild job");
   return id;
-}
-
-export async function queryMemory(query: string, conversationId: string) {
-  return queryMemoryForCli(query, conversationId, getConfig());
 }

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -50,11 +50,7 @@ import {
   memoryChunks,
   memoryEmbeddings,
   memoryEpisodes,
-  memoryItems,
-  memoryItemSources,
   memoryObservations,
-  memorySegments,
-  memorySummaries,
   messageAttachments,
   messages,
   openLoops,
@@ -546,15 +542,12 @@ export function forkConversation(params: {
 
 /**
  * Delete a conversation and all its messages, cleaning up orphaned memory
- * artifacts (items, embeddings). Returns segment and orphaned item IDs so
- * callers can clean up the corresponding Qdrant vector entries.
+ * artifacts (embeddings). Returns deleted observation, chunk, and episode IDs
+ * so callers can clean up the corresponding Qdrant vector entries.
  */
 export function deleteConversation(id: string): DeletedMemoryIds {
   const db = getDb();
   const result: DeletedMemoryIds = {
-    segmentIds: [],
-    orphanedItemIds: [],
-    deletedSummaryIds: [],
     deletedObservationIds: [],
     deletedChunkIds: [],
     deletedEpisodeIds: [],
@@ -568,145 +561,17 @@ export function deleteConversation(id: string): DeletedMemoryIds {
   const isPrivateScope = memoryScopeId?.startsWith("private:") ?? false;
 
   db.transaction((tx) => {
-    // Collect all message IDs for this conversation.
-    const messageRows = tx
-      .select({ id: messages.id })
-      .from(messages)
-      .where(eq(messages.conversationId, id))
-      .all();
-    const messageIds = messageRows.map((r) => r.id);
-
-    if (messageIds.length > 0) {
-      // Collect memory segment IDs linked to these messages before cascade.
-      const linkedSegments = tx
-        .select({ id: memorySegments.id })
-        .from(memorySegments)
-        .where(inArray(memorySegments.messageId, messageIds))
-        .all();
-      result.segmentIds = linkedSegments.map((r) => r.id);
-
-      // Collect memory item IDs linked to these messages before cascade.
-      const linkedItems = tx
-        .select({ memoryItemId: memoryItemSources.memoryItemId })
-        .from(memoryItemSources)
-        .where(inArray(memoryItemSources.messageId, messageIds))
-        .all();
-      const candidateItemIds = [
-        ...new Set(linkedItems.map((r) => r.memoryItemId)),
-      ];
-
-      // Delete non-cascading tables first.
-      tx.delete(llmRequestLogs)
-        .where(eq(llmRequestLogs.conversationId, id))
-        .run();
-      tx.delete(toolInvocations)
-        .where(eq(toolInvocations.conversationId, id))
-        .run();
-      // Cascade deletes memory_segments, memory_item_sources, message_attachments.
-      tx.delete(messages).where(eq(messages.conversationId, id)).run();
-
-      // Clean up segment embeddings.
-      if (result.segmentIds.length > 0) {
-        tx.delete(memoryEmbeddings)
-          .where(
-            and(
-              eq(memoryEmbeddings.targetType, "segment"),
-              inArray(memoryEmbeddings.targetId, result.segmentIds),
-            ),
-          )
-          .run();
-      }
-
-      // Clean up orphaned memory items whose only sources were in this conversation.
-      if (candidateItemIds.length > 0) {
-        const surviving = tx
-          .select({ memoryItemId: memoryItemSources.memoryItemId })
-          .from(memoryItemSources)
-          .where(inArray(memoryItemSources.memoryItemId, candidateItemIds))
-          .all();
-        const survivingIds = new Set(surviving.map((r) => r.memoryItemId));
-        const orphanedIds = candidateItemIds.filter(
-          (itemId) => !survivingIds.has(itemId),
-        );
-        result.orphanedItemIds = orphanedIds;
-
-        if (orphanedIds.length > 0) {
-          tx.delete(memoryEmbeddings)
-            .where(
-              and(
-                eq(memoryEmbeddings.targetType, "item"),
-                inArray(memoryEmbeddings.targetId, orphanedIds),
-              ),
-            )
-            .run();
-          tx.delete(memoryItems)
-            .where(inArray(memoryItems.id, orphanedIds))
-            .run();
-        }
-      }
-    } else {
-      // No messages — just clean up non-message tables.
-      tx.delete(llmRequestLogs)
-        .where(eq(llmRequestLogs.conversationId, id))
-        .run();
-      tx.delete(toolInvocations)
-        .where(eq(toolInvocations.conversationId, id))
-        .run();
-    }
+    // Delete non-cascading tables first.
+    tx.delete(llmRequestLogs)
+      .where(eq(llmRequestLogs.conversationId, id))
+      .run();
+    tx.delete(toolInvocations)
+      .where(eq(toolInvocations.conversationId, id))
+      .run();
+    // Cascade deletes message_attachments.
+    tx.delete(messages).where(eq(messages.conversationId, id)).run();
 
     if (isPrivateScope && memoryScopeId) {
-      // Sweep remaining memory items with this private scopeId.
-      const scopeItems = tx
-        .select({ id: memoryItems.id })
-        .from(memoryItems)
-        .where(eq(memoryItems.scopeId, memoryScopeId))
-        .all();
-      const alreadyDeleted = new Set(result.orphanedItemIds);
-      const scopeItemIds = scopeItems
-        .map((r) => r.id)
-        .filter((id) => !alreadyDeleted.has(id));
-
-      if (scopeItemIds.length > 0) {
-        tx.delete(memoryEmbeddings)
-          .where(
-            and(
-              eq(memoryEmbeddings.targetType, "item"),
-              inArray(memoryEmbeddings.targetId, scopeItemIds),
-            ),
-          )
-          .run();
-        tx.delete(memoryItemSources)
-          .where(inArray(memoryItemSources.memoryItemId, scopeItemIds))
-          .run();
-        tx.delete(memoryItems)
-          .where(inArray(memoryItems.id, scopeItemIds))
-          .run();
-        result.orphanedItemIds.push(...scopeItemIds);
-      }
-
-      // Sweep memory summaries with this private scopeId.
-      const scopeSummaries = tx
-        .select({ id: memorySummaries.id })
-        .from(memorySummaries)
-        .where(eq(memorySummaries.scopeId, memoryScopeId))
-        .all();
-      const scopeSummaryIds = scopeSummaries.map((r) => r.id);
-
-      if (scopeSummaryIds.length > 0) {
-        tx.delete(memoryEmbeddings)
-          .where(
-            and(
-              eq(memoryEmbeddings.targetType, "summary"),
-              inArray(memoryEmbeddings.targetId, scopeSummaryIds),
-            ),
-          )
-          .run();
-        tx.delete(memorySummaries)
-          .where(inArray(memorySummaries.id, scopeSummaryIds))
-          .run();
-        result.deletedSummaryIds.push(...scopeSummaryIds);
-      }
-
       // Sweep conversation starters with this private scopeId.
       tx.delete(conversationStarters)
         .where(eq(conversationStarters.scopeId, memoryScopeId))
@@ -798,186 +663,20 @@ export function deleteConversation(id: string): DeletedMemoryIds {
  *
  * Extends `deleteConversation` with:
  * - Cancelling pending memory jobs before deletion
- * - Restoring memory items that were explicitly superseded by items from this conversation
- * - Restoring orphaned subject-match superseded items after deletion
- * - Deleting conversation-scoped memory summaries and their embeddings
- * - Enqueuing `embed_item` jobs for all restored items
  */
 export function wipeConversation(id: string): WipeConversationResult {
-  const db = getDb();
-  const unsupersededItemIds: string[] = [];
-  const deletedSummaryIds: string[] = [];
-
   // Step A — Cancel pending memory jobs (before deleting messages, since
   // the cancellation queries join on `messages`).
   const cancelledJobCount = cancelPendingJobsForConversation(id);
 
-  // Step B — Un-supersede memory items with explicit `supersededBy` links.
-  // Find memory items whose `superseded_by` points to an item sourced
-  // exclusively from this conversation.
-  const explicitSuperseded = rawAll<{ oldItemId: string }>(
-    `SELECT DISTINCT mi_old.id AS oldItemId
-     FROM memory_items mi_old
-     JOIN memory_items mi_new ON mi_old.superseded_by = mi_new.id
-     WHERE mi_old.status = 'superseded'
-       AND mi_new.id IN (
-         SELECT mis.memory_item_id
-         FROM memory_item_sources mis
-         JOIN messages m ON m.id = mis.message_id
-         WHERE m.conversation_id = ?
-       )
-       AND NOT EXISTS (
-         SELECT 1 FROM memory_item_sources mis2
-         JOIN messages m2 ON m2.id = mis2.message_id
-         WHERE mis2.memory_item_id = mi_new.id
-           AND m2.conversation_id != ?
-       )
-       AND NOT EXISTS (
-         SELECT 1 FROM memory_items mi_active
-         WHERE mi_active.kind = mi_old.kind
-           AND mi_active.subject = mi_old.subject
-           AND mi_active.scope_id = mi_old.scope_id
-           AND mi_active.status = 'active'
-           AND mi_active.id != mi_old.id
-           -- Exclude items sourced exclusively from the conversation being
-           -- wiped — deleteConversation will remove them, so they should not
-           -- block restoration of mi_old.
-           AND NOT (
-             EXISTS (
-               SELECT 1 FROM memory_item_sources mis_a
-               JOIN messages m_a ON m_a.id = mis_a.message_id
-               WHERE mis_a.memory_item_id = mi_active.id
-                 AND m_a.conversation_id = ?
-             )
-             AND NOT EXISTS (
-               SELECT 1 FROM memory_item_sources mis_b
-               JOIN messages m_b ON m_b.id = mis_b.message_id
-               WHERE mis_b.memory_item_id = mi_active.id
-                 AND m_b.conversation_id != ?
-             )
-           )
-       )`,
-    id,
-    id,
-    id,
-    id,
-  );
-  for (const { oldItemId } of explicitSuperseded) {
-    rawRun(
-      "UPDATE memory_items SET status = 'active', superseded_by = NULL WHERE id = ?",
-      oldItemId,
-    );
-    enqueueMemoryJob("embed_item", { itemId: oldItemId });
-    unsupersededItemIds.push(oldItemId);
-  }
-
-  // Step C — Delete conversation-scoped memory summaries and their embeddings.
-  const summaryRows = db
-    .select({ id: memorySummaries.id })
-    .from(memorySummaries)
-    .where(
-      and(
-        eq(memorySummaries.scope, "conversation"),
-        eq(memorySummaries.scopeKey, id),
-      ),
-    )
-    .all();
-  const summaryIds = summaryRows.map((r) => r.id);
-  if (summaryIds.length > 0) {
-    db.delete(memoryEmbeddings)
-      .where(
-        and(
-          eq(memoryEmbeddings.targetType, "summary"),
-          inArray(memoryEmbeddings.targetId, summaryIds),
-        ),
-      )
-      .run();
-    db.delete(memorySummaries)
-      .where(inArray(memorySummaries.id, summaryIds))
-      .run();
-  }
-  deletedSummaryIds.push(...summaryIds);
-
-  // Step D — Get the conversation's memoryScopeId before deletion.
-  const scopeId = getConversationMemoryScopeId(id);
-
-  // Step D.5 — Collect kind + subject pairs of items that will be orphaned
-  // by deleteConversation. These are items sourced from this conversation's
-  // messages that have NO sources from any other conversation. We need this
-  // before deletion so we can scope Step F to only restore superseded items
-  // matching the specific kind + subject pairs that just lost their active
-  // replacement.
-  const orphanedKindSubjects = rawAll<{ kind: string; subject: string }>(
-    `SELECT DISTINCT mi.kind, mi.subject
-     FROM memory_items mi
-     JOIN memory_item_sources mis ON mis.memory_item_id = mi.id
-     JOIN messages m ON m.id = mis.message_id
-     WHERE m.conversation_id = ?
-       AND NOT EXISTS (
-         SELECT 1 FROM memory_item_sources mis2
-         JOIN messages m2 ON m2.id = mis2.message_id
-         WHERE mis2.memory_item_id = mi.id
-           AND m2.conversation_id != ?
-       )`,
-    id,
-    id,
-  );
-
-  // Step E — Delegate to deleteConversation which handles messages (cascade
-  // segments, item_sources, attachments), llmRequestLogs, toolInvocations,
-  // orphaned memory items + embeddings, and the conversation row.
+  // Step B — Delegate to deleteConversation which handles messages (cascade
+  // attachments), llmRequestLogs, toolInvocations, observation/chunk/episode
+  // embeddings, and the conversation row.
   const deletedMemoryIds = deleteConversation(id);
 
-  // Step F — Restore orphaned subject-match superseded items. After
-  // deleteConversation removes superseding items, find superseded items
-  // with no supersededBy link where no active item with the same
-  // kind + subject + scope_id exists. Scoped to only the kind + subject
-  // pairs of items that were just orphaned by deleteConversation, so we
-  // don't accidentally restore items superseded by unrelated conversations.
-  let orphanedSuperseded: Array<{ id: string }> = [];
-  if (orphanedKindSubjects.length > 0) {
-    const placeholders = orphanedKindSubjects.map(() => "(?, ?)").join(", ");
-    const params: Array<string> = [scopeId];
-    for (const { kind, subject } of orphanedKindSubjects) {
-      params.push(kind, subject);
-    }
-    orphanedSuperseded = rawAll<{ id: string }>(
-      `SELECT id FROM (
-         SELECT id, ROW_NUMBER() OVER (
-           PARTITION BY kind, subject, scope_id
-           ORDER BY last_seen_at DESC
-         ) AS rn
-         FROM memory_items
-         WHERE status = 'superseded'
-           AND superseded_by IS NULL
-           AND scope_id = ?
-           AND (kind, subject) IN (VALUES ${placeholders})
-           AND NOT EXISTS (
-             SELECT 1 FROM memory_items mi2
-             WHERE mi2.kind = memory_items.kind
-               AND mi2.subject = memory_items.subject
-               AND mi2.scope_id = memory_items.scope_id
-               AND mi2.status = 'active'
-               AND mi2.id != memory_items.id
-           )
-       ) WHERE rn = 1`,
-      ...params,
-    );
-  }
-  for (const { id: itemId } of orphanedSuperseded) {
-    rawRun("UPDATE memory_items SET status = 'active' WHERE id = ?", itemId);
-    enqueueMemoryJob("embed_item", { itemId });
-    unsupersededItemIds.push(itemId);
-  }
-
-  // Step G — Return the combined result.
+  // Step C — Return the combined result.
   return {
     ...deletedMemoryIds,
-    unsupersededItemIds,
-    deletedSummaryIds: [
-      ...deletedSummaryIds,
-      ...deletedMemoryIds.deletedSummaryIds,
-    ],
     cancelledJobCount,
   };
 }
@@ -1002,9 +701,6 @@ export function purgePrivateConversations(): {
     return {
       count: 0,
       deletedMemory: {
-        segmentIds: [],
-        orphanedItemIds: [],
-        deletedSummaryIds: [],
         deletedObservationIds: [],
         deletedChunkIds: [],
         deletedEpisodeIds: [],
@@ -1012,18 +708,12 @@ export function purgePrivateConversations(): {
     };
   }
 
-  const allSegmentIds: string[] = [];
-  const allOrphanedItemIds: string[] = [];
-  const allDeletedSummaryIds: string[] = [];
   const allDeletedObservationIds: string[] = [];
   const allDeletedChunkIds: string[] = [];
   const allDeletedEpisodeIds: string[] = [];
 
   for (const conv of privateConvs) {
     const deleted = deleteConversation(conv.id);
-    allSegmentIds.push(...deleted.segmentIds);
-    allOrphanedItemIds.push(...deleted.orphanedItemIds);
-    allDeletedSummaryIds.push(...deleted.deletedSummaryIds);
     allDeletedObservationIds.push(...deleted.deletedObservationIds);
     allDeletedChunkIds.push(...deleted.deletedChunkIds);
     allDeletedEpisodeIds.push(...deleted.deletedEpisodeIds);
@@ -1032,9 +722,6 @@ export function purgePrivateConversations(): {
   return {
     count: privateConvs.length,
     deletedMemory: {
-      segmentIds: allSegmentIds,
-      orphanedItemIds: allOrphanedItemIds,
-      deletedSummaryIds: allDeletedSummaryIds,
       deletedObservationIds: allDeletedObservationIds,
       deletedChunkIds: allDeletedChunkIds,
       deletedEpisodeIds: allDeletedEpisodeIds,
@@ -1278,19 +965,14 @@ export function clearAll(): { conversations: number; messages: number } {
   const convCount =
     rawGet<{ c: number }>("SELECT COUNT(*) AS c FROM conversations")?.c ?? 0;
 
-  // Delete in dependency order. Cascades handle memory_segments,
-  // memory_item_sources, and tool_invocations, but we explicitly
-  // clear non-cascading memory tables too.
+  // Delete in dependency order. Cascades handle tool_invocations, but we
+  // explicitly clear non-cascading memory tables too.
   //
   // FTS virtual tables are cleared before their base tables. If an FTS
   // table is corrupted, the DELETE will fail — we drop the associated
   // triggers so that the subsequent base-table DELETEs don't also fail
   // (SQLite triggers are atomic with the triggering statement, so a
   // corrupted FTS table would roll back every base-table DELETE).
-  rawExec("DELETE FROM memory_item_sources");
-  rawExec("DELETE FROM memory_segments");
-  rawExec("DELETE FROM memory_items");
-  rawExec("DELETE FROM memory_summaries");
   rawExec("DELETE FROM memory_embeddings");
   rawExec("DELETE FROM memory_jobs");
   rawExec("DELETE FROM memory_checkpoints");
@@ -1428,16 +1110,12 @@ export function deleteLastExchange(conversationId: string): number {
  * SQLite transaction commits.
  */
 export interface DeletedMemoryIds {
-  segmentIds: string[];
-  orphanedItemIds: string[];
-  deletedSummaryIds: string[];
   deletedObservationIds: string[];
   deletedChunkIds: string[];
   deletedEpisodeIds: string[];
 }
 
 export interface WipeConversationResult extends DeletedMemoryIds {
-  unsupersededItemIds: string[];
   cancelledJobCount: number;
 }
 
@@ -1491,22 +1169,12 @@ export function relinkAttachments(
  * NULL before the message row is removed, so associated run and event
  * records survive.
  *
- * Also cleans up derived memory_items: if the memory worker has already
- * processed an extract_items job for this message, deleting the message
- * cascades memory_item_sources but leaves the memory_items active.
- * Without cleanup, those items would leak into summaries and recall.
- * We delete any memory_items that become orphaned (no remaining sources)
- * after this message is removed.
- *
- * Returns segment and orphaned item IDs so the caller can clean up the
+ * Returns deleted memory IDs so the caller can clean up the
  * corresponding Qdrant vector entries.
  */
 export function deleteMessageById(messageId: string): DeletedMemoryIds {
   const db = getDb();
   const result: DeletedMemoryIds = {
-    segmentIds: [],
-    orphanedItemIds: [],
-    deletedSummaryIds: [],
     deletedObservationIds: [],
     deletedChunkIds: [],
     deletedEpisodeIds: [],
@@ -1523,74 +1191,14 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
     .filter((id): id is string => id !== undefined);
 
   db.transaction((tx) => {
-    // Collect memory segment IDs linked to this message before cascade.
-    const linkedSegments = tx
-      .select({ id: memorySegments.id })
-      .from(memorySegments)
-      .where(eq(memorySegments.messageId, messageId))
-      .all();
-    result.segmentIds = linkedSegments.map((r) => r.id);
-
-    // Collect memory item IDs linked to this message before cascade.
-    const linkedItems = tx
-      .select({ memoryItemId: memoryItemSources.memoryItemId })
-      .from(memoryItemSources)
-      .where(eq(memoryItemSources.messageId, messageId))
-      .all();
-    const candidateItemIds = linkedItems.map((r) => r.memoryItemId);
-
     // Detach nullable FK references so the cascade doesn't destroy them.
     tx.update(channelInboundEvents)
       .set({ messageId: null })
       .where(eq(channelInboundEvents.messageId, messageId))
       .run();
 
-    // Now safe to delete — NOT NULL cascades remove memory_item_sources,
-    // memory_segments, and message_attachments.
+    // Now safe to delete — NOT NULL cascades remove message_attachments.
     tx.delete(messages).where(eq(messages.id, messageId)).run();
-
-    // Clean up segment embeddings from SQLite (Qdrant cleanup is the caller's job).
-    if (result.segmentIds.length > 0) {
-      tx.delete(memoryEmbeddings)
-        .where(
-          and(
-            eq(memoryEmbeddings.targetType, "segment"),
-            inArray(memoryEmbeddings.targetId, result.segmentIds),
-          ),
-        )
-        .run();
-    }
-
-    // Clean up orphaned memory items whose only source was this message.
-    if (candidateItemIds.length > 0) {
-      // Find which items still have at least one remaining source.
-      const surviving = tx
-        .select({ memoryItemId: memoryItemSources.memoryItemId })
-        .from(memoryItemSources)
-        .where(inArray(memoryItemSources.memoryItemId, candidateItemIds))
-        .all();
-      const survivingIds = new Set(surviving.map((r) => r.memoryItemId));
-      const orphanedIds = candidateItemIds.filter(
-        (id) => !survivingIds.has(id),
-      );
-      result.orphanedItemIds = orphanedIds;
-
-      if (orphanedIds.length > 0) {
-        // Delete embeddings referencing these items.
-        tx.delete(memoryEmbeddings)
-          .where(
-            and(
-              eq(memoryEmbeddings.targetType, "item"),
-              inArray(memoryEmbeddings.targetId, orphanedIds),
-            ),
-          )
-          .run();
-        // Delete the orphaned memory items themselves.
-        tx.delete(memoryItems)
-          .where(inArray(memoryItems.id, orphanedIds))
-          .run();
-      }
-    }
   });
 
   deleteOrphanAttachments(candidateAttachmentIds);

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -112,6 +112,7 @@ import {
   migrateRenameVoiceToPhone,
   migrateScheduleOneShotRouting,
   migrateScheduleQuietFlag,
+  migrateDropLegacyMemorySystem,
   migrateSchemaIndexesAndColumns,
   migrateUsageDashboardIndexes,
   migrateVoiceInviteColumns,
@@ -499,6 +500,10 @@ export function initializeDb(): void {
 
   // 88. Add quiet flag to schedule jobs
   migrateScheduleQuietFlag(database);
+
+  // 89. Drop legacy memory tables (memory_items, memory_item_sources, memory_segments, memory_summaries)
+  // and purge orphaned embedding rows for retired target types (item, segment, summary)
+  migrateDropLegacyMemorySystem(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -11,11 +11,7 @@ import {
   extractMediaBlockMeta,
   extractTextFromStoredMessageContent,
 } from "./message-content.js";
-import {
-  memoryChunks,
-  memoryObservations,
-  memorySegments,
-} from "./schema.js";
+import { memoryChunks, memoryObservations } from "./schema.js";
 import { segmentText } from "./segmenter.js";
 
 const log = getLogger("memory-indexer");
@@ -178,20 +174,6 @@ export function enqueueBackfillJob(force = false): string {
 
 export function enqueueRebuildIndexJob(): string {
   return enqueueMemoryJob("rebuild_index", {});
-}
-
-export function getRecentSegmentsForConversation(
-  conversationId: string,
-  limit: number,
-): Array<typeof memorySegments.$inferSelect> {
-  const db = getDb();
-  return db
-    .select()
-    .from(memorySegments)
-    .where(eq(memorySegments.conversationId, conversationId))
-    .orderBy(desc(memorySegments.createdAt))
-    .limit(limit)
-    .all();
 }
 
 /**

--- a/assistant/src/memory/job-handlers/conversation-starters.ts
+++ b/assistant/src/memory/job-handlers/conversation-starters.ts
@@ -25,7 +25,7 @@ import { rawAll, rawGet } from "../raw-query.js";
 import {
   conversationStarters,
   memoryCheckpoints,
-  memoryItems,
+  memoryObservations,
 } from "../schema.js";
 
 const log = getLogger("conversation-starters-gen");
@@ -42,31 +42,28 @@ const CK_LAST_GEN_AT = "conversation_starters:last_gen_at";
 
 export function buildMemoryRollup(scopeId: string): string {
   const db = getDb();
-  const items = db
+  const observations = db
     .select({
-      kind: memoryItems.kind,
-      subject: memoryItems.subject,
-      statement: memoryItems.statement,
-      importance: memoryItems.importance,
+      content: memoryObservations.content,
+      role: memoryObservations.role,
     })
-    .from(memoryItems)
-    .where(
-      and(eq(memoryItems.status, "active"), eq(memoryItems.scopeId, scopeId)),
-    )
-    .orderBy(desc(memoryItems.importance))
+    .from(memoryObservations)
+    .where(eq(memoryObservations.scopeId, scopeId))
+    .orderBy(desc(memoryObservations.createdAt))
     .limit(60)
     .all();
 
-  if (items.length === 0) return "";
+  if (observations.length === 0) return "";
 
   const byKind = new Map<string, string[]>();
-  for (const item of items) {
-    let lines = byKind.get(item.kind);
+  for (const item of observations) {
+    const kind = item.role;
+    let lines = byKind.get(kind);
     if (!lines) {
       lines = [];
-      byKind.set(item.kind, lines);
+      byKind.set(kind, lines);
     }
-    lines.push(`- ${item.subject}: ${item.statement}`);
+    lines.push(`- ${item.content}`);
   }
 
   let rollup = "";
@@ -370,16 +367,14 @@ export async function generateConversationStartersJob(
     ? parseInt(batchCheckpoint.value, 10) + 1
     : 1;
 
-  // Collect the memory kinds that informed this batch
-  const kindRows = db
-    .select({ kind: memoryItems.kind })
-    .from(memoryItems)
-    .where(
-      and(eq(memoryItems.status, "active"), eq(memoryItems.scopeId, scopeId)),
-    )
-    .groupBy(memoryItems.kind)
+  // Collect the memory roles that informed this batch
+  const roleRows = db
+    .select({ role: memoryObservations.role })
+    .from(memoryObservations)
+    .where(eq(memoryObservations.scopeId, scopeId))
+    .groupBy(memoryObservations.role)
     .all();
-  const sourceKinds = kindRows.map((r) => r.kind).join(",");
+  const sourceKinds = roleRows.map((r) => r.role).join(",");
 
   // Remove previous starters for this scope before inserting the new batch
   db.delete(conversationStarters)

--- a/assistant/src/memory/job-handlers/embedding.ts
+++ b/assistant/src/memory/job-handlers/embedding.ts
@@ -14,30 +14,8 @@ import {
   memoryChunks,
   memoryEpisodes,
   memoryObservations,
-  memorySegments,
   messages,
 } from "../schema.js";
-
-export async function embedSegmentJob(
-  job: MemoryJob,
-  config: AssistantConfig,
-): Promise<void> {
-  const segmentId = asString(job.payload.segmentId);
-  if (!segmentId) return;
-  const db = getDb();
-  const segment = db
-    .select()
-    .from(memorySegments)
-    .where(eq(memorySegments.id, segmentId))
-    .get();
-  if (!segment) return;
-  await embedAndUpsert(config, "segment", segment.id, segment.text, {
-    conversation_id: segment.conversationId,
-    message_id: segment.messageId,
-    created_at: segment.createdAt,
-    memory_scope_id: segment.scopeId,
-  });
-}
 
 export async function embedChunkJob(
   job: MemoryJob,

--- a/assistant/src/memory/job-handlers/index-maintenance.ts
+++ b/assistant/src/memory/job-handlers/index-maintenance.ts
@@ -11,10 +11,9 @@ import { withQdrantBreaker } from "../qdrant-circuit-breaker.js";
 import { getQdrantClient } from "../qdrant-client.js";
 import {
   mediaAssets,
+  memoryChunks,
   memoryEmbeddings,
-  memoryItems,
-  memorySegments,
-  memorySummaries,
+  memoryObservations,
   messages,
 } from "../schema.js";
 
@@ -24,29 +23,24 @@ export async function rebuildIndexJob(): Promise<void> {
   const db = getDb();
   db.delete(memoryEmbeddings).run();
 
-  const items = db
-    .select({ id: memoryItems.id })
-    .from(memoryItems)
-    .where(eq(memoryItems.status, "active"))
+  // Enqueue embed jobs for all observations via their chunks.
+  const observations = db
+    .select({ id: memoryObservations.id })
+    .from(memoryObservations)
     .all();
-  for (const item of items) {
-    enqueueMemoryJob("embed_item", { itemId: item.id });
-  }
-
-  const summaries = db
-    .select({ id: memorySummaries.id })
-    .from(memorySummaries)
-    .all();
-  for (const summary of summaries) {
-    enqueueMemoryJob("embed_summary", { summaryId: summary.id });
-  }
-
-  const segments = db
-    .select({ id: memorySegments.id })
-    .from(memorySegments)
-    .all();
-  for (const segment of segments) {
-    enqueueMemoryJob("embed_segment", { segmentId: segment.id });
+  for (const obs of observations) {
+    const chunks = db
+      .select({ id: memoryChunks.id })
+      .from(memoryChunks)
+      .where(eq(memoryChunks.observationId, obs.id))
+      .all();
+    for (const chunk of chunks) {
+      enqueueMemoryJob("embed_observation", {
+        observationId: obs.id,
+        chunkId: chunk.id,
+      });
+      enqueueMemoryJob("embed_chunk", { chunkId: chunk.id });
+    }
   }
 
   // Re-enqueue multimodal embedding jobs only when the resolved embedding

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -9,7 +9,6 @@ import { memoryJobs } from "./schema.js";
 const log = getLogger("memory-jobs-store");
 
 export type MemoryJobType =
-  | "embed_segment"
   | "embed_chunk"
   | "embed_episode"
   | "embed_observation"
@@ -23,6 +22,7 @@ export type MemoryJobType =
   | "generate_conversation_starters"
   | "reduce_conversation_memory"
   | "backfill_simplified_memory"
+  | "embed_segment" // legacy compat — silently dropped by worker (segment-based memory retired)
   | "embed_item" // legacy compat — silently dropped by worker (item-based memory retired)
   | "embed_summary" // legacy compat — silently dropped by worker (item-based memory retired)
   | "extract_items" // legacy compat — silently dropped by worker (item-based memory retired)
@@ -36,7 +36,6 @@ export type MemoryJobType =
   | "generate_thread_starters"; // legacy compat — silently dropped by worker (renamed to generate_conversation_starters)
 
 const EMBED_JOB_TYPES: MemoryJobType[] = [
-  "embed_segment",
   "embed_chunk",
   "embed_episode",
   "embed_observation",

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -12,7 +12,6 @@ import {
   embedEpisodeJob,
   embedMediaJob,
   embedObservationJob,
-  embedSegmentJob,
 } from "./job-handlers/embedding.js";
 import {
   deleteQdrantVectorsJob,
@@ -251,9 +250,6 @@ async function processJob(
   config: AssistantConfig,
 ): Promise<void> {
   switch (job.type) {
-    case "embed_segment":
-      await embedSegmentJob(job, config);
-      return;
     case "embed_chunk":
       await embedChunkJob(job, config);
       return;
@@ -295,6 +291,7 @@ async function processJob(
       return;
 
     // ── Legacy compat — silently drop jobs from retired systems ────
+    case "embed_segment":
     case "embed_item":
     case "embed_summary":
     case "extract_items":

--- a/assistant/src/memory/migrations/189-drop-legacy-memory-system.ts
+++ b/assistant/src/memory/migrations/189-drop-legacy-memory-system.ts
@@ -1,0 +1,51 @@
+import { eq, inArray } from "drizzle-orm";
+
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { memoryEmbeddings } from "../schema/memory-core.js";
+
+/**
+ * Drop the legacy memory tables (memory_items, memory_item_sources,
+ * memory_segments, memory_summaries) and purge any orphaned embedding
+ * rows that reference the retired target types (item, segment, summary).
+ *
+ * This migration is idempotent: DROP TABLE IF EXISTS and DELETE WHERE
+ * are safe to re-run. The simplified-memory tables (memory_observations,
+ * memory_chunks, memory_episodes) are left untouched.
+ */
+export function migrateDropLegacyMemorySystem(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  // ── 1. Purge legacy embedding rows ────────────────────────────────
+  // These target types are tied to the legacy tables being dropped.
+  // Chunk/observation/episode embeddings (simplified-memory) are preserved.
+  const LEGACY_TARGET_TYPES = ["item", "segment", "summary"];
+  database
+    .delete(memoryEmbeddings)
+    .where(inArray(memoryEmbeddings.targetType, LEGACY_TARGET_TYPES))
+    .run();
+
+  // ── 2. Drop legacy tables (child → parent order for FK safety) ────
+  // memory_item_sources references memory_items and messages (CASCADE),
+  // memory_segments references messages (CASCADE).
+  // memory_summaries is standalone.
+  raw.exec(/*sql*/ `DROP TABLE IF EXISTS memory_item_sources`);
+  raw.exec(/*sql*/ `DROP TABLE IF EXISTS memory_segments`);
+  raw.exec(/*sql*/ `DROP TABLE IF EXISTS memory_items`);
+  raw.exec(/*sql*/ `DROP TABLE IF EXISTS memory_summaries`);
+
+  // ── 3. Drop orphaned indexes tied only to the dropped tables ──────
+  // SQLite automatically drops indexes when their table is dropped, but
+  // explicitly listing them documents what was removed and guards against
+  // any future schema where the index names might be reused.
+  raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_memory_segments_scope_id`);
+  raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_memory_items_scope_id`);
+  raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_memory_items_fingerprint`);
+  raw.exec(
+    /*sql*/ `DROP INDEX IF EXISTS idx_memory_item_sources_memory_item_id`,
+  );
+  raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_memory_summaries_scope_id`);
+  raw.exec(
+    /*sql*/ `DROP INDEX IF EXISTS idx_memory_summaries_scope_scope_key`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -130,6 +130,7 @@ export { migrateMemoryBriefState } from "./185-memory-brief-state.js";
 export { migrateMemoryArchiveTables } from "./186-memory-archive.js";
 export { migrateMemoryReducerCheckpoints } from "./187-memory-reducer-checkpoints.js";
 export { migrateScheduleQuietFlag } from "./188-schedule-quiet-flag.js";
+export { migrateDropLegacyMemorySystem } from "./189-drop-legacy-memory-system.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/memory-core.ts
+++ b/assistant/src/memory/schema/memory-core.ts
@@ -10,6 +10,14 @@ import {
 
 import { conversations, messages } from "./conversations.js";
 
+// ---------------------------------------------------------------------------
+// DEPRECATED — Legacy memory tables. The underlying SQLite tables are dropped
+// by migration 189. These Drizzle schema definitions are retained temporarily
+// so downstream code that still references them can compile. Queries against
+// these tables will fail at runtime. Remove in the final cleanup PR.
+// ---------------------------------------------------------------------------
+
+/** @deprecated Table dropped by migration 189. */
 export const memorySegments = sqliteTable(
   "memory_segments",
   {
@@ -32,6 +40,7 @@ export const memorySegments = sqliteTable(
   (table) => [index("idx_memory_segments_scope_id").on(table.scopeId)],
 );
 
+/** @deprecated Table dropped by migration 189. */
 export const memoryItems = sqliteTable(
   "memory_items",
   {
@@ -63,6 +72,7 @@ export const memoryItems = sqliteTable(
   ],
 );
 
+/** @deprecated Table dropped by migration 189. */
 export const memoryItemSources = sqliteTable(
   "memory_item_sources",
   {
@@ -80,6 +90,7 @@ export const memoryItemSources = sqliteTable(
   ],
 );
 
+/** @deprecated Table dropped by migration 189. */
 export const memorySummaries = sqliteTable(
   "memory_summaries",
   {
@@ -103,6 +114,10 @@ export const memorySummaries = sqliteTable(
     ),
   ],
 );
+
+// ---------------------------------------------------------------------------
+// Active memory tables
+// ---------------------------------------------------------------------------
 
 export const memoryEmbeddings = sqliteTable(
   "memory_embeddings",

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -257,24 +257,6 @@ export function conversationManagementRouteDefinitions(
         deps.destroyConversation(resolvedId);
         const result = wipeConversation(resolvedId);
         // Enqueue Qdrant vector cleanup jobs
-        for (const segId of result.segmentIds) {
-          enqueueMemoryJob("delete_qdrant_vectors", {
-            targetType: "segment",
-            targetId: segId,
-          });
-        }
-        for (const itemId of result.orphanedItemIds) {
-          enqueueMemoryJob("delete_qdrant_vectors", {
-            targetType: "item",
-            targetId: itemId,
-          });
-        }
-        for (const summaryId of result.deletedSummaryIds) {
-          enqueueMemoryJob("delete_qdrant_vectors", {
-            targetType: "summary",
-            targetId: summaryId,
-          });
-        }
         for (const obsId of result.deletedObservationIds) {
           enqueueMemoryJob("delete_qdrant_vectors", {
             targetType: "observation",
@@ -296,16 +278,12 @@ export function conversationManagementRouteDefinitions(
         log.info(
           {
             conversationId: resolvedId,
-            unsuperseded: result.unsupersededItemIds.length,
-            summariesDeleted: result.deletedSummaryIds.length,
             jobsCancelled: result.cancelledJobCount,
           },
           "Wiped conversation and reverted memory changes",
         );
         return Response.json({
           wiped: true,
-          unsupersededItems: result.unsupersededItemIds.length,
-          deletedSummaries: result.deletedSummaryIds.length,
           cancelledJobs: result.cancelledJobCount,
         });
       },
@@ -331,24 +309,6 @@ export function conversationManagementRouteDefinitions(
         // Enqueue Qdrant vector cleanup jobs rather than calling directly.
         // Qdrant may not be initialized yet when the HTTP server starts
         // accepting requests, so enqueueing ensures cleanup is retried.
-        for (const segId of deleted.segmentIds) {
-          enqueueMemoryJob("delete_qdrant_vectors", {
-            targetType: "segment",
-            targetId: segId,
-          });
-        }
-        for (const itemId of deleted.orphanedItemIds) {
-          enqueueMemoryJob("delete_qdrant_vectors", {
-            targetType: "item",
-            targetId: itemId,
-          });
-        }
-        for (const summaryId of deleted.deletedSummaryIds) {
-          enqueueMemoryJob("delete_qdrant_vectors", {
-            targetType: "summary",
-            targetId: summaryId,
-          });
-        }
         for (const obsId of deleted.deletedObservationIds) {
           enqueueMemoryJob("delete_qdrant_vectors", {
             targetType: "observation",


### PR DESCRIPTION
## Summary
- Remove code-level references to legacy tables from conversation-crud.ts and embedding handler
- Add migration 189 to drop memory_items, memory_item_sources, memory_segments, memory_summaries tables
- Purge legacy embedding target types (item/segment/summary) from memory_embeddings
- Remove embedSegmentJob and move embed_segment to legacy compat (silently dropped)
- Update DeletedMemoryIds and WipeConversationResult interfaces to remove legacy fields
- Update downstream callers (lifecycle.ts, conversation-history.ts, routes, CLI) to match new interfaces
- Update rebuildIndexJob to use observations/chunks instead of legacy items/segments/summaries
- Update conversation starters to use observations instead of legacy items
- Update memory admin status to report observations/chunks/episodes instead of segments/items/summaries
- Add DB tests for migration upgrade, re-run safety, and simplified-memory preservation

Part of plan: legacy-memory-cleanup.md (PR 6 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
