### PR TITLE
fix: update failure alert to say "Feedback Failed"

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -54,7 +54,7 @@ enum LogExporter {
                 log.error("Failed to build log archive for Sentry: \(error.localizedDescription)")
                 NSApp.activate(ignoringOtherApps: true)
                 let alert = NSAlert()
-                alert.messageText = "Send Failed"
+                alert.messageText = "Feedback Failed"
                 alert.informativeText = "Could not send feedback: \(error.localizedDescription)"
                 alert.alertStyle = .warning
                 alert.runModal()


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for share-feedback-redesign.md.

**Gap:** Failure alert still says 'Send Failed'
**What was expected:** Feedback-first language
**What was found:** alert.messageText was still 'Send Failed'
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
