### PR TITLE
feat: include assistant version and commit SHA in export manifest

### DIFF
--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -37,6 +37,7 @@ import {
   getWorkspaceConfigPath,
   getWorkspaceDir,
 } from "../../util/platform.js";
+import { APP_VERSION, COMMIT_SHA } from "../../version.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 
@@ -264,12 +265,16 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
       ? {
           type: "conversation-export" as const,
           conversationId,
+          assistantVersion: APP_VERSION,
+          commitSha: COMMIT_SHA,
           ...(startTime !== undefined ? { startTime } : {}),
           ...(endTime !== undefined ? { endTime } : {}),
           exportedAt: new Date().toISOString(),
         }
       : {
           type: "global-export" as const,
+          assistantVersion: APP_VERSION,
+          commitSha: COMMIT_SHA,
           exportedAt: new Date().toISOString(),
         };
     writeFileSync(


### PR DESCRIPTION
## Summary
- Add `assistantVersion` and `commitSha` fields to the daemon's `export-manifest.json` response
- Enriches the log export archive so triaging Sentry reports can identify daemon version without downloading

Part of plan: log-report-daemon-version.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
