### PR TITLE
fix: left-align feature flags in macOS Developer settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -1065,11 +1065,12 @@ struct SettingsDeveloperTab: View {
                     .foregroundColor(VColor.contentTertiary)
             } else {
                 ScrollView {
-                    VStack(spacing: VSpacing.sm) {
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
                         ForEach(filteredUnifiedFlags) { flag in
                             unifiedFlagRow(flag: flag)
                         }
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .frame(maxHeight: 400)
             }


### PR DESCRIPTION
## Summary
- Changed the Feature Flags VStack in Developer settings from default center alignment to `.leading`
- Added `.frame(maxWidth: .infinity, alignment: .leading)` to ensure the flags container stretches full width and aligns left

## Original prompt
Left-align the Feature Flags container in the macOS Developer settings. Currently the flags are center-aligned and they should be left-aligned instead.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
