### PR TITLE
fix: redirect legacy "Contacts" settings deep link to Intelligence panel

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -702,6 +702,11 @@ extension AppDelegate {
         let settingsTab: SettingsTab?
         switch tab {
         case "Archived Threads": settingsTab = .archivedConversations
+        case "Contacts":
+            // Contacts moved from Settings to Intelligence panel
+            showMainWindow()
+            mainWindow?.windowState.showPanel(.intelligence)
+            return
         default: settingsTab = SettingsTab(rawValue: tab)
         }
         if let settingsTab {


### PR DESCRIPTION
## Summary
- Add a case for "Contacts" in showSettingsTab() that redirects to the Intelligence panel instead of silently failing
- Contacts was moved from Settings to Intelligence panel; this handles any remaining deep links

Part of plan: resolve-bot-review-feedback.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
