### PR TITLE
fix: pass request arg to signing key bootstrap handler

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -536,7 +536,7 @@ async function main() {
       path: "/internal/signing-key-bootstrap",
       method: "GET",
       auth: "none",
-      handler: () => signingKeyBootstrap.handleGetSigningKey(),
+      handler: (req) => signingKeyBootstrap.handleGetSigningKey(req),
     },
 
     // ── Channel verification sessions ──


### PR DESCRIPTION
## Summary
- Fix TypeScript compile error in gateway: the signing key bootstrap route handler was not passing `req` to `handleGetSigningKey()`, which expects a `Request` argument.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23328091178/job/67853527264