### PR TITLE
JARVIS-294: CES auto-initializes credential store on first write

### DIFF
--- a/credential-executor/src/__tests__/local-secure-key-backend.test.ts
+++ b/credential-executor/src/__tests__/local-secure-key-backend.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Filesystem-level tests for the CES local SecureKeyBackend.
+ *
+ * These tests exercise `createLocalSecureKeyBackend` with real files and
+ * env-var overrides, separate from the in-memory resolver/materialiser
+ * tests in `local-materializers.test.ts`.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync, rmSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { createLocalSecureKeyBackend } from "../materializers/local-secure-key-backend.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `ces-backend-test-${randomBytes(8).toString("hex")}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createLocalSecureKeyBackend — filesystem", () => {
+  let tmpDir: string | undefined;
+  let savedSecurityDir: string | undefined;
+
+  afterEach(() => {
+    if (savedSecurityDir !== undefined) {
+      process.env.CREDENTIAL_SECURITY_DIR = savedSecurityDir;
+    } else {
+      delete process.env.CREDENTIAL_SECURITY_DIR;
+    }
+    if (tmpDir && existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+    tmpDir = undefined;
+    savedSecurityDir = undefined;
+  });
+
+  function setup(): { securityDir: string; vellumRoot: string } {
+    tmpDir = makeTmpDir();
+    const securityDir = join(tmpDir, "security");
+    mkdirSync(securityDir, { recursive: true });
+    savedSecurityDir = process.env.CREDENTIAL_SECURITY_DIR;
+    process.env.CREDENTIAL_SECURITY_DIR = securityDir;
+    // vellumRoot is unused when CREDENTIAL_SECURITY_DIR is set,
+    // but we pass tmpDir for consistency
+    return { securityDir, vellumRoot: tmpDir };
+  }
+
+  test("set() on a fresh security directory creates store.key and keys.enc", async () => {
+    const { securityDir, vellumRoot } = setup();
+    const backend = createLocalSecureKeyBackend(vellumRoot);
+
+    const result = await backend.set("test/key", "secret-value");
+    expect(result).toBe(true);
+
+    // store.key exists, is 32 bytes, mode 0o600
+    const keyPath = join(securityDir, "store.key");
+    expect(existsSync(keyPath)).toBe(true);
+    const keyBuf = readFileSync(keyPath);
+    expect(keyBuf.length).toBe(32);
+    const mode = statSync(keyPath).mode & 0o777;
+    expect(mode).toBe(0o600);
+
+    // keys.enc exists and is valid v2 JSON
+    const encPath = join(securityDir, "keys.enc");
+    expect(existsSync(encPath)).toBe(true);
+    const store = JSON.parse(readFileSync(encPath, "utf-8"));
+    expect(store.version).toBe(2);
+    expect(typeof store.entries).toBe("object");
+
+    // Round-trip
+    const value = await backend.get("test/key");
+    expect(value).toBe("secret-value");
+  });
+
+  test("subsequent set() calls append to the existing store without recreating files", async () => {
+    const { securityDir, vellumRoot } = setup();
+    const backend = createLocalSecureKeyBackend(vellumRoot);
+
+    await backend.set("key1", "val1");
+    const keyAfterFirst = readFileSync(join(securityDir, "store.key"));
+
+    await backend.set("key2", "val2");
+    const keyAfterSecond = readFileSync(join(securityDir, "store.key"));
+
+    // store.key was not regenerated
+    expect(Buffer.compare(keyAfterFirst, keyAfterSecond)).toBe(0);
+
+    // keys.enc has exactly 2 entries
+    const store = JSON.parse(readFileSync(join(securityDir, "keys.enc"), "utf-8"));
+    expect(Object.keys(store.entries).length).toBe(2);
+
+    // Both values round-trip
+    expect(await backend.get("key1")).toBe("val1");
+    expect(await backend.get("key2")).toBe("val2");
+  });
+
+  test("set() against a pre-existing v1 store preserves format and round-trips", async () => {
+    const { securityDir, vellumRoot } = setup();
+
+    // Manually write a v1 store
+    const salt = randomBytes(32).toString("hex");
+    const v1Store = { version: 1, salt, entries: {} };
+    writeFileSync(join(securityDir, "keys.enc"), JSON.stringify(v1Store, null, 2), {
+      mode: 0o600,
+    });
+
+    const backend = createLocalSecureKeyBackend(vellumRoot);
+    const result = await backend.set("v1-key", "v1-value");
+    expect(result).toBe(true);
+
+    // Read back and verify format preserved
+    const storeAfter = JSON.parse(readFileSync(join(securityDir, "keys.enc"), "utf-8"));
+    expect(storeAfter.version).toBe(1);
+    expect(storeAfter.salt).toBe(salt);
+    expect(Object.keys(storeAfter.entries)).toContain("v1-key");
+
+    // store.key was NOT created (v1 stores don't use it)
+    expect(existsSync(join(securityDir, "store.key"))).toBe(false);
+
+    // Round-trip
+    const value = await backend.get("v1-key");
+    expect(value).toBe("v1-value");
+  });
+
+  test("get() returns undefined when no store exists", async () => {
+    const { vellumRoot } = setup();
+    const backend = createLocalSecureKeyBackend(vellumRoot);
+    const value = await backend.get("anything");
+    expect(value).toBeUndefined();
+  });
+
+  test("list() returns empty array when no store exists", async () => {
+    const { vellumRoot } = setup();
+    const backend = createLocalSecureKeyBackend(vellumRoot);
+    const keys = await backend.list();
+    expect(keys).toEqual([]);
+  });
+
+  test("delete() returns error when no store exists", async () => {
+    const { vellumRoot } = setup();
+    const backend = createLocalSecureKeyBackend(vellumRoot);
+    const result = await backend.delete("anything");
+    expect(result).toBe("error");
+  });
+});

--- a/credential-executor/src/materializers/local-secure-key-backend.ts
+++ b/credential-executor/src/materializers/local-secure-key-backend.ts
@@ -124,6 +124,61 @@ function readStoreKey(vellumRoot: string): Buffer | null {
 }
 
 // ---------------------------------------------------------------------------
+// Auto-initialization helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Read or generate the v2 store key. If the key file does not exist,
+ * creates a new 32-byte random key and writes it atomically.
+ */
+function getOrReadStoreKey(vellumRoot: string): Buffer {
+  const existing = readStoreKey(vellumRoot);
+  if (existing) return existing;
+
+  const securityDir = resolveSecurityDir(vellumRoot);
+  mkdirSync(securityDir, { recursive: true });
+
+  const key = randomBytes(KEY_LENGTH);
+  const keyPath = join(securityDir, STORE_KEY_FILENAME);
+  const tmpPath = keyPath + `.tmp.${process.pid}`;
+  writeFileSync(tmpPath, key, { mode: 0o600 });
+  chmodSync(tmpPath, 0o600);
+  renameSync(tmpPath, keyPath);
+
+  return key;
+}
+
+/**
+ * Read an existing store or create a new empty v2 store. Returns the store
+ * and the AES key needed to encrypt/decrypt entries.
+ *
+ * For existing v1 stores, throws so the caller can fall back to the legacy
+ * PBKDF2 path (v1 stores cannot be auto-initialized with a store key).
+ */
+function getOrCreateStore(
+  storePath: string,
+  vellumRoot: string,
+): { store: StoreFile; aesKey: Buffer } {
+  const existing = readStore(storePath);
+  if (existing) {
+    if (existing.version === 1) {
+      throw new Error("v1 store cannot be auto-initialized");
+    }
+    const storeKey = readStoreKey(vellumRoot);
+    if (!storeKey) {
+      throw new Error("v2 store exists but store.key is missing or corrupt");
+    }
+    return { store: existing, aesKey: storeKey };
+  }
+
+  // No store exists — create a new empty v2 store
+  const aesKey = getOrReadStoreKey(vellumRoot);
+  const store: StoreFileV2 = { version: 2, entries: {} };
+  writeStore(store, storePath);
+  return { store, aesKey };
+}
+
+// ---------------------------------------------------------------------------
 // Machine entropy (must match assistant/src/security/encrypted-store.ts)
 // ---------------------------------------------------------------------------
 
@@ -287,19 +342,25 @@ export function createLocalSecureKeyBackend(
     // future improvement.
     async set(key: string, value: string): Promise<boolean> {
       try {
-        const store = readStore(storePath);
-        if (!store) return false;
-
+        let store: StoreFile;
         let aesKey: Buffer;
-        if (store.version === 2) {
-          const storeKey = readStoreKey(vellumRoot);
-          if (!storeKey) return false;
-          aesKey = storeKey;
-        } else {
-          // v1: derive key from machine entropy via PBKDF2
-          const entropy = entropyGetter?.() ?? staticEntropy;
-          const salt = Buffer.from(store.salt, "hex");
-          aesKey = deriveKey(salt, entropy);
+
+        try {
+          const result = getOrCreateStore(storePath, vellumRoot);
+          store = result.store;
+          aesKey = result.aesKey;
+        } catch {
+          // Fallback: v1 store or other error — try legacy PBKDF2 path
+          const existing = readStore(storePath);
+          if (!existing) return false;
+          store = existing;
+          if (store.version === 1) {
+            const entropy = entropyGetter?.() ?? staticEntropy;
+            const salt = Buffer.from(store.salt, "hex");
+            aesKey = deriveKey(salt, entropy);
+          } else {
+            return false;
+          }
         }
 
         store.entries[key] = encrypt(value, aesKey);


### PR DESCRIPTION
## Summary
- Add `getOrReadStoreKey()` and `getOrCreateStore()` helpers to lazily initialize store.key and keys.enc on first `set()` call
- Update `set()` to auto-create a v2 store when no store exists, with fallback to legacy v1 PBKDF2 path
- Add dedicated filesystem-level tests covering auto-init, v1 regression, and baseline missing-store behavior

Closes JARVIS-294

Part of plan: ces-auto-init-store.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
