### PR TITLE
fix: make CLI risk guard test dynamically discover subcommands

### DIFF
--- a/assistant/src/__tests__/cli-command-risk-guard.test.ts
+++ b/assistant/src/__tests__/cli-command-risk-guard.test.ts
@@ -48,6 +48,7 @@ mock.module("../config/loader.js", () => ({
   setNestedValue: () => {},
 }));
 
+import { buildCliProgram } from "../cli/program.js";
 import { classifyRisk } from "../permissions/checker.js";
 import { RiskLevel } from "../permissions/types.js";
 
@@ -68,37 +69,21 @@ function expectLowRisk(command: string, actual: RiskLevel): void {
   expect(actual).toBe(RiskLevel.Low);
 }
 
-// Comprehensive list of all known `assistant` CLI subcommands.
-const ASSISTANT_SUBCOMMANDS = [
-  "auth",
-  "avatar",
-  "bash",
-  "browser",
-  "channel-verification-sessions",
-  "completions",
-  "config",
-  "contacts",
-  "conversations",
-  "credential-execution",
-  "credentials",
-  "doctor",
-  "email",
-  "hooks",
-  "keys",
-  "mcp",
-  "memory",
-  "notifications",
-  "oauth",
-  "platform",
-  "sequence",
-  "shotgun",
-  "skills",
-  "trust",
-  "usage",
-  "autonomy",
-];
+// Dynamically extract subcommand names from the CLI program definition.
+// This ensures new commands added to program.ts are automatically covered
+// by this guard test without manual list maintenance.
+const program = buildCliProgram();
+const ASSISTANT_SUBCOMMANDS = program.commands.map((c) => c.name());
 
 describe("CLI command risk guard: assistant commands", () => {
+  test("subcommand discovery found a reasonable number of commands", () => {
+    // Sanity check: if mocking breaks and no commands are registered,
+    // the risk guard would vacuously pass. Require a minimum count to
+    // catch that failure mode. Update this threshold when commands are
+    // removed (but it should only grow).
+    expect(ASSISTANT_SUBCOMMANDS.length).toBeGreaterThanOrEqual(20);
+  });
+
   test("all assistant CLI subcommands classify as Low risk", async () => {
     for (const subcommand of ASSISTANT_SUBCOMMANDS) {
       const command = `assistant ${subcommand}`;


### PR DESCRIPTION
## Summary
- Replaces static subcommand list with dynamic extraction from `buildCliProgram()`
- Ensures new CLI commands are automatically covered without manual list maintenance
- Fixes missing `audit` subcommand gap found during review

Fixes gaps from plan: cli-risk-guard-test.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
