### PR TITLE
feat: add PATCH /schedules/:id endpoint for inline editing

### DIFF
--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -99,6 +99,44 @@ function handleCancelSchedule(id: string): Response {
   return handleListSchedules();
 }
 
+function handleUpdateSchedule(
+  id: string,
+  body: Record<string, unknown>,
+): Response {
+  const updates: Record<string, unknown> = {};
+  for (const key of [
+    "name",
+    "expression",
+    "timezone",
+    "message",
+    "mode",
+    "routingIntent",
+    "quiet",
+  ] as const) {
+    if (key in body) {
+      updates[key] = body[key];
+    }
+  }
+
+  try {
+    const updated = updateSchedule(id, updates);
+    if (!updated) {
+      return httpError("NOT_FOUND", "Schedule not found", 404);
+    }
+    log.info({ id, updates }, "Schedule updated via HTTP");
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      (err.message.includes("Invalid") || err.message.includes("invalid"))
+    ) {
+      return httpError("BAD_REQUEST", err.message, 400);
+    }
+    log.error({ err }, "Failed to update schedule");
+    return httpError("INTERNAL_ERROR", "Failed to update schedule", 500);
+  }
+  return handleListSchedules();
+}
+
 async function handleRunScheduleNow(
   id: string,
   sendMessageDeps?: SendMessageDeps,
@@ -242,6 +280,13 @@ export function scheduleRouteDefinitions(deps: {
       method: "DELETE",
       policyKey: "schedules",
       handler: ({ params }) => handleDeleteSchedule(params.id),
+    },
+    {
+      endpoint: "schedules/:id",
+      method: "PATCH",
+      policyKey: "schedules",
+      handler: async ({ req, params }) =>
+        handleUpdateSchedule(params.id, await req.json()),
     },
     {
       endpoint: "schedules/:id/run",


### PR DESCRIPTION
## Summary
- Add handleUpdateSchedule handler that accepts partial schedule updates (name, expression, timezone, message, mode, routingIntent, quiet)
- Add PATCH /schedules/:id route definition with policyKey 'schedules'
- Returns 404 for missing schedules, 400 for invalid expressions

Part of plan: settings-schedules-tab.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
