### PR TITLE
fix: eagerly initialize isSchedulesEnabled in SettingsPanel onAppear

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -181,6 +181,7 @@ struct SettingsPanel: View {
         .onAppear {
             isBillingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
             isSoundsEnabled = AssistantFeatureFlagResolver.isEnabled(Self.soundsFeatureFlagKey)
+            isSchedulesEnabled = AssistantFeatureFlagResolver.isEnabled(Self.schedulesFeatureFlagKey)
             store.refreshAPIKeyState()
             store.loadProviderRoutingSources()
             store.refreshTelegramStatus()


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for settings-schedules-tab.md.

**Gap:** isSchedulesEnabled not eagerly initialized in onAppear
**What was expected:** Eager initialization matching isSoundsEnabled pattern
**What was found:** Flag stayed false until async loadFeatureFlags(), causing tab flash
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
