### PR TITLE
Twitter OAuth Service Card in Models & Services Settings

### DIFF
--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -52,7 +52,7 @@ export const GoogleOAuthServiceSchema = BaseServiceSchema.extend({
 export type GoogleOAuthService = z.infer<typeof GoogleOAuthServiceSchema>;
 
 export const TwitterOAuthServiceSchema = BaseServiceSchema.extend({
-  mode: ServiceModeSchema.default("managed"),
+  mode: ServiceModeSchema.default("your-own"),
 });
 export type TwitterOAuthService = z.infer<typeof TwitterOAuthServiceSchema>;
 

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -51,6 +51,11 @@ export const GoogleOAuthServiceSchema = BaseServiceSchema.extend({
 });
 export type GoogleOAuthService = z.infer<typeof GoogleOAuthServiceSchema>;
 
+export const TwitterOAuthServiceSchema = BaseServiceSchema.extend({
+  mode: ServiceModeSchema.default("managed"),
+});
+export type TwitterOAuthService = z.infer<typeof TwitterOAuthServiceSchema>;
+
 export const ServicesSchema = z.object({
   inference: InferenceServiceSchema.default(InferenceServiceSchema.parse({})),
   "image-generation": ImageGenerationServiceSchema.default(
@@ -61,6 +66,9 @@ export const ServicesSchema = z.object({
   ),
   "google-oauth": GoogleOAuthServiceSchema.default(
     GoogleOAuthServiceSchema.parse({}),
+  ),
+  "twitter-oauth": TwitterOAuthServiceSchema.default(
+    TwitterOAuthServiceSchema.parse({}),
   ),
 });
 export type Services = z.infer<typeof ServicesSchema>;

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -156,6 +156,7 @@ const PROVIDER_SEED_DATA: Record<
     },
     tokenEndpointAuthMethod: "client_secret_basic",
     callbackTransport: "gateway",
+    managedServiceConfigKey: "twitter-oauth",
   },
 
   "integration:github": {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -109,6 +109,7 @@ struct SettingsPanel: View {
     @State private var isBillingEnabled: Bool = false
     @State private var isDeveloperEnabled: Bool = false
     @State private var isGoogleOAuthEnabled: Bool = false
+    @State private var isTwitterOAuthEnabled: Bool = false
     @State private var isEmbeddingProviderEnabled: Bool = false
     @State private var showingDevUnlock: Bool = false
     @State private var devUnlockText: String = ""
@@ -118,6 +119,7 @@ struct SettingsPanel: View {
     private static let billingFeatureFlagKey = "settings_billing_enabled"
     private static let developerFeatureFlagKey = "feature_flags.settings-developer-nav.enabled"
     private static let googleOAuthFeatureFlagKey = "feature_flags.managed-google-oauth.enabled"
+    private static let twitterOAuthFeatureFlagKey = "feature_flags.managed-twitter-oauth.enabled"
     private static let embeddingProviderFeatureFlagKey = "feature_flags.settings-embedding-provider.enabled"
 
     var body: some View {
@@ -227,6 +229,8 @@ struct SettingsPanel: View {
                     isBillingEnabled = enabled
                 } else if key == Self.googleOAuthFeatureFlagKey {
                     isGoogleOAuthEnabled = enabled
+                } else if key == Self.twitterOAuthFeatureFlagKey {
+                    isTwitterOAuthEnabled = enabled
                 } else if key == Self.embeddingProviderFeatureFlagKey {
                     isEmbeddingProviderEnabled = enabled
                 }
@@ -425,6 +429,15 @@ struct SettingsPanel: View {
 
                 OAuthProviderServiceCard(store: store, authManager: authManager, showToast: showToast, providerKey: "integration:google")
             }
+
+            // TWITTER OAUTH (feature-flagged)
+            if isTwitterOAuthEnabled {
+                Divider()
+                    .background(VColor.borderBase)
+                    .padding(.vertical, VSpacing.sm)
+
+                OAuthProviderServiceCard(store: store, authManager: authManager, showToast: showToast, providerKey: "integration:twitter")
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -562,6 +575,9 @@ struct SettingsPanel: View {
                 if let googleOAuthFlag = flags.first(where: { $0.key == Self.googleOAuthFeatureFlagKey }) {
                     isGoogleOAuthEnabled = googleOAuthFlag.enabled
                 }
+                if let twitterOAuthFlag = flags.first(where: { $0.key == Self.twitterOAuthFeatureFlagKey }) {
+                    isTwitterOAuthEnabled = twitterOAuthFlag.enabled
+                }
                 if let embeddingProviderFlag = flags.first(where: { $0.key == Self.embeddingProviderFeatureFlagKey }) {
                     isEmbeddingProviderEnabled = embeddingProviderFlag.enabled
                 }
@@ -585,6 +601,9 @@ struct SettingsPanel: View {
         }
         if let googleOAuthEnabled = resolved[Self.googleOAuthFeatureFlagKey] {
             isGoogleOAuthEnabled = googleOAuthEnabled
+        }
+        if let twitterOAuthEnabled = resolved[Self.twitterOAuthFeatureFlagKey] {
+            isTwitterOAuthEnabled = twitterOAuthEnabled
         }
         if let embeddingProviderEnabled = resolved[Self.embeddingProviderFeatureFlagKey] {
             isEmbeddingProviderEnabled = embeddingProviderEnabled

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2153,6 +2153,10 @@ public final class SettingsStore: ObservableObject {
             self.managedOAuthMode["integration:google"] = mode
             setManagedOAuthMode(mode, providerKey: "integration:google")
         }
+        if let twitterOAuth = services["twitter-oauth"] as? [String: Any],
+           let mode = twitterOAuth["mode"] as? String {
+            self.managedOAuthMode["integration:twitter"] = mode
+        }
     }
 
     func setInferenceMode(_ mode: String) {

--- a/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
+++ b/clients/macos/vellum-assistant/Services/WorkspaceConfigIO.swift
@@ -122,7 +122,7 @@ public enum WorkspaceConfigIO {
 
     /// Service keys whose mode is only set when missing (never force-overwritten).
     /// Google OAuth mode is user-selected and must survive app restarts.
-    static let initOnlyServiceKeys = ["google-oauth"]
+    static let initOnlyServiceKeys = ["google-oauth", "twitter-oauth"]
 
     /// Sets the service mode for services that don't already have one configured.
     /// Called during onboarding (BYOK → "your-own") and managed-proxy bootstrap (→ "managed").

--- a/gateway/bun.lock
+++ b/gateway/bun.lock
@@ -13,7 +13,6 @@
       },
       "devDependencies": {
         "@types/bun": "^1.2.4",
-        "@types/uuid": "^11.0.0",
         "eslint": "^10.0.0",
         "knip": "^5.83.1",
         "prettier": "^3.8.1",
@@ -120,8 +119,6 @@
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
-
-    "@types/uuid": ["@types/uuid@11.0.0", "", { "dependencies": { "uuid": "*" } }, "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.56.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.56.0", "@typescript-eslint/type-utils": "8.56.0", "@typescript-eslint/utils": "8.56.0", "@typescript-eslint/visitor-keys": "8.56.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.56.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw=="],
 

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "@types/bun": "^1.2.4",
-    "@types/uuid": "^11.0.0",
     "eslint": "^10.0.0",
     "knip": "^5.83.1",
     "prettier": "^3.8.1",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -250,6 +250,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "managed-twitter-oauth",
+      "scope": "assistant",
+      "key": "feature_flags.managed-twitter-oauth.enabled",
+      "label": "Managed Twitter OAuth",
+      "description": "Show the Twitter OAuth service card in Models & Services settings",
+      "defaultEnabled": false
+    },
+    {
       "id": "settings-embedding-provider",
       "scope": "assistant",
       "key": "feature_flags.settings-embedding-provider.enabled",


### PR DESCRIPTION
## Summary
Adds a Twitter OAuth service card to the Models & Services settings panel, matching the existing Google OAuth card pattern. The card shows Managed and Your Own (BYO) tabs and is gated behind a new `managed-twitter-oauth` feature flag (default off).

## Changes
- Added `managed-twitter-oauth` feature flag to the registry (scope: assistant, default: off)
- Added `TwitterOAuthServiceSchema` and `"twitter-oauth"` entry to `ServicesSchema`
- Linked Twitter seed provider to `twitter-oauth` service config via `managedServiceConfigKey`
- Wired up feature flag in `SettingsPanel.swift` (state, key, notification handler, both load paths)
- Added `OAuthProviderServiceCard` with `providerKey: "integration:twitter"` when flag is enabled
- Added Twitter OAuth mode loading in `SettingsStore.loadServiceModes()`
- Added `"twitter-oauth"` to `initOnlyServiceKeys` in `WorkspaceConfigIO.swift`

## Milestone PRs (merged into feature branch)
- #20087: Add managed-twitter-oauth feature flag and TwitterOAuth service schema
- #20089: Link Twitter seed provider to twitter-oauth service config
- #20093: Wire up Twitter OAuth service card in macOS Settings

## Project issue
Closes #20082

## Test plan
- [ ] Enable `managed-twitter-oauth` flag and verify Twitter OAuth card appears in Models & Services
- [ ] Verify Managed/Your Own toggle persists across app restarts
- [ ] Verify card does NOT appear when flag is off (default)
- [ ] Verify existing Google OAuth card is unaffected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
