### PR TITLE
fix: escape single quotes in AppBundleRenamer shell script

### DIFF
--- a/clients/macos/vellum-assistant/App/AppBundleRenamer.swift
+++ b/clients/macos/vellum-assistant/App/AppBundleRenamer.swift
@@ -21,6 +21,12 @@ enum AppBundleRenamer {
 
     private static let targetName = AppDelegate.appName
 
+    /// Escapes a string for safe interpolation inside bash single-quoted strings.
+    /// Replaces `'` with `'\''` (end quote, escaped quote, reopen quote).
+    private static func shellEscape(_ s: String) -> String {
+        s.replacingOccurrences(of: "'", with: "'\\''")
+    }
+
     /// Returns `true` if the current bundle's display name differs from
     /// "Vellum" and a rename + relaunch is needed.
     static var needsRename: Bool {
@@ -61,13 +67,13 @@ enum AppBundleRenamer {
             sleep 0.1
         done
 
-        APP_DIR='\(bundleURL.path)'
+        APP_DIR='\(shellEscape(bundleURL.path))'
         CONTENTS="$APP_DIR/Contents"
         MACOS="$CONTENTS/MacOS"
-        OLD_EXE='\(currentExeName)'
-        NEW_NAME='\(targetName)'
-        BUNDLE_DIR='\(bundleDir.path)'
-        BUNDLE_ID='\(bundleId)'
+        OLD_EXE='\(shellEscape(currentExeName))'
+        NEW_NAME='\(shellEscape(targetName))'
+        BUNDLE_DIR='\(shellEscape(bundleDir.path))'
+        BUNDLE_ID='\(shellEscape(bundleId))'
         TARGET_APP="$BUNDLE_DIR/$NEW_NAME.app"
 
         # 1. Rename the executable


### PR DESCRIPTION
Escape single quotes in interpolated values within the bash rename script to prevent shell injection when assistant names contain apostrophes.

Adds a `shellEscape` helper that replaces `'` with `'\\'` and applies it to all single-quoted interpolated values (`bundleURL.path`, `currentExeName`, `targetName`, `bundleDir.path`, `bundleId`).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
