### PR TITLE
feat: allow previewing more file types like .py, .go, .rs, etc.

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -24,6 +24,7 @@ import {
   getConfiguredProvider,
   userMessage,
 } from "../../providers/provider-send-message.js";
+import { isTextMimeType as isTextMime } from "../../runtime/routes/workspace-utils.js";
 import {
   clawhubCheckUpdates,
   clawhubInspect,
@@ -49,20 +50,6 @@ import {
 
 // ─── MIME detection helpers ───────────────────────────────────────────────────
 
-const TEXT_MIME_PREFIXES = [
-  "text/",
-  "application/json",
-  "application/javascript",
-  "application/typescript",
-  "application/xml",
-  "application/yaml",
-  "application/x-yaml",
-  "application/toml",
-  "application/x-sh",
-];
-function isTextMime(mimeType: string): boolean {
-  return TEXT_MIME_PREFIXES.some((prefix) => mimeType.startsWith(prefix));
-}
 const MAX_INLINE_SIZE = 2 * 1024 * 1024; // 2 MB
 
 // ─── Shared context for standalone functions ─────────────────────────────────
@@ -380,7 +367,7 @@ function readDirRecursive(dir: string, rootDir: string): SkillFileEntry[] {
     try {
       const stat = statSync(fullPath);
       const mimeType = Bun.file(fullPath).type;
-      const isText = isTextMime(mimeType);
+      const isText = isTextMime(mimeType, dirent.name);
       let content: string | null = null;
       if (isText && stat.size <= MAX_INLINE_SIZE) {
         content = readFileSync(fullPath, "utf-8");

--- a/assistant/src/runtime/routes/workspace-routes.test.ts
+++ b/assistant/src/runtime/routes/workspace-routes.test.ts
@@ -190,8 +190,29 @@ describe("isTextMimeType", () => {
     expect(isTextMimeType("video/mp4")).toBe(false);
   });
 
-  test("application/octet-stream is not text", () => {
+  test("application/octet-stream is not text without filename", () => {
     expect(isTextMimeType("application/octet-stream")).toBe(false);
+  });
+
+  test("application/octet-stream with .py filename is text", () => {
+    expect(isTextMimeType("application/octet-stream", "script.py")).toBe(true);
+  });
+
+  test("application/octet-stream with .go filename is text", () => {
+    expect(isTextMimeType("application/octet-stream", "main.go")).toBe(true);
+  });
+
+  test("application/octet-stream with .rs filename is text", () => {
+    expect(isTextMimeType("application/octet-stream", "lib.rs")).toBe(true);
+  });
+
+  test("application/octet-stream with unknown extension is not text", () => {
+    expect(isTextMimeType("application/octet-stream", "data.bin")).toBe(false);
+  });
+
+  test("extension fallback only applies to application/octet-stream", () => {
+    // A binary plist has a specific MIME type — extension should not override it
+    expect(isTextMimeType("application/x-plist", "Info.plist")).toBe(false);
   });
 });
 

--- a/assistant/src/runtime/routes/workspace-routes.ts
+++ b/assistant/src/runtime/routes/workspace-routes.ts
@@ -119,7 +119,7 @@ function handleWorkspaceFile(ctx: RouteContext): Response {
   }
 
   const mimeType = Bun.file(resolved).type;
-  const isText = isTextMimeType(mimeType);
+  const isText = isTextMimeType(mimeType, basename(resolved));
   const isBinary = !isText;
 
   let content: string | undefined = undefined;

--- a/assistant/src/runtime/routes/workspace-utils.ts
+++ b/assistant/src/runtime/routes/workspace-utils.ts
@@ -119,6 +119,8 @@ const TEXT_FILE_EXTENSIONS = new Set([
   "v",
   "sol",
   "r",
+  "java",
+  "lua",
   // Shell / scripting
   "bash",
   "zsh",

--- a/assistant/src/runtime/routes/workspace-utils.ts
+++ b/assistant/src/runtime/routes/workspace-utils.ts
@@ -85,10 +85,90 @@ const TEXT_MIME_PREFIXES = [
   "application/x-yaml",
   "application/toml",
   "application/x-sh",
+  "application/x-httpd-php",
+  "application/x-perl",
+  "application/x-sql",
+  "application/x-tex",
+  "application/vnd.dart",
 ];
 
-export function isTextMimeType(mimeType: string): boolean {
-  return TEXT_MIME_PREFIXES.some((prefix) => mimeType.startsWith(prefix));
+/**
+ * File extensions that are known text/code files but that Bun's MIME
+ * detection reports as `application/octet-stream`.
+ */
+const TEXT_FILE_EXTENSIONS = new Set([
+  // Programming languages
+  "py",
+  "rb",
+  "go",
+  "rs",
+  "swift",
+  "kt",
+  "kts",
+  "cs",
+  "scala",
+  "ex",
+  "exs",
+  "erl",
+  "hs",
+  "clj",
+  "cljs",
+  "jl",
+  "zig",
+  "nim",
+  "v",
+  "sol",
+  "r",
+  // Shell / scripting
+  "bash",
+  "zsh",
+  "fish",
+  "ps1",
+  "bat",
+  "cmd",
+  "awk",
+  // Web frameworks
+  "vue",
+  "svelte",
+  "scss",
+  "sass",
+  "less",
+  // Config / data
+  "cfg",
+  "conf",
+  "ini",
+  "properties",
+  "env",
+  "plist",
+  "gradle",
+  "cmake",
+  // Markup / docs
+  "rst",
+  "adoc",
+  "org",
+  "tex",
+  "latex",
+  // Other text formats
+  "graphql",
+  "gql",
+  "proto",
+  "tf",
+  "hcl",
+  "diff",
+  "patch",
+  "log",
+  "lock",
+]);
+
+export function isTextMimeType(mimeType: string, fileName?: string): boolean {
+  if (TEXT_MIME_PREFIXES.some((prefix) => mimeType.startsWith(prefix))) {
+    return true;
+  }
+  if (fileName) {
+    const ext = fileName.split(".").pop()?.toLowerCase();
+    if (ext && TEXT_FILE_EXTENSIONS.has(ext)) return true;
+  }
+  return false;
 }
 
 export const MAX_INLINE_TEXT_SIZE = 2 * 1024 * 1024; // 2 MB

--- a/assistant/src/runtime/routes/workspace-utils.ts
+++ b/assistant/src/runtime/routes/workspace-utils.ts
@@ -139,7 +139,6 @@ const TEXT_FILE_EXTENSIONS = new Set([
   "ini",
   "properties",
   "env",
-  "plist",
   "gradle",
   "cmake",
   // Markup / docs
@@ -164,7 +163,10 @@ export function isTextMimeType(mimeType: string, fileName?: string): boolean {
   if (TEXT_MIME_PREFIXES.some((prefix) => mimeType.startsWith(prefix))) {
     return true;
   }
-  if (fileName) {
+  // Only fall back to extension check when the MIME type is genuinely unknown.
+  // Specific MIME types (e.g. application/x-plist for binary plists) should be
+  // trusted over the extension — overriding them risks corrupting binary files.
+  if (fileName && mimeType === "application/octet-stream") {
     const ext = fileName.split(".").pop()?.toLowerCase();
     if (ext && TEXT_FILE_EXTENSIONS.has(ext)) return true;
   }

--- a/clients/ios/Views/Intelligence/SkillDetailView.swift
+++ b/clients/ios/Views/Intelligence/SkillDetailView.swift
@@ -243,7 +243,7 @@ struct SkillDetailView: View {
                 }
             } label: {
                 HStack(spacing: VSpacing.sm) {
-                    VIconView(fileIcon(for: file.mimeType), size: 16)
+                    VIconView(fileIcon(for: file.mimeType, fileName: file.name), size: 16)
                         .foregroundColor(VColor.primaryBase)
                         .frame(width: 24)
 
@@ -287,11 +287,12 @@ struct SkillDetailView: View {
 
     // MARK: - File Helpers
 
-    private func fileIcon(for mimeType: String) -> VIcon {
+    private func fileIcon(for mimeType: String, fileName: String? = nil) -> VIcon {
         if mimeType.hasPrefix("image/") { return .image }
         if mimeType.hasPrefix("video/") { return .video }
         if mimeType.hasPrefix("text/") { return .fileText }
         if mimeType == "application/json" || mimeType == "application/javascript" || mimeType == "application/typescript" { return .fileCode }
+        if let name = fileName, FileExtensions.isCode(name) { return .fileCode }
         return .file
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -390,7 +390,7 @@ extension ChatBubble {
 
     func fileAttachmentChip(_ attachment: ChatAttachment) -> some View {
         HStack(spacing: VSpacing.xs) {
-            VIconView(fileIcon(for: attachment.mimeType), size: 14)
+            VIconView(fileIcon(for: attachment.mimeType, fileName: attachment.filename), size: 14)
                 .foregroundColor(isUser ? VColor.contentSecondary : VColor.contentSecondary)
 
             Text(attachment.filename)
@@ -432,13 +432,14 @@ extension ChatBubble {
         }
     }
 
-    func fileIcon(for mimeType: String) -> VIcon {
+    func fileIcon(for mimeType: String, fileName: String? = nil) -> VIcon {
         if mimeType.hasPrefix("video/") { return .video }
         if mimeType.hasPrefix("audio/") { return .audioWaveform }
         if mimeType.hasPrefix("text/") { return .fileText }
         if mimeType == "application/pdf" { return .file }
         if mimeType.contains("zip") || mimeType.contains("archive") { return .fileArchive }
         if mimeType.contains("json") || mimeType.contains("xml") { return .fileText }
+        if let name = fileName, FileExtensions.isCode(name) { return .fileCode }
         return .file
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -34,13 +34,15 @@ func viewModeLabel(_ mode: FileViewMode) -> String {
 
 // MARK: - File Icon
 
-func fileIcon(for mimeType: String) -> VIcon {
+func fileIcon(for mimeType: String, fileName: String? = nil) -> VIcon {
     if mimeType.hasPrefix("image/") { return .image }
     if mimeType.hasPrefix("video/") { return .video }
     if mimeType.hasPrefix("text/") { return .fileText }
     if mimeType == "application/json" || mimeType == "application/javascript" || mimeType == "application/typescript" { return .fileCode }
+    if let name = fileName, FileExtensions.isCode(name) { return .fileCode }
     return .file
 }
+
 
 // MARK: - File Content View
 
@@ -83,7 +85,7 @@ struct FileContentView: View {
 
         VStack(alignment: .leading, spacing: 0) {
             FileContentHeaderBar(
-                icon: fileIcon(for: mimeType),
+                icon: fileIcon(for: mimeType, fileName: fileName),
                 fileName: fileName
             ) {
                 if modes.count > 1 {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillFileTreeView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillFileTreeView.swift
@@ -58,7 +58,7 @@ struct SkillFileTreeView: View {
                             isDirectory: item.node.isDirectory,
                             isExpanded: item.node.isDirectory && !collapsedPaths.contains(item.node.path),
                             depth: item.depth,
-                            fileIcon: fileIcon(for: item.node.mimeType ?? "application/octet-stream")
+                            fileIcon: fileIcon(for: item.node.mimeType ?? "application/octet-stream", fileName: item.node.name)
                         )
 
                         Spacer()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -541,7 +541,7 @@ private struct WorkspaceTreeRow: View {
                             isDirectory: entry.isDirectory,
                             isExpanded: isExpanded,
                             depth: depth,
-                            fileIcon: .fileText,
+                            fileIcon: fileIcon(for: entry.mimeType ?? "application/octet-stream", fileName: entry.name),
                             minRowWidth: minRowWidth,
                             isDimmed: isHiddenPath(entry.path)
                         )
@@ -772,7 +772,7 @@ private struct WorkspaceFileViewer: View {
                 )
             } else {
                 FileContentHeaderBar(
-                    icon: fileIcon(for: mime),
+                    icon: fileIcon(for: mime, fileName: detail.name),
                     fileName: detail.name
                 )
                 Divider().background(VColor.borderBase)

--- a/clients/shared/Features/FileExtensions.swift
+++ b/clients/shared/Features/FileExtensions.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Common file extension classifications used for icon display and file type detection.
+public enum FileExtensions {
+    private static let codeExtensions: Set<String> = [
+        // Programming languages
+        "py", "rb", "go", "rs", "swift", "kt", "kts", "cs", "scala", "java", "c", "h", "cpp", "cc", "hpp",
+        "ex", "exs", "erl", "hs", "clj", "cljs", "jl", "zig", "nim", "sol", "r", "dart", "php", "pl", "lua",
+        // Shell / scripting
+        "sh", "bash", "zsh", "fish", "ps1", "bat", "cmd", "awk",
+        // Web frameworks
+        "vue", "svelte", "scss", "sass", "less",
+        // Query / schema
+        "sql", "graphql", "gql", "proto", "tf", "hcl",
+        // Config / data
+        "cfg", "conf", "ini", "properties", "gradle", "cmake", "toml", "yaml", "yml",
+    ]
+
+    public static func isCode(_ fileName: String) -> Bool {
+        guard let ext = fileName.split(separator: ".").last?.lowercased() else { return false }
+        return codeExtensions.contains(ext)
+    }
+}


### PR DESCRIPTION
## Summary
- **Backend**: Added a `TEXT_FILE_EXTENSIONS` fallback set (~60 common code/config/markup extensions) to `isTextMimeType()` in `workspace-utils.ts`, so files like `.py`, `.rb`, `.go`, `.rs`, `.swift`, `.kt`, `.cs`, `.scala`, etc. are correctly identified as text and served with inline content instead of being treated as binary
- **Backend**: Added more `application/*` MIME prefixes (php, perl, sql, tex, dart) and deduplicated the MIME detection logic (skills.ts now imports from workspace-utils)
- **Frontend**: Updated `fileIcon()` on both macOS and iOS to show a code file icon for recognized code extensions, and extracted a shared `FileExtensions` utility for cross-platform use

## Original prompt
--safe https://linear.app/vellum/issue/LUM-362/allow-previewing-more-file-types-like-py (look into any obvious file extensions, like .py is basically txt file, etc)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
