### PR TITLE
fix: set logfire feature flag defaultEnabled to true to preserve existing behavior

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -311,7 +311,7 @@
       "key": "feature_flags.logfire.enabled",
       "label": "Logfire Observability",
       "description": "Enable Logfire distributed tracing for LLM provider calls and daemon lifecycle events",
-      "defaultEnabled": false
+      "defaultEnabled": true
     }
   ]
 }


### PR DESCRIPTION
Address review feedback on #20235: change defaultEnabled from false to true so existing installs with LOGFIRE_TOKEN continue to get tracing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
