### PR TITLE
fix: set Sentry user context on log report events for email searchability

### DIFF
--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -120,6 +120,16 @@ import os
                 }
             }
 
+            // Set reporter identity on the event so log reports are searchable
+            // by email (user.email:foo@example.com) in Sentry. Only set for
+            // manual reports where the user explicitly provided their email.
+            if let feedbackData = userFeedback {
+                let user = User()
+                user.email = feedbackData.email
+                user.name = feedbackData.name
+                SentrySDK.setUser(user)
+            }
+
             let eventId = SentrySDK.capture(event: event)
 
             // Send user feedback linked to the event so it appears in Sentry's
@@ -150,6 +160,11 @@ import os
             // spindump .tar.gz) can be several MB on slow connections.
             let flushTimeout: TimeInterval = attachments.isEmpty ? 5 : 15
             SentrySDK.flush(timeout: flushTimeout)
+
+            // Clear reporter identity so it doesn't leak into subsequent events.
+            if userFeedback != nil {
+                SentrySDK.setUser(nil)
+            }
 
             // Restore SDK state: if we switched DSN, close and restart
             // synchronously with the original DSN so no queued events are


### PR DESCRIPTION
## Summary
- Set reporter email/name via `SentrySDK.setUser()` before capturing manual report events so log reports are searchable by `user.email:` in Sentry
- Clear the user context after the flush to prevent leaking into subsequent automatic captures
- Only applies when `userFeedback` is provided — non-feedback manual reports are unaffected

Part of plan: sentry-log-report-fixes.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
