### PR TITLE
fix: only auto-approve confirmations belonging to the active CU conversation

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -122,7 +122,11 @@ extension AppDelegate {
             // Auto-approve low/medium risk tool confirmations during CU sessions
             let cuAutoApprove = self.currentSession?.autoApproveTools == true
                 || self.activeHostCuProxy?.autoApproveTools == true
-            if cuAutoApprove, (msg.riskLevel == "low" || msg.riskLevel == "medium") {
+            let cuConversationId = self.activeHostCuProxy?.conversationId
+            let confirmationMatchesCuSession = cuConversationId != nil
+                && (msg.conversationId == nil || msg.conversationId == cuConversationId)
+            if cuAutoApprove, confirmationMatchesCuSession,
+               (msg.riskLevel == "low" || msg.riskLevel == "medium") {
                 let success = await InteractionClient().sendConfirmationResponse(
                     requestId: msg.requestId,
                     decision: "allow"


### PR DESCRIPTION
## Summary
- Scopes auto-approve to the active CU conversation to prevent approving confirmations from background conversations
- Checks `activeHostCuProxy?.conversationId` against `msg.conversationId`
- Preserves backward compatibility: nil `msg.conversationId` still matches the active session

Part of plan: fix-cu-auto-approve.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
