### PR TITLE
fix: route Docker assistants to local .vbundle backup/restore UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -33,7 +33,7 @@ struct AssistantBackupsSection: View {
                 .font(VFont.sectionTitle)
                 .foregroundColor(VColor.contentDefault)
 
-            if assistant.isManaged || assistant.isRemote {
+            if assistant.isManaged || (assistant.isRemote && !assistant.isDocker) {
                 managedBackupContent
             } else {
                 localBackupContent
@@ -56,7 +56,7 @@ struct AssistantBackupsSection: View {
         .vCard(background: VColor.surfaceOverlay)
         .frame(maxWidth: .infinity, alignment: .leading)
         .task {
-            if assistant.isManaged || assistant.isRemote {
+            if assistant.isManaged || (assistant.isRemote && !assistant.isDocker) {
                 await loadManagedBackupsQuietly()
             }
         }
@@ -186,10 +186,10 @@ struct AssistantBackupsSection: View {
         isExporting = true
         defer { isExporting = false }
 
-        let port = assistant.resolvedDaemonPort()
+        let baseURL = assistant.resolvedRuntimeBaseURL
         let token = ActorTokenManager.getToken()
 
-        guard let url = URL(string: "http://localhost:\(port)/v1/migrations/export") else {
+        guard let url = URL(string: "\(baseURL)/v1/migrations/export") else {
             errorMessage = "Invalid assistant URL"
             return
         }
@@ -362,10 +362,10 @@ extension AssistantBackupsSection {
         isImporting = true
         defer { isImporting = false }
 
-        let port = assistant.resolvedDaemonPort()
+        let baseURL = assistant.resolvedRuntimeBaseURL
         let token = ActorTokenManager.getToken()
 
-        guard let url = URL(string: "http://localhost:\(port)/v1/migrations/import") else {
+        guard let url = URL(string: "\(baseURL)/v1/migrations/import") else {
             errorMessage = "Invalid assistant URL"
             return
         }
@@ -395,8 +395,13 @@ extension AssistantBackupsSection {
 
                     // Auto-restart the assistant so restored state takes effect
                     let assistantName = assistant.assistantId
+                    let isDocker = assistant.isDocker
                     Task {
-                        AppDelegate.shared?.vellumCli.stop(name: assistantName)
+                        if isDocker {
+                            try? await AppDelegate.shared?.vellumCli.sleep(name: assistantName)
+                        } else {
+                            AppDelegate.shared?.vellumCli.stop(name: assistantName)
+                        }
                         try? await Task.sleep(nanoseconds: 500_000_000)
                         try? await AppDelegate.shared?.vellumCli.wake(name: assistantName)
                         // Reload avatar after restart so the restored avatar is displayed


### PR DESCRIPTION
## Summary
- Fix view routing to show Docker assistants the local backup UI instead of managed/cloud backup UI
- Fix URL construction in export/import to use `resolvedRuntimeBaseURL` (routes through gateway for Docker)
- Fix restart-after-restore to use `sleep`/`wake` for Docker (PID-based `stop` doesn't work for containers)

Part of plan: docker-vbundle-backup-ui.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
