### PR TITLE
feat: restructure LogReportReason into error/non-error categories

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -460,7 +460,7 @@ extension AppDelegate {
         }
     }
 
-    func showLogReportWindow(scope: LogExportScope = .global, reason: LogReportReason? = .bugReport) {
+    func showLogReportWindow(scope: LogExportScope = .global, reason: LogReportReason? = .somethingBroken) {
         // If the window is already showing, just bring it forward.
         if let existing = logReportWindow, existing.isVisible {
             existing.makeKeyAndOrderFront(nil)

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -90,7 +90,7 @@ enum LogExporter {
             }
             // When routing to the brain project, tag the event so it's clear
             // it originated from the macOS client (not the daemon itself).
-            if formData.reason == .assistantBehavior {
+            if formData.reason == .somethingBroken {
                 tags["client"] = "macos"
             }
 
@@ -165,7 +165,7 @@ enum LogExporter {
 
             // Route assistant behavior reports to the brain Sentry project
             // so they appear alongside daemon issues for triage.
-            let dsn: String? = formData.reason == .assistantBehavior
+            let dsn: String? = formData.reason == .somethingBroken
                 ? MetricKitManager.brainDSN
                 : nil
 

--- a/clients/macos/vellum-assistant/Logging/LogReportReason.swift
+++ b/clients/macos/vellum-assistant/Logging/LogReportReason.swift
@@ -3,35 +3,45 @@ import VellumAssistantShared
 
 /// Pre-defined categories a user can pick when sending a log report.
 enum LogReportReason: String, CaseIterable, Identifiable, Sendable {
-    case bugReport
+    case somethingBroken
+    case appCrash
     case performanceIssue
     case connectionIssue
-    case assistantBehavior
-    case appCrash
+    case featureRequest
     case other
 
     var id: String { rawValue }
 
     var displayName: String {
         switch self {
-        case .bugReport: return "Bug Report"
-        case .performanceIssue: return "Performance Issue"
-        case .connectionIssue: return "Connection Issue"
-        case .assistantBehavior: return "Assistant Behavior"
-        case .appCrash: return "App Crash"
-        case .other: return "Other"
+        case .somethingBroken: return "Something isn't working"
+        case .appCrash: return "App crashed or won't start"
+        case .performanceIssue: return "Performance is slow"
+        case .connectionIssue: return "Connection issue"
+        case .featureRequest: return "Feature request"
+        case .other: return "Other feedback"
         }
     }
 
     /// Lucide icon raw value suitable for `VIcon.resolve(_:)`.
     var icon: String {
         switch self {
-        case .bugReport: return VIcon.bug.rawValue
+        case .somethingBroken: return VIcon.bug.rawValue
+        case .appCrash: return VIcon.triangleAlert.rawValue
         case .performanceIssue: return VIcon.zap.rawValue
         case .connectionIssue: return VIcon.wifiOff.rawValue
-        case .assistantBehavior: return VIcon.brain.rawValue
-        case .appCrash: return VIcon.triangleAlert.rawValue
+        case .featureRequest: return VIcon.lightbulb.rawValue
         case .other: return VIcon.messageCircle.rawValue
+        }
+    }
+
+    /// Whether this category represents an error/issue that benefits from diagnostic logs.
+    var isErrorCategory: Bool {
+        switch self {
+        case .somethingBroken, .appCrash, .performanceIssue, .connectionIssue:
+            return true
+        case .featureRequest, .other:
+            return false
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace bugReport/assistantBehavior cases with somethingBroken/featureRequest
- Update all display names and icons for new category structure
- Add isErrorCategory computed property for log attachment behavior
- Update all consumers to use new enum cases

Part of plan: share-feedback-redesign.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
