### PR TITLE
fix: replace unsafe Function type in signing-key-bootstrap test

### DIFF
--- a/gateway/src/__tests__/signing-key-bootstrap.test.ts
+++ b/gateway/src/__tests__/signing-key-bootstrap.test.ts
@@ -27,7 +27,7 @@ mock.module("node:fs", () => ({
     if (p === SIGNING_KEY_PATH) {
       return Buffer.from(TEST_SIGNING_KEY);
     }
-    return (actualFs.readFileSync as Function)(p, ...args);
+    return (actualFs.readFileSync as (...a: unknown[]) => unknown)(p, ...args);
   },
   writeFileSync: (
     p: string,


### PR DESCRIPTION
## Summary
- Replace `as Function` cast with `as (...a: unknown[]) => unknown` in signing-key-bootstrap test to fix `@typescript-eslint/no-unsafe-function-type` lint error

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23328020479/job/67853323819
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
