### PR TITLE
Remove getLogfireToken env helper

### DIFF
--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -111,10 +111,6 @@ export function hasUngatedHttpAuthDisabled(): boolean {
 
 // ── Monitoring ───────────────────────────────────────────────────────────────
 
-export function getLogfireToken(): string | undefined {
-  return str("LOGFIRE_TOKEN");
-}
-
 const DEFAULT_SENTRY_DSN =
   "https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992";
 


### PR DESCRIPTION
## Summary
- Remove the now-unused getLogfireToken() function and LOGFIRE_TOKEN env var reference from env.ts

Part of plan: remove-logfire.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
