### PR TITLE
fix: require positive conversationId match for CU auto-approve

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -124,7 +124,7 @@ extension AppDelegate {
                 || self.activeHostCuProxy?.autoApproveTools == true
             let cuConversationId = self.activeHostCuProxy?.conversationId
             let confirmationMatchesCuSession = cuConversationId != nil
-                && (msg.conversationId == nil || msg.conversationId == cuConversationId)
+                && msg.conversationId == cuConversationId
             if cuAutoApprove, confirmationMatchesCuSession,
                (msg.riskLevel == "low" || msg.riskLevel == "medium") {
                 let success = await InteractionClient().sendConfirmationResponse(


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-cu-auto-approve.md.

**Gap:** Auto-approve fires on nil-conversationId confirmation requests from unrelated conversations
**What was expected:** Auto-approve only fires on positive conversationId match
**What was found:** nil conversationId was treated as a match, auto-approving unrelated requests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
