### PR TITLE
fix: CES credential delete and timing-safe token comparison

### DIFF
--- a/credential-executor/src/http/credential-routes.ts
+++ b/credential-executor/src/http/credential-routes.ts
@@ -16,6 +16,8 @@
  * via the environment.
  */
 
+import { timingSafeEqual } from "node:crypto";
+
 import type { SecureKeyBackend } from "@vellumai/credential-storage";
 
 // ---------------------------------------------------------------------------
@@ -43,7 +45,9 @@ function checkAuth(req: Request, serviceToken: string): Response | null {
     );
   }
 
-  if (parts[1] !== serviceToken) {
+  const provided = Buffer.from(parts[1]!);
+  const expected = Buffer.from(serviceToken);
+  if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
     return new Response(
       JSON.stringify({ error: "Invalid service token" }),
       { status: 403, headers: { "Content-Type": "application/json" } },

--- a/credential-executor/src/materializers/local-secure-key-backend.ts
+++ b/credential-executor/src/materializers/local-secure-key-backend.ts
@@ -230,9 +230,9 @@ function readStore(storePath: string): StoreFile | null {
 /**
  * Create a SecureKeyBackend backed by the assistant's encrypted key store.
  *
- * Supports `get` and `set` operations. `set` is needed for persisting
- * refreshed OAuth tokens. `delete` remains unsupported (returns "error")
- * because CES never needs to remove keys.
+ * Supports `get`, `set`, and `delete` operations. `set` is needed for
+ * persisting refreshed OAuth tokens. `delete` removes a key from the
+ * encrypted store.
  *
  * @param vellumRoot - The Vellum root directory (e.g. `~/.vellum`).
  * @param options.entropyOverride - If provided, used instead of local
@@ -310,9 +310,19 @@ export function createLocalSecureKeyBackend(
       }
     },
 
-    // CES never deletes keys — only reads and writes (for token refresh).
-    async delete(_key: string): Promise<SecureKeyDeleteResult> {
-      return "error";
+    async delete(key: string): Promise<SecureKeyDeleteResult> {
+      try {
+        const store = readStore(storePath);
+        if (!store) return "error";
+
+        if (!(key in store.entries)) return "not-found";
+
+        delete store.entries[key];
+        writeStore(store, storePath);
+        return "deleted";
+      } catch {
+        return "error";
+      }
     },
 
     async list(): Promise<string[]> {


### PR DESCRIPTION
## Summary
- Implement real delete() in local-secure-key-backend.ts instead of always returning 'error'
- Replace plain !== token comparison with crypto.timingSafeEqual in credential-routes.ts

Addresses feedback from #19866.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
