### PR TITLE
fix: guard isFishAudioTts against missing calls.voice config

### DIFF
--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -73,5 +73,5 @@ export function isFishAudioTts(
   config?: ReturnType<typeof loadConfig>,
 ): boolean {
   const cfg = config ?? loadConfig();
-  return cfg.calls.voice.ttsProvider === "fish-audio";
+  return cfg.calls.voice?.ttsProvider === "fish-audio";
 }


### PR DESCRIPTION
## Summary
- Add optional chaining (`cfg.calls.voice?.ttsProvider`) in `isFishAudioTts()` so it returns `false` instead of crashing when `calls.voice` is not present in the config
- Fixes 39 test failures in `call-controller.test.ts` where the config mock doesn't include `calls.voice`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23354375213/job/67941305672
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
