### PR TITLE
feat: daemon uses gateway bootstrap for signing key in Docker mode

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -56,8 +56,8 @@ import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import {
   initAuthSigningKey,
-  loadOrCreateSigningKey,
   mintPairingBearerToken,
+  resolveSigningKey,
 } from "../runtime/auth/token-service.js";
 import { ensureVellumGuardianBinding } from "../runtime/guardian-vellum-migration.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
@@ -147,7 +147,7 @@ export async function runDaemon(): Promise<void> {
     // Load (or generate + persist) the auth signing key so tokens survive
     // daemon restarts. Must happen after ensureDataDir() creates the
     // protected directory.
-    const signingKey = loadOrCreateSigningKey();
+    const signingKey = await resolveSigningKey();
     initAuthSigningKey(signingKey);
 
     seedInterfaceFiles();

--- a/assistant/src/runtime/auth/token-service.ts
+++ b/assistant/src/runtime/auth/token-service.ts
@@ -161,6 +161,56 @@ export async function fetchSigningKeyFromGateway(): Promise<Buffer> {
   throw new Error("Signing key bootstrap: timed out waiting for gateway");
 }
 
+/**
+ * Persist a signing key to disk using an atomic-write pattern.
+ * Used after fetching the key from the gateway so daemon restarts can
+ * load it from disk when the gateway returns 403.
+ */
+function persistSigningKey(key: Buffer): void {
+  const keyPath = getSigningKeyPath();
+  const dir = dirname(keyPath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const tmpPath = keyPath + ".tmp." + process.pid;
+  writeFileSync(tmpPath, key, { mode: 0o600 });
+  renameSync(tmpPath, keyPath);
+  chmodSync(keyPath, 0o600);
+}
+
+/**
+ * Resolve the signing key for the current environment.
+ *
+ * In Docker mode (IS_CONTAINERIZED=true + GATEWAY_INTERNAL_URL set), fetches
+ * the key from the gateway's bootstrap endpoint and persists it locally for
+ * restart resilience. On daemon restart (gateway returns 403), falls back to
+ * loading the key from disk.
+ *
+ * In local mode, delegates to the existing file-based loadOrCreateSigningKey().
+ */
+export async function resolveSigningKey(): Promise<Buffer> {
+  const isContainerized = process.env.IS_CONTAINERIZED === "true";
+  const gatewayUrl = process.env.GATEWAY_INTERNAL_URL;
+
+  if (isContainerized && gatewayUrl) {
+    try {
+      const key = await fetchSigningKeyFromGateway();
+      // Persist locally so daemon restarts (where gateway returns 403) load from disk.
+      persistSigningKey(key);
+      return key;
+    } catch (err) {
+      if (err instanceof BootstrapAlreadyCompleted) {
+        // Gateway already bootstrapped (daemon restart) — load from disk.
+        return loadOrCreateSigningKey();
+      }
+      throw err;
+    }
+  }
+
+  // Local mode: use file-based load/create (unchanged behavior).
+  return loadOrCreateSigningKey();
+}
+
 function getSigningKey(): Buffer {
   if (!_authSigningKey) {
     if (process.env.NODE_ENV === "test") {


### PR DESCRIPTION
## Summary
- Add `resolveSigningKey()` async wrapper that checks Docker mode and delegates accordingly
- Add `persistSigningKey()` helper to save gateway-fetched key locally for restart resilience
- Wire into `runDaemon()` startup in `lifecycle.ts` — replaces direct `loadOrCreateSigningKey()` call
- Local mode behavior is completely unchanged

Part of plan: docker-signing-key-bootstrap.md (PR 4 of 7)