### PR TITLE
fix: trigger rehydration on appear for pre-expanded progress cards

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -436,6 +436,22 @@ struct AssistantProgressView: View {
                     isExpanded = true
                 }
             }
+
+            // Rehydrate stripped tool calls for cards that start expanded.
+            // When isExpanded is set to true in init(), onChange(of: isExpanded)
+            // never fires (no false→true transition), so we must check here.
+            if isExpanded, onRehydrate != nil {
+                let hasStrippedToolCall = toolCalls.contains { tc in
+                    tc.isComplete
+                        && tc.inputFull.isEmpty
+                        && tc.result == nil
+                        && tc.inputRawDict == nil
+                        && tc.cachedImage == nil
+                }
+                if hasStrippedToolCall {
+                    onRehydrate?()
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixes rehydration regression for progress cards that start expanded via init-time computation
- When `isExpanded` is set to `true` in `init()`, `onChange(of: isExpanded)` never fires (no state transition), so stripped tool calls were never rehydrated
- Adds a rehydration check at the end of `.onAppear` that detects pre-expanded cards with stripped tool calls and triggers `onRehydrate?()`

## Test plan
- [ ] Open a conversation with completed tool call groups
- [ ] Verify expanded cards show full tool call details (input, output, etc.) instead of empty content
- [ ] Verify cards that expand via user click or phase transition still rehydrate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
