### PR TITLE
fix: inline HTML fallback uses correct base URL and refresh path

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -450,8 +450,12 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
 
             if !appDirExists {
                 // App directory not on host (e.g. Docker instance) — load
-                // the HTML returned by the open API inline.
-                let origin = "vellumapp://\(localDir)/"
+                // the HTML returned by the open API inline. Use the same
+                // https:// origin that updateNSView uses so localStorage
+                // persists across HTML updates and relative assets don't
+                // try to load via the scheme handler.
+                let origin = "https://\(appId).vellum.local/"
+                context.coordinator.isInlineFallback = true
                 webView.loadHTMLString(data.html, baseURL: URL(string: origin))
             } else {
                 let distIndex = appDir.appendingPathComponent("dist/index.html")
@@ -550,7 +554,15 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                 context.coordinator.pendingStatus = status
                 context.coordinator.lastStatus = status
             }
-            webView.reload()
+            if context.coordinator.isInlineFallback {
+                // Inline fallback: webView.reload() would replay stale HTML.
+                // Re-load the current data.html so the update is visible.
+                context.coordinator.currentHTML = data.html
+                let origin = appId.map { "https://\($0).vellum.local/" } ?? "https://surface.vellum.local/"
+                webView.loadHTMLString(data.html, baseURL: URL(string: origin))
+            } else {
+                webView.reload()
+            }
             return
         }
         // Reload if the HTML content has changed.
@@ -682,6 +694,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         var hasCapturedSnapshot = false
         var morphGeneration: Int = 0
         var lastReloadGeneration: Int = 0
+        /// True when the app directory is missing and content is loaded inline via data.html.
+        var isInlineFallback: Bool = false
         var lastStatus: String?
         /// Status message to inject after the next page reload completes.
         var pendingStatus: String?


### PR DESCRIPTION
## Summary
- Use `https://` origin (matching `updateNSView`) for inline HTML fallback when app directory is missing, preventing broken relative asset loads via the scheme handler and ensuring localStorage consistency across updates
- Track inline fallback mode on the Coordinator via `isInlineFallback` flag
- Handle `reloadGeneration` properly for inline content by re-loading the HTML string instead of calling `webView.reload()` (which would replay stale HTML)

Addresses feedback from #19782.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
