### PR TITLE
feat: add Vellum Cloud as a platform hosting option

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -38,6 +38,7 @@ import {
 import type { RemoteHost, Species } from "../lib/constants";
 import { hatchDocker } from "../lib/docker";
 import { hatchGcp } from "../lib/gcp";
+import { hatchPlatform } from "../lib/platform-hatch";
 import type { PollResult, WatchHatchingResult } from "../lib/gcp";
 import {
   startLocalDaemon,
@@ -875,6 +876,11 @@ export async function hatch(): Promise<void> {
 
   if (remote === "docker") {
     await hatchDocker(species, detached, name, watch);
+    return;
+  }
+
+  if (remote === "vellum-cloud") {
+    await hatchPlatform(species, name);
     return;
   }
 

--- a/cli/src/lib/constants.ts
+++ b/cli/src/lib/constants.ts
@@ -33,6 +33,7 @@ export const VALID_REMOTE_HOSTS = [
   "aws",
   "docker",
   "custom",
+  "vellum-cloud",
 ] as const;
 export type RemoteHost = (typeof VALID_REMOTE_HOSTS)[number];
 export const VALID_SPECIES = ["openclaw", "vellum"] as const;

--- a/cli/src/lib/platform-hatch.ts
+++ b/cli/src/lib/platform-hatch.ts
@@ -1,0 +1,122 @@
+import { saveAssistantEntry, setActiveAssistant } from "./assistant-config";
+import type { AssistantEntry } from "./assistant-config";
+import type { Species } from "./constants";
+import { getPlatformUrl, readPlatformToken } from "./platform-client";
+
+interface HatchResponse {
+  id: string;
+  name: string;
+  description: string | null;
+  status: string;
+  created: string;
+  modified: string;
+}
+
+const POLL_INTERVAL_MS = 3000;
+const POLL_TIMEOUT_MS = 5 * 60 * 1000;
+
+function requirePlatformToken(): string {
+  const token = readPlatformToken();
+  if (!token) {
+    throw new Error("Not logged in to Vellum. Please run `vel login` first.");
+  }
+  return token;
+}
+
+export async function hatchPlatform(
+  species: Species,
+  name: string | null,
+): Promise<void> {
+  const token = requirePlatformToken();
+  const platformUrl = getPlatformUrl();
+
+  console.log("\n\u{1F95A} Creating platform assistant...\n");
+
+  const body: Record<string, string> = {};
+  if (name) {
+    body.name = name;
+  }
+
+  const hatchResponse = await fetch(`${platformUrl}/v1/assistants/hatch/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Session-Token": token,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!hatchResponse.ok) {
+    if (hatchResponse.status === 403) {
+      throw new Error(
+        "Access denied. You may not have permission to create platform assistants.",
+      );
+    }
+    if (hatchResponse.status === 402) {
+      throw new Error(
+        "Organization balance depleted. Please add funds to continue.",
+      );
+    }
+    throw new Error(
+      `Platform hatch failed: ${hatchResponse.status} ${hatchResponse.statusText}`,
+    );
+  }
+
+  const assistant = (await hatchResponse.json()) as HatchResponse;
+  const assistantName = assistant.name;
+
+  console.log(`   Name: ${assistantName}`);
+  console.log(`   ID: ${assistant.id}`);
+  console.log(`   Status: ${assistant.status}`);
+  console.log("");
+
+  // Poll until ACTIVE
+  console.log("\u23f3 Waiting for assistant to become active...\n");
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < POLL_TIMEOUT_MS) {
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+
+    const statusResponse = await fetch(
+      `${platformUrl}/v1/assistants/${assistant.id}/`,
+      {
+        headers: { "X-Session-Token": token },
+      },
+    );
+
+    if (!statusResponse.ok) {
+      console.warn(
+        `\u26a0\ufe0f  Poll request failed (${statusResponse.status}), retrying...`,
+      );
+      continue;
+    }
+
+    const current = (await statusResponse.json()) as HatchResponse;
+
+    if (current.status === "ACTIVE") {
+      const runtimeUrl = `${platformUrl}/v1/assistants/${assistant.id}`;
+      const entry: AssistantEntry = {
+        assistantId: assistant.id,
+        runtimeUrl,
+        cloud: "vellum-cloud",
+        species,
+        hatchedAt: assistant.created,
+      };
+      saveAssistantEntry(entry);
+      setActiveAssistant(assistant.id);
+
+      console.log("\u2728 Your assistant has hatched!\n");
+      console.log("Instance details:");
+      console.log(`  Name: ${assistantName}`);
+      console.log(`  ID: ${assistant.id}`);
+      console.log(`  Cloud: Vellum Cloud`);
+      console.log("");
+      return;
+    }
+  }
+
+  throw new Error(
+    `Timed out waiting for assistant to become active (waited ${Math.round(POLL_TIMEOUT_MS / 1000)}s). ` +
+      `Check status at: ${platformUrl}/v1/assistants/${assistant.id}/`,
+  );
+}

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -227,6 +227,12 @@ struct APIKeyStepView: View {
             state.cloudProvider = state.selectedHostingMode.rawValue
         }
 
+        if isAuthenticated && state.selectedHostingMode == .vellumCloud {
+            // Platform-hosted: trigger managed bootstrap directly
+            onHatchManaged?()
+            return
+        }
+
         if isAuthenticated {
             // Authenticated user selecting Local: skip API key, advance to consent step
             state.selectedProvider = "anthropic"

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -87,7 +87,8 @@ struct APIKeyStepView: View {
     private func chipLabel(for mode: OnboardingState.HostingMode) -> String? {
         switch mode {
         case .vellumCloud:
-            return state.skippedAuth ? "Requires Account" : "Coming Soon"
+            if state.skippedAuth { return "Requires Account" }
+            return userHostedEnabled ? nil : "Coming Soon"
         case .docker:
             return userHostedEnabled ? nil : "Coming Soon"
         default:
@@ -206,7 +207,7 @@ struct APIKeyStepView: View {
     // MARK: - Helpers
 
     private var canContinue: Bool {
-        state.selectedHostingMode != .vellumCloud
+        true
     }
 
     private var continueButtonTitle: String {


### PR DESCRIPTION
## Summary
- Enables the "Vellum Cloud" hosting card in onboarding, gated behind `VELLUM_FLAG_USER_HOSTED_ENABLED`
- Adds `vellum-cloud` to `VALID_REMOTE_HOSTS` so the hatch CLI accepts it
- Implements `hatchPlatform()` which POSTs to `/v1/assistants/hatch/` and polls `/v1/assistants/{id}/` until `ACTIVE`

## Test plan
- [ ] Toggle `VELLUM_FLAG_USER_HOSTED_ENABLED` on and verify "Vellum Cloud" card is selectable in onboarding
- [ ] Toggle flag off and verify "Coming Soon" chip still appears
- [ ] Select "Vellum Cloud" and click Continue — verify hatch command runs with `--remote vellum-cloud`
- [ ] Verify platform assistant is created and polling completes when status becomes ACTIVE
- [ ] Verify error handling for 402/403 responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
