### PR TITLE
fix: use contentLayoutRect for reliable traffic light centering

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -463,11 +463,12 @@ public final class MainWindow {
         guard let origin = defaultTrafficLightOrigin else { return }
 
         // Vertically center the traffic light buttons in the 48pt custom toolbar.
-        // Derive the system titlebar height from contentLayoutRect (a documented
-        // API) using the window frame — not contentView.frame, which may be
-        // zero-sized before makeKeyAndOrderFront on NSHostingController windows.
-        let contentRect = window.contentRect(forFrameRect: window.frame)
-        let titlebarHeight = contentRect.height - window.contentLayoutRect.maxY
+        // With fullSizeContentView, contentView.frame spans the entire window
+        // interior (including under the titlebar), while contentLayoutRect covers
+        // only the non-obscured portion. The difference gives the titlebar height.
+        // This call runs after makeKeyAndOrderFront so contentView.frame is valid.
+        guard let contentView = window.contentView else { return }
+        let titlebarHeight = contentView.frame.height - window.contentLayoutRect.maxY
         let toolbarHeight: CGFloat = 48
         guard titlebarHeight > 0, titlebarHeight < toolbarHeight else { return }
         let verticalShift = (toolbarHeight - titlebarHeight) / 2

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -455,21 +455,21 @@ public final class MainWindow {
 
     private func repositionTrafficLights(_ window: NSWindow) {
         guard let closeButton = window.standardWindowButton(.closeButton),
-              let containerView = closeButton.superview else { return }
+              let containerView = closeButton.superview,
+              let contentView = window.contentView else { return }
         if defaultTrafficLightOrigin == nil {
             defaultTrafficLightOrigin = containerView.frame.origin
         }
         guard let origin = defaultTrafficLightOrigin else { return }
 
         // Vertically center the traffic light buttons in the 48pt custom toolbar.
-        // The default position centers them in the system titlebar; shift down
-        // by half the height difference so they sit centered in our taller bar.
-        // Clamp to a reasonable range in case Apple changes the private view
-        // hierarchy and the superview becomes the full theme frame.
-        let rawHeight = containerView.superview?.frame.height ?? 28
-        let systemTitlebarHeight = min(rawHeight, 60)
+        // Derive the system titlebar height from contentLayoutRect — a documented
+        // API that reports the area not obscured by the titlebar, staying correct
+        // across macOS versions without relying on the private view hierarchy.
+        let titlebarHeight = contentView.frame.height - window.contentLayoutRect.maxY
         let toolbarHeight: CGFloat = 48
-        let verticalShift = (toolbarHeight - systemTitlebarHeight) / 2
+        guard titlebarHeight > 0, titlebarHeight < toolbarHeight else { return }
+        let verticalShift = (toolbarHeight - titlebarHeight) / 2
 
         containerView.setFrameOrigin(NSPoint(
             x: origin.x + 2,

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -429,10 +429,11 @@ public final class MainWindow {
         window.setFrameAutosaveName("MainWindow")
         window.delegate = closeDelegate
 
-        configureTrafficLightPadding(window)
         window.observeAppActivation()
 
         window.makeKeyAndOrderFront(nil)
+
+        configureTrafficLightPadding(window)
         NSApp.activate(ignoringOtherApps: true)
 
         self.window = window
@@ -455,18 +456,18 @@ public final class MainWindow {
 
     private func repositionTrafficLights(_ window: NSWindow) {
         guard let closeButton = window.standardWindowButton(.closeButton),
-              let containerView = closeButton.superview,
-              let contentView = window.contentView else { return }
+              let containerView = closeButton.superview else { return }
         if defaultTrafficLightOrigin == nil {
             defaultTrafficLightOrigin = containerView.frame.origin
         }
         guard let origin = defaultTrafficLightOrigin else { return }
 
         // Vertically center the traffic light buttons in the 48pt custom toolbar.
-        // Derive the system titlebar height from contentLayoutRect — a documented
-        // API that reports the area not obscured by the titlebar, staying correct
-        // across macOS versions without relying on the private view hierarchy.
-        let titlebarHeight = contentView.frame.height - window.contentLayoutRect.maxY
+        // Derive the system titlebar height from contentLayoutRect (a documented
+        // API) using the window frame — not contentView.frame, which may be
+        // zero-sized before makeKeyAndOrderFront on NSHostingController windows.
+        let contentRect = window.contentRect(forFrameRect: window.frame)
+        let titlebarHeight = contentRect.height - window.contentLayoutRect.maxY
         let toolbarHeight: CGFloat = 48
         guard titlebarHeight > 0, titlebarHeight < toolbarHeight else { return }
         let verticalShift = (toolbarHeight - titlebarHeight) / 2


### PR DESCRIPTION
## Summary
- Replace `containerView.superview?.frame.height` (private view hierarchy, unreliable) with `window.contentLayoutRect` (documented API) to derive the system titlebar height for traffic light button centering
- The previous approach (`0bc062cb1`) depended on the private `NSTitlebarView` hierarchy returning the correct height, which varies across macOS versions and window states, causing the traffic lights to drift out of alignment with toolbar icons

## Original prompt
--safe why traffic icons are not aligned again; check whom to blame and get it done
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
