### PR TITLE
fix: guard remote assistant check before skip-permissions UI mutation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2940,8 +2940,8 @@ public final class SettingsStore: ObservableObject {
     }
 
     func setDangerouslySkipPermissions(_ enabled: Bool) {
-        dangerouslySkipPermissions = enabled
         guard !isCurrentAssistantRemote else { return }
+        dangerouslySkipPermissions = enabled
         let existingConfig = WorkspaceConfigIO.read(from: configPath)
         var permissions = existingConfig["permissions"] as? [String: Any] ?? [:]
         permissions["dangerouslySkipPermissions"] = enabled


### PR DESCRIPTION
Move the isCurrentAssistantRemote guard before mutating the published dangerouslySkipPermissions state so the toggle doesn't flip for remote assistants where the config can't be persisted.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
