### PR TITLE
feat: gate Sounds tab and playback behind sounds feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -12,12 +12,12 @@ enum SettingsTab: String {
     case developer = "Developer"
 
     /// Primary tabs shown in the main nav list (excludes feature-flagged bottom tabs).
-    static func primaryTabs(billingEnabled: Bool = false) -> [SettingsTab] {
+    static func primaryTabs(billingEnabled: Bool = false, soundsEnabled: Bool = true) -> [SettingsTab] {
         var tabs: [SettingsTab] = [.general]
-        tabs.append(contentsOf: [
-            .voice, .sounds, .modelsAndServices,
-            .permissionsAndPrivacy,
-        ])
+        var middle: [SettingsTab] = [.voice]
+        if soundsEnabled { middle.append(.sounds) }
+        middle.append(contentsOf: [.modelsAndServices, .permissionsAndPrivacy])
+        tabs.append(contentsOf: middle)
         if billingEnabled {
             tabs.append(.billing)
         }
@@ -77,7 +77,7 @@ struct SettingsPanel: View {
             let canShowBilling = billingEnabled && authManager.isAuthenticated && orgId != nil
             // Contacts and developer flags load asynchronously, so default
             // to false at init time — those tabs aren't visible yet.
-            let visibleTabs = SettingsTab.primaryTabs(billingEnabled: canShowBilling)
+            let visibleTabs = SettingsTab.primaryTabs(billingEnabled: canShowBilling, soundsEnabled: isSoundsEnabled)
             if visibleTabs.contains(pending) {
                 _selectedTab = State(initialValue: pending)
             } else {
@@ -108,6 +108,7 @@ struct SettingsPanel: View {
     @State private var deferredDeepLinkTab: SettingsTab?
     @State private var isBillingEnabled: Bool = false
     @State private var isDeveloperEnabled: Bool = false
+    @State private var isSoundsEnabled: Bool = true
     @State private var isGoogleOAuthEnabled: Bool = false
     @State private var isEmbeddingProviderEnabled: Bool = false
     @State private var showingDevUnlock: Bool = false
@@ -119,6 +120,7 @@ struct SettingsPanel: View {
     private static let developerFeatureFlagKey = "feature_flags.settings-developer-nav.enabled"
     private static let googleOAuthFeatureFlagKey = "feature_flags.managed-google-oauth.enabled"
     private static let embeddingProviderFeatureFlagKey = "feature_flags.settings-embedding-provider.enabled"
+    private static let soundsFeatureFlagKey = "feature_flags.sounds.enabled"
 
     var body: some View {
         VStack(spacing: 0) {
@@ -174,6 +176,7 @@ struct SettingsPanel: View {
         }
         .onAppear {
             isBillingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
+            isSoundsEnabled = AssistantFeatureFlagResolver.isEnabled(Self.soundsFeatureFlagKey)
             store.refreshAPIKeyState()
             store.loadProviderRoutingSources()
             store.refreshTelegramStatus()
@@ -193,7 +196,7 @@ struct SettingsPanel: View {
                 // the flag manager directly avoids a stale billingVisible.
                 let billingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
                 let canShowBilling = billingEnabled && authManager.isAuthenticated && connectedOrgId != nil
-                let visibleTabs = SettingsTab.primaryTabs(billingEnabled: canShowBilling)
+                let visibleTabs = SettingsTab.primaryTabs(billingEnabled: canShowBilling, soundsEnabled: isSoundsEnabled)
                     + (isDeveloperEnabled ? [.developer] : [])
                 if visibleTabs.contains(tab) {
                     selectedTab = tab
@@ -229,6 +232,11 @@ struct SettingsPanel: View {
                     isGoogleOAuthEnabled = enabled
                 } else if key == Self.embeddingProviderFeatureFlagKey {
                     isEmbeddingProviderEnabled = enabled
+                } else if key == Self.soundsFeatureFlagKey {
+                    isSoundsEnabled = enabled
+                    if !enabled && selectedTab == .sounds {
+                        selectedTab = .general
+                    }
                 }
             }
         }
@@ -307,7 +315,7 @@ struct SettingsPanel: View {
 
     /// All currently visible tabs (primary + gated bottom tabs).
     private var allVisibleTabs: [SettingsTab] {
-        var tabs = SettingsTab.primaryTabs(billingEnabled: billingVisible)
+        var tabs = SettingsTab.primaryTabs(billingEnabled: billingVisible, soundsEnabled: isSoundsEnabled)
         if isDeveloperEnabled {
             tabs.append(.developer)
         }
@@ -322,7 +330,7 @@ struct SettingsPanel: View {
 
     private var settingsNav: some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
-            ForEach(SettingsTab.primaryTabs(billingEnabled: billingVisible), id: \.self) { tab in
+            ForEach(SettingsTab.primaryTabs(billingEnabled: billingVisible, soundsEnabled: isSoundsEnabled), id: \.self) { tab in
                 SettingsNavRow(tab: tab, isSelected: selectedTab == tab) {
                     selectedTab = tab
                 }
@@ -565,6 +573,9 @@ struct SettingsPanel: View {
                 if let embeddingProviderFlag = flags.first(where: { $0.key == Self.embeddingProviderFeatureFlagKey }) {
                     isEmbeddingProviderEnabled = embeddingProviderFlag.enabled
                 }
+                if let soundsFlag = flags.first(where: { $0.key == Self.soundsFeatureFlagKey }) {
+                    isSoundsEnabled = soundsFlag.enabled
+                }
                 consumeDeferredDeepLinkIfVisible()
                 return
             } catch {
@@ -588,6 +599,9 @@ struct SettingsPanel: View {
         }
         if let embeddingProviderEnabled = resolved[Self.embeddingProviderFeatureFlagKey] {
             isEmbeddingProviderEnabled = embeddingProviderEnabled
+        }
+        if let soundsEnabled = resolved[Self.soundsFeatureFlagKey] {
+            isSoundsEnabled = soundsEnabled
         }
 
         consumeDeferredDeepLinkIfVisible()

--- a/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
@@ -137,6 +137,7 @@ final class SoundManager {
 
     /// Plays the sound associated with the given event, respecting global and per-event toggles.
     func play(_ event: SoundEvent) {
+        guard AssistantFeatureFlagResolver.isEnabled("feature_flags.sounds.enabled") else { return }
         guard config.globalEnabled else { return }
 
         let eventConfig = config.config(for: event)


### PR DESCRIPTION
## Summary
- Add feature flag check in SoundManager.play() to gate all sound playback when sounds flag is disabled
- Gate the Sounds settings tab behind the feature flag with reactive show/hide on toggle
- Follow existing patterns for developer/billing tab gating in SettingsPanel

Part of plan: sounds-feature-flag.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
