### PR TITLE
fix: remove unused contentType from TTSResult.success

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageAudioPlayer.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageAudioPlayer.swift
@@ -27,7 +27,7 @@ final class MessageAudioPlayer: NSObject, ObservableObject, AVAudioPlayerDelegat
         let result = await ttsClient.synthesize(messageId: messageId, conversationId: conversationId)
 
         switch result {
-        case .success(let data, _):
+        case .success(let data):
             do {
                 let player = try AVAudioPlayer(data: data)
                 player.delegate = self

--- a/clients/shared/Network/TTSClient.swift
+++ b/clients/shared/Network/TTSClient.swift
@@ -6,7 +6,7 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 /// Result of a message TTS synthesis request.
 public enum TTSResult: Sendable {
     /// Audio binary returned successfully.
-    case success(data: Data, contentType: String)
+    case success(data: Data)
     /// Feature flag is disabled (403).
     case featureDisabled
     /// TTS provider is not configured (503).
@@ -39,7 +39,7 @@ public struct TTSClient: TTSClientProtocol {
 
             switch response.statusCode {
             case 200:
-                return .success(data: response.data, contentType: "audio/mpeg")
+                return .success(data: response.data)
             case 403:
                 return .featureDisabled
             case 404:


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for msg-audio-playback.md.

**Gap:** TTSResult.success hardcodes contentType instead of reading from response
**What was expected:** contentType should reflect server response or be removed
**What was found:** Hardcoded to audio/mpeg, destructured as _ in consumer — dead code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
