### PR TITLE
fix: resolve AppBundleRenamer actor isolation warning

### DIFF
--- a/clients/macos/vellum-assistant/App/AppBundleRenamer.swift
+++ b/clients/macos/vellum-assistant/App/AppBundleRenamer.swift
@@ -17,6 +17,7 @@ private let log = Logger(
 /// exit, renames the bundle in-place, re-signs it, and relaunches it.
 ///
 /// Production builds always use "Vellum" so this is a no-op for them.
+@MainActor
 enum AppBundleRenamer {
 
     private static let targetName = AppDelegate.appName


### PR DESCRIPTION
## Summary
- Annotated `AppBundleRenamer` with `@MainActor` to fix the Swift strict concurrency warning when accessing `AppDelegate.appName` from a nonisolated context
- `AppBundleRenamer` is only ever called from `AppDelegate` (which is `@MainActor`), so this is the correct isolation boundary

## Original prompt
Fix: warning: main actor-isolated static property 'appName' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
