### PR TITLE
feat: route Docker inline upgrade through CLI instead of gateway

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -529,19 +529,31 @@ struct SettingsDeveloperTab: View {
         isUpgradingInline = true
         defer { isUpgradingInline = false }
 
-        do {
-            let response = try await GatewayHTTPClient.post(path: "assistants/upgrade")
-            if response.isSuccess {
-                inlineUpgradeSuccess = "Upgrade initiated. The assistant may be briefly unavailable."
-                try? await Task.sleep(nanoseconds: 3_000_000_000)
+        let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId })
+
+        if assistant?.isDocker == true {
+            do {
+                try await AppDelegate.shared?.vellumCli.upgrade(name: selectedAssistantId)
+                inlineUpgradeSuccess = "Upgrade complete."
                 await fetchHealthz()
-            } else {
-                inlineUpgradeError = "Upgrade failed (HTTP \(response.statusCode))"
+            } catch {
+                inlineUpgradeError = "Upgrade failed: \(error.localizedDescription)"
             }
-        } catch let error as GatewayHTTPClient.ClientError {
-            inlineUpgradeError = error.localizedDescription
-        } catch {
-            inlineUpgradeError = "Upgrade failed: \(error.localizedDescription)"
+        } else {
+            do {
+                let response = try await GatewayHTTPClient.post(path: "assistants/upgrade")
+                if response.isSuccess {
+                    inlineUpgradeSuccess = "Upgrade initiated. The assistant may be briefly unavailable."
+                    try? await Task.sleep(nanoseconds: 3_000_000_000)
+                    await fetchHealthz()
+                } else {
+                    inlineUpgradeError = "Upgrade failed (HTTP \(response.statusCode))"
+                }
+            } catch let error as GatewayHTTPClient.ClientError {
+                inlineUpgradeError = error.localizedDescription
+            } catch {
+                inlineUpgradeError = "Upgrade failed: \(error.localizedDescription)"
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Route Docker assistant inline upgrades through the bundled CLI binary instead of the gateway
- Docker path calls `VellumCli.upgrade(name:)` directly, which runs the full Docker upgrade flow
- Managed/remote path continues through the gateway (unchanged)

Part of plan: docker-cli-upgrade.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
