### PR TITLE
feat: daemon fetches signing key from gateway at startup in Docker mode

### DIFF
--- a/assistant/src/__tests__/actor-token-service.test.ts
+++ b/assistant/src/__tests__/actor-token-service.test.ts
@@ -57,6 +57,8 @@ import {
 } from "../runtime/actor-token-store.js";
 import { resetExternalAssistantIdCache } from "../runtime/auth/external-assistant-id.js";
 import {
+  BootstrapAlreadyCompleted,
+  fetchSigningKeyFromGateway,
   hashToken,
   initAuthSigningKey,
 } from "../runtime/auth/token-service.js";
@@ -727,5 +729,116 @@ describe("bootstrap private-network guard", () => {
 
     const res = await handleGuardianBootstrap(req, loopbackServer);
     expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchSigningKeyFromGateway
+// ---------------------------------------------------------------------------
+
+describe("fetchSigningKeyFromGateway", () => {
+  const VALID_HEX_KEY = "a".repeat(64); // 64 hex chars = 32 bytes
+  const originalEnv = process.env.GATEWAY_INTERNAL_URL;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    process.env.GATEWAY_INTERNAL_URL = "http://gateway:7822";
+  });
+
+  afterAll(() => {
+    if (originalEnv !== undefined) {
+      process.env.GATEWAY_INTERNAL_URL = originalEnv;
+    } else {
+      delete process.env.GATEWAY_INTERNAL_URL;
+    }
+    globalThis.fetch = originalFetch;
+  });
+
+  test("returns 32-byte buffer on successful 200 response", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ key: VALID_HEX_KEY }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as typeof fetch;
+
+    const key = await fetchSigningKeyFromGateway();
+    expect(key).toBeInstanceOf(Buffer);
+    expect(key.length).toBe(32);
+    expect(key.toString("hex")).toBe(VALID_HEX_KEY);
+  });
+
+  test("throws BootstrapAlreadyCompleted on 403 response", async () => {
+    globalThis.fetch = (async () =>
+      new Response("Forbidden", { status: 403 })) as typeof fetch;
+
+    await expect(fetchSigningKeyFromGateway()).rejects.toBeInstanceOf(
+      BootstrapAlreadyCompleted,
+    );
+  });
+
+  test("throws timeout error after max retry attempts on persistent failure", async () => {
+    // Mock Bun.sleep to avoid waiting 30s in tests
+    const origSleep = Bun.sleep;
+    Bun.sleep = (() => Promise.resolve()) as typeof Bun.sleep;
+
+    let callCount = 0;
+    globalThis.fetch = (async () => {
+      callCount++;
+      throw new Error("ECONNREFUSED");
+    }) as typeof fetch;
+
+    try {
+      await expect(fetchSigningKeyFromGateway()).rejects.toThrow(
+        "timed out waiting for gateway",
+      );
+      expect(callCount).toBe(30);
+    } finally {
+      Bun.sleep = origSleep;
+    }
+  });
+
+  test("throws when GATEWAY_INTERNAL_URL is not set", async () => {
+    delete process.env.GATEWAY_INTERNAL_URL;
+
+    await expect(fetchSigningKeyFromGateway()).rejects.toThrow(
+      "GATEWAY_INTERNAL_URL not set",
+    );
+  });
+
+  test("rejects invalid key length", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ key: "aabb" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as typeof fetch;
+
+    await expect(fetchSigningKeyFromGateway()).rejects.toThrow(
+      "Invalid signing key length",
+    );
+  });
+
+  test("retries on non-200/non-403 status and eventually succeeds", async () => {
+    const origSleep = Bun.sleep;
+    Bun.sleep = (() => Promise.resolve()) as typeof Bun.sleep;
+
+    let callCount = 0;
+    globalThis.fetch = (async () => {
+      callCount++;
+      if (callCount < 3) {
+        return new Response("Service Unavailable", { status: 503 });
+      }
+      return new Response(JSON.stringify({ key: VALID_HEX_KEY }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    try {
+      const key = await fetchSigningKeyFromGateway();
+      expect(key.length).toBe(32);
+      expect(callCount).toBe(3);
+    } finally {
+      Bun.sleep = origSleep;
+    }
   });
 });

--- a/assistant/src/runtime/auth/token-service.ts
+++ b/assistant/src/runtime/auth/token-service.ts
@@ -29,6 +29,22 @@ import type { ScopeProfile, TokenAudience, TokenClaims } from "./types.js";
 const log = getLogger("token-service");
 
 // ---------------------------------------------------------------------------
+// Bootstrap sentinel error
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when the gateway's signing-key bootstrap endpoint returns 403,
+ * indicating that bootstrap has already completed (daemon restart case).
+ * The caller should fall back to loading the key from disk.
+ */
+export class BootstrapAlreadyCompleted extends Error {
+  constructor() {
+    super("Gateway signing key bootstrap already completed");
+    this.name = "BootstrapAlreadyCompleted";
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Signing key management
 // ---------------------------------------------------------------------------
 
@@ -76,6 +92,73 @@ export function loadOrCreateSigningKey(): Buffer {
 
   log.info("Auth signing key generated and persisted");
   return newKey;
+}
+
+/**
+ * Fetch the shared signing key from the gateway's bootstrap endpoint.
+ *
+ * Used in Docker mode where the gateway owns the signing key and the daemon
+ * must fetch it at startup. Retries up to 30 times with 1s intervals to
+ * tolerate gateway startup delays.
+ *
+ * @returns A 32-byte Buffer containing the signing key.
+ * @throws {BootstrapAlreadyCompleted} If the gateway returns 403 (bootstrap
+ *   already completed — daemon restart case). Caller should fall back to
+ *   loading the key from disk.
+ * @throws {Error} If the gateway is unreachable after all retry attempts.
+ */
+export async function fetchSigningKeyFromGateway(): Promise<Buffer> {
+  const gatewayUrl = process.env.GATEWAY_INTERNAL_URL;
+  if (!gatewayUrl) {
+    throw new Error("GATEWAY_INTERNAL_URL not set — cannot fetch signing key");
+  }
+
+  const maxAttempts = 30;
+  const intervalMs = 1000;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    let resp: Response | undefined;
+    try {
+      resp = await fetch(`${gatewayUrl}/internal/signing-key-bootstrap`, {
+        signal: AbortSignal.timeout(5000),
+      });
+    } catch (err) {
+      log.warn(
+        { err, attempt },
+        "Signing key bootstrap: connection failed, retrying",
+      );
+      await Bun.sleep(intervalMs);
+      continue;
+    }
+
+    if (resp.ok) {
+      const body = (await resp.json()) as { key: string };
+      const keyBuf = Buffer.from(body.key, "hex");
+      if (keyBuf.length !== 32) {
+        throw new Error(`Invalid signing key length: ${keyBuf.length}`);
+      }
+      log.info("Signing key fetched from gateway bootstrap endpoint");
+      return keyBuf;
+    }
+
+    if (resp.status === 403) {
+      // Bootstrap already completed — fall through to file-based load.
+      // This happens on daemon restart when the gateway lockfile persists.
+      log.info(
+        "Gateway signing key bootstrap already completed — loading from disk",
+      );
+      throw new BootstrapAlreadyCompleted();
+    }
+
+    log.warn(
+      { status: resp.status, attempt },
+      "Signing key bootstrap: gateway not ready, retrying",
+    );
+
+    await Bun.sleep(intervalMs);
+  }
+
+  throw new Error("Signing key bootstrap: timed out waiting for gateway");
 }
 
 function getSigningKey(): Buffer {


### PR DESCRIPTION
## Summary
- Add `fetchSigningKeyFromGateway()` async function with retry logic (30 attempts, 1s intervals)
- Add `BootstrapAlreadyCompleted` sentinel error for 403 responses (daemon restart case)
- Tests verify success, 403 handling, and timeout behavior

Part of plan: docker-signing-key-bootstrap.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
