### PR TITLE
fix: require bootstrap secret for guardian init in Docker mode

### DIFF
--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -18,6 +18,7 @@ import {
   stopContainers,
 } from "../lib/docker";
 import type { ServiceName } from "../lib/docker";
+import { loadBootstrapSecret } from "../lib/guardian-token";
 import {
   broadcastUpgradeEvent,
   captureContainerEnv,
@@ -162,6 +163,10 @@ export async function rollback(): Promise<void> {
   const cesServiceToken =
     capturedEnv["CES_SERVICE_TOKEN"] || randomBytes(32).toString("hex");
 
+  // Retrieve or generate a bootstrap secret for the gateway.
+  const bootstrapSecret =
+    loadBootstrapSecret(instanceName) || randomBytes(32).toString("hex");
+
   // Build extra env vars, excluding keys managed by serviceDockerRunArgs
   const envKeysSetByRunArgs = new Set([
     "CES_SERVICE_TOKEN",
@@ -220,6 +225,7 @@ export async function rollback(): Promise<void> {
   console.log("🚀 Starting containers with previous version...");
   await startContainers(
     {
+      bootstrapSecret,
       cesServiceToken,
       extraAssistantEnv,
       gatewayPort,

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -27,7 +27,7 @@ import {
   getPlatformUrl,
   readPlatformToken,
 } from "../lib/platform-client";
-import { loadGuardianToken } from "../lib/guardian-token";
+import { loadBootstrapSecret, loadGuardianToken } from "../lib/guardian-token";
 import { exec, execOutput } from "../lib/step-runner";
 
 interface UpgradeArgs {
@@ -322,6 +322,11 @@ async function upgradeDocker(
   const cesServiceToken =
     capturedEnv["CES_SERVICE_TOKEN"] || randomBytes(32).toString("hex");
 
+  // Retrieve or generate a bootstrap secret for the gateway. The secret was
+  // persisted to disk during hatch; older instances won't have one yet.
+  const bootstrapSecret =
+    loadBootstrapSecret(instanceName) || randomBytes(32).toString("hex");
+
   // Build the set of extra env vars to replay on the new assistant container.
   // Captured env vars serve as the base; keys already managed by
   // serviceDockerRunArgs are excluded to avoid duplicates.
@@ -356,6 +361,7 @@ async function upgradeDocker(
   console.log("🚀 Starting upgraded containers...");
   await startContainers(
     {
+      bootstrapSecret,
       cesServiceToken,
       extraAssistantEnv,
       gatewayPort,
@@ -409,6 +415,7 @@ async function upgradeDocker(
 
         await startContainers(
           {
+            bootstrapSecret,
             cesServiceToken,
             extraAssistantEnv,
             gatewayPort,

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -14,7 +14,7 @@ import {
 import type { AssistantEntry } from "./assistant-config";
 import { DEFAULT_GATEWAY_PORT, PROVIDER_ENV_VAR_NAMES } from "./constants";
 import type { Species } from "./constants";
-import { leaseGuardianToken } from "./guardian-token";
+import { leaseGuardianToken, saveBootstrapSecret } from "./guardian-token";
 import { isVellumProcess, stopProcess } from "./process";
 import { generateInstanceName } from "./random-name";
 import { exec, execOutput } from "./step-runner";
@@ -464,6 +464,7 @@ async function buildAllImages(
  * can be restarted independently.
  */
 export function serviceDockerRunArgs(opts: {
+  bootstrapSecret?: string;
   cesServiceToken?: string;
   extraAssistantEnv?: Record<string, string>;
   gatewayPort: number;
@@ -551,6 +552,9 @@ export function serviceDockerRunArgs(opts: {
       `CES_CREDENTIAL_URL=http://${res.cesContainer}:8090`,
       ...(cesServiceToken
         ? ["-e", `CES_SERVICE_TOKEN=${cesServiceToken}`]
+        : []),
+      ...(opts.bootstrapSecret
+        ? ["-e", `GUARDIAN_BOOTSTRAP_SECRET=${opts.bootstrapSecret}`]
         : []),
       imageTags.gateway,
     ],
@@ -1124,8 +1128,10 @@ export async function hatchDocker(
     ]);
 
     const cesServiceToken = randomBytes(32).toString("hex");
+    const bootstrapSecret = randomBytes(32).toString("hex");
+    saveBootstrapSecret(instanceName, bootstrapSecret);
     await startContainers(
-      { cesServiceToken, gatewayPort, imageTags, instanceName, res },
+      { bootstrapSecret, cesServiceToken, gatewayPort, imageTags, instanceName, res },
       log,
     );
 

--- a/cli/src/lib/guardian-token.ts
+++ b/cli/src/lib/guardian-token.ts
@@ -42,6 +42,46 @@ function getPersistedDeviceIdPath(): string {
   return join(getXdgConfigHome(), "vellum", "device-id");
 }
 
+function getBootstrapSecretPath(assistantId: string): string {
+  return join(
+    getXdgConfigHome(),
+    "vellum",
+    "assistants",
+    assistantId,
+    "bootstrap-secret",
+  );
+}
+
+/**
+ * Load a previously saved bootstrap secret for the given assistant.
+ * Returns null if the file does not exist or is unreadable.
+ */
+export function loadBootstrapSecret(assistantId: string): string | null {
+  try {
+    const raw = readFileSync(getBootstrapSecretPath(assistantId), "utf-8").trim();
+    return raw.length > 0 ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist a bootstrap secret for the given assistant so that the desktop
+ * client and upgrade/rollback paths can retrieve it later.
+ */
+export function saveBootstrapSecret(
+  assistantId: string,
+  secret: string,
+): void {
+  const path = getBootstrapSecretPath(assistantId);
+  const dir = dirname(path);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+  writeFileSync(path, secret + "\n", { mode: 0o600 });
+  chmodSync(path, 0o600);
+}
+
 function hashWithSalt(input: string): string {
   return createHash("sha256")
     .update(input + DEVICE_ID_SALT)
@@ -168,9 +208,14 @@ export async function leaseGuardianToken(
   assistantId: string,
 ): Promise<GuardianTokenData> {
   const deviceId = computeDeviceId();
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  const bootstrapSecret = loadBootstrapSecret(assistantId);
+  if (bootstrapSecret) {
+    headers["x-bootstrap-secret"] = bootstrapSecret;
+  }
   const response = await fetch(`${gatewayUrl}/v1/guardian/init`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify({ platform: "cli", deviceId }),
   });
 

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -97,12 +97,20 @@ public enum GatewayHTTPClient {
     /// - Parameters:
     ///   - path: Path segment after `/v1/`.
     ///   - json: A JSON-serializable dictionary used as the request body.
+    ///   - extraHeaders: Optional additional headers to include in the request.
     ///   - timeout: Request timeout in seconds. Defaults to 30.
     /// - Returns: A `Response` with the raw data and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, serialization errors, or network errors.
-    public static func post(path: String, json: [String: Any], timeout: TimeInterval = 30) async throws -> Response {
+    public static func post(path: String, json: [String: Any], extraHeaders: [String: String]? = nil, timeout: TimeInterval = 30) async throws -> Response {
         let body = try JSONSerialization.data(withJSONObject: json)
-        return try await post(path: path, body: body, timeout: timeout)
+        return try await executeWithRetry(path: path, method: "POST", timeout: timeout) { request in
+            request.httpBody = body
+            if let extraHeaders {
+                for (key, value) in extraHeaders {
+                    request.setValue(value, forHTTPHeaderField: key)
+                }
+            }
+        }
     }
 
     /// Performs an authenticated PATCH request against the gateway.

--- a/clients/shared/Network/GuardianClient.swift
+++ b/clients/shared/Network/GuardianClient.swift
@@ -86,8 +86,17 @@ public struct GuardianClient: GuardianClientProtocol {
         ]
 
         do {
+            // Include bootstrap secret header if one was persisted by the CLI
+            // during Docker hatch. This authenticates the bootstrap request to
+            // the gateway in containerized deployments.
+            var extraHeaders: [String: String]? = nil
+            if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
+               let secret = Self.loadBootstrapSecret(assistantId: assistantId) {
+                extraHeaders = ["x-bootstrap-secret": secret]
+            }
+
             let response = try await GatewayHTTPClient.post(
-                path: "guardian/init", json: body, timeout: 15
+                path: "guardian/init", json: body, extraHeaders: extraHeaders, timeout: 15
             )
             guard response.isSuccess else {
                 log.error("Access token bootstrap failed (HTTP \(response.statusCode))")
@@ -109,6 +118,23 @@ public struct GuardianClient: GuardianClientProtocol {
             log.error("Access token bootstrap error: \(error.localizedDescription)")
             return false
         }
+    }
+
+    // MARK: - Bootstrap Secret
+
+    /// Reads the bootstrap secret persisted by the CLI at
+    /// `$XDG_CONFIG_HOME/vellum/assistants/<id>/bootstrap-secret`.
+    private static func loadBootstrapSecret(assistantId: String) -> String? {
+        let configHome: String
+        if let xdg = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !xdg.isEmpty {
+            configHome = xdg
+        } else {
+            configHome = NSHomeDirectory() + "/.config"
+        }
+        let path = "\(configHome)/vellum/assistants/\(assistantId)/bootstrap-secret"
+        return try? String(contentsOfFile: path, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     // MARK: - Response Shapes

--- a/gateway/src/__tests__/guardian-init-lockfile.test.ts
+++ b/gateway/src/__tests__/guardian-init-lockfile.test.ts
@@ -80,6 +80,100 @@ afterEach(() => {
   writtenLockFiles = [];
 });
 
+describe("guardian/init bootstrap secret", () => {
+  test("rejects requests without secret when GUARDIAN_BOOTSTRAP_SECRET is set", async () => {
+    process.env.GUARDIAN_BOOTSTRAP_SECRET = "test-secret-abc123";
+    try {
+      const handler = createChannelVerificationSessionProxyHandler(makeConfig());
+      const res = await handler.handleGuardianInit(
+        new Request("http://localhost:7830/v1/guardian/init", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ platform: "cli", deviceId: "test-device" }),
+        }),
+      );
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe("Invalid bootstrap secret");
+    } finally {
+      delete process.env.GUARDIAN_BOOTSTRAP_SECRET;
+    }
+  });
+
+  test("rejects requests with wrong secret", async () => {
+    process.env.GUARDIAN_BOOTSTRAP_SECRET = "test-secret-abc123";
+    try {
+      const handler = createChannelVerificationSessionProxyHandler(makeConfig());
+      const res = await handler.handleGuardianInit(
+        new Request("http://localhost:7830/v1/guardian/init", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-bootstrap-secret": "wrong-secret",
+          },
+          body: JSON.stringify({ platform: "cli", deviceId: "test-device" }),
+        }),
+      );
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe("Invalid bootstrap secret");
+    } finally {
+      delete process.env.GUARDIAN_BOOTSTRAP_SECRET;
+    }
+  });
+
+  test("accepts requests with correct secret", async () => {
+    process.env.GUARDIAN_BOOTSTRAP_SECRET = "test-secret-abc123";
+    fetchMock = mock(async () => {
+      return new Response(
+        JSON.stringify({ accessToken: "test-jwt", refreshToken: "test-rt" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    try {
+      const handler = createChannelVerificationSessionProxyHandler(makeConfig());
+      const res = await handler.handleGuardianInit(
+        new Request("http://localhost:7830/v1/guardian/init", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-bootstrap-secret": "test-secret-abc123",
+          },
+          body: JSON.stringify({ platform: "cli", deviceId: "test-device" }),
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    } finally {
+      delete process.env.GUARDIAN_BOOTSTRAP_SECRET;
+    }
+  });
+
+  test("skips secret check when GUARDIAN_BOOTSTRAP_SECRET is not set", async () => {
+    delete process.env.GUARDIAN_BOOTSTRAP_SECRET;
+    fetchMock = mock(async () => {
+      return new Response(
+        JSON.stringify({ accessToken: "test-jwt", refreshToken: "test-rt" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const handler = createChannelVerificationSessionProxyHandler(makeConfig());
+    const res = await handler.handleGuardianInit(
+      new Request("http://localhost:7830/v1/guardian/init", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ platform: "cli", deviceId: "test-device" }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+  });
+});
+
 describe("guardian/init one-time-use lockfile", () => {
   test("first call succeeds and creates lock file", async () => {
     fetchMock = mock(async () => {

--- a/gateway/src/http/routes/channel-verification-session-proxy.ts
+++ b/gateway/src/http/routes/channel-verification-session-proxy.ts
@@ -150,6 +150,21 @@ export function createChannelVerificationSessionProxyHandler(
       req: Request,
       clientIp?: string,
     ): Promise<Response> {
+      // When GUARDIAN_BOOTSTRAP_SECRET is set (Docker mode), require the
+      // caller to present the matching secret. This prevents unauthenticated
+      // remote callers from bootstrapping guardian tokens through the gateway.
+      const bootstrapSecret = process.env.GUARDIAN_BOOTSTRAP_SECRET;
+      if (bootstrapSecret) {
+        const provided = req.headers.get("x-bootstrap-secret");
+        if (provided !== bootstrapSecret) {
+          log.warn("Guardian init rejected — invalid or missing bootstrap secret");
+          return Response.json(
+            { error: "Invalid bootstrap secret" },
+            { status: 403 },
+          );
+        }
+      }
+
       const lockDir = process.env.GATEWAY_SECURITY_DIR || getRootDir();
       const lockPath = join(lockDir, "guardian-init.lock");
       if (existsSync(lockPath) || guardianInitInFlight) {


### PR DESCRIPTION
## Summary
- Adds a shared bootstrap secret between the CLI and gateway to prevent unauthenticated remote callers from obtaining guardian tokens in Docker deployments
- CLI generates the secret during hatch, persists to disk, and passes as `GUARDIAN_BOOTSTRAP_SECRET` env var to the gateway container
- Gateway validates the `x-bootstrap-secret` header before proxying bootstrap requests; CLI and desktop client include the secret from the persisted file
- Upgrade/rollback paths thread the bootstrap secret through to new containers

## Original prompt
Fix the container-mode guardian bootstrap bypass. In CLI-managed Docker instances, the gateway exposes `/v1/guardian/init` with `auth: "none"` and the assistant runtime skips the x-forwarded-for public IP check when `IS_CONTAINERIZED=true`. This means any remote attacker who can reach the gateway during the narrow window before the first legitimate bootstrap completes could obtain guardian tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
