### PR TITLE
feat: use Slack Assistants API for native thinking status

### DIFF
--- a/assistant/src/runtime/gateway-client.ts
+++ b/assistant/src/runtime/gateway-client.ts
@@ -37,6 +37,8 @@ export interface ChannelReplyPayload {
   useBlocks?: boolean;
   /** When provided, add or remove an emoji reaction on a message. */
   reaction?: { action: "add" | "remove"; name: string; messageTs: string };
+  /** When provided, set or clear the Slack Assistants API thread status. */
+  assistantThreadStatus?: { channel: string; threadTs: string; status: string };
 }
 
 export interface ChannelDeliveryResult {

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -650,7 +650,6 @@ export async function handleChannelInbound(
       mintBearerToken,
       assistantId: canonicalAssistantId,
       approvalCopyGenerator,
-      externalMessageId: sourceMessageId ?? externalMessageId,
       chatType: sourceChatType,
     });
   }

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -106,7 +106,6 @@ export function processChannelMessageInBackground(
     approvalCopyGenerator,
     commandIntent,
     sourceLanguageCode,
-    externalMessageId,
     chatType,
   } = params;
 
@@ -126,18 +125,18 @@ export function processChannelMessageInBackground(
         )
       : undefined;
 
-    // Add 👀 reaction to the inbound Slack message as a processing indicator
-    const removeSlackReaction =
-      shouldEmitSlackReaction(sourceChannel, replyCallbackUrl) &&
-      externalMessageId
-        ? addSlackEyesReaction(
-            replyCallbackUrl!,
-            externalChatId,
-            externalMessageId,
-            mintBearerToken,
-            assistantId,
-          )
-        : undefined;
+    // Set Slack Assistants API "is thinking..." status indicator
+    const clearSlackThinkingStatus = shouldEmitSlackReaction(
+      sourceChannel,
+      replyCallbackUrl,
+    )
+      ? setSlackThinkingStatus(
+          replyCallbackUrl!,
+          externalChatId,
+          mintBearerToken,
+          assistantId,
+        )
+      : undefined;
     const stopApprovalWatcher = replyCallbackUrl
       ? startPendingApprovalPromptWatcher({
           conversationId,
@@ -230,7 +229,7 @@ export function processChannelMessageInBackground(
       deliveryStatus.recordProcessingFailure(eventId, err);
     } finally {
       stopTypingHeartbeat?.();
-      removeSlackReaction?.();
+      clearSlackThinkingStatus?.();
       stopApprovalWatcher?.();
       stopTcApprovalNotifier?.();
     }
@@ -295,7 +294,7 @@ export function startTelegramTypingHeartbeat(
 }
 
 // ---------------------------------------------------------------------------
-// Slack eyes reaction indicator
+// Slack Assistants API thinking status indicator
 // ---------------------------------------------------------------------------
 
 export function shouldEmitSlackReaction(
@@ -310,65 +309,80 @@ export function shouldEmitSlackReaction(
   }
 }
 
-const SLACK_EYES_MAX_DURATION_MS = 120_000;
+const SLACK_THINKING_MAX_DURATION_MS = 120_000;
 
 /**
- * Add a 👀 reaction to the inbound Slack message and return a cleanup
- * function that removes it. Both operations are fire-and-forget.
+ * Set the Slack Assistants API "is thinking..." status on the thread and
+ * return a cleanup function that clears it. Both operations are fire-and-forget.
  *
- * A safety timer auto-removes the reaction after {@link SLACK_EYES_MAX_DURATION_MS}
- * to prevent stuck eyes when `processMessage` hangs (e.g. queued behind
- * an active session turn that never completes for this message).
+ * A safety timer auto-clears the status after {@link SLACK_THINKING_MAX_DURATION_MS}
+ * to prevent a stuck indicator when `processMessage` hangs.
  */
-export function addSlackEyesReaction(
+export function setSlackThinkingStatus(
   callbackUrl: string,
   chatId: string,
-  messageTs: string,
   mintBearerToken: () => string,
   assistantId?: string,
 ): () => void {
-  let removed = false;
+  let cleared = false;
 
-  // Track the add promise so remove waits for it to settle first,
-  // preventing a race where remove arrives at Slack before add.
-  const addPromise = deliverChannelReply(
+  // Extract the thread timestamp from the callback URL so we can target
+  // the correct thread for the Assistants API status.
+  const threadTs = extractThreadTsFromCallbackUrl(callbackUrl);
+
+  // If there's no thread context, we can't set a thread status — bail.
+  if (!threadTs) {
+    return () => {};
+  }
+
+  // Track the set promise so clear waits for it to settle first,
+  // preventing a race where clear arrives at Slack before set.
+  const setPromise = deliverChannelReply(
     callbackUrl,
     {
       chatId,
       assistantId,
-      reaction: { action: "add", name: "eyes", messageTs },
+      assistantThreadStatus: {
+        channel: chatId,
+        threadTs,
+        status: "is thinking...",
+      },
     },
     mintBearerToken(),
   ).catch((err) => {
-    log.debug({ err, chatId, messageTs }, "Failed to add Slack eyes reaction");
+    log.debug({ err, chatId, threadTs }, "Failed to set Slack thinking status");
   });
 
-  const removeReaction = () => {
-    if (removed) return;
-    removed = true;
+  const clearStatus = () => {
+    if (cleared) return;
+    cleared = true;
     clearTimeout(safetyTimer);
-    void addPromise.then(() =>
+    void setPromise.then(() =>
       deliverChannelReply(
         callbackUrl,
         {
           chatId,
           assistantId,
-          reaction: { action: "remove", name: "eyes", messageTs },
+          assistantThreadStatus: {
+            channel: chatId,
+            threadTs,
+            status: "",
+          },
         },
         mintBearerToken(),
       ).catch((err) => {
         log.debug(
-          { err, chatId, messageTs },
-          "Failed to remove Slack eyes reaction",
+          { err, chatId, threadTs },
+          "Failed to clear Slack thinking status",
         );
       }),
     );
   };
 
-  const safetyTimer = setTimeout(removeReaction, SLACK_EYES_MAX_DURATION_MS);
+  const safetyTimer = setTimeout(clearStatus, SLACK_THINKING_MAX_DURATION_MS);
   (safetyTimer as { unref?: () => void }).unref?.();
 
-  return removeReaction;
+  return clearStatus;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -75,8 +75,6 @@ export interface BackgroundProcessingParams {
   approvalCopyGenerator?: ApprovalCopyGenerator;
   commandIntent?: Record<string, unknown>;
   sourceLanguageCode?: string;
-  /** External message ID (e.g. Slack message ts) used for reaction indicators. */
-  externalMessageId?: string;
   /** Chat type from the gateway (e.g. "private", "group", "supergroup"). */
   chatType?: string;
 }

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -370,6 +370,12 @@ export function createSlackDeliverHandler(
       chatAction?: "typing";
       /** Add or remove an emoji reaction on a message. */
       reaction?: { action: "add" | "remove"; name: string; messageTs: string };
+      /** Set or clear the Slack Assistants API thread status indicator. */
+      assistantThreadStatus?: {
+        channel: string;
+        threadTs: string;
+        status: string;
+      };
       /** Message timestamp to update instead of posting a new message. */
       updateTs?: string;
       /** When provided, use chat.update to edit an existing message instead of posting a new one. */
@@ -445,6 +451,7 @@ export function createSlackDeliverHandler(
       !text &&
       !chatAction &&
       !body.reaction &&
+      !body.assistantThreadStatus &&
       (!attachments || attachments.length === 0)
     ) {
       return Response.json(
@@ -598,6 +605,50 @@ export function createSlackDeliverHandler(
           tlog.warn(
             { err, chatId, method },
             "Failed to deliver Slack reaction",
+          );
+        }
+
+        return Response.json({ ok: true });
+      }
+
+      // Slack Assistants API thread status indicator.
+      // Sets or clears the native "is thinking..." status on a thread.
+      if (body.assistantThreadStatus) {
+        const {
+          channel,
+          threadTs: statusThreadTs,
+          status,
+        } = body.assistantThreadStatus;
+        try {
+          const res = await fetchImpl(
+            "https://slack.com/api/assistant.threads.setStatus",
+            {
+              method: "POST",
+              headers: {
+                Authorization: `Bearer ${botToken}`,
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                channel_id: channel,
+                thread_ts: statusThreadTs,
+                status,
+              }),
+            },
+          );
+          const data = (await res.json()) as {
+            ok?: boolean;
+            error?: string;
+          };
+          if (!data.ok) {
+            tlog.warn(
+              { chatId, slackError: data.error },
+              "Slack assistant.threads.setStatus returned error",
+            );
+          }
+        } catch (err) {
+          tlog.warn(
+            { err, chatId },
+            "Failed to set Slack assistant thread status",
           );
         }
 

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -613,12 +613,14 @@ export function createSlackDeliverHandler(
 
       // Slack Assistants API thread status indicator.
       // Sets or clears the native "is thinking..." status on a thread.
+      // Falls back to emoji reactions for installs without `assistant:write` scope.
       if (body.assistantThreadStatus) {
         const {
           channel,
           threadTs: statusThreadTs,
           status,
         } = body.assistantThreadStatus;
+        let statusSet = false;
         try {
           const res = await fetchImpl(
             "https://slack.com/api/assistant.threads.setStatus",
@@ -639,17 +641,59 @@ export function createSlackDeliverHandler(
             ok?: boolean;
             error?: string;
           };
-          if (!data.ok) {
+          if (data.ok) {
+            statusSet = true;
+          } else {
             tlog.warn(
               { chatId, slackError: data.error },
-              "Slack assistant.threads.setStatus returned error",
+              "Slack assistant.threads.setStatus returned error, falling back to reaction",
             );
           }
         } catch (err) {
           tlog.warn(
             { err, chatId },
-            "Failed to set Slack assistant thread status",
+            "Failed to set Slack assistant thread status, falling back to reaction",
           );
+        }
+
+        // Fallback: use eyes reaction when setStatus is unavailable
+        // (e.g. missing assistant:write scope on older installs).
+        if (!statusSet) {
+          const isSet = status.length > 0;
+          const method = isSet ? "reactions.add" : "reactions.remove";
+          try {
+            const res = await fetchImpl(`https://slack.com/api/${method}`, {
+              method: "POST",
+              headers: {
+                Authorization: `Bearer ${botToken}`,
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                channel,
+                name: "eyes",
+                timestamp: statusThreadTs,
+              }),
+            });
+            const data = (await res.json()) as {
+              ok?: boolean;
+              error?: string;
+            };
+            if (
+              !data.ok &&
+              data.error !== "already_reacted" &&
+              data.error !== "no_reaction"
+            ) {
+              tlog.warn(
+                { chatId, method, slackError: data.error },
+                "Slack reaction fallback returned error",
+              );
+            }
+          } catch (err) {
+            tlog.warn(
+              { err, chatId, method },
+              "Failed to deliver Slack reaction fallback",
+            );
+          }
         }
 
         return Response.json({ ok: true });

--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -61,6 +61,7 @@ Generate the manifest JSON:
     "scopes": {
       "bot": [
         "app_mentions:read",
+        "assistant:write",
         "channels:history",
         "chat:write",
         "files:write",


### PR DESCRIPTION
## Summary
- Replace the eyes reaction (👀) processing indicator with Slack's `assistant.threads.setStatus` API for a native "is thinking..." status in threads
- Add `assistantThreadStatus` action type to the gateway's Slack deliver handler and the assistant's `ChannelReplyPayload`
- Add `assistant:write` scope to the Slack app manifest in `skills/slack-app-setup/SKILL.md`

Closes JARVIS-304

## Test plan
- [x] Gateway type-check passes (`bunx tsc --noEmit`)
- [x] All 36 slack-deliver tests pass
- [x] All 7 slack-deliver-ratelimit tests pass
- [x] All 4 background-dispatch tests pass
- [x] Pre-existing assistant tsc errors only (zod/v4 in ces-contracts, not from this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
