### PR TITLE
fix: add missing bypassSecretCheck param to iOS sendUserMessage calls

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -569,7 +569,8 @@ extension ChatViewModel {
                         conversationId: info.conversationId,
                         attachments: attachments,
                         conversationType: nil,
-                        automated: automated ? true : nil
+                        automated: automated ? true : nil,
+                        bypassSecretCheck: nil
                     )
                 } else {
                     // Message-less conversation create (e.g. private conversation

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1699,7 +1699,8 @@ public final class ChatViewModel: ObservableObject {
             conversationId: conversationId,
             attachments: attachments,
             conversationType: nil,
-            automated: automated ? true : nil
+            automated: automated ? true : nil,
+            bypassSecretCheck: nil
         )
     }
 


### PR DESCRIPTION
## Summary
- Add missing `bypassSecretCheck: nil` argument to two `daemonClient.sendUserMessage()` call sites that were not updated when the parameter was added to the `DaemonStatusProtocol` signature
- Fixes iOS build failure: "Missing argument for parameter 'bypassSecretCheck' in call"

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23360261358/job/67961397708