### PR TITLE
JARVIS-283: Overhaul slack-app-setup skill

### DIFF
--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slack-app-setup
-description: Connect a Slack app to the Vellum Assistant via Socket Mode with guided app creation and guardian verification
+description: Connect a Slack app to the Vellum Assistant via Socket Mode with guided app creation and identity verification
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "💬"
@@ -18,9 +18,22 @@ You are helping your user connect a Slack bot to the Vellum Assistant via Socket
 | App Token | Credential | `credential_store` prompt | **Yes** |
 | Bot Token | Credential | `credential_store` prompt | **Yes** |
 
-- Both tokens are secrets. Always collect via `credential_store` prompt - never accept them pasted in plaintext chat.
+- Both tokens are secrets. Always collect via `credential_store` prompt — never accept them pasted in plaintext chat.
 
 # Setup Steps
+
+## Step 0: Check Existing Configuration
+
+Before starting setup, check whether Slack is already configured:
+
+```bash
+assistant credentials inspect --service slack_channel --field app_token --json
+assistant credentials inspect --service slack_channel --field bot_token --json
+```
+
+- If both credentials have `"hasSecret": true` and the connection is active — Slack is fully configured. Offer to show status or reconfigure.
+- If only one token is present — offer to resume setup from the missing step.
+- If neither is present — continue to Step 1.
 
 ## Step 1: Generate Manifest & Create Slack App
 
@@ -107,8 +120,6 @@ The `slack_channel` secure prompt already routes through the same Slack settings
 - If it returns an error, ask the user to re-enter the token.
 - If it returns a warning that the connection is incomplete, that is expected until the bot token is collected.
 
-Do NOT use `ui_show`, `ui_update`, or any regular form to collect these tokens. Do NOT ask the user to paste them in chat.
-
 ## Step 3: Install App & Collect Bot Token
 
 Tell the user to navigate to **Settings > Install App** in the sidebar, then click **Install to Workspace** and authorize the requested permissions (already pre-configured from the manifest).
@@ -123,63 +134,82 @@ After the bot-token prompt succeeds, the same Slack settings handler used by Set
 - stored workspace metadata (`teamId`, `teamName`, `botUserId`, `botUsername`)
 - activated Socket Mode when both tokens are present
 
-Do NOT run `assistant credentials reveal`, `curl https://slack.com/api/auth.test`, or `assistant config set slack.*` in chat. That is a second implementation path and causes drift from Settings.
-
-## Step 4: Confirm Connection
-
 Use the most recent `credential_store` result as the source of truth:
 
 - If it reports the Slack channel is connected, continue.
 - If it reports an error, stop and fix that error before moving on.
 - If it reports an incomplete setup warning, collect the missing token instead of improvising extra validation commands.
 
-Guardian verification depends on Socket Mode being live, so only proceed once the connection is confirmed.
-
 Show the user their setup progress:
+
 "Setup progress:
 ✅ App created
 ✅ Tokens configured
 ✅ Connection active
 ⬜ Connection tested
 
-Almost there — let's complete the last step!"
+Almost there — let's do a quick test!"
 
-## Step 5: Test Your Connection
+## Step 4: Test Your Connection
 
-Now let's test the connection by verifying the user can receive messages from the bot. This also sets them up as the trusted guardian for this Slack workspace.
+Now let's test the connection by verifying the user can receive messages from the bot. This confirms everything works and links the user's Slack identity for future message delivery.
 
 Load the **guardian-verify-setup** skill:
 
 - Call `skill_load` with `skill: "guardian-verify-setup"`.
 
-If the user explicitly wants to skip this step, proceed to Step 6, but let them know they can always verify later by saying "verify me on slack".
+If the user explicitly wants to skip this step, proceed to Step 5, but let them know they can always verify later by saying "verify me on slack".
 
-## Step 6: Report Success
+## Step 5: Report Success
 
 Summarize with the completed checklist.
 
-If guardian was verified:
+If identity was verified:
+
 "Setup complete!
 ✅ App created
 ✅ Tokens configured
 ✅ Connection active
 ✅ Connection tested
 
-Bot connected: {username} in {workspace}
-Socket Mode: active (gateway auto-connects when credentials are stored)
-Usage: @{botUsername} in any channel, or DM the bot directly"
+Connected: @{botUsername} in {workspace}
+Channels: Invite the bot to any channel with `/invite @{botUsername}`. DMs work immediately.
+Identity: verified"
 
-If guardian was skipped:
+If identity was skipped:
+
 "Setup complete!
 ✅ App created
 ✅ Tokens configured
 ✅ Connection active
-⬜ Connection tested — You can complete this anytime by saying 'help me verify as guardian on slack'
+⬜ Connection tested — you can complete this anytime by saying 'verify me on slack'
 
-Bot connected: {username} in {workspace}
-Socket Mode: active (gateway auto-connects when credentials are stored)
-Usage: @{botUsername} in any channel, or DM the bot directly"
+Connected: @{botUsername} in {workspace}
+Channels: Invite the bot to any channel with `/invite @{botUsername}`. DMs work immediately.
+Identity: skipped"
 
-# Clearing Credentials
+## Troubleshooting
+
+### Bot not responding in channels
+
+The bot must be invited to each channel where you want it to listen. Use `/invite @{botUsername}` in the channel.
+
+### Socket Mode disconnects
+
+The app token may be revoked or expired. Regenerate it in your Slack app settings under **Basic Information > App-Level Tokens**, then re-enter via credential_store prompt.
+
+### Token validation fails
+
+Re-enter the token via credential_store prompt. The handler validates tokens on entry — if it rejects the token, double-check you're copying the right value from the Slack app settings.
+
+### Messages not appearing
+
+Verify that `message.channels` event subscription is enabled in your Slack app settings under **Event Subscriptions > Subscribe to bot events**. The manifest pre-configures this, but it can be accidentally removed.
+
+## Implementation Rules
+
+All token collection goes through `credential_store` prompts. Never accept tokens in chat or use alternative storage paths. Do not use `ui_show`, `ui_update`, `assistant credentials reveal`, `curl`, or `assistant config set slack.*` in chat to collect or manipulate tokens.
+
+## Clearing Credentials
 
 To disconnect Slack, prefer the Settings UI path so the same Slack settings handler clears both secure tokens and workspace metadata together.


### PR DESCRIPTION
Part of #20051. Closes #20052.

Modernizes the Slack app setup skill:
- Adds Step 0 to check existing configuration before starting
- Consolidates scattered Do NOT warnings into a single Implementation Rules section
- Merges the redundant Confirm Connection step into token collection
- Replaces guardian/owner language with identity-neutral phrasing
- Adds troubleshooting section matching Twilio's pattern
- Adds post-setup invite bot guidance
- Cleans up success messages to match Telegram's conversational tone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
