### PR TITLE
fix: serialize Fish Audio sentence synthesis to prevent concurrent rejection

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -552,7 +552,7 @@ export class CallController {
     const useFishAudio = isFishAudioTts(config);
     let fishSession: FishAudioSession | null = null;
     let sentenceBuffer = "";
-    const fishPendingQueue: Promise<void>[] = [];
+    let fishSynthesisChain: Promise<void> = Promise.resolve();
 
     const synthesizeAndPlay = async (text: string): Promise<void> => {
       if (!this.isCurrentRun(runVersion)) return;
@@ -580,7 +580,8 @@ export class CallController {
         sentenceBuffer += safeText;
         let split: ReturnType<typeof splitAtSentenceBoundary>;
         while ((split = splitAtSentenceBoundary(sentenceBuffer)) !== undefined) {
-          fishPendingQueue.push(synthesizeAndPlay(split.complete));
+          const sentence = split.complete;
+          fishSynthesisChain = fishSynthesisChain.then(() => synthesizeAndPlay(sentence));
           sentenceBuffer = split.remainder;
         }
       } else {
@@ -699,10 +700,10 @@ export class CallController {
     // all in-flight synthesis to finish before signaling end-of-turn.
     if (useFishAudio) {
       if (sentenceBuffer.trim().length > 0) {
-        fishPendingQueue.push(synthesizeAndPlay(sentenceBuffer.trim()));
+        fishSynthesisChain = fishSynthesisChain.then(() => synthesizeAndPlay(sentenceBuffer.trim()));
         sentenceBuffer = "";
       }
-      await Promise.all(fishPendingQueue);
+      await fishSynthesisChain;
       if (this.activeFishSession) {
         this.activeFishSession.close();
         this.activeFishSession = null;


### PR DESCRIPTION
## Summary
Fixes bug: concurrent sentence synthesis causes rejection.

**Gap:** Multiple sentences in one chunk caused parallel synthesize() calls
**What was expected:** Sequential synthesis, one sentence at a time
**What was found:** Parallel push pattern triggered concurrent synthesis guard
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
