### PR TITLE
feat: confirm update completion via health check version on reconnect

### DIFF
--- a/clients/shared/Network/DaemonConnection.swift
+++ b/clients/shared/Network/DaemonConnection.swift
@@ -89,6 +89,27 @@ extension DaemonClient {
             #endif
         }
 
+        // Sync daemon version and confirm update completion on health-check version changes.
+        // This provides a faster update-complete signal than waiting for an SSE daemon_status event,
+        // which may be delayed or missed entirely if the SSE stream hasn't reconnected yet.
+        transport.onDaemonVersionChanged = { [weak self] newVersion in
+            guard let self else { return }
+            self.daemonVersion = newVersion
+            self.checkVersionCompatibility(daemonVersion: newVersion)
+            // Confirm update completion when health check detects the daemon is back
+            if self.isUpdateInProgress {
+                if newVersion == self.updateTargetVersion {
+                    log.info("Health check confirmed update completed — now running \(newVersion, privacy: .public)")
+                } else {
+                    log.warning("Health check detected version \(newVersion, privacy: .public) after update — expected \(self.updateTargetVersion ?? "?", privacy: .public), may have rolled back")
+                }
+                self.isUpdateInProgress = false
+                self.updateTargetVersion = nil
+                self.updateExpiresAt = nil
+                self.httpTransport?.setUpdateInProgress(false)
+            }
+        }
+
         self.httpTransport = transport
 
         // Propagate update-in-progress state to the new transport so

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -206,6 +206,10 @@ public final class HTTPTransport {
     /// Callback for connection state changes (health check driven).
     var onConnectionStateChanged: ((Bool) -> Void)?
 
+    /// Called when the daemon version changes during a health check.
+    /// Allows DaemonClient to confirm update completion without waiting for SSE.
+    var onDaemonVersionChanged: ((String) -> Void)?
+
     /// Callback when the bearer token is refreshed via a `token_rotated` SSE event.
     /// Clients should persist the new token (e.g. to Keychain).
     var onTokenRefreshed: ((String) -> Void)?
@@ -664,6 +668,7 @@ public final class HTTPTransport {
                     if let id = UserDefaults.standard.string(forKey: "connectedAssistantId"), !id.isEmpty {
                         LockfilePaths.updateServiceGroupVersion(assistantId: id, version: newVersion)
                     }
+                    onDaemonVersionChanged?(newVersion)
                 } else if let newVersion = decoded.version {
                     daemonVersion = newVersion
                 }


### PR DESCRIPTION
## Summary
- Add onDaemonVersionChanged callback to HTTPTransport, invoked when health check detects a version change
- Wire callback in DaemonConnection to sync daemonVersion, run compatibility check, and clear update-in-progress state when the daemon comes back after an upgrade
- Enables reliable update confirmation even when SSE service_group_update_complete event is missed

Part of plan: upgrade-broadcast.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
