### PR TITLE
feat: instrument suspected hot paths for macOS CPU freeze diagnosis

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatScrollLoopGuard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatScrollLoopGuard.swift
@@ -14,6 +14,10 @@ import Foundation
 /// **Thresholds:**
 /// - More than 40 `anchorPreferenceChange` events in 2 seconds
 /// - More than 15 `scrollToRequested` events in 2 seconds
+/// - More than 50 `avatarFollowerUpdate` events in 2 seconds
+/// - More than 30 `avatarDisplayYApplied` events in 2 seconds
+/// - More than 60 `tailAnchorPreferenceChange` events in 2 seconds
+/// - More than 40 `bodyEvaluation` events in 2 seconds
 ///
 /// Once tripped, the guard emits at most one aggregate warning per cooldown
 /// window (the same 2-second duration), then re-arms after a quiet window
@@ -27,6 +31,10 @@ final class ChatScrollLoopGuard {
         case scrollToRequested
         case repinAttempt
         case suppressionFlip
+        case avatarFollowerUpdate
+        case avatarDisplayYApplied
+        case tailAnchorPreferenceChange
+        case bodyEvaluation
     }
 
     // MARK: - Aggregate Snapshot
@@ -49,6 +57,18 @@ final class ChatScrollLoopGuard {
 
     /// Maximum scrollTo requests allowed in the detection window.
     static let scrollToThreshold: Int = 15
+
+    /// Maximum updateAvatarFollower() calls allowed in the detection window.
+    static let avatarFollowerThreshold: Int = 50
+
+    /// Maximum applyAvatarDisplayY() @State mutations allowed in the detection window.
+    static let avatarApplyThreshold: Int = 30
+
+    /// Maximum ConversationTailAnchorYKey preference fires allowed in the detection window.
+    static let tailAnchorThreshold: Int = 60
+
+    /// Maximum body evaluations allowed in the detection window.
+    static let bodyEvaluationThreshold: Int = 40
 
     /// Rolling window duration in seconds for event counting.
     static let windowDuration: TimeInterval = 2.0
@@ -115,12 +135,24 @@ final class ChatScrollLoopGuard {
         // Check thresholds.
         let anchorCount = state.events[.anchorPreferenceChange]?.count ?? 0
         let scrollToCount = state.events[.scrollToRequested]?.count ?? 0
+        let avatarFollowerCount = state.events[.avatarFollowerUpdate]?.count ?? 0
+        let avatarApplyCount = state.events[.avatarDisplayYApplied]?.count ?? 0
+        let tailAnchorCount = state.events[.tailAnchorPreferenceChange]?.count ?? 0
+        let bodyEvalCount = state.events[.bodyEvaluation]?.count ?? 0
 
         var trippedBy: EventKind?
         if anchorCount > Self.anchorThreshold {
             trippedBy = .anchorPreferenceChange
         } else if scrollToCount > Self.scrollToThreshold {
             trippedBy = .scrollToRequested
+        } else if avatarFollowerCount > Self.avatarFollowerThreshold {
+            trippedBy = .avatarFollowerUpdate
+        } else if avatarApplyCount > Self.avatarApplyThreshold {
+            trippedBy = .avatarDisplayYApplied
+        } else if tailAnchorCount > Self.tailAnchorThreshold {
+            trippedBy = .tailAnchorPreferenceChange
+        } else if bodyEvalCount > Self.bodyEvaluationThreshold {
+            trippedBy = .bodyEvaluation
         }
 
         var snapshot: AggregateSnapshot?
@@ -159,6 +191,20 @@ final class ChatScrollLoopGuard {
     /// Resets all tracking state for all conversations.
     func resetAll() {
         states.removeAll()
+    }
+
+    /// Returns the current rolling event counts for a conversation.
+    /// Used by `DebugStateWriter` to include hot-path rates in `debug-state.json`.
+    func currentCounts(conversationId: String) -> [EventKind: Int] {
+        guard let state = states[conversationId] else { return [:] }
+        var counts: [EventKind: Int] = [:]
+        for kind in EventKind.allCases {
+            let count = state.events[kind]?.count ?? 0
+            if count > 0 {
+                counts[kind] = count
+            }
+        }
+        return counts
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -407,12 +407,14 @@ struct MessageListView: View {
         // Each avatarDisplayY change triggers a MessageListView body re-evaluation;
         // sub-pixel jitter during scroll would otherwise cause continuous re-renders.
         guard abs(avatarDisplayY - y) > 2 else { return }
+        recordScrollLoopEvent(.avatarDisplayYApplied)
         withAnimation(ConversationAvatarFollower.spring) {
             avatarDisplayY = y
         }
     }
 
     private func updateAvatarFollower(anchorY: CGFloat) {
+        recordScrollLoopEvent(.avatarFollowerUpdate)
         // Compute visibility once and update @State only on boundary crossings.
         let nowVisible = anchorY.isFinite
             && ConversationAvatarFollower.shouldShow(anchorY: anchorY, viewportHeight: scrollViewportHeight)
@@ -745,6 +747,12 @@ struct MessageListView: View {
         let safeContainerWidth = sanitizer.sanitize(containerWidth, field: "containerWidth")
         logNonFiniteGeometryOnce(sanitizer: sanitizer)
 
+        // Capture rolling scroll loop guard counts for debug-state.json.
+        let guardCounts = scrollLoopGuard.currentCounts(conversationId: convId.uuidString)
+        let guardCountsStringKeyed: [String: Int]? = guardCounts.isEmpty ? nil : Dictionary(
+            uniqueKeysWithValues: guardCounts.map { ($0.key.rawValue, $0.value) }
+        )
+
         ChatDiagnosticsStore.shared.updateSnapshot(ChatTranscriptSnapshot(
             conversationId: convId.uuidString,
             capturedAt: Date(),
@@ -765,6 +773,7 @@ struct MessageListView: View {
             tailAnchorY: safeTailAnchorY,
             scrollViewportHeight: safeViewportHeight,
             containerWidth: safeContainerWidth,
+            scrollLoopGuardCounts: guardCountsStringKeyed,
             nonFiniteFields: sanitizer.nonFiniteFields
         ))
     }
@@ -919,6 +928,7 @@ struct MessageListView: View {
                             }
                     }
 
+                    let _ = recordScrollLoopEvent(.bodyEvaluation)
                     let state = precomputedState
                     ForEach(Array(zip(state.displayMessages.indices, state.displayMessages)), id: \.1.id) { index, message in
                         MessageCellView(
@@ -1162,6 +1172,7 @@ struct MessageListView: View {
                     previous: scrollTracking.lastTailAnchorY
                 )
                 guard case .accept(let accepted) = decision else { return }
+                recordScrollLoopEvent(.tailAnchorPreferenceChange)
                 scrollTracking.lastTailAnchorY = accepted
                 updateAvatarFollower(anchorY: accepted)
             }

--- a/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
+++ b/clients/macos/vellum-assistant/Logging/ChatDiagnosticsStore.swift
@@ -244,6 +244,10 @@ struct ChatTranscriptSnapshot: Codable, Sendable {
     let lastScrollToReason: String?
     /// Timestamp of the last scroll-loop warning from `ChatScrollLoopGuard`.
     let lastLoopWarningTimestamp: Date?
+    /// Rolling event counts from `ChatScrollLoopGuard` at snapshot time.
+    /// Keys are `EventKind.rawValue` strings; values are counts within the
+    /// rolling 2-second window. Only non-zero counts are included.
+    let scrollLoopGuardCounts: [String: Int]?
 
     // MARK: Sanitization metadata
 
@@ -273,6 +277,7 @@ struct ChatTranscriptSnapshot: Codable, Sendable {
         containerWidth: Double? = nil,
         lastScrollToReason: String? = nil,
         lastLoopWarningTimestamp: Date? = nil,
+        scrollLoopGuardCounts: [String: Int]? = nil,
         nonFiniteFields: [String]? = nil
     ) {
         self.conversationId = conversationId
@@ -296,6 +301,7 @@ struct ChatTranscriptSnapshot: Codable, Sendable {
         self.containerWidth = containerWidth
         self.lastScrollToReason = lastScrollToReason
         self.lastLoopWarningTimestamp = lastLoopWarningTimestamp
+        self.scrollLoopGuardCounts = scrollLoopGuardCounts
         self.nonFiniteFields = nonFiniteFields
     }
 }

--- a/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
+++ b/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
@@ -224,6 +224,10 @@ struct DebugSnapshot: Codable {
         let containerWidth: Double?
         let lastScrollToReason: String?
         let lastLoopWarningTimestamp: Date?
+        /// Rolling event counts from `ChatScrollLoopGuard` within the 2-second
+        /// detection window. Keys are event kind names; values are counts.
+        /// Non-zero counts only. Useful for identifying hot paths before a freeze.
+        let scrollLoopGuardCounts: [String: Int]?
         /// Names of geometry fields whose original values were non-finite
         /// (nan, inf, -inf) and were replaced with `nil` during sanitization.
         let nonFiniteFields: [String]?
@@ -249,6 +253,7 @@ struct DebugSnapshot: Codable {
             self.containerWidth = snapshot.containerWidth
             self.lastScrollToReason = snapshot.lastScrollToReason
             self.lastLoopWarningTimestamp = snapshot.lastLoopWarningTimestamp
+            self.scrollLoopGuardCounts = snapshot.scrollLoopGuardCounts
             self.nonFiniteFields = snapshot.nonFiniteFields
         }
     }

--- a/clients/macos/vellum-assistantTests/ChatScrollLoopGuardTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatScrollLoopGuardTests.swift
@@ -322,4 +322,210 @@ final class ChatScrollLoopGuardTests: XCTestCase {
             XCTAssertGreaterThanOrEqual(s.timestamp, 42.0)
         }
     }
+
+    // MARK: - New Hot-Path Event Kinds
+
+    func testAvatarFollowerBurstTripsGuard() {
+        var timestamp: TimeInterval = 1000.0
+        var tripped = false
+
+        // Fire 51 avatarFollowerUpdate events in under 2 seconds (exceeds threshold of 50).
+        for _ in 0..<55 {
+            let result = guard_.record(
+                .avatarFollowerUpdate,
+                conversationId: conversationId,
+                timestamp: timestamp
+            )
+            if let snapshot = result {
+                XCTAssertFalse(tripped, "Guard should trip exactly once per cooldown window")
+                tripped = true
+                XCTAssertEqual(snapshot.trippedBy, .avatarFollowerUpdate)
+                XCTAssertGreaterThan(snapshot.counts[.avatarFollowerUpdate] ?? 0, ChatScrollLoopGuard.avatarFollowerThreshold)
+            }
+            timestamp += 0.035
+        }
+
+        XCTAssertTrue(tripped, "Guard should have tripped for avatar follower burst")
+    }
+
+    func testAvatarFollowerNormalRateDoesNotTrip() {
+        var timestamp: TimeInterval = 1000.0
+
+        // 20 events in 2 seconds — well under threshold of 50.
+        for _ in 0..<20 {
+            let result = guard_.record(
+                .avatarFollowerUpdate,
+                conversationId: conversationId,
+                timestamp: timestamp
+            )
+            XCTAssertNil(result, "Normal-rate avatar follower updates should not trip the guard")
+            timestamp += 0.1
+        }
+    }
+
+    func testAvatarDisplayYAppliedBurstTripsGuard() {
+        var timestamp: TimeInterval = 1000.0
+        var tripped = false
+
+        // Fire 31 avatarDisplayYApplied events in under 2 seconds (exceeds threshold of 30).
+        for _ in 0..<35 {
+            let result = guard_.record(
+                .avatarDisplayYApplied,
+                conversationId: conversationId,
+                timestamp: timestamp
+            )
+            if let snapshot = result {
+                XCTAssertFalse(tripped)
+                tripped = true
+                XCTAssertEqual(snapshot.trippedBy, .avatarDisplayYApplied)
+                XCTAssertGreaterThan(snapshot.counts[.avatarDisplayYApplied] ?? 0, ChatScrollLoopGuard.avatarApplyThreshold)
+            }
+            timestamp += 0.055
+        }
+
+        XCTAssertTrue(tripped, "Guard should have tripped for avatar display Y burst")
+    }
+
+    func testAvatarDisplayYAppliedNormalRateDoesNotTrip() {
+        var timestamp: TimeInterval = 1000.0
+
+        // 15 events in 2 seconds — under threshold of 30.
+        for _ in 0..<15 {
+            let result = guard_.record(
+                .avatarDisplayYApplied,
+                conversationId: conversationId,
+                timestamp: timestamp
+            )
+            XCTAssertNil(result)
+            timestamp += 0.13
+        }
+    }
+
+    func testTailAnchorPreferenceBurstTripsGuard() {
+        var timestamp: TimeInterval = 1000.0
+        var tripped = false
+
+        // Fire 61 tailAnchorPreferenceChange events in under 2 seconds (exceeds threshold of 60).
+        for _ in 0..<65 {
+            let result = guard_.record(
+                .tailAnchorPreferenceChange,
+                conversationId: conversationId,
+                timestamp: timestamp
+            )
+            if let snapshot = result {
+                XCTAssertFalse(tripped)
+                tripped = true
+                XCTAssertEqual(snapshot.trippedBy, .tailAnchorPreferenceChange)
+                XCTAssertGreaterThan(snapshot.counts[.tailAnchorPreferenceChange] ?? 0, ChatScrollLoopGuard.tailAnchorThreshold)
+            }
+            timestamp += 0.03
+        }
+
+        XCTAssertTrue(tripped, "Guard should have tripped for tail anchor preference burst")
+    }
+
+    func testTailAnchorPreferenceNormalRateDoesNotTrip() {
+        var timestamp: TimeInterval = 1000.0
+
+        // 30 events in 2 seconds — under threshold of 60.
+        for _ in 0..<30 {
+            let result = guard_.record(
+                .tailAnchorPreferenceChange,
+                conversationId: conversationId,
+                timestamp: timestamp
+            )
+            XCTAssertNil(result)
+            timestamp += 0.066
+        }
+    }
+
+    func testBodyEvaluationBurstTripsGuard() {
+        var timestamp: TimeInterval = 1000.0
+        var tripped = false
+
+        // Fire 41 bodyEvaluation events in under 2 seconds (exceeds threshold of 40).
+        for _ in 0..<45 {
+            let result = guard_.record(
+                .bodyEvaluation,
+                conversationId: conversationId,
+                timestamp: timestamp
+            )
+            if let snapshot = result {
+                XCTAssertFalse(tripped)
+                tripped = true
+                XCTAssertEqual(snapshot.trippedBy, .bodyEvaluation)
+                XCTAssertGreaterThan(snapshot.counts[.bodyEvaluation] ?? 0, ChatScrollLoopGuard.bodyEvaluationThreshold)
+            }
+            timestamp += 0.045
+        }
+
+        XCTAssertTrue(tripped, "Guard should have tripped for body evaluation burst")
+    }
+
+    func testBodyEvaluationNormalRateDoesNotTrip() {
+        var timestamp: TimeInterval = 1000.0
+
+        // 20 events in 2 seconds — under threshold of 40.
+        for _ in 0..<20 {
+            let result = guard_.record(
+                .bodyEvaluation,
+                conversationId: conversationId,
+                timestamp: timestamp
+            )
+            XCTAssertNil(result)
+            timestamp += 0.1
+        }
+    }
+
+    func testNewEventKindsCooldownRearms() {
+        var timestamp: TimeInterval = 1000.0
+        var tripCount = 0
+
+        // Trip via avatarFollowerUpdate.
+        for _ in 0..<55 {
+            if guard_.record(.avatarFollowerUpdate, conversationId: conversationId, timestamp: timestamp) != nil {
+                tripCount += 1
+            }
+            timestamp += 0.035
+        }
+        XCTAssertEqual(tripCount, 1, "First burst should trip once")
+
+        // Wait for cooldown to expire.
+        timestamp += ChatScrollLoopGuard.cooldownDuration + 0.1
+
+        // Second burst: should re-arm and trip again.
+        for _ in 0..<55 {
+            if guard_.record(.avatarFollowerUpdate, conversationId: conversationId, timestamp: timestamp) != nil {
+                tripCount += 1
+            }
+            timestamp += 0.035
+        }
+        XCTAssertEqual(tripCount, 2, "Guard should re-arm and trip again after quiet window")
+    }
+
+    // MARK: - currentCounts
+
+    func testCurrentCountsReturnsRollingCounts() {
+        var timestamp: TimeInterval = 1000.0
+
+        // Record a mix of events.
+        for _ in 0..<10 {
+            guard_.record(.avatarFollowerUpdate, conversationId: conversationId, timestamp: timestamp)
+            timestamp += 0.01
+        }
+        for _ in 0..<5 {
+            guard_.record(.bodyEvaluation, conversationId: conversationId, timestamp: timestamp)
+            timestamp += 0.01
+        }
+
+        let counts = guard_.currentCounts(conversationId: conversationId)
+        XCTAssertEqual(counts[.avatarFollowerUpdate], 10)
+        XCTAssertEqual(counts[.bodyEvaluation], 5)
+        XCTAssertNil(counts[.anchorPreferenceChange], "Unrecorded kinds should not appear")
+    }
+
+    func testCurrentCountsReturnsEmptyForUnknownConversation() {
+        let counts = guard_.currentCounts(conversationId: "nonexistent")
+        XCTAssertTrue(counts.isEmpty)
+    }
 }

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -140,6 +140,15 @@ public final class HTTPTransport {
         #endif
     }
 
+    // MARK: - SSE Parse Time Tracking
+
+    /// Accumulated main-thread time spent in `parseSSEData` within the current
+    /// 1-second window. When this exceeds 500ms, a warning is logged to help
+    /// diagnose main-thread saturation during rapid streaming.
+    private var sseParseTimeAccumulator: TimeInterval = 0
+    private var sseParseCountInWindow: Int = 0
+    private var sseWindowStart: CFAbsoluteTime = 0
+
     /// Currently active SSE task.
     private var sseTask: Task<Void, Never>?
 
@@ -851,6 +860,21 @@ public final class HTTPTransport {
             let elapsed = CFAbsoluteTimeGetCurrent() - start
             if elapsed > 0.05 || byteCount > 100_000 {
                 log.warning("Slow SSE event: \(String(format: "%.1f", elapsed * 1000))ms, \(byteCount) bytes")
+            }
+            // Track rolling main-thread time spent parsing SSE events.
+            // Flags when >500ms of a 1-second window is consumed by SSE parsing.
+            sseParseTimeAccumulator += elapsed
+            sseParseCountInWindow += 1
+            let now = CFAbsoluteTimeGetCurrent()
+            if now - sseWindowStart > 1.0 {
+                if sseParseTimeAccumulator > 0.5 {
+                    let totalMs = String(format: "%.0f", sseParseTimeAccumulator * 1000)
+                    let count = sseParseCountInWindow
+                    log.warning("SSE main-thread saturation: \(totalMs)ms in \(count) events over 1s")
+                }
+                sseParseTimeAccumulator = 0
+                sseParseCountInWindow = 0
+                sseWindowStart = now
             }
         }
         var jsonString = data


### PR DESCRIPTION
## Summary

- Extended `ChatScrollLoopGuard` with 4 new event kinds (`avatarFollowerUpdate`, `avatarDisplayYApplied`, `tailAnchorPreferenceChange`, `bodyEvaluation`) and per-kind thresholds to detect runaway loops in each suspected hot path
- Instrumented `updateAvatarFollower`, `applyAvatarDisplayY`, `ConversationTailAnchorYKey` preference handler, and body evaluation in `MessageListView` so the next freeze produces definitive data identifying the spinning code path
- Added rolling scroll loop guard counts to `debug-state.json` (via transcript snapshots) and SSE main-thread saturation warnings for >500ms parse time per second
- Added 10 new unit tests covering burst detection, normal-rate safety, cooldown re-arming, and `currentCounts()` for all new event kinds