### PR TITLE
fix: conditionally retry scrollbar controller install when scroll view not yet resolved

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1934,6 +1934,14 @@ private struct ConversationScrollbarVisibilityController: NSViewRepresentable, E
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
+        // If the initial async install in makeNSView ran before the view was in
+        // the hierarchy, findEnclosingScrollView would have returned nil and the
+        // controller stays permanently uninstalled. Retry here — but only when
+        // still unresolved, to avoid the render loop that unconditional
+        // re-installation would cause.
+        if context.coordinator.lastResolvedScrollView == nil {
+            context.coordinator.install(from: nsView)
+        }
         context.coordinator.update(isAppActive: isAppActive, suppressScrollbar: suppressScrollbar)
     }
 


### PR DESCRIPTION
Addresses review feedback on #20039. Adds a conditional install retry in updateNSView only when lastResolvedScrollView is nil, preventing permanent scrollbar failure without reintroducing the render loop.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
