### PR TITLE
fix: strip raw inline command tokens from child skill fallback body

### DIFF
--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -442,10 +442,15 @@ export class SkillLoadTool implements Tool {
             } catch (err) {
               log.error(
                 { err, skillId: childId, parentSkillId: skill.id },
-                "Failed to render inline commands for included skill; falling back to raw body",
+                "Failed to render inline commands for included skill; falling back to sanitized body",
               );
-              // Leave childBody unchanged — the raw body is used as a fallback
-              // so that a crash in one child does not prevent sibling rendering.
+              // Strip raw !`...` inline command tokens so they don't leak into
+              // the prompt. Replace with a safe stub to maintain fail-closed
+              // contract for raw tokens while still isolating child failures.
+              childBody = childBody.replace(
+                /!`[^`]*`/g,
+                "[inline command unavailable]",
+              );
             }
           }
 


### PR DESCRIPTION
## Summary
- When child skill renderInlineCommands fails and falls back to the raw body, strip all raw inline command tokens (`!\`...\``) from the fallback
- Replaces raw tokens with `[inline command unavailable]` stub to prevent them from leaking into the prompt
- Preserves the isolation behavior (child failure doesn't abort siblings)

Addresses feedback on #19983
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
