### PR TITLE
fix: narrow SIGPIPE success bypass to code===null only

### DIFF
--- a/assistant/src/skills/inline-command-runner.ts
+++ b/assistant/src/skills/inline-command-runner.ts
@@ -181,9 +181,11 @@ export async function runInlineCommand(
 
       // ── Non-zero exit ────────────────────────────────────────────────
       // When stdout was capped we destroyed the read end of the pipe,
-      // which typically causes SIGPIPE (code=null). Treat that as
-      // success and fall through to process the buffered output.
-      if (code !== 0 && !stdoutCapped) {
+      // which typically causes SIGPIPE — the process is killed by the
+      // signal so the exit code is null. Only suppress the error in that
+      // specific case; a command that outputs a lot but exits with a
+      // genuine non-zero code (e.g. exit 1) should still be an error.
+      if (code !== 0 && !(stdoutCapped && code === null)) {
         log.debug(
           { command, exitCode: code },
           "Inline command exited with non-zero code",


### PR DESCRIPTION
## Summary
- Narrowed the stdoutCapped success bypass to only apply when exit code is null (actual SIGPIPE)
- Commands that produce large output but exit with a real non-zero code are now correctly reported as failures

Addresses feedback on #19993
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
