### PR TITLE
Use major.minor version compatibility in Developer Settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -342,6 +342,20 @@ struct SettingsDeveloperTab: View {
         return nil
     }
 
+    /// Whether the assistant and client versions are incompatible (different major.minor).
+    private var isVersionIncompatible: Bool {
+        guard let assistantVersion = healthz?.version, !assistantVersion.isEmpty,
+              let appVersion = desktopAppVersion, !appVersion.isEmpty else {
+            return false
+        }
+        return !VersionCompat.isCompatible(
+            clientVersion: appVersion,
+            serviceGroupVersion: assistantVersion
+        )
+    }
+
+    /// Whether the assistant version is strictly behind the client version.
+    /// Used to determine if an upgrade action should be offered.
     private var assistantVersionBehind: Bool {
         guard let assistantVersion = healthz?.version, !assistantVersion.isEmpty,
               let appVersion = desktopAppVersion, !appVersion.isEmpty else {
@@ -362,7 +376,7 @@ struct SettingsDeveloperTab: View {
             if let version = effectiveVersion {
                 Text(version)
                     .font(VFont.mono)
-                    .foregroundColor(assistantVersionBehind ? VColor.systemNegativeStrong : VColor.contentDefault)
+                    .foregroundColor(isVersionIncompatible ? VColor.systemNegativeStrong : VColor.contentDefault)
                     .textSelection(.enabled)
 
                 if assistantVersionBehind {
@@ -385,9 +399,9 @@ struct SettingsDeveloperTab: View {
             Spacer()
         }
 
-        if assistantVersionBehind, let appVersion = desktopAppVersion {
+        if isVersionIncompatible, let appVersion = desktopAppVersion {
             HStack(spacing: VSpacing.xs) {
-                Text("Desktop is on")
+                Text(assistantVersionBehind ? "Desktop is on" : "Incompatible with desktop")
                     .font(VFont.caption)
                     .foregroundColor(VColor.contentTertiary)
                 Text(appVersion)


### PR DESCRIPTION
## Summary
- Add `isVersionIncompatible` computed property using `VersionCompat.isCompatible()`
- Red version text now triggers on any major.minor mismatch (not just when behind)
- Upgrade button still only shows when assistant is behind
- Context-appropriate label: "Desktop is on" vs "Incompatible with desktop"

Part of plan: version-compat-checking.md (PR 7 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
