### PR TITLE
fix: preserve image tags and retain digests in rollback containerInfo

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -356,14 +356,27 @@ async function upgradeDocker(
 
         const rollbackReady = await waitForReady(entry.runtimeUrl);
         if (rollbackReady) {
-          // Restore previous container info in lockfile after rollback
+          // Restore previous container info in lockfile after rollback.
+          // previousImageRefs contains sha256 digests from `docker inspect
+          // --format {{.Image}}`.  The *Image fields should hold
+          // human-readable image:tag names, so prefer the pre-upgrade
+          // containerInfo values and store digests in the *Digest fields.
           if (previousImageRefs) {
             const rolledBackEntry: AssistantEntry = {
               ...entry,
               containerInfo: {
-                assistantImage: previousImageRefs.assistant,
-                gatewayImage: previousImageRefs.gateway,
-                cesImage: previousImageRefs["credential-executor"],
+                assistantImage:
+                  entry.containerInfo?.assistantImage ??
+                  previousImageRefs.assistant,
+                gatewayImage:
+                  entry.containerInfo?.gatewayImage ??
+                  previousImageRefs.gateway,
+                cesImage:
+                  entry.containerInfo?.cesImage ??
+                  previousImageRefs["credential-executor"],
+                assistantDigest: previousImageRefs.assistant,
+                gatewayDigest: previousImageRefs.gateway,
+                cesDigest: previousImageRefs["credential-executor"],
                 networkName: res.network,
               },
             };


### PR DESCRIPTION
Addresses review feedback on #19859. The rollback path was writing sha256 digests into *Image fields (which should hold image:tag names) and dropping *Digest fields entirely. Now preserves the pre-upgrade image tags in *Image fields and stores rollback digests in *Digest fields.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
