### PR TITLE
fix: remove double v prefix in rollback version display

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -275,7 +275,7 @@ struct SettingsDeveloperTab: View {
                 Task { await performRollback() }
             }
         } message: {
-            Text("Roll back to version v\(rollbackVersion)? The assistant will be briefly unavailable.")
+            Text("Roll back to version \(rollbackVersion)? The assistant will be briefly unavailable.")
         }
         .sheet(isPresented: $isRestarting) {
             VStack(spacing: VSpacing.lg) {
@@ -1408,7 +1408,7 @@ private struct DockerRollbackSection: View {
                 Text("Previous version:")
                     .font(VFont.caption)
                     .foregroundColor(VColor.contentTertiary)
-                Text("v\(previousVersion)")
+                Text("\(previousVersion)")
                     .font(VFont.mono)
                     .foregroundColor(VColor.contentDefault)
             }
@@ -1457,7 +1457,7 @@ private struct ManagedRollbackSection: View {
                 Text("Previous version:")
                     .font(VFont.caption)
                     .foregroundColor(VColor.contentTertiary)
-                Text("v\(previousVersion)")
+                Text("\(previousVersion)")
                     .font(VFont.mono)
                     .foregroundColor(VColor.contentDefault)
             }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for upgrade-controls.md.

**Gap:** Double v prefix in rollback version display
**What was expected:** Version displayed as `v0.1.135`
**What was found:** Version displayed as `vv0.1.135` because the stored value already includes the `v` prefix
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
