### PR TITLE
Add ttsProvider field to calls voice config schema

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -638,6 +638,7 @@ describe("AssistantConfigSchema", () => {
       voice: {
         language: "en-US",
         transcriptionProvider: "Deepgram",
+        ttsProvider: "elevenlabs",
       },
       callerIdentity: {
         allowPerCallOverride: true,

--- a/assistant/src/config/schemas/calls.ts
+++ b/assistant/src/config/schemas/calls.ts
@@ -6,6 +6,7 @@ export const VALID_CALLER_IDENTITY_MODES = [
   "user_number",
 ] as const;
 const VALID_CALL_TRANSCRIPTION_PROVIDERS = ["Deepgram", "Google"] as const;
+export const VALID_TTS_PROVIDERS = ["elevenlabs", "fish-audio"] as const;
 
 export const CallsDisclosureConfigSchema = z
   .object({
@@ -57,6 +58,12 @@ export const CallsVoiceConfigSchema = z
       })
       .default("Deepgram")
       .describe("Speech-to-text provider used for call transcription"),
+    ttsProvider: z
+      .enum(VALID_TTS_PROVIDERS, {
+        error: `calls.voice.ttsProvider must be one of: ${VALID_TTS_PROVIDERS.join(", ")}`,
+      })
+      .default("elevenlabs")
+      .describe("Text-to-speech provider for phone calls"),
   })
   .describe("Voice and speech settings for phone calls");
 


### PR DESCRIPTION
## Summary
- Add VALID_TTS_PROVIDERS const with elevenlabs and fish-audio options
- Add ttsProvider field to CallsVoiceConfigSchema, defaulting to elevenlabs

Part of plan: fish-audio-s2-tts.md (PR 2 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
