### PR TITLE
fix: use .resize in testPinRequestSuppressedWhileDetached to avoid duplicate test

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
@@ -105,7 +105,7 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
         let convId = UUID()
         coordinator.handleUserAction(.scrollUp)
 
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
+        coordinator.requestPin(reason: .resize, conversationId: convId)
 
         XCTAssertEqual(pinRequestCount, 0)
         XCTAssertNil(coordinator.activeSession)


### PR DESCRIPTION
Addresses review feedback on #20096. Changes the pin reason in testPinRequestSuppressedWhileDetached from .messageCount to .resize to restore coverage breadth after .streaming was removed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
