### PR TITLE
fix: gateway config file watcher respects WORKSPACE_DIR

### DIFF
--- a/gateway/src/config-file-watcher.ts
+++ b/gateway/src/config-file-watcher.ts
@@ -6,7 +6,7 @@
 import { existsSync, readFileSync, watch, type FSWatcher } from "node:fs";
 import { dirname, join } from "node:path";
 import { getLogger } from "./logger.js";
-import { getRootDir } from "./credential-reader.js";
+import { getWorkspaceDir } from "./credential-reader.js";
 
 const log = getLogger("config-file-watcher");
 
@@ -23,7 +23,7 @@ export type ConfigChangeEvent = {
 export type ConfigChangeCallback = (event: ConfigChangeEvent) => void;
 
 function getConfigPath(): string {
-  return join(getRootDir(), "workspace", CONFIG_FILENAME);
+  return join(getWorkspaceDir(), CONFIG_FILENAME);
 }
 
 function readConfigFile(path: string): Record<string, unknown> {


### PR DESCRIPTION
## Summary
- Update config-file-watcher.ts to use `getWorkspaceDir()` instead of hardcoded `join(getRootDir(), 'workspace')` for config path resolution
- Ensures config file changes are detected in Docker deployments where `WORKSPACE_DIR` is set

Addresses feedback from #19846.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
