### PR TITLE
feat: add `isDocker` and `resolvedRuntimeBaseURL` to LockfileAssistant

### DIFF
--- a/clients/shared/Network/LockfileAssistant.swift
+++ b/clients/shared/Network/LockfileAssistant.swift
@@ -90,6 +90,11 @@ public struct LockfileAssistant {
         cloud.lowercased() == "vellum"
     }
 
+    /// Whether this assistant is running in Docker.
+    public var isDocker: Bool {
+        cloud.lowercased() == "docker"
+    }
+
     /// The resolved workspace directory for this assistant, accounting for both
     /// the canonical `instanceDir` (post-migration) and legacy `baseDataDir`.
     public var workspaceDir: String? {
@@ -123,6 +128,16 @@ public struct LockfileAssistant {
 
     public var localRuntimeBaseURL: String {
         "http://localhost:\(resolvedDaemonPort())"
+    }
+
+    /// Base URL for HTTP calls to the assistant's runtime.
+    /// Docker assistants route through the gateway; local assistants
+    /// hit the daemon port directly.
+    public var resolvedRuntimeBaseURL: String {
+        if isDocker, let runtimeUrl {
+            return runtimeUrl
+        }
+        return localRuntimeBaseURL
     }
 
     public static func loadLatest() -> LockfileAssistant? {


### PR DESCRIPTION
## Summary
- Add `isDocker` computed property to `LockfileAssistant` (matches `cloud == "docker"`)
- Add `resolvedRuntimeBaseURL` that routes Docker through the gateway and local through the daemon port

Part of plan: docker-vbundle-backup-ui.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
