### PR TITLE
Make voice quality profile TTS provider configurable

### DIFF
--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -42,19 +42,36 @@ export function buildElevenLabsVoiceSpec(config: {
 /**
  * Resolve the effective voice quality profile from config.
  *
- * Always uses ElevenLabs TTS via Twilio ConversationRelay.
- * The voice ID comes from the shared `elevenlabs.voiceId` config
- * (defaults to Amelia — ZF6FPAbjXT4488VcRRnw).
+ * Supports ElevenLabs (default) and Fish Audio TTS providers.
+ * When Fish Audio is selected, `ttsProvider` is set to `"Google"` as a
+ * placeholder — ConversationRelay requires a valid provider in TwiML, but
+ * actual audio is delivered via `play` messages from the call-controller.
+ * The voice string is left empty since it is unused in that mode.
+ *
+ * For ElevenLabs, the voice ID comes from the shared `elevenlabs.voiceId`
+ * config (defaults to Amelia — ZF6FPAbjXT4488VcRRnw).
  */
 export function resolveVoiceQualityProfile(
   config?: ReturnType<typeof loadConfig>,
 ): VoiceQualityProfile {
   const cfg = config ?? loadConfig();
   const voice = cfg.calls.voice;
+  const configuredTts = voice.ttsProvider ?? "elevenlabs";
+  const fishAudio = configuredTts === "fish-audio";
   return {
     language: voice.language,
     transcriptionProvider: voice.transcriptionProvider,
-    ttsProvider: "ElevenLabs",
-    voice: buildElevenLabsVoiceSpec(cfg.elevenlabs),
+    ttsProvider: fishAudio ? "Google" : "ElevenLabs",
+    voice: fishAudio ? "" : buildElevenLabsVoiceSpec(cfg.elevenlabs),
   };
+}
+
+/**
+ * Check whether Fish Audio TTS is configured for phone calls.
+ */
+export function isFishAudioTts(
+  config?: ReturnType<typeof loadConfig>,
+): boolean {
+  const cfg = config ?? loadConfig();
+  return cfg.calls.voice.ttsProvider === "fish-audio";
 }


### PR DESCRIPTION
## Summary
- Read ttsProvider from calls.voice config instead of hardcoding ElevenLabs
- When fish-audio is selected, use Google as placeholder ttsProvider in TwiML
- Export isFishAudioTts() helper for call-controller

Part of plan: fish-audio-s2-tts.md (PR 3 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
