### PR TITLE
Link Twitter seed provider to twitter-oauth service config

### DIFF
--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -156,6 +156,7 @@ const PROVIDER_SEED_DATA: Record<
     },
     tokenEndpointAuthMethod: "client_secret_basic",
     callbackTransport: "gateway",
+    managedServiceConfigKey: "twitter-oauth",
   },
 
   "integration:github": {


### PR DESCRIPTION
## Summary
- Adds `managedServiceConfigKey: "twitter-oauth"` to the `integration:twitter` seed provider entry
- This links the Twitter provider to the service config so the connection resolver checks `services.twitter-oauth.mode` when resolving Twitter OAuth connections

## Test plan
- [x] `bunx tsc --noEmit` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
