### PR TITLE
feat: route Docker AssistantUpgradeSection upgrade through CLI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -10,6 +10,7 @@ import VellumAssistantShared
 @MainActor
 struct AssistantUpgradeSection: View {
     let currentVersion: String?
+    let isDocker: Bool
 
     @State private var availableReleases: [AssistantRelease] = []
     @State private var selectedVersion: String?
@@ -179,6 +180,31 @@ struct AssistantUpgradeSection: View {
         isUpgrading = true
         defer { isUpgrading = false }
 
+        if isDocker {
+            await performDockerUpgrade()
+        } else {
+            await performManagedUpgrade()
+        }
+    }
+
+    private func performDockerUpgrade() async {
+        guard let cli = AppDelegate.shared?.vellumCli else {
+            errorMessage = "CLI not available"
+            return
+        }
+        let name = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
+        let version = selectedVersion ?? latestRelease?.version
+        do {
+            try await cli.upgrade(name: name, version: version)
+            successMessage = "Upgrade complete."
+            await loadReleasesQuietly()
+            if successMessage != nil { errorMessage = nil }
+        } catch {
+            errorMessage = "Upgrade failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func performManagedUpgrade() async {
         do {
             let body: [String: String] = selectedVersion.map { ["version": $0] } ?? [:]
             let response = try await GatewayHTTPClient.post(path: "assistants/upgrade", json: body)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -127,7 +127,7 @@ struct SettingsDeveloperTab: View {
             // Upgrade (managed/remote only)
             if let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }),
                assistant.isManaged || assistant.isRemote {
-                AssistantUpgradeSection(currentVersion: healthz?.version)
+                AssistantUpgradeSection(currentVersion: healthz?.version, isDocker: assistant.isDocker)
             }
             // Rollback (when previous version is available)
             if let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }),


### PR DESCRIPTION
## Summary
- Add `isDocker` property to AssistantUpgradeSection
- Route Docker upgrades through CLI with selected version instead of gateway
- Update call site in SettingsDeveloperTab to pass `assistant.isDocker`
- Managed/remote path continues through gateway (unchanged)

Part of plan: docker-cli-upgrade.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
