### PR TITLE
fix: escape command output in XML skill tags to prevent marker injection

### DIFF
--- a/assistant/src/skills/inline-command-render.ts
+++ b/assistant/src/skills/inline-command-render.ts
@@ -14,6 +14,7 @@
  */
 
 import { getLogger } from "../util/logger.js";
+import { escapeXmlContent } from "../util/xml.js";
 import type { InlineCommandExpansion } from "./inline-command-expansions.js";
 import type { InlineCommandResult } from "./inline-command-runner.js";
 import { runInlineCommand } from "./inline-command-runner.js";
@@ -91,7 +92,10 @@ export async function renderInlineCommands(
 
     let replacement: string;
     if (commandResult.ok) {
-      replacement = wrapInXml(expansion.placeholderId, commandResult.output);
+      replacement = wrapInXml(
+        expansion.placeholderId,
+        escapeXmlContent(commandResult.output),
+      );
       expandedCount++;
     } else {
       const stub = failureReasonToStub(commandResult);

--- a/assistant/src/util/xml.ts
+++ b/assistant/src/util/xml.ts
@@ -6,3 +6,11 @@ export function escapeXmlAttr(s: string): string {
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
 }
+
+/** Escape a string for safe inclusion as XML/HTML text content. */
+export function escapeXmlContent(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}


### PR DESCRIPTION
## Summary
- Escape raw command output before embedding in XML tags so that output containing skill marker patterns (like \</inline_skill_command\>) cannot break the wrapping structure
- Added `escapeXmlContent` utility alongside existing `escapeXmlAttr`

Addresses feedback from #19623.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
