### PR TITLE
fix: pre-compute isSoundsEnabled in SettingsPanel init for correct deep-link validation

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -65,6 +65,11 @@ struct SettingsPanel: View {
         let billingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
         _isBillingEnabled = State(initialValue: billingEnabled)
 
+        // Pre-compute the sounds flag so deep-link validation below uses
+        // the actual config value instead of the @State default (true).
+        let soundsEnabled = AssistantFeatureFlagResolver.isEnabled(Self.soundsFeatureFlagKey)
+        _isSoundsEnabled = State(initialValue: soundsEnabled)
+
         // Derive the initial tab from the pending deep-link at construction
         // time. Previous attempts set selectedTab in onAppear / onChange, but
         // those fire *after* the first render and are susceptible to timing
@@ -79,7 +84,7 @@ struct SettingsPanel: View {
             let canShowBilling = billingEnabled && authManager.isAuthenticated && orgId != nil
             // Contacts and developer flags load asynchronously, so default
             // to false at init time — those tabs aren't visible yet.
-            let visibleTabs = SettingsTab.primaryTabs(billingEnabled: canShowBilling, soundsEnabled: isSoundsEnabled, schedulesEnabled: false)
+            let visibleTabs = SettingsTab.primaryTabs(billingEnabled: canShowBilling, soundsEnabled: soundsEnabled, schedulesEnabled: false)
             if visibleTabs.contains(pending) {
                 _selectedTab = State(initialValue: pending)
             } else {
@@ -220,6 +225,11 @@ struct SettingsPanel: View {
         }
         .onChange(of: billingVisible) { _, visible in
             if !visible && selectedTab == .billing {
+                selectedTab = .general
+            }
+        }
+        .onChange(of: isSoundsEnabled) { _, enabled in
+            if !enabled && selectedTab == .sounds {
                 selectedTab = .general
             }
         }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for sounds-feature-flag.md.

**Gap:** isSoundsEnabled not pre-computed in init, causing stale deep-link validation
**What was expected:** isSoundsEnabled should be pre-computed in init() like isBillingEnabled
**What was found:** Default true value used during init deep-link validation even when flag is disabled

- Pre-compute sounds flag in init() following the billing pattern
- Use local variable in visibleTabs call so @State default doesn't leak
- Add onChange(of: isSoundsEnabled) redirect handler for the initial load case

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
