### PR TITLE
refactor: use resolveImageRefs in Docker upgrade

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -12,7 +12,6 @@ import type { AssistantEntry } from "../lib/assistant-config";
 import {
   captureImageRefs,
   clearSigningKeyBootstrapLock,
-  DOCKERHUB_IMAGES,
   DOCKER_READY_TIMEOUT_MS,
   GATEWAY_INTERNAL_PORT,
   dockerResourceNames,
@@ -21,7 +20,7 @@ import {
   startContainers,
   stopContainers,
 } from "../lib/docker";
-import type { ServiceName } from "../lib/docker";
+import { resolveImageRefs } from "../lib/platform-releases";
 import {
   fetchOrganizationId,
   getPlatformUrl,
@@ -239,11 +238,8 @@ async function upgradeDocker(
 
   const versionTag =
     version ?? (cliPkg.version ? `v${cliPkg.version}` : "latest");
-  const imageTags: Record<ServiceName, string> = {
-    assistant: `${DOCKERHUB_IMAGES.assistant}:${versionTag}`,
-    "credential-executor": `${DOCKERHUB_IMAGES["credential-executor"]}:${versionTag}`,
-    gateway: `${DOCKERHUB_IMAGES.gateway}:${versionTag}`,
-  };
+  console.log("🔍 Resolving image references...");
+  const { imageTags } = await resolveImageRefs(versionTag);
 
   console.log(
     `🔄 Upgrading Docker assistant '${instanceName}' to ${versionTag}...\n`,


### PR DESCRIPTION
## Summary
- Replace hardcoded DockerHub tag construction in `upgradeDocker()` with `resolveImageRefs()`
- Platform API is tried first for GCR digest-based refs, with DockerHub fallback
- Single-line change at the call site — all resolution logic lives in `platform-releases.ts`

Part of plan: platform-image-refs.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
