### PR TITLE
fix: remove dead logfire feature flag from registry

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -304,14 +304,6 @@
       "label": "Message Text-to-Speech",
       "description": "Show a speaker button on assistant messages to generate and play the message as audio via Fish Audio TTS",
       "defaultEnabled": false
-    },
-    {
-      "id": "logfire",
-      "scope": "assistant",
-      "key": "feature_flags.logfire.enabled",
-      "label": "Logfire Observability",
-      "description": "Enable Logfire distributed tracing for LLM provider calls and daemon lifecycle events",
-      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for remove-logfire.md.

**Gap:** Dead logfire feature flag re-added to canonical registry
**What was expected:** No logfire feature flag in any registry JSON
**What was found:** Concurrent PR #20235 re-added the logfire flag entry after our removal PR landed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
