### PR TITLE
Add ephemeral in-memory audio store for synthesized TTS segments

### DIFF
--- a/assistant/src/calls/audio-store.test.ts
+++ b/assistant/src/calls/audio-store.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { getAudio, storeAudio } from "./audio-store.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Reset module-level state between tests by re-importing.
+ * Since the store uses module-level variables, we isolate via fresh imports
+ * where needed, but for most tests the shared module state is fine as long
+ * as we account for it.
+ */
+
+function makeBuffer(sizeBytes: number): Buffer {
+  return Buffer.alloc(sizeBytes, 0x42);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("audio-store", () => {
+  describe("storeAudio / getAudio", () => {
+    test("stores and retrieves audio by id", () => {
+      const buf = makeBuffer(1024);
+      const id = storeAudio(buf, "mp3");
+      const result = getAudio(id);
+      expect(result).not.toBeNull();
+      expect(result!.buffer).toEqual(buf);
+      expect(result!.contentType).toBe("audio/mpeg");
+    });
+
+    test("returns correct content type for each format", () => {
+      const buf = makeBuffer(64);
+
+      const mp3Id = storeAudio(buf, "mp3");
+      expect(getAudio(mp3Id)!.contentType).toBe("audio/mpeg");
+
+      const wavId = storeAudio(buf, "wav");
+      expect(getAudio(wavId)!.contentType).toBe("audio/wav");
+
+      const opusId = storeAudio(buf, "opus");
+      expect(getAudio(opusId)!.contentType).toBe("audio/opus");
+    });
+
+    test("returns null for unknown id", () => {
+      expect(getAudio("nonexistent-id")).toBeNull();
+    });
+  });
+
+  describe("TTL expiration", () => {
+    test("expired entries return null", () => {
+      const buf = makeBuffer(128);
+      const id = storeAudio(buf, "wav");
+
+      // Fast-forward time past TTL (60s)
+      const originalNow = Date.now;
+      Date.now = () => originalNow() + 61_000;
+      try {
+        const result = getAudio(id);
+        expect(result).toBeNull();
+      } finally {
+        Date.now = originalNow;
+      }
+    });
+  });
+
+  describe("capacity eviction", () => {
+    test("evicts oldest entries when capacity is exceeded", () => {
+      // The store has a 50MB cap. Fill it with entries, then add one more
+      // that would exceed the cap. The oldest should be evicted.
+      const chunkSize = 10 * 1024 * 1024; // 10MB per chunk
+      const ids: string[] = [];
+
+      // Store 5 x 10MB = 50MB (at capacity)
+      for (let i = 0; i < 5; i++) {
+        ids.push(storeAudio(makeBuffer(chunkSize), "opus"));
+      }
+
+      // All 5 should be retrievable
+      for (const id of ids) {
+        expect(getAudio(id)).not.toBeNull();
+      }
+
+      // Add one more 10MB entry — should evict the oldest
+      const newId = storeAudio(makeBuffer(chunkSize), "mp3");
+      expect(getAudio(newId)).not.toBeNull();
+      // The first entry should have been evicted
+      expect(getAudio(ids[0]!)).toBeNull();
+    });
+  });
+});

--- a/assistant/src/calls/audio-store.ts
+++ b/assistant/src/calls/audio-store.ts
@@ -1,0 +1,63 @@
+import { randomUUID } from "node:crypto";
+
+interface AudioEntry {
+  buffer: Buffer;
+  contentType: string;
+  expiresAt: number;
+}
+
+const store = new Map<string, AudioEntry>();
+const MAX_STORE_BYTES = 50 * 1024 * 1024; // 50MB cap
+const TTL_MS = 60_000; // 60 seconds
+
+let currentBytes = 0;
+
+export function storeAudio(
+  buffer: Buffer,
+  format: "mp3" | "wav" | "opus",
+): string {
+  evictExpired();
+  // Evict oldest if over capacity
+  while (currentBytes + buffer.length > MAX_STORE_BYTES && store.size > 0) {
+    const oldest = store.keys().next().value;
+    if (oldest) removeEntry(oldest);
+  }
+  const id = randomUUID();
+  const contentType =
+    format === "mp3"
+      ? "audio/mpeg"
+      : format === "wav"
+        ? "audio/wav"
+        : "audio/opus";
+  store.set(id, { buffer, contentType, expiresAt: Date.now() + TTL_MS });
+  currentBytes += buffer.length;
+  return id;
+}
+
+export function getAudio(
+  id: string,
+): { buffer: Buffer; contentType: string } | null {
+  evictExpired();
+  const entry = store.get(id);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    removeEntry(id);
+    return null;
+  }
+  return { buffer: entry.buffer, contentType: entry.contentType };
+}
+
+function removeEntry(id: string): void {
+  const entry = store.get(id);
+  if (entry) {
+    currentBytes -= entry.buffer.length;
+    store.delete(id);
+  }
+}
+
+function evictExpired(): void {
+  const now = Date.now();
+  for (const [id, entry] of store) {
+    if (now > entry.expiresAt) removeEntry(id);
+  }
+}


### PR DESCRIPTION
## Summary
- Create audio-store.ts with storeAudio/getAudio functions
- LRU eviction with 50MB cap and 60-second TTL
- Add comprehensive tests for store/retrieve/evict lifecycle

Part of plan: fish-audio-s2-tts.md (PR 5 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
