### PR TITLE
feat: add POST /v1/messages/:id/tts endpoint for message audio synthesis

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -174,6 +174,7 @@ import { surfaceContentRouteDefinitions } from "./routes/surface-content-routes.
 import { telemetryRouteDefinitions } from "./routes/telemetry-routes.js";
 import { traceEventRouteDefinitions } from "./routes/trace-event-routes.js";
 import { trustRulesRouteDefinitions } from "./routes/trust-rules-routes.js";
+import { ttsRouteDefinitions } from "./routes/tts-routes.js";
 import { upgradeBroadcastRouteDefinitions } from "./routes/upgrade-broadcast-routes.js";
 import { usageRouteDefinitions } from "./routes/usage-routes.js";
 import { watchRouteDefinitions } from "./routes/watch-routes.js";
@@ -971,6 +972,7 @@ export class RuntimeHttpServer {
             }
           : undefined,
       }),
+      ...ttsRouteDefinitions(),
 
       // Browser relay — not extracted into a domain module because
       // these two routes depend on the in-process extensionRelayServer

--- a/assistant/src/runtime/routes/tts-routes.ts
+++ b/assistant/src/runtime/routes/tts-routes.ts
@@ -1,0 +1,86 @@
+/**
+ * HTTP route definitions for message text-to-speech synthesis.
+ *
+ * POST /v1/messages/:id/tts?conversationId=... — synthesize message text to audio
+ *
+ * Gated behind the `feature_flags.message-tts.enabled` assistant feature flag.
+ * Uses Fish Audio for synthesis when configured.
+ */
+
+import { synthesizeWithFishAudio } from "../../calls/fish-audio-client.js";
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
+import { getConfig } from "../../config/loader.js";
+import { getMessageContent } from "../../daemon/handlers/conversation-history.js";
+import { getLogger } from "../../util/logger.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+const log = getLogger("tts-routes");
+
+const MESSAGE_TTS_FLAG = "feature_flags.message-tts.enabled" as const;
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function ttsRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "messages/:id/tts",
+      method: "POST",
+      policyKey: "messages/tts",
+      handler: async ({ url, params }) => {
+        const config = getConfig();
+
+        if (!isAssistantFeatureFlagEnabled(MESSAGE_TTS_FLAG, config)) {
+          return httpError("FORBIDDEN", "Message TTS is not enabled", 403);
+        }
+
+        const messageId = params.id;
+        const conversationId =
+          url.searchParams.get("conversationId") ?? undefined;
+
+        const result = getMessageContent(messageId, conversationId);
+        if (!result) {
+          return httpError("NOT_FOUND", `Message ${messageId} not found`, 404);
+        }
+
+        if (!result.text) {
+          return httpError("BAD_REQUEST", "Message has no text content", 400);
+        }
+
+        const { fishAudio } = config;
+        if (!fishAudio?.referenceId) {
+          return httpError(
+            "SERVICE_UNAVAILABLE",
+            "Fish Audio TTS is not configured",
+            503,
+          );
+        }
+
+        try {
+          const audioBuffer = await synthesizeWithFishAudio(
+            result.text,
+            fishAudio,
+          );
+
+          const format = fishAudio.format ?? "mp3";
+          const contentType =
+            format === "wav"
+              ? "audio/wav"
+              : format === "opus"
+                ? "audio/opus"
+                : "audio/mpeg";
+
+          return new Response(new Uint8Array(audioBuffer), {
+            status: 200,
+            headers: { "Content-Type": contentType },
+          });
+        } catch (err) {
+          log.error({ err, messageId }, "TTS synthesis failed");
+          return httpError("INTERNAL_ERROR", "TTS synthesis failed", 502);
+        }
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Add `POST /v1/messages/:id/tts` endpoint that synthesizes message text to audio via Fish Audio
- Gated behind `feature_flags.message-tts.enabled` flag
- Returns raw audio binary with appropriate Content-Type header

Part of plan: msg-audio-playback.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
