### PR TITLE
fix: use GATEWAY_INTERNAL_URL for gateway health checks in Docker

### DIFF
--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -51,9 +51,15 @@ export function getGatewayPort(): number {
   return int("GATEWAY_PORT", DEFAULT_GATEWAY_PORT);
 }
 
-/** Resolve the gateway base URL for internal service-to-service calls. */
+/**
+ * Resolve the gateway base URL for internal service-to-service calls.
+ *
+ * In containerized deployments the gateway runs in a separate container,
+ * reachable via `GATEWAY_INTERNAL_URL` (e.g. `http://gateway:7822`).
+ * Falls back to `http://127.0.0.1:<GATEWAY_PORT>` for local deployments.
+ */
 export function getGatewayInternalBaseUrl(): string {
-  return `http://127.0.0.1:${getGatewayPort()}`;
+  return str("GATEWAY_INTERNAL_URL") ?? `http://127.0.0.1:${getGatewayPort()}`;
 }
 
 // ── Ingress ──────────────────────────────────────────────────────────────────

--- a/assistant/src/permissions/trust-client.ts
+++ b/assistant/src/permissions/trust-client.ts
@@ -33,17 +33,6 @@ export interface AcceptStarterBundleResult {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Resolve the gateway base URL for trust rule requests.
- *
- * Prefers the `GATEWAY_INTERNAL_URL` env var (set in Docker environments
- * where the gateway runs in a separate container), falling back to the
- * existing `getGatewayInternalBaseUrl()` helper for local deployments.
- */
-function getBaseUrl(): string {
-  return process.env.GATEWAY_INTERNAL_URL ?? getGatewayInternalBaseUrl();
-}
-
 function authHeaders(): Record<string, string> {
   return {
     Authorization: `Bearer ${mintDaemonDeliveryToken()}`,
@@ -60,7 +49,7 @@ async function request<T>(
   path: string,
   body?: unknown,
 ): Promise<T> {
-  const url = `${getBaseUrl()}${path}`;
+  const url = `${getGatewayInternalBaseUrl()}${path}`;
   const options: RequestInit = {
     method,
     headers: authHeaders(),
@@ -102,7 +91,7 @@ async function request<T>(
  * Write operations are user-initiated and infrequent, so blocking is acceptable.
  */
 function requestSync<T>(method: string, path: string, body?: unknown): T {
-  const url = `${getBaseUrl()}${path}`;
+  const url = `${getGatewayInternalBaseUrl()}${path}`;
   const headers = authHeaders();
   const args: string[] = [
     "curl",


### PR DESCRIPTION
## Summary
- `getGatewayInternalBaseUrl()` now prefers `GATEWAY_INTERNAL_URL` env var (set by the CLI for containerized deployments) before falling back to `http://127.0.0.1:<port>`. This fixes the voice call preflight health check failing in Docker because it was hitting localhost instead of the gateway container.
- Removes the redundant `getBaseUrl()` wrapper in `trust-client.ts` that was working around the same issue — now that the canonical helper handles Docker, all callers get the right URL automatically.

## Original prompt
Fix the `call_start` tool's gateway health check in Docker — it hardcodes `127.0.0.1:7830` but the gateway is on `host.docker.internal`, so the preflight fails and blocks outbound calls.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
