### PR TITLE
Add tts_provider and fish_audio_reference_id to voice config update tool

### DIFF
--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -24,6 +24,11 @@ const VOICE_SETTINGS = {
     type: "number" as const,
   },
   tts_voice_id: { userDefaultsKey: "ttsVoiceId", type: "string" as const },
+  tts_provider: { userDefaultsKey: "ttsProvider", type: "string" as const },
+  fish_audio_reference_id: {
+    userDefaultsKey: "fishAudioReferenceId",
+    type: "string" as const,
+  },
 } as const;
 
 type VoiceSettingName = keyof typeof VOICE_SETTINGS;
@@ -36,6 +41,8 @@ const FRIENDLY_NAMES: Record<VoiceSettingName, string> = {
   activation_key: "PTT activation key",
   conversation_timeout: "Conversation timeout",
   tts_voice_id: "ElevenLabs voice",
+  tts_provider: "TTS provider",
+  fish_audio_reference_id: "Fish Audio voice",
 };
 
 function validateSetting(
@@ -96,6 +103,25 @@ function validateSetting(
         };
       }
       return { ok: true, coerced: trimmed };
+    }
+    case "tts_provider": {
+      const valid = ["elevenlabs", "fish-audio"];
+      if (typeof value !== "string" || !valid.includes(value.trim())) {
+        return {
+          ok: false,
+          error: `tts_provider must be one of: ${valid.join(", ")}`,
+        };
+      }
+      return { ok: true, coerced: value.trim() };
+    }
+    case "fish_audio_reference_id": {
+      if (typeof value !== "string" || value.trim().length === 0) {
+        return {
+          ok: false,
+          error: "fish_audio_reference_id must be a non-empty string",
+        };
+      }
+      return { ok: true, coerced: value.trim() };
     }
     default:
       return { ok: false, error: `Unknown setting "${setting}"` };
@@ -162,6 +188,22 @@ export async function run(
       "elevenlabs.conversationTimeoutSeconds",
       validation.coerced,
     );
+    saveRawConfig(raw);
+    invalidateConfigCache();
+  }
+
+  // For tts_provider, persist to config file (calls.voice.ttsProvider).
+  if (setting === "tts_provider") {
+    const raw = loadRawConfig();
+    setNestedValue(raw, "calls.voice.ttsProvider", validation.coerced);
+    saveRawConfig(raw);
+    invalidateConfigCache();
+  }
+
+  // For fish_audio_reference_id, persist to config file (fishAudio.referenceId).
+  if (setting === "fish_audio_reference_id") {
+    const raw = loadRawConfig();
+    setNestedValue(raw, "fishAudio.referenceId", validation.coerced);
     saveRawConfig(raw);
     invalidateConfigCache();
   }


### PR DESCRIPTION
## Summary
- Add tts_provider setting (elevenlabs or fish-audio) with config persistence
- Add fish_audio_reference_id setting for Fish Audio voice selection
- Both settings validate input and persist to correct config paths

Part of plan: fish-audio-s2-tts.md (PR 9 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
