### PR TITLE
fix: reset SSE reconnect delay before version-change callback clears update state

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -677,6 +677,11 @@ public final class HTTPTransport {
                     if let id = UserDefaults.standard.string(forKey: "connectedAssistantId"), !id.isEmpty {
                         LockfilePaths.updateServiceGroupVersion(assistantId: id, version: newVersion)
                     }
+                    // Reset SSE reconnect backoff BEFORE the version-change
+                    // callback, which clears isUpdateInProgress synchronously.
+                    if isUpdateInProgress {
+                        sseReconnectDelay = 1.0
+                    }
                     onDaemonVersionChanged?(newVersion)
                 } else if let newVersion = decoded.version {
                     daemonVersion = newVersion


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for upgrade-broadcast.md.

**Gap:** SSE reconnect delay reset happens after callback clears isUpdateInProgress
**What was expected:** SSE reconnect delay should be reset to 1.0 before update-in-progress state is cleared
**What was found:** The onDaemonVersionChanged callback clears isUpdateInProgress before the delay reset check runs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20024" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
