### PR TITLE
Add native image save interactions to chat images

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -10,10 +10,21 @@ import VellumAssistantShared
 /// so it is accessible from private structs without coupling to `ChatBubble`.
 private enum ImageActions {
 
-    /// Copies the image to the system clipboard as TIFF data.
-    static func copyToClipboard(_ image: NSImage) {
+    /// Copies the image to the system clipboard.
+    /// Prefers full-resolution data decoded from `base64Data` when available,
+    /// falling back to the provided (possibly thumbnail) NSImage.
+    static func copyToClipboard(_ image: NSImage, base64Data: String? = nil) {
+        // Prefer full-res from base64 data when available
+        let imageToWrite: NSImage
+        if let base64Data, !base64Data.isEmpty,
+           let decoded = Data(base64Encoded: base64Data), !decoded.isEmpty,
+           let fullRes = NSImage(data: decoded) {
+            imageToWrite = fullRes
+        } else {
+            imageToWrite = image
+        }
         NSPasteboard.general.clearContents()
-        NSPasteboard.general.writeObjects([image])
+        NSPasteboard.general.writeObjects([imageToWrite])
     }
 
     /// Opens an NSSavePanel and writes the image to the chosen path.
@@ -40,15 +51,23 @@ private enum ImageActions {
         panel.canCreateDirectories = true
         panel.begin { response in
             guard response == .OK, let url = panel.url else { return }
+            // Determine data to write on the main thread.
+            // tiffRepresentation is not thread-safe (see ChatAttachmentManager.swift)
+            // so PNG encoding must happen here, not in a background queue.
+            let dataToWrite: Data?
+            if let base64Data, !base64Data.isEmpty,
+               let decoded = Data(base64Encoded: base64Data), !decoded.isEmpty {
+                dataToWrite = decoded
+            } else if let tiff = image.tiffRepresentation,
+                      let rep = NSBitmapImageRep(data: tiff),
+                      let png = rep.representation(using: .png, properties: [:]) {
+                dataToWrite = png
+            } else {
+                dataToWrite = nil
+            }
+            guard let dataToWrite else { return }
             DispatchQueue.global(qos: .userInitiated).async {
-                if let base64Data, !base64Data.isEmpty,
-                   let decoded = Data(base64Encoded: base64Data), !decoded.isEmpty {
-                    try? decoded.write(to: url)
-                } else if let tiff = image.tiffRepresentation,
-                          let rep = NSBitmapImageRep(data: tiff),
-                          let png = rep.representation(using: .png, properties: [:]) {
-                    try? png.write(to: url)
-                }
+                try? dataToWrite.write(to: url)
             }
         }
     }
@@ -113,7 +132,7 @@ private enum ImageActions {
         base64Data: String? = nil
     ) -> some View {
         Button {
-            copyToClipboard(image)
+            copyToClipboard(image, base64Data: base64Data)
         } label: {
             Label { Text("Copy Image") } icon: { VIconView(.copy, size: 12) }
         }
@@ -245,24 +264,23 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                             }
                             .onDrag {
                                 let provider = NSItemProvider()
-                                // Attempt base64 decode to determine if full-res
-                                // data is actually available. This prevents
-                                // extension/content mismatch when attachment.data
-                                // is non-empty but corrupt.
-                                let fullResData: Data? = {
-                                    guard !attachment.data.isEmpty else { return nil }
-                                    guard let decoded = Data(base64Encoded: attachment.data), !decoded.isEmpty else { return nil }
-                                    return decoded
-                                }()
-                                if let fullResData {
+                                let hasFullData = !attachment.data.isEmpty
+                                if hasFullData {
                                     let mimeType = attachment.mimeType
                                     let utType = UTType(mimeType: mimeType) ?? .png
+                                    // Capture attachment data string by value for lazy decode in callback
+                                    let base64String = attachment.data
                                     provider.registerDataRepresentation(forTypeIdentifier: utType.identifier, visibility: .all) { completion in
-                                        completion(fullResData, nil)
+                                        // Decode lazily when drop target requests data (off main thread)
+                                        if let decoded = Data(base64Encoded: base64String), !decoded.isEmpty {
+                                            completion(decoded, nil)
+                                        } else {
+                                            completion(nil, nil)
+                                        }
                                         return nil
                                     }
                                 } else if let nsImage = loadedImages[attachment.id] {
-                                    // Fallback to thumbnail — re-encoded as PNG
+                                    // tiffRepresentation is called here on the main thread (thread-safe)
                                     if let tiff = nsImage.tiffRepresentation,
                                        let rep = NSBitmapImageRep(data: tiff),
                                        let pngData = rep.representation(using: .png, properties: [:]) {
@@ -272,11 +290,9 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                                         }
                                     }
                                 }
-                                // Use original filename only when full-res data
-                                // decoded successfully; otherwise force .png to
-                                // match the actual PNG re-encoding.
+                                // Force .png extension when falling back to PNG encoding
                                 let filename = attachment.filename
-                                if fullResData != nil {
+                                if hasFullData {
                                     provider.suggestedName = filename
                                 } else {
                                     provider.suggestedName = (filename as NSString).deletingPathExtension + ".png"

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -23,12 +23,13 @@ private enum ImageActions {
         let sanitized = (filename as NSString).lastPathComponent
         let fallbackName = sanitized.isEmpty ? "image.png" : sanitized
 
-        // When base64Data is unavailable we re-encode the NSImage as PNG.
-        // Force the suggested filename to .png so the extension matches the
-        // actual content encoding — mirrors the same pattern in openInPreview.
-        let hasFullData = base64Data.map { !$0.isEmpty } ?? false
+        // Use non-emptiness as a lightweight proxy for valid base64 data to
+        // decide the suggested filename. Full decode is deferred to the
+        // background write block to avoid blocking the main thread for large
+        // payloads (multi-MB screenshots).
+        let hasBase64 = base64Data.map { !$0.isEmpty } ?? false
         let suggestedName: String
-        if hasFullData {
+        if hasBase64 {
             suggestedName = fallbackName
         } else {
             suggestedName = (fallbackName as NSString).deletingPathExtension + ".png"
@@ -40,8 +41,7 @@ private enum ImageActions {
         panel.begin { response in
             guard response == .OK, let url = panel.url else { return }
             DispatchQueue.global(qos: .userInitiated).async {
-                if hasFullData,
-                   let base64Data,
+                if let base64Data, !base64Data.isEmpty,
                    let decoded = Data(base64Encoded: base64Data), !decoded.isEmpty {
                     try? decoded.write(to: url)
                 } else if let tiff = image.tiffRepresentation,
@@ -245,14 +245,20 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                             }
                             .onDrag {
                                 let provider = NSItemProvider()
-                                // Prefer full-res base64 data
-                                let hasFullData = !attachment.data.isEmpty
-                                if hasFullData,
-                                   let decoded = Data(base64Encoded: attachment.data), !decoded.isEmpty {
+                                // Attempt base64 decode to determine if full-res
+                                // data is actually available. This prevents
+                                // extension/content mismatch when attachment.data
+                                // is non-empty but corrupt.
+                                let fullResData: Data? = {
+                                    guard !attachment.data.isEmpty else { return nil }
+                                    guard let decoded = Data(base64Encoded: attachment.data), !decoded.isEmpty else { return nil }
+                                    return decoded
+                                }()
+                                if let fullResData {
                                     let mimeType = attachment.mimeType
                                     let utType = UTType(mimeType: mimeType) ?? .png
                                     provider.registerDataRepresentation(forTypeIdentifier: utType.identifier, visibility: .all) { completion in
-                                        completion(decoded, nil)
+                                        completion(fullResData, nil)
                                         return nil
                                     }
                                 } else if let nsImage = loadedImages[attachment.id] {
@@ -266,10 +272,11 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                                         }
                                     }
                                 }
-                                // Force .png extension when falling back to PNG encoding
-                                // so the filename matches the actual content type.
+                                // Use original filename only when full-res data
+                                // decoded successfully; otherwise force .png to
+                                // match the actual PNG re-encoding.
                                 let filename = attachment.filename
-                                if hasFullData {
+                                if fullResData != nil {
                                     provider.suggestedName = filename
                                 } else {
                                     provider.suggestedName = (filename as NSString).deletingPathExtension + ".png"
@@ -368,7 +375,11 @@ extension ChatBubble {
 
     func attachmentImageGrid(_ images: [ChatAttachment]) -> some View {
         AttachmentImageGrid(imageAttachments: images, onTap: { attachment, image in
-            openImageInPreview(attachment, image: image)
+            ImageActions.openInPreview(
+                image,
+                filename: attachment.filename,
+                base64Data: attachment.data.isEmpty ? nil : attachment.data
+            )
         }) { attachment in
             fileAttachmentChip(attachment)
         }
@@ -401,47 +412,6 @@ extension ChatBubble {
             saveFileAttachment(attachment)
         }
         .pointerCursor()
-    }
-
-    func openImageInPreview(_ attachment: ChatAttachment, image: NSImage? = nil) {
-        let tempDir = FileManager.default.temporaryDirectory
-        let sanitized = (attachment.filename as NSString).lastPathComponent
-        let fallbackName = sanitized.isEmpty ? "image.png" : sanitized
-
-        // Prefer the original base64 data when available (full resolution).
-        // Fall back to the in-memory NSImage (thumbnail) when data has been cleared.
-        var usedNSImageFallback = false
-        let fileData: Data? = {
-            if !attachment.data.isEmpty,
-               let decoded = Data(base64Encoded: attachment.data),
-               !decoded.isEmpty {
-                return decoded
-            }
-            if let image, let tiff = image.tiffRepresentation,
-               let rep = NSBitmapImageRep(data: tiff) {
-                usedNSImageFallback = true
-                return rep.representation(using: .png, properties: [:])
-            }
-            return nil
-        }()
-
-        // When the NSImage fallback encodes as PNG, force the extension to .png
-        // so the file extension matches the actual content encoding.
-        let fileName: String
-        if usedNSImageFallback {
-            fileName = (fallbackName as NSString).deletingPathExtension + ".png"
-        } else {
-            fileName = fallbackName
-        }
-        let fileURL = tempDir.appendingPathComponent(fileName)
-
-        guard let fileData else { return }
-        do {
-            try fileData.write(to: fileURL)
-            NSWorkspace.shared.open(fileURL)
-        } catch {
-            // Silently fail — not critical
-        }
     }
 
     func saveFileAttachment(_ attachment: ChatAttachment) {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 import VellumAssistantShared
 
 // MARK: - Image Context Menu Actions
@@ -155,6 +156,19 @@ private struct InlineToolCallImageView: View {
             .contextMenu {
                 ImageActions.contextMenuItems(image: image, filename: "image.png")
             }
+            .onDrag {
+                let provider = NSItemProvider()
+                if let tiff = image.tiffRepresentation,
+                   let rep = NSBitmapImageRep(data: tiff),
+                   let pngData = rep.representation(using: .png, properties: [:]) {
+                    provider.registerDataRepresentation(forTypeIdentifier: UTType.png.identifier, visibility: .all) { completion in
+                        completion(pngData, nil)
+                        return nil
+                    }
+                }
+                provider.suggestedName = "image.png"
+                return provider
+            }
             .pointerCursor()
     }
 
@@ -228,6 +242,39 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                                     filename: attachment.filename,
                                     base64Data: attachment.data.isEmpty ? nil : attachment.data
                                 )
+                            }
+                            .onDrag {
+                                let provider = NSItemProvider()
+                                // Prefer full-res base64 data
+                                let hasFullData = !attachment.data.isEmpty
+                                if hasFullData,
+                                   let decoded = Data(base64Encoded: attachment.data), !decoded.isEmpty {
+                                    let mimeType = attachment.mimeType
+                                    let utType = UTType(mimeType: mimeType) ?? .png
+                                    provider.registerDataRepresentation(forTypeIdentifier: utType.identifier, visibility: .all) { completion in
+                                        completion(decoded, nil)
+                                        return nil
+                                    }
+                                } else if let nsImage = loadedImages[attachment.id] {
+                                    // Fallback to thumbnail — re-encoded as PNG
+                                    if let tiff = nsImage.tiffRepresentation,
+                                       let rep = NSBitmapImageRep(data: tiff),
+                                       let pngData = rep.representation(using: .png, properties: [:]) {
+                                        provider.registerDataRepresentation(forTypeIdentifier: UTType.png.identifier, visibility: .all) { completion in
+                                            completion(pngData, nil)
+                                            return nil
+                                        }
+                                    }
+                                }
+                                // Force .png extension when falling back to PNG encoding
+                                // so the filename matches the actual content type.
+                                let filename = attachment.filename
+                                if hasFullData {
+                                    provider.suggestedName = filename
+                                } else {
+                                    provider.suggestedName = (filename as NSString).deletingPathExtension + ".png"
+                                }
+                                return provider
                             }
                             .pointerCursor()
                     } else if failedIds.contains(attachment.id) {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -264,35 +264,43 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                             }
                             .onDrag {
                                 let provider = NSItemProvider()
-                                let hasFullData = !attachment.data.isEmpty
-                                if hasFullData {
+                                let hasBase64 = !attachment.data.isEmpty
+
+                                // Pre-compute thumbnail PNG on main thread as a fallback.
+                                // tiffRepresentation is not thread-safe so this must happen
+                                // here, not in the lazy registerDataRepresentation callback.
+                                let thumbnailPNG: Data? = {
+                                    guard let img = loadedImages[attachment.id],
+                                          let tiff = img.tiffRepresentation,
+                                          let rep = NSBitmapImageRep(data: tiff) else { return nil }
+                                    return rep.representation(using: .png, properties: [:])
+                                }()
+
+                                if hasBase64 {
                                     let mimeType = attachment.mimeType
                                     let utType = UTType(mimeType: mimeType) ?? .png
-                                    // Capture attachment data string by value for lazy decode in callback
                                     let base64String = attachment.data
                                     provider.registerDataRepresentation(forTypeIdentifier: utType.identifier, visibility: .all) { completion in
-                                        // Decode lazily when drop target requests data (off main thread)
+                                        // Decode lazily when drop target requests data
                                         if let decoded = Data(base64Encoded: base64String), !decoded.isEmpty {
                                             completion(decoded, nil)
+                                        } else if let thumbnailPNG {
+                                            // Corrupt base64 — fall back to pre-computed thumbnail
+                                            completion(thumbnailPNG, nil)
                                         } else {
                                             completion(nil, nil)
                                         }
                                         return nil
                                     }
-                                } else if let nsImage = loadedImages[attachment.id] {
-                                    // tiffRepresentation is called here on the main thread (thread-safe)
-                                    if let tiff = nsImage.tiffRepresentation,
-                                       let rep = NSBitmapImageRep(data: tiff),
-                                       let pngData = rep.representation(using: .png, properties: [:]) {
-                                        provider.registerDataRepresentation(forTypeIdentifier: UTType.png.identifier, visibility: .all) { completion in
-                                            completion(pngData, nil)
-                                            return nil
-                                        }
+                                } else if let thumbnailPNG {
+                                    provider.registerDataRepresentation(forTypeIdentifier: UTType.png.identifier, visibility: .all) { completion in
+                                        completion(thumbnailPNG, nil)
+                                        return nil
                                     }
                                 }
                                 // Force .png extension when falling back to PNG encoding
                                 let filename = attachment.filename
-                                if hasFullData {
+                                if hasBase64 {
                                     provider.suggestedName = filename
                                 } else {
                                     provider.suggestedName = (filename as NSString).deletingPathExtension + ".png"

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -2,6 +2,143 @@ import AppKit
 import SwiftUI
 import VellumAssistantShared
 
+// MARK: - Image Context Menu Actions
+
+/// Standalone helper for image context menu actions used by both
+/// `InlineToolCallImageView` and `AttachmentImageGrid`. Kept at file scope
+/// so it is accessible from private structs without coupling to `ChatBubble`.
+private enum ImageActions {
+
+    /// Copies the image to the system clipboard as TIFF data.
+    static func copyToClipboard(_ image: NSImage) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.writeObjects([image])
+    }
+
+    /// Opens an NSSavePanel and writes the image to the chosen path.
+    /// Prefers `base64Data` (full resolution) when available, falling back to
+    /// PNG-encoding the in-memory NSImage.
+    static func saveImageAs(_ image: NSImage, filename: String, base64Data: String? = nil) {
+        let sanitized = (filename as NSString).lastPathComponent
+        let fallbackName = sanitized.isEmpty ? "image.png" : sanitized
+
+        // When base64Data is unavailable we re-encode the NSImage as PNG.
+        // Force the suggested filename to .png so the extension matches the
+        // actual content encoding — mirrors the same pattern in openInPreview.
+        let hasFullData = base64Data.map { !$0.isEmpty } ?? false
+        let suggestedName: String
+        if hasFullData {
+            suggestedName = fallbackName
+        } else {
+            suggestedName = (fallbackName as NSString).deletingPathExtension + ".png"
+        }
+
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = suggestedName
+        panel.canCreateDirectories = true
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            DispatchQueue.global(qos: .userInitiated).async {
+                if hasFullData,
+                   let base64Data,
+                   let decoded = Data(base64Encoded: base64Data), !decoded.isEmpty {
+                    try? decoded.write(to: url)
+                } else if let tiff = image.tiffRepresentation,
+                          let rep = NSBitmapImageRep(data: tiff),
+                          let png = rep.representation(using: .png, properties: [:]) {
+                    try? png.write(to: url)
+                }
+            }
+        }
+    }
+
+    /// Writes the image to a temporary file and opens it in the default app (Preview).
+    /// Prefers `base64Data` (full resolution), falling back to PNG-encoding the NSImage.
+    static func openInPreview(_ image: NSImage, filename: String, base64Data: String? = nil) {
+        let tempDir = FileManager.default.temporaryDirectory
+        let sanitized = (filename as NSString).lastPathComponent
+        let fallbackName = sanitized.isEmpty ? "image.png" : sanitized
+
+        var usedPNGFallback = false
+        let fileData: Data? = {
+            if let base64Data, !base64Data.isEmpty,
+               let decoded = Data(base64Encoded: base64Data), !decoded.isEmpty {
+                return decoded
+            }
+            if let tiff = image.tiffRepresentation,
+               let rep = NSBitmapImageRep(data: tiff) {
+                usedPNGFallback = true
+                return rep.representation(using: .png, properties: [:])
+            }
+            return nil
+        }()
+
+        let fileName: String
+        if usedPNGFallback {
+            fileName = (fallbackName as NSString).deletingPathExtension + ".png"
+        } else {
+            fileName = fallbackName
+        }
+        let fileURL = tempDir.appendingPathComponent(fileName)
+
+        guard let fileData else { return }
+        do {
+            try fileData.write(to: fileURL)
+            NSWorkspace.shared.open(fileURL)
+        } catch {
+            // Silently fail — not critical
+        }
+    }
+
+    /// Presents the macOS share sheet anchored to the center of the key window.
+    static func shareImage(_ image: NSImage) {
+        let picker = NSSharingServicePicker(items: [image])
+        if let window = NSApp.keyWindow, let contentView = window.contentView {
+            let rect = CGRect(
+                x: contentView.bounds.midX,
+                y: contentView.bounds.midY,
+                width: 1,
+                height: 1
+            )
+            picker.show(relativeTo: rect, of: contentView, preferredEdge: .minY)
+        }
+    }
+
+    /// Builds a SwiftUI context menu with Copy, Save As, Open in Preview, and Share actions.
+    @ViewBuilder
+    static func contextMenuItems(
+        image: NSImage,
+        filename: String,
+        base64Data: String? = nil
+    ) -> some View {
+        Button {
+            copyToClipboard(image)
+        } label: {
+            Label { Text("Copy Image") } icon: { VIconView(.copy, size: 12) }
+        }
+
+        Button {
+            saveImageAs(image, filename: filename, base64Data: base64Data)
+        } label: {
+            Label { Text("Save Image As\u{2026}") } icon: { VIconView(.arrowDownToLine, size: 12) }
+        }
+
+        Button {
+            openInPreview(image, filename: filename, base64Data: base64Data)
+        } label: {
+            Label { Text("Open in Preview") } icon: { VIconView(.eye, size: 12) }
+        }
+
+        Divider()
+
+        Button {
+            shareImage(image)
+        } label: {
+            Label { Text("Share\u{2026}") } icon: { VIconView(.share, size: 12) }
+        }
+    }
+}
+
 // MARK: - Inline Tool Call Image
 
 /// Renders a single tool-call-generated image at full width in the message flow.
@@ -11,6 +148,18 @@ private struct InlineToolCallImageView: View {
     @Environment(\.displayScale) private var displayScale
 
     var body: some View {
+        imageContent
+            .onTapGesture {
+                ImageActions.openInPreview(image, filename: "image.png")
+            }
+            .contextMenu {
+                ImageActions.contextMenuItems(image: image, filename: "image.png")
+            }
+            .pointerCursor()
+    }
+
+    @ViewBuilder
+    private var imageContent: some View {
         if let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) {
             let nativeWidth = CGFloat(cgImage.width) / displayScale
             let nativeHeight = CGFloat(cgImage.height) / displayScale
@@ -72,6 +221,13 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                             .onTapGesture {
                                 onTap(attachment, nsImage)
+                            }
+                            .contextMenu {
+                                ImageActions.contextMenuItems(
+                                    image: nsImage,
+                                    filename: attachment.filename,
+                                    base64Data: attachment.data.isEmpty ? nil : attachment.data
+                                )
                             }
                             .pointerCursor()
                     } else if failedIds.contains(attachment.id) {

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -779,7 +779,7 @@ extension ChatViewModel {
             // Reset processing messages to sent and drop attachment base64 data
             // for lazy-loadable attachments (sizeBytes != nil means the daemon can
             // re-serve them). Locally-added attachments (sizeBytes == nil) keep their
-            // data because openImageInPreview / saveFileAttachment rely on it.
+            // data because ImageActions.openInPreview / saveFileAttachment rely on it.
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {
                     messages[i].status = .sent


### PR DESCRIPTION
## Summary
Adds platform-native macOS interactions for saving, copying, and sharing images in assistant chat messages. Previously, images could only be opened in Preview by clicking. Now users get right-click context menus and drag-and-drop support — zero new visible UI, just native interactions users already know.

## Changes
- **Right-click context menu** on all chat images (inline tool call images + attachment grid thumbnails) with Copy Image, Save Image As..., Open in Preview, and Share... options
- **Drag-and-drop** support via `.onDrag` — users can drag images to Finder, Desktop, or other apps
- **`ImageActions` helper** — consolidated, file-scoped utility enum with shared methods for all image interactions (copy, save, open, share)
- **Removed duplicate** `ChatBubble.openImageInPreview` in favor of the consolidated `ImageActions.openInPreview`
- **PNG extension enforcement** — when falling back to NSImage re-encoding, filename extensions are forced to `.png` to prevent extension/content mismatches
- **Background decoding** — base64 decode happens off the main thread to avoid UI blocking for large images

## Milestone PRs (merged into feature branch)
- #20071: M1: Add right-click context menu to chat images
- #20072: M2: Add drag-and-drop support to chat images
- #20075: Address review feedback: validate base64 and consolidate openInPreview

## Project issue
Closes #20068

## Test plan
- [ ] Right-click an inline tool call image (e.g., browser screenshot) — verify context menu appears with all 4 options
- [ ] Right-click an attachment thumbnail — verify same context menu
- [ ] Copy Image → paste into another app — verify image is on clipboard
- [ ] Save Image As... → verify NSSavePanel opens with correct filename, saves correctly
- [ ] Open in Preview → verify image opens in Preview.app
- [ ] Share... → verify macOS share sheet appears
- [ ] Drag inline image to Desktop → verify file is created with correct content
- [ ] Drag attachment thumbnail to Finder → verify file is created
- [ ] Verify existing click-to-open-Preview behavior still works on attachment thumbnails
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
