### PR TITLE
fix: lint unused vars in docker-signing-key-bootstrap test

### DIFF
--- a/assistant/src/__tests__/docker-signing-key-bootstrap.test.ts
+++ b/assistant/src/__tests__/docker-signing-key-bootstrap.test.ts
@@ -47,8 +47,8 @@ mock.module("../util/logger.js", () => ({
 
 const {
   resolveSigningKey,
-  loadOrCreateSigningKey,
-  BootstrapAlreadyCompleted,
+  loadOrCreateSigningKey: _loadOrCreateSigningKey,
+  BootstrapAlreadyCompleted: _BootstrapAlreadyCompleted,
 } = await import("../runtime/auth/token-service.js");
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Prefix `loadOrCreateSigningKey` and `BootstrapAlreadyCompleted` with `_` in the test's destructured import since they are not referenced as runtime values, fixing the `@typescript-eslint/no-unused-vars` lint error.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23328199604/job/67853852534