### PR TITLE
fix: resolve import sort lint errors in audio-store test and fish-audio-client

### DIFF
--- a/assistant/src/calls/audio-store.test.ts
+++ b/assistant/src/calls/audio-store.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+
 import { getAudio, storeAudio } from "./audio-store.js";
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/calls/fish-audio-client.ts
+++ b/assistant/src/calls/fish-audio-client.ts
@@ -1,4 +1,4 @@
-import { encode, decode } from "@msgpack/msgpack";
+import { decode, encode } from "@msgpack/msgpack";
 
 import type { FishAudioConfig } from "../config/schemas/fish-audio.js";
 import { credentialKey } from "../security/credential-key.js";


### PR DESCRIPTION
## Summary
- Add missing blank line between import groups in `audio-store.test.ts`
- Sort named imports alphabetically in `fish-audio-client.ts` (`decode, encode` instead of `encode, decode`)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23354229903/job/67940783793
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
