### PR TITLE
feat: reaction approval hint and guardian DM confirmation

### DIFF
--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -520,11 +520,11 @@ const accessRequestResolver: GuardianRequestResolver = {
       let codeDelivered = true;
 
       // Deliver verification code to guardian
+      const codeText =
+        `You approved access for ${requesterExternalUserId}. ` +
+        `Give them this verification code: \`${session.secret}\`. ` +
+        `The code expires in 10 minutes.`;
       try {
-        const codeText =
-          `You approved access for ${requesterExternalUserId}. ` +
-          `Give them this verification code: \`${session.secret}\`. ` +
-          `The code expires in 10 minutes.`;
         await deliverChannelReply(
           channelDeliveryContext.replyCallbackUrl,
           {
@@ -540,6 +540,46 @@ const accessRequestResolver: GuardianRequestResolver = {
           "Failed to deliver verification code to guardian",
         );
         codeDelivered = false;
+      }
+
+      // If the guardian approved in a shared channel (not a DM), also send
+      // them a DM with the verification code for better privacy and
+      // discoverability. On Slack, posting to a user ID opens a DM.
+      const guardianUserId = ctx.actor.actorExternalUserId;
+      if (
+        codeDelivered &&
+        channel === "slack" &&
+        guardianUserId &&
+        channelDeliveryContext.guardianChatId !== guardianUserId
+      ) {
+        // Strip threadTs from the callback URL — it belongs to the shared
+        // channel thread and would cause thread_not_found errors in the DM.
+        let dmCallbackUrl = channelDeliveryContext.replyCallbackUrl;
+        try {
+          const url = new URL(channelDeliveryContext.replyCallbackUrl);
+          url.searchParams.delete("threadTs");
+          dmCallbackUrl = url.toString();
+        } catch {
+          // Malformed URL — use as-is
+        }
+
+        try {
+          await deliverChannelReply(
+            dmCallbackUrl,
+            {
+              chatId: guardianUserId,
+              text: codeText,
+              assistantId,
+            },
+            channelDeliveryContext.bearerToken,
+          );
+        } catch (err) {
+          // Best-effort: the code was already delivered in the shared channel
+          log.warn(
+            { err, guardianUserId },
+            "Failed to send guardian DM confirmation with verification code",
+          );
+        }
       }
 
       // Notify the requester

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -550,7 +550,7 @@ const accessRequestResolver: GuardianRequestResolver = {
         codeDelivered &&
         channel === "slack" &&
         guardianUserId &&
-        channelDeliveryContext.guardianChatId !== guardianUserId
+        !channelDeliveryContext.guardianChatId.startsWith("D")
       ) {
         // Strip threadTs from the callback URL — it belongs to the shared
         // channel thread and would cause thread_not_found errors in the DM.
@@ -582,13 +582,29 @@ const accessRequestResolver: GuardianRequestResolver = {
         }
       }
 
-      // Notify the requester
+      // Notify the requester. For Slack, route to DM via the user ID and
+      // strip threadTs (which belongs to the guardian's channel thread).
+      const requesterTargetChatId =
+        channel === "slack" && requesterExternalUserId
+          ? requesterExternalUserId
+          : requesterChatId;
+      let requesterCallbackUrl = channelDeliveryContext.replyCallbackUrl;
+      if (channel === "slack" && requesterExternalUserId) {
+        try {
+          const url = new URL(channelDeliveryContext.replyCallbackUrl);
+          url.searchParams.delete("threadTs");
+          requesterCallbackUrl = url.toString();
+        } catch {
+          // Malformed URL — use as-is
+        }
+      }
+
       if (codeDelivered) {
         try {
           await deliverChannelReply(
-            channelDeliveryContext.replyCallbackUrl,
+            requesterCallbackUrl,
             {
-              chatId: requesterChatId,
+              chatId: requesterTargetChatId,
               text:
                 "Your access request has been approved! " +
                 "Please enter the 6-digit verification code you receive from the guardian.",
@@ -606,9 +622,9 @@ const accessRequestResolver: GuardianRequestResolver = {
       } else {
         try {
           await deliverChannelReply(
-            channelDeliveryContext.replyCallbackUrl,
+            requesterCallbackUrl,
             {
-              chatId: requesterChatId,
+              chatId: requesterTargetChatId,
               text:
                 "Your access request was approved, but we were unable to " +
                 "deliver the verification code. Please try again later.",

--- a/gateway/src/slack/block-kit-builder.test.ts
+++ b/gateway/src/slack/block-kit-builder.test.ts
@@ -154,7 +154,7 @@ describe("BlockKitBuilder", () => {
 // ---------------------------------------------------------------------------
 
 describe("approvalPrompt", () => {
-  it("produces section + actions blocks", () => {
+  it("produces section + actions + context blocks", () => {
     const blocks = approvalPrompt({
       message: "Allow file access?",
       requestId: "req-1",
@@ -164,13 +164,20 @@ describe("approvalPrompt", () => {
       ],
     });
 
-    expect(blocks).toHaveLength(2);
+    expect(blocks).toHaveLength(3);
     expect(blocks[0].type).toBe("section");
     expect((blocks[0] as SectionBlock).text.text).toBe("Allow file access?");
 
     const actions = blocks[1] as ActionsBlock;
     expect(actions.type).toBe("actions");
     expect(actions.elements).toHaveLength(2);
+
+    const ctx = blocks[2] as ContextBlock;
+    expect(ctx.type).toBe("context");
+    expect(ctx.elements[0]).toEqual({
+      type: "mrkdwn",
+      text: "You can also react with :thumbsup: to approve or :thumbsdown: to deny",
+    });
   });
 
   it("encodes requestId and actionId into action_id", () => {
@@ -212,7 +219,7 @@ describe("permissionRequest", () => {
       requestId: "req-99",
     });
 
-    expect(blocks).toHaveLength(2);
+    expect(blocks).toHaveLength(3);
     const actions = blocks[1] as ActionsBlock;
     expect(actions.elements).toHaveLength(2);
 

--- a/gateway/src/slack/block-kit-builder.ts
+++ b/gateway/src/slack/block-kit-builder.ts
@@ -178,6 +178,9 @@ export function approvalPrompt(opts: {
   return new BlockKitBuilder()
     .section(opts.message)
     .actions(buttons)
+    .contextMrkdwn(
+      "You can also react with :thumbsup: to approve or :thumbsdown: to deny",
+    )
     .toBlocks();
 }
 


### PR DESCRIPTION
## Summary
- **JARVIS-310**: Adds a context hint below Slack approval prompt buttons informing users they can react with :thumbsup: to approve or :thumbsdown: to deny.
- **JARVIS-311**: When a guardian approves an access request in a shared Slack channel, sends them a DM with the verification code for better privacy and discoverability. The DM is only sent when the approval happened in a shared channel (not already a DM) to avoid duplicates.

Closes JARVIS-310
Closes JARVIS-311

## Test plan
- [x] `gateway/src/slack/block-kit-builder.test.ts` — updated to expect the new context block in `approvalPrompt()` and `permissionRequest()` output
- [x] `assistant/src/__tests__/slack-reaction-approvals.test.ts` — existing tests pass (reaction mapping unchanged)
- [x] Type-check passes in both gateway and assistant packages
- [ ] Manual: trigger an approval prompt in Slack and verify the reaction hint appears
- [ ] Manual: approve an access request in a shared Slack channel and verify the guardian receives a DM with the code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
