### PR TITLE
fix: add fish-audio-client to secure-keys allowlist

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -216,6 +216,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "calls/twilio-config.ts", // call infrastructure credential lookup
       "calls/twilio-provider.ts", // call infrastructure credential lookup
       "calls/twilio-rest.ts", // Twilio REST API credential lookup
+      "calls/fish-audio-client.ts", // Fish Audio TTS API key lookup
       "runtime/channel-invite-transports/telegram.ts", // Telegram invite transport bot token lookup
       "cli/commands/keys.ts", // CLI credential management commands
       "cli/commands/credentials.ts", // CLI credential management commands


### PR DESCRIPTION
## Summary
- Add `calls/fish-audio-client.ts` to the `ALLOWED_IMPORTERS` set in `credential-security-invariants.test.ts`
- The Fish Audio S2 WebSocket TTS client (#20124) imports `secure-keys` for API key lookup but wasn't added to the allowlist

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23354229903/job/67940783758
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
