### PR TITLE
fix: add missing keyPath variable in loadOrCreateSigningKey

### DIFF
--- a/assistant/src/runtime/auth/token-service.ts
+++ b/assistant/src/runtime/auth/token-service.ts
@@ -95,6 +95,7 @@ export function loadOrCreateSigningKey(): Buffer {
   }
 
   // Generate and persist a new key
+  const keyPath = getSigningKeyPath();
   const newKey = randomBytes(32);
   const dir = dirname(keyPath);
   if (!existsSync(dir)) {


### PR DESCRIPTION
## Summary
- `loadOrCreateSigningKey()` in `token-service.ts` referenced `keyPath` without defining it, causing `TS2304: Cannot find name 'keyPath'` on 4 lines
- Added `const keyPath = getSigningKeyPath()` to match the pattern in the sibling `loadSigningKey()` function

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23360249582/job/67961355784
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
