### PR TITLE
LUM-307: Sync dock icon immediately on avatar update

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -334,10 +334,12 @@ extension AppDelegate {
             }
         }
 
-        // Handle avatar_updated from daemon: reload the avatar image from disk
-        daemonClient.onAvatarUpdated = { _ in
+        // Handle avatar_updated from daemon: reload the avatar image from disk.
+        // Pass the avatarPath so the dock icon updates immediately from the
+        // local file before the HTTP fetch completes.
+        daemonClient.onAvatarUpdated = { msg in
             Task { @MainActor in
-                AvatarAppearanceManager.shared.reloadAvatar()
+                AvatarAppearanceManager.shared.reloadAvatar(avatarPath: msg.avatarPath)
             }
         }
 

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -277,6 +277,16 @@ final class AvatarAppearanceManager {
     /// and re-reads the identity so the dock label reflects the current assistant.
     /// Fetches via HTTP through the gateway for consistency across all instance types.
     func reloadAvatar() {
+        reloadAvatar(avatarPath: nil)
+    }
+
+    /// Reloads the avatar, optionally using a local file path for an immediate
+    /// dock-icon update before the HTTP round-trip completes.
+    /// - Parameter avatarPath: Absolute path to the updated avatar image
+    ///   (from the daemon's `avatar_updated` event). When non-nil and the file
+    ///   is readable, the dock icon updates immediately; the subsequent HTTP
+    ///   fetch still runs to keep all cached state consistent.
+    func reloadAvatar(avatarPath: String?) {
         assistantName = AssistantDisplayName.resolve(
             IdentityInfo.load()?.name,
             fallback: "V"
@@ -286,6 +296,15 @@ final class AvatarAppearanceManager {
         cachedFallbackName = nil
         cachedFullFallbackAvatar = nil
         cachedFullFallbackName = nil
+
+        // Fast path: load the image directly from disk so the dock icon
+        // reflects the new avatar immediately, without waiting for the
+        // HTTP round-trip through the gateway.
+        if let avatarPath, let image = NSImage(contentsOfFile: avatarPath) {
+            customAvatarImage = image
+            updateDockIcon()
+        }
+
         Task { [weak self] in
             await self?.fetchAvatarViaHTTP()
             await self?.fetchTraitsViaHTTP()


### PR DESCRIPTION
## Summary
- Use the `avatarPath` from the daemon's `avatar_updated` message to load the new avatar image directly from disk, so the dock icon updates instantly instead of waiting for the HTTP round-trip through the gateway.
- The existing HTTP fetch still runs afterward to keep all cached state consistent.

Closes LUM-307

## Test plan
- [ ] Change avatar via the avatar management sheet → dock icon updates immediately
- [ ] Change avatar via a daemon skill (e.g. vellum-avatar) → dock icon updates without app restart
- [ ] Restart app → dock icon still shows correct avatar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
