### PR TITLE
Add Fish Audio config schema and compose into root config

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -40,6 +40,8 @@ export {
   ElevenLabsConfigSchema,
   VALID_CONVERSATION_TIMEOUTS,
 } from "./schemas/elevenlabs.js";
+export type { FishAudioConfig } from "./schemas/fish-audio.js";
+export { FishAudioConfigSchema } from "./schemas/fish-audio.js";
 export type { HeartbeatConfig } from "./schemas/heartbeat.js";
 export { HeartbeatConfigSchema } from "./schemas/heartbeat.js";
 export type {
@@ -193,6 +195,7 @@ import {
   WhatsAppConfigSchema,
 } from "./schemas/channels.js";
 import { ElevenLabsConfigSchema } from "./schemas/elevenlabs.js";
+import { FishAudioConfigSchema } from "./schemas/fish-audio.js";
 import { HeartbeatConfigSchema } from "./schemas/heartbeat.js";
 import {
   ContextWindowConfigSchema,
@@ -293,6 +296,7 @@ export const AssistantConfigSchema = z
     elevenlabs: ElevenLabsConfigSchema.default(
       ElevenLabsConfigSchema.parse({}),
     ),
+    fishAudio: FishAudioConfigSchema.default(FishAudioConfigSchema.parse({})),
     whatsapp: WhatsAppConfigSchema.default(WhatsAppConfigSchema.parse({})),
     telegram: TelegramConfigSchema.default(TelegramConfigSchema.parse({})),
     slack: SlackConfigSchema.default(SlackConfigSchema.parse({})),

--- a/assistant/src/config/schemas/fish-audio.ts
+++ b/assistant/src/config/schemas/fish-audio.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+export const FishAudioConfigSchema = z
+  .object({
+    referenceId: z
+      .string({ error: "fishAudio.referenceId must be a string" })
+      .default("")
+      .describe("Fish Audio voice/clone reference ID"),
+    chunkLength: z
+      .number({ error: "fishAudio.chunkLength must be a number" })
+      .int("fishAudio.chunkLength must be an integer")
+      .min(100, "fishAudio.chunkLength must be >= 100")
+      .max(300, "fishAudio.chunkLength must be <= 300")
+      .default(200)
+      .describe("Text chunk size for streaming synthesis"),
+    format: z
+      .enum(["mp3", "wav", "opus"], {
+        error: "fishAudio.format must be one of: mp3, wav, opus",
+      })
+      .default("mp3")
+      .describe("Output audio format"),
+    speed: z
+      .number({ error: "fishAudio.speed must be a number" })
+      .min(0.5, "fishAudio.speed must be >= 0.5")
+      .max(2.0, "fishAudio.speed must be <= 2.0")
+      .default(1.0)
+      .describe("Playback speed multiplier (0.5 = slower, 2.0 = faster)"),
+  })
+  .describe("Fish Audio text-to-speech configuration");
+
+export type FishAudioConfig = z.infer<typeof FishAudioConfigSchema>;


### PR DESCRIPTION
## Summary
- Create FishAudioConfigSchema with referenceId, chunkLength, format, speed fields
- Compose into root AssistantConfigSchema alongside elevenlabs

Part of plan: fish-audio-s2-tts.md (PR 1 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
