### PR TITLE
fix: guard TTS button against nil daemonMessageId

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -431,7 +431,7 @@ struct ChatBubble: View {
                 .accessibilityLabel(showCopyConfirmation ? "Copied" : "Copy message")
                 .animation(VAnimation.fast, value: showCopyConfirmation)
             }
-            if !isUser && hasCopyableText && isTTSEnabled {
+            if !isUser && hasCopyableText && isTTSEnabled && message.daemonMessageId != nil {
                 ttsButton
             }
             if let onReportMessage, !isUser {
@@ -497,11 +497,11 @@ struct ChatBubble: View {
             .buttonStyle(.plain)
             .pointerCursor()
             .accessibilityLabel("Stop audio")
-        } else {
+        } else if let daemonMessageId = message.daemonMessageId {
             Button {
                 Task {
                     await audioPlayer.playMessage(
-                        messageId: message.daemonMessageId ?? "",
+                        messageId: daemonMessageId,
                         conversationId: nil
                     )
                 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for msg-audio-playback.md.

**Gap:** TTS button passes empty string for nil daemonMessageId
**What was expected:** Guard against nil like fork/inspect buttons do
**What was found:** Used `?? ""` fallback instead of nil guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
