### PR TITLE
fix: actionable user-facing error messages for Slack failures

### DIFF
--- a/assistant/src/__tests__/gateway-client-managed-outbound.test.ts
+++ b/assistant/src/__tests__/gateway-client-managed-outbound.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { deliverChannelReply } from "../runtime/gateway-client.js";
+import {
+  ChannelDeliveryError,
+  deliverChannelReply,
+} from "../runtime/gateway-client.js";
 
 type FetchCall = {
   url: string;
@@ -162,5 +165,80 @@ describe("gateway-client managed outbound lane", () => {
       chatId: "+15550001111",
       text: "standard gateway callback",
     });
+  });
+
+  test("throws ChannelDeliveryError with userMessage when gateway returns JSON error with userMessage", async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response(
+        JSON.stringify({
+          error: "Permission denied",
+          userMessage:
+            "The bot is not a member of this channel. Please invite it first.",
+        }),
+        { status: 403 },
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    let caught: unknown;
+    try {
+      await deliverChannelReply("https://gateway.test/deliver/slack", {
+        chatId: "C123",
+        text: "hello",
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(ChannelDeliveryError);
+    const deliveryError = caught as ChannelDeliveryError;
+    expect(deliveryError.statusCode).toBe(403);
+    expect(deliveryError.userMessage).toBe(
+      "The bot is not a member of this channel. Please invite it first.",
+    );
+    expect(deliveryError.message).toContain("403");
+  });
+
+  test("throws ChannelDeliveryError without userMessage when gateway returns JSON error without userMessage", async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response(JSON.stringify({ error: "Delivery failed" }), {
+        status: 502,
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    let caught: unknown;
+    try {
+      await deliverChannelReply("https://gateway.test/deliver/slack", {
+        chatId: "C123",
+        text: "hello",
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(ChannelDeliveryError);
+    const deliveryError = caught as ChannelDeliveryError;
+    expect(deliveryError.statusCode).toBe(502);
+    expect(deliveryError.userMessage).toBeUndefined();
+  });
+
+  test("throws ChannelDeliveryError without userMessage when gateway returns non-JSON error", async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response("Internal Server Error", { status: 500 });
+    }) as unknown as typeof globalThis.fetch;
+
+    let caught: unknown;
+    try {
+      await deliverChannelReply("https://gateway.test/deliver/slack", {
+        chatId: "C123",
+        text: "hello",
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(ChannelDeliveryError);
+    const deliveryError = caught as ChannelDeliveryError;
+    expect(deliveryError.statusCode).toBe(500);
+    expect(deliveryError.userMessage).toBeUndefined();
   });
 });

--- a/assistant/src/runtime/gateway-client.ts
+++ b/assistant/src/runtime/gateway-client.ts
@@ -6,6 +6,24 @@ import type { RuntimeAttachmentMetadata } from "./http-types.js";
 
 const log = getLogger("gateway-client");
 
+/**
+ * Error thrown when the gateway returns a non-OK response for channel delivery.
+ * Carries the optional `userMessage` field from the gateway so callers can
+ * surface actionable error text to end-users.
+ */
+export class ChannelDeliveryError extends Error {
+  readonly statusCode: number;
+  /** A user-facing error message from the gateway, if available. */
+  readonly userMessage?: string;
+
+  constructor(statusCode: number, body: string, userMessage?: string) {
+    super(`Channel reply delivery failed (${statusCode}): ${body}`);
+    this.name = "ChannelDeliveryError";
+    this.statusCode = statusCode;
+    this.userMessage = userMessage;
+  }
+}
+
 const DELIVERY_TIMEOUT_MS = 30_000;
 const MANAGED_OUTBOUND_SEND_PATH =
   "/v1/internal/managed-gateway/outbound-send/";
@@ -81,13 +99,36 @@ export async function deliverChannelReply(
 
   if (!response.ok) {
     const body = await response.text().catch(() => "<unreadable>");
+
+    // Try to extract userMessage from JSON error responses (e.g. from the
+    // Slack delivery endpoint) so callers can surface actionable errors.
+    let userMessage: string | undefined;
+    try {
+      const parsed = JSON.parse(body) as { userMessage?: string };
+      if (typeof parsed.userMessage === "string") {
+        userMessage = parsed.userMessage;
+      }
+    } catch {
+      // Body wasn't JSON — that's fine, userMessage stays undefined.
+    }
+
     log.error(
-      { status: response.status, body, callbackUrl, chatId: payload.chatId },
+      {
+        status: response.status,
+        body,
+        callbackUrl,
+        chatId: payload.chatId,
+        ...(userMessage && { userMessage }),
+      },
       "Channel reply delivery failed",
     );
-    throw new Error(
-      `Channel reply delivery failed (${response.status}): ${body}`,
-    );
+    if (userMessage) {
+      log.warn(
+        { chatId: payload.chatId, userMessage },
+        "Gateway returned actionable error for user",
+      );
+    }
+    throw new ChannelDeliveryError(response.status, body, userMessage);
   }
 
   const result: ChannelDeliveryResult = { ok: true };

--- a/gateway/src/__tests__/slack-errors.test.ts
+++ b/gateway/src/__tests__/slack-errors.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect } from "bun:test";
-import { classifySlackError, isRetryable } from "../slack/errors.js";
+import {
+  classifySlackError,
+  isRetryable,
+  getUserMessage,
+} from "../slack/errors.js";
 
 describe("classifySlackError", () => {
   test("classifies auth errors", () => {
@@ -73,5 +77,85 @@ describe("isRetryable", () => {
 
   test("channel_not_found is not retryable", () => {
     expect(isRetryable("channel_not_found")).toBe(false);
+  });
+});
+
+describe("getUserMessage", () => {
+  test("returns specific message for channel_not_found", () => {
+    expect(getUserMessage("channel_not_found")).toBe(
+      "I can't send messages to this channel. Please re-add me to the channel.",
+    );
+  });
+
+  test("returns specific message for not_in_channel", () => {
+    expect(getUserMessage("not_in_channel")).toBe(
+      "I need to be invited to this channel first. Please add me to the channel.",
+    );
+  });
+
+  test("returns specific message for missing_scope", () => {
+    expect(getUserMessage("missing_scope")).toBe(
+      "I don't have the required permissions. Please re-install the Slack app with the necessary scopes.",
+    );
+  });
+
+  test("returns specific message for token_revoked", () => {
+    expect(getUserMessage("token_revoked")).toBe(
+      "My Slack connection has expired. Please re-configure the Slack integration.",
+    );
+  });
+
+  test("returns specific message for token_expired", () => {
+    expect(getUserMessage("token_expired")).toBe(
+      "My Slack connection has expired. Please re-configure the Slack integration.",
+    );
+  });
+
+  test("returns specific message for invalid_auth", () => {
+    expect(getUserMessage("invalid_auth")).toBe(
+      "My Slack connection has expired. Please re-configure the Slack integration.",
+    );
+  });
+
+  test("returns specific message for is_archived", () => {
+    expect(getUserMessage("is_archived")).toBe(
+      "This channel has been archived. Please unarchive it or use a different channel.",
+    );
+  });
+
+  test("returns specific message for cannot_dm_bot", () => {
+    expect(getUserMessage("cannot_dm_bot")).toBe(
+      "I can't send direct messages to other bots.",
+    );
+  });
+
+  test("falls back to category message for auth errors without specific override", () => {
+    expect(getUserMessage("not_authed")).toBe(
+      "My Slack connection has expired. Please re-configure the Slack integration.",
+    );
+    expect(getUserMessage("account_inactive")).toBe(
+      "My Slack connection has expired. Please re-configure the Slack integration.",
+    );
+  });
+
+  test("falls back to category message for permission errors without specific override", () => {
+    expect(getUserMessage("ekm_access_denied")).toBe(
+      "I don't have the required permissions for this channel. Please check my access.",
+    );
+    expect(getUserMessage("restricted_action")).toBe(
+      "I don't have the required permissions for this channel. Please check my access.",
+    );
+  });
+
+  test("returns undefined for unknown errors", () => {
+    expect(getUserMessage("some_new_error")).toBeUndefined();
+    expect(getUserMessage(undefined)).toBeUndefined();
+    expect(getUserMessage("")).toBeUndefined();
+  });
+
+  test("returns message for rate_limit errors", () => {
+    expect(getUserMessage("rate_limited")).toBe(
+      "Slack rate limit reached. Please try again in a moment.",
+    );
   });
 });

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -9,7 +9,7 @@ import {
   downloadAttachment,
   type RuntimeAttachmentMeta,
 } from "../../runtime/client.js";
-import { classifySlackError } from "../../slack/errors.js";
+import { classifySlackError, getUserMessage } from "../../slack/errors.js";
 import { approvalPrompt, type Block } from "../../slack/block-kit-builder.js";
 import { textToBlocks } from "../../slack/text-to-blocks.js";
 
@@ -105,19 +105,33 @@ async function callSlackApiWithRetries(
         "Slack API returned error",
       );
 
+      const userMessage = getUserMessage(data.error);
+
       if (category === "rate_limit") {
-        return Response.json({ error: "Rate limited" }, { status: 429 });
+        return Response.json(
+          { error: "Rate limited", ...(userMessage && { userMessage }) },
+          { status: 429 },
+        );
       }
       if (category === "channel_not_found" || category === "not_found") {
-        return Response.json({ error: "Channel not found" }, { status: 404 });
+        return Response.json(
+          { error: "Channel not found", ...(userMessage && { userMessage }) },
+          { status: 404 },
+        );
       }
       if (category === "permission") {
-        return Response.json({ error: "Permission denied" }, { status: 403 });
+        return Response.json(
+          { error: "Permission denied", ...(userMessage && { userMessage }) },
+          { status: 403 },
+        );
       }
       // Auth errors use 502 so downstream retry logic treats them as
       // transient (token rotation, brief credential desync). Permanent
       // auth failures will exhaust retries and be dead-lettered normally.
-      return Response.json({ error: "Delivery failed" }, { status: 502 });
+      return Response.json(
+        { error: "Delivery failed", ...(userMessage && { userMessage }) },
+        { status: 502 },
+      );
     }
 
     return { ok: true, ts: data.ts };

--- a/gateway/src/slack/errors.ts
+++ b/gateway/src/slack/errors.ts
@@ -65,3 +65,56 @@ export function isRetryable(category: SlackErrorCategory): boolean {
     category === "unknown"
   );
 }
+
+/**
+ * User-friendly error messages by category.
+ * These are actionable: they tell the user what to do to fix the problem.
+ */
+const CATEGORY_USER_MESSAGES: Record<SlackErrorCategory, string | undefined> = {
+  auth: "My Slack connection has expired. Please re-configure the Slack integration.",
+  channel_not_found:
+    "I can't find this channel. It may have been deleted or I may need to be re-added.",
+  permission:
+    "I don't have the required permissions for this channel. Please check my access.",
+  not_found: "The requested resource could not be found in Slack.",
+  rate_limit: "Slack rate limit reached. Please try again in a moment.",
+  transient: undefined,
+  unknown: undefined,
+};
+
+/**
+ * More specific user messages for individual Slack error codes, overriding
+ * the category-level default when a more actionable message is available.
+ */
+const ERROR_CODE_USER_MESSAGES: Record<string, string> = {
+  channel_not_found:
+    "I can't send messages to this channel. Please re-add me to the channel.",
+  is_archived:
+    "This channel has been archived. Please unarchive it or use a different channel.",
+  not_in_channel:
+    "I need to be invited to this channel first. Please add me to the channel.",
+  missing_scope:
+    "I don't have the required permissions. Please re-install the Slack app with the necessary scopes.",
+  cannot_dm_bot: "I can't send direct messages to other bots.",
+  token_revoked:
+    "My Slack connection has expired. Please re-configure the Slack integration.",
+  token_expired:
+    "My Slack connection has expired. Please re-configure the Slack integration.",
+  invalid_auth:
+    "My Slack connection has expired. Please re-configure the Slack integration.",
+};
+
+/**
+ * Return a user-friendly, actionable error message for a Slack error.
+ * Prefers a code-specific message, then falls back to the category default.
+ * Returns `undefined` for transient/unknown errors that have no useful user guidance.
+ */
+export function getUserMessage(
+  errorCode: string | undefined,
+): string | undefined {
+  if (errorCode && ERROR_CODE_USER_MESSAGES[errorCode]) {
+    return ERROR_CODE_USER_MESSAGES[errorCode];
+  }
+  const category = classifySlackError(errorCode);
+  return CATEGORY_USER_MESSAGES[category];
+}


### PR DESCRIPTION
## Summary
- Add a `getUserMessage()` function to `gateway/src/slack/errors.ts` that maps Slack API error codes to actionable, user-friendly messages (e.g. "I need to be invited to this channel first" instead of "Permission denied")
- Include `userMessage` field in Slack delivery error responses so downstream consumers can display helpful guidance
- Cover all error categories: auth (re-configure integration), channel_not_found (re-add bot), permission (missing scopes / not in channel), with code-specific overrides for the most common errors

## Test plan
- [x] All 26 existing + new `getUserMessage` tests pass (`bun test src/__tests__/slack-errors.test.ts`)
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] Lint passes (pre-commit hook)

Closes JARVIS-306

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
