### PR TITLE
fix: prevent assistant avatar from jumping upward during streaming

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -390,6 +390,17 @@ struct MessageListView: View {
         // Each avatarDisplayY change triggers a MessageListView body re-evaluation;
         // sub-pixel jitter during scroll would otherwise cause continuous re-renders.
         guard abs(avatarDisplayY - y) > 2 else { return }
+
+        // During streaming / sending / thinking, only allow the avatar to move
+        // downward (increasing Y).  Auto-scroll viewport adjustments can briefly
+        // report a smaller tail-anchor Y, which would yank the avatar back toward
+        // the top of the viewport.  Clamping to downward-only movement keeps the
+        // avatar tracking smoothly with the growing content.  When coalescing ends
+        // (streaming finishes), the onChange handler re-applies the true position.
+        if shouldCoalesceAvatarUpdates && avatarDisplayY.isFinite && y < avatarDisplayY {
+            return
+        }
+
         recordScrollLoopEvent(.avatarDisplayYApplied)
         withAnimation(ConversationAvatarFollower.spring) {
             avatarDisplayY = y


### PR DESCRIPTION
## Summary
- During text streaming, the assistant avatar would jump back toward the top of the viewport whenever auto-scroll adjusted the viewport position
- Added a downward-only clamp to `applyAvatarDisplayY` that prevents upward repositioning while streaming/sending/thinking is active
- The correct final position is applied automatically when coalescing ends (streaming finishes) via the existing `onChange(of: shouldCoalesceAvatarUpdates)` handler

## Original prompt
assistant avatar should just go down without any auto position back to top; once user scroll to the bottom just reveal avatar how it usually is - basically no reposition to the top

Closes LUM-361

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
