### PR TITLE
fix: handle web_search_tool_result in window-manager orphaned pair expansion

### DIFF
--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -722,7 +722,7 @@ function adjustForToolPairs(
     // Collect tool_use_ids referenced by tool_results in this user message
     const referencedIds = new Set<string>();
     for (const block of msg.content) {
-      if (block.type === "tool_result" && "tool_use_id" in block) {
+      if ((block.type === "tool_result" || block.type === "web_search_tool_result") && "tool_use_id" in block) {
         referencedIds.add((block as { tool_use_id: string }).tool_use_id);
       }
     }


### PR DESCRIPTION
## Summary

- `context/window-manager.ts:725` had a raw `block.type === "tool_result"` check that didn't account for `web_search_tool_result` blocks, failing the structural guard test
- Added `|| block.type === "web_search_tool_result"` to the condition so orphaned tool-use/result pair expansion also covers web search results

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23326789964/job/67849543244
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19947" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
