### PR TITLE
LUM-347: Fix file attachment chip padding to be uniform

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -188,7 +188,7 @@ extension ChatBubble {
             }
         }
         .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.sm)
+        .padding(.vertical, VSpacing.xs)
         .background(
             RoundedRectangle(cornerRadius: VRadius.sm)
                 .fill(isUser ? VColor.contentDefault.opacity(0.15) : VColor.borderBase.opacity(0.5))

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -188,7 +188,7 @@ extension ChatBubble {
             }
         }
         .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.xs)
+        .padding(.vertical, VSpacing.sm)
         .background(
             RoundedRectangle(cornerRadius: VRadius.sm)
                 .fill(isUser ? VColor.contentDefault.opacity(0.15) : VColor.borderBase.opacity(0.5))

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerAttachments.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerAttachments.swift
@@ -36,8 +36,7 @@ extension ComposerView {
                 .font(VFont.caption)
                 .foregroundColor(VColor.contentTertiary)
         }
-        .padding(.vertical, VSpacing.xs)
-        .padding(.horizontal, VSpacing.sm)
+        .padding(VSpacing.xs)
         .background(VColor.borderBase.opacity(0.3))
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
     }
@@ -90,8 +89,7 @@ extension ComposerView {
             .buttonStyle(.plain)
             .accessibilityLabel("Remove \(attachment.filename)")
         }
-        .padding(.vertical, VSpacing.xs)
-        .padding(.horizontal, VSpacing.sm)
+        .padding(VSpacing.xs)
         .background(VColor.borderBase.opacity(0.3))
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .frame(maxWidth: 280)


### PR DESCRIPTION
## Summary
Fix inconsistent padding on the file attachment chip in ChatBubbleAttachmentContent. The file icon had more margin on the left (8pt) than above/below (4pt). Changed vertical padding from `VSpacing.xs` to `VSpacing.sm` to give uniform 8pt padding all around.

## Changes
- Changed `.padding(.vertical, VSpacing.xs)` to `.padding(.vertical, VSpacing.sm)` in `fileAttachmentChip` (ChatBubbleAttachmentContent.swift:191)

## Milestone PRs (merged into feature branch)
- #20079: LUM-347: Fix file attachment chip padding to be uniform

## Test plan
- [ ] Open a chat with file attachments and verify the file icon chip has uniform padding on all sides
- [ ] Verify the chip doesn't look too tall after the padding increase
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
