### PR TITLE
fix: validate exact 64-hex-char format on bootstrap signing key

### DIFF
--- a/assistant/src/runtime/auth/token-service.ts
+++ b/assistant/src/runtime/auth/token-service.ts
@@ -133,10 +133,12 @@ export async function fetchSigningKeyFromGateway(): Promise<Buffer> {
 
     if (resp.ok) {
       const body = (await resp.json()) as { key: string };
-      const keyBuf = Buffer.from(body.key, "hex");
-      if (keyBuf.length !== 32) {
-        throw new Error(`Invalid signing key length: ${keyBuf.length}`);
+      if (!/^[0-9a-f]{64}$/i.test(body.key)) {
+        throw new Error(
+          `Invalid signing key: expected 64 hex characters, got ${body.key.length} chars`,
+        );
       }
+      const keyBuf = Buffer.from(body.key, "hex");
       log.info("Signing key fetched from gateway bootstrap endpoint");
       return keyBuf;
     }


### PR DESCRIPTION
Addresses review feedback on #20006. Enforces strict hex format validation on the signing key before Buffer.from() to prevent silent truncation of malformed keys.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
