### PR TITLE
fix: include logTimeRange in Sentry tags and report metadata

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -82,6 +82,7 @@ enum LogExporter {
                 "source": "log_report",
                 "report_reason": formData.reason.rawValue,
                 "logs_included": formData.includeLogs ? "true" : "false",
+                "log_time_range": formData.logTimeRange.rawValue,
             ]
             if case .conversation(let conversationId, _, _, _) = formData.scope {
                 tags["conversation_id"] = conversationId
@@ -292,6 +293,7 @@ enum LogExporter {
             var metadata: [String: Any] = [
                 "reason": formData.reason.rawValue,
                 "message": formData.message,
+                "log_time_range": formData.logTimeRange.rawValue,
                 // device_id intentionally matches ~/.vellum/device.json UUID
                 // so log exports correlate with daemon Sentry events and telemetry.
                 "device_id": SentryDeviceInfo.deviceId,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for share-feedback-redesign.md.

**Gap:** logTimeRange is collected but never used
**What was expected:** The user's time range selection should be recorded
**What was found:** logTimeRange was stored in FormData but never sent to Sentry or metadata
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
