### PR TITLE
Remove Logfire mentions from README and plan docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ bun install
 bun run src/index.ts assistant start
 ```
 
-> **Note:** Some dependencies (`agentmail`, `@pydantic/logfire-node`) are optional at runtime but required for full `tsc --noEmit` type-checking to pass. They are installed automatically by `bun install`.
+> **Note:** Some dependencies (`agentmail`) are optional at runtime but required for full `tsc --noEmit` type-checking to pass. They are installed automatically by `bun install`.
 
 </details>
 


### PR DESCRIPTION
## Summary
- Remove @pydantic/logfire-node from optional dependencies note in README.md
- Remove logfire wrapping caveat from pdf-provider-support.md plan

Part of plan: remove-logfire.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
