### PR TITLE
test: add Docker signing key bootstrap integration test

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -159,6 +159,19 @@ In Docker mode (`IS_CONTAINERIZED=true`), services that need data from another s
 - **Trust rules**: The assistant reads/writes trust rules via the gateway's HTTP trust API. The gateway owns the filesystem copy at `/gateway-security/trust.json`.
 - **Credentials**: The assistant and gateway access credential CRUD via the CES HTTP API (`CES_CREDENTIAL_URL`), authenticated with `CES_SERVICE_TOKEN`. The CES owns the encryption keys at `/ces-security/`.
 
+### Signing Key Bootstrap Protocol
+
+In Docker mode, the gateway and daemon must share the same actor-token signing key so both can mint and verify JWTs. The gateway owns the key and the daemon fetches it at startup:
+
+1. **Gateway startup**: The gateway generates the signing key (or loads it from `/gateway-security/actor-token-signing-key`) and registers the `GET /internal/signing-key-bootstrap` endpoint.
+2. **Daemon startup**: The daemon calls `resolveSigningKey()`, which detects Docker mode (`IS_CONTAINERIZED=true` + `GATEWAY_INTERNAL_URL` set) and calls `fetchSigningKeyFromGateway()`. This fetches the key from the gateway's bootstrap endpoint (retrying up to 30 times with 1s intervals to tolerate gateway startup delays).
+3. **Lockfile guard**: After the first successful response, the gateway writes a lockfile (`signing-key-bootstrap.lock`) to prevent re-serving the key. Subsequent requests return 403.
+4. **Local persistence**: The daemon persists the fetched key to its local filesystem (`protected/actor-token-signing-key`).
+5. **Daemon restart**: On restart, the gateway returns 403 (lockfile present). The daemon catches `BootstrapAlreadyCompleted` and loads the key from its local disk copy.
+6. **Docker upgrade**: The CLI's `hatch` command deletes the gateway lockfile before starting containers, allowing the bootstrap to repeat with a fresh daemon container.
+
+In local mode (non-Docker), `resolveSigningKey()` delegates to `loadOrCreateSigningKey()`, which loads an existing key from disk or generates a new one — no network calls involved.
+
 ### Legacy Data Volume Migration
 
 The former shared data volume (`<name>-data`) is no longer created for new instances. Existing instances that still have a data volume are migrated on startup: `migrateGatewaySecurityFiles()` copies `trust.json` and `actor-token-signing-key` to the gateway security volume, and `migrateCesSecurityFiles()` copies `keys.enc` and `store.key` to the CES security volume (with ownership set to the CES service user `1001:1001`). Both migrations are idempotent.

--- a/assistant/src/__tests__/docker-signing-key-bootstrap.test.ts
+++ b/assistant/src/__tests__/docker-signing-key-bootstrap.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Integration tests for resolveSigningKey() covering the Docker bootstrap
+ * lifecycle: fresh fetch from gateway, daemon restart (load from disk),
+ * and local mode (file-based load/create).
+ */
+
+import { mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Temp directory for signing key persistence
+// ---------------------------------------------------------------------------
+
+const testDir = realpathSync(mkdtempSync(join(tmpdir(), "docker-signing-key-test-")));
+
+// ---------------------------------------------------------------------------
+// Mock platform to redirect signing key file to our temp directory
+// ---------------------------------------------------------------------------
+
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  getDbPath: () => join(testDir, "test.db"),
+  normalizeAssistantId: (id: string) => (id === "self" ? "self" : id),
+  readLockfile: () => null,
+  writeLockfile: () => {},
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import the functions under test (after mocks are installed)
+// ---------------------------------------------------------------------------
+
+const {
+  resolveSigningKey,
+  loadOrCreateSigningKey,
+  BootstrapAlreadyCompleted,
+} = await import("../runtime/auth/token-service.js");
+
+// ---------------------------------------------------------------------------
+// Test constants
+// ---------------------------------------------------------------------------
+
+const VALID_32_BYTE_KEY = "ab".repeat(32); // 64 hex chars = 32 bytes
+const SIGNING_KEY_PATH = join(testDir, "protected", "actor-token-signing-key");
+
+// ---------------------------------------------------------------------------
+// Environment & fetch state management
+// ---------------------------------------------------------------------------
+
+const originalFetch = globalThis.fetch;
+const savedEnv: Record<string, string | undefined> = {};
+
+function saveEnv(...keys: string[]) {
+  for (const key of keys) {
+    savedEnv[key] = process.env[key];
+  }
+}
+
+function restoreEnv() {
+  for (const [key, val] of Object.entries(savedEnv)) {
+    if (val === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = val;
+    }
+  }
+}
+
+beforeEach(() => {
+  saveEnv("IS_CONTAINERIZED", "GATEWAY_INTERNAL_URL");
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  restoreEnv();
+});
+
+afterAll(() => {
+  try {
+    rmSync(testDir, { recursive: true, force: true });
+  } catch {}
+});
+
+// ---------------------------------------------------------------------------
+// Docker mode tests — resolveSigningKey() bootstrap lifecycle
+// ---------------------------------------------------------------------------
+
+describe("resolveSigningKey — Docker bootstrap lifecycle", () => {
+  test("fresh bootstrap: fetches key from gateway and persists to disk", async () => {
+    process.env.IS_CONTAINERIZED = "true";
+    process.env.GATEWAY_INTERNAL_URL = "http://localhost:19876";
+
+    // Mock fetch to return a known 32-byte key on first call.
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ key: VALID_32_BYTE_KEY }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof fetch;
+
+    const key = await resolveSigningKey();
+
+    // Verify the returned key is a 32-byte buffer with the expected content.
+    expect(key).toBeInstanceOf(Buffer);
+    expect(key.length).toBe(32);
+    expect(key.toString("hex")).toBe(VALID_32_BYTE_KEY);
+
+    // Verify the key was persisted to disk.
+    const persisted = readFileSync(SIGNING_KEY_PATH);
+    expect(persisted.length).toBe(32);
+    expect(Buffer.from(persisted).equals(key)).toBe(true);
+  });
+
+  test("daemon restart: gateway returns 403, loads persisted key from disk", async () => {
+    process.env.IS_CONTAINERIZED = "true";
+    process.env.GATEWAY_INTERNAL_URL = "http://localhost:19876";
+
+    // The previous test persisted the key. Simulate a daemon restart where
+    // the gateway returns 403 (bootstrap already completed).
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ error: "Bootstrap already completed" }), {
+        status: 403,
+      })) as unknown as typeof fetch;
+
+    const key = await resolveSigningKey();
+
+    // Should have loaded the previously persisted key from disk.
+    expect(key).toBeInstanceOf(Buffer);
+    expect(key.length).toBe(32);
+    expect(key.toString("hex")).toBe(VALID_32_BYTE_KEY);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Local mode tests — resolveSigningKey() file-based path
+// ---------------------------------------------------------------------------
+
+describe("resolveSigningKey — local mode", () => {
+  test("uses file-based loadOrCreateSigningKey without calling fetch", async () => {
+    // Ensure Docker env vars are unset.
+    delete process.env.IS_CONTAINERIZED;
+    delete process.env.GATEWAY_INTERNAL_URL;
+
+    let fetchCalled = false;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("should not be called", { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const key = await resolveSigningKey();
+
+    // Should return a valid 32-byte key (loaded from disk or newly created).
+    expect(key).toBeInstanceOf(Buffer);
+    expect(key.length).toBe(32);
+
+    // Crucially, fetch should NOT have been called.
+    expect(fetchCalled).toBe(false);
+  });
+
+  test("IS_CONTAINERIZED=false does not trigger gateway fetch", async () => {
+    process.env.IS_CONTAINERIZED = "false";
+    process.env.GATEWAY_INTERNAL_URL = "http://localhost:19876";
+
+    let fetchCalled = false;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("should not be called", { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const key = await resolveSigningKey();
+
+    expect(key).toBeInstanceOf(Buffer);
+    expect(key.length).toBe(32);
+    expect(fetchCalled).toBe(false);
+  });
+
+  test("IS_CONTAINERIZED=true without GATEWAY_INTERNAL_URL uses local path", async () => {
+    process.env.IS_CONTAINERIZED = "true";
+    delete process.env.GATEWAY_INTERNAL_URL;
+
+    let fetchCalled = false;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("should not be called", { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const key = await resolveSigningKey();
+
+    expect(key).toBeInstanceOf(Buffer);
+    expect(key.length).toBe(32);
+    expect(fetchCalled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `docker-signing-key-bootstrap.test.ts` testing the full bootstrap lifecycle
- Tests cover: fresh fetch, restart fallback, local mode, key persistence
- Update ARCHITECTURE.md with signing key bootstrap protocol documentation

Part of plan: docker-signing-key-bootstrap.md (PR 7 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
