### PR TITLE
fix: document intentional requireFreshApproval bypass in dangerouslySkipPermissions

### DIFF
--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -140,6 +140,12 @@ export class PermissionChecker {
         // dangerouslySkipPermissions: when enabled, auto-approve all prompts
         // without user interaction. Deny rules are still respected (they
         // return before reaching this block).
+        //
+        // Note: unlike guardian auto-approve and temporary overrides below,
+        // this intentionally does NOT check `context.requireFreshApproval`.
+        // The setting is designed to skip ALL interactive prompts
+        // unconditionally — it is an explicit operator opt-out from the
+        // permission system, so requireFreshApproval does not apply.
         const cfg = getConfig();
         if (cfg.permissions.dangerouslySkipPermissions) {
           log.info(


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for dangerously-skip-permissions.md.

**Gap:** Missing comment explaining intentional requireFreshApproval bypass
**What was expected:** Documentation explaining why dangerouslySkipPermissions does not check requireFreshApproval
**What was found:** No comment explaining the intentional divergence from other auto-approve paths
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
