### PR TITLE
fix: pass fishAudio.speed config to Fish Audio S2 StartEvent

### DIFF
--- a/assistant/src/calls/fish-audio-client.ts
+++ b/assistant/src/calls/fish-audio-client.ts
@@ -21,6 +21,7 @@ interface StartEvent {
     normalize?: boolean;
     latency?: string;
     streaming?: boolean;
+    speed?: number;
   };
 }
 
@@ -106,6 +107,7 @@ export class FishAudioSession {
             reference_id: config.referenceId || undefined,
             format: config.format,
             chunk_length: config.chunkLength,
+            speed: config.speed,
             streaming: true,
           },
         };


### PR DESCRIPTION
## Summary
Fixes gap: fishAudio.speed config field was declared but never consumed.

**Gap:** speed config field unused
**What was expected:** speed should be passed to Fish Audio API
**What was found:** StartEvent.request didn't include speed

- Added `speed?: number` to the StartEvent.request interface
- Pass `config.speed` in the start event request inside FishAudioSession.create()
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
