### PR TITLE
fix: fetch skip-permissions on initial load and guard against rapid toggle races

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -91,6 +91,8 @@ public final class SettingsStore: ObservableObject {
     // MARK: - Permissions Settings
 
     @Published var dangerouslySkipPermissions: Bool
+    /// Monotonic counter to ignore stale rollback responses from rapid toggles.
+    private var skipPermissionsToggleGeneration: UInt = 0
 
     // MARK: - Telegram Integration State
 
@@ -575,6 +577,9 @@ public final class SettingsStore: ObservableObject {
 
             // Fetch embedding config on init
             refreshEmbeddingConfig()
+
+            // Fetch skip-permissions state for Docker assistants on init
+            refreshDangerouslySkipPermissions()
         }
     }
 
@@ -2963,12 +2968,14 @@ public final class SettingsStore: ObservableObject {
         // Docker assistants: use the HTTP API (workspace is on a Docker volume,
         // not directly writable from the host).
         if isCurrentAssistantDocker {
+            skipPermissionsToggleGeneration &+= 1
+            let requestGeneration = skipPermissionsToggleGeneration
             dangerouslySkipPermissions = enabled
-            Task {
+            Task { @MainActor in
                 let success = await settingsClient.setDangerouslySkipPermissions(enabled)
-                if !success {
-                    // Revert optimistic toggle on failure
-                    dangerouslySkipPermissions = !enabled
+                if !success, self.skipPermissionsToggleGeneration == requestGeneration {
+                    // Revert optimistic toggle on failure only if no newer toggle has fired
+                    self.dangerouslySkipPermissions = !enabled
                 }
             }
             return


### PR DESCRIPTION
Addresses review feedback on #20042. Adds skip-permissions fetch to initial bootstrap path and uses a monotonic counter to ignore stale rollback responses from rapid toggles.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
