### PR TITLE
fix: add unauthenticated gateway route for audio serving endpoint

### DIFF
--- a/gateway/src/http/routes/audio-proxy.ts
+++ b/gateway/src/http/routes/audio-proxy.ts
@@ -1,0 +1,56 @@
+/**
+ * Gateway proxy for the daemon's audio serving endpoint.
+ *
+ * GET /v1/audio/:audioId — unauthenticated, proxied directly to the daemon.
+ *
+ * Twilio fetches synthesized TTS audio at these URLs. The audioId is an
+ * unguessable UUID that acts as a capability token, so no additional auth
+ * is required. This mirrors the daemon's own handling where the audio
+ * endpoint is served before the auth middleware.
+ */
+
+import type { GatewayConfig } from "../../config.js";
+import { fetchImpl } from "../../fetch.js";
+import { getLogger } from "../../logger.js";
+
+const log = getLogger("audio-proxy");
+
+export function createAudioProxyHandler(config: GatewayConfig) {
+  async function handleGetAudio(
+    _req: Request,
+    audioId: string,
+  ): Promise<Response> {
+    const upstream = `${config.assistantRuntimeBaseUrl}/v1/audio/${encodeURIComponent(audioId)}`;
+
+    let response: Response;
+    try {
+      response = await fetchImpl(upstream, {
+        method: "GET",
+        signal: AbortSignal.timeout(config.runtimeTimeoutMs),
+      });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "TimeoutError") {
+        log.error({ audioId }, "Audio proxy upstream timed out");
+        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
+      }
+      log.error({ err, audioId }, "Audio proxy upstream connection failed");
+      return Response.json({ error: "Bad Gateway" }, { status: 502 });
+    }
+
+    if (!response.ok) {
+      // Pass through 404s and other errors from the daemon as-is
+      const body = await response.text();
+      return new Response(body, {
+        status: response.status,
+        headers: { "Content-Type": response.headers.get("Content-Type") ?? "application/json" },
+      });
+    }
+
+    return new Response(response.body, {
+      status: response.status,
+      headers: { "Content-Type": response.headers.get("Content-Type") ?? "application/octet-stream" },
+    });
+  }
+
+  return { handleGetAudio };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -29,6 +29,7 @@ import {
 } from "./http/routes/browser-relay-websocket.js";
 import { createTelegramDeliverHandler } from "./http/routes/telegram-deliver.js";
 import { createTelegramWebhookHandler } from "./http/routes/telegram-webhook.js";
+import { createAudioProxyHandler } from "./http/routes/audio-proxy.js";
 import { createTwilioVoiceWebhookHandler } from "./http/routes/twilio-voice-webhook.js";
 import { createTwilioStatusWebhookHandler } from "./http/routes/twilio-status-webhook.js";
 import { createTwilioConnectActionWebhookHandler } from "./http/routes/twilio-connect-action-webhook.js";
@@ -296,6 +297,8 @@ async function main() {
   const handleTrustRulesMatch = createTrustRulesMatchHandler();
   const handleTrustRulesStarterBundle = createTrustRulesStarterBundleHandler();
 
+  const audioProxy = createAudioProxyHandler(config);
+
   const handleRuntimeProxy = config.runtimeProxyEnabled
     ? createRuntimeProxyHandler(config)
     : null;
@@ -351,6 +354,13 @@ async function main() {
       path: "/webhooks/whatsapp",
       precondition: requireWhatsApp,
       handler: (req) => handleWhatsAppWebhook(req),
+    },
+
+    // ── Audio serving (unauthenticated — Twilio fetches these URLs directly) ──
+    {
+      path: /^\/v1\/audio\/([^/]+)$/,
+      method: "GET",
+      handler: (_req, params) => audioProxy.handleGetAudio(_req, params[0]),
     },
     {
       path: "/webhooks/oauth/callback",

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -567,6 +567,57 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/audio/{audioId}": {
+        get: {
+          summary: "Retrieve synthesized audio",
+          description:
+            "Serves a previously synthesized TTS audio segment. Unauthenticated — the audioId is an unguessable UUID that acts as a capability token. Used by Twilio to fetch audio for playback during voice calls.",
+          operationId: "getAudio",
+          parameters: [
+            {
+              name: "audioId",
+              in: "path",
+              required: true,
+              schema: { type: "string", format: "uuid" },
+              description: "Unique identifier of the audio segment",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Audio content",
+              content: {
+                "audio/*": {
+                  schema: { type: "string", format: "binary" },
+                },
+              },
+            },
+            "404": {
+              description: "Audio not found or expired",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "502": {
+              description: "Failed to reach upstream runtime",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "504": {
+              description: "Upstream runtime timed out",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
       "/deliver/whatsapp": {
         post: {
           summary: "WhatsApp delivery (internal)",


### PR DESCRIPTION
## Summary
Fixes gap: Twilio cannot fetch synthesized audio through the gateway.

**Gap:** Audio endpoint unreachable through gateway
**What was expected:** Twilio can fetch /v1/audio/:audioId unauthenticated
**What was found:** Gateway has no dedicated route; runtime proxy requires auth

- Added `audio-proxy.ts` handler that proxies `GET /v1/audio/:audioId` to the daemon without auth
- Registered the route in the gateway route table as unauthenticated (same pattern as Twilio webhooks)
- Added OpenAPI schema entry for the new endpoint

The audioId is an unguessable UUID that acts as a capability token, so no additional authentication is needed — this matches the daemon's own handling where the audio endpoint is served before the auth middleware.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
