### PR TITLE
Remove Logfire feature flag from feature-flag registry

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -66,14 +66,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "logfire",
-      "scope": "assistant",
-      "key": "feature_flags.logfire.enabled",
-      "label": "Logfire LLM Observability",
-      "description": "Enable Logfire tracing for LLM request/response telemetry when LOGFIRE_TOKEN is set",
-      "defaultEnabled": false
-    },
-    {
       "id": "ces-tools",
       "scope": "assistant",
       "key": "feature_flags.ces-tools.enabled",


### PR DESCRIPTION
## Summary
- Remove the logfire feature flag entry from the canonical feature-flag registry JSON file (`meta/feature-flags/feature-flag-registry.json`)
- The bundled copies (`assistant/src/config/` and `gateway/src/`) are generated at build time from the canonical source and are `.gitignore`d

Part of plan: remove-logfire.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
