### PR TITLE
feat: register settings-schedules feature flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -258,6 +258,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "settings-schedules",
+      "scope": "assistant",
+      "key": "feature_flags.settings-schedules.enabled",
+      "label": "Schedules Settings Tab",
+      "description": "Show the Schedules tab in Settings for viewing and managing schedules",
+      "defaultEnabled": false
+    },
+    {
       "id": "quick-input",
       "scope": "macos",
       "key": "quick_input_enabled",


### PR DESCRIPTION
## Summary
- Add settings-schedules feature flag to the registry with scope assistant
- Key: feature_flags.settings-schedules.enabled, defaultEnabled: false
- Will gate the Schedules tab visibility in macOS Settings

Part of plan: settings-schedules-tab.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
