### PR TITLE
fix: add isTTSEnabled to MessageCellView Equatable check

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1651,6 +1651,7 @@ private struct MessageCellView: View, Equatable {
             && lhs.configuredProviders == rhs.configuredProviders
             && lhs.providerCatalog.count == rhs.providerCatalog.count
             && zip(lhs.providerCatalog, rhs.providerCatalog).allSatisfy({ $0.id == $1.id && $0.displayName == $1.displayName && $0.models.count == $1.models.count && zip($0.models, $1.models).allSatisfy({ $0.id == $1.id && $0.displayName == $1.displayName }) })
+            && lhs.isTTSEnabled == rhs.isTTSEnabled
     }
 
     let message: ChatMessage


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for msg-audio-playback.md.

**Gap:** isTTSEnabled missing from MessageCellView Equatable check
**What was expected:** isTTSEnabled should be compared in the custom == so SwiftUI detects flag changes
**What was found:** The property was added but not included in the Equatable comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
