### PR TITLE
fix: hide version picker for local topology, prevent concurrent upgrade operations

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -83,7 +83,7 @@ struct AssistantUpgradeSection: View {
                     }
                 }
 
-                if !availableReleases.isEmpty && topology != .remote {
+                if !availableReleases.isEmpty && topology != .remote && topology != .local {
                     HStack(spacing: VSpacing.sm) {
                         Text(isRollback ? "Roll back to:" : "Upgrade to:")
                             .font(VFont.caption)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -441,6 +441,7 @@ struct SettingsDeveloperTab: View {
                     isVersionIncompatible: isVersionIncompatible,
                     assistantVersionBehind: assistantVersionBehind,
                     isUpgradingInline: isUpgradingInline,
+                    isUpgradeSectionActive: isDockerOperationInProgress,
                     topology: topo,
                     onUpgradeTapped: { showingInlineUpgradeConfirmation = true }
                 )
@@ -1361,6 +1362,7 @@ private struct DeveloperUpdateProgressRow: View {
     let isVersionIncompatible: Bool
     let assistantVersionBehind: Bool
     let isUpgradingInline: Bool
+    let isUpgradeSectionActive: Bool
     let topology: AssistantTopology
     let onUpgradeTapped: () -> Void
 
@@ -1386,7 +1388,7 @@ private struct DeveloperUpdateProgressRow: View {
                         VButton(label: "Upgrade", style: .primary) {
                             onUpgradeTapped()
                         }
-                        .disabled(isUpgradingInline)
+                        .disabled(isUpgradingInline || isUpgradeSectionActive)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Hide version picker for local topology (was shown but not actionable — local uses Sparkle)
- Disable inline upgrade button when a version-picker upgrade is in progress (prevents concurrent upgrade requests to the same backend)

## Original prompt
Fix the two remaining easy issues from holistic review: local picker and concurrent upgrade guard.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
