### PR TITLE
feat: hybrid search for memory items list

### DIFF
--- a/assistant/src/runtime/routes/memory-item-routes.test.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.test.ts
@@ -37,11 +37,53 @@ mock.module("../../util/logger.js", () => ({
     }),
 }));
 
-// Stub config loader
+// Stub config loader — returns a config with memory enabled by default
 mock.module("../../config/loader.js", () => ({
-  loadConfig: () => ({}),
-  getConfig: () => ({}),
+  loadConfig: () => mockConfig,
+  getConfig: () => mockConfig,
   invalidateConfigCache: () => {},
+}));
+
+// ── Controllable mocks for semantic search ─────────────────────────────
+const mockConfig: unknown = {};
+
+let mockBackendStatus: {
+  enabled: boolean;
+  provider: string | null;
+  model: string | null;
+} = { enabled: false, provider: null, model: null };
+
+const mockEmbedResult: {
+  provider: string;
+  model: string;
+  vectors: number[][];
+} = { provider: "local", model: "test", vectors: [[0.1, 0.2, 0.3]] };
+
+let mockHybridSearchResults: Array<{
+  id: string;
+  score: number;
+  payload: Record<string, unknown>;
+}> = [];
+
+mock.module("../../memory/embedding-backend.js", () => ({
+  getMemoryBackendStatus: async () => mockBackendStatus,
+  embedWithBackend: async () => mockEmbedResult,
+  generateSparseEmbedding: () => ({
+    indices: [0, 1, 2],
+    values: [0.5, 0.3, 0.2],
+  }),
+}));
+
+mock.module("../../memory/qdrant-client.js", () => ({
+  getQdrantClient: () => ({
+    hybridSearch: async () => [...mockHybridSearchResults],
+    searchWithFilter: async () => [...mockHybridSearchResults],
+  }),
+  initQdrantClient: () => {},
+}));
+
+mock.module("../../memory/qdrant-circuit-breaker.js", () => ({
+  withQdrantBreaker: async (fn: () => Promise<unknown>) => fn(),
 }));
 
 import { and, eq } from "drizzle-orm";
@@ -391,6 +433,182 @@ describe("Memory Item Routes", () => {
       const ctx = makeCtx({ sort: "bogus" });
       const res = await handler(ctx);
       expect(res.status).toBe(400);
+    });
+
+    // ── Semantic / hybrid search ──────────────────────────────────────
+
+    test("uses semantic search when embedding backend is available", async () => {
+      insertItem({
+        id: "i1",
+        kind: "preference",
+        subject: "dark mode",
+        statement: "User prefers dark mode",
+      });
+      insertItem({
+        id: "i2",
+        kind: "identity",
+        subject: "name",
+        statement: "User name is Alice",
+      });
+
+      // Enable semantic search
+      mockBackendStatus = {
+        enabled: true,
+        provider: "local",
+        model: "test",
+      };
+      // Qdrant returns i2 first (higher relevance), then i1
+      mockHybridSearchResults = [
+        {
+          id: "pt-2",
+          score: 0.95,
+          payload: { target_type: "item", target_id: "i2" },
+        },
+        {
+          id: "pt-1",
+          score: 0.7,
+          payload: { target_type: "item", target_id: "i1" },
+        },
+      ];
+
+      const ctx = makeCtx({ search: "alice" });
+      const res = await handler(ctx);
+      const body = (await res.json()) as {
+        items: Array<{ id: string }>;
+        total: number;
+      };
+
+      // Results in Qdrant relevance order (i2 first)
+      expect(body.items.length).toBe(2);
+      expect(body.items[0].id).toBe("i2");
+      expect(body.items[1].id).toBe("i1");
+      expect(body.total).toBe(2);
+
+      // Reset
+      mockBackendStatus = { enabled: false, provider: null, model: null };
+      mockHybridSearchResults = [];
+    });
+
+    test("falls back to SQL LIKE when backend is unavailable", async () => {
+      insertItem({
+        id: "i1",
+        kind: "preference",
+        subject: "dark mode",
+        statement: "User prefers dark mode",
+      });
+      insertItem({
+        id: "i2",
+        kind: "identity",
+        subject: "name",
+        statement: "User name is Alice",
+      });
+
+      // Backend unavailable
+      mockBackendStatus = { enabled: false, provider: null, model: null };
+      mockHybridSearchResults = [];
+
+      const ctx = makeCtx({ search: "dark" });
+      const res = await handler(ctx);
+      const body = (await res.json()) as {
+        items: Array<{ id: string }>;
+        total: number;
+      };
+
+      // SQL LIKE fallback finds "dark" in subject/statement
+      expect(body.total).toBe(1);
+      expect(body.items[0].id).toBe("i1");
+    });
+
+    test("semantic search respects pagination", async () => {
+      insertItem({
+        id: "i1",
+        kind: "preference",
+        subject: "s1",
+        statement: "first item",
+      });
+      insertItem({
+        id: "i2",
+        kind: "preference",
+        subject: "s2",
+        statement: "second item",
+      });
+      insertItem({
+        id: "i3",
+        kind: "preference",
+        subject: "s3",
+        statement: "third item",
+      });
+
+      mockBackendStatus = {
+        enabled: true,
+        provider: "local",
+        model: "test",
+      };
+      mockHybridSearchResults = [
+        {
+          id: "pt-1",
+          score: 0.9,
+          payload: { target_type: "item", target_id: "i1" },
+        },
+        {
+          id: "pt-2",
+          score: 0.8,
+          payload: { target_type: "item", target_id: "i2" },
+        },
+        {
+          id: "pt-3",
+          score: 0.7,
+          payload: { target_type: "item", target_id: "i3" },
+        },
+      ];
+
+      // Request page 2 (offset=1, limit=1)
+      const ctx = makeCtx({ search: "item", limit: "1", offset: "1" });
+      const res = await handler(ctx);
+      const body = (await res.json()) as {
+        items: Array<{ id: string }>;
+        total: number;
+      };
+
+      expect(body.items.length).toBe(1);
+      expect(body.items[0].id).toBe("i2"); // second by relevance
+      expect(body.total).toBe(3);
+
+      // Reset
+      mockBackendStatus = { enabled: false, provider: null, model: null };
+      mockHybridSearchResults = [];
+    });
+
+    test("falls back to SQL when semantic returns empty results", async () => {
+      insertItem({
+        id: "i1",
+        kind: "preference",
+        subject: "dark mode",
+        statement: "User prefers dark mode",
+      });
+
+      mockBackendStatus = {
+        enabled: true,
+        provider: "local",
+        model: "test",
+      };
+      // Qdrant returns nothing
+      mockHybridSearchResults = [];
+
+      const ctx = makeCtx({ search: "dark" });
+      const res = await handler(ctx);
+      const body = (await res.json()) as {
+        items: Array<{ id: string }>;
+        total: number;
+      };
+
+      // Falls through to SQL LIKE
+      expect(body.total).toBe(1);
+      expect(body.items[0].id).toBe("i1");
+
+      // Reset
+      mockBackendStatus = { enabled: false, provider: null, model: null };
+      mockHybridSearchResults = [];
     });
   });
 

--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -11,17 +11,28 @@
 import { and, asc, count, desc, eq, inArray, like, ne, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { getConfig } from "../../config/loader.js";
 import { getDb } from "../../memory/db.js";
+import {
+  embedWithBackend,
+  generateSparseEmbedding,
+  getMemoryBackendStatus,
+} from "../../memory/embedding-backend.js";
 import { computeMemoryFingerprint } from "../../memory/fingerprint.js";
 import { enqueueMemoryJob } from "../../memory/jobs-store.js";
+import { withQdrantBreaker } from "../../memory/qdrant-circuit-breaker.js";
+import { getQdrantClient } from "../../memory/qdrant-client.js";
 import {
   conversations,
   memoryEmbeddings,
   memoryItems,
 } from "../../memory/schema.js";
+import { getLogger } from "../../util/logger.js";
 import { truncate } from "../../util/truncate.js";
 import { httpError } from "../http-errors.js";
 import type { RouteContext, RouteDefinition } from "../http-router.js";
+
+const log = getLogger("memory-item-routes");
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -117,10 +128,75 @@ function buildConversationTitleMap(
 }
 
 // ---------------------------------------------------------------------------
+// Semantic search helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempt hybrid semantic search for memory items via Qdrant.
+ * Returns ordered item IDs + total count on success, or `null` when
+ * the embedding backend / Qdrant is unavailable (caller falls back to SQL).
+ */
+async function searchItemsSemantic(
+  query: string,
+  fetchLimit: number,
+  kindFilter: string | null,
+  statusFilter: string,
+): Promise<{ ids: string[]; total: number } | null> {
+  try {
+    const config = getConfig();
+    const backendStatus = await getMemoryBackendStatus(config);
+    if (!backendStatus.provider) return null;
+
+    const embedded = await embedWithBackend(config, [query]);
+    const queryVector = embedded.vectors[0];
+    if (!queryVector) return null;
+
+    const sparse = generateSparseEmbedding(query);
+    const sparseVector = { indices: sparse.indices, values: sparse.values };
+
+    // Build Qdrant filter — items only, exclude capability kind and sentinel
+    const mustConditions: Array<Record<string, unknown>> = [
+      { key: "target_type", match: { value: "item" } },
+    ];
+    if (statusFilter && statusFilter !== "all") {
+      mustConditions.push({ key: "status", match: { value: statusFilter } });
+    }
+    if (kindFilter) {
+      mustConditions.push({ key: "kind", match: { value: kindFilter } });
+    }
+
+    const filter = {
+      must: mustConditions,
+      must_not: [
+        { key: "kind", match: { value: "capability" } },
+        { key: "_meta", match: { value: true } },
+      ],
+    };
+
+    const qdrant = getQdrantClient();
+    const results = await withQdrantBreaker(() =>
+      qdrant.hybridSearch({
+        denseVector: queryVector,
+        sparseVector,
+        filter,
+        limit: fetchLimit,
+        prefetchLimit: fetchLimit,
+      }),
+    );
+
+    const ids = results.map((r) => r.payload.target_id);
+    return { ids, total: ids.length };
+  } catch (err) {
+    log.warn({ err }, "Semantic memory search failed, falling back to SQL");
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // GET /v1/memory-items
 // ---------------------------------------------------------------------------
 
-export function handleListMemoryItems(url: URL): Response {
+export async function handleListMemoryItems(url: URL): Promise<Response> {
   const kindParam = url.searchParams.get("kind");
   const statusParam = url.searchParams.get("status") ?? "active";
   const searchParam = url.searchParams.get("search");
@@ -155,7 +231,53 @@ export function handleListMemoryItems(url: URL): Response {
 
   const db = getDb();
 
-  // Build WHERE conditions
+  // ── Semantic search path ────────────────────────────────────────────
+  // When a search query is present, try Qdrant hybrid search first.
+  // Falls back to SQL LIKE when embeddings / Qdrant are unavailable.
+  if (searchParam) {
+    const semanticResult = await searchItemsSemantic(
+      searchParam,
+      limitParam + offsetParam,
+      kindParam,
+      statusParam,
+    );
+
+    if (semanticResult && semanticResult.ids.length > 0) {
+      // Slice for pagination
+      const pageIds = semanticResult.ids.slice(
+        offsetParam,
+        offsetParam + limitParam,
+      );
+
+      // Batch-fetch full rows from SQLite
+      const rows = db
+        .select()
+        .from(memoryItems)
+        .where(inArray(memoryItems.id, pageIds))
+        .all();
+
+      // Preserve Qdrant relevance ordering
+      const idOrder = new Map(pageIds.map((id, i) => [id, i]));
+      rows.sort((a, b) => (idOrder.get(a.id) ?? 0) - (idOrder.get(b.id) ?? 0));
+
+      const titleMap = buildConversationTitleMap(
+        db,
+        rows.map((i) => i.scopeId),
+      );
+      const enrichedItems = rows.map((item) => ({
+        ...item,
+        scopeLabel: resolveScopeLabel(item.scopeId, titleMap),
+      }));
+
+      return Response.json({
+        items: enrichedItems,
+        total: semanticResult.total,
+      });
+    }
+    // semanticResult was null (Qdrant unavailable) or empty — fall through to SQL
+  }
+
+  // ── SQL path (default or fallback) ──────────────────────────────────
   const conditions = [];
   // Hide system-managed capability memories (skill announcements) from the UI
   conditions.push(ne(memoryItems.kind, "capability"));


### PR DESCRIPTION
## Summary

- When the user searches memories in the Intelligence panel, the endpoint now uses Qdrant hybrid search (dense + sparse RRF fusion) for relevance-ranked semantic results instead of SQL `LIKE` substring matching
- Memory items are already embedded into Qdrant — this wires the existing infrastructure into the `GET /v1/memory-items` list endpoint
- Gracefully falls back to SQL `LIKE` when Qdrant/embeddings are unavailable (circuit breaker open, backend not configured, etc.)

## Test plan

- [x] All 34 tests pass (30 existing + 4 new semantic search tests)
- [x] Type-check, lint, prettier all clean
- [ ] Manual: open Intelligence → Memories, search for a conceptual query (e.g. "music preferences"), verify results include semantically related items not just substring matches
- [ ] Manual: verify search still works when embedding backend is disabled (SQL fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
