### PR TITLE
fix: wire bypassSecretCheck through HTTP transport and validate as strict boolean

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -709,7 +709,7 @@ export async function handleSendMessage(
   // This mirrors the legacy handleUserMessage behavior: secrets are
   // detected and the message is rejected with a safe notice. The client
   // should prompt the user to use the secure credential flow instead.
-  if (trimmedContent.length > 0 && !body.bypassSecretCheck) {
+  if (trimmedContent.length > 0 && body.bypassSecretCheck !== true) {
     const ingressCheck = checkIngressForSecrets(trimmedContent);
     if (ingressCheck.blocked) {
       log.warn(

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2476,7 +2476,8 @@ public final class ChatViewModel: ObservableObject {
             conversationId: conversationId,
             attachments: attachments,
             conversationType: nil,
-            automated: nil
+            automated: nil,
+            bypassSecretCheck: true
         )
     }
 

--- a/clients/shared/Network/DaemonStatus.swift
+++ b/clients/shared/Network/DaemonStatus.swift
@@ -14,7 +14,7 @@ private let networkLog = OSLog(
 public protocol DaemonStatusProtocol: AnyObject {
     var isConnected: Bool { get }
     func subscribe() -> AsyncStream<ServerMessage>
-    func sendUserMessage(content: String?, conversationId: String, attachments: [UserMessageAttachment]?, conversationType: String?, automated: Bool?)
+    func sendUserMessage(content: String?, conversationId: String, attachments: [UserMessageAttachment]?, conversationType: String?, automated: Bool?, bypassSecretCheck: Bool?)
     func connect() async throws
     func disconnect()
     func startSSE()
@@ -148,14 +148,16 @@ public final class DaemonStatus: ObservableObject, DaemonStatusProtocol {
         conversationId: String,
         attachments: [UserMessageAttachment]? = nil,
         conversationType: String? = nil,
-        automated: Bool? = nil
+        automated: Bool? = nil,
+        bypassSecretCheck: Bool? = nil
     ) {
         eventStreamClient.sendUserMessage(
             content: content,
             conversationId: conversationId,
             attachments: attachments,
             conversationType: conversationType,
-            automated: automated
+            automated: automated,
+            bypassSecretCheck: bypassSecretCheck
         )
     }
 

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -134,7 +134,8 @@ public final class EventStreamClient {
         conversationId: String,
         attachments: [UserMessageAttachment]? = nil,
         conversationType: String? = nil,
-        automated: Bool? = nil
+        automated: Bool? = nil,
+        bypassSecretCheck: Bool? = nil
     ) {
         locallyOwnedConversationIds.insert(conversationId)
 
@@ -181,7 +182,8 @@ public final class EventStreamClient {
                 conversationKey: conversationId,
                 attachmentIds: attachmentIds,
                 conversationType: resolvedConversationType,
-                automated: automated
+                automated: automated,
+                bypassSecretCheck: bypassSecretCheck
             )
 
             switch sendResult {

--- a/clients/shared/Network/MessageClient.swift
+++ b/clients/shared/Network/MessageClient.swift
@@ -26,7 +26,7 @@ public enum MessageSendResult: Sendable {
 @MainActor
 public protocol MessageClientProtocol {
     func uploadAttachment(filename: String, mimeType: String, data: String, filePath: String?) async -> AttachmentUploadResult
-    func sendMessage(content: String?, conversationKey: String, attachmentIds: [String], conversationType: String?, automated: Bool?) async -> MessageSendResult
+    func sendMessage(content: String?, conversationKey: String, attachmentIds: [String], conversationType: String?, automated: Bool?, bypassSecretCheck: Bool?) async -> MessageSendResult
 }
 
 /// Gateway-backed implementation of ``MessageClientProtocol``.
@@ -83,7 +83,7 @@ public struct MessageClient: MessageClientProtocol {
         }
     }
 
-    public func sendMessage(content: String?, conversationKey: String, attachmentIds: [String] = [], conversationType: String? = nil, automated: Bool? = nil) async -> MessageSendResult {
+    public func sendMessage(content: String?, conversationKey: String, attachmentIds: [String] = [], conversationType: String? = nil, automated: Bool? = nil, bypassSecretCheck: Bool? = nil) async -> MessageSendResult {
         log.info("[send-pipeline] message request start — uploadedAttachmentIds=\(attachmentIds.count)")
 
         var body: [String: Any] = [
@@ -102,6 +102,9 @@ public struct MessageClient: MessageClientProtocol {
         }
         if automated == true {
             body["automated"] = true
+        }
+        if bypassSecretCheck == true {
+            body["bypassSecretCheck"] = true
         }
 
         do {

--- a/clients/shared/Network/MockDaemonClient.swift
+++ b/clients/shared/Network/MockDaemonClient.swift
@@ -28,7 +28,7 @@ public final class MockDaemonClient: DaemonStatusProtocol, ObservableObject {
     /// Messages recorded by `sendUserMessage()` for assertion in tests.
     public private(set) var sentMessages: [(content: String?, conversationId: String)] = []
 
-    public func sendUserMessage(content: String?, conversationId: String, attachments: [UserMessageAttachment]? = nil, conversationType: String? = nil, automated: Bool? = nil) {
+    public func sendUserMessage(content: String?, conversationId: String, attachments: [UserMessageAttachment]? = nil, conversationType: String? = nil, automated: Bool? = nil, bypassSecretCheck: Bool? = nil) {
         sentMessages.append((content: content, conversationId: conversationId))
     }
 


### PR DESCRIPTION
Addresses review feedback on #20040. Fixes infinite 'Send Anyway' loop by forwarding bypassSecretCheck through the HTTP transport, and validates it as a strict boolean to prevent bypass via truthy non-boolean values.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
