### PR TITLE
feat: enable Dangerously Skip Permissions toggle for Docker assistants

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -348,6 +348,10 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "config/embeddings:GET", scopes: ["settings.read"] },
   { endpoint: "config/embeddings:PUT", scopes: ["settings.write"] },
 
+  // Permissions config
+  { endpoint: "config/permissions/skip:GET", scopes: ["settings.read"] },
+  { endpoint: "config/permissions/skip:PUT", scopes: ["settings.write"] },
+
   // Conversation management
   { endpoint: "conversations:DELETE", scopes: ["chat.write"] },
   { endpoint: "conversations/wipe", scopes: ["chat.write"] },

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1,7 +1,7 @@
 /**
  * HTTP route definitions for model configuration, embedding configuration,
- * conversation search, message content, LLM context inspection, and queued
- * message deletion.
+ * permissions configuration, conversation search, message content, LLM
+ * context inspection, and queued message deletion.
  *
  * These routes expose conversation query functionality over the HTTP API.
  *
@@ -10,12 +10,15 @@
  * PUT    /v1/model/image-gen            — set image-gen model
  * GET    /v1/config/embeddings          — current embedding config
  * PUT    /v1/config/embeddings          — set embedding provider/model
+ * GET    /v1/config/permissions/skip    — dangerouslySkipPermissions status
+ * PUT    /v1/config/permissions/skip    — toggle dangerouslySkipPermissions
  * GET    /v1/conversations/search       — search conversations
  * GET    /v1/messages/:id/content       — full message content
  * GET    /v1/messages/:id/llm-context   — LLM request logs for a message
  * DELETE /v1/messages/queued/:id        — delete queued message
  */
 
+import { getConfig, loadRawConfig, saveRawConfig } from "../../config/loader.js";
 import { VALID_MEMORY_EMBEDDING_PROVIDERS } from "../../config/schemas/memory-storage.js";
 import { VALID_INFERENCE_PROVIDERS } from "../../config/schemas/services.js";
 import {
@@ -247,6 +250,45 @@ export function conversationQueryRouteDefinitions(
             500,
           );
         }
+      },
+    },
+
+    // ── Permissions config ─────────────────────────────────────────────
+    {
+      endpoint: "config/permissions/skip",
+      method: "GET",
+      policyKey: "config/permissions/skip",
+      handler: () => {
+        const config = getConfig();
+        return Response.json({
+          enabled: config.permissions.dangerouslySkipPermissions,
+        });
+      },
+    },
+    {
+      endpoint: "config/permissions/skip",
+      method: "PUT",
+      policyKey: "config/permissions/skip",
+      handler: async ({ req }) => {
+        const body = (await req.json()) as { enabled?: unknown };
+        if (typeof body.enabled !== "boolean") {
+          return httpError(
+            "BAD_REQUEST",
+            "Missing or invalid field: enabled (boolean)",
+            400,
+          );
+        }
+        const raw = loadRawConfig();
+        const permissions: Record<string, unknown> =
+          raw.permissions != null &&
+          typeof raw.permissions === "object" &&
+          !Array.isArray(raw.permissions)
+            ? (raw.permissions as Record<string, unknown>)
+            : {};
+        permissions.dangerouslySkipPermissions = body.enabled;
+        raw.permissions = permissions;
+        saveRawConfig(raw);
+        return Response.json({ enabled: body.enabled });
       },
     },
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -161,20 +161,21 @@ struct SettingsDeveloperTab: View {
 
             // Dangerously Skip Permissions
             SettingsCard(title: "Dangerously Skip Permissions", subtitle: "Auto-accept all permission prompts without asking. The assistant will never pause for approval — use with caution.") {
-                let isRemote = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId })?.isRemote ?? false
+                let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId })
+                let isDisabled = (assistant?.isRemote ?? false) && !(assistant?.isDocker ?? false)
                 HStack(alignment: .top, spacing: VSpacing.sm) {
                     VToggle(isOn: Binding(
                         get: { store.dangerouslySkipPermissions },
                         set: { store.setDangerouslySkipPermissions($0) }
                     ))
                     .accessibilityLabel("Dangerously Skip Permissions")
-                    .disabled(isRemote)
+                    .disabled(isDisabled)
                     .padding(.top, 2)
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         Text("Skip all permission prompts")
                             .font(VFont.body)
                             .foregroundColor(VColor.contentSecondary)
-                        Text(isRemote
+                        Text(isDisabled
                             ? "This setting cannot be changed for remote assistants."
                             : "When enabled, tools execute immediately without asking for approval. Explicit deny rules are still respected.")
                             .font(VFont.caption)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -306,6 +306,14 @@ public final class SettingsStore: ObservableObject {
             .flatMap { LockfileAssistant.loadByName($0) }?.isRemote ?? false
     }
 
+    /// Whether the connected assistant runs in Docker on the local machine.
+    /// Docker assistants are "remote" for filesystem purposes (workspace is on
+    /// a Docker volume) but support config changes via the HTTP API.
+    private var isCurrentAssistantDocker: Bool {
+        UserDefaults.standard.string(forKey: "connectedAssistantId")
+            .flatMap { LockfileAssistant.loadByName($0) }?.isDocker ?? false
+    }
+
     /// Guards against stale `get` responses overwriting an optimistic
     /// toggle. Set when `setIngressEnabled` fires; cleared once a matching
     /// response arrives.
@@ -458,6 +466,7 @@ public final class SettingsStore: ObservableObject {
                 self?.refreshChannelVerificationStatus(channel: "slack")
                 self?.loadProviderRoutingSources()
                 self?.refreshEmbeddingConfig()
+                self?.refreshDangerouslySkipPermissions()
             }
             .store(in: &cancellables)
 
@@ -1014,6 +1023,17 @@ public final class SettingsStore: ObservableObject {
                 self.embeddingEnabled = status.enabled
                 self.embeddingDegraded = status.degraded
             }
+        }
+    }
+
+    /// Fetches the current dangerouslySkipPermissions state from the daemon
+    /// over HTTP. Only meaningful for Docker assistants where the config lives
+    /// inside the container and cannot be read from the host filesystem.
+    func refreshDangerouslySkipPermissions() {
+        guard isCurrentAssistantDocker else { return }
+        Task { @MainActor in
+            guard let enabled = await settingsClient.fetchDangerouslySkipPermissions() else { return }
+            self.dangerouslySkipPermissions = enabled
         }
     }
 
@@ -2940,7 +2960,22 @@ public final class SettingsStore: ObservableObject {
     }
 
     func setDangerouslySkipPermissions(_ enabled: Bool) {
+        // Docker assistants: use the HTTP API (workspace is on a Docker volume,
+        // not directly writable from the host).
+        if isCurrentAssistantDocker {
+            dangerouslySkipPermissions = enabled
+            Task {
+                let success = await settingsClient.setDangerouslySkipPermissions(enabled)
+                if !success {
+                    // Revert optimistic toggle on failure
+                    dangerouslySkipPermissions = !enabled
+                }
+            }
+            return
+        }
+        // Truly remote (managed/cloud) assistants: not supported.
         guard !isCurrentAssistantRemote else { return }
+        // Local assistants: write directly to workspace config file.
         dangerouslySkipPermissions = enabled
         let existingConfig = WorkspaceConfigIO.read(from: configPath)
         var permissions = existingConfig["permissions"] as? [String: Any] ?? [:]

--- a/clients/macos/vellum-assistantTests/MockSettingsClient.swift
+++ b/clients/macos/vellum-assistantTests/MockSettingsClient.swift
@@ -32,6 +32,10 @@ final class MockSettingsClient: SettingsClientProtocol {
     var setEmbeddingConfigResponse: EmbeddingConfigMessage?
     var telegramConfigResponse: TelegramConfigResponseMessage?
     var setTelegramConfigResponse: TelegramConfigResponseMessage?
+    var fetchDangerouslySkipPermissionsResponse: Bool?
+    var setDangerouslySkipPermissionsResponse: Bool = true
+    var fetchDangerouslySkipPermissionsCallCount = 0
+    var setDangerouslySkipPermissionsCalls: [Bool] = []
     var setSlackWebhookConfigResponse: Bool = true
     var channelVerificationResponses: [String: ChannelVerificationSessionResponseMessage] = [:]
     var sendChannelVerificationSessionResponse: ChannelVerificationSessionResponseMessage?
@@ -86,6 +90,16 @@ final class MockSettingsClient: SettingsClientProtocol {
     func setTelegramConfig(action: String, botToken: String?, commands: [TelegramConfigRequestCommand]?) async -> TelegramConfigResponseMessage? {
         setTelegramConfigCalls.append((action: action, botToken: botToken, commands: commands))
         return setTelegramConfigResponse
+    }
+
+    func fetchDangerouslySkipPermissions() async -> Bool? {
+        fetchDangerouslySkipPermissionsCallCount += 1
+        return fetchDangerouslySkipPermissionsResponse
+    }
+
+    func setDangerouslySkipPermissions(_ enabled: Bool) async -> Bool {
+        setDangerouslySkipPermissionsCalls.append(enabled)
+        return setDangerouslySkipPermissionsResponse
     }
 
     func setSlackWebhookConfig(action: String, webhookUrl: String?) async -> Bool {

--- a/clients/shared/Network/SettingsClient.swift
+++ b/clients/shared/Network/SettingsClient.swift
@@ -19,6 +19,8 @@ public protocol SettingsClientProtocol {
     func setEmbeddingConfig(provider: String, model: String?) async -> EmbeddingConfigMessage?
     func fetchTelegramConfig() async -> TelegramConfigResponseMessage?
     func setTelegramConfig(action: String, botToken: String?, commands: [TelegramConfigRequestCommand]?) async -> TelegramConfigResponseMessage?
+    func fetchDangerouslySkipPermissions() async -> Bool?
+    func setDangerouslySkipPermissions(_ enabled: Bool) async -> Bool
     func setSlackWebhookConfig(action: String, webhookUrl: String?) async -> Bool
     func fetchChannelVerificationStatus(channel: String) async -> ChannelVerificationSessionResponseMessage?
     func sendChannelVerificationSession(
@@ -226,6 +228,43 @@ public struct SettingsClient: SettingsClientProtocol {
         } catch {
             log.error("setTelegramConfig error: \(error.localizedDescription)")
             return nil
+        }
+    }
+
+    public func fetchDangerouslySkipPermissions() async -> Bool? {
+        do {
+            let response = try await GatewayHTTPClient.get(
+                path: "config/permissions/skip", timeout: 10
+            )
+            guard response.isSuccess else {
+                log.error("fetchDangerouslySkipPermissions failed (HTTP \(response.statusCode))")
+                return nil
+            }
+            guard let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
+                  let enabled = json["enabled"] as? Bool else {
+                return nil
+            }
+            return enabled
+        } catch {
+            log.error("fetchDangerouslySkipPermissions error: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    public func setDangerouslySkipPermissions(_ enabled: Bool) async -> Bool {
+        do {
+            let body: [String: Any] = ["enabled": enabled]
+            let response = try await GatewayHTTPClient.put(
+                path: "config/permissions/skip", json: body, timeout: 10
+            )
+            guard response.isSuccess else {
+                log.error("setDangerouslySkipPermissions failed (HTTP \(response.statusCode))")
+                return false
+            }
+            return true
+        } catch {
+            log.error("setDangerouslySkipPermissions error: \(error.localizedDescription)")
+            return false
         }
     }
 

--- a/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
+++ b/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
@@ -33,6 +33,10 @@ final class ChatViewModelSlashCommandTests: XCTestCase {
             commands: [TelegramConfigRequestCommand]?
         ) async -> TelegramConfigResponseMessage? { nil }
 
+        func fetchDangerouslySkipPermissions() async -> Bool? { nil }
+
+        func setDangerouslySkipPermissions(_ enabled: Bool) async -> Bool { false }
+
         func setSlackWebhookConfig(action: String, webhookUrl: String?) async -> Bool { false }
 
         func fetchChannelVerificationStatus(channel: String) async -> ChannelVerificationSessionResponseMessage? { nil }


### PR DESCRIPTION
## Summary
- Adds `GET/PUT /v1/config/permissions/skip` HTTP endpoints to the daemon so the macOS client can read/write the `dangerouslySkipPermissions` config setting without direct filesystem access
- Updates the macOS client to use the HTTP API for Docker assistants (whose workspace config lives inside the Docker container) while preserving the direct filesystem write path for local assistants
- Unblocks the UI toggle for Docker assistants — it was previously disabled because Docker was treated as "remote", but Docker assistants run locally and should support this setting

## Original prompt
I want to be able to use this for my local docker assistant
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
