### PR TITLE
Remove Share option from image context menu

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -110,21 +110,7 @@ private enum ImageActions {
         }
     }
 
-    /// Presents the macOS share sheet anchored to the center of the key window.
-    static func shareImage(_ image: NSImage) {
-        let picker = NSSharingServicePicker(items: [image])
-        if let window = NSApp.keyWindow, let contentView = window.contentView {
-            let rect = CGRect(
-                x: contentView.bounds.midX,
-                y: contentView.bounds.midY,
-                width: 1,
-                height: 1
-            )
-            picker.show(relativeTo: rect, of: contentView, preferredEdge: .minY)
-        }
-    }
-
-    /// Builds a SwiftUI context menu with Copy, Save As, Open in Preview, and Share actions.
+    /// Builds a SwiftUI context menu with Copy, Save As, and Open in Preview actions.
     @ViewBuilder
     static func contextMenuItems(
         image: NSImage,
@@ -149,13 +135,6 @@ private enum ImageActions {
             Label { Text("Open in Preview") } icon: { VIconView(.eye, size: 12) }
         }
 
-        Divider()
-
-        Button {
-            shareImage(image)
-        } label: {
-            Label { Text("Share\u{2026}") } icon: { VIconView(.share, size: 12) }
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Remove the Share... option from the image right-click context menu — `NSSharingServicePicker` doesn't work reliably from SwiftUI context menu actions because the context menu dismisses before the action runs, leaving no stable anchor view
- Remove the `shareImage` helper method (now unused)

## Original prompt
just remove the share option from that window
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
