### PR TITLE
feat: add `vellum rollback` CLI command for Docker assistants

### DIFF
--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -1,0 +1,274 @@
+import { randomBytes } from "crypto";
+
+import {
+  findAssistantByName,
+  getActiveAssistant,
+  loadAllAssistants,
+  saveAssistantEntry,
+} from "../lib/assistant-config";
+import type { AssistantEntry } from "../lib/assistant-config";
+import {
+  captureImageRefs,
+  clearSigningKeyBootstrapLock,
+  GATEWAY_INTERNAL_PORT,
+  dockerResourceNames,
+  migrateCesSecurityFiles,
+  migrateGatewaySecurityFiles,
+  startContainers,
+  stopContainers,
+} from "../lib/docker";
+import type { ServiceName } from "../lib/docker";
+import {
+  broadcastUpgradeEvent,
+  captureContainerEnv,
+  waitForReady,
+} from "./upgrade";
+
+function parseArgs(): { name: string | null } {
+  const args = process.argv.slice(3);
+  let name: string | null = null;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--help" || arg === "-h") {
+      console.log("Usage: vellum rollback [<name>]");
+      console.log("");
+      console.log("Roll back a Docker assistant to the previous version.");
+      console.log("");
+      console.log("Arguments:");
+      console.log(
+        "  <name>  Name of the assistant to roll back (default: active or only assistant)",
+      );
+      console.log("");
+      console.log("Examples:");
+      console.log(
+        "  vellum rollback                # Roll back the active assistant",
+      );
+      console.log(
+        "  vellum rollback my-assistant   # Roll back a specific assistant by name",
+      );
+      process.exit(0);
+    } else if (!arg.startsWith("-")) {
+      name = arg;
+    } else {
+      console.error(`Error: Unknown option '${arg}'.`);
+      process.exit(1);
+    }
+  }
+
+  return { name };
+}
+
+function resolveCloud(entry: AssistantEntry): string {
+  if (entry.cloud) {
+    return entry.cloud;
+  }
+  if (entry.project) {
+    return "gcp";
+  }
+  if (entry.sshUser) {
+    return "custom";
+  }
+  return "local";
+}
+
+/**
+ * Resolve which assistant to target for the rollback command. Priority:
+ * 1. Explicit name argument
+ * 2. Active assistant set via `vellum use`
+ * 3. Sole assistant (when exactly one exists)
+ */
+function resolveTargetAssistant(nameArg: string | null): AssistantEntry {
+  if (nameArg) {
+    const entry = findAssistantByName(nameArg);
+    if (!entry) {
+      console.error(`No assistant found with name '${nameArg}'.`);
+      process.exit(1);
+    }
+    return entry;
+  }
+
+  const active = getActiveAssistant();
+  if (active) {
+    const entry = findAssistantByName(active);
+    if (entry) return entry;
+  }
+
+  const all = loadAllAssistants();
+  if (all.length === 1) return all[0];
+
+  if (all.length === 0) {
+    console.error("No assistants found. Run 'vellum hatch' first.");
+  } else {
+    console.error(
+      "Multiple assistants found. Specify a name or set an active assistant with 'vellum use <name>'.",
+    );
+  }
+  process.exit(1);
+}
+
+export async function rollback(): Promise<void> {
+  const { name } = parseArgs();
+  const entry = resolveTargetAssistant(name);
+  const cloud = resolveCloud(entry);
+
+  // Only Docker assistants support rollback
+  if (cloud !== "docker") {
+    console.error(
+      "Rollback is only supported for Docker assistants. For managed assistants, use the version picker to upgrade to the previous version.",
+    );
+    process.exit(1);
+  }
+
+  // Verify rollback state exists
+  if (!entry.previousServiceGroupVersion || !entry.previousContainerInfo) {
+    console.error(
+      "No rollback state available. Run `vellum upgrade` first to create a rollback point.",
+    );
+    process.exit(1);
+  }
+
+  // Verify all three digest fields are present
+  const prev = entry.previousContainerInfo;
+  if (!prev.assistantDigest || !prev.gatewayDigest || !prev.cesDigest) {
+    console.error(
+      "Incomplete rollback state. Previous container digests are missing.",
+    );
+    process.exit(1);
+  }
+
+  // Build image refs from the previous digests
+  const previousImageRefs: Record<ServiceName, string> = {
+    assistant: prev.assistantDigest,
+    "credential-executor": prev.cesDigest,
+    gateway: prev.gatewayDigest,
+  };
+
+  const instanceName = entry.assistantId;
+  const res = dockerResourceNames(instanceName);
+
+  console.log(
+    `🔄 Rolling back Docker assistant '${instanceName}' to ${entry.previousServiceGroupVersion}...\n`,
+  );
+
+  // Capture current container env
+  console.log("💾 Capturing existing container environment...");
+  const capturedEnv = await captureContainerEnv(res.assistantContainer);
+  console.log(
+    `   Captured ${Object.keys(capturedEnv).length} env var(s) from ${res.assistantContainer}\n`,
+  );
+
+  // Extract CES_SERVICE_TOKEN from captured env, or generate fresh one
+  const cesServiceToken =
+    capturedEnv["CES_SERVICE_TOKEN"] || randomBytes(32).toString("hex");
+
+  // Build extra env vars, excluding keys managed by serviceDockerRunArgs
+  const envKeysSetByRunArgs = new Set([
+    "CES_SERVICE_TOKEN",
+    "VELLUM_ASSISTANT_NAME",
+    "RUNTIME_HTTP_HOST",
+    "PATH",
+  ]);
+  for (const envVar of ["ANTHROPIC_API_KEY", "VELLUM_PLATFORM_URL"]) {
+    if (process.env[envVar]) {
+      envKeysSetByRunArgs.add(envVar);
+    }
+  }
+  const extraAssistantEnv: Record<string, string> = {};
+  for (const [key, value] of Object.entries(capturedEnv)) {
+    if (!envKeysSetByRunArgs.has(key)) {
+      extraAssistantEnv[key] = value;
+    }
+  }
+
+  // Parse gateway port from entry's runtimeUrl, fall back to default
+  let gatewayPort = GATEWAY_INTERNAL_PORT;
+  try {
+    const parsed = new URL(entry.runtimeUrl);
+    const port = parseInt(parsed.port, 10);
+    if (!isNaN(port)) {
+      gatewayPort = port;
+    }
+  } catch {
+    // use default
+  }
+
+  // Notify connected clients that a rollback is about to begin (best-effort)
+  console.log("📢 Notifying connected clients...");
+  await broadcastUpgradeEvent(entry.runtimeUrl, entry.assistantId, {
+    type: "starting",
+    targetVersion: entry.previousServiceGroupVersion,
+    expectedDowntimeSeconds: 60,
+  });
+  // Brief pause to allow SSE delivery before containers stop.
+  await new Promise((r) => setTimeout(r, 500));
+
+  console.log("🛑 Stopping existing containers...");
+  await stopContainers(res);
+  console.log("✅ Containers stopped\n");
+
+  // Run security file migrations and signing key cleanup
+  console.log("🔄 Migrating security files to gateway volume...");
+  await migrateGatewaySecurityFiles(res, (msg) => console.log(msg));
+
+  console.log("🔄 Migrating credential files to CES security volume...");
+  await migrateCesSecurityFiles(res, (msg) => console.log(msg));
+
+  console.log("🔑 Clearing signing key bootstrap lock...");
+  await clearSigningKeyBootstrapLock(res);
+
+  console.log("🚀 Starting containers with previous version...");
+  await startContainers(
+    {
+      cesServiceToken,
+      extraAssistantEnv,
+      gatewayPort,
+      imageTags: previousImageRefs,
+      instanceName,
+      res,
+    },
+    (msg) => console.log(msg),
+  );
+  console.log("✅ Containers started\n");
+
+  console.log("Waiting for assistant to become ready...");
+  const ready = await waitForReady(entry.runtimeUrl);
+
+  if (ready) {
+    // Capture new digests from the rolled-back containers
+    const newDigests = await captureImageRefs(res);
+
+    // Swap current/previous state to enable "rollback the rollback"
+    const updatedEntry: AssistantEntry = {
+      ...entry,
+      serviceGroupVersion: entry.previousServiceGroupVersion,
+      containerInfo: {
+        assistantImage: prev.assistantImage ?? previousImageRefs.assistant,
+        gatewayImage: prev.gatewayImage ?? previousImageRefs.gateway,
+        cesImage: prev.cesImage ?? previousImageRefs["credential-executor"],
+        assistantDigest: newDigests?.assistant,
+        gatewayDigest: newDigests?.gateway,
+        cesDigest: newDigests?.["credential-executor"],
+        networkName: res.network,
+      },
+      previousServiceGroupVersion: entry.serviceGroupVersion,
+      previousContainerInfo: entry.containerInfo,
+    };
+    saveAssistantEntry(updatedEntry);
+
+    // Notify clients that the rollback succeeded
+    await broadcastUpgradeEvent(entry.runtimeUrl, entry.assistantId, {
+      type: "complete",
+      installedVersion: entry.previousServiceGroupVersion,
+      success: true,
+    });
+
+    console.log(
+      `\n✅ Docker assistant '${instanceName}' rolled back to ${entry.previousServiceGroupVersion}.`,
+    );
+  } else {
+    console.error(`\n❌ Containers failed to become ready within the timeout.`);
+    console.log(`   Check logs with: docker logs -f ${res.assistantContainer}`);
+    process.exit(1);
+  }
+}

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -139,7 +139,7 @@ function resolveTargetAssistant(nameArg: string | null): AssistantEntry {
  * Capture environment variables from a running Docker container so they
  * can be replayed onto the replacement container after upgrade.
  */
-async function captureContainerEnv(
+export async function captureContainerEnv(
   containerName: string,
 ): Promise<Record<string, string>> {
   const captured: Record<string, string> = {};
@@ -167,7 +167,7 @@ async function captureContainerEnv(
  * Poll the gateway `/readyz` endpoint until it returns 200 or the timeout
  * elapses. Returns whether the assistant became ready.
  */
-async function waitForReady(runtimeUrl: string): Promise<boolean> {
+export async function waitForReady(runtimeUrl: string): Promise<boolean> {
   const readyUrl = `${runtimeUrl}/readyz`;
   const start = Date.now();
 
@@ -206,7 +206,7 @@ async function waitForReady(runtimeUrl: string): Promise<boolean> {
  * via the gateway's upgrade-broadcast proxy. Uses guardian token auth.
  * Failures are logged but never block the upgrade flow.
  */
-async function broadcastUpgradeEvent(
+export async function broadcastUpgradeEvent(
   gatewayUrl: string,
   assistantId: string,
   event: Record<string, unknown>,

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -11,6 +11,7 @@ import { ps } from "./commands/ps";
 import { recover } from "./commands/recover";
 import { restore } from "./commands/restore";
 import { retire } from "./commands/retire";
+import { rollback } from "./commands/rollback";
 import { setup } from "./commands/setup";
 import { sleep } from "./commands/sleep";
 import { ssh } from "./commands/ssh";
@@ -39,6 +40,7 @@ const commands = {
   recover,
   restore,
   retire,
+  rollback,
   setup,
   sleep,
   ssh,
@@ -68,6 +70,9 @@ function printHelp(): void {
   console.log("  recover  Restore a previously retired local assistant");
   console.log("  restore  Restore a .vbundle backup into a running assistant");
   console.log("  retire   Delete an assistant instance");
+  console.log(
+    "  rollback  Roll back a Docker assistant to the previous version",
+  );
   console.log("  setup    Configure API keys interactively");
   console.log("  sleep    Stop the assistant process");
   console.log("  ssh      SSH into a remote assistant instance");


### PR DESCRIPTION
## Summary
- Create `cli/src/commands/rollback.ts` with full Docker rollback flow
- Export `broadcastUpgradeEvent`, `captureContainerEnv`, and `waitForReady` from upgrade.ts for reuse
- Register `rollback` command in CLI index with help text
- Swaps current/previous state to enable 'rollback the rollback'

Part of plan: upgrade-controls.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
