### PR TITLE
fix: correct pagination total, guard empty pageIds, and re-apply DB filters in semantic search

### DIFF
--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -185,7 +185,25 @@ async function searchItemsSemantic(
     );
 
     const ids = results.map((r) => r.payload.target_id);
-    return { ids, total: ids.length };
+
+    // Use SQL COUNT(*) for accurate pagination total — Qdrant results are
+    // capped by fetchLimit and would undercount when more matches exist.
+    const db = getDb();
+    const countConditions = [ne(memoryItems.kind, "capability")];
+    if (statusFilter && statusFilter !== "all") {
+      countConditions.push(eq(memoryItems.status, statusFilter));
+    }
+    if (kindFilter) {
+      countConditions.push(eq(memoryItems.kind, kindFilter));
+    }
+    const countResult = db
+      .select({ count: count() })
+      .from(memoryItems)
+      .where(and(...countConditions))
+      .get();
+    const total = countResult?.count ?? 0;
+
+    return { ids, total };
   } catch (err) {
     log.warn({ err }, "Semantic memory search failed, falling back to SQL");
     return null;
@@ -249,11 +267,27 @@ export async function handleListMemoryItems(url: URL): Promise<Response> {
         offsetParam + limitParam,
       );
 
-      // Batch-fetch full rows from SQLite
+      if (pageIds.length === 0) {
+        return Response.json({ items: [], total: semanticResult.total });
+      }
+
+      // Re-apply the same DB-side filters used in the SQL path as defense-
+      // in-depth against stale Qdrant payloads leaking deleted/mismatched rows.
+      const hydrationConditions = [
+        inArray(memoryItems.id, pageIds),
+        ne(memoryItems.kind, "capability"),
+      ];
+      if (statusParam && statusParam !== "all") {
+        hydrationConditions.push(eq(memoryItems.status, statusParam));
+      }
+      if (kindParam) {
+        hydrationConditions.push(eq(memoryItems.kind, kindParam));
+      }
+
       const rows = db
         .select()
         .from(memoryItems)
-        .where(inArray(memoryItems.id, pageIds))
+        .where(and(...hydrationConditions))
         .all();
 
       // Preserve Qdrant relevance ordering


### PR DESCRIPTION
Addresses review feedback on #19997. Fixes three issues in semantic memory search:

1. **Pagination total**: Uses SQL `COUNT(*)` with the same kind/status/capability filters instead of `ids.length` (which was capped by `fetchLimit`), giving clients an accurate total for pagination.
2. **Empty pageIds guard**: Returns early with `{ items: [], total }` when `offset` exceeds Qdrant result count, preventing `IN ()` SQLite syntax error (500).
3. **DB-side filter re-application**: Adds `ne(kind, 'capability')`, status, and kind conditions to the hydration query, matching the SQL path's defense-in-depth against stale Qdrant payloads.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
