### PR TITLE
fix: include meta/provider-env-vars.json in assistant Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 !assistant/**
 !credential-executor/
 !credential-executor/**
+!meta/provider-env-vars.json
 !packages/
 !packages/**
 

--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -25,6 +25,9 @@ COPY packages/egress-proxy ./packages/egress-proxy
 COPY assistant/package.json assistant/bun.lock ./assistant/
 RUN cd /app/assistant && bun install --frozen-lockfile
 
+# Copy meta files needed by assistant (provider-env-vars.json)
+COPY meta/provider-env-vars.json ./meta/provider-env-vars.json
+
 # Copy source
 COPY assistant ./assistant
 


### PR DESCRIPTION
## Summary
- Add `meta/provider-env-vars.json` to `.dockerignore` allowlist so it's included in the Docker build context
- Add `COPY meta/provider-env-vars.json` to `assistant/Dockerfile` so the file is available at runtime

Fixes a startup crash: `Cannot find module '../../../meta/provider-env-vars.json'`

## Test plan
- [ ] Build the assistant Docker image and verify it starts without the missing module error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
