### PR TITLE
feat: add runNow method to ScheduleClient

### DIFF
--- a/clients/shared/Network/ScheduleClient.swift
+++ b/clients/shared/Network/ScheduleClient.swift
@@ -10,6 +10,7 @@ public protocol ScheduleClientProtocol {
     func toggleSchedule(id: String, enabled: Bool) async throws -> [ScheduleItem]
     func deleteSchedule(id: String) async throws -> [ScheduleItem]
     func cancelSchedule(id: String) async throws -> [ScheduleItem]
+    func runNow(id: String) async throws -> [ScheduleItem]
 }
 
 /// Gateway-backed implementation of ``ScheduleClientProtocol``.
@@ -75,6 +76,19 @@ public struct ScheduleClient: ScheduleClientProtocol {
         )
         guard response.isSuccess else {
             log.error("cancelSchedule failed (HTTP \(response.statusCode))")
+            throw ScheduleClientError.httpError(statusCode: response.statusCode)
+        }
+        return try JSONDecoder().decode(SchedulesResponse.self, from: response.data).schedules
+    }
+
+    public func runNow(id: String) async throws -> [ScheduleItem] {
+        let response = try await GatewayHTTPClient.post(
+            path: "assistants/{assistantId}/schedules/\(id)/run",
+            json: [:],
+            timeout: 30
+        )
+        guard response.isSuccess else {
+            log.error("runNow failed (HTTP \(response.statusCode))")
             throw ScheduleClientError.httpError(statusCode: response.statusCode)
         }
         return try JSONDecoder().decode(SchedulesResponse.self, from: response.data).schedules


### PR DESCRIPTION
## Summary
- Add runNow(id:) to ScheduleClientProtocol and ScheduleClient
- POSTs to assistants/{assistantId}/schedules/{id}/run with 30s timeout
- Follows the same pattern as existing cancelSchedule method

Part of plan: settings-schedules-tab.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
