### PR TITLE
feat: include assistant version in log report Sentry tags and report-metadata

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -134,8 +134,13 @@ enum LogExporter {
                     }
                 }
             }
-            if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") {
+            let connectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+            let connectedAssistantForTags = connectedAssistantId.flatMap { LockfileAssistant.loadByName($0) }
+            if let assistantId = connectedAssistantId {
                 tags["assistant_id"] = assistantId
+            }
+            if let assistantVersion = connectedAssistantForTags?.serviceGroupVersion {
+                tags["assistant_version"] = assistantVersion
             }
             if !extra.isEmpty {
                 event.extra = extra
@@ -297,6 +302,12 @@ enum LogExporter {
             if daemonUnreachable {
                 metadata["daemon-unreachable"] = true
             }
+            if let assistantVersion = connectedAssistant?.serviceGroupVersion {
+                metadata["assistant_version"] = assistantVersion
+            }
+            if let clientVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+                metadata["client_version"] = clientVersion
+            }
             if let data = try? JSONSerialization.data(
                 withJSONObject: metadata,
                 options: [.prettyPrinted, .sortedKeys]
@@ -306,7 +317,13 @@ enum LogExporter {
         } else if daemonUnreachable {
             // Write a minimal manifest when no form data is available so the
             // receiving end still knows these are raw filesystem reads.
-            let manifest: [String: Any] = ["daemon-unreachable": true]
+            var manifest: [String: Any] = ["daemon-unreachable": true]
+            if let assistantVersion = connectedAssistant?.serviceGroupVersion {
+                manifest["assistant_version"] = assistantVersion
+            }
+            if let clientVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+                manifest["client_version"] = clientVersion
+            }
             if let data = try? JSONSerialization.data(
                 withJSONObject: manifest,
                 options: [.prettyPrinted, .sortedKeys]


### PR DESCRIPTION
## Summary
- Add `assistant_version` Sentry tag to log report events using lockfile `serviceGroupVersion`
- Add `assistant_version` and `client_version` to `report-metadata.json` in the archive
- Works even when daemon is unreachable since lockfile persists the last-known version

Part of plan: log-report-daemon-version.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
