### PR TITLE
fix: prune stale timestamps in currentCounts before computing scroll loop guard counts

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatScrollLoopGuard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatScrollLoopGuard.swift
@@ -195,11 +195,15 @@ final class ChatScrollLoopGuard {
 
     /// Returns the current rolling event counts for a conversation.
     /// Used by `DebugStateWriter` to include hot-path rates in `debug-state.json`.
-    func currentCounts(conversationId: String) -> [EventKind: Int] {
+    func currentCounts(
+        conversationId: String,
+        timestamp: TimeInterval = ProcessInfo.processInfo.systemUptime
+    ) -> [EventKind: Int] {
         guard let state = states[conversationId] else { return [:] }
+        let windowStart = timestamp - Self.windowDuration
         var counts: [EventKind: Int] = [:]
         for kind in EventKind.allCases {
-            let count = state.events[kind]?.count ?? 0
+            let count = (state.events[kind] ?? []).filter { $0 > windowStart }.count
             if count > 0 {
                 counts[kind] = count
             }

--- a/clients/macos/vellum-assistantTests/ChatScrollLoopGuardTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatScrollLoopGuardTests.swift
@@ -518,10 +518,32 @@ final class ChatScrollLoopGuardTests: XCTestCase {
             timestamp += 0.01
         }
 
-        let counts = guard_.currentCounts(conversationId: conversationId)
+        let counts = guard_.currentCounts(conversationId: conversationId, timestamp: timestamp)
         XCTAssertEqual(counts[.avatarFollowerUpdate], 10)
         XCTAssertEqual(counts[.bodyEvaluation], 5)
         XCTAssertNil(counts[.anchorPreferenceChange], "Unrecorded kinds should not appear")
+    }
+
+    func testCurrentCountsPrunesStaleEntries() {
+        var timestamp: TimeInterval = 1000.0
+
+        // Record events that will become stale.
+        for _ in 0..<10 {
+            guard_.record(.avatarFollowerUpdate, conversationId: conversationId, timestamp: timestamp)
+            timestamp += 0.01
+        }
+
+        // Advance past the 2-second window so all prior events are stale.
+        timestamp += ChatScrollLoopGuard.windowDuration + 0.1
+
+        // Record a few fresh events.
+        for _ in 0..<3 {
+            guard_.record(.avatarFollowerUpdate, conversationId: conversationId, timestamp: timestamp)
+            timestamp += 0.01
+        }
+
+        let counts = guard_.currentCounts(conversationId: conversationId, timestamp: timestamp)
+        XCTAssertEqual(counts[.avatarFollowerUpdate], 3, "Stale entries outside the window should be excluded")
     }
 
     func testCurrentCountsReturnsEmptyForUnknownConversation() {


### PR DESCRIPTION
Addresses review feedback on #20016. Applies the same 2-second window pruning used in record() to currentCounts so exported diagnostic counts don't include stale entries.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
