### PR TITLE
feat: preset feedback category and log defaults when opened from error screens

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -460,7 +460,7 @@ extension AppDelegate {
         }
     }
 
-    func showLogReportWindow(scope: LogExportScope = .global, reason: LogReportReason? = .somethingBroken) {
+    func showLogReportWindow(scope: LogExportScope = .global, reason: LogReportReason? = nil) {
         // If the window is already showing, just bring it forward.
         if let existing = logReportWindow, existing.isVisible {
             existing.makeKeyAndOrderFront(nil)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -382,7 +382,7 @@ struct MainWindowView: View {
             DaemonLoadingOverlayContent(
                 error: daemonStartupError,
                 onRetry: { handleDaemonRetry() },
-                onSendLogs: { AppDelegate.shared?.showLogReportWindow(reason: .connectionIssue) },
+                onSendLogs: { AppDelegate.shared?.showLogReportWindow(reason: .appCrash) },
                 onGoToDeveloper: {
                     settingsStore.pendingSettingsTab = .developer
                     windowState.selection = .panel(.settings)

--- a/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
@@ -16,13 +16,13 @@ struct LogReportFormView: View {
     @State private var message: String = ""
     @AppStorage("logReportEmail") private var email: String = ""
     @State private var includeLogs: Bool = true
+    @State private var hasManuallyToggledLogs: Bool = false
     @State private var logTimeRange: LogTimeRange = .pastHour
     @FocusState private var focusedField: Field?
 
     init(
         authManager: AuthManager,
         initialReason: LogReportReason? = nil,
-        initialIncludeLogs: Bool = true,
         onSend: @escaping (LogReportFormData) -> Void,
         onCancel: @escaping () -> Void
     ) {
@@ -31,7 +31,9 @@ struct LogReportFormView: View {
         self.onSend = onSend
         self.onCancel = onCancel
         self._selectedReason = State(initialValue: initialReason)
-        self._includeLogs = State(initialValue: initialIncludeLogs)
+        if let reason = initialReason {
+            self._includeLogs = State(initialValue: reason.isErrorCategory)
+        }
     }
 
     private var canSend: Bool {
@@ -62,12 +64,8 @@ struct LogReportFormView: View {
             }
         }
         .onChange(of: selectedReason) { _, newReason in
-            guard let reason = newReason else { return }
-            if reason.isErrorCategory {
-                includeLogs = true
-            } else {
-                includeLogs = false
-            }
+            guard !hasManuallyToggledLogs, let reason = newReason else { return }
+            includeLogs = reason.isErrorCategory
         }
     }
 
@@ -131,7 +129,13 @@ struct LogReportFormView: View {
         if selectedReason != .featureRequest {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
                 HStack(spacing: VSpacing.md) {
-                    Toggle(isOn: $includeLogs) {
+                    Toggle(isOn: Binding(
+                        get: { includeLogs },
+                        set: { newValue in
+                            includeLogs = newValue
+                            hasManuallyToggledLogs = true
+                        }
+                    )) {
                         Text("Include diagnostic logs")
                             .font(VFont.body)
                             .foregroundColor(VColor.contentDefault)


### PR DESCRIPTION
## Summary
- Daemon startup errors now pre-select 'App crashed or won't start' (was Connection issue)
- Menu bar opens with no category pre-selected (was Bug Report)
- Log toggle respects manual user override when switching categories
- initialReason correctly pre-sets includeLogs based on isErrorCategory

Part of plan: share-feedback-redesign.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
