### PR TITLE
Fix slack-app-setup skill regression test

### DIFF
--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -208,7 +208,7 @@ Verify that `message.channels` event subscription is enabled in your Slack app s
 
 ## Implementation Rules
 
-All token collection goes through `credential_store` prompts. Never accept tokens in chat or use alternative storage paths. Do not use `ui_show`, `ui_update`, `assistant credentials reveal`, `curl`, or `assistant config set slack.*` in chat to collect or manipulate tokens.
+All token collection goes through `credential_store` prompts. Do NOT use `ui_show`, `ui_update`, `assistant credentials reveal`, `curl`, or `assistant config set slack.*` in chat to collect or manipulate tokens. Do NOT ask the user to paste them in chat — always use the secure credential prompt.
 
 ## Clearing Credentials
 


### PR DESCRIPTION
## Summary
- Updated Implementation Rules section in `skills/slack-app-setup/SKILL.md` to use `Do NOT` (uppercase) instead of `Do not`, matching the exact strings the regression test expects
- Added explicit `Do NOT ask the user to paste them in chat` phrase that the test asserts on

## Original prompt
fix this test FAIL: src/__tests__/slack-app-setup-skill-regression.test.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20059" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
