### PR TITLE
feat: make inline upgrade button topology-aware

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -466,12 +466,18 @@ struct SettingsDeveloperTab: View {
                 .frame(width: 100, alignment: .leading)
 
             if let daemonClient {
+                let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId })
+                let topo: AssistantTopology = assistant?.isDocker == true ? .docker
+                    : assistant?.isManaged == true ? .managed
+                    : assistant?.cloud.lowercased() == "local" ? .local
+                    : .remote
                 DeveloperUpdateProgressRow(
                     daemonClient: daemonClient,
                     effectiveVersion: effectiveVersion,
                     isVersionIncompatible: isVersionIncompatible,
                     assistantVersionBehind: assistantVersionBehind,
                     isUpgradingInline: isUpgradingInline,
+                    topology: topo,
                     onUpgradeTapped: { showingInlineUpgradeConfirmation = true }
                 )
             } else if let version = effectiveVersion {
@@ -1428,6 +1434,7 @@ private struct DeveloperUpdateProgressRow: View {
     let isVersionIncompatible: Bool
     let assistantVersionBehind: Bool
     let isUpgradingInline: Bool
+    let topology: AssistantTopology
     let onUpgradeTapped: () -> Void
 
     var body: some View {
@@ -1444,14 +1451,16 @@ private struct DeveloperUpdateProgressRow: View {
                 .textSelection(.enabled)
 
             if assistantVersionBehind {
-                if isUpgradingInline {
-                    ProgressView()
-                        .controlSize(.small)
-                } else {
-                    VButton(label: "Upgrade", style: .primary) {
-                        onUpgradeTapped()
+                if topology == .docker || topology == .managed {
+                    if isUpgradingInline {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        VButton(label: "Upgrade", style: .primary) {
+                            onUpgradeTapped()
+                        }
+                        .disabled(isUpgradingInline)
                     }
-                    .disabled(isUpgradingInline)
                 }
             }
         } else {


### PR DESCRIPTION
## Summary
- Add `topology` parameter to `DeveloperUpdateProgressRow`
- Hide inline upgrade button for local and remote topologies
- Prevents silent 404 failures for GCP/custom assistants

Part of plan: upgrade-topology-parity.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
