### PR TITLE
fix: use getWorkspaceDir() in gateway config-file-utils for Docker support

### DIFF
--- a/gateway/src/http/routes/config-file-utils.ts
+++ b/gateway/src/http/routes/config-file-utils.ts
@@ -7,7 +7,7 @@ import {
 } from "node:fs";
 import { join, dirname } from "node:path";
 import { randomBytes } from "node:crypto";
-import { getRootDir } from "../../credential-reader.js";
+import { getWorkspaceDir } from "../../credential-reader.js";
 
 /**
  * Serializes config writes so concurrent PATCH requests don't race on
@@ -28,7 +28,7 @@ export function enqueueConfigWrite(fn: () => void): void {
 }
 
 export function getConfigPath(): string {
-  return join(getRootDir(), "workspace", "config.json");
+  return join(getWorkspaceDir(), "config.json");
 }
 
 export type ConfigReadResult =


### PR DESCRIPTION
## Summary
- Updated config-file-utils.ts to use getWorkspaceDir() instead of join(getRootDir(), 'workspace', ...) for resolving config.json path
- Fixes split-brain in Docker mode where API routes would read/write to a different config.json than the watcher and cache

Addresses feedback on #19966
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
