### PR TITLE
fix: make approval-related Slack messages ephemeral

### DIFF
--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -40,6 +40,22 @@ const log = getLogger("guardian-request-resolvers");
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Determines whether a Slack delivery should use ephemeral mode.
+ *
+ * Ephemeral messages (`chat.postEphemeral`) require a real channel ID
+ * (starts with `C` for public/private channels, or `D` for DM conversations).
+ * When the chat ID is a user ID (starts with `U`), `chat.postEphemeral` fails
+ * with `channel_not_found`. In that case the message is already going to a DM
+ * opened by `chat.postMessage`, so ephemeral isn't needed.
+ *
+ * Returns `true` only when the source channel is Slack AND the chatId is a
+ * shared channel (starts with `C`), meaning other users could see the message.
+ */
+function shouldUseEphemeral(sourceChannel: string, chatId: string): boolean {
+  return sourceChannel === "slack" && chatId.startsWith("C");
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -377,8 +393,11 @@ const accessRequestResolver: GuardianRequestResolver = {
             text: "Your access request has been denied by the guardian.",
             assistantId,
           };
-          // On Slack, deliver as ephemeral so only the requester sees the denial
-          if (channel === "slack" && requesterExternalUserId) {
+          // On Slack shared channels, deliver as ephemeral so only the requester sees the denial
+          if (
+            shouldUseEphemeral(channel, requesterChatId) &&
+            requesterExternalUserId
+          ) {
             denialPayload.ephemeral = true;
             denialPayload.user = requesterExternalUserId;
           }
@@ -531,13 +550,23 @@ const accessRequestResolver: GuardianRequestResolver = {
         `Give them this verification code: \`${session.secret}\`. ` +
         `The code expires in 10 minutes.`;
       try {
+        const codePayload: Parameters<typeof deliverChannelReply>[1] = {
+          chatId: channelDeliveryContext.guardianChatId,
+          text: codeText,
+          assistantId,
+        };
+        // On Slack shared channels, deliver the verification code as ephemeral
+        // so only the guardian sees the secret — not all channel members.
+        if (
+          shouldUseEphemeral(channel, channelDeliveryContext.guardianChatId) &&
+          ctx.actor.actorExternalUserId
+        ) {
+          codePayload.ephemeral = true;
+          codePayload.user = ctx.actor.actorExternalUserId;
+        }
         await deliverChannelReply(
           channelDeliveryContext.replyCallbackUrl,
-          {
-            chatId: channelDeliveryContext.guardianChatId,
-            text: codeText,
-            assistantId,
-          },
+          codePayload,
           channelDeliveryContext.bearerToken,
         );
       } catch (err) {
@@ -614,8 +643,11 @@ const accessRequestResolver: GuardianRequestResolver = {
               "Please enter the 6-digit verification code you receive from the guardian.",
             assistantId,
           };
-          // On Slack, deliver as ephemeral so only the requester sees
-          if (channel === "slack" && requesterExternalUserId) {
+          // On Slack shared channels, deliver as ephemeral so only the requester sees
+          if (
+            shouldUseEphemeral(channel, requesterChatId) &&
+            requesterExternalUserId
+          ) {
             approvalPayload.ephemeral = true;
             approvalPayload.user = requesterExternalUserId;
           }
@@ -640,7 +672,10 @@ const accessRequestResolver: GuardianRequestResolver = {
               "deliver the verification code. Please try again later.",
             assistantId,
           };
-          if (channel === "slack" && requesterExternalUserId) {
+          if (
+            shouldUseEphemeral(channel, requesterChatId) &&
+            requesterExternalUserId
+          ) {
             failurePayload.ephemeral = true;
             failurePayload.user = requesterExternalUserId;
           }
@@ -766,7 +801,7 @@ const toolGrantRequestResolver: GuardianRequestResolver = {
               assistantId,
             };
           if (
-            request.sourceChannel === "slack" &&
+            shouldUseEphemeral(request.sourceChannel ?? "", requesterChatId) &&
             request.requesterExternalUserId
           ) {
             grantDenialPayload.ephemeral = true;
@@ -864,7 +899,7 @@ const toolGrantRequestResolver: GuardianRequestResolver = {
             assistantId,
           };
         if (
-          request.sourceChannel === "slack" &&
+          shouldUseEphemeral(request.sourceChannel ?? "", requesterChatId) &&
           request.requesterExternalUserId
         ) {
           grantApprovalPayload.ephemeral = true;

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -372,13 +372,19 @@ const accessRequestResolver: GuardianRequestResolver = {
       // Deliver denial notification and lifecycle signals when channel context is available
       if (channelDeliveryContext) {
         try {
+          const denialPayload: Parameters<typeof deliverChannelReply>[1] = {
+            chatId: requesterChatId,
+            text: "Your access request has been denied by the guardian.",
+            assistantId,
+          };
+          // On Slack, deliver as ephemeral so only the requester sees the denial
+          if (channel === "slack" && requesterExternalUserId) {
+            denialPayload.ephemeral = true;
+            denialPayload.user = requesterExternalUserId;
+          }
           await deliverChannelReply(
             channelDeliveryContext.replyCallbackUrl,
-            {
-              chatId: requesterChatId,
-              text: "Your access request has been denied by the guardian.",
-              assistantId,
-            },
+            denialPayload,
             channelDeliveryContext.bearerToken,
           );
         } catch (err) {
@@ -601,15 +607,21 @@ const accessRequestResolver: GuardianRequestResolver = {
 
       if (codeDelivered) {
         try {
+          const approvalPayload: Parameters<typeof deliverChannelReply>[1] = {
+            chatId: requesterTargetChatId,
+            text:
+              "Your access request has been approved! " +
+              "Please enter the 6-digit verification code you receive from the guardian.",
+            assistantId,
+          };
+          // On Slack, deliver as ephemeral so only the requester sees
+          if (channel === "slack" && requesterExternalUserId) {
+            approvalPayload.ephemeral = true;
+            approvalPayload.user = requesterExternalUserId;
+          }
           await deliverChannelReply(
             requesterCallbackUrl,
-            {
-              chatId: requesterTargetChatId,
-              text:
-                "Your access request has been approved! " +
-                "Please enter the 6-digit verification code you receive from the guardian.",
-              assistantId,
-            },
+            approvalPayload,
             channelDeliveryContext.bearerToken,
           );
           requesterNotified = true;
@@ -621,15 +633,20 @@ const accessRequestResolver: GuardianRequestResolver = {
         }
       } else {
         try {
+          const failurePayload: Parameters<typeof deliverChannelReply>[1] = {
+            chatId: requesterTargetChatId,
+            text:
+              "Your access request was approved, but we were unable to " +
+              "deliver the verification code. Please try again later.",
+            assistantId,
+          };
+          if (channel === "slack" && requesterExternalUserId) {
+            failurePayload.ephemeral = true;
+            failurePayload.user = requesterExternalUserId;
+          }
           await deliverChannelReply(
             requesterCallbackUrl,
-            {
-              chatId: requesterTargetChatId,
-              text:
-                "Your access request was approved, but we were unable to " +
-                "deliver the verification code. Please try again later.",
-              assistantId,
-            },
+            failurePayload,
             channelDeliveryContext.bearerToken,
           );
         } catch (err) {
@@ -742,13 +759,22 @@ const toolGrantRequestResolver: GuardianRequestResolver = {
 
       if (channelDeliveryContext && requesterChatId) {
         try {
-          await deliverChannelReply(
-            channelDeliveryContext.replyCallbackUrl,
+          const grantDenialPayload: Parameters<typeof deliverChannelReply>[1] =
             {
               chatId: requesterChatId,
               text: `Your request to use "${request.toolName}" has been denied by the guardian.`,
               assistantId,
-            },
+            };
+          if (
+            request.sourceChannel === "slack" &&
+            request.requesterExternalUserId
+          ) {
+            grantDenialPayload.ephemeral = true;
+            grantDenialPayload.user = request.requesterExternalUserId;
+          }
+          await deliverChannelReply(
+            channelDeliveryContext.replyCallbackUrl,
+            grantDenialPayload,
             channelDeliveryContext.bearerToken,
           );
         } catch (err) {
@@ -831,13 +857,22 @@ const toolGrantRequestResolver: GuardianRequestResolver = {
       );
     } else if (channelDeliveryContext && requesterChatId) {
       try {
-        await deliverChannelReply(
-          channelDeliveryContext.replyCallbackUrl,
+        const grantApprovalPayload: Parameters<typeof deliverChannelReply>[1] =
           {
             chatId: requesterChatId,
             text: `Your request to use "${request.toolName}" has been approved. Please retry your request.`,
             assistantId,
-          },
+          };
+        if (
+          request.sourceChannel === "slack" &&
+          request.requesterExternalUserId
+        ) {
+          grantApprovalPayload.ephemeral = true;
+          grantApprovalPayload.user = request.requesterExternalUserId;
+        }
+        await deliverChannelReply(
+          channelDeliveryContext.replyCallbackUrl,
+          grantApprovalPayload,
           channelDeliveryContext.bearerToken,
         );
       } catch (err) {

--- a/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
+++ b/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
@@ -43,6 +43,17 @@ import {
 
 const log = getLogger("runtime-http");
 
+/**
+ * Resolve the Slack ephemeral user ID when the source channel is Slack.
+ * Returns `undefined` for non-Slack channels.
+ */
+function slackEphemeralUserId(
+  sourceChannel: ChannelId,
+  userId: string | undefined,
+): string | undefined {
+  return sourceChannel === "slack" && userId ? userId : undefined;
+}
+
 export interface GuardianCallbackDecisionParams {
   content: string;
   callbackData?: string;
@@ -133,6 +144,7 @@ export async function handleGuardianCallbackDecision(
           "Failed to deliver stale callback disambiguation notice",
         extraContext: { pendingCount: allPending.length },
         errorLogContext: { conversationExternalId },
+        ephemeralUserId: slackEphemeralUserId(sourceChannel, actorExternalId),
       });
       return { handled: true, type: "stale_ignored" };
     }
@@ -185,6 +197,7 @@ export async function handleGuardianCallbackDecision(
       logger: log,
       errorLogMessage: "Failed to deliver guardian identity rejection notice",
       errorLogContext: { conversationExternalId },
+      ephemeralUserId: slackEphemeralUserId(sourceChannel, actorExternalId),
     });
     return { handled: true, type: "guardian_decision_applied" };
   }
@@ -252,15 +265,20 @@ export async function handleGuardianCallbackDecision(
         {},
         approvalCopyGenerator,
       );
-      await deliverChannelReply(
-        replyCallbackUrl,
-        {
-          chatId: conversationExternalId,
-          text,
-          assistantId,
-        },
-        bearerToken,
+      const fallbackPayload: Parameters<typeof deliverChannelReply>[1] = {
+        chatId: conversationExternalId,
+        text,
+        assistantId,
+      };
+      const guardianFallbackEphemeral = slackEphemeralUserId(
+        sourceChannel,
+        actorExternalId,
       );
+      if (guardianFallbackEphemeral) {
+        fallbackPayload.ephemeral = true;
+        fallbackPayload.user = guardianFallbackEphemeral;
+      }
+      await deliverChannelReply(replyCallbackUrl, fallbackPayload, bearerToken);
     } catch (err) {
       log.error(
         { err, conversationExternalId },
@@ -346,15 +364,20 @@ async function handleCallbackDecision(params: {
       approvalCopyGenerator,
     );
     try {
-      await deliverChannelReply(
-        replyCallbackUrl,
-        {
-          chatId: guardianApproval.requesterChatId,
-          text: outcomeText,
-          assistantId,
-        },
-        bearerToken,
+      const outcomePayload: Parameters<typeof deliverChannelReply>[1] = {
+        chatId: guardianApproval.requesterChatId,
+        text: outcomeText,
+        assistantId,
+      };
+      const requesterEphemeral = slackEphemeralUserId(
+        sourceChannel,
+        guardianApproval.requesterExternalUserId,
       );
+      if (requesterEphemeral) {
+        outcomePayload.ephemeral = true;
+        outcomePayload.user = requesterEphemeral;
+      }
+      await deliverChannelReply(replyCallbackUrl, outcomePayload, bearerToken);
     } catch (err) {
       log.error(
         { err, conversationId: guardianApproval.conversationId },
@@ -483,13 +506,22 @@ async function handleConversationalDecision(params: {
   if (engineResult.disposition === "keep_pending") {
     // Non-decision follow-up (clarification, disambiguation, etc.)
     try {
+      const keepPendingPayload: Parameters<typeof deliverChannelReply>[1] = {
+        chatId: conversationExternalId,
+        text: engineResult.replyText,
+        assistantId,
+      };
+      const guardianEphemeral = slackEphemeralUserId(
+        sourceChannel,
+        actorExternalId,
+      );
+      if (guardianEphemeral) {
+        keepPendingPayload.ephemeral = true;
+        keepPendingPayload.user = guardianEphemeral;
+      }
       await deliverChannelReply(
         replyCallbackUrl,
-        {
-          chatId: conversationExternalId,
-          text: engineResult.replyText,
-          assistantId,
-        },
+        keepPendingPayload,
         bearerToken,
       );
     } catch (err) {
@@ -549,6 +581,7 @@ async function handleConversationalDecision(params: {
       errorLogMessage:
         "Failed to deliver guardian identity mismatch notice for engine target",
       errorLogContext: { conversationExternalId },
+      ephemeralUserId: slackEphemeralUserId(sourceChannel, actorExternalId),
     });
     return { handled: true, type: "guardian_decision_applied" };
   }
@@ -596,13 +629,23 @@ async function handleConversationalDecision(params: {
       approvalCopyGenerator,
     );
     try {
-      await deliverChannelReply(
-        replyCallbackUrl,
+      const requesterOutcomePayload: Parameters<typeof deliverChannelReply>[1] =
         {
           chatId: targetApproval.requesterChatId,
           text: outcomeText,
           assistantId,
-        },
+        };
+      const requesterEphemeral = slackEphemeralUserId(
+        sourceChannel,
+        targetApproval.requesterExternalUserId,
+      );
+      if (requesterEphemeral) {
+        requesterOutcomePayload.ephemeral = true;
+        requesterOutcomePayload.user = requesterEphemeral;
+      }
+      await deliverChannelReply(
+        replyCallbackUrl,
+        requesterOutcomePayload,
         bearerToken,
       );
     } catch (err) {
@@ -614,13 +657,22 @@ async function handleConversationalDecision(params: {
 
     // Deliver the engine's reply to the guardian
     try {
+      const guardianReplyPayload: Parameters<typeof deliverChannelReply>[1] = {
+        chatId: conversationExternalId,
+        text: engineResult.replyText,
+        assistantId,
+      };
+      const guardianEphemeral = slackEphemeralUserId(
+        sourceChannel,
+        actorExternalId,
+      );
+      if (guardianEphemeral) {
+        guardianReplyPayload.ephemeral = true;
+        guardianReplyPayload.user = guardianEphemeral;
+      }
       await deliverChannelReply(
         replyCallbackUrl,
-        {
-          chatId: conversationExternalId,
-          text: engineResult.replyText,
-          assistantId,
-        },
+        guardianReplyPayload,
         bearerToken,
       );
     } catch (err) {
@@ -646,6 +698,7 @@ async function handleConversationalDecision(params: {
     logger: log,
     errorLogMessage: "Failed to deliver stale guardian approval notice",
     errorLogContext: { conversationId: targetApproval.conversationId },
+    ephemeralUserId: slackEphemeralUserId(sourceChannel, actorExternalId),
   });
 
   return { handled: true, type: "stale_ignored" };

--- a/assistant/src/runtime/routes/approval-strategies/guardian-text-engine-strategy.ts
+++ b/assistant/src/runtime/routes/approval-strategies/guardian-text-engine-strategy.ts
@@ -22,6 +22,17 @@ import { deliverStaleApprovalReply } from "../guardian-approval-reply-helpers.js
 
 const log = getLogger("runtime-http");
 
+/**
+ * Resolve the Slack ephemeral user ID when the source channel is Slack.
+ * Returns `undefined` for non-Slack channels.
+ */
+function slackEphemeralUserId(
+  sourceChannel: ChannelId,
+  userId: string | undefined,
+): string | undefined {
+  return sourceChannel === "slack" && userId ? userId : undefined;
+}
+
 export interface TextEngineDecisionParams {
   conversationId: string;
   conversationExternalId: string;
@@ -36,6 +47,8 @@ export interface TextEngineDecisionParams {
   pending: Array<{ requestId: string; toolName: string }>;
   /** Allowed actions from the pending prompt. */
   allowedActions: string[];
+  /** External user ID of the actor (for Slack ephemeral routing). */
+  actorExternalId?: string;
 }
 
 /**
@@ -58,6 +71,7 @@ export async function handleGuardianTextEngineDecision(
     approvalConversationGenerator,
     pending,
     allowedActions,
+    actorExternalId,
   } = params;
 
   const engineContext: ApprovalConversationContext = {
@@ -79,13 +93,19 @@ export async function handleGuardianTextEngineDecision(
   if (engineResult.disposition === "keep_pending") {
     // Non-decision follow-up — deliver the engine's reply and keep the request pending
     try {
+      const keepPendingPayload: Parameters<typeof deliverChannelReply>[1] = {
+        chatId: conversationExternalId,
+        text: engineResult.replyText,
+        assistantId,
+      };
+      const ephemeral = slackEphemeralUserId(sourceChannel, actorExternalId);
+      if (ephemeral) {
+        keepPendingPayload.ephemeral = true;
+        keepPendingPayload.user = ephemeral;
+      }
       await deliverChannelReply(
         replyCallbackUrl,
-        {
-          chatId: conversationExternalId,
-          text: engineResult.replyText,
-          assistantId,
-        },
+        keepPendingPayload,
         bearerToken,
       );
     } catch (err) {
@@ -112,15 +132,17 @@ export async function handleGuardianTextEngineDecision(
   if (result.applied) {
     // Deliver the engine's reply text to the user
     try {
-      await deliverChannelReply(
-        replyCallbackUrl,
-        {
-          chatId: conversationExternalId,
-          text: engineResult.replyText,
-          assistantId,
-        },
-        bearerToken,
-      );
+      const decisionPayload: Parameters<typeof deliverChannelReply>[1] = {
+        chatId: conversationExternalId,
+        text: engineResult.replyText,
+        assistantId,
+      };
+      const ephemeral = slackEphemeralUserId(sourceChannel, actorExternalId);
+      if (ephemeral) {
+        decisionPayload.ephemeral = true;
+        decisionPayload.user = ephemeral;
+      }
+      await deliverChannelReply(replyCallbackUrl, decisionPayload, bearerToken);
     } catch (err) {
       log.error(
         { err, conversationId },
@@ -145,6 +167,7 @@ export async function handleGuardianTextEngineDecision(
     logger: log,
     errorLogMessage: "Failed to deliver stale approval notice",
     errorLogContext: { conversationId },
+    ephemeralUserId: slackEphemeralUserId(sourceChannel, actorExternalId),
   });
 
   return { handled: true, type: "stale_ignored" };

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -42,6 +42,18 @@ import { deliverStaleApprovalReply } from "./guardian-approval-reply-helpers.js"
 
 const log = getLogger("runtime-http");
 
+/**
+ * Resolve the Slack ephemeral user ID when the source channel is Slack.
+ * Returns `undefined` for non-Slack channels so callers can pass the
+ * result directly to `ephemeralUserId` without branching.
+ */
+function slackEphemeralUserId(
+  sourceChannel: ChannelId,
+  userId: string | undefined,
+): string | undefined {
+  return sourceChannel === "slack" && userId ? userId : undefined;
+}
+
 export interface ApprovalInterceptionParams {
   conversationId: string;
   callbackData?: string;
@@ -266,13 +278,23 @@ export async function handleApprovalInterception(
                   approvalCopyGenerator,
                 ));
               try {
-                await deliverChannelReply(
-                  replyCallbackUrl,
+                const cancelPayload: Parameters<typeof deliverChannelReply>[1] =
                   {
                     chatId: conversationExternalId,
                     text: replyText,
                     assistantId,
-                  },
+                  };
+                const requesterEphemeral = slackEphemeralUserId(
+                  sourceChannel,
+                  actorExternalId,
+                );
+                if (requesterEphemeral) {
+                  cancelPayload.ephemeral = true;
+                  cancelPayload.user = requesterEphemeral;
+                }
+                await deliverChannelReply(
+                  replyCallbackUrl,
+                  cancelPayload,
                   bearerToken,
                 );
               } catch (err) {
@@ -294,13 +316,24 @@ export async function handleApprovalInterception(
                   {},
                   approvalCopyGenerator,
                 );
+                const guardianCancelPayload: Parameters<
+                  typeof deliverChannelReply
+                >[1] = {
+                  chatId: guardianApprovalForRequest.guardianChatId,
+                  text: guardianNotice,
+                  assistantId,
+                };
+                const guardianEphemeral = slackEphemeralUserId(
+                  sourceChannel,
+                  guardianApprovalForRequest.guardianExternalUserId,
+                );
+                if (guardianEphemeral) {
+                  guardianCancelPayload.ephemeral = true;
+                  guardianCancelPayload.user = guardianEphemeral;
+                }
                 await deliverChannelReply(
                   replyCallbackUrl,
-                  {
-                    chatId: guardianApprovalForRequest.guardianChatId,
-                    text: guardianNotice,
-                    assistantId,
-                  },
+                  guardianCancelPayload,
                   bearerToken,
                 );
               } catch (err) {
@@ -326,19 +359,33 @@ export async function handleApprovalInterception(
               errorLogMessage:
                 "Failed to deliver stale requester-cancel notice",
               errorLogContext: { conversationId },
+              ephemeralUserId: slackEphemeralUserId(
+                sourceChannel,
+                actorExternalId,
+              ),
             });
             return { handled: true, type: "stale_ignored" };
           }
 
           if (requesterFollowupReplyText) {
             try {
-              await deliverChannelReply(
-                replyCallbackUrl,
+              const followupPayload: Parameters<typeof deliverChannelReply>[1] =
                 {
                   chatId: conversationExternalId,
                   text: requesterFollowupReplyText,
                   assistantId,
-                },
+                };
+              const followupEphemeral = slackEphemeralUserId(
+                sourceChannel,
+                actorExternalId,
+              );
+              if (followupEphemeral) {
+                followupPayload.ephemeral = true;
+                followupPayload.user = followupEphemeral;
+              }
+              await deliverChannelReply(
+                replyCallbackUrl,
+                followupPayload,
                 bearerToken,
               );
             } catch (err) {
@@ -364,6 +411,7 @@ export async function handleApprovalInterception(
           errorLogMessage:
             "Failed to deliver guardian-pending notice to requester",
           errorLogContext: { conversationId },
+          ephemeralUserId: slackEphemeralUserId(sourceChannel, actorExternalId),
         });
         return { handled: true, type: "assistant_turn" };
       }
@@ -398,6 +446,7 @@ export async function handleApprovalInterception(
             "Failed to deliver guardian-expiry notice to requester",
           extraContext: { toolName: pending[0].toolName },
           errorLogContext: { conversationId },
+          ephemeralUserId: slackEphemeralUserId(sourceChannel, actorExternalId),
         });
         return { handled: true, type: "decision_applied" };
       }
@@ -434,6 +483,7 @@ export async function handleApprovalInterception(
           errorLogMessage:
             "Failed to deliver guardian-pending notice to non-guardian actor (pre-row guard)",
           errorLogContext: { conversationId },
+          ephemeralUserId: slackEphemeralUserId(sourceChannel, actorExternalId),
         });
         return { handled: true, type: "assistant_turn" };
       }
@@ -569,6 +619,7 @@ export async function handleApprovalInterception(
       approvalConversationGenerator,
       pending,
       allowedActions,
+      actorExternalId,
     });
   }
 
@@ -611,6 +662,7 @@ export async function handleApprovalInterception(
       toolName: pending.length > 0 ? pending[0].toolName : undefined,
     },
     errorLogContext: { conversationId },
+    ephemeralUserId: slackEphemeralUserId(sourceChannel, actorExternalId),
   });
 
   return { handled: true, type: "assistant_turn" };

--- a/assistant/src/runtime/routes/guardian-approval-reply-helpers.ts
+++ b/assistant/src/runtime/routes/guardian-approval-reply-helpers.ts
@@ -41,6 +41,12 @@ interface DeliverApprovalReplyParams {
   errorLogMessage: string;
   /** Extra fields merged into the pino error context. */
   errorLogContext?: Record<string, unknown>;
+  /**
+   * When set, deliver via `chat.postEphemeral` so only this Slack user
+   * sees the message. Used to keep approval-related noise out of shared
+   * channels.
+   */
+  ephemeralUserId?: string;
 }
 
 /**
@@ -57,6 +63,7 @@ async function composeAndDeliver(
     assistantId,
     bearerToken,
     approvalCopyGenerator,
+    ephemeralUserId,
   } = params;
 
   const text = await composeApprovalMessageGenerative(
@@ -64,11 +71,16 @@ async function composeAndDeliver(
     {},
     approvalCopyGenerator,
   );
-  await deliverChannelReply(
-    replyCallbackUrl,
-    { chatId, text, assistantId },
-    bearerToken,
-  );
+  const payload: Parameters<typeof deliverChannelReply>[1] = {
+    chatId,
+    text,
+    assistantId,
+  };
+  if (ephemeralUserId) {
+    payload.ephemeral = true;
+    payload.user = ephemeralUserId;
+  }
+  await deliverChannelReply(replyCallbackUrl, payload, bearerToken);
 }
 
 /**
@@ -107,6 +119,11 @@ export interface DeliverStaleApprovalReplyParams {
   extraContext?: Partial<ApprovalMessageContext>;
   /** Extra fields merged into the pino error context. */
   errorLogContext?: Record<string, unknown>;
+  /**
+   * When set, deliver via `chat.postEphemeral` so only this Slack user
+   * sees the message. Keeps approval noise out of shared channels.
+   */
+  ephemeralUserId?: string;
 }
 
 /**
@@ -120,10 +137,12 @@ export interface DeliverStaleApprovalReplyParams {
 export async function deliverStaleApprovalReply(
   params: DeliverStaleApprovalReplyParams,
 ): Promise<void> {
-  const { scenario, sourceChannel, extraContext, ...rest } = params;
+  const { scenario, sourceChannel, extraContext, ephemeralUserId, ...rest } =
+    params;
 
   const replyParams: DeliverApprovalReplyParams = {
     ...rest,
+    ephemeralUserId,
     context: {
       scenario,
       channel: sourceChannel,
@@ -171,6 +190,11 @@ export interface DeliverIdentityMismatchReplyParams {
   errorLogMessage: string;
   /** Extra fields merged into the pino error context. */
   errorLogContext?: Record<string, unknown>;
+  /**
+   * When set, deliver via `chat.postEphemeral` so only this Slack user
+   * sees the message.
+   */
+  ephemeralUserId?: string;
 }
 
 /**
@@ -180,10 +204,11 @@ export interface DeliverIdentityMismatchReplyParams {
 export async function deliverIdentityMismatchReply(
   params: DeliverIdentityMismatchReplyParams,
 ): Promise<void> {
-  const { sourceChannel, ...rest } = params;
+  const { sourceChannel, ephemeralUserId, ...rest } = params;
 
   await deliverApprovalReply({
     ...rest,
+    ephemeralUserId,
     context: {
       scenario: "guardian_identity_mismatch",
       channel: sourceChannel,


### PR DESCRIPTION
## Summary
- When the source channel is Slack, all approval-related messages (decision outcomes, stale/pending notices, cancel confirmations, follow-up replies, verification code notifications, tool grant approvals/denials) are now delivered as ephemeral messages visible only to the relevant user
- Adds `ephemeralUserId` support to `deliverStaleApprovalReply` and `deliverIdentityMismatchReply` helpers so all call sites can opt into ephemeral routing
- Uses a `slackEphemeralUserId()` helper in each strategy module to cleanly resolve the ephemeral target only on Slack

Closes JARVIS-305

## Test plan
- [x] `bunx tsc --noEmit` passes (no new type errors)
- [x] `bun test non-member-access-request.test.ts channel-approval.test.ts guardian-decision-primitive-canonical.test.ts approval-conversation-turn.test.ts` — all 61 tests pass
- [x] `bun test trusted-contact-inline-approval-integration.test.ts confirmation-request-guardian-bridge.test.ts handlers-user-message-approval-consumption.test.ts` — all 38 tests pass
- [ ] Manual: trigger approval flow in a Slack shared channel and verify messages appear only to the relevant user (ephemeral)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
