### PR TITLE
refactor: replace isDocker flag with topology enum in AssistantUpgradeSection

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -2,6 +2,14 @@ import Foundation
 import SwiftUI
 import VellumAssistantShared
 
+/// Topology classification for upgrade UI behavior.
+enum AssistantTopology {
+    case local       // Sparkle-managed binary
+    case docker      // CLI-managed containers
+    case managed     // Platform-managed (Vellum cloud)
+    case remote      // GCP, custom, SSH — no automatic upgrade mechanism
+}
+
 /// Upgrade section for managed/remote assistants.
 ///
 /// Shows the current version, checks for available releases, and provides
@@ -10,7 +18,7 @@ import VellumAssistantShared
 @MainActor
 struct AssistantUpgradeSection: View {
     let currentVersion: String?
-    let isDocker: Bool
+    let topology: AssistantTopology
 
     @State private var availableReleases: [AssistantRelease] = []
     @State private var selectedVersion: String?
@@ -190,10 +198,13 @@ struct AssistantUpgradeSection: View {
         isUpgrading = true
         defer { isUpgrading = false }
 
-        if isDocker {
+        switch topology {
+        case .docker:
             await performDockerUpgrade()
-        } else {
+        case .managed:
             await performManagedUpgrade()
+        case .local, .remote:
+            break // These topologies don't support upgrade from here
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -131,7 +131,14 @@ struct SettingsDeveloperTab: View {
             // Upgrade (managed/remote only)
             if let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }),
                assistant.isManaged || assistant.isRemote {
-                AssistantUpgradeSection(currentVersion: healthz?.version, isDocker: assistant.isDocker)
+                let topo: AssistantTopology = assistant.isDocker ? .docker
+                    : assistant.isManaged ? .managed
+                    : assistant.cloud.lowercased() == "local" ? .local
+                    : .remote
+                AssistantUpgradeSection(
+                    currentVersion: healthz?.version,
+                    topology: topo
+                )
             }
             // Rollback (when previous version is available)
             if let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }),


### PR DESCRIPTION
## Summary
- Add `AssistantTopology` enum with `.local`, `.docker`, `.managed`, `.remote` cases
- Replace `isDocker: Bool` with `topology: AssistantTopology` in AssistantUpgradeSection
- Route upgrade action via `switch topology` instead of `if isDocker`
- Update call site in SettingsDeveloperTab to compute and pass topology

Part of plan: upgrade-topology-parity.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
