### PR TITLE
fix: add nil guard for VellumCli in Docker upgrade and rollback paths

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -561,8 +561,12 @@ struct SettingsDeveloperTab: View {
             dockerOperationLabel = "Upgrading assistant..."
             isDockerOperationInProgress = true
             defer { isDockerOperationInProgress = false }
+            guard let cli = AppDelegate.shared?.vellumCli else {
+                inlineUpgradeError = "CLI not available"
+                return
+            }
             do {
-                try await AppDelegate.shared?.vellumCli.upgrade(name: selectedAssistantId)
+                try await cli.upgrade(name: selectedAssistantId)
                 inlineUpgradeSuccess = "Upgrade complete."
                 await fetchHealthz()
             } catch {
@@ -598,8 +602,12 @@ struct SettingsDeveloperTab: View {
             dockerOperationLabel = "Rolling back assistant..."
             isDockerOperationInProgress = true
             defer { isDockerOperationInProgress = false }
+            guard let cli = AppDelegate.shared?.vellumCli else {
+                rollbackError = "CLI not available"
+                return
+            }
             do {
-                try await AppDelegate.shared?.vellumCli.rollback(name: selectedAssistantId)
+                try await cli.rollback(name: selectedAssistantId)
                 rollbackSuccess = "Rollback complete."
                 await fetchHealthz()
             } catch {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for docker-cli-upgrade.md.

**Gap:** Silent no-op on nil CLI in performInlineUpgrade and performRollback
**What was expected:** Error message shown when CLI is unavailable
**What was found:** Optional chaining silently skipped CLI call, then reported false success
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
