### PR TITLE
fix: use getWorkspaceDir() instead of hardcoded workspace path

### DIFF
--- a/assistant/src/messaging/draft-store.ts
+++ b/assistant/src/messaging/draft-store.ts
@@ -10,7 +10,7 @@ import { readdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { ensureDir, pathExists } from "../util/fs.js";
-import { getRootDir } from "../util/platform.js";
+import { getWorkspaceDir } from "../util/platform.js";
 
 export interface Draft {
   id: string;
@@ -25,7 +25,7 @@ export interface Draft {
 }
 
 function getDraftsDir(platform: string): string {
-  const dir = join(getRootDir(), "workspace", "data", "drafts", platform);
+  const dir = join(getWorkspaceDir(), "data", "drafts", platform);
   ensureDir(dir);
   return dir;
 }

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -2,7 +2,7 @@ import { join } from "node:path";
 
 import { getConfig } from "../config/loader.js";
 import { getBundledSkillsDir } from "../config/skills.js";
-import { getRootDir } from "../util/platform.js";
+import { getWorkspaceDir } from "../util/platform.js";
 
 export interface DefaultRuleTemplate {
   id: string;
@@ -116,7 +116,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   // Workspace prompt files — the agent should always be able to read, edit,
   // and write these without prompting.  Also allow `rm BOOTSTRAP.md` so the
   // agent can delete it at the end of the onboarding ritual.
-  const workspaceDir = join(getRootDir(), "workspace").replaceAll("\\", "/");
+  const workspaceDir = getWorkspaceDir().replaceAll("\\", "/");
   const WORKSPACE_PROMPT_FILES = [
     "IDENTITY.md",
     "USER.md",
@@ -163,7 +163,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   // Skill source directories — writing or editing skill source files should
   // require explicit user approval so a compromised agent loop cannot silently
   // modify skill code to escalate privileges.
-  const managedSkillsDir = join(getRootDir(), "workspace", "skills").replaceAll(
+  const managedSkillsDir = join(getWorkspaceDir(), "skills").replaceAll(
     "\\",
     "/",
   );


### PR DESCRIPTION
## Summary
- Replace hardcoded join(getRootDir(), 'workspace') with getWorkspaceDir() in permissions/defaults.ts
- Replace hardcoded workspace path in draft-store.ts with getWorkspaceDir()
- Ensures Docker instances with WORKSPACE_DIR set use correct paths for trust rules and drafts

Addresses feedback from #19839.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
