### PR TITLE
fix: add OpenAPI schema entry for upgrade-broadcast gateway route

### DIFF
--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1643,7 +1643,9 @@ export function buildSchema(): Record<string, unknown> {
                 },
               },
             },
-            "400": { description: "Missing or invalid provider_key query parameter" },
+            "400": {
+              description: "Missing or invalid provider_key query parameter",
+            },
             "401": {
               description: "Unauthorized — missing or invalid bearer token",
             },
@@ -2522,6 +2524,31 @@ export function buildSchema(): Record<string, unknown> {
                 },
               },
             },
+          },
+        },
+      },
+      "/v1/admin/upgrade-broadcast": {
+        post: {
+          summary: "Broadcast upgrade to connected clients",
+          description:
+            "Internal control-plane endpoint that proxies an upgrade-broadcast request to the assistant daemon. Authenticated with an edge JWT. The daemon notifies all connected clients that a new version is available.",
+          operationId: "upgradeBroadcast",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: false,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Broadcast sent successfully" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "502": { description: "Failed to reach assistant daemon" },
+            "504": { description: "Assistant daemon request timed out" },
           },
         },
       },


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for upgrade-broadcast.md.

**Gap:** Missing OpenAPI schema entry for gateway route
**What was expected:** The gateway route /v1/admin/upgrade-broadcast should have schema coverage
**What was found:** No schema entry or exclusion for the new route
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
