### PR TITLE
fix: use currentVersion to disable rollback button when already on previous version

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -1449,6 +1449,13 @@ private struct ManagedRollbackSection: View {
     @Binding var showingRollbackConfirmation: Bool
     @Binding var rollbackVersion: String
 
+    /// Whether the assistant is already running the previous version,
+    /// meaning a rollback would be a no-op.
+    private var alreadyOnPreviousVersion: Bool {
+        guard let currentVersion else { return false }
+        return currentVersion == previousVersion
+    }
+
     var body: some View {
         SettingsCard(
             title: "Rollback",
@@ -1468,7 +1475,7 @@ private struct ManagedRollbackSection: View {
                     rollbackVersion = previousVersion
                     showingRollbackConfirmation = true
                 }
-                .disabled(isRollingBack)
+                .disabled(isRollingBack || alreadyOnPreviousVersion)
 
                 if isRollingBack {
                     ProgressView()
@@ -1477,6 +1484,12 @@ private struct ManagedRollbackSection: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)
                 }
+            }
+
+            if alreadyOnPreviousVersion {
+                Text("You are already on this version.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
             }
 
             if let error = rollbackError {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for upgrade-controls.md.

**Gap:** Unused currentVersion in ManagedRollbackSection
**What was expected:** Rollback button disabled when already on the previous version
**What was found:** currentVersion parameter was declared but never used

## Changes
- Added `alreadyOnPreviousVersion` computed property that compares `currentVersion` to `previousVersion`
- Disabled the Roll Back button when `currentVersion == previousVersion`
- Added informational message "You are already on this version." when rollback is unnecessary
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
