### PR TITLE
fix: remove unnecessary nonisolated(unsafe) warning in AppDelegate

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -15,7 +15,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     /// The canonical product name shown in menus and the About panel.
     /// Use this instead of hardcoding "Vellum" so the name is defined
     /// in one place.
-    public nonisolated(unsafe) static let appName = "Vellum"
+    public static let appName = "Vellum"
 
     /// Shared reference — `NSApp.delegate as? AppDelegate` fails under
     /// SwiftUI's `@NSApplicationDelegateAdaptor` because SwiftUI wraps


### PR DESCRIPTION
## Summary

- Remove `nonisolated(unsafe)` from `AppDelegate.appName` — `String` is `Sendable`, so the annotation is unnecessary and produces a compiler warning.

## Original prompt

Fix compiler warning: `'nonisolated(unsafe)' is unnecessary for a constant with 'Sendable' type 'String', consider removing it` in `AppDelegate.swift:18`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
