### PR TITLE
feat: extract action keys from pipeline commands for broader trust rules

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -1606,13 +1606,15 @@ describe("Permission Checker", () => {
       expect(options[0].description).toContain("compound");
     });
 
-    test("compound command via pipeline yields exact-only allowlist option", async () => {
+    test("compound command via pipeline yields exact + action-key allowlist options", async () => {
       const options = await generateAllowlistOptions("bash", {
         command: "git log | grep fix",
       });
-      expect(options).toHaveLength(1);
+      expect(options.length).toBeGreaterThanOrEqual(2);
       expect(options[0].description).toContain("compound");
       expect(options[0].pattern).toBe("git log | grep fix");
+      // Pipeline action keys should be offered as broader options
+      expect(options.some((o) => o.pattern.startsWith("action:"))).toBe(true);
     });
 
     test("compound command via && yields exact-only allowlist option", async () => {

--- a/assistant/src/__tests__/shell-identity.test.ts
+++ b/assistant/src/__tests__/shell-identity.test.ts
@@ -82,12 +82,76 @@ describe("deriveShellActionKeys", () => {
     ]);
   });
 
-  test("pipelines are marked non-simple", async () => {
+  test("pipelines are marked non-simple but produce action keys", async () => {
     const analysis = await analyzeShellCommand("git log | grep fix");
     const result = deriveShellActionKeys(analysis);
 
     expect(result.isSimpleAction).toBe(false);
-    expect(result.keys).toHaveLength(0);
+    expect(result.keys).toEqual([
+      { key: "action:git log", depth: 2 },
+      { key: "action:git", depth: 1 },
+    ]);
+  });
+
+  test("pipeline extracts action keys from first segment", async () => {
+    const analysis = await analyzeShellCommand(
+      "pdftotext file.pdf | head -100",
+    );
+    const result = deriveShellActionKeys(analysis);
+
+    expect(result.isSimpleAction).toBe(false);
+    // file.pdf is treated as a subcommand token (doesn't start with . or contain /)
+    expect(result.keys).toEqual([
+      { key: "action:pdftotext file.pdf", depth: 2 },
+      { key: "action:pdftotext", depth: 1 },
+    ]);
+  });
+
+  test("setup-prefix + pipeline extracts action keys", async () => {
+    const analysis = await analyzeShellCommand(
+      "cd /tmp && pdftotext file.pdf | grep oil",
+    );
+    const result = deriveShellActionKeys(analysis);
+
+    expect(result.isSimpleAction).toBe(false);
+    expect(result.keys).toEqual([
+      { key: "action:pdftotext file.pdf", depth: 2 },
+      { key: "action:pdftotext", depth: 1 },
+    ]);
+  });
+
+  test("pipeline with subcommand extracts deeper keys", async () => {
+    const analysis = await analyzeShellCommand("cd repo && gh pr list | head");
+    const result = deriveShellActionKeys(analysis);
+
+    expect(result.isSimpleAction).toBe(false);
+    expect(result.keys).toEqual([
+      { key: "action:gh pr list", depth: 3 },
+      { key: "action:gh pr", depth: 2 },
+      { key: "action:gh", depth: 1 },
+    ]);
+  });
+
+  test("multi-pipe pipeline extracts first segment only", async () => {
+    const analysis = await analyzeShellCommand("cat file | grep error | wc -l");
+    const result = deriveShellActionKeys(analysis);
+
+    expect(result.isSimpleAction).toBe(false);
+    expect(result.keys).toEqual([
+      { key: "action:cat file", depth: 2 },
+      { key: "action:cat", depth: 1 },
+    ]);
+  });
+
+  test("dangerous pipe_to_shell still extracts keys", async () => {
+    const analysis = await analyzeShellCommand("curl url | bash");
+    const result = deriveShellActionKeys(analysis);
+
+    expect(result.isSimpleAction).toBe(false);
+    expect(result.keys).toEqual([
+      { key: "action:curl url", depth: 2 },
+      { key: "action:curl", depth: 1 },
+    ]);
   });
 
   test("complex chains with multiple actions are non-simple", async () => {
@@ -198,9 +262,19 @@ describe("buildShellCommandCandidates", () => {
     expect(candidates).toEqual(['git add . && git commit -m "fix"']);
   });
 
-  test("pipeline returns raw-only", async () => {
+  test("pipeline returns raw and action key candidates", async () => {
     const candidates = await buildShellCommandCandidates("git log | grep fix");
-    expect(candidates).toEqual(["git log | grep fix"]);
+    expect(candidates[0]).toBe("git log | grep fix");
+    expect(candidates).toContain("action:git log");
+    expect(candidates).toContain("action:git");
+  });
+
+  test("pipeline with setup prefix includes action candidates", async () => {
+    const candidates = await buildShellCommandCandidates(
+      "cd /tmp && pdftotext file.pdf | wc -c",
+    );
+    expect(candidates[0]).toBe("cd /tmp && pdftotext file.pdf | wc -c");
+    expect(candidates).toContain("action:pdftotext");
   });
 
   test("candidate order is stable", async () => {
@@ -241,13 +315,29 @@ describe("buildShellAllowlistOptions — complex command restrictions", () => {
     expect(options[0].description).toContain("compound");
   });
 
-  test("pipeline offers exact only", async () => {
+  test("pipeline offers exact and action-key options", async () => {
     const options = await buildShellAllowlistOptions(
       "cat file.txt | grep error | wc -l",
     );
-    expect(options).toHaveLength(1);
+    expect(options.length).toBeGreaterThanOrEqual(2);
     expect(options[0].pattern).toBe("cat file.txt | grep error | wc -l");
     expect(options[0].description).toContain("compound");
+    expect(options.some((o) => o.pattern.startsWith("action:"))).toBe(true);
+  });
+
+  test("pipeline offers action-key options from first segment", async () => {
+    const options = await buildShellAllowlistOptions(
+      "pdftotext file.pdf | head -100",
+    );
+    expect(options.length).toBeGreaterThanOrEqual(2);
+    expect(options[0].pattern).toBe("pdftotext file.pdf | head -100");
+    expect(
+      options.some(
+        (o) =>
+          o.pattern === "action:pdftotext" &&
+          o.description.includes('Any "pdftotext" command'),
+      ),
+    ).toBe(true);
   });
 
   test("semicolon chain offers exact only", async () => {

--- a/assistant/src/__tests__/tool-executor-shell-integration.test.ts
+++ b/assistant/src/__tests__/tool-executor-shell-integration.test.ts
@@ -330,7 +330,7 @@ describe("ToolExecutor → real shell allowlist integration", () => {
     expect(patterns).toContain("action:git");
   });
 
-  test("pipeline command produces only exact option", async () => {
+  test("pipeline command produces exact + action-key options", async () => {
     const { prompter, getAllowlist } = makeCapturingPrompter();
     const executor = new ToolExecutor(prompter);
 
@@ -343,9 +343,11 @@ describe("ToolExecutor → real shell allowlist integration", () => {
     const allowlist = getAllowlist();
     expect(allowlist).toBeDefined();
 
-    // Pipelines are complex commands — only exact option, no action keys
-    expect(allowlist!.length).toBe(1);
+    // Pipelines now produce exact option + action key options
+    expect(allowlist!.length).toBeGreaterThanOrEqual(2);
     expect(allowlist![0].pattern).toBe("cat file.txt | grep error");
     expect(allowlist![0].description).toContain("compound");
+    // Action keys from the first segment before the pipe
+    expect(allowlist!.some((o) => o.pattern.startsWith("action:"))).toBe(true);
   });
 });

--- a/assistant/src/permissions/shell-identity.ts
+++ b/assistant/src/permissions/shell-identity.ts
@@ -105,8 +105,10 @@ export async function analyzeShellCommand(
  *   - action:gh pr
  *   - action:gh
  *
- * Only "simple action" commands (optional setup prefix + one action) get
- * action keys. Pipelines and complex chains are marked non-simple.
+ * Simple actions (optional setup prefix + one action) and pipelines get
+ * action keys. Both are marked non-simple when they involve pipes, but
+ * pipelines extract keys from the first segment before the first pipe.
+ * Complex chains (semicolons, ||, &, newlines) get no action keys.
  */
 export function deriveShellActionKeys(
   analysis: ShellIdentityAnalysis,
@@ -117,17 +119,21 @@ export function deriveShellActionKeys(
     return { keys: [], isSimpleAction: false };
   }
 
-  // For multi-segment commands, only allow simple-action classification if
-  // ALL inter-segment operators are explicitly &&. Any other operator (|, ||,
-  // ;, &, empty/missing) means the separator is unknown or unsafe.
-  // This safely handles cases where the parser doesn't capture certain
-  // separators (;, newline, &) and leaves them as empty operators.
+  // For multi-segment commands, check operators to determine the command shape.
+  // Pipes (|) get special handling — we can extract action keys from the first
+  // segment before the pipe. Other complex operators (||, ;, &, empty/missing)
+  // are truly opaque and get no action keys.
   if (segments.length > 1) {
+    let hasPipe = false;
+
     for (const seg of segments) {
       const op = seg.operator;
-      // Non-empty operator that isn't && → definitely complex
-      if (op && op !== "&&") {
+      // Non-empty operator that isn't && or | → definitely complex, no keys
+      if (op && op !== "&&" && op !== "|") {
         return { keys: [], isSimpleAction: false };
+      }
+      if (op === "|") {
+        hasPipe = true;
       }
     }
     // Also check: if there are multiple segments but no operators at all
@@ -139,6 +145,42 @@ export function deriveShellActionKeys(
       if (!segments[i].operator) {
         return { keys: [], isSimpleAction: false };
       }
+    }
+
+    // For pipelines, extract action keys from the first non-setup-prefix segment
+    // before the first pipe. This enables broader "Any pdftotext command" rules
+    // that match pipelines like "pdftotext file | head -100".
+    if (hasPipe) {
+      const firstPipeIndex = segments.findIndex((s) => s.operator === "|");
+      if (firstPipeIndex > 0) {
+        const preSegments = segments.slice(0, firstPipeIndex);
+        const actionSegs = preSegments.filter(
+          (s) => !SETUP_PREFIX_PROGRAMS.has(s.program),
+        );
+        if (actionSegs.length === 1) {
+          const seg = actionSegs[0];
+          const tokens: string[] = [seg.program];
+          for (const arg of seg.args) {
+            if (tokens.length >= MAX_ACTION_KEY_DEPTH) break;
+            if (arg.startsWith("-")) continue;
+            if (arg.includes("/") || arg.startsWith(".")) continue;
+            if (/^\d+$/.test(arg)) continue;
+            if (arg.includes("$") || arg.includes('"') || arg.includes("'"))
+              continue;
+            tokens.push(arg);
+          }
+          const keys: ShellActionKey[] = [];
+          for (let depth = tokens.length; depth >= 1; depth--) {
+            keys.push({
+              key: `action:${tokens.slice(0, depth).join(" ")}`,
+              depth,
+            });
+          }
+          return { keys, isSimpleAction: false, primarySegment: seg };
+        }
+      }
+      // Pipeline but couldn't extract a single primary action — no keys
+      return { keys: [], isSimpleAction: false };
     }
   }
 
@@ -190,9 +232,10 @@ export function deriveShellActionKeys(
  * Candidate ordering:
  *   1. Raw command (most specific match — the full command as written)
  *   2. Canonical primary command (if simple action) — the full primary segment text
- *   3. Action keys from narrowest to broadest (if simple action)
+ *   3. Action keys from narrowest to broadest (if simple action or pipeline)
  *
- * Complex commands (pipelines, multi-action chains) only return the raw candidate.
+ * Complex non-pipeline commands (multi-action chains, semicolons, etc.) only
+ * return the raw candidate.
  */
 export async function buildShellCommandCandidates(
   command: string,
@@ -206,14 +249,15 @@ export async function buildShellCommandCandidates(
 
   const candidates: string[] = [trimmed];
 
-  if (actionResult.isSimpleAction && actionResult.primarySegment) {
-    // Add canonical primary command text (the actual segment, not the full command with setup prefixes)
-    const canonical = actionResult.primarySegment.command;
-    if (canonical !== trimmed) {
-      candidates.push(canonical);
+  // Add action keys as candidates if available (simple actions AND pipelines)
+  if (actionResult.keys.length > 0) {
+    // For simple actions, also add the canonical primary command text
+    if (actionResult.isSimpleAction && actionResult.primarySegment) {
+      const canonical = actionResult.primarySegment.command;
+      if (canonical !== trimmed) {
+        candidates.push(canonical);
+      }
     }
-
-    // Add action keys
     for (const actionKey of actionResult.keys) {
       candidates.push(actionKey.key);
     }
@@ -231,8 +275,9 @@ export async function buildShellCommandCandidates(
  *   2. Deepest action key (e.g. "action:gh pr view")
  *   3. Broader action keys (e.g. "action:gh pr", "action:gh")
  *
- * For complex commands (pipelines, multi-action chains), only the exact
- * command is offered (no broad options).
+ * For pipelines, the exact command plus action-key-based broader options
+ * are offered. For other complex commands (multi-action chains, semicolons,
+ * etc.), only the exact command is offered.
  */
 export async function buildShellAllowlistOptions(
   command: string,
@@ -244,14 +289,23 @@ export async function buildShellAllowlistOptions(
   const actionResult = deriveShellActionKeys(analysis);
 
   if (!actionResult.isSimpleAction || !actionResult.primarySegment) {
-    // Complex command — exact only
-    return [
+    const options: AllowlistOption[] = [
       {
         label: trimmed,
         description: "This exact compound command",
         pattern: trimmed,
       },
     ];
+    // If pipeline action keys were extracted, offer them as broader options
+    for (const actionKey of actionResult.keys) {
+      const keyTokens = actionKey.key.replace(/^action:/, "");
+      options.push({
+        label: `${keyTokens} *`,
+        description: `Any "${keyTokens}" command`,
+        pattern: actionKey.key,
+      });
+    }
+    return options;
   }
 
   const options: AllowlistOption[] = [];


### PR DESCRIPTION
## Summary
- Extends action-key extraction from simple commands to also cover pipeline commands
- Users can now approve 'Any pdftotext command' to cover 'pdftotext file | head', 'pdftotext file | grep', etc.
- Non-pipeline complex commands (semicolons, ||, &amp;) remain exact-match only for safety

Part of plan: trust-shell-broad-options.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
