### PR TITLE
fix: add missing permissions mock to test configs

### DIFF
--- a/assistant/src/__tests__/require-fresh-approval.test.ts
+++ b/assistant/src/__tests__/require-fresh-approval.test.ts
@@ -58,6 +58,10 @@ const mockConfig = {
     action: "warn" as const,
     entropyThreshold: 4.0,
   },
+  permissions: {
+    mode: "workspace" as const,
+    dangerouslySkipPermissions: false,
+  },
 };
 
 let fakeToolResult: ToolExecutionResult = { content: "ok", isError: false };

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -32,6 +32,10 @@ const mockConfig = {
     action: "warn" as const,
     entropyThreshold: 4.0,
   },
+  permissions: {
+    mode: "workspace" as const,
+    dangerouslySkipPermissions: false,
+  },
 };
 
 let checkerDecision: "allow" | "prompt" | "deny" = "allow";

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -50,6 +50,10 @@ const mockConfig = {
     action: "warn" as const,
     entropyThreshold: 4.0,
   },
+  permissions: {
+    mode: "workspace" as const,
+    dangerouslySkipPermissions: false,
+  },
 };
 
 let fakeToolResult: ToolExecutionResult = { content: "ok", isError: false };


### PR DESCRIPTION
## Summary
- Added `permissions: { mode: "workspace", dangerouslySkipPermissions: false }` to the mock config in `tool-executor.test.ts`, `require-fresh-approval.test.ts`, and `tool-executor-lifecycle-events.test.ts`
- These mocks were missed when commit `48bc226b7` added the `dangerouslySkipPermissions` config property and the permission checker started reading it

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23327332498/job/67851198857
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
