### PR TITLE
Add Fish Audio S2 WebSocket TTS client

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -10,6 +10,7 @@
         "@anthropic-ai/sdk": "^0.78.0",
         "@google/genai": "^1.40.0",
         "@modelcontextprotocol/sdk": "^1.15.1",
+        "@msgpack/msgpack": "^3.1.3",
         "@qdrant/js-client-rest": "^1.16.2",
         "@resvg/resvg-js": "^2.6.2",
         "@sentry/node": "^10.38.0",
@@ -193,6 +194,8 @@
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
+
+    "@msgpack/msgpack": ["@msgpack/msgpack@3.1.3", "", {}, "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -32,6 +32,7 @@
     "@anthropic-ai/sdk": "^0.78.0",
     "@google/genai": "^1.40.0",
     "@modelcontextprotocol/sdk": "^1.15.1",
+    "@msgpack/msgpack": "^3.1.3",
     "@qdrant/js-client-rest": "^1.16.2",
     "@resvg/resvg-js": "^2.6.2",
     "@sentry/node": "^10.38.0",

--- a/assistant/src/calls/fish-audio-client.ts
+++ b/assistant/src/calls/fish-audio-client.ts
@@ -1,0 +1,289 @@
+import { encode, decode } from "@msgpack/msgpack";
+
+import type { FishAudioConfig } from "../config/schemas/fish-audio.js";
+import { credentialKey } from "../security/credential-key.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("fish-audio-client");
+
+// ---------------------------------------------------------------------------
+// Fish Audio S2 WebSocket MessagePack protocol types
+// ---------------------------------------------------------------------------
+
+interface StartEvent {
+  event: "start";
+  request: {
+    reference_id?: string;
+    format?: string;
+    sample_rate?: number;
+    chunk_length?: number;
+    normalize?: boolean;
+    latency?: string;
+    streaming?: boolean;
+  };
+}
+
+interface TextEvent {
+  event: "text";
+  text: string;
+}
+
+interface FlushEvent {
+  event: "flush";
+}
+
+interface StopEvent {
+  event: "stop";
+}
+
+interface AudioEvent {
+  event: "audio";
+  audio: Uint8Array;
+}
+
+interface FinishEvent {
+  event: "finish";
+  reason: string;
+}
+
+type InboundEvent = AudioEvent | FinishEvent;
+
+// ---------------------------------------------------------------------------
+// FishAudioSession — manages a single WebSocket connection
+// ---------------------------------------------------------------------------
+
+interface PendingSynthesis {
+  chunks: Uint8Array[];
+  resolve: (buffer: Buffer) => void;
+  reject: (error: Error) => void;
+}
+
+export class FishAudioSession {
+  private ws: WebSocket;
+  private pending: PendingSynthesis | null = null;
+  private closed = false;
+
+  private constructor(ws: WebSocket) {
+    this.ws = ws;
+    this.setupHandlers();
+  }
+
+  /**
+   * Open a WebSocket connection to Fish Audio S2 and send the initial
+   * StartEvent with the provided configuration.
+   */
+  static async create(config: FishAudioConfig): Promise<FishAudioSession> {
+    const apiKey = await getSecureKeyAsync(
+      credentialKey("fish-audio", "api_key"),
+    );
+    if (!apiKey) {
+      throw new Error(
+        "Fish Audio API key not configured. Store it via: assistant credentials set fish-audio api_key",
+      );
+    }
+
+    return new Promise<FishAudioSession>((resolve, reject) => {
+      // Bun's WebSocket supports headers in its options object, but the
+      // constructor overload may not be visible when lib.dom types are
+      // loaded. Cast through unknown to use the Bun-specific signature.
+      const ws = new WebSocket(
+        "wss://api.fish.audio/v1/tts/live",
+        {
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            model: "speech-01",
+          },
+        } as unknown as string[],
+      );
+
+      ws.binaryType = "arraybuffer";
+
+      ws.addEventListener("open", () => {
+        const startEvent: StartEvent = {
+          event: "start",
+          request: {
+            reference_id: config.referenceId || undefined,
+            format: config.format,
+            chunk_length: config.chunkLength,
+            streaming: true,
+          },
+        };
+
+        ws.send(encode(startEvent));
+        log.info(
+          { referenceId: config.referenceId, format: config.format },
+          "Fish Audio session started",
+        );
+
+        const session = new FishAudioSession(ws);
+        resolve(session);
+      });
+
+      ws.addEventListener("error", (ev) => {
+        const errorMsg =
+          ev instanceof ErrorEvent ? ev.message : "WebSocket connection failed";
+        reject(new Error(`Fish Audio WebSocket error: ${errorMsg}`));
+      });
+    });
+  }
+
+  /**
+   * Send text for synthesis and wait for the complete audio response.
+   * Sends a TextEvent followed by a FlushEvent, then collects AudioEvent
+   * chunks until a FinishEvent is received.
+   */
+  synthesize(text: string): Promise<Buffer> {
+    if (this.closed) {
+      return Promise.reject(
+        new Error("FishAudioSession is closed"),
+      );
+    }
+
+    if (this.pending) {
+      return Promise.reject(
+        new Error(
+          "A synthesis is already in progress. Wait for it to complete before starting another.",
+        ),
+      );
+    }
+
+    return new Promise<Buffer>((resolve, reject) => {
+      this.pending = { chunks: [], resolve, reject };
+
+      const textEvent: TextEvent = { event: "text", text };
+      this.ws.send(encode(textEvent));
+
+      const flushEvent: FlushEvent = { event: "flush" };
+      this.ws.send(encode(flushEvent));
+
+      log.debug({ textLength: text.length }, "Sent text for synthesis");
+    });
+  }
+
+  /**
+   * Close the WebSocket session gracefully.
+   */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+
+    try {
+      const closeEvent: StopEvent = { event: "stop" };
+      this.ws.send(encode(closeEvent));
+    } catch {
+      // WebSocket may already be closed
+    }
+
+    this.ws.close();
+    log.debug("Fish Audio session closed");
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal message handling
+  // -------------------------------------------------------------------------
+
+  private setupHandlers(): void {
+    this.ws.addEventListener("message", (ev) => {
+      try {
+        const data =
+          ev.data instanceof ArrayBuffer
+            ? new Uint8Array(ev.data)
+            : new Uint8Array(ev.data as ArrayBuffer);
+
+        const decoded = decode(data) as InboundEvent;
+        this.handleMessage(decoded);
+      } catch (err) {
+        log.error(
+          { err },
+          "Failed to decode Fish Audio message",
+        );
+        this.rejectPending(
+          new Error(
+            `Failed to decode Fish Audio message: ${err instanceof Error ? err.message : String(err)}`,
+          ),
+        );
+      }
+    });
+
+    this.ws.addEventListener("error", (ev) => {
+      const errorMsg =
+        ev instanceof ErrorEvent ? ev.message : "WebSocket error";
+      log.error({ error: errorMsg }, "Fish Audio WebSocket error");
+      this.rejectPending(new Error(`Fish Audio WebSocket error: ${errorMsg}`));
+    });
+
+    this.ws.addEventListener("close", (ev) => {
+      this.closed = true;
+      if (this.pending) {
+        log.warn(
+          { code: ev.code, reason: ev.reason },
+          "Fish Audio WebSocket closed with pending synthesis",
+        );
+        this.rejectPending(
+          new Error(
+            `Fish Audio WebSocket closed unexpectedly (code: ${ev.code})`,
+          ),
+        );
+      }
+    });
+  }
+
+  private handleMessage(msg: InboundEvent): void {
+    switch (msg.event) {
+      case "audio": {
+        if (this.pending) {
+          this.pending.chunks.push(msg.audio);
+        }
+        break;
+      }
+      case "finish": {
+        if (this.pending) {
+          const { chunks, resolve } = this.pending;
+          this.pending = null;
+          const totalLength = chunks.reduce((sum, c) => sum + c.byteLength, 0);
+          const merged = new Uint8Array(totalLength);
+          let offset = 0;
+          for (const chunk of chunks) {
+            merged.set(chunk, offset);
+            offset += chunk.byteLength;
+          }
+          log.debug(
+            { reason: msg.reason, bytes: totalLength },
+            "Synthesis complete",
+          );
+          resolve(Buffer.from(merged));
+        }
+        break;
+      }
+    }
+  }
+
+  private rejectPending(error: Error): void {
+    if (this.pending) {
+      const { reject } = this.pending;
+      this.pending = null;
+      reject(error);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Convenience function
+// ---------------------------------------------------------------------------
+
+/**
+ * Synthesize text to audio using Fish Audio S2 in a single call.
+ * Opens a session, synthesizes the text, and closes the session.
+ */
+export async function synthesizeWithFishAudio(
+  text: string,
+  config: FishAudioConfig,
+): Promise<Buffer> {
+  const session = await FishAudioSession.create(config);
+  try {
+    return await session.synthesize(text);
+  } finally {
+    session.close();
+  }
+}


### PR DESCRIPTION
## Summary
- Add @msgpack/msgpack dependency for MessagePack serialization
- Create FishAudioSession class with WebSocket connection to Fish Audio S2
- Supports streaming text-to-speech with StartEvent/TextEvent/FlushEvent/AudioEvent protocol
- Export synthesizeWithFishAudio convenience function

Part of plan: fish-audio-s2-tts.md (PR 7 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
