### PR TITLE
fix: deep-link to Contacts tab when redirecting from settings

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -705,7 +705,7 @@ extension AppDelegate {
         case "Contacts":
             // Contacts moved from Settings to Intelligence panel
             showMainWindow()
-            mainWindow?.windowState.showPanel(.intelligence)
+            mainWindow?.windowState.showIntelligenceTab("Contacts")
             return
         default: settingsTab = SettingsTab(rawValue: tab)
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -61,6 +61,11 @@ public final class MainWindowState: ObservableObject {
     /// Transient memory ID to deep-link into when the Intelligence panel opens.
     /// Consumed once by IntelligencePanel/MemoriesPanel, then set back to nil.
     @Published var pendingMemoryId: String?
+
+    /// Transient tab name to deep-link into when the Intelligence panel opens.
+    /// Takes priority over the memory-based tab selection. Consumed once by
+    /// PanelCoordinator, then set back to nil.
+    @Published var pendingIntelligenceTab: String?
     @Published var activeDynamicSurface: UiSurfaceShowMessage?
     @Published var activeDynamicParsedSurface: Surface?
     @Published var activeDynamicUserAppsDirectory: URL?
@@ -231,6 +236,12 @@ public final class MainWindowState: ObservableObject {
     /// Navigate to the Intelligence panel and deep-link to a specific memory.
     func showMemory(id: String) {
         pendingMemoryId = id
+        showPanel(.intelligence)
+    }
+
+    /// Navigate to the Intelligence panel and deep-link to a specific tab.
+    func showIntelligenceTab(_ tab: String) {
+        pendingIntelligenceTab = tab
         showPanel(.intelligence)
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -97,9 +97,10 @@ extension MainWindowView {
                 store: settingsStore,
                 conversationManager: conversationManager,
                 showToast: { msg, style in windowState.showToast(message: msg, style: style) },
-                initialTab: windowState.pendingMemoryId != nil ? "Memories" : nil,
+                initialTab: windowState.pendingIntelligenceTab ?? (windowState.pendingMemoryId != nil ? "Memories" : nil),
                 pendingMemoryId: $windowState.pendingMemoryId
             )
+            .onAppear { windowState.pendingIntelligenceTab = nil }
         case .usageDashboard:
             UsageDashboardPanel(
                 store: usageDashboardStore,
@@ -478,9 +479,10 @@ extension MainWindowView {
                 store: settingsStore,
                 conversationManager: conversationManager,
                 showToast: { msg, style in windowState.showToast(message: msg, style: style) },
-                initialTab: windowState.pendingMemoryId != nil ? "Memories" : nil,
+                initialTab: windowState.pendingIntelligenceTab ?? (windowState.pendingMemoryId != nil ? "Memories" : nil),
                 pendingMemoryId: $windowState.pendingMemoryId
             )
+            .onAppear { windowState.pendingIntelligenceTab = nil }
             .overlay(alignment: .topTrailing) { panelDismissButton }
             .background(VColor.surfaceOverlay)
         case .usageDashboard:


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for resolve-bot-review-feedback.md.

**Gap:** Contacts redirect does not deep-link to the Contacts tab within Intelligence panel
**What was expected:** showSettingsTab("Contacts") should open the Intelligence panel to the Contacts tab
**What was found:** The redirect opened Intelligence panel but landed on the default Identity tab
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
