### PR TITLE
Format verification codes prominently with Block Kit

### DIFF
--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -523,7 +523,7 @@ const accessRequestResolver: GuardianRequestResolver = {
       try {
         const codeText =
           `You approved access for ${requesterExternalUserId}. ` +
-          `Give them this verification code: ${session.secret}. ` +
+          `Give them this verification code: *\`${session.secret}\`*. ` +
           `The code expires in 10 minutes.`;
         await deliverChannelReply(
           channelDeliveryContext.replyCallbackUrl,
@@ -635,8 +635,8 @@ const accessRequestResolver: GuardianRequestResolver = {
     }
 
     const verificationReplyText = requesterNotified
-      ? `Access approved for ${requesterLabel}. Give them this verification code: ${session.secret}. The code expires in 10 minutes.`
-      : `Access approved for ${requesterLabel}. Give them this verification code: ${session.secret}. The code expires in 10 minutes. I could not notify them automatically, so please tell them to send the code manually.`;
+      ? `Access approved for ${requesterLabel}. Give them this verification code: *\`${session.secret}\`*. The code expires in 10 minutes.`
+      : `Access approved for ${requesterLabel}. Give them this verification code: *\`${session.secret}\`*. The code expires in 10 minutes. I could not notify them automatically, so please tell them to send the code manually.`;
 
     return {
       ok: true,

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -523,7 +523,7 @@ const accessRequestResolver: GuardianRequestResolver = {
       try {
         const codeText =
           `You approved access for ${requesterExternalUserId}. ` +
-          `Give them this verification code: *\`${session.secret}\`*. ` +
+          `Give them this verification code: \`${session.secret}\`. ` +
           `The code expires in 10 minutes.`;
         await deliverChannelReply(
           channelDeliveryContext.replyCallbackUrl,
@@ -635,8 +635,8 @@ const accessRequestResolver: GuardianRequestResolver = {
     }
 
     const verificationReplyText = requesterNotified
-      ? `Access approved for ${requesterLabel}. Give them this verification code: *\`${session.secret}\`*. The code expires in 10 minutes.`
-      : `Access approved for ${requesterLabel}. Give them this verification code: *\`${session.secret}\`*. The code expires in 10 minutes. I could not notify them automatically, so please tell them to send the code manually.`;
+      ? `Access approved for ${requesterLabel}. Give them this verification code: \`${session.secret}\`. The code expires in 10 minutes.`
+      : `Access approved for ${requesterLabel}. Give them this verification code: \`${session.secret}\`. The code expires in 10 minutes. I could not notify them automatically, so please tell them to send the code manually.`;
 
     return {
       ok: true,

--- a/assistant/src/runtime/routes/access-request-decision.ts
+++ b/assistant/src/runtime/routes/access-request-decision.ts
@@ -116,7 +116,7 @@ export async function deliverVerificationCodeToGuardian(params: {
 }): Promise<DeliveryResult> {
   const text =
     `You approved access for ${params.requesterIdentifier}. ` +
-    `Give them this verification code: *\`${params.verificationCode}\`*. ` +
+    `Give them this verification code: \`${params.verificationCode}\`. ` +
     `The code expires in 10 minutes.`;
 
   try {
@@ -189,7 +189,7 @@ export async function deliverVerificationCodeToRequester(params: {
 }): Promise<DeliveryResult> {
   const text =
     `Great news — your access request was approved! ` +
-    `Your verification code is: *\`${params.verificationCode}\`*. ` +
+    `Your verification code is: \`${params.verificationCode}\`. ` +
     `Reply with it here to complete verification. The code expires in 10 minutes.`;
 
   const target = resolveRequesterTarget(params);

--- a/assistant/src/runtime/routes/access-request-decision.ts
+++ b/assistant/src/runtime/routes/access-request-decision.ts
@@ -116,7 +116,7 @@ export async function deliverVerificationCodeToGuardian(params: {
 }): Promise<DeliveryResult> {
   const text =
     `You approved access for ${params.requesterIdentifier}. ` +
-    `Give them this verification code: ${params.verificationCode}. ` +
+    `Give them this verification code: *\`${params.verificationCode}\`*. ` +
     `The code expires in 10 minutes.`;
 
   try {
@@ -189,7 +189,7 @@ export async function deliverVerificationCodeToRequester(params: {
 }): Promise<DeliveryResult> {
   const text =
     `Great news — your access request was approved! ` +
-    `Your verification code is: ${params.verificationCode}. ` +
+    `Your verification code is: *\`${params.verificationCode}\`*. ` +
     `Reply with it here to complete verification. The code expires in 10 minutes.`;
 
   const target = resolveRequesterTarget(params);


### PR DESCRIPTION
## Summary
- Format verification codes with bold monospace (`*\`CODE\`*`) in all messages sent to guardians and requesters so codes are easy to spot at a glance in Slack
- Updated four message templates across `access-request-decision.ts` and `guardian-request-resolvers.ts`
- Slack mrkdwn syntax degrades gracefully in plain-text channels

## Test plan
- [x] `access-request-decision.test.ts` — 15/15 pass
- [x] `guardian-routing-invariants.test.ts` — 49/49 pass
- [x] `slack-inbound-verification.test.ts` — 7/7 pass

Closes JARVIS-302

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
