### PR TITLE
fix: suppress scroll-to-bottom when scroll loop guard has tripped

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -770,6 +770,14 @@ struct MessageListView: View {
     private func configureBottomPinCoordinator(proxy: ScrollViewProxy) {
         bottomPinCoordinator.onPinRequested = { [self] reason, animated in
             guard !isSuppressingBottomScroll else { return false }
+            // Circuit breaker: suppress scroll-to when a scroll loop was detected.
+            // The guard re-arms after a quiet cooldown window elapses.
+            let convIdString = conversationId?.uuidString ?? "unknown"
+            if scrollLoopGuard.isTripped(conversationId: convIdString) {
+                os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested",
+                            "target=bottomAnchor reason=circuitBreakerSuppressed")
+                return false
+            }
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested",
                         "target=bottomAnchor reason=coordinator-%{public}s", reason.rawValue)
             recordScrollLoopEvent(.scrollToRequested)


### PR DESCRIPTION
## Summary
- Wire ChatScrollLoopGuard circuit breaker into MessageListView's onPinRequested callback
- When a scroll loop is detected (guard tripped), suppress further proxy.scrollTo calls until cooldown expires
- Emit os_signpost event for circuit breaker suppressions (visible in Instruments)

Part of plan: scroll-loop-freeze-fix.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
