### PR TITLE
feat: add upgrade-broadcast endpoint with gateway control-plane proxy

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -172,6 +172,7 @@ import { surfaceContentRouteDefinitions } from "./routes/surface-content-routes.
 import { telemetryRouteDefinitions } from "./routes/telemetry-routes.js";
 import { traceEventRouteDefinitions } from "./routes/trace-event-routes.js";
 import { trustRulesRouteDefinitions } from "./routes/trust-rules-routes.js";
+import { upgradeBroadcastRouteDefinitions } from "./routes/upgrade-broadcast-routes.js";
 import { usageRouteDefinitions } from "./routes/usage-routes.js";
 import { watchRouteDefinitions } from "./routes/watch-routes.js";
 import { workItemRouteDefinitions } from "./routes/work-items-routes.js";
@@ -918,6 +919,7 @@ export class RuntimeHttpServer {
         getCesClient: this.getCesClient,
       }),
       ...identityRouteDefinitions(),
+      ...upgradeBroadcastRouteDefinitions(),
       ...debugRouteDefinitions(),
       ...usageRouteDefinitions(),
       ...telemetryRouteDefinitions(),

--- a/assistant/src/runtime/routes/upgrade-broadcast-routes.ts
+++ b/assistant/src/runtime/routes/upgrade-broadcast-routes.ts
@@ -1,0 +1,150 @@
+/**
+ * Upgrade broadcast endpoint — publishes service group update lifecycle
+ * events (starting / complete) to all connected SSE clients.
+ *
+ * This endpoint is unprotected at the daemon level (no policy registration),
+ * following the same pattern as health, identity, and debug routes. The
+ * gateway is responsible for auth — it requires a valid edge JWT and
+ * forwards the request with a service token.
+ */
+
+import type {
+  ServiceGroupUpdateComplete,
+  ServiceGroupUpdateStarting,
+} from "../../daemon/message-types/upgrades.js";
+import { buildAssistantEvent } from "../assistant-event.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+export function upgradeBroadcastRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "admin/upgrade-broadcast",
+      method: "POST",
+      handler: async ({ req }) => {
+        let body: unknown;
+        try {
+          body = await req.json();
+        } catch {
+          return httpError("BAD_REQUEST", "Invalid JSON body", 400);
+        }
+
+        if (!body || typeof body !== "object") {
+          return httpError(
+            "BAD_REQUEST",
+            "Request body must be a JSON object",
+            400,
+          );
+        }
+
+        const { type } = body as { type?: unknown };
+
+        if (type === "starting") {
+          const { targetVersion, expectedDowntimeSeconds } = body as {
+            targetVersion?: unknown;
+            expectedDowntimeSeconds?: unknown;
+          };
+
+          if (typeof targetVersion !== "string" || targetVersion.length === 0) {
+            return httpError(
+              "BAD_REQUEST",
+              "targetVersion is required and must be a non-empty string",
+              400,
+            );
+          }
+
+          const downtime =
+            expectedDowntimeSeconds === undefined
+              ? 60
+              : expectedDowntimeSeconds;
+
+          if (
+            typeof downtime !== "number" ||
+            !isFinite(downtime) ||
+            downtime < 0
+          ) {
+            return httpError(
+              "BAD_REQUEST",
+              "expectedDowntimeSeconds must be a non-negative number",
+              400,
+            );
+          }
+
+          const message: ServiceGroupUpdateStarting = {
+            type: "service_group_update_starting",
+            targetVersion,
+            expectedDowntimeSeconds: downtime,
+          };
+
+          await assistantEventHub.publish(
+            buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, message),
+          );
+
+          return Response.json({ ok: true });
+        }
+
+        if (type === "complete") {
+          const { installedVersion, success, rolledBackToVersion } = body as {
+            installedVersion?: unknown;
+            success?: unknown;
+            rolledBackToVersion?: unknown;
+          };
+
+          if (
+            typeof installedVersion !== "string" ||
+            installedVersion.length === 0
+          ) {
+            return httpError(
+              "BAD_REQUEST",
+              "installedVersion is required and must be a non-empty string",
+              400,
+            );
+          }
+
+          if (typeof success !== "boolean") {
+            return httpError(
+              "BAD_REQUEST",
+              "success is required and must be a boolean",
+              400,
+            );
+          }
+
+          if (
+            rolledBackToVersion !== undefined &&
+            (typeof rolledBackToVersion !== "string" ||
+              rolledBackToVersion.length === 0)
+          ) {
+            return httpError(
+              "BAD_REQUEST",
+              "rolledBackToVersion must be a non-empty string when provided",
+              400,
+            );
+          }
+
+          const message: ServiceGroupUpdateComplete = {
+            type: "service_group_update_complete",
+            installedVersion,
+            success,
+            ...(typeof rolledBackToVersion === "string"
+              ? { rolledBackToVersion }
+              : {}),
+          };
+
+          await assistantEventHub.publish(
+            buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, message),
+          );
+
+          return Response.json({ ok: true });
+        }
+
+        return httpError(
+          "BAD_REQUEST",
+          'type must be "starting" or "complete"',
+          400,
+        );
+      },
+    },
+  ];
+}

--- a/gateway/src/http/routes/upgrade-broadcast-proxy.ts
+++ b/gateway/src/http/routes/upgrade-broadcast-proxy.ts
@@ -1,0 +1,90 @@
+/**
+ * Gateway proxy for the daemon upgrade-broadcast control-plane endpoint.
+ *
+ * Follows the same forwarding pattern as channel-readiness-proxy.ts:
+ * strips hop-by-hop headers, replaces the client's edge JWT with a
+ * minted service token, and proxies the request to the daemon.
+ */
+
+import { mintServiceToken } from "../../auth/token-exchange.js";
+import type { GatewayConfig } from "../../config.js";
+import { fetchImpl } from "../../fetch.js";
+import { getLogger } from "../../logger.js";
+import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
+
+const log = getLogger("upgrade-broadcast-proxy");
+
+export function createUpgradeBroadcastProxyHandler(config: GatewayConfig) {
+  return async function handleUpgradeBroadcast(
+    req: Request,
+  ): Promise<Response> {
+    const start = performance.now();
+    const bodyBuffer = await req.arrayBuffer();
+
+    const upstream = `${config.assistantRuntimeBaseUrl}/v1/admin/upgrade-broadcast`;
+
+    const reqHeaders = stripHopByHop(new Headers(req.headers));
+    reqHeaders.delete("host");
+    reqHeaders.delete("authorization");
+
+    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
+    reqHeaders.set("content-length", String(bodyBuffer.byteLength));
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(
+        new DOMException(
+          "The operation was aborted due to timeout",
+          "TimeoutError",
+        ),
+      );
+    }, config.runtimeTimeoutMs);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(upstream, {
+        method: "POST",
+        headers: reqHeaders,
+        body: bodyBuffer,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+    } catch (err) {
+      clearTimeout(timeoutId);
+      const duration = Math.round(performance.now() - start);
+      if (err instanceof DOMException && err.name === "TimeoutError") {
+        log.error({ duration }, "Upgrade broadcast proxy upstream timed out");
+        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
+      }
+      log.error(
+        { err, duration },
+        "Upgrade broadcast proxy upstream connection failed",
+      );
+      return Response.json({ error: "Bad Gateway" }, { status: 502 });
+    }
+
+    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const duration = Math.round(performance.now() - start);
+
+    if (response.status >= 400) {
+      const body = await response.text();
+      log.warn(
+        { status: response.status, duration },
+        "Upgrade broadcast proxy upstream error",
+      );
+      return new Response(body, {
+        status: response.status,
+        headers: resHeaders,
+      });
+    }
+
+    log.info(
+      { status: response.status, duration },
+      "Upgrade broadcast proxy completed",
+    );
+    return new Response(response.body, {
+      status: response.status,
+      headers: resHeaders,
+    });
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -54,6 +54,7 @@ import { createSlackControlPlaneProxyHandler } from "./http/routes/slack-control
 import { createOAuthAppsProxyHandler } from "./http/routes/oauth-apps-proxy.js";
 import { createChannelReadinessProxyHandler } from "./http/routes/channel-readiness-proxy.js";
 import { createRuntimeHealthProxyHandler } from "./http/routes/runtime-health-proxy.js";
+import { createUpgradeBroadcastProxyHandler } from "./http/routes/upgrade-broadcast-proxy.js";
 import { createBrainGraphProxyHandler } from "./http/routes/brain-graph-proxy.js";
 import {
   createTrustRulesListHandler,
@@ -282,6 +283,7 @@ async function main() {
   const oauthAppsProxy = createOAuthAppsProxyHandler(config);
   const channelReadinessProxy = createChannelReadinessProxyHandler(config);
   const runtimeHealthProxy = createRuntimeHealthProxyHandler(config);
+  const upgradeBroadcastProxy = createUpgradeBroadcastProxyHandler(config);
   const brainGraphProxy = createBrainGraphProxyHandler(config);
   const handleFeatureFlagsGet = createFeatureFlagsGetHandler();
   const handleFeatureFlagsPatch = createFeatureFlagsPatchHandler();
@@ -716,6 +718,14 @@ async function main() {
       method: "POST",
       auth: "edge",
       handler: (req, params) => oauthAppsProxy.handleConnect(req, params[0]),
+    },
+
+    // ── Upgrade broadcast ──
+    {
+      path: "/v1/admin/upgrade-broadcast",
+      method: "POST",
+      auth: "edge",
+      handler: (req) => upgradeBroadcastProxy(req),
     },
 
     // ── Channel readiness ──


### PR DESCRIPTION
## Summary
- Add daemon POST endpoint at admin/upgrade-broadcast that publishes service_group_update_starting and service_group_update_complete SSE events
- Add gateway control-plane proxy at /v1/admin/upgrade-broadcast with edge JWT auth, forwarding to daemon with service token
- Register the new route in both the daemon HTTP server and gateway route table

Part of plan: upgrade-broadcast.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
