### PR TITLE
fix: set gateway maxRequestBodySize to 512 MB

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -884,6 +884,9 @@ async function main() {
   const server = Bun.serve({
     port: config.port,
     idleTimeout: 0,
+    // Match the daemon's 512 MB limit (assistant/src/runtime/http-server.ts)
+    // so large .vbundle imports proxied through the gateway aren't rejected.
+    maxRequestBodySize: 512 * 1024 * 1024,
     websocket: {
       open(ws) {
         if (isBrowserRelaySocketData(ws.data)) {


### PR DESCRIPTION
## Summary
- The gateway's `Bun.serve()` was not setting `maxRequestBodySize`, defaulting to ~128 MB
- Large `.vbundle` restore imports (e.g. 204 MB) sent through the gateway proxy were rejected with 413
- Set `maxRequestBodySize` to 512 MB to match the daemon's limit (`assistant/src/runtime/http-server.ts`)

## Original prompt
fix gateway maxRequestBodySize to match daemon's 512 MB limit for large .vbundle imports
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
