### PR TITLE
feat: persist previous version and container info in lockfile during Docker upgrade

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -265,6 +265,18 @@ async function upgradeDocker(
     );
   }
 
+  // Persist rollback state to lockfile BEFORE any destructive changes.
+  // This enables the `vellum rollback` command to restore the previous version.
+  if (entry.serviceGroupVersion && entry.containerInfo) {
+    const rollbackEntry: AssistantEntry = {
+      ...entry,
+      previousServiceGroupVersion: entry.serviceGroupVersion,
+      previousContainerInfo: { ...entry.containerInfo },
+    };
+    saveAssistantEntry(rollbackEntry);
+    console.log(`   Saved rollback state: ${entry.serviceGroupVersion}\n`);
+  }
+
   console.log("💾 Capturing existing container environment...");
   const capturedEnv = await captureContainerEnv(res.assistantContainer);
   console.log(
@@ -372,6 +384,8 @@ async function upgradeDocker(
         cesDigest: newDigests?.["credential-executor"],
         networkName: res.network,
       },
+      previousServiceGroupVersion: entry.serviceGroupVersion,
+      previousContainerInfo: entry.containerInfo,
     };
     saveAssistantEntry(updatedEntry);
 
@@ -430,6 +444,8 @@ async function upgradeDocker(
                 cesDigest: previousImageRefs["credential-executor"],
                 networkName: res.network,
               },
+              previousServiceGroupVersion: undefined,
+              previousContainerInfo: undefined,
             };
             saveAssistantEntry(rolledBackEntry);
           }


### PR DESCRIPTION
## Summary
- Save current `serviceGroupVersion` and `containerInfo` as `previousServiceGroupVersion` and `previousContainerInfo` before Docker upgrade
- Preserve previous-version fields after successful upgrade for manual rollback support
- Clear previous-version fields after automatic rollback (failed upgrade)
- Rollback state is persisted before any destructive operations

Part of plan: upgrade-controls.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
