### PR TITLE
fix: reset snapshot state and add build-placeholder guard in inline fallback transition

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -560,16 +560,39 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             let appDir = appsDirectory.appendingPathComponent(localDir)
             if FileManager.default.fileExists(atPath: appDir.path) {
                 context.coordinator.isInlineFallback = false
+                context.coordinator.hasCapturedSnapshot = false
+                context.coordinator.loadStartTime = CFAbsoluteTimeGetCurrent()
+
                 // Reload from disk so the web view picks up the real app files.
-                let entryPath: String
                 let distIndex = appDir.appendingPathComponent("dist/index.html")
-                if FileManager.default.fileExists(atPath: distIndex.path) {
-                    entryPath = "dist/index.html"
+                let hasSrcDir = FileManager.default.fileExists(atPath: appDir.appendingPathComponent("src").path)
+
+                if hasSrcDir && !FileManager.default.fileExists(atPath: distIndex.path) {
+                    // Multifile app whose dist/ hasn't been compiled yet — show a
+                    // "building" placeholder that auto-retries by navigating to the
+                    // scheme URL (not reload, which would just re-render this inline HTML).
+                    let distSchemeURL = "vellumapp://\(localDir)/dist/index.html"
+                    let origin = "vellumapp://\(localDir)/"
+                    let buildingHTML = """
+                    <!DOCTYPE html><html><head><meta charset="UTF-8">
+                    <style>body{display:flex;align-items:center;justify-content:center;height:100vh;margin:0;
+                    font-family:system-ui;color:#666;background:#fafafa}
+                    .c{text-align:center}.spin{animation:r 1s linear infinite;font-size:24px;display:inline-block}
+                    @keyframes r{to{transform:rotate(360deg)}}
+                    button{margin-top:12px;padding:8px 16px;border:1px solid #ccc;border-radius:6px;
+                    background:#fff;cursor:pointer;font-size:13px}button:hover{background:#f0f0f0}</style>
+                    </head><body><div class="c"><div class="spin">⚙️</div><p>Building app…</p>
+                    <button onclick="window.location.href='\(distSchemeURL)'">Refresh</button></div>
+                    <script>setTimeout(()=>{window.location.href='\(distSchemeURL)'},2000)</script></body></html>
+                    """
+                    webView.loadHTMLString(buildingHTML, baseURL: URL(string: origin))
                 } else {
-                    entryPath = "index.html"
+                    let entryPath = FileManager.default.fileExists(atPath: distIndex.path)
+                        ? "dist/index.html"
+                        : "index.html"
+                    let schemeURL = URL(string: "vellumapp://\(localDir)/\(entryPath)")!
+                    webView.load(URLRequest(url: schemeURL))
                 }
-                let schemeURL = URL(string: "vellumapp://\(localDir)/\(entryPath)")!
-                webView.load(URLRequest(url: schemeURL))
                 return
             }
         }


### PR DESCRIPTION
## Summary
- Reset `hasCapturedSnapshot` and `loadStartTime` when transitioning from inline fallback to disk-backed mode, matching every other reload path in `updateNSView`
- Added `hasSrcDir && !distIndex` check to show build placeholder when app directory exists but `dist/` hasn't been generated yet, mirroring the `makeNSView` safeguard

Addresses feedback on #19991
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
