### PR TITLE
M1: Add right-click context menu to chat images

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -22,13 +22,25 @@ private enum ImageActions {
         let sanitized = (filename as NSString).lastPathComponent
         let fallbackName = sanitized.isEmpty ? "image.png" : sanitized
 
+        // When base64Data is unavailable we re-encode the NSImage as PNG.
+        // Force the suggested filename to .png so the extension matches the
+        // actual content encoding — mirrors the same pattern in openInPreview.
+        let hasFullData = base64Data.map { !$0.isEmpty } ?? false
+        let suggestedName: String
+        if hasFullData {
+            suggestedName = fallbackName
+        } else {
+            suggestedName = (fallbackName as NSString).deletingPathExtension + ".png"
+        }
+
         let panel = NSSavePanel()
-        panel.nameFieldStringValue = fallbackName
+        panel.nameFieldStringValue = suggestedName
         panel.canCreateDirectories = true
         panel.begin { response in
             guard response == .OK, let url = panel.url else { return }
             DispatchQueue.global(qos: .userInitiated).async {
-                if let base64Data, !base64Data.isEmpty,
+                if hasFullData,
+                   let base64Data,
                    let decoded = Data(base64Encoded: base64Data), !decoded.isEmpty {
                     try? decoded.write(to: url)
                 } else if let tiff = image.tiffRepresentation,

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -2,6 +2,131 @@ import AppKit
 import SwiftUI
 import VellumAssistantShared
 
+// MARK: - Image Context Menu Actions
+
+/// Standalone helper for image context menu actions used by both
+/// `InlineToolCallImageView` and `AttachmentImageGrid`. Kept at file scope
+/// so it is accessible from private structs without coupling to `ChatBubble`.
+private enum ImageActions {
+
+    /// Copies the image to the system clipboard as TIFF data.
+    static func copyToClipboard(_ image: NSImage) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.writeObjects([image])
+    }
+
+    /// Opens an NSSavePanel and writes the image to the chosen path.
+    /// Prefers `base64Data` (full resolution) when available, falling back to
+    /// PNG-encoding the in-memory NSImage.
+    static func saveImageAs(_ image: NSImage, filename: String, base64Data: String? = nil) {
+        let sanitized = (filename as NSString).lastPathComponent
+        let fallbackName = sanitized.isEmpty ? "image.png" : sanitized
+
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = fallbackName
+        panel.canCreateDirectories = true
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            DispatchQueue.global(qos: .userInitiated).async {
+                if let base64Data, !base64Data.isEmpty,
+                   let decoded = Data(base64Encoded: base64Data), !decoded.isEmpty {
+                    try? decoded.write(to: url)
+                } else if let tiff = image.tiffRepresentation,
+                          let rep = NSBitmapImageRep(data: tiff),
+                          let png = rep.representation(using: .png, properties: [:]) {
+                    try? png.write(to: url)
+                }
+            }
+        }
+    }
+
+    /// Writes the image to a temporary file and opens it in the default app (Preview).
+    /// Prefers `base64Data` (full resolution), falling back to PNG-encoding the NSImage.
+    static func openInPreview(_ image: NSImage, filename: String, base64Data: String? = nil) {
+        let tempDir = FileManager.default.temporaryDirectory
+        let sanitized = (filename as NSString).lastPathComponent
+        let fallbackName = sanitized.isEmpty ? "image.png" : sanitized
+
+        var usedPNGFallback = false
+        let fileData: Data? = {
+            if let base64Data, !base64Data.isEmpty,
+               let decoded = Data(base64Encoded: base64Data), !decoded.isEmpty {
+                return decoded
+            }
+            if let tiff = image.tiffRepresentation,
+               let rep = NSBitmapImageRep(data: tiff) {
+                usedPNGFallback = true
+                return rep.representation(using: .png, properties: [:])
+            }
+            return nil
+        }()
+
+        let fileName: String
+        if usedPNGFallback {
+            fileName = (fallbackName as NSString).deletingPathExtension + ".png"
+        } else {
+            fileName = fallbackName
+        }
+        let fileURL = tempDir.appendingPathComponent(fileName)
+
+        guard let fileData else { return }
+        do {
+            try fileData.write(to: fileURL)
+            NSWorkspace.shared.open(fileURL)
+        } catch {
+            // Silently fail — not critical
+        }
+    }
+
+    /// Presents the macOS share sheet anchored to the center of the key window.
+    static func shareImage(_ image: NSImage) {
+        let picker = NSSharingServicePicker(items: [image])
+        if let window = NSApp.keyWindow, let contentView = window.contentView {
+            let rect = CGRect(
+                x: contentView.bounds.midX,
+                y: contentView.bounds.midY,
+                width: 1,
+                height: 1
+            )
+            picker.show(relativeTo: rect, of: contentView, preferredEdge: .minY)
+        }
+    }
+
+    /// Builds a SwiftUI context menu with Copy, Save As, Open in Preview, and Share actions.
+    @ViewBuilder
+    static func contextMenuItems(
+        image: NSImage,
+        filename: String,
+        base64Data: String? = nil
+    ) -> some View {
+        Button {
+            copyToClipboard(image)
+        } label: {
+            Label { Text("Copy Image") } icon: { VIconView(.copy, size: 12) }
+        }
+
+        Button {
+            saveImageAs(image, filename: filename, base64Data: base64Data)
+        } label: {
+            Label { Text("Save Image As\u{2026}") } icon: { VIconView(.arrowDownToLine, size: 12) }
+        }
+
+        Button {
+            openInPreview(image, filename: filename, base64Data: base64Data)
+        } label: {
+            Label { Text("Open in Preview") } icon: { VIconView(.eye, size: 12) }
+        }
+
+        Divider()
+
+        Button {
+            shareImage(image)
+        } label: {
+            Label { Text("Share\u{2026}") } icon: { VIconView(.share, size: 12) }
+        }
+    }
+}
+
 // MARK: - Inline Tool Call Image
 
 /// Renders a single tool-call-generated image at full width in the message flow.
@@ -11,6 +136,18 @@ private struct InlineToolCallImageView: View {
     @Environment(\.displayScale) private var displayScale
 
     var body: some View {
+        imageContent
+            .onTapGesture {
+                ImageActions.openInPreview(image, filename: "image.png")
+            }
+            .contextMenu {
+                ImageActions.contextMenuItems(image: image, filename: "image.png")
+            }
+            .pointerCursor()
+    }
+
+    @ViewBuilder
+    private var imageContent: some View {
         if let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) {
             let nativeWidth = CGFloat(cgImage.width) / displayScale
             let nativeHeight = CGFloat(cgImage.height) / displayScale
@@ -72,6 +209,13 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                             .onTapGesture {
                                 onTap(attachment, nsImage)
+                            }
+                            .contextMenu {
+                                ImageActions.contextMenuItems(
+                                    image: nsImage,
+                                    filename: attachment.filename,
+                                    base64Data: attachment.data.isEmpty ? nil : attachment.data
+                                )
                             }
                             .pointerCursor()
                     } else if failedIds.contains(attachment.id) {


### PR DESCRIPTION
## Summary
- Adds `.contextMenu` modifier to both `InlineToolCallImageView` and `AttachmentImageGrid` thumbnail images with four actions: Copy Image, Save Image As..., Open in Preview, and Share...
- Introduces a private `ImageActions` helper enum with static utility methods (`copyToClipboard`, `saveImageAs`, `openInPreview`, `shareImage`, `contextMenuItems`) at file scope, accessible from both private structs without coupling to `ChatBubble`
- Adds tap gesture and pointer cursor to `InlineToolCallImageView` for consistency with `AttachmentImageGrid` (click to open in Preview)

Part of #20068.

## Test plan
- [ ] Right-click an inline tool call image (full-width) — verify context menu appears with Copy Image, Save Image As..., Open in Preview, Share...
- [ ] Right-click an attachment grid thumbnail — verify same context menu appears
- [ ] Test Copy Image — paste into another app, verify image is on clipboard
- [ ] Test Save Image As... — verify NSSavePanel opens and image saves correctly
- [ ] Test Open in Preview — verify image opens in default app
- [ ] Test Share... — verify macOS share sheet appears
- [ ] Click an inline tool call image — verify it opens in Preview (new behavior)
- [ ] Click an attachment grid thumbnail — verify existing tap-to-preview behavior still works
- [ ] Verify context menu uses full-resolution base64 data for Save As when available

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
