### PR TITLE
feat: add max height and scroll to Feature Flags container

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -1043,9 +1043,14 @@ struct SettingsDeveloperTab: View {
                     .font(VFont.body)
                     .foregroundColor(VColor.contentTertiary)
             } else {
-                ForEach(filteredUnifiedFlags) { flag in
-                    unifiedFlagRow(flag: flag)
+                ScrollView {
+                    VStack(spacing: VSpacing.sm) {
+                        ForEach(filteredUnifiedFlags) { flag in
+                            unifiedFlagRow(flag: flag)
+                        }
+                    }
                 }
+                .frame(maxHeight: 400)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Wraps the feature flags list in a `ScrollView` with `maxHeight: 400` so the container doesn't grow indefinitely as more flags are added
- Search bar and filter dropdown remain pinned above the scrollable area

## Original prompt
/frontend-design lets put a max height on the container for Feature Flags so that it doesn't grow indefinitely with the number of feature flags we have and instead it scrolls
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
