### PR TITLE
fix: resolve main actor isolation warning for AppDelegate.appName

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -15,7 +15,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     /// The canonical product name shown in menus and the About panel.
     /// Use this instead of hardcoding "Vellum" so the name is defined
     /// in one place.
-    public static let appName = "Vellum"
+    public nonisolated(unsafe) static let appName = "Vellum"
 
     /// Shared reference — `NSApp.delegate as? AppDelegate` fails under
     /// SwiftUI's `@NSApplicationDelegateAdaptor` because SwiftUI wraps


### PR DESCRIPTION
## Summary
- Mark `AppDelegate.appName` as `nonisolated(unsafe)` to fix the Swift strict concurrency warning about accessing a main actor-isolated static property from a nonisolated context (`AppBundleRenamer`)
- Safe because `appName` is an immutable `String` constant — no actual data race is possible

## Original prompt
Fix Swift 6 warning: `main actor-isolated static property 'appName' can not be referenced from a nonisolated context` in `AppBundleRenamer.swift:22`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19975" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
