### PR TITLE
fix: dynamically allocate cesPort in allocateLocalResources

### DIFF
--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -426,6 +426,7 @@ export async function allocateLocalResources(
         entry.resources.daemonPort,
         entry.resources.gatewayPort,
         entry.resources.qdrantPort,
+        entry.resources.cesPort,
       );
     }
   }
@@ -445,13 +446,19 @@ export async function allocateLocalResources(
     daemonPort,
     gatewayPort,
   ]);
+  const cesPort = await findAvailablePort(DEFAULT_CES_PORT, [
+    ...reservedPorts,
+    daemonPort,
+    gatewayPort,
+    qdrantPort,
+  ]);
 
   return {
     instanceDir,
     daemonPort,
     gatewayPort,
     qdrantPort,
-    cesPort: DEFAULT_CES_PORT,
+    cesPort,
     pidFile: join(instanceDir, ".vellum", "vellum.pid"),
   };
 }


### PR DESCRIPTION
Addresses review feedback on #19840. cesPort was hardcoded to DEFAULT_CES_PORT for every instance, causing port collisions in multi-instance setups. Now dynamically allocated via findAvailablePort, matching the pattern used for daemonPort/gatewayPort/qdrantPort. Also adds cesPort to reservedPorts so other port scans avoid it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
