### PR TITLE
M1: Fix skill card alignment, action positioning, and spacing (LUM-348)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -298,10 +298,10 @@ struct AgentPanelContent: View {
                     ScrollView {
                         LazyVGrid(
                             columns: [
-                                GridItem(.flexible(), spacing: VSpacing.md),
-                                GridItem(.flexible(), spacing: VSpacing.md)
+                                GridItem(.flexible(), spacing: VSpacing.sm),
+                                GridItem(.flexible(), spacing: VSpacing.sm)
                             ],
-                            spacing: VSpacing.md
+                            spacing: VSpacing.sm
                         ) {
                             ForEach(categoryFilteredSkills) { skill in
                                 skillCard(skill)
@@ -337,7 +337,7 @@ struct AgentPanelContent: View {
 
         var body: some View {
             Button(action: onSelect) {
-                HStack(alignment: .center, spacing: VSpacing.lg) {
+                HStack(alignment: .top, spacing: VSpacing.lg) {
                     // Icon — centered vertically, large
                     skillIcon(skill.emoji)
 
@@ -350,8 +350,6 @@ struct AgentPanelContent: View {
                                 .foregroundColor(VColor.contentDefault)
                                 .lineLimit(1)
                                 .truncationMode(.tail)
-
-                            Spacer()
 
                             VSkillTypePill(source: skill.source)
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -338,7 +338,7 @@ struct AgentPanelContent: View {
         var body: some View {
             Button(action: onSelect) {
                 HStack(alignment: .top, spacing: VSpacing.lg) {
-                    // Icon — centered vertically, large
+                    // Icon — top-aligned, large
                     skillIcon(skill.emoji)
 
                     // Text content


### PR DESCRIPTION
Part of #20080

- Changed SkillCardButton HStack alignment from .center to .top so the icon aligns with the title
- Removed Spacer() between title and actions so VSkillTypePill and delete button appear next to the name
- Reduced grid spacing from VSpacing.md (12px) to VSpacing.sm (8px)

Part of LUM-348
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
