### PR TITLE
fix: make restart bootstrap test self-contained by seeding persisted key

### DIFF
--- a/assistant/src/__tests__/docker-signing-key-bootstrap.test.ts
+++ b/assistant/src/__tests__/docker-signing-key-bootstrap.test.ts
@@ -4,7 +4,7 @@
  * and local mode (file-based load/create).
  */
 
-import { mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -129,8 +129,13 @@ describe("resolveSigningKey — Docker bootstrap lifecycle", () => {
     process.env.IS_CONTAINERIZED = "true";
     process.env.GATEWAY_INTERNAL_URL = "http://localhost:19876";
 
-    // The previous test persisted the key. Simulate a daemon restart where
-    // the gateway returns 403 (bootstrap already completed).
+    // Seed the persisted key so this test is self-contained (no dependency
+    // on the previous test having run first).
+    mkdirSync(join(testDir, "protected"), { recursive: true });
+    writeFileSync(SIGNING_KEY_PATH, Buffer.from(VALID_32_BYTE_KEY, "hex"));
+
+    // Simulate a daemon restart where the gateway returns 403
+    // (bootstrap already completed).
     globalThis.fetch = (async () =>
       new Response(JSON.stringify({ error: "Bootstrap already completed" }), {
         status: 403,


### PR DESCRIPTION
Addresses review feedback on #20014. Removes test ordering dependency by seeding the persisted signing key within the restart test itself, so it can run independently with --grep.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
