### PR TITLE
feat: rename all "Send Logs" touchpoints to "Share Feedback" / "Report to Vellum"

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -31,7 +31,7 @@ struct VellumAssistantApp: App {
                 }
                 .disabled(!appDelegate.updateManager.updateMenuItemIsEnabled)
                 Divider()
-                Button("Send Logs to \(appName)") {
+                Button("Share Feedback") {
                     appDelegate.sendLogsToSentry()
                 }
                 Divider()

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -494,9 +494,9 @@ extension AppDelegate {
         window.contentViewController = hostingController
         switch scope {
         case .global:
-            window.title = "Send Logs to Vellum"
+            window.title = "Share Feedback"
         case .conversation:
-            window.title = "Send Logs for Conversation"
+            window.title = "Share Feedback"
         }
         window.backgroundColor = NSColor(VColor.surfaceOverlay)
         window.isReleasedWhenClosed = false

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -121,7 +121,7 @@ struct ChatView: View {
     /// timeout window. Shows a failure screen instead of the loading skeleton.
     var isBootstrapTimedOut: Bool = false
 
-    /// Called when the user taps "Send Logs to Vellum" on the bootstrap
+    /// Called when the user taps "Report to Vellum" on the bootstrap
     /// timeout view.
     var onBootstrapSendLogs: (() -> Void)?
 
@@ -649,7 +649,7 @@ private struct ChatBootstrapTimeoutView: View {
             }
 
             if let onSendLogs {
-                VButton(label: "Send Logs to Vellum", leftIcon: VIcon.send.rawValue, style: .primary) {
+                VButton(label: "Report to Vellum", leftIcon: VIcon.send.rawValue, style: .primary) {
                     onSendLogs()
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Chat/DaemonConnectionTimeoutView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/DaemonConnectionTimeoutView.swift
@@ -39,7 +39,7 @@ struct DaemonConnectionTimeoutView: View {
                 }
             }
 
-            VButton(label: "Send Logs to Vellum", leftIcon: VIcon.send.rawValue, style: .ghost) {
+            VButton(label: "Report to Vellum", leftIcon: VIcon.send.rawValue, style: .ghost) {
                 onSendLogs()
             }
 

--- a/clients/macos/vellum-assistant/Features/Chat/DaemonStartupErrorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/DaemonStartupErrorView.swift
@@ -37,7 +37,7 @@ struct DaemonStartupErrorView: View {
                 VButton(label: "Retry", leftIcon: VIcon.refreshCw.rawValue, style: .outlined) {
                     onRetry()
                 }
-                VButton(label: "Send Logs to Vellum", leftIcon: VIcon.send.rawValue, style: .primary) {
+                VButton(label: "Report to Vellum", leftIcon: VIcon.send.rawValue, style: .primary) {
                     onSendLogs()
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -211,7 +211,7 @@ struct SidebarConversationItem: View {
                 guard let conversationId = conversation.conversationId else { return }
                 AppDelegate.shared?.showLogReportWindow(scope: .conversation(conversationId: conversationId, conversationTitle: conversation.title))
             } label: {
-                Label { Text("Send Logs") } icon: { VIconView(.upload, size: 14) }
+                Label { Text("Share Feedback") } icon: { VIconView(.messageCircle, size: 14) }
             }
             .disabled(conversation.conversationId == nil || LogExporter.isManagedAssistant)
         }


### PR DESCRIPTION
## Summary
- Menu bar: 'Send Logs to Vellum' → 'Share Feedback'
- Conversation context menu: 'Send Logs' → 'Share Feedback'
- Error screens: 'Send Logs to Vellum' → 'Report to Vellum'
- Window titles updated to 'Share Feedback'

Part of plan: share-feedback-redesign.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
