### PR TITLE
fix: require bootstrap secret for signing-key bootstrap endpoint

### DIFF
--- a/assistant/src/runtime/auth/token-service.ts
+++ b/assistant/src/runtime/auth/token-service.ts
@@ -119,7 +119,13 @@ export async function fetchSigningKeyFromGateway(): Promise<Buffer> {
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     let resp: Response | undefined;
     try {
+      const headers: Record<string, string> = {};
+      const bootstrapSecret = process.env.GUARDIAN_BOOTSTRAP_SECRET;
+      if (bootstrapSecret) {
+        headers["x-bootstrap-secret"] = bootstrapSecret;
+      }
       resp = await fetch(`${gatewayUrl}/internal/signing-key-bootstrap`, {
+        headers,
         signal: AbortSignal.timeout(5000),
       });
     } catch (err) {

--- a/gateway/src/http/routes/signing-key-bootstrap.ts
+++ b/gateway/src/http/routes/signing-key-bootstrap.ts
@@ -18,7 +18,22 @@ export function createSigningKeyBootstrapHandler(_config: GatewayConfig) {
   let inFlight = false;
 
   return {
-    async handleGetSigningKey(_req: Request): Promise<Response> {
+    async handleGetSigningKey(req: Request): Promise<Response> {
+      // When GUARDIAN_BOOTSTRAP_SECRET is set (Docker mode), require the
+      // caller to present the matching secret. This prevents unauthenticated
+      // remote callers from fetching the raw signing key through the gateway.
+      const bootstrapSecret = process.env.GUARDIAN_BOOTSTRAP_SECRET;
+      if (bootstrapSecret) {
+        const provided = req.headers.get("x-bootstrap-secret");
+        if (provided !== bootstrapSecret) {
+          log.warn("Signing key bootstrap rejected — invalid or missing bootstrap secret");
+          return Response.json(
+            { error: "Invalid bootstrap secret" },
+            { status: 403 },
+          );
+        }
+      }
+
       const lockDir = process.env.GATEWAY_SECURITY_DIR || getRootDir();
       const lockPath = join(lockDir, "signing-key-bootstrap.lock");
 


### PR DESCRIPTION
Addresses review feedback on #20007. Gates the signing-key bootstrap endpoint behind the GUARDIAN_BOOTSTRAP_SECRET to prevent unauthorized access to the raw signing key.

When GUARDIAN_BOOTSTRAP_SECRET is set (Docker mode), both the gateway endpoint and the daemon's fetch call now use the x-bootstrap-secret header, matching the existing pattern from guardian-init.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
