### PR TITLE
fix: initialize progress card expansion state at construction to prevent scroll cascade

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -152,7 +152,7 @@ struct AssistantProgressView: View {
     var activeConfirmationRequestId: String? = nil  // For keyboard focus
 
     @Environment(\.suppressAutoScroll) private var suppressAutoScroll
-    @State private var isExpanded: Bool = false
+    @State private var isExpanded: Bool
     @State private var startDate: Date = Date()
     @State private var processingStartDate: Date?
     @State private var isOverflowPopoverShown: Bool = false
@@ -196,6 +196,12 @@ struct AssistantProgressView: View {
             toolCalls: toolCalls,
             decidedConfirmations: decidedConfirmations
         ))
+        let derived = _derived.wrappedValue
+        let isComplete = derived.hasTools && derived.allComplete
+        let isDenied = derived.hasDeniedToolCalls && derived.hasTools && !derived.allComplete
+        let expandFlag = MacOSClientFeatureFlagManager.shared.isEnabled("expand_completed_steps")
+        let shouldAutoExpand = (isComplete || isDenied) && expandFlag
+        _isExpanded = State(initialValue: shouldAutoExpand || derived.hasPendingConfirmation)
     }
 
     // MARK: - Derived State (reads from cached DerivedProgressState)


### PR DESCRIPTION
## Summary
- Initialize `isExpanded` based on derived state at construction time so completed/denied progress cards start expanded
- Eliminates cascading `.onAppear` expansion mutations that cause scroll loop storms during conversation switch
- Existing `.onAppear` handler preserved as safety net (becomes no-op for pre-expanded cards)

Part of plan: scroll-loop-freeze-fix.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
