### PR TITLE
fix: use correct snake_case column names in drop-simplified-memory migration

### DIFF
--- a/assistant/src/memory/migrations/189-drop-simplified-memory.ts
+++ b/assistant/src/memory/migrations/189-drop-simplified-memory.ts
@@ -20,9 +20,9 @@ export function migrateDropSimplifiedMemory(database: DrizzleDb): void {
   // SQLite doesn't support DROP COLUMN before 3.35.0, but Bun's built-in
   // SQLite is >= 3.38, so this is safe.
   for (const col of [
-    "memoryReducedThroughMessageId",
-    "memoryDirtyTailSinceMessageId",
-    "memoryLastReducedAt",
+    "memory_reduced_through_message_id",
+    "memory_dirty_tail_since_message_id",
+    "memory_last_reduced_at",
   ]) {
     try {
       raw.exec(`ALTER TABLE conversations DROP COLUMN ${col}`);
@@ -34,9 +34,9 @@ export function migrateDropSimplifiedMemory(database: DrizzleDb): void {
   // Remove embedding rows for archive target types that no longer exist.
   try {
     raw.exec(
-      `DELETE FROM memory_embeddings WHERE targetType IN ('observation', 'chunk', 'episode')`,
+      `DELETE FROM memory_embeddings WHERE target_type IN ('observation', 'chunk', 'episode')`,
     );
   } catch {
-    // Column doesn't exist — table was never migrated to include targetType.
+    // Column doesn't exist — table was never migrated to include target_type.
   }
 }


### PR DESCRIPTION
Fixes column name references in migration 189 that used camelCase JS property names instead of actual SQLite column names. The DELETE query on memory_embeddings used targetType instead of target_type, and DROP COLUMN statements used camelCase instead of snake_case.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
