### PR TITLE
fix: managed rollback messages, version comparison, stale selection, progress text, empty state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -109,6 +109,12 @@ struct AssistantUpgradeSection: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.systemPositiveStrong)
                 }
+
+                if availableReleases.isEmpty && !isLoadingReleases && errorMessage == nil {
+                    Text("No releases available.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                }
             }
 
             if topology == .remote {
@@ -154,7 +160,7 @@ struct AssistantUpgradeSection: View {
                 HStack(spacing: VSpacing.sm) {
                     ProgressView()
                         .controlSize(.small)
-                    Text(isUpgrading ? "Upgrading assistant..." : "Checking for updates...")
+                    Text(isUpgrading ? (isRollback ? "Rolling back assistant..." : "Upgrading assistant...") : "Checking for updates...")
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)
                 }
@@ -236,6 +242,11 @@ struct AssistantUpgradeSection: View {
             let decoder = JSONDecoder()
             decoder.keyDecodingStrategy = .convertFromSnakeCase
             availableReleases = try decoder.decode([AssistantRelease].self, from: data)
+            // Reset selection if the previously selected version is no longer in the list
+            if let selected = selectedVersion,
+               !availableReleases.contains(where: { $0.version == selected }) {
+                selectedVersion = nil
+            }
         } catch {
             errorMessage = "Failed to check for updates: \(error.localizedDescription)"
         }
@@ -282,18 +293,20 @@ struct AssistantUpgradeSection: View {
             let body: [String: String] = version.map { ["version": $0] } ?? [:]
             let response = try await GatewayHTTPClient.post(path: "assistants/upgrade", json: body)
             if response.isSuccess {
-                successMessage = "Upgrade initiated. The assistant may be briefly unavailable."
+                successMessage = isRollback
+                    ? "Rollback initiated. The assistant may be briefly unavailable."
+                    : "Upgrade initiated. The assistant may be briefly unavailable."
                 // Refresh releases to update UI without clearing success message
                 await loadReleasesQuietly()
                 // Clear any error from the releases fetch so it doesn't appear alongside the success
                 if successMessage != nil { errorMessage = nil }
             } else {
-                errorMessage = "Upgrade failed (HTTP \(response.statusCode))"
+                errorMessage = "\(isRollback ? "Rollback" : "Upgrade") failed (HTTP \(response.statusCode))"
             }
         } catch let error as GatewayHTTPClient.ClientError {
-            errorMessage = "Unable to start upgrade: \(error.localizedDescription)"
+            errorMessage = "Unable to start \(isRollback ? "rollback" : "upgrade"): \(error.localizedDescription)"
         } catch {
-            errorMessage = "Upgrade failed: \(error.localizedDescription)"
+            errorMessage = "\(isRollback ? "Rollback" : "Upgrade") failed: \(error.localizedDescription)"
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -410,10 +410,14 @@ struct SettingsDeveloperTab: View {
     /// Used to determine if an upgrade action should be offered.
     private var assistantVersionBehind: Bool {
         guard let assistantVersion = healthz?.version, !assistantVersion.isEmpty,
-              let appVersion = desktopAppVersion, !appVersion.isEmpty else {
+              let appVersion = desktopAppVersion, !appVersion.isEmpty,
+              let assistantParsed = VersionCompat.parse(assistantVersion),
+              let appParsed = VersionCompat.parse(appVersion) else {
             return false
         }
-        return assistantVersion.compare(appVersion, options: .numeric) == .orderedAscending
+        if assistantParsed.major != appParsed.major { return assistantParsed.major < appParsed.major }
+        if assistantParsed.minor != appParsed.minor { return assistantParsed.minor < appParsed.minor }
+        return assistantParsed.patch < appParsed.patch
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
Five targeted fixes for the upgrade/rollback UI:

1. **Managed rollback messages now say "Rollback"** — `performManagedUpgrade()` success/error messages branch on `isRollback` (were always "Upgrade")
2. **`assistantVersionBehind` uses `VersionCompat.parse()`** — handles `v` prefix correctly instead of `.compare(options: .numeric)` which breaks with prefixed versions
3. **Stale `selectedVersion` cleared after releases refresh** — if the selected version is no longer in the releases list after a refresh, `selectedVersion` resets to `nil`
4. **Progress spinner text branches on `isRollback`** — shows "Rolling back assistant..." instead of always "Upgrading assistant..."
5. **Empty releases state feedback** — shows "No releases available." when the API returns an empty list and there's no error

## Original prompt
Fix all remaining upgrade UI bugs from holistic review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
