### PR TITLE
feat: show Sparkle update version and status in local upgrade section

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -23,6 +23,11 @@ struct AssistantUpgradeSection: View {
     @Binding var isDockerOperationInProgress: Bool
     @Binding var dockerOperationLabel: String
 
+    /// Whether a Sparkle update is available (local topology only).
+    var sparkleUpdateAvailable: Bool = false
+    /// The version Sparkle would upgrade to (local topology only).
+    var sparkleUpdateVersion: String?
+
     @State private var availableReleases: [AssistantRelease] = []
     @State private var selectedVersion: String?
     @State private var isLoadingReleases = false
@@ -83,6 +88,23 @@ struct AssistantUpgradeSection: View {
                     }
                 }
 
+                if topology == .local {
+                    if sparkleUpdateAvailable, let updateVersion = sparkleUpdateVersion {
+                        HStack(spacing: VSpacing.sm) {
+                            Text("Update available:")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.contentTertiary)
+                            Text(updateVersion)
+                                .font(VFont.mono)
+                                .foregroundColor(VColor.primaryBase)
+                        }
+                    } else if !sparkleUpdateAvailable && currentVersion != nil {
+                        Text("You are on the latest version.")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.systemPositiveStrong)
+                    }
+                }
+
                 if !availableReleases.isEmpty && topology != .remote && topology != .local {
                     HStack(spacing: VSpacing.sm) {
                         Text(isRollback ? "Roll back to:" : "Upgrade to:")
@@ -102,7 +124,7 @@ struct AssistantUpgradeSection: View {
                     }
                 }
 
-                if !upgradeAvailable && !isLoadingReleases && !availableReleases.isEmpty {
+                if !upgradeAvailable && !isLoadingReleases && !availableReleases.isEmpty && topology != .local {
                     Text(selectedVersion == nil
                          ? "You are on the latest version."
                          : "You are already on this version.")
@@ -110,7 +132,7 @@ struct AssistantUpgradeSection: View {
                         .foregroundColor(VColor.systemPositiveStrong)
                 }
 
-                if availableReleases.isEmpty && !isLoadingReleases && errorMessage == nil {
+                if availableReleases.isEmpty && !isLoadingReleases && errorMessage == nil && topology != .local {
                     Text("No releases available.")
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -74,6 +74,10 @@ struct SettingsDeveloperTab: View {
     @State private var isDockerOperationInProgress = false
     @State private var dockerOperationLabel: String = ""
 
+    // -- Sparkle update state (local topology) --
+    @State private var sparkleUpdateAvailable: Bool = false
+    @State private var sparkleUpdateVersion: String?
+
     // -- Sentry testing state --
     @State private var lastSentryStatus: String?
     @State private var sentryDismissTask: Task<Void, Never>?
@@ -131,7 +135,9 @@ struct SettingsDeveloperTab: View {
                     currentVersion: healthz?.version,
                     topology: topo,
                     isDockerOperationInProgress: $isDockerOperationInProgress,
-                    dockerOperationLabel: $dockerOperationLabel
+                    dockerOperationLabel: $dockerOperationLabel,
+                    sparkleUpdateAvailable: sparkleUpdateAvailable,
+                    sparkleUpdateVersion: sparkleUpdateVersion
                 )
             }
             // Hatch New Assistant
@@ -208,6 +214,14 @@ struct SettingsDeveloperTab: View {
             // Sentry setup
             isSentryEnabled = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
                 ?? true
+
+            // Sparkle update state (local topology)
+            sparkleUpdateAvailable = AppDelegate.shared?.updateManager.isUpdateAvailable ?? false
+            sparkleUpdateVersion = AppDelegate.shared?.updateManager.availableUpdateVersion
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            sparkleUpdateAvailable = AppDelegate.shared?.updateManager.isUpdateAvailable ?? false
+            sparkleUpdateVersion = AppDelegate.shared?.updateManager.availableUpdateVersion
         }
         .alert("Retire Assistant", isPresented: $showingRetireConfirmation) {
             Button("Cancel", role: .cancel) {}


### PR DESCRIPTION
## Summary
- Show 'Update available: X.Y.Z' for local topology when Sparkle finds an update
- Show 'You are on the latest version.' when no Sparkle update available
- Hide platform releases messages for local (they don't fetch platform releases)
- Sparkle state refreshes when app becomes active

Part of plan: local-upgrade-sparkle-ux.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
