### PR TITLE
fix: replace === null with == null in inline-command-runner

### DIFF
--- a/assistant/src/skills/inline-command-runner.ts
+++ b/assistant/src/skills/inline-command-runner.ts
@@ -185,7 +185,7 @@ export async function runInlineCommand(
       // signal so the exit code is null. Only suppress the error in that
       // specific case; a command that outputs a lot but exits with a
       // genuine non-zero code (e.g. exit 1) should still be an error.
-      if (code !== 0 && !(stdoutCapped && code === null)) {
+      if (code !== 0 && !(stdoutCapped && code == null)) {
         log.debug(
           { command, exitCode: code },
           "Inline command exited with non-zero code",


### PR DESCRIPTION
## Summary
- Replace `=== null` with `== null` in `inline-command-runner.ts` to satisfy the `no-restricted-syntax` lint rule that forbids strict null comparisons

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23328057653/job/67853431252
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
