### PR TITLE
feat: add Dangerously Skip Permissions toggle to Developer settings tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -132,6 +132,26 @@ struct SettingsDeveloperTab: View {
                 revokeAssistantApiKeySection
             }
 
+            // Dangerously Skip Permissions
+            SettingsCard(title: "Dangerously Skip Permissions", subtitle: "Auto-accept all permission prompts without asking. The assistant will never pause for approval — use with caution.") {
+                HStack(alignment: .top, spacing: VSpacing.sm) {
+                    VToggle(isOn: Binding(
+                        get: { store.dangerouslySkipPermissions },
+                        set: { store.setDangerouslySkipPermissions($0) }
+                    ))
+                    .accessibilityLabel("Dangerously Skip Permissions")
+                    .padding(.top, 2)
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Skip all permission prompts")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.contentSecondary)
+                        Text("When enabled, tools execute immediately without asking for approval. Explicit deny rules are still respected.")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentTertiary)
+                    }
+                }
+            }
+
             // Permission Simulator
             if let model = testerModel {
                 ToolPermissionTesterView(model: model)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -88,6 +88,10 @@ public final class SettingsStore: ObservableObject {
     @Published var mediaEmbedVideoAllowlistDomains: [String]
     @Published var userTimezone: String?
 
+    // MARK: - Permissions Settings
+
+    @Published var dangerouslySkipPermissions: Bool
+
     // MARK: - Telegram Integration State
 
     @Published var telegramHasBotToken: Bool = false
@@ -404,6 +408,10 @@ public final class SettingsStore: ObservableObject {
         self.mediaEmbedsEnabledSince = mediaSettings.enabledSince
         self.mediaEmbedVideoAllowlistDomains = mediaSettings.domains
         self.userTimezone = Self.loadUserTimezone(from: configPath)
+
+        // Load permissions settings from workspace config
+        let permissionsConfig = WorkspaceConfigIO.read(from: configPath)["permissions"] as? [String: Any]
+        self.dangerouslySkipPermissions = (permissionsConfig?["dangerouslySkipPermissions"] as? Bool) ?? false
 
         // Load web search provider from workspace config
         let config = WorkspaceConfigIO.read(from: configPath)
@@ -2928,6 +2936,19 @@ public final class SettingsStore: ObservableObject {
             guard mediaEmbedsEnabled else { return }
             mediaEmbedsEnabled = false
             persistMediaEmbedState()
+        }
+    }
+
+    func setDangerouslySkipPermissions(_ enabled: Bool) {
+        dangerouslySkipPermissions = enabled
+        guard !isCurrentAssistantRemote else { return }
+        let existingConfig = WorkspaceConfigIO.read(from: configPath)
+        var permissions = existingConfig["permissions"] as? [String: Any] ?? [:]
+        permissions["dangerouslySkipPermissions"] = enabled
+        do {
+            try WorkspaceConfigIO.merge(["permissions": permissions], into: configPath)
+        } catch {
+            log.error("Failed to persist dangerouslySkipPermissions: \(error)")
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `dangerouslySkipPermissions` published property to `SettingsStore` with workspace config persistence
- Add toggle card in Developer tab above the Permission Simulator section
- Reads from and writes to `permissions.dangerouslySkipPermissions` in workspace config.json

Part of plan: dangerously-skip-permissions.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
