### PR TITLE
fix: show auto-approve toggle in overlay during awaitingConfirmation state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Session/SessionOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/SessionOverlayWindow.swift
@@ -515,6 +515,24 @@ final class SessionOverlayWindow {
 
             return hstack
 
+        case .awaitingConfirmation:
+            let hstack = NSStackView()
+            hstack.orientation = .horizontal
+            hstack.spacing = 8
+
+            let autoApproveBtn = makeAutoApproveButton()
+            let spacer = NSView()
+            spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+            let stopBtn = makeButton("Stop", action: #selector(SessionOverlayButtonTarget.stopClicked))
+            stopBtn.bezelStyle = .rounded
+            stopBtn.contentTintColor = NSColor(VColor.systemNegativeStrong)
+
+            hstack.addArrangedSubview(autoApproveBtn)
+            hstack.addArrangedSubview(spacer)
+            hstack.addArrangedSubview(stopBtn)
+
+            return hstack
+
         default:
             return NSView()
         }


### PR DESCRIPTION
## Summary
- The `controlsForState` switch in `SessionOverlayWindow` fell through to `default: NSView()` for `.awaitingConfirmation`, hiding the auto-approve button
- Adds an explicit case showing the auto-approve toggle and stop button during confirmation prompts
- The undo button is intentionally omitted since there's nothing to undo mid-confirmation

Part of plan: fix-cu-auto-approve.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
