### PR TITLE
Return version from CLI health check responses

### DIFF
--- a/cli/src/__tests__/health-check.test.ts
+++ b/cli/src/__tests__/health-check.test.ts
@@ -10,6 +10,7 @@ describe("checkHealth", () => {
   test("returns unreachable for non-existent host", async () => {
     const result = await checkHealth("http://127.0.0.1:1");
     expect(["unreachable", "timeout"]).toContain(result.status);
+    expect(result.version).toBeUndefined();
   });
 
   test("returns healthy for a mock healthy endpoint", async () => {
@@ -24,6 +25,24 @@ describe("checkHealth", () => {
       const result = await checkHealth(`http://localhost:${server.port}`);
       expect(result.status).toBe("healthy");
       expect(result.detail).toBeNull();
+      expect(result.version).toBeUndefined();
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("returns version when present in response", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.json({ status: "healthy", version: "1.2.3" });
+      },
+    });
+
+    try {
+      const result = await checkHealth(`http://localhost:${server.port}`);
+      expect(result.status).toBe("healthy");
+      expect(result.version).toBe("1.2.3");
     } finally {
       server.stop(true);
     }
@@ -33,7 +52,11 @@ describe("checkHealth", () => {
     const server = Bun.serve({
       port: 0,
       fetch() {
-        return Response.json({ status: "degraded", message: "high latency" });
+        return Response.json({
+          status: "degraded",
+          message: "high latency",
+          version: "0.9.0",
+        });
       },
     });
 
@@ -41,6 +64,7 @@ describe("checkHealth", () => {
       const result = await checkHealth(`http://localhost:${server.port}`);
       expect(result.status).toBe("degraded");
       expect(result.detail).toBe("high latency");
+      expect(result.version).toBe("0.9.0");
     } finally {
       server.stop(true);
     }
@@ -57,6 +81,7 @@ describe("checkHealth", () => {
     try {
       const result = await checkHealth(`http://localhost:${server.port}`);
       expect(result.status).toBe("error (500)");
+      expect(result.version).toBeUndefined();
     } finally {
       server.stop(true);
     }

--- a/cli/src/lib/health-check.ts
+++ b/cli/src/lib/health-check.ts
@@ -3,11 +3,13 @@ export const HEALTH_CHECK_TIMEOUT_MS = 1500;
 interface HealthResponse {
   status: string;
   message?: string;
+  version?: string;
 }
 
 export interface HealthCheckResult {
   status: string;
   detail: string | null;
+  version?: string;
 }
 
 export async function checkManagedHealth(
@@ -63,6 +65,7 @@ export async function checkManagedHealth(
     return {
       status,
       detail: status !== "healthy" ? (data.message ?? null) : null,
+      version: data.version,
     };
   } catch (error) {
     const status =
@@ -108,6 +111,7 @@ export async function checkHealth(
     return {
       status,
       detail: status !== "healthy" ? (data.message ?? null) : null,
+      version: data.version,
     };
   } catch (error) {
     const status =


### PR DESCRIPTION
## Summary
- Add `version?: string` to `HealthCheckResult` interface
- Extract version from `/v1/health` and managed healthz response JSON
- Update tests to verify version is returned when present and undefined when absent

Part of plan: version-compat-checking.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19951" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
