### PR TITLE
chore: update remaining log-centric comments and Sentry title to feedback language

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -623,7 +623,7 @@ private struct ChatBootstrapLoadingView: View {
 
 /// Shown during first-launch bootstrap when the daemon fails to connect
 /// within the timeout window. Mirrors the hatch-failure pattern from
-/// onboarding: a centered error message with an option to send logs.
+/// onboarding: a centered error message with an option to report to Vellum.
 private struct ChatBootstrapTimeoutView: View {
     var onSendLogs: (() -> Void)?
 

--- a/clients/macos/vellum-assistant/Features/Chat/DaemonConnectionTimeoutView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/DaemonConnectionTimeoutView.swift
@@ -3,7 +3,7 @@ import VellumAssistantShared
 
 /// Shown when the daemon loading skeleton times out without connecting.
 /// Displays an "unreachable" message with actions to retry, navigate to
-/// the developer settings tab, or send logs.
+/// the developer settings tab, or report to Vellum.
 struct DaemonConnectionTimeoutView: View {
     let onRetry: () -> Void
     let onGoToDeveloper: () -> Void

--- a/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// A sheet displayed before sending logs, letting the user pick a reason
+/// A sheet displayed for sharing feedback, letting the user pick a reason
 /// category, describe the issue, and provide an email for follow-up.
 @MainActor
 struct LogReportFormView: View {

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -67,9 +67,9 @@ enum LogExporter {
             let errorTitle: String
             switch formData.scope {
             case .conversation(_, let conversationTitle, _, _):
-                errorTitle = "\(formData.reason.displayName) log report (conversation: \(conversationTitle))"
+                errorTitle = "\(formData.reason.displayName) feedback (conversation: \(conversationTitle))"
             case .global:
-                errorTitle = "\(formData.reason.displayName) log report"
+                errorTitle = "\(formData.reason.displayName) feedback"
             }
             event.message = SentryMessage(formatted: errorTitle)
             // Set error so Sentry displays the error message (not "No error message provided").

--- a/clients/macos/vellum-assistant/Logging/LogReportReason.swift
+++ b/clients/macos/vellum-assistant/Logging/LogReportReason.swift
@@ -1,7 +1,7 @@
 import Foundation
 import VellumAssistantShared
 
-/// Pre-defined categories a user can pick when sending a log report.
+/// Pre-defined categories a user can pick when sharing feedback.
 enum LogReportReason: String, CaseIterable, Identifiable, Sendable {
     case somethingBroken
     case appCrash
@@ -72,7 +72,7 @@ enum LogTimeRange: String, CaseIterable, Identifiable, Sendable {
     }
 }
 
-/// Aggregated form data collected from the log report sheet.
+/// Aggregated form data collected from the feedback sheet.
 struct LogReportFormData: Sendable {
     var reason: LogReportReason
     var name: String


### PR DESCRIPTION
## Summary
- Update Sentry event title from "log report" to "feedback" (visible in Sentry dashboards)
- Update doc comments in LogReportReason, LogReportFormView, ChatView, and DaemonConnectionTimeoutView to use feedback-first language

## Original prompt
clean these last little things up
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
