### PR TITLE
fix: read auto-approve state from activeHostCuProxy, not dead currentSession

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -120,8 +120,9 @@ extension AppDelegate {
     func handleToolConfirmationRequest(_ msg: ConfirmationRequestMessage) {
         Task { @MainActor in
             // Auto-approve low/medium risk tool confirmations during CU sessions
-            if self.currentSession?.autoApproveTools == true,
-               msg.riskLevel == "low" || msg.riskLevel == "medium" {
+            let cuAutoApprove = self.currentSession?.autoApproveTools == true
+                || self.activeHostCuProxy?.autoApproveTools == true
+            if cuAutoApprove, (msg.riskLevel == "low" || msg.riskLevel == "medium") {
                 let success = await InteractionClient().sendConfirmationResponse(
                     requestId: msg.requestId,
                     decision: "allow"


### PR DESCRIPTION
## Summary
- The auto-approve check read from `self.currentSession` which is always nil during active CU sessions — the proxy lives in `activeHostCuProxy`
- Now checks both `currentSession` and `activeHostCuProxy` for the auto-approve toggle
- Adds parentheses around the risk-level `||` check for operator-precedence safety

Part of plan: fix-cu-auto-approve.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
