### PR TITLE
feat: add TTS playback button to assistant message bubbles (macOS)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -41,6 +41,9 @@ struct ChatBubble: View {
     var isProcessingAfterTools: Bool = false
     /// Status text from the assistant activity state, forwarded for inline display.
     var processingStatusText: String?
+    /// Whether the message-tts feature flag is enabled. Passed from the parent.
+    var isTTSEnabled: Bool = false
+    @StateObject private var audioPlayer = MessageAudioPlayer()
     @State private var isHovered = false
     /// Stores async-parsed segments for large messages (>500 chars) that missed the
     /// synchronous cache. Keyed by text content so multiple segments can be in flight.
@@ -67,6 +70,7 @@ struct ChatBubble: View {
         onReportMessage: ((String?) -> Void)? = nil,
         onForkFromMessage: ((String) -> Void)? = nil,
         showInspectButton: Bool = false,
+        isTTSEnabled: Bool = false,
         onInspectMessage: ((String?) -> Void)? = nil,
         onSurfaceRefetch: ((String, String) -> Void)? = nil,
         onRehydrate: (() -> Void)? = nil,
@@ -92,6 +96,7 @@ struct ChatBubble: View {
         self.onReportMessage = onReportMessage
         self.onForkFromMessage = onForkFromMessage
         self.showInspectButton = showInspectButton
+        self.isTTSEnabled = isTTSEnabled
         self.onInspectMessage = onInspectMessage
         self.onSurfaceRefetch = onSurfaceRefetch
         self.onRehydrate = onRehydrate
@@ -161,7 +166,7 @@ struct ChatBubble: View {
         hasCopyableText || canReportMessage || canInspectMessage || canForkFromMessage
     }
     private var showOverflowMenu: Bool {
-        hasOverflowActions && !message.isStreaming && (isHovered || showCopyConfirmation)
+        hasOverflowActions && !message.isStreaming && (isHovered || showCopyConfirmation || audioPlayer.isPlaying || audioPlayer.isLoading)
     }
 
     /// Composite identity for the `.task` modifier so it re-runs when either
@@ -426,6 +431,9 @@ struct ChatBubble: View {
                 .accessibilityLabel(showCopyConfirmation ? "Copied" : "Copy message")
                 .animation(VAnimation.fast, value: showCopyConfirmation)
             }
+            if !isUser && hasCopyableText && isTTSEnabled {
+                ttsButton
+            }
             if let onReportMessage, !isUser {
                 Button {
                     onReportMessage(message.daemonMessageId)
@@ -465,6 +473,48 @@ struct ChatBubble: View {
                 .pointerCursor()
                 .accessibilityLabel("Inspect LLM context")
             }
+        }
+    }
+
+    // MARK: - TTS Button
+
+    @ViewBuilder
+    private var ttsButton: some View {
+        if audioPlayer.isLoading {
+            ProgressView()
+                .controlSize(.small)
+                .frame(width: 24, height: 24)
+                .tint(VColor.contentTertiary)
+        } else if audioPlayer.isPlaying {
+            Button {
+                audioPlayer.stop()
+            } label: {
+                VIconView(.square, size: 11)
+                    .foregroundColor(VColor.systemPositiveStrong)
+                    .frame(width: 24, height: 24)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .pointerCursor()
+            .accessibilityLabel("Stop audio")
+        } else {
+            Button {
+                Task {
+                    await audioPlayer.playMessage(
+                        messageId: message.daemonMessageId ?? "",
+                        conversationId: nil
+                    )
+                }
+            } label: {
+                VIconView(.volume2, size: 11)
+                    .foregroundColor(audioPlayer.error != nil ? VColor.systemNegativeStrong : VColor.contentTertiary)
+                    .frame(width: 24, height: 24)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .pointerCursor()
+            .accessibilityLabel("Play as audio")
+            .help(audioPlayer.error ?? "Play as audio")
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -46,6 +46,7 @@ struct ChatView: View {
     var onReportMessage: ((String?) -> Void)?
     var onForkFromMessage: ((String) -> Void)? = nil
     var showInspectButton: Bool = false
+    var isTTSEnabled: Bool = false
     var onInspectMessage: ((String?) -> Void)?
     var mediaEmbedSettings: MediaEmbedResolverSettings?
     var isTemporaryChat: Bool = false
@@ -241,6 +242,7 @@ struct ChatView: View {
                             onReportMessage: onReportMessage,
                             onForkFromMessage: onForkFromMessage,
                             showInspectButton: showInspectButton,
+                            isTTSEnabled: isTTSEnabled,
                             onInspectMessage: onInspectMessage,
                             mediaEmbedSettings: mediaEmbedSettings,
                             resolveHttpPort: resolveHttpPort,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageAudioPlayer.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageAudioPlayer.swift
@@ -1,0 +1,71 @@
+import AVFoundation
+import Foundation
+import VellumAssistantShared
+
+/// Manages TTS audio playback for a single message bubble.
+///
+/// Each ChatBubble owns its own instance so multiple messages can have
+/// independent playback state.
+@MainActor
+final class MessageAudioPlayer: NSObject, ObservableObject, AVAudioPlayerDelegate {
+    @Published var isLoading: Bool = false
+    @Published var isPlaying: Bool = false
+    @Published var error: String? = nil
+
+    private var audioPlayer: AVAudioPlayer?
+    private let ttsClient: any TTSClientProtocol
+
+    init(ttsClient: any TTSClientProtocol = TTSClient()) {
+        self.ttsClient = ttsClient
+        super.init()
+    }
+
+    func playMessage(messageId: String, conversationId: String?) async {
+        isLoading = true
+        error = nil
+
+        let result = await ttsClient.synthesize(messageId: messageId, conversationId: conversationId)
+
+        switch result {
+        case .success(let data, _):
+            do {
+                let player = try AVAudioPlayer(data: data)
+                player.delegate = self
+                audioPlayer = player
+                player.play()
+                isPlaying = true
+            } catch {
+                self.error = "Failed to play audio"
+            }
+
+        case .featureDisabled:
+            error = "Text-to-speech is not enabled"
+
+        case .notConfigured:
+            error = "Text-to-speech is not configured"
+
+        case .notFound:
+            error = "Message not found"
+
+        case .error(_, let message):
+            error = message
+        }
+
+        isLoading = false
+    }
+
+    func stop() {
+        audioPlayer?.stop()
+        audioPlayer = nil
+        isPlaying = false
+    }
+
+    // MARK: - AVAudioPlayerDelegate
+
+    nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        Task { @MainActor in
+            isPlaying = false
+            audioPlayer = nil
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -100,6 +100,7 @@ struct MessageListView: View {
     let onReportMessage: ((String?) -> Void)?
     var onForkFromMessage: ((String) -> Void)? = nil
     var showInspectButton: Bool = false
+    var isTTSEnabled: Bool = false
     var onInspectMessage: ((String?) -> Void)?
     let mediaEmbedSettings: MediaEmbedResolverSettings?
     /// Resolves the daemon HTTP port at call time so lazy-loaded video
@@ -940,6 +941,7 @@ struct MessageListView: View {
                             onReportMessage: onReportMessage,
                             onForkFromMessage: forkFromMessageAction,
                             showInspectButton: showInspectButton,
+                            isTTSEnabled: isTTSEnabled,
                             onInspectMessage: onInspectMessage,
                             onRehydrateMessage: onRehydrateMessage,
                             onSurfaceRefetch: onSurfaceRefetch,
@@ -1678,6 +1680,7 @@ private struct MessageCellView: View, Equatable {
     let onReportMessage: ((String?) -> Void)?
     var onForkFromMessage: ((String) -> Void)?
     var showInspectButton: Bool = false
+    var isTTSEnabled: Bool = false
     var onInspectMessage: ((String?) -> Void)?
     var onRehydrateMessage: ((UUID) -> Void)?
     /// Called when a stripped surface scrolls into view and needs its data re-fetched.
@@ -1722,6 +1725,7 @@ private struct MessageCellView: View, Equatable {
                 onReportMessage: onReportMessage,
                 onForkFromMessage: onForkFromMessage,
                 showInspectButton: showInspectButton,
+                isTTSEnabled: isTTSEnabled,
                 onInspectMessage: onInspectMessage,
                 onSurfaceRefetch: onSurfaceRefetch,
                 onRehydrate: (message.wasTruncated || message.isContentStripped) ? { onRehydrateMessage?(message.id) } : nil,
@@ -1862,6 +1866,7 @@ private struct MessageCellView: View, Equatable {
                 onReportMessage: onReportMessage,
                 onForkFromMessage: onForkFromMessage,
                 showInspectButton: showInspectButton,
+                isTTSEnabled: isTTSEnabled,
                 onInspectMessage: onInspectMessage,
                 onSurfaceRefetch: onSurfaceRefetch,
                 onRehydrate: (message.wasTruncated || message.isContentStripped) ? { onRehydrateMessage?(message.id) } : nil,

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -379,11 +379,15 @@ extension MainWindowView {
             let showInspectButton = assistantFeatureFlagStore.isEnabled(
                 "feature_flags.settings-developer-nav.enabled"
             )
+            let isTTSEnabled = assistantFeatureFlagStore.isEnabled(
+                "feature_flags.message-tts.enabled"
+            )
             ActiveChatViewWrapper(
                 viewModel: viewModel,
                 windowState: windowState,
                 conversationStartersEnabled: conversationStartersEnabled,
                 showInspectButton: showInspectButton,
+                isTTSEnabled: isTTSEnabled,
                 daemonClient: daemonClient,
                 ambientAgent: ambientAgent,
                 settingsStore: settingsStore,
@@ -584,6 +588,7 @@ struct ActiveChatViewWrapper: View {
     @ObservedObject var windowState: MainWindowState
     let conversationStartersEnabled: Bool
     var showInspectButton: Bool = false
+    var isTTSEnabled: Bool = false
     let daemonClient: DaemonClient
     @ObservedObject var ambientAgent: AmbientAgent
     @ObservedObject var settingsStore: SettingsStore
@@ -702,6 +707,7 @@ struct ActiveChatViewWrapper: View {
                 }
             },
             showInspectButton: showInspectButton,
+            isTTSEnabled: isTTSEnabled,
             onInspectMessage: { daemonMessageId in
                 presentInspector(for: daemonMessageId)
             },

--- a/clients/shared/Network/TTSClient.swift
+++ b/clients/shared/Network/TTSClient.swift
@@ -1,0 +1,59 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "TTSClient")
+
+/// Result of a message TTS synthesis request.
+public enum TTSResult: Sendable {
+    /// Audio binary returned successfully.
+    case success(data: Data, contentType: String)
+    /// Feature flag is disabled (403).
+    case featureDisabled
+    /// TTS provider is not configured (503).
+    case notConfigured
+    /// Message not found (404).
+    case notFound
+    /// Generic error.
+    case error(statusCode: Int?, message: String)
+}
+
+/// Focused client for message text-to-speech synthesis routed through the gateway.
+@MainActor
+public protocol TTSClientProtocol {
+    func synthesize(messageId: String, conversationId: String?) async -> TTSResult
+}
+
+/// Gateway-backed implementation of ``TTSClientProtocol``.
+@MainActor
+public struct TTSClient: TTSClientProtocol {
+    nonisolated public init() {}
+
+    public func synthesize(messageId: String, conversationId: String?) async -> TTSResult {
+        do {
+            var path = "assistants/{assistantId}/messages/\(messageId)/tts"
+            if let conversationId, !conversationId.isEmpty {
+                path += "?conversationId=\(conversationId)"
+            }
+
+            let response = try await GatewayHTTPClient.post(path: path, timeout: 60)
+
+            switch response.statusCode {
+            case 200:
+                return .success(data: response.data, contentType: "audio/mpeg")
+            case 403:
+                return .featureDisabled
+            case 404:
+                return .notFound
+            case 503:
+                return .notConfigured
+            default:
+                let body = String(data: response.data, encoding: .utf8) ?? "unknown"
+                log.error("TTS synthesis failed (HTTP \(response.statusCode)): \(body)")
+                return .error(statusCode: response.statusCode, message: "TTS synthesis failed (HTTP \(response.statusCode))")
+            }
+        } catch {
+            log.error("TTS synthesis error: \(error.localizedDescription)")
+            return .error(statusCode: nil, message: error.localizedDescription)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add TTSClient for calling the message TTS endpoint via GatewayHTTPClient
- Add MessageAudioPlayer (ObservableObject) managing loading/playing/error states with AVAudioPlayer
- Add speaker button to ChatBubble overflow menu with three states: idle, loading (spinner), playing (stop)
- Gate button visibility behind `feature_flags.message-tts.enabled` feature flag

Part of plan: msg-audio-playback.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
