### PR TITLE
fix: make signing key lock cleanup best-effort during upgrade

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -352,7 +352,14 @@ async function upgradeDocker(
   await migrateCesSecurityFiles(res, (msg) => console.log(msg));
 
   console.log("🔑 Clearing signing key bootstrap lock...");
-  await clearSigningKeyBootstrapLock(res);
+  try {
+    await clearSigningKeyBootstrapLock(res);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `⚠️  Failed to clear signing key bootstrap lock (${message}), continuing...`,
+    );
+  }
 
   console.log("🚀 Starting upgraded containers...");
   await startContainers(


### PR DESCRIPTION
## Summary
- Wraps `clearSigningKeyBootstrapLock()` call in `upgrade.ts` with try/catch and warning log
- Prevents upgrade from aborting after containers are stopped if the lock cleanup fails
- Matches the non-fatal error handling pattern of `migrateGatewaySecurityFiles` and `migrateCesSecurityFiles`

Addresses review feedback on #20013.

## Test plan
- [ ] Verify upgrade succeeds even when busybox image is unavailable
- [ ] Verify warning is logged when lock cleanup fails
- [ ] Verify normal upgrade path still clears the lock file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
