### PR TITLE
feat: add LogTimeRange enum and includeLogs/logTimeRange to LogReportFormData

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogReportReason.swift
+++ b/clients/macos/vellum-assistant/Logging/LogReportReason.swift
@@ -45,6 +45,23 @@ enum LogExportScope: Sendable {
                       startTime: Date? = nil, endTime: Date? = nil)
 }
 
+/// Time window for diagnostic log collection.
+enum LogTimeRange: String, CaseIterable, Identifiable, Sendable {
+    case pastHour
+    case past24Hours
+    case allTime
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .pastHour: return "Past hour"
+        case .past24Hours: return "Past 24 hours"
+        case .allTime: return "All time"
+        }
+    }
+}
+
 /// Aggregated form data collected from the log report sheet.
 struct LogReportFormData: Sendable {
     var reason: LogReportReason
@@ -52,4 +69,6 @@ struct LogReportFormData: Sendable {
     var message: String
     var email: String  // Required — used for follow-up via Sentry Feedback
     var scope: LogExportScope = .global
+    var includeLogs: Bool = true
+    var logTimeRange: LogTimeRange = .pastHour
 }


### PR DESCRIPTION
## Summary
- Add LogTimeRange enum with pastHour, past24Hours, allTime cases
- Extend LogReportFormData with includeLogs and logTimeRange fields with defaults

Part of plan: share-feedback-redesign.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
