### PR TITLE
fix: use guardian's actual name in Slack requester messages

### DIFF
--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -191,7 +191,7 @@ describe("non-member access request notification", () => {
     expect(deliverReplyCalls.length).toBe(1);
     expect(
       (deliverReplyCalls[0].payload as Record<string, unknown>).text,
-    ).toContain("let them know");
+    ).toContain("know you tried talking to me");
   });
 
   test("guardian is notified when a non-member messages and a guardian binding exists", async () => {
@@ -290,7 +290,7 @@ describe("non-member access request notification", () => {
     expect(deliverReplyCalls.length).toBe(1);
     expect(
       (deliverReplyCalls[0].payload as Record<string, unknown>).text,
-    ).toContain("let them know");
+    ).toContain("know you tried talking to me");
 
     // Notification signal was emitted
     expect(emitSignalCalls.length).toBe(1);

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -11,7 +11,6 @@ import type { ChannelId } from "../../../channels/types.js";
 import {
   findContactChannel,
   findGuardianForChannel,
-  listGuardianChannels,
 } from "../../../contacts/contact-store.js";
 import { touchChannelLastSeen } from "../../../contacts/contacts-write.js";
 import type {
@@ -37,6 +36,7 @@ import {
   resolveBootstrapToken,
 } from "../../channel-verification-service.js";
 import { deliverChannelReply } from "../../gateway-client.js";
+import { ensureVellumGuardianBinding } from "../../guardian-vellum-migration.js";
 import {
   redeemInvite,
   redeemInviteByCode,
@@ -47,13 +47,38 @@ const log = getLogger("runtime-http");
 
 /**
  * Resolve the guardian's display name for use in requester-facing messages.
- * Mirrors the pattern used in relay-server.ts for phone channel copy.
+ *
+ * Uses the assistant's anchored vellum principal to validate the guardian
+ * contact, matching the same strategy used by `notifyGuardianOfAccessRequest`.
+ * This prevents stale or cross-assistant contacts from leaking a wrong name.
  */
-function resolveGuardianLabel(sourceChannel: ChannelId): string {
-  const channelGuardian = findGuardianForChannel(sourceChannel);
-  const guardianChannels = channelGuardian ? null : listGuardianChannels();
-  const guardianContact = channelGuardian?.contact ?? guardianChannels?.contact;
-  return resolveGuardianName(guardianContact?.displayName);
+function resolveGuardianLabel(
+  sourceChannel: ChannelId,
+  canonicalAssistantId: string,
+): string {
+  const anchoredPrincipalId = ensureVellumGuardianBinding(canonicalAssistantId);
+
+  // Try source-channel guardian, but only accept it when the principal
+  // matches the assistant's anchor.
+  const sourceGuardian = findGuardianForChannel(sourceChannel);
+  if (
+    sourceGuardian &&
+    sourceGuardian.contact.principalId === anchoredPrincipalId
+  ) {
+    return resolveGuardianName(sourceGuardian.contact.displayName);
+  }
+
+  // Fall back to the vellum-channel guardian with the same anchor check.
+  const vellumGuardian = findGuardianForChannel("vellum");
+  if (
+    vellumGuardian &&
+    vellumGuardian.contact.principalId === anchoredPrincipalId
+  ) {
+    return resolveGuardianName(vellumGuardian.contact.displayName);
+  }
+
+  // No anchored guardian found — use generic fallback.
+  return resolveGuardianName(undefined);
 }
 
 // ---------------------------------------------------------------------------
@@ -365,7 +390,7 @@ export async function enforceIngressAcl(
                   dmCallbackUrl,
                   {
                     chatId: senderUserId,
-                    text: `I don't recognize you yet! I've let ${resolveGuardianLabel(sourceChannel)} know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.`,
+                    text: `I don't recognize you yet! I've let ${resolveGuardianLabel(sourceChannel, canonicalAssistantId)} know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.`,
                     assistantId,
                   },
                   mintBearerToken(),
@@ -414,7 +439,7 @@ export async function enforceIngressAcl(
 
         if (replyCallbackUrl) {
           const replyText = guardianNotified
-            ? `Hmm looks like you don't have access to talk to me. I'll let ${resolveGuardianLabel(sourceChannel)} know you tried talking to me and get back to you.`
+            ? `Hmm looks like you don't have access to talk to me. I'll let ${resolveGuardianLabel(sourceChannel, canonicalAssistantId)} know you tried talking to me and get back to you.`
             : "Sorry, you haven't been approved to message this assistant.";
           const replyPayload: Parameters<typeof deliverChannelReply>[1] = {
             chatId: conversationExternalId,
@@ -619,7 +644,7 @@ export async function enforceIngressAcl(
                     dmCallbackUrl,
                     {
                       chatId: senderUserId,
-                      text: `I don't recognize you yet! I've let ${resolveGuardianLabel(sourceChannel)} know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.`,
+                      text: `I don't recognize you yet! I've let ${resolveGuardianLabel(sourceChannel, canonicalAssistantId)} know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.`,
                       assistantId,
                     },
                     mintBearerToken(),
@@ -673,7 +698,7 @@ export async function enforceIngressAcl(
 
           if (replyCallbackUrl) {
             const replyText = guardianNotified
-              ? `Hmm looks like you don't have access to talk to me. I'll let ${resolveGuardianLabel(sourceChannel)} know you tried talking to me and get back to you.`
+              ? `Hmm looks like you don't have access to talk to me. I'll let ${resolveGuardianLabel(sourceChannel, canonicalAssistantId)} know you tried talking to me and get back to you.`
               : "Sorry, you haven't been approved to message this assistant.";
             const inactiveReplyPayload: Parameters<
               typeof deliverChannelReply

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -8,7 +8,11 @@
  */
 import { isInviteCodeRedemptionEnabled } from "../../../channels/config.js";
 import type { ChannelId } from "../../../channels/types.js";
-import { findContactChannel } from "../../../contacts/contact-store.js";
+import {
+  findContactChannel,
+  findGuardianForChannel,
+  listGuardianChannels,
+} from "../../../contacts/contact-store.js";
 import { touchChannelLastSeen } from "../../../contacts/contacts-write.js";
 import type {
   ChannelStatus,
@@ -21,6 +25,7 @@ import {
   findByInviteCodeHash,
   findByInviteCodeHashAnyChannel,
 } from "../../../memory/invite-store.js";
+import { resolveGuardianName } from "../../../prompts/user-reference.js";
 import { getLogger } from "../../../util/logger.js";
 import { hashVoiceCode } from "../../../util/voice-code.js";
 import { notifyGuardianOfAccessRequest } from "../../access-request-helper.js";
@@ -39,6 +44,17 @@ import {
 import { getInviteRedemptionReply } from "../../invite-redemption-templates.js";
 
 const log = getLogger("runtime-http");
+
+/**
+ * Resolve the guardian's display name for use in requester-facing messages.
+ * Mirrors the pattern used in relay-server.ts for phone channel copy.
+ */
+function resolveGuardianLabel(sourceChannel: ChannelId): string {
+  const channelGuardian = findGuardianForChannel(sourceChannel);
+  const guardianChannels = channelGuardian ? null : listGuardianChannels();
+  const guardianContact = channelGuardian?.contact ?? guardianChannels?.contact;
+  return resolveGuardianName(guardianContact?.displayName);
+}
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -349,7 +365,7 @@ export async function enforceIngressAcl(
                   dmCallbackUrl,
                   {
                     chatId: senderUserId,
-                    text: "I don't recognize you yet! I've let my owner know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.",
+                    text: `I don't recognize you yet! I've let ${resolveGuardianLabel(sourceChannel)} know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.`,
                     assistantId,
                   },
                   mintBearerToken(),
@@ -398,7 +414,7 @@ export async function enforceIngressAcl(
 
         if (replyCallbackUrl) {
           const replyText = guardianNotified
-            ? "Hmm looks like you don't have access to talk to me. I'll let them know you tried talking to me and get back to you."
+            ? `Hmm looks like you don't have access to talk to me. I'll let ${resolveGuardianLabel(sourceChannel)} know you tried talking to me and get back to you.`
             : "Sorry, you haven't been approved to message this assistant.";
           const replyPayload: Parameters<typeof deliverChannelReply>[1] = {
             chatId: conversationExternalId,
@@ -603,7 +619,7 @@ export async function enforceIngressAcl(
                     dmCallbackUrl,
                     {
                       chatId: senderUserId,
-                      text: "I don't recognize you yet! I've let my owner know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.",
+                      text: `I don't recognize you yet! I've let ${resolveGuardianLabel(sourceChannel)} know you're trying to reach me. They'll need to share a 6-digit verification code with you — ask them directly if you know them. Once you have the code, reply here with it.`,
                       assistantId,
                     },
                     mintBearerToken(),
@@ -657,7 +673,7 @@ export async function enforceIngressAcl(
 
           if (replyCallbackUrl) {
             const replyText = guardianNotified
-              ? "Hmm looks like you don't have access to talk to me. I'll let them know you tried talking to me and get back to you."
+              ? `Hmm looks like you don't have access to talk to me. I'll let ${resolveGuardianLabel(sourceChannel)} know you tried talking to me and get back to you.`
               : "Sorry, you haven't been approved to message this assistant.";
             const inactiveReplyPayload: Parameters<
               typeof deliverChannelReply


### PR DESCRIPTION
## Summary
- Replaced impersonal "my owner" / "them" with the guardian's actual resolved name in Slack requester-facing messages (verification DM and access denial reply)
- Added `resolveGuardianLabel()` helper to `acl-enforcement.ts`, mirroring the existing pattern from `relay-server.ts` (phone channel)
- Updated test assertions in `non-member-access-request.test.ts` to match the new dynamic text

Closes JARVIS-298

## Test plan
- [x] `slack-inbound-verification.test.ts` — 7/7 pass
- [x] `non-member-access-request.test.ts` — 15/15 pass
- [x] TypeScript type-check passes (no new errors)
- [ ] Manual: message a Slack bot as an unrecognized user; verify the rejection message shows the guardian's name instead of "my owner" / "them"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
