### PR TITLE
fix: quote baseDir path in inline command, update stale inference docs

### DIFF
--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -38,7 +38,7 @@ Consult these reference files for detailed knowledge on specific topics. Read th
 
 ## Current Assistant Info
 
-!`bun run {baseDir}/scripts/self-info.ts`
+!`bun run "{baseDir}/scripts/self-info.ts"`
 
 ## Critical Rule
 

--- a/skills/vellum-self-knowledge/references/inference.md
+++ b/skills/vellum-self-knowledge/references/inference.md
@@ -2,21 +2,9 @@
 
 ## Current Model Identity
 
-To determine what model and provider you are currently running as, run the self-info script command shown in SKILL.md above.
+Your current model identity (model ID, provider, and mode) is automatically injected into the SKILL.md body at skill-load time via inline command expansion. There is no need to run a script manually — the information is pre-populated when the skill loads and reflects the live configuration.
 
-The script returns JSON with the current model ID, display name, provider, and provider display name. **Always run this script when asked about your model identity** rather than guessing — the config can change mid-session via the model switcher in the UI.
-
-Example output:
-
-```json
-{
-  "ok": true,
-  "model": { "id": "gpt-5.2", "displayName": "GPT-5.2" },
-  "provider": { "id": "openai", "displayName": "OpenAI" },
-  "mode": "your-own",
-  "summary": "You are running as GPT-5.2 via OpenAI (your-own API key)."
-}
-```
+If the user switches models mid-session via the UI, the skill will reflect the updated config the next time it is loaded.
 
 ## Model Catalog
 


### PR DESCRIPTION
## Summary
- Quote `{baseDir}` in inline `bash -c` command to handle paths with spaces
- Update `references/inference.md` to remove stale manual script instructions now handled by inline command expansion

Addresses feedback from #19649.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
