### PR TITLE
Decode daemon version from health check response in HTTPTransport

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -94,6 +94,13 @@ public struct WorkspaceFileResponse: Codable, Sendable {
     }
 }
 
+/// Minimal decode of the healthz response to extract the version field.
+/// The full `DaemonHealthz` model lives in Settings and includes disk/memory/cpu;
+/// this struct intentionally only decodes what the transport layer needs.
+private struct HealthzVersionResponse: Decodable {
+    let version: String?
+}
+
 // MARK: - HTTP Transport
 
 /// Internal helper that handles HTTP REST + SSE communication with a remote
@@ -147,6 +154,10 @@ public final class HTTPTransport {
 
     /// Whether the SSE stream is active and receiving events.
     private(set) var isSSEConnected: Bool = false
+
+    /// The daemon's self-reported version from the most recent health check.
+    /// Updated on every successful health check that includes a version.
+    private(set) var daemonVersion: String?
 
     /// Whether we should attempt to reconnect on disconnect.
     private var shouldReconnect = true
@@ -644,6 +655,10 @@ public final class HTTPTransport {
                     }
                 }
                 throw HTTPTransportError.healthCheckFailed
+            }
+            // Extract daemon version from response body (best-effort, never fails the health check)
+            if let decoded = try? JSONDecoder().decode(HealthzVersionResponse.self, from: data) {
+                daemonVersion = decoded.version
             }
             log.info("Health check passed for \(self.baseURL, privacy: .public)")
             // When the daemon comes back during a planned update, reset the


### PR DESCRIPTION
## Summary
- Add `HealthzVersionResponse` private decodable struct for lightweight version extraction
- Add `daemonVersion: String?` property to `HTTPTransport`
- Decode version from healthz response on every successful health check (best-effort, never breaks health check)

Part of plan: version-compat-checking.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19953" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
