### PR TITLE
feat: decode image ref fields in AssistantRelease model

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -248,6 +248,9 @@ struct AssistantUpgradeSection: View {
 struct AssistantRelease: Decodable, Identifiable {
     let version: String
     let releasedAt: String?
+    let assistantImageRef: String?
+    let gatewayImageRef: String?
+    let credentialExecutorImageRef: String?
 
     var id: String { version }
 }


### PR DESCRIPTION
## Summary
- Add `assistantImageRef`, `gatewayImageRef`, `credentialExecutorImageRef` optional fields to `AssistantRelease`
- Decoded via existing snake_case key decoding from platform API response
- No behavior change — fields are available for future use

Part of plan: platform-image-refs.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
