### PR TITLE
Add GET /v1/audio/:audioId endpoint for serving synthesized audio

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -106,6 +106,7 @@ import { handleServePage } from "./routes/app-routes.js";
 import { appRouteDefinitions } from "./routes/app-routes.js";
 import { approvalRouteDefinitions } from "./routes/approval-routes.js";
 import { attachmentRouteDefinitions } from "./routes/attachment-routes.js";
+import { handleGetAudio } from "./routes/audio-routes.js";
 import { avatarRouteDefinitions } from "./routes/avatar-routes.js";
 import { brainGraphRouteDefinitions } from "./routes/brain-graph-routes.js";
 import { btwRouteDefinitions } from "./routes/btw-routes.js";
@@ -503,6 +504,13 @@ export class RuntimeHttpServer {
     // webhook POSTs don't include bearer tokens.
     const twilioResponse = await this.handleTwilioWebhook(req, path);
     if (twilioResponse) return twilioResponse;
+
+    // Audio serving endpoint — before auth check because Twilio
+    // fetches these URLs directly. The audioId is an unguessable UUID.
+    const audioMatch = path.match(/^\/v1\/audio\/([^/]+)$/);
+    if (audioMatch && req.method === "GET") {
+      return handleGetAudio(audioMatch[1]);
+    }
 
     // Pairing endpoints (unauthenticated, secret-gated)
     if (path === "/v1/pairing/request" && req.method === "POST") {

--- a/assistant/src/runtime/routes/audio-routes.ts
+++ b/assistant/src/runtime/routes/audio-routes.ts
@@ -1,0 +1,29 @@
+/**
+ * HTTP route handler for serving synthesized TTS audio.
+ *
+ * GET /v1/audio/:audioId — retrieve a previously stored audio segment.
+ *
+ * This endpoint is unauthenticated because Twilio fetches audio URLs
+ * directly; the audioId itself is an unguessable UUID that acts as a
+ * capability token.
+ */
+
+import { getAudio } from "../../calls/audio-store.js";
+import { httpError } from "../http-errors.js";
+
+/**
+ * Handle GET /v1/audio/:audioId.
+ *
+ * Returns the audio buffer with its stored Content-Type on hit,
+ * or a 404 when the audioId is unknown or expired.
+ */
+export function handleGetAudio(audioId: string): Response {
+  const entry = getAudio(audioId);
+  if (!entry) {
+    return httpError("NOT_FOUND", "Audio not found", 404);
+  }
+  return new Response(new Uint8Array(entry.buffer), {
+    status: 200,
+    headers: { "Content-Type": entry.contentType },
+  });
+}


### PR DESCRIPTION
## Summary
- Create audio-routes.ts with GET audio/:audioId endpoint
- Skip auth since Twilio fetches these (audioId is unguessable UUID)
- Returns audio with correct Content-Type or 404

Part of plan: fish-audio-s2-tts.md (PR 6 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
