### PR TITLE
fix: correct follow-ups sort order to most-urgent-first

### DIFF
--- a/assistant/src/followups/followup-store.ts
+++ b/assistant/src/followups/followup-store.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, lte, or } from "drizzle-orm";
+import { and, asc, eq, lte, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../memory/db.js";
@@ -217,7 +217,7 @@ export function getPendingAndOverdueFollowUps(): BriefFollowUp[] {
         eq(followups.status, "nudged"),
       ),
     )
-    .orderBy(desc(followups.expectedResponseBy))
+    .orderBy(asc(followups.expectedResponseBy))
     .all();
 
   return rows as BriefFollowUp[];


### PR DESCRIPTION
## Summary
- Change sort from desc(expectedResponseBy) to asc(expectedResponseBy) so most urgent follow-ups appear first, matching the docstring
- Remove unused `desc` import

Addresses feedback from #19644.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
