### PR TITLE
fix: isolate child skill inline command render failures

### DIFF
--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -442,12 +442,10 @@ export class SkillLoadTool implements Tool {
             } catch (err) {
               log.error(
                 { err, skillId: childId, parentSkillId: skill.id },
-                "Failed to render inline commands for included skill",
+                "Failed to render inline commands for included skill; falling back to raw body",
               );
-              return {
-                content: `Error: failed to render inline commands for included skill "${childId}": ${err instanceof Error ? err.message : String(err)}`,
-                isError: true,
-              };
+              // Leave childBody unchanged — the raw body is used as a fallback
+              // so that a crash in one child does not prevent sibling rendering.
             }
           }
 


### PR DESCRIPTION
## Summary

- Changed the `catch` block in `load.ts` for child skill inline command rendering to log and fall back to the raw body instead of returning a fatal error
- This ensures a render exception in one included child skill does not prevent sibling skills from loading

## Original prompt

Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23327504526/job/67851765737
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
