### PR TITLE
fix: increase runNow timeout to 120s to accommodate longer schedule executions

### DIFF
--- a/clients/shared/Network/ScheduleClient.swift
+++ b/clients/shared/Network/ScheduleClient.swift
@@ -86,7 +86,7 @@ public struct ScheduleClient: ScheduleClientProtocol {
         let response = try await GatewayHTTPClient.post(
             path: "assistants/{assistantId}/schedules/\(id)/run",
             json: [:],
-            timeout: 30
+            timeout: 120
         )
         guard response.isSuccess else {
             log.error("runNow failed (HTTP \(response.statusCode))")


### PR DESCRIPTION
Addresses review feedback on #20102. Increases the ScheduleClient.runNow timeout from 30s to 120s since the backend awaits full schedule execution before responding.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
