### PR TITLE
fix: auto-recover from stuck isSending state after 60s (LUM-353)

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -216,7 +216,9 @@ public final class ChatViewModel: ObservableObject {
                     self.cancelledDuringRefinement = false
                     self.refinementTextBuffer = ""
                     self.refinementReceivedSurfaceUpdate = false
-                    // Activity phase state
+                    // Activity phase state — reset version so a late activity
+                    // event from the abandoned run can't re-trigger isSending.
+                    self.lastActivityVersion = 0
                     self.assistantActivityPhase = "idle"
                     self.assistantActivityAnchor = "global"
                     self.assistantActivityReason = nil

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -205,6 +205,14 @@ public final class ChatViewModel: ObservableObject {
                     log.error("isSending watchdog: still true after 60s — auto-recovering, conversationId=\(self.conversationId ?? "nil")")
                     self.isThinking = false
                     self.isCancelling = false
+                    self.isWorkspaceRefinementInFlight = false
+                    self.refinementFlushTask?.cancel()
+                    self.refinementFlushTask = nil
+                    self.refinementMessagePreview = nil
+                    self.refinementStreamingText = nil
+                    self.cancelledDuringRefinement = false
+                    self.refinementTextBuffer = ""
+                    self.refinementReceivedSurfaceUpdate = false
                     if let existingId = self.currentAssistantMessageId,
                        let index = self.messages.firstIndex(where: { $0.id == existingId }) {
                         self.messages[index].isStreaming = false

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -194,12 +194,30 @@ public final class ChatViewModel: ObservableObject {
         set {
             messageManager.isSending = newValue
             if newValue {
-                // Start watchdog: log a warning if isSending is still true after 60s
+                // Start watchdog: if isSending is still true after 60s, auto-recover
+                // by resetting transient state so the user can send new messages.
+                // Without this, a missed messageComplete (e.g. server-side error with
+                // the SSE stream still alive) leaves the chat permanently stuck.
                 sendingWatchdogTask?.cancel()
                 sendingWatchdogTask = Task { @MainActor [weak self] in
                     try? await Task.sleep(for: .seconds(60))
                     guard !Task.isCancelled, let self, self.isSending else { return }
-                    log.warning("isSending watchdog: still true after 60s, conversationId=\(self.conversationId ?? "nil")")
+                    log.error("isSending watchdog: still true after 60s — auto-recovering, conversationId=\(self.conversationId ?? "nil")")
+                    self.isThinking = false
+                    self.isCancelling = false
+                    if let existingId = self.currentAssistantMessageId,
+                       let index = self.messages.firstIndex(where: { $0.id == existingId }) {
+                        self.messages[index].isStreaming = false
+                        self.messages[index].streamingCodePreview = nil
+                        self.messages[index].streamingCodeToolName = nil
+                    }
+                    self.currentAssistantMessageId = nil
+                    self.discardStreamingBuffer()
+                    self.discardPartialOutputBuffer()
+                    // Setting isSending = false triggers the setter again which
+                    // cancels this watchdog task — use the backing store directly.
+                    self.messageManager.isSending = false
+                    self.sendingWatchdogTask = nil
                 }
             } else {
                 sendingWatchdogTask?.cancel()

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -203,8 +203,11 @@ public final class ChatViewModel: ObservableObject {
                     try? await Task.sleep(for: .seconds(60))
                     guard !Task.isCancelled, let self, self.isSending else { return }
                     log.error("isSending watchdog: still true after 60s — auto-recovering, conversationId=\(self.conversationId ?? "nil")")
+                    // Reset all transient state to match the reconnect recovery
+                    // path, so the chat is fully usable again.
                     self.isThinking = false
                     self.isCancelling = false
+                    // Workspace refinement state
                     self.isWorkspaceRefinementInFlight = false
                     self.refinementFlushTask?.cancel()
                     self.refinementFlushTask = nil
@@ -213,6 +216,12 @@ public final class ChatViewModel: ObservableObject {
                     self.cancelledDuringRefinement = false
                     self.refinementTextBuffer = ""
                     self.refinementReceivedSurfaceUpdate = false
+                    // Activity phase state
+                    self.assistantActivityPhase = "idle"
+                    self.assistantActivityAnchor = "global"
+                    self.assistantActivityReason = nil
+                    self.assistantStatusText = nil
+                    // Streaming message state
                     if let existingId = self.currentAssistantMessageId,
                        let index = self.messages.firstIndex(where: { $0.id == existingId }) {
                         self.messages[index].isStreaming = false
@@ -220,8 +229,17 @@ public final class ChatViewModel: ObservableObject {
                         self.messages[index].streamingCodeToolName = nil
                     }
                     self.currentAssistantMessageId = nil
+                    self.currentTurnUserText = nil
+                    self.currentAssistantHasText = false
+                    self.lastContentWasToolCall = false
                     self.discardStreamingBuffer()
                     self.discardPartialOutputBuffer()
+                    // Queue tracking state
+                    self.pendingQueuedCount = 0
+                    self.pendingMessageIds.removeAll()
+                    self.requestIdToMessageId.removeAll()
+                    self.activeRequestIdToMessageId.removeAll()
+                    self.pendingLocalDeletions.removeAll()
                     // Setting isSending = false triggers the setter again which
                     // cancels this watchdog task — use the backing store directly.
                     self.messageManager.isSending = false

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -263,10 +263,15 @@ public final class ChatViewModel: ObservableObject {
                             self.messages[i].status = .sent
                         }
                     }
+                    // Cancel stale cancel-timeout task
+                    self.cancelTimeoutTask?.cancel()
+                    self.cancelTimeoutTask = nil
                     // Setting isSending = false triggers the setter again which
                     // cancels this watchdog task — use the backing store directly.
                     self.messageManager.isSending = false
                     self.sendingWatchdogTask = nil
+                    // Dispatch any pending send-direct so the user's message isn't lost.
+                    self.dispatchPendingSendDirect()
                 }
             } else {
                 sendingWatchdogTask?.cancel()

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -228,6 +228,10 @@ public final class ChatViewModel: ObservableObject {
                         self.messages[index].isStreaming = false
                         self.messages[index].streamingCodePreview = nil
                         self.messages[index].streamingCodeToolName = nil
+                        for j in self.messages[index].toolCalls.indices where !self.messages[index].toolCalls[j].isComplete {
+                            self.messages[index].toolCalls[j].isComplete = true
+                            self.messages[index].toolCalls[j].completedAt = Date()
+                        }
                     }
                     self.currentAssistantMessageId = nil
                     self.currentTurnUserText = nil
@@ -235,12 +239,30 @@ public final class ChatViewModel: ObservableObject {
                     self.lastContentWasToolCall = false
                     self.discardStreamingBuffer()
                     self.discardPartialOutputBuffer()
+                    // Voice state
+                    self.pendingVoiceMessage = false
+                    // Bootstrap state — if the first message triggered the watchdog
+                    // before a conversationId was assigned, clear these so the next
+                    // sendMessage() doesn't take the isBootstrapping early-return path.
+                    self.bootstrapCorrelationId = nil
+                    self.pendingUserMessage = nil
+                    self.pendingUserMessageDisplayText = nil
+                    self.pendingUserAttachments = nil
+                    self.pendingUserMessageAutomated = false
                     // Queue tracking state
                     self.pendingQueuedCount = 0
                     self.pendingMessageIds.removeAll()
                     self.requestIdToMessageId.removeAll()
                     self.activeRequestIdToMessageId.removeAll()
                     self.pendingLocalDeletions.removeAll()
+                    // Reset queued/processing user messages to .sent
+                    for i in self.messages.indices {
+                        if case .queued = self.messages[i].status, self.messages[i].role == .user {
+                            self.messages[i].status = .sent
+                        } else if self.messages[i].role == .user && self.messages[i].status == .processing {
+                            self.messages[i].status = .sent
+                        }
+                    }
                     // Setting isSending = false triggers the setter again which
                     // cancels this watchdog task — use the backing store directly.
                     self.messageManager.isSending = false

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -221,6 +221,7 @@ public final class ChatViewModel: ObservableObject {
                     self.assistantActivityAnchor = "global"
                     self.assistantActivityReason = nil
                     self.assistantStatusText = nil
+                    self.isCompacting = false
                     // Streaming message state
                     if let existingId = self.currentAssistantMessageId,
                        let index = self.messages.firstIndex(where: { $0.id == existingId }) {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -216,9 +216,9 @@ public final class ChatViewModel: ObservableObject {
                     self.cancelledDuringRefinement = false
                     self.refinementTextBuffer = ""
                     self.refinementReceivedSurfaceUpdate = false
-                    // Activity phase state — reset version so a late activity
-                    // event from the abandoned run can't re-trigger isSending.
-                    self.lastActivityVersion = 0
+                    // Activity phase state — keep lastActivityVersion at its
+                    // current value so late activity events from the abandoned
+                    // run with a lower version are rejected.
                     self.assistantActivityPhase = "idle"
                     self.assistantActivityAnchor = "global"
                     self.assistantActivityReason = nil


### PR DESCRIPTION
## Summary
- Upgrades the `isSending` watchdog (added in #19919) from diagnostic-only logging to actual auto-recovery
- When `isSending` stays true for 60+ seconds, the watchdog now resets all transient send state (`isThinking`, `isCancelling`, streaming buffers, `currentAssistantMessageId`) and clears `isSending` so the user can send new messages
- Root cause: if the server fails to send a `messageComplete` event but the SSE stream stays alive, the client has no recovery path — the chat is permanently stuck until force-quit

## Original prompt
--safe investigate that and check if it's still an issue https://linear.app/vellum/issue/LUM-353/app-freeze-on-message-submit-recurring-force-quit-required-p0
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
