### PR TITLE
fix: resolve lint errors in test files

### DIFF
--- a/assistant/src/__tests__/conversation-title-service.test.ts
+++ b/assistant/src/__tests__/conversation-title-service.test.ts
@@ -138,7 +138,6 @@ describe("conversation-title-service", () => {
     await regenerateConversationTitle({ conversationId: "conv-1", provider });
 
     // The prompt sent to the sidechain should contain plain text, not raw JSON
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const prompt = (mockRunBtwSidechain.mock.calls[0] as any)?.[0]
       ?.content as string;
     expect(prompt).not.toContain('"type":"text"');
@@ -186,7 +185,6 @@ describe("conversation-title-service", () => {
 
     await regenerateConversationTitle({ conversationId: "conv-1", provider });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const prompt = (mockRunBtwSidechain.mock.calls[0] as any)?.[0]
       ?.content as string;
     expect(prompt).not.toContain('"type":"tool_result"');

--- a/assistant/src/calls/audio-store.test.ts
+++ b/assistant/src/calls/audio-store.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { getAudio, storeAudio } from "./audio-store.js";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Remove unused `afterEach` import from `audio-store.test.ts` (fixes `no-unused-vars` and `simple-import-sort` errors)
- Remove two unnecessary `eslint-disable-next-line @typescript-eslint/no-explicit-any` directives from `conversation-title-service.test.ts`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23354045708/job/67940129525
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
