### PR TITLE
feat: change upgrade button label to "Roll Back" when selecting older version

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -41,6 +41,15 @@ struct AssistantUpgradeSection: View {
         return target != current
     }
 
+    /// Whether the selected target version is older than the current version.
+    private var isRollback: Bool {
+        guard let target = effectiveSelectedVersion,
+              let current = currentVersion, !current.isEmpty else {
+            return false
+        }
+        return target.compare(current, options: .numeric) == .orderedAscending
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
             Text("Upgrade")
@@ -92,8 +101,10 @@ struct AssistantUpgradeSection: View {
 
             HStack(spacing: VSpacing.md) {
                 VButton(
-                    label: isUpgrading ? "Upgrading..." : "Upgrade Now",
-                    style: .primary
+                    label: isUpgrading
+                        ? (isRollback ? "Rolling back..." : "Upgrading...")
+                        : (isRollback ? "Roll Back" : "Upgrade Now"),
+                    style: isRollback ? .outlined : .primary
                 ) {
                     showingUpgradeConfirmation = true
                 }
@@ -135,13 +146,17 @@ struct AssistantUpgradeSection: View {
         .vCard(background: VColor.surfaceOverlay)
         .frame(maxWidth: .infinity, alignment: .leading)
         .task { await loadReleases() }
-        .alert("Upgrade Assistant", isPresented: $showingUpgradeConfirmation) {
+        .alert(isRollback ? "Roll Back Assistant" : "Upgrade Assistant", isPresented: $showingUpgradeConfirmation) {
             Button("Cancel", role: .cancel) {}
-            Button("Upgrade") {
+            Button(isRollback ? "Roll Back" : "Upgrade") {
                 Task { await performUpgrade() }
             }
         } message: {
-            Text("Upgrade to version \(selectedVersion ?? latestRelease?.version ?? "latest")? The assistant will be briefly unavailable during the upgrade.")
+            if isRollback {
+                Text("Roll back to version \(effectiveSelectedVersion ?? "unknown")? The assistant will be briefly unavailable.")
+            } else {
+                Text("Upgrade to version \(effectiveSelectedVersion ?? "latest")? The assistant will be briefly unavailable during the upgrade.")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `isRollback` computed property that compares selected version to current
- Button label changes: 'Upgrade Now' → 'Roll Back' when older version selected
- Button style changes: `.primary` → `.outlined` for rollback
- Confirmation dialog adapts title and message to match the action

Part of plan: upgrade-topology-parity.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
