### PR TITLE
fix: use Slack mention format for access request notifications

### DIFF
--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -648,6 +648,20 @@ describe("notification decision strategy", () => {
       expect(line).not.toContain("<@U04BTP01B2S>");
     });
 
+    test("does not duplicate Slack mention when senderIdentifier equals raw external ID", () => {
+      // When actorDisplayName and actorUsername are missing, senderIdentifier
+      // falls back to the raw actorExternalId. The identity line should produce
+      // exactly one <@U...> mention, not two.
+      const line = buildAccessRequestIdentityLine({
+        senderIdentifier: "U04BTP01B2S",
+        actorExternalId: "U04BTP01B2S",
+        sourceChannel: "slack",
+      });
+      const mentionCount = (line.match(/<@U04BTP01B2S>/g) || []).length;
+      expect(mentionCount).toBe(1);
+      expect(line).toContain("via slack");
+    });
+
     test("does not use <@U...> format for non-user-ID external IDs on Slack", () => {
       const line = buildAccessRequestIdentityLine({
         senderIdentifier: "Alice",

--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -627,6 +627,37 @@ describe("notification decision strategy", () => {
       expect(line).toContain("requesting access");
     });
 
+    test("uses <@U...> mention format for Slack external IDs", () => {
+      const line = buildAccessRequestIdentityLine({
+        senderIdentifier: "Alice",
+        actorExternalId: "U04BTP01B2S",
+        sourceChannel: "slack",
+      });
+      expect(line).toContain("<@U04BTP01B2S>");
+      expect(line).not.toContain("[U04BTP01B2S]");
+      expect(line).toContain("via slack");
+    });
+
+    test("does not use <@U...> format for non-Slack channels", () => {
+      const line = buildAccessRequestIdentityLine({
+        senderIdentifier: "Alice",
+        actorExternalId: "U04BTP01B2S",
+        sourceChannel: "telegram",
+      });
+      expect(line).toContain("[U04BTP01B2S]");
+      expect(line).not.toContain("<@U04BTP01B2S>");
+    });
+
+    test("does not use <@U...> format for non-user-ID external IDs on Slack", () => {
+      const line = buildAccessRequestIdentityLine({
+        senderIdentifier: "Alice",
+        actorExternalId: "someone@example.com",
+        sourceChannel: "slack",
+      });
+      expect(line).not.toContain("<@someone@example.com>");
+      expect(line).toContain("[someone@example.com]");
+    });
+
     test("sanitizes adversarial display names", () => {
       const line = buildAccessRequestIdentityLine({
         senderIdentifier: "Alice",

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -99,7 +99,14 @@ export function buildAccessRequestIdentityLine(
   const sanitizedExternalId = actorExternalId
     ? sanitizeIdentityField(actorExternalId)
     : undefined;
-  const parts = [requester];
+  // When the requester is a raw Slack user ID (e.g. the fallback path in
+  // access-request-helper sets senderIdentifier to the raw actorExternalId),
+  // format it as a Slack mention so it renders as a clickable display name.
+  const formattedRequester =
+    sourceChannel === "slack" && /^U[A-Z0-9]+$/i.test(requester)
+      ? `<@${requester}>`
+      : requester;
+  const parts = [formattedRequester];
   if (sanitizedUsername && sanitizedUsername !== requester) {
     parts.push(`@${sanitizedUsername}`);
   }

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -108,7 +108,13 @@ export function buildAccessRequestIdentityLine(
     sanitizedExternalId !== requester &&
     sanitizedExternalId !== sanitizedUsername
   ) {
-    parts.push(`[${sanitizedExternalId}]`);
+    // For Slack, use the <@U...> mention format so Slack auto-renders
+    // the user ID as a clickable display name.
+    const formattedId =
+      sourceChannel === "slack" && /^U[A-Z0-9]+$/i.test(sanitizedExternalId)
+        ? `<@${sanitizedExternalId}>`
+        : `[${sanitizedExternalId}]`;
+    parts.push(formattedId);
   }
   if (sourceChannel) {
     parts.push(`via ${sourceChannel}`);

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -181,10 +181,7 @@ export function notifyGuardianOfAccessRequest(
     };
   }
 
-  const senderIdentifier =
-    actorDisplayName ||
-    actorUsername ||
-    (sourceChannel === "slack" ? `<@${actorExternalId}>` : actorExternalId);
+  const senderIdentifier = actorDisplayName || actorUsername || actorExternalId;
   const requestId = `access-req-${canonicalAssistantId}-${sourceChannel}-${actorExternalId}-${Date.now()}`;
 
   const canonicalRequest = createCanonicalGuardianRequest({

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -181,7 +181,10 @@ export function notifyGuardianOfAccessRequest(
     };
   }
 
-  const senderIdentifier = actorDisplayName || actorUsername || actorExternalId;
+  const senderIdentifier =
+    actorDisplayName ||
+    actorUsername ||
+    (sourceChannel === "slack" ? `<@${actorExternalId}>` : actorExternalId);
   const requestId = `access-req-${canonicalAssistantId}-${sourceChannel}-${actorExternalId}-${Date.now()}`;
 
   const canonicalRequest = createCanonicalGuardianRequest({


### PR DESCRIPTION
## Summary
- When a Slack user's display name isn't resolved (cache miss on first message), the access request notification now uses `<@U...>` mention format instead of showing the raw user ID. Slack auto-renders these as clickable display names.
- Applied in both `access-request-helper.ts` (senderIdentifier construction) and `copy-composer.ts` (identity line external ID formatting).
- Only applies the `<@U...>` format for IDs matching the Slack user ID pattern (`U` followed by alphanumeric chars).

Closes JARVIS-297
Closes JARVIS-301

## Test plan
- [x] Existing notification decision strategy tests pass (75 tests)
- [x] New tests verify `<@U...>` format for Slack, bracketed format for non-Slack, and no mention format for non-user-ID strings
- [x] Non-member access request integration tests pass (15 tests)
- [x] Type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
