### PR TITLE
fix: increase iOS conversation lifecycle test timeouts for CI stability

### DIFF
--- a/clients/ios/Tests/ConversationLifecycleIOSTests.swift
+++ b/clients/ios/Tests/ConversationLifecycleIOSTests.swift
@@ -69,7 +69,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
             }
         }
         poll()
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 10.0)
         cancelled = true
 
         XCTAssertNotNil(vm.conversationId, "Should have a locally-generated conversation ID")
@@ -99,7 +99,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
             }
         }
         poll()
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 10.0)
         cancelled = true
 
         XCTAssertEqual(vm.conversationType, "private")
@@ -123,7 +123,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
             }
         }
         poll()
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 10.0)
         cancelled = true
 
         XCTAssertNotNil(vm.conversationId)
@@ -147,7 +147,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
             }
         }
         poll()
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 10.0)
         cancelled = true
 
         let localId = vm.conversationId
@@ -181,7 +181,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
             }
         }
         poll()
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 10.0)
         cancelled = true
 
         XCTAssertNotNil(capturedConversationId)
@@ -210,7 +210,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
             }
         }
         poll()
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 10.0)
         cancelled = true
 
         XCTAssertNotNil(vm.conversationId)


### PR DESCRIPTION
## Summary
- Increase XCTestExpectation timeouts from 2s to 10s in 6 polling-based tests in `ConversationLifecycleIOSTests`
- These tests poll for `conversationId` assignment which happens inside a `Task { @MainActor in }` block — on slower CI runners, the task scheduling can exceed the 2s timeout
- The longer timeout is purely a safety margin; tests still complete in <1s when the task is scheduled promptly

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23354379012/job/67941318376
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
