### PR TITLE
fix: exclude signing-key-bootstrap from route-schema guard

### DIFF
--- a/gateway/src/__tests__/route-schema-guard.test.ts
+++ b/gateway/src/__tests__/route-schema-guard.test.ts
@@ -130,6 +130,9 @@ const EXCLUDED_FROM_SCHEMA = new Set([
 
   // Runtime proxy catch-all — documented as /{path} in the schema
   "catch-all",
+
+  // Internal Docker bootstrap endpoint — not a public API
+  "/internal/signing-key-bootstrap",
 ]);
 
 // ── Schema paths that don't map to a discrete route definition ──


### PR DESCRIPTION
## Summary
- Add `/internal/signing-key-bootstrap` to the `EXCLUDED_FROM_SCHEMA` set in `route-schema-guard.test.ts`
- This internal Docker bootstrap endpoint was added in #20013 but not excluded from the schema guard, causing CI failure

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23329299424/job/67857369215