### PR TITLE
fix: guard PID file operations against non-vellum processes

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -13,7 +13,7 @@ import { dirname, join } from "path";
 import { type LocalInstanceResources } from "./assistant-config.js";
 import { GATEWAY_PORT } from "./constants.js";
 import { httpHealthCheck, waitForDaemonReady } from "./http-client.js";
-import { stopProcessByPidFile } from "./process.js";
+import { isVellumProcess, stopProcessByPidFile } from "./process.js";
 import { openLogFile, pipeToLogFile } from "./xdg-log.js";
 
 const _require = createRequire(import.meta.url);
@@ -580,6 +580,13 @@ function recoverPidFile(
 ): number | undefined {
   const pid = findPidListeningOnPort(daemonPort);
   if (pid) {
+    // Verify the listener is actually a vellum daemon before adopting it.
+    // Without this check, a user's own process (e.g. a dev server) that
+    // happens to be on the daemon port would be written into the PID file
+    // and later killed by lifecycle commands (sleep, retire, stop).
+    if (!isVellumProcess(pid)) {
+      return undefined;
+    }
     mkdirSync(dirname(pidFile), { recursive: true });
     writeFileSync(pidFile, String(pid), "utf-8");
   }

--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -698,6 +698,10 @@ final class VellumCli {
 
     /// Send SIGTERM to a process identified by a PID file. Does not wait for
     /// the process to exit — the next launch will clean up any stragglers.
+    ///
+    /// Guards against stale PID reuse: if the OS has recycled the PID and it
+    /// now belongs to a non-vellum process (e.g. a user's localhost dev server),
+    /// the signal is skipped and the stale PID file is removed.
     private func signalViaPIDFile(_ pidFileURL: URL, label: String) {
         guard FileManager.default.fileExists(atPath: pidFileURL.path) else { return }
         let pidData: Data
@@ -712,8 +716,53 @@ final class VellumCli {
             return
         }
 
+        // Verify the PID belongs to a vellum-related process before signaling.
+        // Without this check, a stale PID file (or one corrupted by recoverPidFile
+        // adopting a non-vellum listener) could cause us to SIGTERM an unrelated
+        // process such as the user's localhost dev server.
+        guard Self.isVellumProcess(pid) else {
+            log.info("PID \(pid) is not a vellum process — skipping SIGTERM for \(label, privacy: .public) and removing stale PID file")
+            try? FileManager.default.removeItem(at: pidFileURL)
+            return
+        }
+
         log.info("Sending SIGTERM to \(label, privacy: .public) (pid \(pid))")
         kill(pid, SIGTERM)
+    }
+
+    /// Check whether a PID belongs to a vellum-related process by inspecting
+    /// its command line via `ps`. Mirrors the logic in cli/src/lib/process.ts.
+    private static func isVellumProcess(_ pid: pid_t) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/ps")
+        process.arguments = ["-p", "\(pid)", "-o", "command="]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return false
+        }
+
+        guard process.terminationStatus == 0 else { return false }
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        guard let command = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !command.isEmpty else {
+            return false
+        }
+
+        // Match the same patterns as cli/src/lib/process.ts isVellumProcess()
+        let patterns = [
+            "vellum-daemon", "vellum-cli", "vellum-gateway",
+            "@vellumai", "/.vellum/", "/daemon/main",
+            "/vellum/", "qdrant/bin/qdrant"
+        ]
+        return patterns.contains { command.contains($0) }
     }
 
     /// Run a CLI command, log the invocation and result, and return

--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -756,13 +756,18 @@ final class VellumCli {
             return false
         }
 
-        // Match the same patterns as cli/src/lib/process.ts isVellumProcess()
+        // Match the same patterns as cli/src/lib/process.ts isVellumProcess().
+        // See also: AppDelegate+AuthLifecycle.swift isVellumProcess(pid:)
         let patterns = [
             "vellum-daemon", "vellum-cli", "vellum-gateway",
             "@vellumai", "/.vellum/", "/daemon/main",
-            "/vellum/", "qdrant/bin/qdrant"
+            "/vellum/"
         ]
-        return patterns.contains { command.contains($0) }
+        let matchesVellumPattern = patterns.contains { command.contains($0) }
+        // Qdrant managed by vellum lives under /.vellum/; match the TS regex
+        // `\/\.vellum\/.*qdrant\/bin\/qdrant` which requires both parts.
+        let matchesManagedQdrant = command.contains("/.vellum/") && command.contains("qdrant/bin/qdrant")
+        return matchesVellumPattern || matchesManagedQdrant
     }
 
     /// Run a CLI command, log the invocation and result, and return


### PR DESCRIPTION
## Summary
- Add `isVellumProcess()` guard to `recoverPidFile` in `cli/src/lib/local.ts` — prevents writing a non-vellum PID (e.g. user's dev server on the daemon port) into the daemon PID file
- Add `isVellumProcess()` guard to `signalViaPIDFile` in `VellumCli.swift` — prevents sending SIGTERM to a non-vellum process via a stale/corrupted PID file, with automatic cleanup of the stale file

## Original prompt
--safe https://linear.app/vellum/issue/LUM-363/app-panel-switching-sends-sigterm-to-users-localhost-process
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
