### PR TITLE
M2: Add drag-and-drop support to chat images

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 import VellumAssistantShared
 
 // MARK: - Image Context Menu Actions
@@ -155,6 +156,18 @@ private struct InlineToolCallImageView: View {
             .contextMenu {
                 ImageActions.contextMenuItems(image: image, filename: "image.png")
             }
+            .onDrag {
+                let provider = NSItemProvider()
+                if let tiff = image.tiffRepresentation,
+                   let rep = NSBitmapImageRep(data: tiff),
+                   let pngData = rep.representation(using: .png, properties: [:]) {
+                    provider.registerDataRepresentation(forTypeIdentifier: UTType.png.identifier, visibility: .all) { completion in
+                        completion(pngData, nil)
+                        return nil
+                    }
+                }
+                return provider
+            }
             .pointerCursor()
     }
 
@@ -228,6 +241,32 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                                     filename: attachment.filename,
                                     base64Data: attachment.data.isEmpty ? nil : attachment.data
                                 )
+                            }
+                            .onDrag {
+                                let provider = NSItemProvider()
+                                // Prefer full-res base64 data
+                                if !attachment.data.isEmpty,
+                                   let decoded = Data(base64Encoded: attachment.data), !decoded.isEmpty {
+                                    let mimeType = attachment.mimeType
+                                    let utType = UTType(mimeType: mimeType) ?? .png
+                                    provider.registerDataRepresentation(forTypeIdentifier: utType.identifier, visibility: .all) { completion in
+                                        completion(decoded, nil)
+                                        return nil
+                                    }
+                                } else if let nsImage = loadedImages[attachment.id] {
+                                    // Fallback to thumbnail
+                                    if let tiff = nsImage.tiffRepresentation,
+                                       let rep = NSBitmapImageRep(data: tiff),
+                                       let pngData = rep.representation(using: .png, properties: [:]) {
+                                        provider.registerDataRepresentation(forTypeIdentifier: UTType.png.identifier, visibility: .all) { completion in
+                                            completion(pngData, nil)
+                                            return nil
+                                        }
+                                    }
+                                }
+                                // Also provide a suggested filename
+                                provider.suggestedName = attachment.filename
+                                return provider
                             }
                             .pointerCursor()
                     } else if failedIds.contains(attachment.id) {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -166,6 +166,7 @@ private struct InlineToolCallImageView: View {
                         return nil
                     }
                 }
+                provider.suggestedName = "image.png"
                 return provider
             }
             .pointerCursor()
@@ -245,7 +246,8 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                             .onDrag {
                                 let provider = NSItemProvider()
                                 // Prefer full-res base64 data
-                                if !attachment.data.isEmpty,
+                                let hasFullData = !attachment.data.isEmpty
+                                if hasFullData,
                                    let decoded = Data(base64Encoded: attachment.data), !decoded.isEmpty {
                                     let mimeType = attachment.mimeType
                                     let utType = UTType(mimeType: mimeType) ?? .png
@@ -254,7 +256,7 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                                         return nil
                                     }
                                 } else if let nsImage = loadedImages[attachment.id] {
-                                    // Fallback to thumbnail
+                                    // Fallback to thumbnail — re-encoded as PNG
                                     if let tiff = nsImage.tiffRepresentation,
                                        let rep = NSBitmapImageRep(data: tiff),
                                        let pngData = rep.representation(using: .png, properties: [:]) {
@@ -264,8 +266,14 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                                         }
                                     }
                                 }
-                                // Also provide a suggested filename
-                                provider.suggestedName = attachment.filename
+                                // Force .png extension when falling back to PNG encoding
+                                // so the filename matches the actual content type.
+                                let filename = attachment.filename
+                                if hasFullData {
+                                    provider.suggestedName = filename
+                                } else {
+                                    provider.suggestedName = (filename as NSString).deletingPathExtension + ".png"
+                                }
                                 return provider
                             }
                             .pointerCursor()


### PR DESCRIPTION
## Summary
- Adds `.onDrag` modifier to `InlineToolCallImageView` providing PNG image data via `NSItemProvider`
- Adds `.onDrag` modifier to `AttachmentImageGrid` thumbnails, preferring full-resolution base64 data with correct UTType, falling back to PNG-encoded thumbnail
- Adds `import UniformTypeIdentifiers` for `UTType` usage

Part of #20068.

## Test plan
- [ ] Drag an inline tool-call image from chat to Finder/Desktop — verify a PNG file is created
- [ ] Drag an attachment thumbnail image to Finder — verify the file is saved with correct format
- [ ] Verify context menus and tap-to-preview still work after adding drag support
- [ ] Verify drag preview appears correctly (handled automatically by SwiftUI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
