### PR TITLE
JARVIS-283: Fix Step 0 credential check hanging on bash inspect

### DIFF
--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -24,12 +24,10 @@ You are helping your user connect a Slack bot to the Vellum Assistant via Socket
 
 ## Step 0: Check Existing Configuration
 
-Before starting setup, check whether Slack is already configured:
+Before starting setup, check whether Slack is already configured by calling `credential_store` with `action: "inspect"` for each token:
 
-```bash
-assistant credentials inspect --service slack_channel --field app_token --json
-assistant credentials inspect --service slack_channel --field bot_token --json
-```
+- Call `credential_store` with `action: "inspect"`, `service: "slack_channel"`, `field: "app_token"`
+- Call `credential_store` with `action: "inspect"`, `service: "slack_channel"`, `field: "bot_token"`
 
 - If both credentials have `"hasSecret": true` and the connection is active — Slack is fully configured. Offer to show status or reconfigure.
 - If only one token is present — offer to resume setup from the missing step.


### PR DESCRIPTION
## Summary
- Fixes a blocking bug where `assistant credentials inspect` bash commands in the slack-app-setup skill's Step 0 hang indefinitely (~120s timeout) for the `slack_channel` service
- Replaces bash commands with `credential_store` tool calls (`action: "inspect"`), matching how the rest of the skill handles credentials
- Reported by Marina via Becky assistant on a fresh Slack setup attempt

## Test plan
- [ ] Run Slack setup from scratch — Step 0 should complete instantly and proceed to Step 1
- [ ] Run Slack setup with existing tokens — Step 0 should detect them and offer to reconfigure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
