### PR TITLE
fix: restore missing MemoryItemCreateSheet.swift

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemCreateSheet.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemCreateSheet.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct MemoryItemCreateSheet: View {
+    let store: MemoryItemsStore
+    let onDismiss: () -> Void
+
+    @State private var kind: String = "identity"
+    @State private var subject: String = ""
+    @State private var statement: String = ""
+    @State private var importance: Double = 0.8
+    @State private var isCreating = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VModal(title: "New Memory") {
+            VStack(alignment: .leading, spacing: VSpacing.lg) {
+                // Kind picker
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Kind")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                    VDropdown(
+                        placeholder: "Kind",
+                        selection: $kind,
+                        options: MemoryKind.allCases.map { ($0.label, $0.rawValue) }
+                    )
+                }
+
+                // Subject
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Subject")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                    VTextField(placeholder: "Brief topic or label", text: $subject)
+                }
+
+                // Statement
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Statement")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                    TextEditor(text: $statement)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentDefault)
+                        .scrollContentBackground(.hidden)
+                        .padding(VSpacing.sm)
+                        .background(VColor.surfaceActive)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.md)
+                                .stroke(VColor.borderBase, lineWidth: 1)
+                        )
+                        .frame(minHeight: 100)
+                        .overlay(alignment: .topLeading) {
+                            if statement.isEmpty {
+                                Text("What should the assistant remember?")
+                                    .font(VFont.body)
+                                    .foregroundColor(VColor.contentTertiary)
+                                    .padding(VSpacing.sm)
+                                    .padding(.top, 1)
+                                    .allowsHitTesting(false)
+                            }
+                        }
+                }
+
+                // Importance slider
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    HStack {
+                        Text("Importance")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentTertiary)
+                        Spacer()
+                        Text("\(Int(importance * 100))%")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentSecondary)
+                    }
+                    VSlider(value: $importance, range: 0...1, step: 0.1)
+                }
+
+                if let errorMessage {
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.circleAlert, size: 11)
+                            .foregroundColor(VColor.systemNegativeStrong)
+                        Text(errorMessage)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.systemNegativeStrong)
+                    }
+                }
+            }
+        } footer: {
+            HStack {
+                Spacer()
+                VButton(label: "Cancel", style: .outlined) {
+                    onDismiss()
+                }
+                VButton(
+                    label: isCreating ? "Creating..." : "Create",
+                    leftIcon: isCreating ? nil : VIcon.plus.rawValue,
+                    style: .primary,
+                    isDisabled: !isFormValid || isCreating
+                ) {
+                    create()
+                }
+            }
+        }
+        .frame(width: 480, height: 460)
+    }
+
+    // MARK: - Validation
+
+    private var isFormValid: Bool {
+        !subject.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !statement.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    // MARK: - Actions
+
+    private func create() {
+        isCreating = true
+        errorMessage = nil
+        Task {
+            let result = await store.createItem(
+                kind: kind,
+                subject: subject.trimmingCharacters(in: .whitespacesAndNewlines),
+                statement: statement.trimmingCharacters(in: .whitespacesAndNewlines),
+                importance: importance
+            )
+            isCreating = false
+            if result != nil {
+                onDismiss()
+            } else {
+                errorMessage = "Failed to create memory. Please try again."
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Restores `MemoryItemCreateSheet.swift` which was deleted by the simp-mem-ui plan (#19902) but missed in the memory system revert PR (#19943)
- Fixes macOS build error: `cannot find 'MemoryItemCreateSheet' in scope` in `MemoriesPanel.swift`

## Test plan
- [ ] macOS app builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19945" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
