### PR TITLE
fix: use vector search result count for semantic pagination total

### DIFF
--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -186,24 +186,11 @@ async function searchItemsSemantic(
 
     const ids = results.map((r) => r.payload.target_id);
 
-    // Use SQL COUNT(*) for accurate pagination total — Qdrant results are
-    // capped by fetchLimit and would undercount when more matches exist.
-    const db = getDb();
-    const countConditions = [ne(memoryItems.kind, "capability")];
-    if (statusFilter && statusFilter !== "all") {
-      countConditions.push(eq(memoryItems.status, statusFilter));
-    }
-    if (kindFilter) {
-      countConditions.push(eq(memoryItems.kind, kindFilter));
-    }
-    const countResult = db
-      .select({ count: count() })
-      .from(memoryItems)
-      .where(and(...countConditions))
-      .get();
-    const total = countResult?.count ?? 0;
-
-    return { ids, total };
+    // Use the vector search result count as the pagination total.
+    // A DB-wide COUNT would include items with no embedding yet (lagging) and
+    // items irrelevant to the search query, inflating the total and causing
+    // clients to paginate into empty pages.
+    return { ids, total: ids.length };
   } catch (err) {
     log.warn({ err }, "Semantic memory search failed, falling back to SQL");
     return null;


### PR DESCRIPTION
Address review feedback on #20213: replace DB-wide COUNT with Qdrant result count (ids.length) for semantic search pagination total. This prevents inflated totals when embeddings are lagging or the search query filters results.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
