### PR TITLE
fix: remove enrichment from shutdown commits to prevent index.lock race

### DIFF
--- a/assistant/src/workspace/heartbeat-service.ts
+++ b/assistant/src/workspace/heartbeat-service.ts
@@ -210,13 +210,11 @@ export class WorkspaceHeartbeatService {
 
       try {
         const now = this.now();
-        let shutdownFiles: string[] = [];
         const { committed } = await service.commitIfDirty(
           (st) => {
             const uniqueFiles = [
               ...new Set([...st.staged, ...st.modified, ...st.untracked]),
             ];
-            shutdownFiles = uniqueFiles;
             log.info(
               { workspaceDir, totalChanges: uniqueFiles.length },
               "Committing pending changes on shutdown",
@@ -237,28 +235,11 @@ export class WorkspaceHeartbeatService {
         if (committed) {
           firstSeenDirty.delete(workspaceDir);
           result.committed++;
-
-          // Fire-and-forget enrichment
-          try {
-            const commitHash = await service.getHeadHash();
-            const shutdownCtx: CommitContext = {
-              workspaceDir,
-              trigger: "shutdown",
-              changedFiles: shutdownFiles,
-              timestampMs: this.now(),
-            };
-            getEnrichmentService().enqueue({
-              workspaceDir,
-              commitHash,
-              context: shutdownCtx,
-              gitService: service,
-            });
-          } catch (enrichErr) {
-            log.debug(
-              { enrichErr },
-              "Failed to enqueue shutdown enrichment (non-fatal)",
-            );
-          }
+          // Skip enrichment for shutdown commits — the enrichment queue is
+          // about to be shut down anyway, and the fire-and-forget writeNote()
+          // can race with subsequent commitAllPending() calls (the async
+          // git-notes operation acquires the mutex and may leave behind an
+          // index.lock on some git versions, causing the next commit to fail).
         } else {
           result.skipped++;
         }


### PR DESCRIPTION
## Summary
- Removed fire-and-forget enrichment enqueue from `commitAllPending()` (shutdown path)
- The async `writeNote()` triggered by enrichment acquires the git mutex and can race with subsequent `commitAllPending()` calls, leaving behind an `index.lock` that causes the next commit to fail
- Shutdown commits are safety nets — the enrichment queue is about to shut down anyway, so enriching these commits is pointless

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23327719366/job/67852455966
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
