### PR TITLE
fix: deduplicate stale approval ephemeral messages

### DIFF
--- a/assistant/src/__tests__/stale-approval-dedup.test.ts
+++ b/assistant/src/__tests__/stale-approval-dedup.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the module under test
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+const deliveredMessages: Array<{
+  url: string;
+  body: Record<string, unknown>;
+}> = [];
+
+mock.module("../runtime/gateway-client.js", () => ({
+  deliverChannelReply: async (url: string, body: Record<string, unknown>) => {
+    deliveredMessages.push({ url, body });
+  },
+}));
+
+mock.module("../runtime/approval-message-composer.js", () => ({
+  composeApprovalMessageGenerative: async () => "Already resolved.",
+}));
+
+// ---------------------------------------------------------------------------
+// Import the module under test after mocks are set up
+// ---------------------------------------------------------------------------
+
+import type pino from "pino";
+
+import {
+  clearStaleNotificationCache,
+  deliverStaleApprovalReply,
+} from "../runtime/routes/guardian-approval-reply-helpers.js";
+
+const noopLogger = new Proxy({} as pino.Logger, {
+  get: () => () => {},
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("deliverStaleApprovalReply deduplication", () => {
+  beforeEach(() => {
+    deliveredMessages.length = 0;
+    clearStaleNotificationCache();
+  });
+
+  afterEach(() => {
+    clearStaleNotificationCache();
+  });
+
+  test("sends the first 'approval_already_resolved' notification", async () => {
+    await deliverStaleApprovalReply({
+      scenario: "approval_already_resolved",
+      sourceChannel: "slack",
+      replyCallbackUrl: "https://example.com/reply",
+      chatId: "chat-1",
+      assistantId: "asst-1",
+      logger: noopLogger,
+      errorLogMessage: "test",
+    });
+
+    expect(deliveredMessages).toHaveLength(1);
+  });
+
+  test("suppresses duplicate 'approval_already_resolved' for the same chat", async () => {
+    const params = {
+      scenario: "approval_already_resolved" as const,
+      sourceChannel: "slack" as const,
+      replyCallbackUrl: "https://example.com/reply",
+      chatId: "chat-1",
+      assistantId: "asst-1",
+      logger: noopLogger,
+      errorLogMessage: "test",
+    };
+
+    await deliverStaleApprovalReply(params);
+    await deliverStaleApprovalReply(params);
+    await deliverStaleApprovalReply(params);
+
+    expect(deliveredMessages).toHaveLength(1);
+  });
+
+  test("allows 'approval_already_resolved' for different chats", async () => {
+    const base = {
+      scenario: "approval_already_resolved" as const,
+      sourceChannel: "slack" as const,
+      replyCallbackUrl: "https://example.com/reply",
+      assistantId: "asst-1",
+      logger: noopLogger,
+      errorLogMessage: "test",
+    };
+
+    await deliverStaleApprovalReply({ ...base, chatId: "chat-1" });
+    await deliverStaleApprovalReply({ ...base, chatId: "chat-2" });
+
+    expect(deliveredMessages).toHaveLength(2);
+  });
+
+  test("does not deduplicate non-'approval_already_resolved' scenarios", async () => {
+    const params = {
+      scenario: "reminder_prompt" as const,
+      sourceChannel: "slack" as const,
+      replyCallbackUrl: "https://example.com/reply",
+      chatId: "chat-1",
+      assistantId: "asst-1",
+      logger: noopLogger,
+      errorLogMessage: "test",
+    };
+
+    await deliverStaleApprovalReply(params);
+    await deliverStaleApprovalReply(params);
+
+    expect(deliveredMessages).toHaveLength(2);
+  });
+
+  test("allows re-send after cache is cleared (simulates TTL expiry)", async () => {
+    const params = {
+      scenario: "approval_already_resolved" as const,
+      sourceChannel: "slack" as const,
+      replyCallbackUrl: "https://example.com/reply",
+      chatId: "chat-1",
+      assistantId: "asst-1",
+      logger: noopLogger,
+      errorLogMessage: "test",
+    };
+
+    await deliverStaleApprovalReply(params);
+    expect(deliveredMessages).toHaveLength(1);
+
+    // Simulate TTL expiry
+    clearStaleNotificationCache();
+
+    await deliverStaleApprovalReply(params);
+    expect(deliveredMessages).toHaveLength(2);
+  });
+});

--- a/assistant/src/__tests__/stale-approval-dedup.test.ts
+++ b/assistant/src/__tests__/stale-approval-dedup.test.ts
@@ -16,8 +16,13 @@ const deliveredMessages: Array<{
   body: Record<string, unknown>;
 }> = [];
 
+let deliveryShouldFail = false;
+
 mock.module("../runtime/gateway-client.js", () => ({
   deliverChannelReply: async (url: string, body: Record<string, unknown>) => {
+    if (deliveryShouldFail) {
+      throw new Error("simulated delivery failure");
+    }
     deliveredMessages.push({ url, body });
   },
 }));
@@ -48,6 +53,7 @@ const noopLogger = new Proxy({} as pino.Logger, {
 describe("deliverStaleApprovalReply deduplication", () => {
   beforeEach(() => {
     deliveredMessages.length = 0;
+    deliveryShouldFail = false;
     clearStaleNotificationCache();
   });
 
@@ -139,5 +145,27 @@ describe("deliverStaleApprovalReply deduplication", () => {
 
     await deliverStaleApprovalReply(params);
     expect(deliveredMessages).toHaveLength(2);
+  });
+
+  test("does not cache dedup key when delivery fails, allowing retries", async () => {
+    const params = {
+      scenario: "approval_already_resolved" as const,
+      sourceChannel: "slack" as const,
+      replyCallbackUrl: "https://example.com/reply",
+      chatId: "chat-1",
+      assistantId: "asst-1",
+      logger: noopLogger,
+      errorLogMessage: "test",
+    };
+
+    // First attempt fails — should not cache the dedup key
+    deliveryShouldFail = true;
+    await deliverStaleApprovalReply(params);
+    expect(deliveredMessages).toHaveLength(0);
+
+    // Second attempt succeeds — should not be suppressed by dedup
+    deliveryShouldFail = false;
+    await deliverStaleApprovalReply(params);
+    expect(deliveredMessages).toHaveLength(1);
   });
 });

--- a/assistant/src/runtime/routes/guardian-approval-reply-helpers.ts
+++ b/assistant/src/runtime/routes/guardian-approval-reply-helpers.ts
@@ -11,6 +11,25 @@ import { composeApprovalMessageGenerative } from "../approval-message-composer.j
 import { deliverChannelReply } from "../gateway-client.js";
 import type { ApprovalCopyGenerator } from "../http-types.js";
 
+// ---------------------------------------------------------------------------
+// Deduplication for "already resolved" ephemeral messages
+// ---------------------------------------------------------------------------
+
+/**
+ * Tracks recently sent stale approval notifications to prevent flooding the
+ * user when they rapidly click stale approval buttons. Keyed by
+ * `${chatId}:${scenario}` with a 30-second TTL per entry.
+ */
+const recentStaleNotifications = new Set<string>();
+
+/** TTL in milliseconds for dedup entries. Exported for testing. */
+export const STALE_DEDUP_TTL_MS = 30_000;
+
+/** Clear the dedup cache. Exported for testing only. */
+export function clearStaleNotificationCache(): void {
+  recentStaleNotifications.clear();
+}
+
 interface DeliverApprovalReplyParams {
   context: ApprovalMessageContext;
   replyCallbackUrl: string;
@@ -83,11 +102,28 @@ export interface DeliverStaleApprovalReplyParams {
 /**
  * Deliver a stale/already-resolved approval notice to a channel chat.
  * Consolidates the repeated compose + deliver + try/catch pattern.
+ *
+ * For `approval_already_resolved` scenarios, deduplicates notifications
+ * per chat so rapid stale button clicks don't flood the user with
+ * repeated ephemeral warnings.
  */
 export async function deliverStaleApprovalReply(
   params: DeliverStaleApprovalReplyParams,
 ): Promise<void> {
   const { scenario, sourceChannel, extraContext, ...rest } = params;
+
+  // Deduplicate "already resolved" ephemeral messages per chat.
+  // If the same (chatId, scenario) pair was notified within the TTL, skip.
+  if (scenario === "approval_already_resolved") {
+    const dedupeKey = `${rest.chatId}:${scenario}`;
+    if (recentStaleNotifications.has(dedupeKey)) {
+      return;
+    }
+    recentStaleNotifications.add(dedupeKey);
+    setTimeout(() => {
+      recentStaleNotifications.delete(dedupeKey);
+    }, STALE_DEDUP_TTL_MS);
+  }
 
   await deliverApprovalReply({
     ...rest,

--- a/assistant/src/runtime/routes/guardian-approval-reply-helpers.ts
+++ b/assistant/src/runtime/routes/guardian-approval-reply-helpers.ts
@@ -45,10 +45,9 @@ interface DeliverApprovalReplyParams {
 
 /**
  * Compose a generative approval message and deliver it as a channel reply.
- * Swallows delivery errors and logs them — callers don't need their own
- * try/catch blocks.
+ * Throws on failure — callers decide whether to swallow or propagate.
  */
-async function deliverApprovalReply(
+async function composeAndDeliver(
   params: DeliverApprovalReplyParams,
 ): Promise<void> {
   const {
@@ -58,24 +57,35 @@ async function deliverApprovalReply(
     assistantId,
     bearerToken,
     approvalCopyGenerator,
-    logger,
-    errorLogMessage,
-    errorLogContext,
   } = params;
 
+  const text = await composeApprovalMessageGenerative(
+    context,
+    {},
+    approvalCopyGenerator,
+  );
+  await deliverChannelReply(
+    replyCallbackUrl,
+    { chatId, text, assistantId },
+    bearerToken,
+  );
+}
+
+/**
+ * Compose a generative approval message and deliver it as a channel reply.
+ * Swallows delivery errors and logs them — callers don't need their own
+ * try/catch blocks.
+ */
+async function deliverApprovalReply(
+  params: DeliverApprovalReplyParams,
+): Promise<void> {
   try {
-    const text = await composeApprovalMessageGenerative(
-      context,
-      {},
-      approvalCopyGenerator,
-    );
-    await deliverChannelReply(
-      replyCallbackUrl,
-      { chatId, text, assistantId },
-      bearerToken,
-    );
+    await composeAndDeliver(params);
   } catch (err) {
-    logger.error({ err, ...errorLogContext }, errorLogMessage);
+    params.logger.error(
+      { err, ...params.errorLogContext },
+      params.errorLogMessage,
+    );
   }
 }
 
@@ -112,6 +122,15 @@ export async function deliverStaleApprovalReply(
 ): Promise<void> {
   const { scenario, sourceChannel, extraContext, ...rest } = params;
 
+  const replyParams: DeliverApprovalReplyParams = {
+    ...rest,
+    context: {
+      scenario,
+      channel: sourceChannel,
+      ...extraContext,
+    },
+  };
+
   // Deduplicate "already resolved" ephemeral messages per chat.
   // If the same (chatId, scenario) pair was notified within the TTL, skip.
   if (scenario === "approval_already_resolved") {
@@ -119,20 +138,22 @@ export async function deliverStaleApprovalReply(
     if (recentStaleNotifications.has(dedupeKey)) {
       return;
     }
-    recentStaleNotifications.add(dedupeKey);
-    setTimeout(() => {
-      recentStaleNotifications.delete(dedupeKey);
-    }, STALE_DEDUP_TTL_MS);
+
+    // Cache the dedup key only after successful delivery so that failures
+    // don't silently suppress retries for the TTL window.
+    try {
+      await composeAndDeliver(replyParams);
+      recentStaleNotifications.add(dedupeKey);
+      setTimeout(() => {
+        recentStaleNotifications.delete(dedupeKey);
+      }, STALE_DEDUP_TTL_MS);
+    } catch (err) {
+      rest.logger.error({ err, ...rest.errorLogContext }, rest.errorLogMessage);
+    }
+    return;
   }
 
-  await deliverApprovalReply({
-    ...rest,
-    context: {
-      scenario,
-      channel: sourceChannel,
-      ...extraContext,
-    },
-  });
+  await deliverApprovalReply(replyParams);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds an in-memory deduplication cache to `deliverStaleApprovalReply` that suppresses repeated "already resolved" ephemeral messages for the same chat within a 30-second window
- Prevents user flooding when rapidly clicking stale approval buttons
- Only deduplicates `approval_already_resolved` scenario; other stale scenarios (reminders, disambiguation) are unaffected

## Test plan
- [x] New test: `stale-approval-dedup.test.ts` — verifies first send goes through, duplicates are suppressed, different chats are independent, non-dedup scenarios are unaffected, and cache expiry allows re-send
- [x] Type-check passes (`bunx tsc --noEmit`)

Closes JARVIS-307

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
