### PR TITLE
Add semver major.minor version compatibility utility

### DIFF
--- a/cli/knip.json
+++ b/cli/knip.json
@@ -2,7 +2,8 @@
   "entry": [
     "src/**/*.test.ts",
     "src/**/__tests__/**/*.ts",
-    "src/adapters/openclaw-http-server.ts"
+    "src/adapters/openclaw-http-server.ts",
+    "src/lib/version-compat.ts"
   ],
   "project": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/cli/src/lib/version-compat.ts
+++ b/cli/src/lib/version-compat.ts
@@ -1,0 +1,45 @@
+/**
+ * Parse a version string into { major, minor, patch } components.
+ * Handles optional `v` prefix (e.g., "v1.2.3" or "1.2.3").
+ * Returns null if the string cannot be parsed as semver.
+ */
+export function parseVersion(
+  version: string,
+): { major: number; minor: number; patch: number } | null {
+  const stripped = version.replace(/^[vV]/, "");
+  const segments = stripped.split(".");
+
+  if (segments.length < 2) {
+    return null;
+  }
+
+  const major = parseInt(segments[0], 10);
+  const minor = parseInt(segments[1], 10);
+  const patch = segments.length >= 3 ? parseInt(segments[2], 10) : 0;
+
+  if (isNaN(major) || isNaN(minor) || isNaN(patch)) {
+    return null;
+  }
+
+  return { major, minor, patch };
+}
+
+/**
+ * Check whether two version strings are compatible.
+ * Compatibility requires matching major AND minor versions.
+ * Patch differences are allowed.
+ * Returns false if either version cannot be parsed.
+ */
+export function isVersionCompatible(
+  clientVersion: string,
+  serviceGroupVersion: string,
+): boolean {
+  const a = parseVersion(clientVersion);
+  const b = parseVersion(serviceGroupVersion);
+
+  if (a === null || b === null) {
+    return false;
+  }
+
+  return a.major === b.major && a.minor === b.minor;
+}


### PR DESCRIPTION
## Summary
- Add `parseVersion()` to parse version strings (with optional `v` prefix) into major.minor.patch components
- Add `isVersionCompatible()` to check major.minor compatibility between client and service group versions

Part of plan: version-compat-checking.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19950" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
