### PR TITLE
fix: match server_tool_use in window-manager orphaned pair expansion

### DIFF
--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -734,7 +734,7 @@ function adjustForToolPairs(
 
     const hasOrphanedPair = prev.content.some(
       (block) =>
-        block.type === "tool_use" &&
+        (block.type === "tool_use" || block.type === "server_tool_use") &&
         "id" in block &&
         referencedIds.has((block as { id: string }).id),
     );


### PR DESCRIPTION
The web_search_tool_result fix in PR #19947 collected tool_use_ids but the matching side only checked for tool_use blocks. Since web_search_tool_result references server_tool_use blocks, the boundary expansion never fired. Now also matches server_tool_use.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
