### PR TITLE
fix: propagate real docker stop errors, warn on ignored wake flags

### DIFF
--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -40,6 +40,14 @@ export async function wake(): Promise<void> {
   const entry = resolveTargetAssistant(nameArg);
 
   if (entry.cloud === "docker") {
+    if (watch || foreground) {
+      const ignored = [watch && "--watch", foreground && "--foreground"]
+        .filter(Boolean)
+        .join(" and ");
+      console.warn(
+        `Warning: ${ignored} ignored for Docker instances (not supported).`,
+      );
+    }
     const res = dockerResourceNames(entry.assistantId);
     await wakeContainers(res);
     console.log("Docker containers started.");

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -771,8 +771,17 @@ export async function sleepContainers(
   ]) {
     try {
       await exec("docker", ["stop", container]);
-    } catch {
-      // container may not exist or already stopped
+    } catch (err) {
+      const msg =
+        err instanceof Error ? err.message.toLowerCase() : String(err);
+      if (
+        msg.includes("no such container") ||
+        msg.includes("is not running")
+      ) {
+        // container doesn't exist or already stopped — expected, skip
+        continue;
+      }
+      throw err;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Replace blanket catch in sleepContainers that swallowed all docker stop errors with targeted catch for expected container-not-found/already-stopped errors
- Add warning when --watch or --foreground flags are used with Docker instances (they have no effect)

Addresses feedback from #19765.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
