### PR TITLE
fix: add bootstrapSecret to startContainers type signature

### DIFF
--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -739,6 +739,7 @@ export const SERVICE_START_ORDER: ServiceName[] = [
 /** Start all three containers in dependency order. */
 export async function startContainers(
   opts: {
+    bootstrapSecret?: string;
     cesServiceToken?: string;
     extraAssistantEnv?: Record<string, string>;
     gatewayPort: number;


### PR DESCRIPTION
## Summary
- Add `bootstrapSecret` to `startContainers()` type signature in `cli/src/lib/docker.ts`
- Fixes TS2353 errors in `rollback.ts`, `upgrade.ts`, and `docker.ts` where callers pass `bootstrapSecret` but the function type didn't include it
- The property was already accepted by `serviceDockerRunArgs()` which `startContainers` delegates to

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23330811103/job/67861862958
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20038" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
