### PR TITLE
fix: URL-encode messageId in TTSClient path

### DIFF
--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -83,11 +83,13 @@ public enum GatewayHTTPClient {
     /// - Parameters:
     ///   - path: Path segment after `/v1/` (e.g. `"assistants/upgrade"`).
     ///   - body: Optional HTTP body data.
+    ///   - params: Optional query parameters. Keys and values are percent-encoded
+    ///     using a restricted character set that escapes `&`, `=`, `+`, and `#`.
     ///   - timeout: Request timeout in seconds. Defaults to 30.
     /// - Returns: A `Response` with the raw data and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func post(path: String, body: Data? = nil, timeout: TimeInterval = 30) async throws -> Response {
-        return try await executeWithRetry(path: path, method: "POST", timeout: timeout) { request in
+    public static func post(path: String, body: Data? = nil, params: [String: String]? = nil, timeout: TimeInterval = 30) async throws -> Response {
+        return try await executeWithRetry(path: path, params: params, method: "POST", timeout: timeout) { request in
             request.httpBody = body
         }
     }

--- a/clients/shared/Network/TTSClient.swift
+++ b/clients/shared/Network/TTSClient.swift
@@ -30,12 +30,14 @@ public struct TTSClient: TTSClientProtocol {
 
     public func synthesize(messageId: String, conversationId: String?) async -> TTSResult {
         do {
-            var path = "assistants/{assistantId}/messages/\(messageId)/tts"
+            let encoded = messageId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? messageId
+            let path = "assistants/{assistantId}/messages/\(encoded)/tts"
+            var params: [String: String]? = nil
             if let conversationId, !conversationId.isEmpty {
-                path += "?conversationId=\(conversationId)"
+                params = ["conversationId": conversationId]
             }
 
-            let response = try await GatewayHTTPClient.post(path: path, timeout: 60)
+            let response = try await GatewayHTTPClient.post(path: path, params: params, timeout: 60)
 
             switch response.statusCode {
             case 200:


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for msg-audio-playback.md.

**Gap:** TTSClient does not URL-encode messageId in path
**What was expected:** Percent-encoding consistent with ConversationClient
**What was found:** Raw string interpolation without encoding

- Apply `.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)` to `messageId` in path construction
- Use `GatewayHTTPClient`'s `params:` support for `conversationId` query parameter instead of manual string concatenation
- Add `params` parameter to `GatewayHTTPClient.post(path:body:params:timeout:)` to support query parameters on POST requests (matching `get`'s existing pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
