### PR TITLE
feat: add previousServiceGroupVersion and previousContainerInfo to lockfile schema

### DIFF
--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -78,6 +78,10 @@ export interface AssistantEntry {
   serviceGroupVersion?: string;
   /** Docker image metadata for rollback. Only present for docker topology entries. */
   containerInfo?: ContainerInfo;
+  /** The service group version that was running before the last upgrade. */
+  previousServiceGroupVersion?: string;
+  /** Docker image metadata from before the last upgrade. Enables rollback to the prior version. */
+  previousContainerInfo?: ContainerInfo;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
- Add `previousServiceGroupVersion?: string` field to `AssistantEntry` interface
- Add `previousContainerInfo?: ContainerInfo` field to `AssistantEntry` interface
- Enables persisting rollback state across upgrades

Part of plan: upgrade-controls.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
