### PR TITLE
feat: wire Schedules tab into SettingsPanel behind feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -9,10 +9,11 @@ enum SettingsTab: String {
     case permissionsAndPrivacy = "Permissions & Privacy"
     case billing = "Billing"
     case archivedConversations = "Archived Conversations"
+    case schedules = "Schedules"
     case developer = "Developer"
 
     /// Primary tabs shown in the main nav list (excludes feature-flagged bottom tabs).
-    static func primaryTabs(billingEnabled: Bool = false) -> [SettingsTab] {
+    static func primaryTabs(billingEnabled: Bool = false, schedulesEnabled: Bool = false) -> [SettingsTab] {
         var tabs: [SettingsTab] = [.general]
         tabs.append(contentsOf: [
             .voice, .sounds, .modelsAndServices,
@@ -22,6 +23,7 @@ enum SettingsTab: String {
             tabs.append(.billing)
         }
         tabs.append(.archivedConversations)
+        if schedulesEnabled { tabs.append(.schedules) }
         return tabs
     }
 }
@@ -77,7 +79,7 @@ struct SettingsPanel: View {
             let canShowBilling = billingEnabled && authManager.isAuthenticated && orgId != nil
             // Contacts and developer flags load asynchronously, so default
             // to false at init time — those tabs aren't visible yet.
-            let visibleTabs = SettingsTab.primaryTabs(billingEnabled: canShowBilling)
+            let visibleTabs = SettingsTab.primaryTabs(billingEnabled: canShowBilling, schedulesEnabled: false)
             if visibleTabs.contains(pending) {
                 _selectedTab = State(initialValue: pending)
             } else {
@@ -107,6 +109,7 @@ struct SettingsPanel: View {
     /// Re-evaluated after loadFeatureFlags() completes.
     @State private var deferredDeepLinkTab: SettingsTab?
     @State private var isBillingEnabled: Bool = false
+    @State private var isSchedulesEnabled: Bool = false
     @State private var isDeveloperEnabled: Bool = false
     @State private var isGoogleOAuthEnabled: Bool = false
     @State private var isEmbeddingProviderEnabled: Bool = false
@@ -115,6 +118,7 @@ struct SettingsPanel: View {
     @State private var devUnlockMonitor: Any?
     @State private var bootstrapGeneration: Int = 0
     @AppStorage("connectedOrganizationId") private var connectedOrgId: String?
+    private static let schedulesFeatureFlagKey = "feature_flags.settings-schedules.enabled"
     private static let billingFeatureFlagKey = "settings_billing_enabled"
     private static let developerFeatureFlagKey = "feature_flags.settings-developer-nav.enabled"
     private static let googleOAuthFeatureFlagKey = "feature_flags.managed-google-oauth.enabled"
@@ -193,7 +197,7 @@ struct SettingsPanel: View {
                 // the flag manager directly avoids a stale billingVisible.
                 let billingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
                 let canShowBilling = billingEnabled && authManager.isAuthenticated && connectedOrgId != nil
-                let visibleTabs = SettingsTab.primaryTabs(billingEnabled: canShowBilling)
+                let visibleTabs = SettingsTab.primaryTabs(billingEnabled: canShowBilling, schedulesEnabled: isSchedulesEnabled)
                     + (isDeveloperEnabled ? [.developer] : [])
                 if visibleTabs.contains(tab) {
                     selectedTab = tab
@@ -229,6 +233,11 @@ struct SettingsPanel: View {
                     isGoogleOAuthEnabled = enabled
                 } else if key == Self.embeddingProviderFeatureFlagKey {
                     isEmbeddingProviderEnabled = enabled
+                } else if key == Self.schedulesFeatureFlagKey {
+                    isSchedulesEnabled = enabled
+                    if !enabled && selectedTab == .schedules {
+                        selectedTab = .general
+                    }
                 }
             }
         }
@@ -307,7 +316,7 @@ struct SettingsPanel: View {
 
     /// All currently visible tabs (primary + gated bottom tabs).
     private var allVisibleTabs: [SettingsTab] {
-        var tabs = SettingsTab.primaryTabs(billingEnabled: billingVisible)
+        var tabs = SettingsTab.primaryTabs(billingEnabled: billingVisible, schedulesEnabled: isSchedulesEnabled)
         if isDeveloperEnabled {
             tabs.append(.developer)
         }
@@ -322,7 +331,7 @@ struct SettingsPanel: View {
 
     private var settingsNav: some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
-            ForEach(SettingsTab.primaryTabs(billingEnabled: billingVisible), id: \.self) { tab in
+            ForEach(SettingsTab.primaryTabs(billingEnabled: billingVisible, schedulesEnabled: isSchedulesEnabled), id: \.self) { tab in
                 SettingsNavRow(tab: tab, isSelected: selectedTab == tab) {
                     selectedTab = tab
                 }
@@ -374,6 +383,10 @@ struct SettingsPanel: View {
             SettingsBillingTab(authManager: authManager)
         case .archivedConversations:
             SettingsArchivedConversationsTab(conversationManager: conversationManager)
+        case .schedules:
+            Text("Schedules") // Placeholder — replaced in PR 6
+                .font(VFont.body)
+                .foregroundColor(VColor.contentTertiary)
         case .developer:
             SettingsDeveloperTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose)
         }
@@ -565,6 +578,9 @@ struct SettingsPanel: View {
                 if let embeddingProviderFlag = flags.first(where: { $0.key == Self.embeddingProviderFeatureFlagKey }) {
                     isEmbeddingProviderEnabled = embeddingProviderFlag.enabled
                 }
+                if let schedulesFlag = flags.first(where: { $0.key == Self.schedulesFeatureFlagKey }) {
+                    isSchedulesEnabled = schedulesFlag.enabled
+                }
                 consumeDeferredDeepLinkIfVisible()
                 return
             } catch {
@@ -588,6 +604,9 @@ struct SettingsPanel: View {
         }
         if let embeddingProviderEnabled = resolved[Self.embeddingProviderFeatureFlagKey] {
             isEmbeddingProviderEnabled = embeddingProviderEnabled
+        }
+        if let schedulesEnabled = resolved[Self.schedulesFeatureFlagKey] {
+            isSchedulesEnabled = schedulesEnabled
         }
 
         consumeDeferredDeepLinkIfVisible()


### PR DESCRIPTION
## Summary
- Add .schedules case to SettingsTab enum
- Gate tab visibility behind feature_flags.settings-schedules.enabled flag
- Load flag from gateway API with local registry fallback
- Handle dynamic flag toggling (hide tab + fall back to General when disabled)
- Placeholder content — real tab view comes in PR 6

Part of plan: settings-schedules-tab.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
