### PR TITLE
feat: include requester's message preview in access request notifications

### DIFF
--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -18,6 +18,7 @@ import {
   hasInviteFlowDirective,
   normalizeForDirectiveMatching,
   sanitizeIdentityField,
+  sanitizeMessagePreview,
 } from "../notifications/copy-composer.js";
 import {
   enforceGuardianCallConversationAffinity,
@@ -593,6 +594,31 @@ describe("notification decision strategy", () => {
       expect(sanitizeIdentityField("O'Brien")).toBe("O'Brien");
       expect(sanitizeIdentityField("user@domain.com")).toBe("user@domain.com");
       expect(sanitizeIdentityField('"quoted"')).toBe('"quoted"');
+    });
+  });
+
+  describe("access-request message preview sanitization", () => {
+    test("strips control characters from message previews", () => {
+      expect(sanitizeMessagePreview("Hello\nWorld")).toBe("Hello World");
+      expect(sanitizeMessagePreview("Test\r\nMessage")).toBe("Test Message");
+    });
+
+    test("clamps to 200 characters (not 120)", () => {
+      const longMessage = "A".repeat(250);
+      const result = sanitizeMessagePreview(longMessage);
+      expect(result.length).toBeLessThanOrEqual(201); // 200 + '…'
+      expect(result).toEndWith("…");
+
+      // Verify it allows messages longer than the identity field limit (120)
+      const midMessage = "B".repeat(150);
+      const midResult = sanitizeMessagePreview(midMessage);
+      expect(midResult).toBe(midMessage); // no truncation at 150 chars
+    });
+
+    test("preserves normal messages", () => {
+      expect(sanitizeMessagePreview("Hello, can you help me?")).toBe(
+        "Hello, can you help me?",
+      );
     });
   });
 

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -130,6 +130,35 @@ export function buildAccessRequestIdentityLine(
   return `${parts.join(" ")} is requesting access to the assistant.`;
 }
 
+const MESSAGE_PREVIEW_MAX_LENGTH = 200;
+
+/**
+ * Build a quoted preview of the requester's original message for inclusion
+ * in guardian-facing access-request copy. Sanitizes and truncates to keep
+ * the notification concise.
+ *
+ * Returns `undefined` when no usable preview is available.
+ */
+export function buildAccessRequestMessagePreview(
+  payload: Record<string, unknown>,
+): string | undefined {
+  const raw =
+    typeof payload.messagePreview === "string"
+      ? payload.messagePreview
+      : undefined;
+  if (!raw) return undefined;
+
+  const sanitized = sanitizeIdentityField(raw);
+  if (sanitized.length === 0) return undefined;
+
+  const truncated =
+    sanitized.length > MESSAGE_PREVIEW_MAX_LENGTH
+      ? sanitized.slice(0, MESSAGE_PREVIEW_MAX_LENGTH) + "..."
+      : sanitized;
+
+  return `> Their message: "${truncated}"`;
+}
+
 export function buildAccessRequestInviteDirective(): string {
   return 'Reply "open invite flow" to start Trusted Contacts invite flow.';
 }
@@ -240,6 +269,10 @@ export function buildAccessRequestContractText(
 
   const lines: string[] = [];
   lines.push(buildAccessRequestIdentityLine(payload));
+  const preview = buildAccessRequestMessagePreview(payload);
+  if (preview) {
+    lines.push(preview);
+  }
   if (previousMemberStatus === "revoked") {
     lines.push("Note: this user was previously revoked.");
   }

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -130,7 +130,23 @@ export function buildAccessRequestIdentityLine(
   return `${parts.join(" ")} is requesting access to the assistant.`;
 }
 
-const MESSAGE_PREVIEW_MAX_LENGTH = 200;
+export const MESSAGE_PREVIEW_MAX_LENGTH = 200;
+
+/**
+ * Sanitize an untrusted message preview for inclusion in notification copy.
+ *
+ * Like {@link sanitizeIdentityField} but uses the higher
+ * MESSAGE_PREVIEW_MAX_LENGTH limit (200 chars) instead of the identity
+ * field limit (120 chars).
+ */
+export function sanitizeMessagePreview(value: string): string {
+  const stripped = value.replace(/[\x00-\x1f\x7f-\x9f\r\n]+/g, " ").trim();
+  const clamped =
+    stripped.length > MESSAGE_PREVIEW_MAX_LENGTH
+      ? stripped.slice(0, MESSAGE_PREVIEW_MAX_LENGTH) + "…"
+      : stripped;
+  return clamped;
+}
 
 /**
  * Build a quoted preview of the requester's original message for inclusion
@@ -148,15 +164,10 @@ export function buildAccessRequestMessagePreview(
       : undefined;
   if (!raw) return undefined;
 
-  const sanitized = sanitizeIdentityField(raw);
+  const sanitized = sanitizeMessagePreview(raw);
   if (sanitized.length === 0) return undefined;
 
-  const truncated =
-    sanitized.length > MESSAGE_PREVIEW_MAX_LENGTH
-      ? sanitized.slice(0, MESSAGE_PREVIEW_MAX_LENGTH) + "..."
-      : sanitized;
-
-  return `> Their message: "${truncated}"`;
+  return `> Their message: "${sanitized}"`;
 }
 
 export function buildAccessRequestInviteDirective(): string {

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -151,6 +151,8 @@ export interface AccessRequestContextPayload {
   guardianBindingChannel: string | null;
   guardianResolutionSource: GuardianResolutionSource;
   previousMemberStatus: string | null;
+  /** Preview of the requester's original message (first ~200 chars). */
+  messagePreview: string | null;
 }
 
 export interface NotificationEventContextPayloadMap {

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -55,6 +55,8 @@ export interface AccessRequestParams {
   actorDisplayName?: string;
   actorUsername?: string;
   previousMemberStatus?: Exclude<ChannelStatus, "unverified">;
+  /** Preview of the requester's original message, shown to the guardian. */
+  messagePreview?: string;
 }
 
 export type AccessRequestResult =
@@ -90,6 +92,7 @@ export function notifyGuardianOfAccessRequest(
     actorDisplayName,
     actorUsername,
     previousMemberStatus,
+    messagePreview,
   } = params;
 
   if (!actorExternalId) {
@@ -244,6 +247,7 @@ export function notifyGuardianOfAccessRequest(
       guardianBindingChannel,
       guardianResolutionSource,
       previousMemberStatus: previousMemberStatus ?? null,
+      messagePreview: messagePreview ?? null,
     },
     dedupeKey: `access-request:${canonicalRequest.id}`,
     onConversationCreated: (info) => {

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -362,6 +362,7 @@ export async function enforceIngressAcl(
                 actorExternalId: canonicalSenderId ?? rawSenderId,
                 actorDisplayName,
                 actorUsername,
+                messagePreview: trimmedContent,
               });
             } catch (err) {
               log.error(
@@ -428,6 +429,7 @@ export async function enforceIngressAcl(
             actorExternalId: canonicalSenderId ?? rawSenderId,
             actorDisplayName,
             actorUsername,
+            messagePreview: trimmedContent,
           });
           guardianNotified = accessResult.notified;
         } catch (err) {
@@ -620,6 +622,7 @@ export async function enforceIngressAcl(
                   previousMemberStatus: channelStatusToMemberStatus(
                     resolvedMember.channel.status,
                   ),
+                  messagePreview: trimmedContent,
                 });
               } catch (err) {
                 log.error(
@@ -686,6 +689,7 @@ export async function enforceIngressAcl(
                 previousMemberStatus: channelStatusToMemberStatus(
                   resolvedMember.channel.status,
                 ),
+                messagePreview: trimmedContent,
               });
               guardianNotified = accessResult.notified;
             } catch (err) {

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -24,8 +24,10 @@ import {
   findByInviteCodeHash,
   findByInviteCodeHashAnyChannel,
 } from "../../../memory/invite-store.js";
+import { MESSAGE_PREVIEW_MAX_LENGTH } from "../../../notifications/copy-composer.js";
 import { resolveGuardianName } from "../../../prompts/user-reference.js";
 import { getLogger } from "../../../util/logger.js";
+import { truncate } from "../../../util/truncate.js";
 import { hashVoiceCode } from "../../../util/voice-code.js";
 import { notifyGuardianOfAccessRequest } from "../../access-request-helper.js";
 import { getInviteAdapterRegistry } from "../../channel-invite-transport.js";
@@ -362,7 +364,10 @@ export async function enforceIngressAcl(
                 actorExternalId: canonicalSenderId ?? rawSenderId,
                 actorDisplayName,
                 actorUsername,
-                messagePreview: trimmedContent,
+                messagePreview: truncate(
+                  trimmedContent,
+                  MESSAGE_PREVIEW_MAX_LENGTH,
+                ),
               });
             } catch (err) {
               log.error(
@@ -429,7 +434,10 @@ export async function enforceIngressAcl(
             actorExternalId: canonicalSenderId ?? rawSenderId,
             actorDisplayName,
             actorUsername,
-            messagePreview: trimmedContent,
+            messagePreview: truncate(
+              trimmedContent,
+              MESSAGE_PREVIEW_MAX_LENGTH,
+            ),
           });
           guardianNotified = accessResult.notified;
         } catch (err) {
@@ -622,7 +630,10 @@ export async function enforceIngressAcl(
                   previousMemberStatus: channelStatusToMemberStatus(
                     resolvedMember.channel.status,
                   ),
-                  messagePreview: trimmedContent,
+                  messagePreview: truncate(
+                    trimmedContent,
+                    MESSAGE_PREVIEW_MAX_LENGTH,
+                  ),
                 });
               } catch (err) {
                 log.error(
@@ -689,7 +700,10 @@ export async function enforceIngressAcl(
                 previousMemberStatus: channelStatusToMemberStatus(
                   resolvedMember.channel.status,
                 ),
-                messagePreview: trimmedContent,
+                messagePreview: truncate(
+                  trimmedContent,
+                  MESSAGE_PREVIEW_MAX_LENGTH,
+                ),
               });
               guardianNotified = accessResult.notified;
             } catch (err) {


### PR DESCRIPTION
## Summary
- Pass the requester's original message text (`trimmedContent`) through the access request notification pipeline as `messagePreview`
- Add `buildAccessRequestMessagePreview()` to the copy composer that sanitizes, truncates (200 chars), and formats the preview as `> Their message: "..."`
- Include the preview in the guardian-facing access request contract text, positioned right after the identity line

Closes JARVIS-308

## Test plan
- [x] `notification-decision-strategy.test.ts` — 72 tests pass (includes access-request contract text builder tests)
- [x] `non-member-access-request.test.ts` — 15 tests pass
- [x] Type-checking passes (`bunx tsc --noEmit`)
- [ ] Manual: send a message as an unrecognized user and verify the guardian notification includes the message preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
