### PR TITLE
Persist serviceGroupVersion to lockfile from Swift health checks

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -656,9 +656,17 @@ public final class HTTPTransport {
                 }
                 throw HTTPTransportError.healthCheckFailed
             }
-            // Extract daemon version from response body (best-effort, never fails the health check)
+            // Extract daemon version from response body (best-effort, never fails the health check).
+            // Persist to lockfile only when the version actually changes to avoid constant disk I/O.
             if let decoded = try? JSONDecoder().decode(HealthzVersionResponse.self, from: data) {
-                daemonVersion = decoded.version
+                if let newVersion = decoded.version, newVersion != daemonVersion {
+                    daemonVersion = newVersion
+                    if let id = UserDefaults.standard.string(forKey: "connectedAssistantId"), !id.isEmpty {
+                        LockfilePaths.updateServiceGroupVersion(assistantId: id, version: newVersion)
+                    }
+                } else if let newVersion = decoded.version {
+                    daemonVersion = newVersion
+                }
             }
             log.info("Health check passed for \(self.baseURL, privacy: .public)")
             // When the daemon comes back during a planned update, reset the

--- a/clients/shared/Utilities/LockfilePaths.swift
+++ b/clients/shared/Utilities/LockfilePaths.swift
@@ -87,4 +87,29 @@ public enum LockfilePaths {
 
         return "http://127.0.0.1:\(resolveGatewayPort(connectedAssistantId: connectedAssistantId))"
     }
+
+    /// Update `serviceGroupVersion` on a lockfile entry.
+    /// No-op if the entry doesn't exist or the version hasn't changed.
+    public static func updateServiceGroupVersion(
+        assistantId: String,
+        version: String
+    ) {
+        guard var lockfile = read() else { return }
+        guard var assistants = lockfile["assistants"] as? [[String: Any]] else { return }
+        guard let index = assistants.firstIndex(where: {
+            ($0["assistantId"] as? String) == assistantId
+        }) else { return }
+
+        let current = assistants[index]["serviceGroupVersion"] as? String
+        if current == version { return }
+
+        assistants[index]["serviceGroupVersion"] = version
+        lockfile["assistants"] = assistants
+
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: lockfile,
+            options: [.prettyPrinted, .sortedKeys]
+        ) else { return }
+        try? data.write(to: primary, options: .atomic)
+    }
 }


### PR DESCRIPTION
## Summary
- Add `LockfilePaths.updateServiceGroupVersion()` for atomic lockfile field updates
- Wire into HTTPTransport health check to persist version changes to lockfile
- Only writes when version changes to avoid constant disk I/O

Part of plan: version-compat-checking.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
