### PR TITLE
Wire up Twitter OAuth service card in macOS Settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -109,6 +109,7 @@ struct SettingsPanel: View {
     @State private var isBillingEnabled: Bool = false
     @State private var isDeveloperEnabled: Bool = false
     @State private var isGoogleOAuthEnabled: Bool = false
+    @State private var isTwitterOAuthEnabled: Bool = false
     @State private var isEmbeddingProviderEnabled: Bool = false
     @State private var showingDevUnlock: Bool = false
     @State private var devUnlockText: String = ""
@@ -118,6 +119,7 @@ struct SettingsPanel: View {
     private static let billingFeatureFlagKey = "settings_billing_enabled"
     private static let developerFeatureFlagKey = "feature_flags.settings-developer-nav.enabled"
     private static let googleOAuthFeatureFlagKey = "feature_flags.managed-google-oauth.enabled"
+    private static let twitterOAuthFeatureFlagKey = "feature_flags.managed-twitter-oauth.enabled"
     private static let embeddingProviderFeatureFlagKey = "feature_flags.settings-embedding-provider.enabled"
 
     var body: some View {
@@ -227,6 +229,8 @@ struct SettingsPanel: View {
                     isBillingEnabled = enabled
                 } else if key == Self.googleOAuthFeatureFlagKey {
                     isGoogleOAuthEnabled = enabled
+                } else if key == Self.twitterOAuthFeatureFlagKey {
+                    isTwitterOAuthEnabled = enabled
                 } else if key == Self.embeddingProviderFeatureFlagKey {
                     isEmbeddingProviderEnabled = enabled
                 }
@@ -425,6 +429,15 @@ struct SettingsPanel: View {
 
                 OAuthProviderServiceCard(store: store, authManager: authManager, showToast: showToast, providerKey: "integration:google")
             }
+
+            // TWITTER OAUTH (feature-flagged)
+            if isTwitterOAuthEnabled {
+                Divider()
+                    .background(VColor.borderBase)
+                    .padding(.vertical, VSpacing.sm)
+
+                OAuthProviderServiceCard(store: store, authManager: authManager, showToast: showToast, providerKey: "integration:twitter")
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -562,6 +575,9 @@ struct SettingsPanel: View {
                 if let googleOAuthFlag = flags.first(where: { $0.key == Self.googleOAuthFeatureFlagKey }) {
                     isGoogleOAuthEnabled = googleOAuthFlag.enabled
                 }
+                if let twitterOAuthFlag = flags.first(where: { $0.key == Self.twitterOAuthFeatureFlagKey }) {
+                    isTwitterOAuthEnabled = twitterOAuthFlag.enabled
+                }
                 if let embeddingProviderFlag = flags.first(where: { $0.key == Self.embeddingProviderFeatureFlagKey }) {
                     isEmbeddingProviderEnabled = embeddingProviderFlag.enabled
                 }
@@ -585,6 +601,9 @@ struct SettingsPanel: View {
         }
         if let googleOAuthEnabled = resolved[Self.googleOAuthFeatureFlagKey] {
             isGoogleOAuthEnabled = googleOAuthEnabled
+        }
+        if let twitterOAuthEnabled = resolved[Self.twitterOAuthFeatureFlagKey] {
+            isTwitterOAuthEnabled = twitterOAuthEnabled
         }
         if let embeddingProviderEnabled = resolved[Self.embeddingProviderFeatureFlagKey] {
             isEmbeddingProviderEnabled = embeddingProviderEnabled

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2153,6 +2153,10 @@ public final class SettingsStore: ObservableObject {
             self.managedOAuthMode["integration:google"] = mode
             setManagedOAuthMode(mode, providerKey: "integration:google")
         }
+        if let twitterOAuth = services["twitter-oauth"] as? [String: Any],
+           let mode = twitterOAuth["mode"] as? String {
+            self.managedOAuthMode["integration:twitter"] = mode
+        }
     }
 
     func setInferenceMode(_ mode: String) {

--- a/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
+++ b/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
@@ -122,7 +122,7 @@ public enum WorkspaceConfigIO {
 
     /// Service keys whose mode is only set when missing (never force-overwritten).
     /// Google OAuth mode is user-selected and must survive app restarts.
-    static let initOnlyServiceKeys = ["google-oauth"]
+    static let initOnlyServiceKeys = ["google-oauth", "twitter-oauth"]
 
     /// Sets the service mode for services that don't already have one configured.
     /// Called during onboarding (BYOK → "your-own") and managed-proxy bootstrap (→ "managed").


### PR DESCRIPTION
## Summary
- Adds `isTwitterOAuthEnabled` state and `twitterOAuthFeatureFlagKey` to SettingsPanel
- Renders `OAuthProviderServiceCard` with `providerKey: "integration:twitter"` when flag is enabled
- Loads Twitter OAuth mode in `SettingsStore.loadServiceModes()`
- Adds `"twitter-oauth"` to `initOnlyServiceKeys` so user-selected mode survives app restarts

Closes #20082

## Test plan
- [x] `./build.sh lint` passes
- [ ] Enable `managed-twitter-oauth` flag and verify Twitter OAuth card appears in Models & Services
- [ ] Verify Managed/Your Own toggle persists across app restarts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
