### PR TITLE
feat: add updateSchedule method to ScheduleClient

### DIFF
--- a/clients/shared/Network/ScheduleClient.swift
+++ b/clients/shared/Network/ScheduleClient.swift
@@ -11,6 +11,7 @@ public protocol ScheduleClientProtocol {
     func deleteSchedule(id: String) async throws -> [ScheduleItem]
     func cancelSchedule(id: String) async throws -> [ScheduleItem]
     func runNow(id: String) async throws -> [ScheduleItem]
+    func updateSchedule(id: String, updates: [String: Any]) async throws -> [ScheduleItem]
 }
 
 /// Gateway-backed implementation of ``ScheduleClientProtocol``.
@@ -89,6 +90,19 @@ public struct ScheduleClient: ScheduleClientProtocol {
         )
         guard response.isSuccess else {
             log.error("runNow failed (HTTP \(response.statusCode))")
+            throw ScheduleClientError.httpError(statusCode: response.statusCode)
+        }
+        return try JSONDecoder().decode(SchedulesResponse.self, from: response.data).schedules
+    }
+
+    public func updateSchedule(id: String, updates: [String: Any]) async throws -> [ScheduleItem] {
+        let response = try await GatewayHTTPClient.patch(
+            path: "assistants/{assistantId}/schedules/\(id)",
+            json: updates,
+            timeout: 10
+        )
+        guard response.isSuccess else {
+            log.error("updateSchedule failed (HTTP \(response.statusCode))")
             throw ScheduleClientError.httpError(statusCode: response.statusCode)
         }
         return try JSONDecoder().decode(SchedulesResponse.self, from: response.data).schedules


### PR DESCRIPTION
## Summary
- Add updateSchedule(id:updates:) to ScheduleClientProtocol and ScheduleClient
- PATCHes to assistants/{assistantId}/schedules/{id} with partial update dict
- Follows the same pattern as existing schedule client methods

Part of plan: settings-schedules-tab.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
