### PR TITLE
feat: clear signing key bootstrap lockfile during Docker hatch

### DIFF
--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -1089,6 +1089,19 @@ export async function hatchDocker(
       "/workspace",
     ]);
 
+    // Clear any stale signing-key bootstrap lockfile so the daemon can
+    // fetch the key from the gateway on first startup.
+    await exec("docker", [
+      "run",
+      "--rm",
+      "-v",
+      `${res.gatewaySecurityVolume}:/gateway-security`,
+      "busybox",
+      "rm",
+      "-f",
+      "/gateway-security/signing-key-bootstrap.lock",
+    ]);
+
     const cesServiceToken = randomBytes(32).toString("hex");
     await startContainers(
       { cesServiceToken, gatewayPort, imageTags, instanceName, res },


### PR DESCRIPTION
## Summary
- Add busybox `rm -f` step in `hatchDocker()` to clear stale `signing-key-bootstrap.lock`
- Runs after volume creation, before container startup
- Idempotent: no error if the lockfile doesn't exist

Part of plan: docker-signing-key-bootstrap.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
