### PR TITLE
fix: disable dangerouslySkipPermissions toggle for remote assistants

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -134,18 +134,22 @@ struct SettingsDeveloperTab: View {
 
             // Dangerously Skip Permissions
             SettingsCard(title: "Dangerously Skip Permissions", subtitle: "Auto-accept all permission prompts without asking. The assistant will never pause for approval — use with caution.") {
+                let isRemote = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId })?.isRemote ?? false
                 HStack(alignment: .top, spacing: VSpacing.sm) {
                     VToggle(isOn: Binding(
                         get: { store.dangerouslySkipPermissions },
                         set: { store.setDangerouslySkipPermissions($0) }
                     ))
                     .accessibilityLabel("Dangerously Skip Permissions")
+                    .disabled(isRemote)
                     .padding(.top, 2)
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         Text("Skip all permission prompts")
                             .font(VFont.body)
                             .foregroundColor(VColor.contentSecondary)
-                        Text("When enabled, tools execute immediately without asking for approval. Explicit deny rules are still respected.")
+                        Text(isRemote
+                            ? "This setting cannot be changed for remote assistants."
+                            : "When enabled, tools execute immediately without asking for approval. Explicit deny rules are still respected.")
                             .font(VFont.caption)
                             .foregroundColor(VColor.contentTertiary)
                     }


### PR DESCRIPTION
## Summary
- Disabled the dangerouslySkipPermissions toggle in SettingsDeveloperTab when the current assistant is remote
- Remote assistants cannot persist this setting, so the toggle should be visually disabled rather than silently ignoring the action

Addresses feedback on #19988
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20002" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
