### PR TITLE
feat: add dangerouslySkipPermissions config to auto-approve all permission prompts

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -437,7 +437,7 @@ describe("AssistantConfigSchema", () => {
 
   test("defaults permissions.mode to workspace", () => {
     const result = AssistantConfigSchema.parse({});
-    expect(result.permissions).toEqual({ mode: "workspace" });
+    expect(result.permissions).toEqual({ mode: "workspace", dangerouslySkipPermissions: false });
   });
 
   test("accepts explicit permissions.mode strict", () => {
@@ -1139,7 +1139,7 @@ describe("loadConfig with schema validation", () => {
   test("defaults permissions.mode to workspace when not specified", () => {
     writeConfig({});
     const config = loadConfig();
-    expect(config.permissions).toEqual({ mode: "workspace" });
+    expect(config.permissions).toEqual({ mode: "workspace", dangerouslySkipPermissions: false });
   });
 
   test("loads explicit permissions.mode strict", () => {

--- a/assistant/src/config/schemas/security.ts
+++ b/assistant/src/config/schemas/security.ts
@@ -77,6 +77,10 @@ export const PermissionsConfigSchema = z
       .describe(
         "Permission mode — 'strict' requires explicit approval for all operations, 'workspace' allows operations within the workspace",
       ),
+    dangerouslySkipPermissions: z
+      .boolean({ error: "permissions.dangerouslySkipPermissions must be a boolean" })
+      .default(false)
+      .describe("Auto-accept all permission prompts without asking"),
   })
   .describe("Permission enforcement mode for tool operations");
 

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -137,6 +137,18 @@ export class PermissionChecker {
       }
 
       if (result.decision === "prompt") {
+        // dangerouslySkipPermissions: when enabled, auto-approve all prompts
+        // without user interaction. Deny rules are still respected (they
+        // return before reaching this block).
+        const cfg = getConfig();
+        if (cfg.permissions.dangerouslySkipPermissions) {
+          log.info(
+            { toolName: name, riskLevel },
+            "dangerouslySkipPermissions active — auto-approving without prompt",
+          );
+          return { allowed: true, decision: "dangerously_skip_permissions", riskLevel };
+        }
+
         // Guardian-trust sessions (e.g. scheduled jobs, reminders) should be
         // able to use bundled tools without interactive approval. The guardian
         // is the owner - prompting makes no sense when there is no client.


### PR DESCRIPTION
## Summary
- Add `dangerouslySkipPermissions` boolean field to `PermissionsConfigSchema` (defaults to `false`)
- Wire permission checker to auto-approve all prompts when the config flag is enabled
- Deny rules are still respected — only the interactive prompt path is bypassed

Part of plan: dangerously-skip-permissions.md (PR 1 of 2)