### PR TITLE
fix: disambiguate bootstrap 403/401 and use timing-safe secret comparison

### DIFF
--- a/assistant/src/runtime/auth/token-service.ts
+++ b/assistant/src/runtime/auth/token-service.ts
@@ -165,6 +165,14 @@ export async function fetchSigningKeyFromGateway(): Promise<Buffer> {
       return keyBuf;
     }
 
+    if (resp.status === 401) {
+      // Invalid or missing bootstrap secret — configuration mismatch.
+      throw new Error(
+        "Signing key bootstrap rejected: invalid or missing bootstrap secret " +
+          "(GUARDIAN_BOOTSTRAP_SECRET mismatch between daemon and gateway)",
+      );
+    }
+
     if (resp.status === 403) {
       // Bootstrap already completed — fall through to file-based load.
       // This happens on daemon restart when the gateway lockfile persists.

--- a/gateway/src/http/routes/signing-key-bootstrap.ts
+++ b/gateway/src/http/routes/signing-key-bootstrap.ts
@@ -4,6 +4,7 @@
  * can only be read once (across restarts).
  */
 
+import { timingSafeEqual } from "node:crypto";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -24,12 +25,17 @@ export function createSigningKeyBootstrapHandler(_config: GatewayConfig) {
       // remote callers from fetching the raw signing key through the gateway.
       const bootstrapSecret = process.env.GUARDIAN_BOOTSTRAP_SECRET;
       if (bootstrapSecret) {
-        const provided = req.headers.get("x-bootstrap-secret");
-        if (provided !== bootstrapSecret) {
+        const provided = req.headers.get("x-bootstrap-secret") ?? "";
+        const providedBuf = Buffer.from(provided);
+        const expectedBuf = Buffer.from(bootstrapSecret);
+        const valid =
+          providedBuf.length === expectedBuf.length &&
+          timingSafeEqual(providedBuf, expectedBuf);
+        if (!valid) {
           log.warn("Signing key bootstrap rejected — invalid or missing bootstrap secret");
           return Response.json(
             { error: "Invalid bootstrap secret" },
-            { status: 403 },
+            { status: 401 },
           );
         }
       }


### PR DESCRIPTION
Address review feedback on #20217: (1) Return 401 instead of 403 for invalid bootstrap secret to prevent the daemon from confusing it with 'already completed'. (2) Use timingSafeEqual for bootstrap secret comparison to prevent timing side-channel.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
