### PR TITLE
feat: fetch releases from platform API directly for all topologies

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -149,27 +149,47 @@ struct AssistantUpgradeSection: View {
         isLoadingReleases = true
         defer { isLoadingReleases = false }
 
+        let platformBase = AuthService.shared.baseURL
+        var urlString = "\(platformBase)/v1/releases/?stable=true"
+        if let current = currentVersion, !current.isEmpty {
+            let normalizedVersion = current.hasPrefix("v") ? String(current.dropFirst()) : current
+            if let encoded = normalizedVersion.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
+                urlString += "&since_version=\(encoded)"
+            }
+        }
+        guard let url = URL(string: urlString) else {
+            errorMessage = "Failed to check for updates"
+            return
+        }
+
         do {
-            let (paginated, response): (PaginatedReleasesResponse?, _) = try await GatewayHTTPClient.get(
-                path: "assistants/releases"
-            ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
-            guard response.statusCode == 200 else {
+            let (data, response) = try await URLSession.shared.data(from: url)
+            guard let httpResponse = response as? HTTPURLResponse else {
                 errorMessage = "Failed to check for updates"
                 return
             }
-            if let paginated {
-                availableReleases = paginated.results
-            } else {
-                let decoder = JSONDecoder()
-                decoder.keyDecodingStrategy = .convertFromSnakeCase
-                if let decoded = try? decoder.decode(ReleasesResponse.self, from: response.data) {
-                    availableReleases = decoded.releases
-                } else {
-                    availableReleases = try decoder.decode([AssistantRelease].self, from: response.data)
+            if httpResponse.statusCode == 400, currentVersion != nil {
+                // since_version not found on platform (e.g. local dev build) — retry without filter
+                let fallbackString = "\(platformBase)/v1/releases/?stable=true"
+                if let fallbackURL = URL(string: fallbackString) {
+                    let (fbData, fbResp) = try await URLSession.shared.data(from: fallbackURL)
+                    if let fbHttp = fbResp as? HTTPURLResponse, fbHttp.statusCode == 200 {
+                        let decoder = JSONDecoder()
+                        decoder.keyDecodingStrategy = .convertFromSnakeCase
+                        availableReleases = try decoder.decode([AssistantRelease].self, from: fbData)
+                        return
+                    }
                 }
+                errorMessage = "Failed to check for updates"
+                return
             }
-        } catch let error as GatewayHTTPClient.ClientError {
-            errorMessage = "Unable to check for updates: \(error.localizedDescription)"
+            guard httpResponse.statusCode == 200 else {
+                errorMessage = "Failed to check for updates (HTTP \(httpResponse.statusCode))"
+                return
+            }
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            availableReleases = try decoder.decode([AssistantRelease].self, from: data)
         } catch {
             errorMessage = "Failed to check for updates: \(error.localizedDescription)"
         }
@@ -237,14 +257,8 @@ struct AssistantUpgradeSection: View {
 
 struct AssistantRelease: Decodable, Identifiable {
     let version: String
+    let releasedAt: String?
 
     var id: String { version }
 }
 
-private struct ReleasesResponse: Decodable {
-    let releases: [AssistantRelease]
-}
-
-private struct PaginatedReleasesResponse: Decodable {
-    let results: [AssistantRelease]
-}


### PR DESCRIPTION
## Summary
- Rewrite `loadReleasesQuietly()` to fetch from platform `GET /v1/releases/` directly via URLSession
- Single code path for all topologies (managed, Docker, local) — no more GatewayHTTPClient for releases
- Pass `since_version` query param to filter server-side, with fallback for unknown versions
- Remove dead `ReleasesResponse` and `PaginatedReleasesResponse` types
- Fixes version picker for Docker assistants (was 404 through gateway proxy)

Part of plan: unified-releases-fetch.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
