### PR TITLE
fix: child skill catch block propagates errors like root skill

### DIFF
--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -440,10 +440,14 @@ export class SkillLoadTool implements Tool {
                 "Rendered inline command expansions for included skill",
               );
             } catch (err) {
-              log.warn(
+              log.error(
                 { err, skillId: childId, parentSkillId: skill.id },
-                "Failed to render inline commands for included skill, using raw body",
+                "Failed to render inline commands for included skill",
               );
+              return {
+                content: `Error: failed to render inline commands for included skill "${childId}": ${err instanceof Error ? err.message : String(err)}`,
+                isError: true,
+              };
             }
           }
 


### PR DESCRIPTION
## Summary
- Change child skill catch block from fail-open (raw body fallback) to fail-closed (propagate error) matching root skill behavior
- Prevents unexpanded tokens from appearing in prompts on render exceptions

Addresses feedback from #19672.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
