### PR TITLE
feat: add isTripped circuit breaker query to ChatScrollLoopGuard

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatScrollLoopGuard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatScrollLoopGuard.swift
@@ -206,6 +206,14 @@ final class ChatScrollLoopGuard {
         }
         return counts
     }
+
+    /// Returns true when the guard has tripped for this conversation and is
+    /// still in cooldown. Callers can use this as a circuit breaker to suppress
+    /// further scroll-to calls until the cascade subsides.
+    func isTripped(conversationId: String) -> Bool {
+        guard let state = states[conversationId] else { return false }
+        return state.inCooldown
+    }
 }
 
 // MARK: - Hashable conformance for EventKind (dictionary key)

--- a/clients/macos/vellum-assistantTests/ChatScrollLoopGuardTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatScrollLoopGuardTests.swift
@@ -528,4 +528,43 @@ final class ChatScrollLoopGuardTests: XCTestCase {
         let counts = guard_.currentCounts(conversationId: "nonexistent")
         XCTAssertTrue(counts.isEmpty)
     }
+
+    // MARK: - isTripped
+
+    func testIsTrippedReturnsFalseForUnknownConversation() {
+        XCTAssertFalse(guard_.isTripped(conversationId: "nonexistent"))
+    }
+
+    func testIsTrippedReturnsTrueAfterThresholdExceeded() {
+        var timestamp: TimeInterval = 1000.0
+
+        // Fire enough events to trip the guard.
+        for _ in 0..<50 {
+            guard_.record(.anchorPreferenceChange, conversationId: conversationId, timestamp: timestamp)
+            timestamp += 0.03
+        }
+
+        XCTAssertTrue(guard_.isTripped(conversationId: conversationId),
+                       "isTripped should return true immediately after threshold is exceeded")
+    }
+
+    func testIsTrippedReturnsFalseAfterCooldownAndQuietWindow() {
+        var timestamp: TimeInterval = 1000.0
+
+        // Trip the guard.
+        for _ in 0..<50 {
+            guard_.record(.anchorPreferenceChange, conversationId: conversationId, timestamp: timestamp)
+            timestamp += 0.03
+        }
+        XCTAssertTrue(guard_.isTripped(conversationId: conversationId))
+
+        // Advance past the cooldown duration with no events.
+        timestamp += ChatScrollLoopGuard.cooldownDuration + 0.1
+
+        // Record a single event to trigger the cooldown re-arm check.
+        guard_.record(.anchorPreferenceChange, conversationId: conversationId, timestamp: timestamp)
+
+        XCTAssertFalse(guard_.isTripped(conversationId: conversationId),
+                        "isTripped should return false after cooldown expires and quiet window elapses")
+    }
 }


### PR DESCRIPTION
## Summary
- Add `isTripped(conversationId:)` method to ChatScrollLoopGuard
- Returns true when the guard has tripped and is in cooldown, enabling callers to suppress further scroll-to calls
- Add test coverage for the new circuit breaker query

Part of plan: scroll-loop-freeze-fix.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
