### PR TITLE
fix: prevent double rehydration when progress card expands in onAppear

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -402,6 +402,7 @@ struct AssistantProgressView: View {
             }
         }
         .onAppear {
+            let wasExpandedOnEntry = isExpanded
             if phase == .processing && processingStartDate == nil {
                 processingStartDate = Date()
             }
@@ -440,7 +441,9 @@ struct AssistantProgressView: View {
             // Rehydrate stripped tool calls for cards that start expanded.
             // When isExpanded is set to true in init(), onChange(of: isExpanded)
             // never fires (no false→true transition), so we must check here.
-            if isExpanded, onRehydrate != nil {
+            // Gate on wasExpandedOnEntry so cards that just expanded above
+            // don't double-fire — onChange already handles their rehydration.
+            if wasExpandedOnEntry, onRehydrate != nil {
                 let hasStrippedToolCall = toolCalls.contains { tc in
                     tc.isComplete
                         && tc.inputFull.isEmpty


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for scroll-loop-freeze-fix.md.

**Gap:** Double rehydration call in .onAppear
**What was expected:** onRehydrate called once per expansion
**What was found:** When isExpanded transitions false→true in .onAppear, both onChange(of: isExpanded) and the explicit .onAppear rehydration block fire, calling onRehydrate twice

**Fix:** Capture `wasExpandedOnEntry` at the top of `.onAppear` and gate the rehydration block on it. This way:
- Pre-expanded cards (init set true): rehydration fires once via the .onAppear block (onChange never fires for init-time state)
- Cards that expand during .onAppear: rehydration fires once via onChange only (the .onAppear block skips since wasExpandedOnEntry is false)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
