### PR TITLE
Add managed-twitter-oauth feature flag and TwitterOAuth service schema

### DIFF
--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -51,6 +51,11 @@ export const GoogleOAuthServiceSchema = BaseServiceSchema.extend({
 });
 export type GoogleOAuthService = z.infer<typeof GoogleOAuthServiceSchema>;
 
+export const TwitterOAuthServiceSchema = BaseServiceSchema.extend({
+  mode: ServiceModeSchema.default("managed"),
+});
+export type TwitterOAuthService = z.infer<typeof TwitterOAuthServiceSchema>;
+
 export const ServicesSchema = z.object({
   inference: InferenceServiceSchema.default(InferenceServiceSchema.parse({})),
   "image-generation": ImageGenerationServiceSchema.default(
@@ -61,6 +66,9 @@ export const ServicesSchema = z.object({
   ),
   "google-oauth": GoogleOAuthServiceSchema.default(
     GoogleOAuthServiceSchema.parse({}),
+  ),
+  "twitter-oauth": TwitterOAuthServiceSchema.default(
+    TwitterOAuthServiceSchema.parse({}),
   ),
 });
 export type Services = z.infer<typeof ServicesSchema>;

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -250,6 +250,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "managed-twitter-oauth",
+      "scope": "assistant",
+      "key": "feature_flags.managed-twitter-oauth.enabled",
+      "label": "Managed Twitter OAuth",
+      "description": "Show the Twitter OAuth service card in Models & Services settings",
+      "defaultEnabled": false
+    },
+    {
       "id": "settings-embedding-provider",
       "scope": "assistant",
       "key": "feature_flags.settings-embedding-provider.enabled",


### PR DESCRIPTION
## Summary
- Adds `managed-twitter-oauth` feature flag to the registry (scope: assistant, default: off)
- Adds `TwitterOAuthServiceSchema` and `twitter-oauth` entry to `ServicesSchema` in services.ts

## Test plan
- [x] Feature flag registries are identical (meta/ and assistant/src/config/)
- [x] `bunx tsc --noEmit` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
