### PR TITLE
feat: show update-in-progress indicator in Developer Settings version display

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -397,7 +397,13 @@ struct SettingsDeveloperTab: View {
                 .foregroundColor(VColor.contentTertiary)
                 .frame(width: 100, alignment: .leading)
 
-            if let version = effectiveVersion {
+            if daemonClient?.isUpdateInProgress == true {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Updating to \(daemonClient?.updateTargetVersion ?? "...")...")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.systemMidStrong)
+            } else if let version = effectiveVersion {
                 Text(version)
                     .font(VFont.mono)
                     .foregroundColor(isVersionIncompatible ? VColor.systemNegativeStrong : VColor.contentDefault)


### PR DESCRIPTION
## Summary
- Add update-in-progress indicator to Developer Settings version display
- When isUpdateInProgress is true, show 'Updating to vX.Y.Z...' with spinner instead of version text and upgrade button
- View automatically returns to normal version display when update completes via SwiftUI reactivity

Part of plan: upgrade-broadcast.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
