### PR TITLE
fix: always show "Send Anyway" for secret-blocked messages

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -637,6 +637,7 @@ export async function handleSendMessage(
     interface?: string;
     conversationType?: string;
     automated?: boolean;
+    bypassSecretCheck?: boolean;
   };
 
   const { conversationKey, content, attachmentIds } = body;
@@ -708,7 +709,7 @@ export async function handleSendMessage(
   // This mirrors the legacy handleUserMessage behavior: secrets are
   // detected and the message is rejected with a safe notice. The client
   // should prompt the user to use the secure credential flow instead.
-  if (trimmedContent.length > 0) {
+  if (trimmedContent.length > 0 && !body.bypassSecretCheck) {
     const ingressCheck = checkIngressForSecrets(trimmedContent);
     if (ingressCheck.blocked) {
       log.warn(

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1170,17 +1170,15 @@ public final class HTTPTransport {
                       let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                       let errorCategory = json["error"] as? String,
                       errorCategory == "secret_blocked" {
-                // HTTP mode cannot handle secret-blocked retries (no bypassSecretCheck
-                // support), so surface as a non-retryable conversation error instead
-                // of routing through .error(category: "secret_blocked") which would
-                // activate ChatViewModel's "Send Anyway" UI and create an unrecoverable loop.
+                // Route through .error(category: "secret_blocked") so ChatViewModel
+                // activates the "Send Anyway" UI. The backend now respects
+                // bypassSecretCheck, so resending won't loop.
                 let message = (json["message"] as? String) ?? "Message blocked — contains secrets"
                 log.warning("Message blocked by secret-ingress check")
-                onMessage?(.conversationError(ConversationErrorMessage(
-                    conversationId: conversationId,
-                    code: .providerApi,
-                    userMessage: message,
-                    retryable: false
+                onMessage?(.error(ErrorMessage(
+                    type: "error",
+                    message: message,
+                    category: "secret_blocked"
                 )))
             } else {
                 let errorBody = String(data: data, encoding: .utf8) ?? "unknown"


### PR DESCRIPTION
## Summary
- **Backend**: `POST /v1/messages` now checks `body.bypassSecretCheck` and skips the secret-ingress check when true, so "Send Anyway" resends actually work
- **Client**: `HTTPDaemonClient` routes `secret_blocked` 422 responses through `.error(category: "secret_blocked")` instead of `.conversationError(code: .providerApi)`, activating the existing "Send Anyway" stashing logic in ChatViewModel

## Original prompt
This should always have a "send anyway" button
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
