### PR TITLE
fix: add public init to ContainerInfo struct for cross-module access

### DIFF
--- a/clients/shared/Network/LockfileAssistant.swift
+++ b/clients/shared/Network/LockfileAssistant.swift
@@ -9,6 +9,24 @@ public struct ContainerInfo {
     public let gatewayDigest: String?
     public let cesDigest: String?
     public let networkName: String?
+
+    public init(
+        assistantImage: String? = nil,
+        gatewayImage: String? = nil,
+        cesImage: String? = nil,
+        assistantDigest: String? = nil,
+        gatewayDigest: String? = nil,
+        cesDigest: String? = nil,
+        networkName: String? = nil
+    ) {
+        self.assistantImage = assistantImage
+        self.gatewayImage = gatewayImage
+        self.cesImage = cesImage
+        self.assistantDigest = assistantDigest
+        self.gatewayDigest = gatewayDigest
+        self.cesDigest = cesDigest
+        self.networkName = networkName
+    }
 }
 
 public struct LockfileAssistant {


### PR DESCRIPTION
Addresses review feedback on #19845. The ContainerInfo struct was declared public but had no explicit public init, meaning code outside VellumAssistantShared couldn't construct instances. Adds an explicit public memberwise initializer with all-optional parameters defaulting to nil.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
