### PR TITLE
fix: sort null expectedResponseBy after actionable follow-ups

### DIFF
--- a/assistant/src/followups/followup-store.ts
+++ b/assistant/src/followups/followup-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, lte, or } from "drizzle-orm";
+import { and, asc, eq, lte, or, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../memory/db.js";
@@ -217,7 +217,10 @@ export function getPendingAndOverdueFollowUps(): BriefFollowUp[] {
         eq(followups.status, "nudged"),
       ),
     )
-    .orderBy(asc(followups.expectedResponseBy))
+    .orderBy(
+      sql`CASE WHEN ${followups.expectedResponseBy} IS NULL THEN 1 ELSE 0 END`,
+      asc(followups.expectedResponseBy),
+    )
     .all();
 
   return rows as BriefFollowUp[];


### PR DESCRIPTION
NULL values in expectedResponseBy now sort last instead of first, ensuring follow-ups with actual deadlines appear before unscheduled ones in the most-urgent-first ordering.

Closes #19971 feedback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
