### PR TITLE
fix: register logfire feature flag and fix actor-token test assertion

### DIFF
--- a/assistant/src/__tests__/actor-token-service.test.ts
+++ b/assistant/src/__tests__/actor-token-service.test.ts
@@ -813,7 +813,7 @@ describe("fetchSigningKeyFromGateway", () => {
       })) as unknown as typeof fetch;
 
     await expect(fetchSigningKeyFromGateway()).rejects.toThrow(
-      "Invalid signing key length",
+      "Invalid signing key: expected 64 hex characters",
     );
   });
 

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -304,6 +304,14 @@
       "label": "Message Text-to-Speech",
       "description": "Show a speaker button on assistant messages to generate and play the message as audio via Fish Audio TTS",
       "defaultEnabled": false
+    },
+    {
+      "id": "logfire",
+      "scope": "assistant",
+      "key": "feature_flags.logfire.enabled",
+      "label": "Logfire Observability",
+      "description": "Enable Logfire distributed tracing for LLM provider calls and daemon lifecycle events",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `feature_flags.logfire.enabled` to the unified feature flag registry (used in `daemon/lifecycle.ts` but was undeclared)
- Update `actor-token-service.test.ts` to match the current error message format for invalid signing key length validation

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23359919138/job/67960263734
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
