### PR TITLE
fix: refresh diagnostics snapshot after removal

### DIFF
--- a/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
+++ b/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
@@ -470,6 +470,9 @@ final class ChatDiagnosticsStore {
         if let index = snapshotOrder.firstIndex(of: conversationId) {
             snapshotOrder.remove(at: index)
         }
+
+        // Refresh the background-safe snapshot.
+        refreshLastKnownSnapshot()
     }
 
     // MARK: - Session Log Writing


### PR DESCRIPTION
## Summary
- Add refreshLastKnownSnapshot() call in removeSnapshot to prevent stale diagnostics data in the background-safe copy used for hang context writes

Addresses feedback from #19585.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
