### PR TITLE
Persist serviceGroupVersion to lockfile from CLI health checks

### DIFF
--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -425,7 +425,7 @@ async function listAllAssistants(): Promise<void> {
       // hitting the health endpoint. If the PID file is missing or the
       // process isn't running, the assistant is sleeping — skip the
       // network health check to avoid a misleading "unreachable" status.
-      let health: { status: string; detail: string | null };
+      let health: { status: string; detail: string | null; version?: string };
       const resources = a.resources;
       if (a.cloud === "local" && resources) {
         const pid = readPidFile(resources.pidFile);

--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -4,6 +4,7 @@ import {
   findAssistantByName,
   getActiveAssistant,
   loadAllAssistants,
+  updateServiceGroupVersion,
   type AssistantEntry,
 } from "../lib/assistant-config";
 import { loadGuardianToken } from "../lib/guardian-token";
@@ -449,6 +450,10 @@ async function listAllAssistants(): Promise<void> {
       } else {
         const token = loadGuardianToken(a.assistantId)?.accessToken;
         health = await checkHealth(a.localUrl ?? a.runtimeUrl, token);
+      }
+
+      if (health.status === "healthy" && health.version) {
+        updateServiceGroupVersion(a.assistantId, health.version);
       }
 
       const infoParts = [a.runtimeUrl];

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -361,6 +361,23 @@ export function saveAssistantEntry(entry: AssistantEntry): void {
 }
 
 /**
+ * Update just the serviceGroupVersion field on a lockfile entry.
+ * Reads the current entry, updates the version if changed, and writes back.
+ * No-op if the entry doesn't exist or the version hasn't changed.
+ */
+export function updateServiceGroupVersion(
+  assistantId: string,
+  version: string,
+): void {
+  const entries = readAssistants();
+  const entry = entries.find((e) => e.assistantId === assistantId);
+  if (!entry) return;
+  if (entry.serviceGroupVersion === version) return;
+  entry.serviceGroupVersion = version;
+  writeAssistants(entries);
+}
+
+/**
  * Scan upward from `basePort` to find an available port. A port is considered
  * available when `probePort()` returns false (nothing listening). Scans up to
  * 100 ports above the base before giving up.


### PR DESCRIPTION
## Summary
- Add `updateServiceGroupVersion()` helper to assistant-config.ts for targeted lockfile updates
- Wire into `vellum ps` to persist version from health check responses
- No-op when version unchanged to avoid unnecessary lockfile writes

Part of plan: version-compat-checking.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19954" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
