### PR TITLE
fix: defensive try/catch for targetType in drop-simplified-memory migration

### DIFF
--- a/assistant/src/memory/migrations/189-drop-simplified-memory.ts
+++ b/assistant/src/memory/migrations/189-drop-simplified-memory.ts
@@ -32,7 +32,11 @@ export function migrateDropSimplifiedMemory(database: DrizzleDb): void {
   }
 
   // Remove embedding rows for archive target types that no longer exist.
-  raw.exec(
-    `DELETE FROM memory_embeddings WHERE targetType IN ('observation', 'chunk', 'episode')`,
-  );
+  try {
+    raw.exec(
+      `DELETE FROM memory_embeddings WHERE targetType IN ('observation', 'chunk', 'episode')`,
+    );
+  } catch {
+    // Column doesn't exist — table was never migrated to include targetType.
+  }
 }


### PR DESCRIPTION
## Summary
- The `migrateDropSimplifiedMemory` migration crashed on startup with `SQLiteError: no such column: targetType` when the `memory_embeddings` table never had that column
- Wrapped the DELETE statement in a try/catch, matching the defensive pattern already used for the column drops in the same migration
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
