### PR TITLE
fix: remove premature service_group_update_complete broadcast from platform upgrade success path

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -538,12 +538,12 @@ async function upgradePlatform(
 
   const result = (await response.json()) as UpgradeApiResponse;
 
-  // Notify clients that the platform upgrade was initiated successfully.
-  await broadcastUpgradeEvent(entry.runtimeUrl, entry.assistantId, {
-    type: "complete",
-    installedVersion: result.version ?? targetVersion,
-    success: true,
-  });
+  // NOTE: We intentionally do NOT broadcast a "complete" event here.
+  // The platform API returning 200 only means "upgrade request accepted" —
+  // the service group has not yet restarted with the new version.  The
+  // completion signal will come from the client's health-check
+  // version-change detection (DaemonConnection.swift) once the new
+  // version actually appears after the platform restarts the service group.
 
   console.log(`✅ ${result.detail}`);
   if (result.version) {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for upgrade-broadcast.md.

**Gap:** Platform upgrade sends premature complete before actual restart
**What was expected:** The complete event should only fire after the service group actually restarts
**What was found:** CLI sends complete immediately after platform API returns 200 (which only means 'accepted', not 'restarted')
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
