### PR TITLE
fix: add missing bypassSecretCheck to iOS AppDelegate

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -327,7 +327,8 @@ extension AppDelegate: @preconcurrency UNUserNotificationCenterDelegate {
                         conversationId: sid,
                         attachments: nil,
                         conversationType: nil,
-                        automated: nil
+                        automated: nil,
+                        bypassSecretCheck: nil
                     )
                 }
                 // Call completionHandler inside the Task so iOS keeps the app alive


### PR DESCRIPTION
## Summary
- Add missing `bypassSecretCheck: nil` parameter to the `sendUserMessage` call in `AppDelegate.swift` (notification reply handler)
- This call site was missed in #20242 which added the parameter to all other call sites, causing the iOS build to fail

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23360440224/job/67962003927
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
