### PR TITLE
feat: show upgrade section for all topologies with topology-aware behavior

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -90,14 +90,31 @@ struct AssistantUpgradeSection: View {
                 }
             }
 
-            HStack(spacing: VSpacing.md) {
-                VButton(
-                    label: isUpgrading ? "Upgrading..." : "Upgrade Now",
-                    style: .primary
-                ) {
-                    showingUpgradeConfirmation = true
+            if topology == .remote {
+                HStack(spacing: VSpacing.xs) {
+                    VIconView(.triangleAlert, size: 12)
+                        .foregroundColor(VColor.systemMidStrong)
+                    Text("Automatic upgrades are not available for this deployment. Upgrade your infrastructure manually.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
                 }
-                .disabled(!upgradeAvailable || isUpgrading)
+            }
+
+            HStack(spacing: VSpacing.md) {
+                if topology == .local {
+                    VButton(label: "Check for App Updates", style: .outlined) {
+                        AppDelegate.shared?.updateManager.checkForUpdates()
+                    }
+                } else if topology != .remote {
+                    // Docker and managed get the upgrade button
+                    VButton(
+                        label: isUpgrading ? "Upgrading..." : "Upgrade Now",
+                        style: .primary
+                    ) {
+                        showingUpgradeConfirmation = true
+                    }
+                    .disabled(!upgradeAvailable || isUpgrading)
+                }
 
                 VButton(
                     label: isLoadingReleases ? "Checking..." : "Check for Updates",

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -128,9 +128,8 @@ struct SettingsDeveloperTab: View {
                 daemonClient: daemonClient,
                 isManaged: lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId })?.isManaged ?? false
             )
-            // Upgrade (managed/remote only)
-            if let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }),
-               assistant.isManaged || assistant.isRemote {
+            // Upgrade
+            if let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }) {
                 let topo: AssistantTopology = assistant.isDocker ? .docker
                     : assistant.isManaged ? .managed
                     : assistant.cloud.lowercased() == "local" ? .local


### PR DESCRIPTION
## Summary
- Remove the `isManaged || isRemote` gate — upgrade section now shown for all topologies
- Local topology: shows 'Check for App Updates' button that triggers Sparkle
- Remote (GCP/Custom): hides upgrade button, shows warning about manual upgrades
- Docker and managed: unchanged behavior

Part of plan: upgrade-topology-parity.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
