### PR TITLE
fix: fail closed when signing-key bootstrap lockfile write fails

### DIFF
--- a/gateway/src/http/routes/signing-key-bootstrap.ts
+++ b/gateway/src/http/routes/signing-key-bootstrap.ts
@@ -42,7 +42,12 @@ export function createSigningKeyBootstrapHandler(_config: GatewayConfig) {
         try {
           writeFileSync(lockPath, new Date().toISOString(), { mode: 0o600 });
         } catch (err) {
+          inFlight = false;
           log.error({ err }, "Failed to write signing-key-bootstrap lock file");
+          return Response.json(
+            { error: "Failed to persist bootstrap lock — refusing to serve key" },
+            { status: 500 },
+          );
         }
 
         return response;


### PR DESCRIPTION
Addresses review feedback on #19998. Returns 500 instead of serving the key when lockfile persistence fails, preserving the one-shot guarantee across gateway restarts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
