### PR TITLE
fix: cancel all recording modes on enter, teardown voice monitors on disappear

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -300,6 +300,7 @@ struct SettingsAppearanceTab: View {
             }
             .onDisappear {
                 stopRecording()
+                stopRecordingVoiceInput()
             }
 
             // MEDIA EMBEDS section
@@ -484,6 +485,7 @@ struct SettingsAppearanceTab: View {
     /// Shared recording logic. The callback receives the shortcut string and the raw NSEvent key code.
     private func startRecordingShortcut(onRecord: @escaping (String, UInt16) -> Void) {
         stopRecording()
+        stopRecordingVoiceInput()
         shortcutConflictWarning = nil
         recordingDisplayString = nil
 
@@ -549,6 +551,7 @@ struct SettingsAppearanceTab: View {
     }
 
     private func startRecordingVoiceInput() {
+        stopRecording()
         stopRecordingVoiceInput()
         isRecordingVoiceInput = true
 


### PR DESCRIPTION
## Summary
- When starting any recording mode (global hotkey, quick input, or voice input), cancel all other active recording modes first
- Add stopRecordingVoiceInput() to the onDisappear path so voice monitors are cleaned up when leaving the Settings tab

Addresses feedback on #19949
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/19999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
