### PR TITLE
fix: add clarifying comment for end-of-turn signal in Fish Audio mode

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -579,9 +579,13 @@ export class CallController {
       if (useFishAudio) {
         sentenceBuffer += safeText;
         let split: ReturnType<typeof splitAtSentenceBoundary>;
-        while ((split = splitAtSentenceBoundary(sentenceBuffer)) !== undefined) {
+        while (
+          (split = splitAtSentenceBoundary(sentenceBuffer)) !== undefined
+        ) {
           const sentence = split.complete;
-          fishSynthesisChain = fishSynthesisChain.then(() => synthesizeAndPlay(sentence));
+          fishSynthesisChain = fishSynthesisChain.then(() =>
+            synthesizeAndPlay(sentence),
+          );
           sentenceBuffer = split.remainder;
         }
       } else {
@@ -700,7 +704,9 @@ export class CallController {
     // all in-flight synthesis to finish before signaling end-of-turn.
     if (useFishAudio) {
       if (sentenceBuffer.trim().length > 0) {
-        fishSynthesisChain = fishSynthesisChain.then(() => synthesizeAndPlay(sentenceBuffer.trim()));
+        fishSynthesisChain = fishSynthesisChain.then(() =>
+          synthesizeAndPlay(sentenceBuffer.trim()),
+        );
         sentenceBuffer = "";
       }
       await fishSynthesisChain;
@@ -710,7 +716,11 @@ export class CallController {
       }
     }
 
-    // Signal end of this turn's speech
+    // Signal end of this turn's speech.  An empty token with `last: true`
+    // tells ConversationRelay to start listening — it does NOT trigger TTS
+    // synthesis.  This is required even when Fish Audio handled all audio
+    // playback, because ConversationRelay still needs the end-of-turn signal
+    // to transition from "assistant speaking" to "caller speaking" state.
     this.relay.sendTextToken("", true);
 
     // Mark the greeting's first response as awaiting ack


### PR DESCRIPTION
## Summary
- Addresses review concern that `sendTextToken('', true)` after Fish Audio playback might cause Google TTS to produce a silence artifact
- An empty token with `last: true` is the ConversationRelay end-of-turn signal that transitions from "assistant speaking" to "caller speaking" — it does **not** trigger TTS synthesis
- Added clarifying comment explaining why this signal is needed even in Fish Audio mode

## Test plan
- [x] Type-check passes (no new errors)
- [x] Prettier + ESLint pass
- [ ] Comment-only change; no behavioral change to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
