### PR TITLE
feat: handle signing key bootstrap during Docker upgrades

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -11,6 +11,7 @@ import {
 import type { AssistantEntry } from "../lib/assistant-config";
 import {
   captureImageRefs,
+  clearSigningKeyBootstrapLock,
   DOCKERHUB_IMAGES,
   DOCKER_READY_TIMEOUT_MS,
   GATEWAY_INTERNAL_PORT,
@@ -296,6 +297,9 @@ async function upgradeDocker(
 
   console.log("🔄 Migrating credential files to CES security volume...");
   await migrateCesSecurityFiles(res, (msg) => console.log(msg));
+
+  console.log("🔑 Clearing signing key bootstrap lock...");
+  await clearSigningKeyBootstrapLock(res);
 
   console.log("🚀 Starting upgraded containers...");
   await startContainers(

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -760,6 +760,27 @@ export async function stopContainers(
   await removeContainer(res.assistantContainer);
 }
 
+/**
+ * Remove the signing-key-bootstrap lockfile from the gateway security volume.
+ * This allows the daemon to re-fetch the signing key from the gateway on the
+ * next startup — necessary during upgrades where the gateway may generate a
+ * new key.
+ */
+export async function clearSigningKeyBootstrapLock(
+  res: ReturnType<typeof dockerResourceNames>,
+): Promise<void> {
+  await exec("docker", [
+    "run",
+    "--rm",
+    "-v",
+    `${res.gatewaySecurityVolume}:/gateway-security`,
+    "busybox",
+    "rm",
+    "-f",
+    "/gateway-security/signing-key-bootstrap.lock",
+  ]);
+}
+
 /** Stop containers without removing them (preserves state for `docker start`). */
 export async function sleepContainers(
   res: ReturnType<typeof dockerResourceNames>,


### PR DESCRIPTION
## Summary
- Add exported `clearSigningKeyBootstrapLock()` helper in `cli/src/lib/docker.ts`
- Call it during the upgrade flow before starting new containers
- Ensures pre-fix instances get matching signing keys after upgrade

Part of plan: docker-signing-key-bootstrap.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
