### PR TITLE
fix: enable MCP reload signal handling in containerized mode

### DIFF
--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -12,7 +12,6 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
-import { getIsContainerized } from "../config/env-registry.js";
 import { getConfig, invalidateConfigCache } from "../config/loader.js";
 import { clearEmbeddingBackendCache } from "../memory/embedding-backend.js";
 import { clearCache as clearTrustCache } from "../permissions/trust-store.js";
@@ -210,9 +209,7 @@ export class ConfigWatcher {
       );
     }
 
-    if (!getIsContainerized()) {
-      this.startSignalsWatcher();
-    }
+    this.startSignalsWatcher();
     this.startSkillsWatchers(onConversationEvict);
   }
 


### PR DESCRIPTION
## Summary
- Restore signals watcher in containerized mode so that `assistant mcp reload` works in Docker
- The outer `getIsContainerized()` guard on `startSignalsWatcher()` was redundant — each signal handler that shouldn't run in containers (cancel, confirm, bash, shotgun, trust-rule, conversation-undo) already has its own `getIsContainerized()` guard
- The MCP reload handler intentionally lacks a containerized guard because it needs to work within the container

Addresses feedback from #19842.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
