### PR TITLE
fix: bound stdout buffering during inline command streaming

### DIFF
--- a/assistant/src/skills/inline-command-runner.ts
+++ b/assistant/src/skills/inline-command-runner.ts
@@ -38,6 +38,15 @@ const DEFAULT_TIMEOUT_MS = 10_000;
 const MAX_OUTPUT_CHARS = 20_000;
 
 /**
+ * Maximum bytes to buffer from stdout during streaming. Once this limit is
+ * reached we stop accepting data so a long-running command (e.g. `yes`) cannot
+ * grow memory unbounded before the timeout fires. Set generously above
+ * MAX_OUTPUT_CHARS to account for multi-byte UTF-8 and ANSI sequences that will
+ * be stripped before the character-level clamp.
+ */
+const MAX_STDOUT_BUFFER_BYTES = MAX_OUTPUT_CHARS * 4;
+
+/**
  * ANSI escape sequence pattern (covers SGR, cursor movement, erase, etc.).
  * Matches: ESC[ ... final_byte  and  ESC] ... ST  (OSC sequences).
  */
@@ -116,6 +125,7 @@ export async function runInlineCommand(
   return new Promise<InlineCommandResult>((resolve) => {
     let timedOut = false;
     const stdoutChunks: Buffer[] = [];
+    let stdoutBytes = 0;
 
     let child: ReturnType<typeof spawn>;
     try {
@@ -140,7 +150,15 @@ export async function runInlineCommand(
       child.kill("SIGKILL");
     }, timeoutMs);
 
-    child.stdout!.on("data", (data: Buffer) => stdoutChunks.push(data));
+    child.stdout!.on("data", (data: Buffer) => {
+      if (stdoutBytes >= MAX_STDOUT_BUFFER_BYTES) return;
+      stdoutChunks.push(data);
+      stdoutBytes += data.length;
+      if (stdoutBytes >= MAX_STDOUT_BUFFER_BYTES) {
+        // Stop reading to release backpressure on the child process
+        child.stdout!.destroy();
+      }
+    });
 
     child.on("close", (code) => {
       clearTimeout(timer);


### PR DESCRIPTION
## Summary
- Add a byte-level size limit (`MAX_STDOUT_BUFFER_BYTES`) to stdout buffering during inline command execution
- Stop accepting data and destroy the stdout stream once the cap is reached, so memory doesn't grow unbounded for long-running commands before the 10s timeout fires

Addresses feedback from #19610.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
