### PR TITLE
GA Custom Inference Provider

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -12,12 +12,6 @@ struct APIKeyEntryStepView: View {
     @State private var showContent = false
     @FocusState private var keyFieldFocused: Bool
 
-    // MARK: - Feature Flag
-
-    private var isCustomProviderEnabled: Bool {
-        MacOSClientFeatureFlagManager.shared.isEnabled("custom_inference_provider_enabled")
-    }
-
     // MARK: - Provider Catalog
 
     private var providerCatalog: [ProviderCatalogEntry] {
@@ -68,16 +62,14 @@ struct APIKeyEntryStepView: View {
     // MARK: - Body
 
     var body: some View {
-        Text(isCustomProviderEnabled ? "Connect a Model Provider" : "Anthropic API Key")
+        Text("Connect a Model Provider")
             .font(.system(size: 32, weight: .regular, design: .serif))
             .foregroundColor(VColor.contentDefault)
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)
             .padding(.bottom, VSpacing.md)
 
-        Text(isCustomProviderEnabled
-            ? "Enter an API key to connect your model provider."
-            : "Enter your Anthropic API key to get started.")
+        Text("Enter an API key to connect your model provider.")
             .font(VFont.buttonLarge)
             .multilineTextAlignment(.center)
             .foregroundColor(VColor.contentSecondary)
@@ -87,49 +79,29 @@ struct APIKeyEntryStepView: View {
 
         VStack(spacing: VSpacing.md) {
             VStack(spacing: VSpacing.md) {
-                if isCustomProviderEnabled {
-                    providerPicker
+                providerPicker
 
-                    if providerRequiresKey {
-                        apiKeyField
-                    }
-
-                    OnboardingButton(
-                        title: "Continue",
-                        style: .primary,
-                        disabled: providerRequiresKey && apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                    ) {
-                        saveAndHatch()
-                    }
-
-                    if let apiKeyUrl = currentProviderEntry?.apiKeyUrl,
-                       let url = URL(string: apiKeyUrl) {
-                        OnboardingButton(title: "Get an API key", style: .ghostPrimary) {
-                            NSWorkspace.shared.open(url)
-                        }
-                    }
-
-                    OnboardingButton(title: "Back", style: .ghost) {
-                        goBack()
-                    }
-                } else {
+                if providerRequiresKey {
                     apiKeyField
+                }
 
-                    OnboardingButton(
-                        title: "Continue",
-                        style: .primary,
-                        disabled: apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                    ) {
-                        saveAndHatch()
-                    }
+                OnboardingButton(
+                    title: "Continue",
+                    style: .primary,
+                    disabled: providerRequiresKey && apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ) {
+                    saveAndHatch()
+                }
 
+                if let apiKeyUrl = currentProviderEntry?.apiKeyUrl,
+                   let url = URL(string: apiKeyUrl) {
                     OnboardingButton(title: "Get an API key", style: .ghostPrimary) {
-                        NSWorkspace.shared.open(URL(string: "https://console.anthropic.com/settings/keys")!)
+                        NSWorkspace.shared.open(url)
                     }
+                }
 
-                    OnboardingButton(title: "Back", style: .ghost) {
-                        goBack()
-                    }
+                OnboardingButton(title: "Back", style: .ghost) {
+                    goBack()
                 }
             }
         }
@@ -137,16 +109,9 @@ struct APIKeyEntryStepView: View {
         .opacity(showContent ? 1 : 0)
         .offset(y: showContent ? 0 : 12)
         .onAppear {
-            if isCustomProviderEnabled {
-                if let existingKey = APIKeyManager.getKey(for: state.selectedProvider) {
-                    apiKey = existingKey
-                    hasExistingKey = true
-                }
-            } else {
-                if let existingKey = APIKeyManager.getKey(for: "anthropic") {
-                    apiKey = existingKey
-                    hasExistingKey = true
-                }
+            if let existingKey = APIKeyManager.getKey(for: state.selectedProvider) {
+                apiKey = existingKey
+                hasExistingKey = true
             }
             withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
                 showTitle = true
@@ -197,7 +162,7 @@ struct APIKeyEntryStepView: View {
         Group {
             if hasExistingKey && !isEditing {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    Text(isCustomProviderEnabled ? "\(providerDisplayName) API Key" : "API Key")
+                    Text("\(providerDisplayName) API Key")
                         .font(VFont.inputLabel)
                         .foregroundColor(VColor.contentSecondary)
                     Text(maskedKey)
@@ -217,7 +182,7 @@ struct APIKeyEntryStepView: View {
                 }
             } else {
                 VTextField(
-                    isCustomProviderEnabled ? "\(providerDisplayName) API Key" : "API Key",
+                    "\(providerDisplayName) API Key",
                     placeholder: currentProviderEntry?.apiKeyPlaceholder ?? "Enter your API key",
                     text: $apiKey,
                     isSecure: true,
@@ -250,45 +215,20 @@ struct APIKeyEntryStepView: View {
     }
 
     private func saveAndHatch() {
-        if isCustomProviderEnabled {
-            let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !providerRequiresKey || !trimmed.isEmpty else { return }
-            if providerRequiresKey {
-                APIKeyManager.setKey(trimmed, for: state.selectedProvider)
-            }
-            WorkspaceConfigIO.initializeServiceDefaults(defaultMode: "your-own", force: true)
-            // Persist provider + model
-            let existingConfig = WorkspaceConfigIO.read()
-            var services = existingConfig["services"] as? [String: Any] ?? [:]
-            var inference = services["inference"] as? [String: Any] ?? [:]
-            inference["provider"] = state.selectedProvider
-            inference["model"] = state.selectedModel
-            services["inference"] = inference
-            try? WorkspaceConfigIO.merge(["services": services])
-            state.advance()
-        } else {
-            let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else { return }
-            state.selectedProvider = "anthropic"
-            state.selectedModel = "claude-opus-4-6"
-            APIKeyManager.setKey(trimmed, for: "anthropic")
-
-            // Force service modes to "your-own" — the user explicitly chose to
-            // provide their own API key, which should override any mode that the
-            // managed bootstrap may have set asynchronously before this point.
-            WorkspaceConfigIO.initializeServiceDefaults(defaultMode: "your-own", force: true)
-
-            saveModelToConfig("claude-opus-4-6")
-            state.advance()
+        let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !providerRequiresKey || !trimmed.isEmpty else { return }
+        if providerRequiresKey {
+            APIKeyManager.setKey(trimmed, for: state.selectedProvider)
         }
-    }
-
-    private func saveModelToConfig(_ model: String) {
+        WorkspaceConfigIO.initializeServiceDefaults(defaultMode: "your-own", force: true)
+        // Persist provider + model
         let existingConfig = WorkspaceConfigIO.read()
         var services = existingConfig["services"] as? [String: Any] ?? [:]
         var inference = services["inference"] as? [String: Any] ?? [:]
-        inference["model"] = model
+        inference["provider"] = state.selectedProvider
+        inference["model"] = state.selectedModel
         services["inference"] = inference
         try? WorkspaceConfigIO.merge(["services": services])
+        state.advance()
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -6,11 +6,7 @@ import VellumAssistantShared
 /// Shows different content based on mode and auth state:
 /// - **Managed + logged in**: Model picker, Save button
 /// - **Managed + not logged in**: Empty state prompting login
-/// - **Your Own**: API key field, model picker, Save + Reset buttons
-///
-/// When the `custom-inference-provider` feature flag is enabled,
-/// shows an additional provider picker in Your Own mode, adapts the
-/// API key label, and switches model catalogs per-provider.
+/// - **Your Own**: Provider picker, API key field, model picker, Save + Reset buttons
 @MainActor
 struct InferenceServiceCard: View {
     @ObservedObject var store: SettingsStore
@@ -37,17 +33,10 @@ struct InferenceServiceCard: View {
     /// from user-initiated picks and skip the model/key reset.
     @State private var isSyncingProviderFromStore = false
 
-    // MARK: - Feature Flag
-
-    private var isCustomProviderEnabled: Bool {
-        MacOSClientFeatureFlagManager.shared.isEnabled("custom_inference_provider_enabled")
-    }
-
     // MARK: - Provider Helpers
 
-    /// When the flag is off, always Anthropic; when on, use the draft provider.
     private var effectiveProvider: String {
-        isCustomProviderEnabled ? draftProvider : "anthropic"
+        draftProvider
     }
 
     private var providerDisplayName: String {
@@ -57,7 +46,7 @@ struct InferenceServiceCard: View {
     // MARK: - Computed State
 
     private var isConnected: Bool {
-        isCustomProviderEnabled ? store.hasKeyForProvider(effectiveProvider) : store.hasKey
+        store.hasKeyForProvider(effectiveProvider)
     }
 
     private var isLoggedIn: Bool {
@@ -96,7 +85,7 @@ struct InferenceServiceCard: View {
         let hasNewKey = draftMode == "your-own" && !apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let modelChanged = draftModel != initialModel
         let effectiveDraftProvider = draftMode == "managed" ? "anthropic" : draftProvider
-        let providerChanged = isCustomProviderEnabled && effectiveDraftProvider != initialProvider
+        let providerChanged = effectiveDraftProvider != initialProvider
         return modeChanged || hasNewKey || modelChanged || providerChanged
     }
 
@@ -120,9 +109,7 @@ struct InferenceServiceCard: View {
             },
             yourOwnContent: {
                 VStack(alignment: .leading, spacing: VSpacing.md) {
-                    if isCustomProviderEnabled {
-                        providerPicker
-                    }
+                    providerPicker
 
                     // Model picker
                     modelPicker
@@ -137,11 +124,7 @@ struct InferenceServiceCard: View {
                         onSave: { save() },
                         savingLabel: "Validating...",
                         onReset: {
-                            if isCustomProviderEnabled {
-                                store.clearAPIKeyForProvider(effectiveProvider)
-                            } else {
-                                store.clearAPIKey()
-                            }
+                            store.clearAPIKeyForProvider(effectiveProvider)
                             apiKeyText = ""
                         },
                         showReset: isConnected
@@ -241,22 +224,20 @@ struct InferenceServiceCard: View {
                 return
             }
             guard didInitialSync else { return }
-            if isCustomProviderEnabled {
-                let defaultModel = store.dynamicProviderDefaultModel(newProvider)
-                let fallback = store.dynamicProviderModels(newProvider).first?.id ?? ""
-                draftModel = defaultModel.isEmpty ? fallback : defaultModel
-            }
+            let defaultModel = store.dynamicProviderDefaultModel(newProvider)
+            let fallback = store.dynamicProviderModels(newProvider).first?.id ?? ""
+            draftModel = defaultModel.isEmpty ? fallback : defaultModel
             apiKeyText = ""
         }
         .onChange(of: draftMode) { _, newMode in
-            if newMode == "managed" && isCustomProviderEnabled {
+            if newMode == "managed" {
                 let anthropicModels = store.dynamicProviderModels("anthropic")
                 let isCurrentModelAnthropic = anthropicModels.contains { $0.id == draftModel }
                 if !isCurrentModelAnthropic {
                     let defaultModel = store.dynamicProviderDefaultModel("anthropic")
                     draftModel = defaultModel.isEmpty ? "claude-opus-4-6" : defaultModel
                 }
-            } else if newMode == "your-own" && isCustomProviderEnabled {
+            } else if newMode == "your-own" {
                 let providerModels = store.dynamicProviderModels(draftProvider)
                 let isCurrentModelValid = providerModels.contains { $0.id == draftModel }
                 if !isCurrentModelValid {
@@ -328,7 +309,7 @@ struct InferenceServiceCard: View {
             return "Enter your API key"
         }()
         return VTextField(
-            isCustomProviderEnabled ? "\(providerDisplayName) API Key" : "API Key",
+            "\(providerDisplayName) API Key",
             placeholder: placeholder,
             text: $apiKeyText,
             isSecure: true,
@@ -345,27 +326,11 @@ struct InferenceServiceCard: View {
             Text("Active Model")
                 .font(VFont.inputLabel)
                 .foregroundColor(VColor.contentSecondary)
-            if isCustomProviderEnabled {
-                providerModelPicker
-            } else {
-                defaultModelPicker
-            }
+            providerModelPicker
         }
     }
 
-    /// Anthropic-only model dropdown (flag off, backward compat).
-    private var defaultModelPicker: some View {
-        VDropdown(
-            placeholder: "Select a model\u{2026}",
-            selection: $draftModel,
-            options: store.dynamicProviderModels("anthropic").map { model in
-                (label: model.displayName, value: model.id)
-            },
-            maxWidth: 400
-        )
-    }
-
-    /// Per-provider catalog model dropdown (flag on).
+    /// Per-provider catalog model dropdown.
     private var providerModelPicker: some View {
         let provider = draftMode == "managed" ? "anthropic" : draftProvider
         return VDropdown(
@@ -400,18 +365,18 @@ struct InferenceServiceCard: View {
             store.setInferenceMode(draftMode)
         }
 
-        // Persist provider if changed and flag is on. Also re-persist when
-        // the mode changed — switching between managed and your-own implies
-        // a provider change even if the resolved provider ID happens to
+        // Persist provider if changed. Also re-persist when the mode
+        // changed — switching between managed and your-own implies a
+        // provider change even if the resolved provider ID happens to
         // match initialProvider (ensures config stays consistent).
         let persistProvider = draftMode == "managed" ? "anthropic" : draftProvider
-        if isCustomProviderEnabled && (persistProvider != initialProvider || modeChanged) {
+        if persistProvider != initialProvider || modeChanged {
             store.setInferenceProvider(persistProvider)
             initialProvider = persistProvider
         }
         // Normalize draftProvider to match what was persisted so hasChanges
         // (which compares draftProvider against initialProvider) stays in sync.
-        if isCustomProviderEnabled && draftProvider != persistProvider {
+        if draftProvider != persistProvider {
             draftProvider = persistProvider
         }
 
@@ -422,29 +387,18 @@ struct InferenceServiceCard: View {
         if draftMode == "your-own" && !trimmedKey.isEmpty {
             let keyTextBinding = $apiKeyText
             let displayName = providerDisplayName
-            if isCustomProviderEnabled {
-                store.saveInferenceAPIKey(trimmedKey, provider: effectiveProvider, onSuccess: {
-                    keyTextBinding.wrappedValue = ""
-                    showToast("\(displayName) API key saved", .success)
-                })
-            } else {
-                store.saveAPIKey(trimmedKey, onSuccess: {
-                    keyTextBinding.wrappedValue = ""
-                    showToast("API key saved", .success)
-                })
-            }
+            store.saveInferenceAPIKey(trimmedKey, provider: effectiveProvider, onSuccess: {
+                keyTextBinding.wrappedValue = ""
+                showToast("\(displayName) API key saved", .success)
+            })
         }
 
         // Persist model selection. Force-send to daemon when the mode
         // changed so the model+provider pair is always re-persisted,
         // even if IDs happen to match the daemon's cached state.
         store.selectedModel = draftModel
-        if isCustomProviderEnabled {
-            let saveProvider = draftMode == "managed" ? "anthropic" : draftProvider
-            store.setModel(draftModel, provider: saveProvider, force: modeChanged)
-        } else {
-            store.setModel(draftModel, force: modeChanged)
-        }
+        let saveProvider = draftMode == "managed" ? "anthropic" : draftProvider
+        store.setModel(draftModel, provider: saveProvider, force: modeChanged)
         initialModel = draftModel
     }
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -26,14 +26,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "custom-inference-provider",
-      "scope": "macos",
-      "key": "custom_inference_provider_enabled",
-      "label": "Custom Inference Provider",
-      "description": "Allow selecting a specific LLM provider and model for inference in Your Own mode",
-      "defaultEnabled": false
-    },
-    {
       "id": "email-channel",
       "scope": "assistant",
       "key": "feature_flags.email-channel.enabled",


### PR DESCRIPTION
## Summary
- Remove the `custom-inference-provider` feature flag from the registry and all Swift consumers
- Settings and onboarding now always show the provider picker, provider-specific API key labels, and per-provider model catalogs
- Simplify `InferenceServiceCard` and `APIKeyEntryStepView` by removing all flag-gated branching (the "flag off" Anthropic-only code paths are deleted)

## Original prompt
Help me GA Custom Inference Provider by deleting the feature flag and updating all consumers to just always have the functionality
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
