### PR TITLE
fix: add placeholder message for empty Sentry user feedback

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -159,7 +159,7 @@ enum LogExporter {
             // out of event tags/extras and lets us use Sentry's built-in
             // feedback UI for triage.
             let feedback = MetricKitManager.UserFeedbackData(
-                comments: formData.message.isEmpty ? nil : formData.message,
+                comments: formData.message.isEmpty ? "(No message provided)" : formData.message,
                 email: formData.email,
                 name: formData.name.isEmpty ? nil : formData.name
             )


### PR DESCRIPTION
## Summary
- Sentry's server-side `create_feedback_issue()` filters feedback with empty messages before creating an issue occurrence
- When a user submits a log report without typing a message, the comments field was set to `nil` which became an empty string `""` in the Feedback API
- Changed to use `"(No message provided)"` as a placeholder so these reports always appear in Sentry's User Feedback UI

Part of plan: sentry-log-report-fixes.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
