### PR TITLE
fix: add tts_provider and fish_audio_reference_id to TOOLS.json enum

### DIFF
--- a/assistant/src/config/bundled-skills/settings/TOOLS.json
+++ b/assistant/src/config/bundled-skills/settings/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "voice_config_update",
-      "description": "Update a voice configuration setting (TTS voice ID, PTT activation key, conversation timeout). Changes take effect immediately.",
+      "description": "Update a voice configuration setting (TTS provider, TTS voice ID, Fish Audio reference ID, PTT activation key, conversation timeout). Changes take effect immediately.",
       "category": "system",
       "risk": "low",
       "input_schema": {
@@ -11,7 +11,7 @@
         "properties": {
           "setting": {
             "type": "string",
-            "enum": ["activation_key", "conversation_timeout", "tts_voice_id"],
+            "enum": ["activation_key", "conversation_timeout", "fish_audio_reference_id", "tts_provider", "tts_voice_id"],
             "description": "The voice setting to change"
           },
           "value": {


### PR DESCRIPTION
## Summary
Fixes gap: TOOLS.json voice_config_update enum missing new Fish Audio settings.

**Gap:** TOOLS.json enum does not include new settings
**What was expected:** LLM should see tts_provider and fish_audio_reference_id as valid options
**What was found:** Only activation_key, conversation_timeout, tts_voice_id in enum
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
