### PR TITLE
fix: register route policy for admin/upgrade-broadcast endpoint

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -502,3 +502,9 @@ for (const endpoint of INTERNAL_ENDPOINTS) {
     allowedPrincipalTypes: ["svc_gateway"],
   });
 }
+
+// Admin control-plane endpoints: gateway-only
+registerPolicy("admin/upgrade-broadcast", {
+  requiredScopes: ["internal.write"],
+  allowedPrincipalTypes: ["svc_gateway"],
+});

--- a/assistant/src/runtime/routes/upgrade-broadcast-routes.ts
+++ b/assistant/src/runtime/routes/upgrade-broadcast-routes.ts
@@ -2,10 +2,11 @@
  * Upgrade broadcast endpoint — publishes service group update lifecycle
  * events (starting / complete) to all connected SSE clients.
  *
- * This endpoint is unprotected at the daemon level (no policy registration),
- * following the same pattern as health, identity, and debug routes. The
- * gateway is responsible for auth — it requires a valid edge JWT and
- * forwards the request with a service token.
+ * Protected by a route policy restricting access to gateway service
+ * principals only (`svc_gateway` with `internal.write` scope), following
+ * the same pattern as other gateway-forwarded control-plane endpoints.
+ * The gateway requires a valid edge JWT and forwards the request with a
+ * minted service token.
  */
 
 import type {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for upgrade-broadcast.md.

**Gap:** Missing route policy for admin/upgrade-broadcast
**What was expected:** The endpoint should have a registered route policy restricting it to gateway service principals
**What was found:** No policy registration, leaving the endpoint unprotected at the daemon level

### Changes
- Register a route policy for `admin/upgrade-broadcast` in `route-policy.ts` restricting it to `svc_gateway` principals with `internal.write` scope, matching the pattern used by other gateway-forwarded control-plane endpoints
- Update the JSDoc comment in `upgrade-broadcast-routes.ts` to accurately describe the security model (was incorrectly claiming the endpoint is unprotected)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
