### PR TITLE
feat: register message-tts feature flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -304,6 +304,14 @@
       "label": "Sounds",
       "description": "Enable the Sounds tab in Settings and all app sound playback (event sounds, random ambient sounds)",
       "defaultEnabled": true
+    },
+    {
+      "id": "message-tts",
+      "scope": "assistant",
+      "key": "feature_flags.message-tts.enabled",
+      "label": "Message Text-to-Speech",
+      "description": "Show a speaker button on assistant messages to generate and play the message as audio via Fish Audio TTS",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `message-tts` feature flag to the registry (scope: assistant, default: disabled)
- Gates the upcoming TTS playback button on assistant messages

Part of plan: msg-audio-playback.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
