### PR TITLE
fix: extract update-in-progress indicator into @ObservedObject sub-view for SwiftUI reactivity

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -397,29 +397,20 @@ struct SettingsDeveloperTab: View {
                 .foregroundColor(VColor.contentTertiary)
                 .frame(width: 100, alignment: .leading)
 
-            if daemonClient?.isUpdateInProgress == true {
-                ProgressView()
-                    .controlSize(.small)
-                Text("Updating to \(daemonClient?.updateTargetVersion ?? "...")...")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.systemMidStrong)
+            if let daemonClient {
+                DeveloperUpdateProgressRow(
+                    daemonClient: daemonClient,
+                    effectiveVersion: effectiveVersion,
+                    isVersionIncompatible: isVersionIncompatible,
+                    assistantVersionBehind: assistantVersionBehind,
+                    isUpgradingInline: isUpgradingInline,
+                    onUpgradeTapped: { showingInlineUpgradeConfirmation = true }
+                )
             } else if let version = effectiveVersion {
                 Text(version)
                     .font(VFont.mono)
                     .foregroundColor(isVersionIncompatible ? VColor.systemNegativeStrong : VColor.contentDefault)
                     .textSelection(.enabled)
-
-                if assistantVersionBehind {
-                    if isUpgradingInline {
-                        ProgressView()
-                            .controlSize(.small)
-                    } else {
-                        VButton(label: "Upgrade", style: .primary) {
-                            showingInlineUpgradeConfirmation = true
-                        }
-                        .disabled(isUpgradingInline)
-                    }
-                }
             } else {
                 Text("Not available")
                     .font(VFont.body)
@@ -1289,6 +1280,54 @@ private struct DeveloperDaemonStatusRows: View {
                 .foregroundColor(VColor.contentDefault)
 
             Spacer()
+        }
+    }
+}
+
+// MARK: - Update Progress Row (Developer Tab)
+
+/// Extracted sub-view that uses `@ObservedObject` to subscribe to
+/// `DaemonClient.isUpdateInProgress` and `updateTargetVersion` changes.
+/// The parent (`healthzInfoRows`) passes in a non-optional `DaemonClient`
+/// via `if let`, which is the standard SwiftUI pattern for observing
+/// optional ObservableObjects.
+private struct DeveloperUpdateProgressRow: View {
+    @ObservedObject var daemonClient: DaemonClient
+
+    let effectiveVersion: String?
+    let isVersionIncompatible: Bool
+    let assistantVersionBehind: Bool
+    let isUpgradingInline: Bool
+    let onUpgradeTapped: () -> Void
+
+    var body: some View {
+        if daemonClient.isUpdateInProgress {
+            ProgressView()
+                .controlSize(.small)
+            Text("Updating to \(daemonClient.updateTargetVersion ?? "...")...")
+                .font(VFont.body)
+                .foregroundColor(VColor.systemMidStrong)
+        } else if let version = effectiveVersion {
+            Text(version)
+                .font(VFont.mono)
+                .foregroundColor(isVersionIncompatible ? VColor.systemNegativeStrong : VColor.contentDefault)
+                .textSelection(.enabled)
+
+            if assistantVersionBehind {
+                if isUpgradingInline {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    VButton(label: "Upgrade", style: .primary) {
+                        onUpgradeTapped()
+                    }
+                    .disabled(isUpgradingInline)
+                }
+            }
+        } else {
+            Text("Not available")
+                .font(VFont.body)
+                .foregroundColor(VColor.contentTertiary)
         }
     }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for upgrade-broadcast.md.

**Gap:** SwiftUI reactivity — daemonClient is a plain var, not @ObservedObject
**What was expected:** The update-in-progress indicator should reactively update when DaemonClient published properties change
**What was found:** daemonClient is a plain var, so SwiftUI doesn't observe its @Published property changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
