### PR TITLE
feat: expose available update version string from Sparkle in UpdateManager

### DIFF
--- a/clients/macos/vellum-assistant/App/UpdateManager.swift
+++ b/clients/macos/vellum-assistant/App/UpdateManager.swift
@@ -15,6 +15,7 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
 
     @Published public private(set) var isUpdateAvailable = false
     @Published public private(set) var isDeferredUpdateReady = false
+    @Published public private(set) var availableUpdateVersion: String?
 
     /// Called before the app is replaced — stop the daemon so the new version
     /// can launch its own bundled daemon cleanly.
@@ -140,6 +141,7 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
         Task { @MainActor in
             log.info("Found valid update: \(item.displayVersionString, privacy: .public)")
             self.isUpdateAvailable = true
+            self.availableUpdateVersion = item.displayVersionString
         }
     }
 
@@ -148,6 +150,7 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
     nonisolated public func updaterDidNotFindUpdate(_ updater: SPUUpdater) {
         Task { @MainActor in
             self.isUpdateAvailable = false
+            self.availableUpdateVersion = nil
         }
     }
 
@@ -163,6 +166,7 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
             if choice == .skip {
                 log.info("User skipped update \(updateItem.displayVersionString, privacy: .public)")
                 self.isUpdateAvailable = false
+                self.availableUpdateVersion = nil
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add `availableUpdateVersion: String?` published property to UpdateManager
- Captured from `SUAppcastItem.displayVersionString` in `didFindValidUpdate`
- Cleared when no update found or user skips

Part of plan: local-upgrade-sparkle-ux.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
