### PR TITLE
fix: include dangerouslySkipPermissions in allow-decision set and domain events

### DIFF
--- a/assistant/src/__tests__/permission-types.test.ts
+++ b/assistant/src/__tests__/permission-types.test.ts
@@ -15,6 +15,7 @@ describe("isAllowDecision", () => {
     "always_allow",
     "always_allow_high_risk",
     "temporary_override",
+    "dangerously_skip_permissions",
   ];
 
   for (const decision of allowDecisions) {

--- a/assistant/src/events/domain-events.ts
+++ b/assistant/src/events/domain-events.ts
@@ -25,7 +25,8 @@ export interface ToolDomainEvents {
       | "always_allow_high_risk"
       | "deny"
       | "always_deny"
-      | "temporary_override";
+      | "temporary_override"
+      | "dangerously_skip_permissions";
     riskLevel: string;
     decidedAtMs: number;
   };

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -24,7 +24,8 @@ export type UserDecision =
   | "always_allow_high_risk"
   | "deny"
   | "always_deny"
-  | "temporary_override";
+  | "temporary_override"
+  | "dangerously_skip_permissions";
 
 /** Returns true for any allow-variant decision. Centralizes the check to prevent omissions when new allow variants are added. */
 export function isAllowDecision(decision: UserDecision): boolean {
@@ -34,7 +35,8 @@ export function isAllowDecision(decision: UserDecision): boolean {
     decision === "allow_conversation" ||
     decision === "always_allow" ||
     decision === "always_allow_high_risk" ||
-    decision === "temporary_override"
+    decision === "temporary_override" ||
+    decision === "dangerously_skip_permissions"
   );
 }
 


### PR DESCRIPTION
Addresses review feedback on #19955. Adds 'dangerously_skip_permissions' to isAllowDecision and tool.permission.decided typing so permission decision events are emitted when skip-permissions mode is active.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
