### PR TITLE
fix: show Docker progress sheet for version-picker upgrade and rollback

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -20,6 +20,9 @@ struct AssistantUpgradeSection: View {
     let currentVersion: String?
     let topology: AssistantTopology
 
+    @Binding var isDockerOperationInProgress: Bool
+    @Binding var dockerOperationLabel: String
+
     @State private var availableReleases: [AssistantRelease] = []
     @State private var selectedVersion: String?
     @State private var isLoadingReleases = false
@@ -247,13 +250,16 @@ struct AssistantUpgradeSection: View {
         }
         let name = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
         let version = selectedVersion ?? latestRelease?.version
+        dockerOperationLabel = isRollback ? "Rolling back assistant..." : "Upgrading assistant..."
+        isDockerOperationInProgress = true
+        defer { isDockerOperationInProgress = false }
         do {
             try await cli.upgrade(name: name, version: version)
-            successMessage = "Upgrade complete."
+            successMessage = isRollback ? "Rollback complete." : "Upgrade complete."
             await loadReleasesQuietly()
             if successMessage != nil { errorMessage = nil }
         } catch {
-            errorMessage = "Upgrade failed: \(error.localizedDescription)"
+            errorMessage = "\(isRollback ? "Rollback" : "Upgrade") failed: \(error.localizedDescription)"
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -129,7 +129,9 @@ struct SettingsDeveloperTab: View {
                     : .remote
                 AssistantUpgradeSection(
                     currentVersion: healthz?.version,
-                    topology: topo
+                    topology: topo,
+                    isDockerOperationInProgress: $isDockerOperationInProgress,
+                    dockerOperationLabel: $dockerOperationLabel
                 )
             }
             // Hatch New Assistant


### PR DESCRIPTION
## Summary
- Pass Docker progress sheet bindings (`isDockerOperationInProgress`, `dockerOperationLabel`) to AssistantUpgradeSection
- Show modal progress sheet during Docker CLI upgrade/rollback from version picker
- Use rollback-appropriate labels when selecting an older version

Part of plan: upgrade-ui-bugfixes.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
