### PR TITLE
fix: add assertion for outbound message dispatch in iOS bootstrap tests

### DIFF
--- a/clients/ios/Tests/ChatViewModelIOSTests.swift
+++ b/clients/ios/Tests/ChatViewModelIOSTests.swift
@@ -176,6 +176,10 @@ final class ChatViewModelIOSTests: XCTestCase {
         // Bootstrap should have created a conversation ID locally and cleared bootstrap state
         XCTAssertNotNil(viewModel.conversationId)
         XCTAssertNil(viewModel.bootstrapCorrelationId)
+
+        // Verify the user message was actually dispatched to the daemon
+        XCTAssertEqual(mockClient.sentMessages.count, 1, "Bootstrap should send the user message to the daemon")
+        XCTAssertEqual(mockClient.sentMessages[0].content, "Hello")
     }
 
     // MARK: - Streaming Deltas
@@ -324,6 +328,10 @@ final class ChatViewModelIOSTests: XCTestCase {
 
         // 2. Bootstrap should have created a conversation ID locally
         XCTAssertNotNil(viewModel.conversationId)
+
+        // Verify the user message was actually dispatched to the daemon
+        XCTAssertEqual(mockClient.sentMessages.count, 1, "Bootstrap should send the user message to the daemon")
+        XCTAssertEqual(mockClient.sentMessages[0].content, "Tell me about iOS")
 
         // 3. Assistant starts streaming
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "iOS is ")))


### PR DESCRIPTION
Addresses review feedback on #20097. Adds explicit assertion that the user message is actually sent to the daemon after bootstrap, not just that conversationId was assigned.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
