### PR TITLE
fix: persist generated bootstrap secret in upgrade and rollback paths

### DIFF
--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -18,7 +18,7 @@ import {
   stopContainers,
 } from "../lib/docker";
 import type { ServiceName } from "../lib/docker";
-import { loadBootstrapSecret } from "../lib/guardian-token";
+import { loadBootstrapSecret, saveBootstrapSecret } from "../lib/guardian-token";
 import {
   broadcastUpgradeEvent,
   captureContainerEnv,
@@ -164,8 +164,11 @@ export async function rollback(): Promise<void> {
     capturedEnv["CES_SERVICE_TOKEN"] || randomBytes(32).toString("hex");
 
   // Retrieve or generate a bootstrap secret for the gateway.
-  const bootstrapSecret =
-    loadBootstrapSecret(instanceName) || randomBytes(32).toString("hex");
+  const loadedSecret = loadBootstrapSecret(instanceName);
+  const bootstrapSecret = loadedSecret || randomBytes(32).toString("hex");
+  if (!loadedSecret) {
+    saveBootstrapSecret(instanceName, bootstrapSecret);
+  }
 
   // Build extra env vars, excluding keys managed by serviceDockerRunArgs
   const envKeysSetByRunArgs = new Set([

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -26,7 +26,7 @@ import {
   getPlatformUrl,
   readPlatformToken,
 } from "../lib/platform-client";
-import { loadBootstrapSecret, loadGuardianToken } from "../lib/guardian-token";
+import { loadBootstrapSecret, saveBootstrapSecret, loadGuardianToken } from "../lib/guardian-token";
 import { exec, execOutput } from "../lib/step-runner";
 
 interface UpgradeArgs {
@@ -320,8 +320,11 @@ async function upgradeDocker(
 
   // Retrieve or generate a bootstrap secret for the gateway. The secret was
   // persisted to disk during hatch; older instances won't have one yet.
-  const bootstrapSecret =
-    loadBootstrapSecret(instanceName) || randomBytes(32).toString("hex");
+  const loadedSecret = loadBootstrapSecret(instanceName);
+  const bootstrapSecret = loadedSecret || randomBytes(32).toString("hex");
+  if (!loadedSecret) {
+    saveBootstrapSecret(instanceName, bootstrapSecret);
+  }
 
   // Build the set of extra env vars to replay on the new assistant container.
   // Captured env vars serve as the base; keys already managed by


### PR DESCRIPTION
Addresses review feedback on #20033. Saves the generated bootstrap secret to disk in upgrade/rollback paths, matching the hatchDocker pattern, so CLI and desktop clients can discover it later.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
