### PR TITLE
fix: change getSecureKeyAsync to return SecureKeyResult and surface unreachable errors

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -558,7 +558,7 @@ describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store"
       await getSecureKeyAsync(
         credentialKey("integration:google", "client_secret"),
       ),
-    ).toBe("my-secret");
+    ).toEqual({ value: "my-secret", unreachable: false });
   });
 
   test("v2 metadata with oauth2ClientSecret is stripped on migration", () => {

--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -84,10 +84,10 @@ mock.module("../oauth/manual-token-connection.js", () => ({
     if (providerKey === "slack_channel") {
       const hasBotToken = !!(await getSecureKeyAsync(
         credentialKey("slack_channel", "bot_token"),
-      ));
+      )).value;
       const hasAppToken = !!(await getSecureKeyAsync(
         credentialKey("slack_channel", "app_token"),
-      ));
+      )).value;
       if (hasBotToken && hasAppToken) {
         manualConnectionStore[providerKey] = "active";
       } else {
@@ -109,10 +109,10 @@ mock.module("../daemon/handlers/config-slack-channel.js", () => ({
 
     const hasExistingBotToken = !!(await getSecureKeyAsync(
       credentialKey("slack_channel", "bot_token"),
-    ));
+    )).value;
     const hasExistingAppToken = !!(await getSecureKeyAsync(
       credentialKey("slack_channel", "app_token"),
-    ));
+    )).value;
 
     if (appToken && !appToken.startsWith("xapp-")) {
       return {
@@ -151,10 +151,10 @@ mock.module("../daemon/handlers/config-slack-channel.js", () => ({
 
     const hasBotToken = !!(await getSecureKeyAsync(
       credentialKey("slack_channel", "bot_token"),
-    ));
+    )).value;
     const hasAppToken = !!(await getSecureKeyAsync(
       credentialKey("slack_channel", "app_token"),
-    ));
+    )).value;
 
     if (hasBotToken && hasAppToken) {
       manualConnectionStore["slack_channel"] = "active";
@@ -588,7 +588,7 @@ describe("credential_store tool — prompt action", () => {
     // Verify stored
     expect(
       await getSecureKeyAsync(credentialKey("test-prompt", "api_key")),
-    ).toBe("prompt-secret-val");
+    ).toEqual({ value: "prompt-secret-val", unreachable: false });
   });
 
   test("prompt with policy fields persists metadata", async () => {
@@ -725,7 +725,7 @@ describe("credential_store tool — prompt action", () => {
     expect(botResult.content).toContain("invalid_auth");
     expect(
       await getSecureKeyAsync(credentialKey("slack_channel", "bot_token")),
-    ).toBeUndefined();
+    ).toEqual({ value: undefined, unreachable: false });
   });
 
   test("prompt rejects invalid policy input", async () => {
@@ -1257,8 +1257,8 @@ describe("credential_store tool — store validation edge cases", () => {
     );
 
     // Verify stored
-    expect(await getSecureKeyAsync(credentialKey("del-test", "key"))).toBe(
-      "secret",
+    expect(await getSecureKeyAsync(credentialKey("del-test", "key"))).toEqual(
+      { value: "secret", unreachable: false },
     );
     const { getCredentialMetadata } =
       await import("../tools/credentials/metadata-store.js");
@@ -1278,7 +1278,7 @@ describe("credential_store tool — store validation edge cases", () => {
     // Both should be gone
     expect(
       await getSecureKeyAsync(credentialKey("del-test", "key")),
-    ).toBeUndefined();
+    ).toEqual({ value: undefined, unreachable: false });
     expect(getCredentialMetadata("del-test", "key")).toBeUndefined();
   });
 });

--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -700,7 +700,7 @@ describe("credential_store tool", () => {
       // Verify it's actually gone
       expect(
         await getSecureKeyAsync(credentialKey("gmail", "password")),
-      ).toBeUndefined();
+      ).toEqual({ value: undefined, unreachable: false });
     });
 
     test("returns error for non-existent credential", async () => {
@@ -776,15 +776,15 @@ describe("credential_store tool", () => {
   describe("credential value access", () => {
     test("credential values are stored via secure keys", async () => {
       await setSecureKeyAsync(credentialKey("github", "token"), "ghp_abc123");
-      expect(await getSecureKeyAsync(credentialKey("github", "token"))).toBe(
-        "ghp_abc123",
+      expect(await getSecureKeyAsync(credentialKey("github", "token"))).toEqual(
+        { value: "ghp_abc123", unreachable: false },
       );
     });
 
     test("returns undefined for non-existent credential", async () => {
       expect(
         await getSecureKeyAsync(credentialKey("nonexistent", "field")),
-      ).toBeUndefined();
+      ).toEqual({ value: undefined, unreachable: false });
     });
   });
 
@@ -1229,11 +1229,11 @@ describe("credential_store tool", () => {
         value: "github-pass",
       });
 
-      expect(await getSecureKeyAsync(credentialKey("gmail", "password"))).toBe(
-        "gmail-pass",
+      expect(await getSecureKeyAsync(credentialKey("gmail", "password"))).toEqual(
+        { value: "gmail-pass", unreachable: false },
       );
-      expect(await getSecureKeyAsync(credentialKey("github", "password"))).toBe(
-        "github-pass",
+      expect(await getSecureKeyAsync(credentialKey("github", "password"))).toEqual(
+        { value: "github-pass", unreachable: false },
       );
     });
 
@@ -1251,12 +1251,12 @@ describe("credential_store tool", () => {
         value: "backup@example.com",
       });
 
-      expect(await getSecureKeyAsync(credentialKey("gmail", "password"))).toBe(
-        "pass123",
+      expect(await getSecureKeyAsync(credentialKey("gmail", "password"))).toEqual(
+        { value: "pass123", unreachable: false },
       );
       expect(
         await getSecureKeyAsync(credentialKey("gmail", "recovery_email")),
-      ).toBe("backup@example.com");
+      ).toEqual({ value: "backup@example.com", unreachable: false });
     });
   });
 });

--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -10,6 +10,7 @@ import type { CredentialMetadata } from "../tools/credentials/metadata-store.js"
 // ---------------------------------------------------------------------------
 
 let secureKeyStore = new Map<string, string>();
+let mockBrokerUnreachable = false;
 let metadataStore: CredentialMetadata[] = [];
 let idCounter = 0;
 
@@ -42,8 +43,9 @@ mock.module("../security/secure-keys.js", () => ({
   listSecureKeysAsync: async (): Promise<string[]> => {
     return [...secureKeyStore.keys()];
   },
-  getSecureKeyAsync: async (account: string): Promise<string | undefined> => {
-    return secureKeyStore.get(account);
+  getSecureKeyAsync: async (account: string) => {
+    const value = secureKeyStore.get(account);
+    return { value, unreachable: mockBrokerUnreachable };
   },
   _resetBackend: (): void => {},
 }));
@@ -262,6 +264,7 @@ function seedMetadataOnly(
 describe("assistant credentials CLI", () => {
   beforeEach(() => {
     secureKeyStore = new Map();
+    mockBrokerUnreachable = false;
     metadataStore = [];
     idCounter = 0;
     disconnectOAuthProviderCalls = [];
@@ -870,6 +873,23 @@ describe("assistant credentials CLI", () => {
       expect(parsed.hasSecret).toBe(false);
       expect(parsed.scrubbedValue).toBe("(not set)");
     });
+
+    test("inspect returns unreachable error when broker is down", async () => {
+      mockBrokerUnreachable = true;
+
+      const result = await runCli([
+        "inspect",
+        "--service",
+        "nonexistent",
+        "--field",
+        "field",
+        "--json",
+      ]);
+      expect(result.exitCode).toBe(1);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("unreachable");
+    });
   });
 
   // =========================================================================
@@ -962,6 +982,41 @@ describe("assistant credentials CLI", () => {
         "test",
         "--field",
         "nosecret",
+        "--json",
+      ]);
+      expect(result.exitCode).toBe(1);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("not found");
+    });
+
+    test("reveal returns unreachable error when broker is down", async () => {
+      mockBrokerUnreachable = true;
+      seedMetadataOnly("twilio", "auth_token");
+
+      const result = await runCli([
+        "reveal",
+        "--service",
+        "twilio",
+        "--field",
+        "auth_token",
+        "--json",
+      ]);
+      expect(result.exitCode).toBe(1);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("unreachable");
+    });
+
+    test("reveal returns credential-not-found when broker is up", async () => {
+      mockBrokerUnreachable = false;
+
+      const result = await runCli([
+        "reveal",
+        "--service",
+        "nonexistent",
+        "--field",
+        "field",
         "--json",
       ]);
       expect(result.exitCode).toBe(1);

--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -130,17 +130,17 @@ describe("secure-keys", () => {
   describe("CRUD with encrypted backend (broker unavailable)", () => {
     test("set and get a key", async () => {
       await setSecureKeyAsync("openai", "sk-openai-789");
-      expect(await getSecureKeyAsync("openai")).toBe("sk-openai-789");
+      expect(await getSecureKeyAsync("openai")).toEqual({ value: "sk-openai-789", unreachable: false });
     });
 
     test("get returns undefined for nonexistent key", async () => {
-      expect(await getSecureKeyAsync("nonexistent")).toBeUndefined();
+      expect(await getSecureKeyAsync("nonexistent")).toEqual({ value: undefined, unreachable: false });
     });
 
     test("delete removes a key", async () => {
       await setSecureKeyAsync("gemini", "gem-key");
       expect(await deleteSecureKeyAsync("gemini")).toBe("deleted");
-      expect(await getSecureKeyAsync("gemini")).toBeUndefined();
+      expect(await getSecureKeyAsync("gemini")).toEqual({ value: undefined, unreachable: false });
     });
 
     test("delete returns not-found for nonexistent key", async () => {
@@ -185,7 +185,7 @@ describe("secure-keys", () => {
 
       mockBrokerStore.set("api-key", "broker-value");
       const result = await getSecureKeyAsync("api-key");
-      expect(result).toBe("broker-value");
+      expect(result).toEqual({ value: "broker-value", unreachable: false });
       expect(mockBrokerGetCalled).toBe(true);
     });
 
@@ -197,7 +197,7 @@ describe("secure-keys", () => {
       encryptedStore.setKey("legacy-key", "legacy-value");
 
       const result = await getSecureKeyAsync("legacy-key");
-      expect(result).toBe("legacy-value");
+      expect(result).toEqual({ value: "legacy-value", unreachable: false });
       // Broker was checked first (returned nothing), then encrypted store
       expect(mockBrokerGetCalled).toBe(true);
     });
@@ -206,7 +206,7 @@ describe("secure-keys", () => {
       mockBrokerAvailable = true;
       _resetBackend();
 
-      expect(await getSecureKeyAsync("missing-key")).toBeUndefined();
+      expect(await getSecureKeyAsync("missing-key")).toEqual({ value: undefined, unreachable: false });
     });
 
     test("getSecureKeyAsync returns broker value even when encrypted store also has a value", async () => {
@@ -218,7 +218,7 @@ describe("secure-keys", () => {
       encryptedStore.setKey("api-key", "encrypted-value");
 
       const result = await getSecureKeyAsync("api-key");
-      expect(result).toBe("broker-value");
+      expect(result).toEqual({ value: "broker-value", unreachable: false });
     });
   });
 
@@ -249,7 +249,7 @@ describe("secure-keys", () => {
       encryptedStore.setKey("api-key", "encrypted-value");
 
       const result = await getSecureKeyAsync("api-key");
-      expect(result).toBe("encrypted-value");
+      expect(result).toEqual({ value: "encrypted-value", unreachable: false });
       // Broker should not have been contacted
       expect(mockBrokerGetCalled).toBe(false);
     });
@@ -262,7 +262,7 @@ describe("secure-keys", () => {
       mockBrokerStore.set("api-key", "broker-value");
 
       const result = await getSecureKeyAsync("api-key");
-      expect(result).toBeUndefined();
+      expect(result).toEqual({ value: undefined, unreachable: false });
       expect(mockBrokerGetCalled).toBe(false);
     });
   });
@@ -339,7 +339,7 @@ describe("secure-keys", () => {
       encryptedStore.setKey("legacy-account", "legacy-secret");
 
       const result = await getSecureKeyAsync("legacy-account");
-      expect(result).toBe("legacy-secret");
+      expect(result).toEqual({ value: "legacy-secret", unreachable: false });
     });
 
     test("does not fall back to encrypted store when already using encrypted store backend", async () => {
@@ -350,8 +350,46 @@ describe("secure-keys", () => {
 
       // Should read directly from encrypted store (primary)
       const result = await getSecureKeyAsync("account");
-      expect(result).toBe("value");
+      expect(result).toEqual({ value: "value", unreachable: false });
       // Broker should not have been contacted
+      expect(mockBrokerGetCalled).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Unreachable propagation
+  // -----------------------------------------------------------------------
+  describe("unreachable propagation", () => {
+    test("getSecureKeyAsync returns unreachable true when broker errors", async () => {
+      mockBrokerAvailable = true;
+      mockBrokerGetError = true;
+      _resetBackend();
+
+      const result = await getSecureKeyAsync("api-key");
+      expect(result).toEqual({ value: undefined, unreachable: true });
+    });
+
+    test("getSecureKeyAsync falls back to encrypted store when broker unreachable", async () => {
+      mockBrokerAvailable = true;
+      mockBrokerGetError = true;
+      _resetBackend();
+
+      // Pre-populate encrypted store with a legacy key
+      encryptedStore.setKey("legacy-key", "legacy-value");
+
+      const result = await getSecureKeyAsync("legacy-key");
+      expect(result).toEqual({ value: "legacy-value", unreachable: false });
+    });
+
+    test("getSecureKeyAsync returns unreachable false in dev mode", async () => {
+      process.env.VELLUM_DEV = "1";
+      mockBrokerAvailable = true;
+      mockBrokerGetError = true;
+      _resetBackend();
+
+      const result = await getSecureKeyAsync("api-key");
+      expect(result).toEqual({ value: undefined, unreachable: false });
+      // Broker should not have been contacted in dev mode
       expect(mockBrokerGetCalled).toBe(false);
     });
   });

--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -135,10 +135,10 @@ mock.module("../oauth/manual-token-connection.js", () => ({
     if (providerKey !== "slack_channel") return;
     const hasBotToken = !!(await getSecureKeyAsync(
       credentialKey("slack_channel", "bot_token"),
-    ));
+    )).value;
     const hasAppToken = !!(await getSecureKeyAsync(
       credentialKey("slack_channel", "app_token"),
-    ));
+    )).value;
     if (hasBotToken && hasAppToken) {
       oauthConnectionStore[providerKey] = {
         id: `conn-${providerKey}`,
@@ -316,7 +316,7 @@ describe("Slack channel config handler", () => {
     expect(result.hasAppToken).toBe(true);
     expect(
       await getSecureKeyAsync(credentialKey("slack_channel", "app_token")),
-    ).toBe("xapp-valid-token-123");
+    ).toEqual({ value: "xapp-valid-token-123", unreachable: false });
   });
 
   test("POST validates bot token via Slack auth.test API and writes config", async () => {
@@ -399,10 +399,10 @@ describe("Slack channel config handler", () => {
 
     expect(
       await getSecureKeyAsync(credentialKey("slack_channel", "bot_token")),
-    ).toBeUndefined();
+    ).toEqual({ value: undefined, unreachable: false });
     expect(
       await getSecureKeyAsync(credentialKey("slack_channel", "app_token")),
-    ).toBeUndefined();
+    ).toEqual({ value: undefined, unreachable: false });
     expect(listCredentialMetadata()).toHaveLength(0);
 
     // Assert config values were cleared

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -193,7 +193,7 @@ export async function resolveCallerIdentity(
     userNumber = identityConfig.userNumber;
     numberSource = "user_config";
   } else {
-    const secureKeyValue = await getSecureKeyAsync(
+    const { value: secureKeyValue } = await getSecureKeyAsync(
       credentialKey("twilio", "user_phone_number"),
     );
     if (secureKeyValue) {

--- a/assistant/src/calls/fish-audio-client.ts
+++ b/assistant/src/calls/fish-audio-client.ts
@@ -75,7 +75,7 @@ export class FishAudioSession {
    * StartEvent with the provided configuration.
    */
   static async create(config: FishAudioConfig): Promise<FishAudioSession> {
-    const apiKey = await getSecureKeyAsync(
+    const { value: apiKey } = await getSecureKeyAsync(
       credentialKey("fish-audio", "api_key"),
     );
     if (!apiKey) {

--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -42,7 +42,8 @@ export async function getTwilioConfig(): Promise<TwilioConfig> {
   const config = loadConfig();
   const accountSid = config.twilio?.accountSid || "";
   const authToken =
-    (await getSecureKeyAsync(credentialKey("twilio", "auth_token"))) || "";
+    (await getSecureKeyAsync(credentialKey("twilio", "auth_token"))).value ||
+    "";
   const phoneNumber = resolveTwilioPhoneNumber();
   const webhookBaseUrl = getPublicBaseUrl(config);
 

--- a/assistant/src/calls/twilio-provider.ts
+++ b/assistant/src/calls/twilio-provider.ts
@@ -285,7 +285,8 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
    */
   static async getAuthToken(): Promise<string | null> {
     return (
-      (await getSecureKeyAsync(credentialKey("twilio", "auth_token"))) || null
+      (await getSecureKeyAsync(credentialKey("twilio", "auth_token"))).value ||
+      null
     );
   }
 

--- a/assistant/src/calls/twilio-rest.ts
+++ b/assistant/src/calls/twilio-rest.ts
@@ -30,7 +30,7 @@ function resolveAccountSid(): string | undefined {
 /** Resolve the Twilio Auth Token from the credential store. */
 async function resolveAuthToken(): Promise<string | undefined> {
   return (
-    (await getSecureKeyAsync(credentialKey("twilio", "auth_token"))) ||
+    (await getSecureKeyAsync(credentialKey("twilio", "auth_token"))).value ||
     undefined
   );
 }

--- a/assistant/src/cli/commands/avatar.ts
+++ b/assistant/src/cli/commands/avatar.ts
@@ -74,7 +74,7 @@ Examples:
       // without the daemon's in-memory state.
       try {
         const key = credentialKey("vellum", "platform_base_url");
-        const persisted = await getSecureKeyAsync(key);
+        const { value: persisted } = await getSecureKeyAsync(key);
         if (persisted) {
           setPlatformBaseUrl(persisted);
         }

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -309,7 +309,7 @@ Examples:
 
         const credentials = await Promise.all(
           allMetadata.map(async (m) => {
-            const secret = await getSecureKeyAsync(
+            const { value: secret } = await getSecureKeyAsync(
               credentialKey(m.service, m.field),
             );
             const connection = connectionsByProvider.get(m.service);
@@ -608,10 +608,19 @@ Examples:
             return;
           }
 
-          const secret = await getSecureKeyAsync(storageKey);
+          const { value: secret, unreachable } =
+            await getSecureKeyAsync(storageKey);
 
           if (!metadata && (secret == null || secret.length === 0)) {
-            writeOutput(cmd, { ok: false, error: "Credential not found" });
+            if (unreachable) {
+              writeOutput(cmd, {
+                ok: false,
+                error:
+                  "Keychain broker is unreachable — is the macOS app running?",
+              });
+            } else {
+              writeOutput(cmd, { ok: false, error: "Credential not found" });
+            }
             process.exitCode = 1;
             return;
           }
@@ -725,10 +734,19 @@ Examples:
             return;
           }
 
-          const secret = await getSecureKeyAsync(storageKey);
+          const { value: secret, unreachable } =
+            await getSecureKeyAsync(storageKey);
 
           if (secret == null || secret.length === 0) {
-            writeOutput(cmd, { ok: false, error: "Credential not found" });
+            if (unreachable) {
+              writeOutput(cmd, {
+                ok: false,
+                error:
+                  "Keychain broker is unreachable — is the macOS app running?",
+              });
+            } else {
+              writeOutput(cmd, { ok: false, error: "Credential not found" });
+            }
             process.exitCode = 1;
             return;
           }

--- a/assistant/src/cli/commands/keys.ts
+++ b/assistant/src/cli/commands/keys.ts
@@ -61,7 +61,7 @@ Examples:
     .action(async () => {
       const stored: string[] = [];
       for (const provider of API_KEY_PROVIDERS) {
-        const value = await getSecureKeyAsync(provider);
+        const { value } = await getSecureKeyAsync(provider);
         if (value) stored.push(provider);
       }
       if (stored.length === 0) {

--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -633,7 +633,7 @@ Examples:
 
           if (dbApp) {
             if (!clientId) clientId = dbApp.clientId;
-            const storedSecret = await getSecureKeyAsync(
+            const { value: storedSecret } = await getSecureKeyAsync(
               dbApp.clientSecretCredentialPath,
             );
             if (storedSecret) clientSecret = storedSecret;

--- a/assistant/src/config/bundled-skills/slack/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/slack/tools/shared.ts
@@ -22,7 +22,7 @@ export function err(message: string): ToolExecutionResult {
  * raw token string.
  */
 export async function getSlackConnection(): Promise<string> {
-  const token = await getSecureKeyAsync(
+  const { value: token } = await getSecureKeyAsync(
     credentialKey("slack_channel", "bot_token"),
   );
   if (!token) {

--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -49,10 +49,10 @@ export async function getSlackChannelConfig(): Promise<SlackChannelConfigResult>
 
   const hasBotToken = !!(await getSecureKeyAsync(
     credentialKey("slack_channel", "bot_token"),
-  ));
+  )).value;
   const hasAppToken = !!(await getSecureKeyAsync(
     credentialKey("slack_channel", "app_token"),
-  ));
+  )).value;
   const conn = getConnectionByProvider("slack_channel");
   const connected =
     !!(conn && conn.status === "active") && hasBotToken && hasAppToken;
@@ -99,10 +99,10 @@ export async function setSlackChannelConfig(
       if (!data.ok) {
         const errHasBotToken = !!(await getSecureKeyAsync(
           credentialKey("slack_channel", "bot_token"),
-        ));
+        )).value;
         const errHasAppToken = !!(await getSecureKeyAsync(
           credentialKey("slack_channel", "app_token"),
-        ));
+        )).value;
         const errConn = getConnectionByProvider("slack_channel");
         return {
           success: false,
@@ -239,10 +239,10 @@ export async function setSlackChannelConfig(
 
   const hasBotToken = !!(await getSecureKeyAsync(
     credentialKey("slack_channel", "bot_token"),
-  ));
+  )).value;
   const hasAppToken = !!(await getSecureKeyAsync(
     credentialKey("slack_channel", "app_token"),
-  ));
+  )).value;
 
   if (hasBotToken && !hasAppToken) {
     warning =

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -77,10 +77,10 @@ export async function getTelegramConfig(): Promise<TelegramConfigResult> {
   );
   const hasBotToken = !!(await getSecureKeyAsync(
     credentialKey("telegram", "bot_token"),
-  ));
+  )).value;
   const hasWebhookSecret = !!(await getSecureKeyAsync(
     credentialKey("telegram", "webhook_secret"),
-  ));
+  )).value;
   const conn = getConnectionByProvider("telegram");
   const connected = !!(conn && conn.status === "active");
   const botId = getTelegramBotId();
@@ -102,7 +102,7 @@ export async function setTelegramConfig(
   const isNewToken = !!botToken;
   const resolvedToken =
     botToken ||
-    (await getSecureKeyAsync(credentialKey("telegram", "bot_token")));
+    (await getSecureKeyAsync(credentialKey("telegram", "bot_token"))).value;
   if (!resolvedToken) {
     return {
       success: false,
@@ -184,7 +184,7 @@ export async function setTelegramConfig(
   // Ensure webhook secret exists (generate if missing)
   let hasWebhookSecret = !!(await getSecureKeyAsync(
     credentialKey("telegram", "webhook_secret"),
-  ));
+  )).value;
   if (!hasWebhookSecret) {
     const { randomUUID } = await import("node:crypto");
     const webhookSecret = randomUUID();
@@ -259,7 +259,7 @@ export async function clearTelegramConfig(): Promise<TelegramConfigResult> {
   // The gateway reconcile short-circuits when credentials are absent,
   // so we must call the Telegram API directly while the token is still
   // available.
-  const botToken = await getSecureKeyAsync(
+  const { value: botToken } = await getSecureKeyAsync(
     credentialKey("telegram", "bot_token"),
   );
   if (botToken) {
@@ -320,7 +320,7 @@ export async function clearTelegramConfig(): Promise<TelegramConfigResult> {
 export async function setTelegramCommands(
   commands?: Array<{ command: string; description: string }>,
 ): Promise<TelegramConfigResult> {
-  const storedToken = await getSecureKeyAsync(
+  const { value: storedToken } = await getSecureKeyAsync(
     credentialKey("telegram", "bot_token"),
   );
   if (!storedToken) {

--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -36,7 +36,7 @@ export async function initializeProvidersAndTools(
   // normally only set by handleAddSecret/handleDeleteSecret at runtime.
   try {
     const key = credentialKey("vellum", "platform_base_url");
-    const persisted = await getSecureKeyAsync(key);
+    const { value: persisted } = await getSecureKeyAsync(key);
     if (persisted) {
       setPlatformBaseUrl(persisted);
       log.info("Rehydrated platform base URL from credential store");
@@ -52,7 +52,7 @@ export async function initializeProvidersAndTools(
   // shouldUsePlatformCallbacks() works after assistant restarts.
   try {
     const key = credentialKey("vellum", "platform_assistant_id");
-    const persisted = await getSecureKeyAsync(key);
+    const { value: persisted } = await getSecureKeyAsync(key);
     const trimmed = persisted?.trim();
     if (trimmed) {
       setPlatformAssistantId(trimmed);
@@ -69,7 +69,7 @@ export async function initializeProvidersAndTools(
   // Sentry events include organization context after restarts.
   try {
     const key = credentialKey("vellum", "platform_organization_id");
-    const persisted = await getSecureKeyAsync(key);
+    const { value: persisted } = await getSecureKeyAsync(key);
     const trimmed = persisted?.trim();
     if (trimmed) {
       setPlatformOrganizationId(trimmed);
@@ -87,7 +87,7 @@ export async function initializeProvidersAndTools(
   // telemetry events include user context after restarts.
   try {
     const key = credentialKey("vellum", "platform_user_id");
-    const persisted = await getSecureKeyAsync(key);
+    const { value: persisted } = await getSecureKeyAsync(key);
     const trimmed = persisted?.trim();
     if (trimmed) {
       setPlatformUserId(trimmed);

--- a/assistant/src/email/providers/index.ts
+++ b/assistant/src/email/providers/index.ts
@@ -47,7 +47,8 @@ export async function createProvider(
       const candidates = PROVIDER_KEY_MAP.agentmail;
       let apiKey: string | undefined;
       for (const account of candidates) {
-        apiKey = await getSecureKeyAsync(account);
+        const result = await getSecureKeyAsync(account);
+        apiKey = result.value;
         if (apiKey) break;
       }
       if (!apiKey) {

--- a/assistant/src/mcp/client.ts
+++ b/assistant/src/mcp/client.ts
@@ -59,7 +59,7 @@ export class McpClient {
     // during daemon startup. If no tokens, try without auth — if the server
     // requires it, skip silently.
     if (isHttpTransport) {
-      const cachedTokens = await getSecureKeyAsync(
+      const { value: cachedTokens } = await getSecureKeyAsync(
         `mcp:${this.serverId}:tokens`,
       );
       if (cachedTokens) {

--- a/assistant/src/mcp/mcp-oauth-provider.ts
+++ b/assistant/src/mcp/mcp-oauth-provider.ts
@@ -87,7 +87,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
   // --- Tokens ---
 
   async tokens(): Promise<OAuthTokens | undefined> {
-    const raw = await getSecureKeyAsync(tokensKey(this.serverId));
+    const { value: raw } = await getSecureKeyAsync(tokensKey(this.serverId));
     if (!raw) return undefined;
     try {
       return JSON.parse(raw) as OAuthTokens;
@@ -118,7 +118,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
   // --- Client Information ---
 
   async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
-    const raw = await getSecureKeyAsync(clientInfoKey(this.serverId));
+    const { value: raw } = await getSecureKeyAsync(clientInfoKey(this.serverId));
     if (!raw) return undefined;
     try {
       return JSON.parse(raw) as OAuthClientInformationMixed;
@@ -164,7 +164,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
   // --- Discovery State ---
 
   async discoveryState(): Promise<OAuthDiscoveryState | undefined> {
-    const raw = await getSecureKeyAsync(discoveryKey(this.serverId));
+    const { value: raw } = await getSecureKeyAsync(discoveryKey(this.serverId));
     if (!raw) return undefined;
     try {
       return JSON.parse(raw) as OAuthDiscoveryState;

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -120,7 +120,7 @@ export const slackProvider: MessagingProvider = {
     // Socket Mode: check for bot token directly in credential store.
     // The token is the source of truth; the slack_channel connection row
     // is advisory (backfill can fail non-fatally on startup).
-    const botToken = await getSecureKeyAsync(
+    const { value: botToken } = await getSecureKeyAsync(
       credentialKey("slack_channel", "bot_token"),
     );
     if (botToken) return true;
@@ -131,7 +131,7 @@ export const slackProvider: MessagingProvider = {
   async resolveConnection(account?: string): Promise<OAuthConnection | string> {
     // Socket Mode: return raw bot token if available.
     // Token presence is sufficient — no connection row required.
-    const botToken = await getSecureKeyAsync(
+    const { value: botToken } = await getSecureKeyAsync(
       credentialKey("slack_channel", "bot_token"),
     );
     if (botToken) return botToken;

--- a/assistant/src/messaging/providers/telegram-bot/adapter.ts
+++ b/assistant/src/messaging/providers/telegram-bot/adapter.ts
@@ -45,7 +45,10 @@ function getBearerToken(): string {
 
 /** Read the Telegram bot token from the credential vault. */
 async function getBotToken(): Promise<string | undefined> {
-  return getSecureKeyAsync(credentialKey("telegram", "bot_token"));
+  const { value } = await getSecureKeyAsync(
+    credentialKey("telegram", "bot_token"),
+  );
+  return value;
 }
 
 export const telegramBotMessagingProvider: MessagingProvider = {
@@ -70,7 +73,7 @@ export const telegramBotMessagingProvider: MessagingProvider = {
     if (!(conn && conn.status === "active")) return false;
     const botToken = await getBotToken();
     if (!botToken) return false;
-    const webhookSecret = await getSecureKeyAsync(
+    const { value: webhookSecret } = await getSecureKeyAsync(
       credentialKey("telegram", "webhook_secret"),
     );
     return !!webhookSecret;

--- a/assistant/src/messaging/providers/whatsapp/adapter.ts
+++ b/assistant/src/messaging/providers/whatsapp/adapter.ts
@@ -43,11 +43,11 @@ function getBearerToken(): string {
 
 /** Check whether WhatsApp credentials are stored. */
 async function hasWhatsAppCredentials(): Promise<boolean> {
-  const phoneNumberId = await getSecureKeyAsync(
+  const { value: phoneNumberId } = await getSecureKeyAsync(
     credentialKey("whatsapp", "phone_number_id"),
   );
   if (!phoneNumberId) return false;
-  const accessToken = await getSecureKeyAsync(
+  const { value: accessToken } = await getSecureKeyAsync(
     credentialKey("whatsapp", "access_token"),
   );
   return !!accessToken;
@@ -81,16 +81,16 @@ export const whatsappMessagingProvider: MessagingProvider = {
       };
     }
 
-    const phoneNumberId = (await getSecureKeyAsync(
+    const { value: phoneNumberId } = await getSecureKeyAsync(
       credentialKey("whatsapp", "phone_number_id"),
-    ))!;
+    );
 
     return {
       connected: true,
-      user: phoneNumberId,
+      user: phoneNumberId!,
       platform: "whatsapp",
       metadata: {
-        phoneNumberId: phoneNumberId.slice(0, 6) + "...",
+        phoneNumberId: phoneNumberId!.slice(0, 6) + "...",
       },
     };
   },

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -93,7 +93,7 @@ export async function resolveOAuthConnection(
     );
   }
 
-  const accessToken = await getSecureKeyAsync(
+  const { value: accessToken } = await getSecureKeyAsync(
     `oauth_connection/${conn.id}/access_token`,
   );
   if (!accessToken) {

--- a/assistant/src/oauth/manual-token-connection.ts
+++ b/assistant/src/oauth/manual-token-connection.ts
@@ -80,10 +80,10 @@ export async function syncManualTokenConnection(
     case "telegram": {
       const hasBotToken = !!(await getSecureKeyAsync(
         credentialKey("telegram", "bot_token"),
-      ));
+      )).value;
       const hasWebhookSecret = !!(await getSecureKeyAsync(
         credentialKey("telegram", "webhook_secret"),
-      ));
+      )).value;
       if (hasBotToken && hasWebhookSecret) {
         await ensureManualTokenConnection(providerKey, accountInfo);
       } else {
@@ -95,10 +95,10 @@ export async function syncManualTokenConnection(
     case "slack_channel": {
       const hasBotToken = !!(await getSecureKeyAsync(
         credentialKey("slack_channel", "bot_token"),
-      ));
+      )).value;
       const hasAppToken = !!(await getSecureKeyAsync(
         credentialKey("slack_channel", "app_token"),
-      ));
+      )).value;
       if (hasBotToken && hasAppToken) {
         await ensureManualTokenConnection(providerKey, accountInfo);
       } else {

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -240,7 +240,7 @@ export async function upsertApp(
 
   // Verify the credential path points to an existing secret.
   if (clientSecretCredentialPath) {
-    const existing = await getSecureKeyAsync(clientSecretCredentialPath);
+    const { value: existing } = await getSecureKeyAsync(clientSecretCredentialPath);
     if (existing === undefined) {
       throw new Error(
         `No secret found at credential path: ${clientSecretCredentialPath}`,
@@ -347,7 +347,8 @@ export async function getAppClientSecret(
 ): Promise<string | undefined> {
   const app = typeof appOrId === "string" ? getApp(appOrId) : appOrId;
   if (!app) return undefined;
-  return getSecureKeyAsync(app.clientSecretCredentialPath);
+  const { value } = await getSecureKeyAsync(app.clientSecretCredentialPath);
+  return value;
 }
 
 /** Look up an app by (provider_key, client_id). */
@@ -560,7 +561,7 @@ export async function isProviderConnected(
   const conn = getActiveConnection(providerKey);
   if (!conn || conn.status !== "active") return false;
   return (
-    (await getSecureKeyAsync(oauthConnectionAccessTokenPath(conn.id))) !==
+    (await getSecureKeyAsync(oauthConnectionAccessTokenPath(conn.id))).value !==
     undefined
   );
 }
@@ -681,7 +682,7 @@ export async function disconnectOAuthProvider(
   // Wrap the assistant's secure-key functions into the SecureKeyBackend
   // interface expected by the shared deleteOAuthTokens helper.
   const backend: SecureKeyBackend = {
-    get: (key: string) => getSecureKeyAsync(key),
+    get: async (key: string) => (await getSecureKeyAsync(key)).value,
     set: (key: string, value: string) => setSecureKeyAsync(key, value),
     delete: (key: string) => deleteSecureKeyAsync(key),
     list: async () => [],

--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -40,7 +40,7 @@ import {
 // ---------------------------------------------------------------------------
 
 const secureKeyBackend: SecureKeyBackend = {
-  get: (key: string) => getSecureKeyAsync(key),
+  get: async (key: string) => (await getSecureKeyAsync(key)).value,
   set: (key: string, value: string) => setSecureKeyAsync(key, value),
   delete: async (key: string) => deleteSecureKeyAsync(key),
   list: async () => [],

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -49,13 +49,13 @@ export class VellumPlatformClient {
       baseUrl =
         (await getSecureKeyAsync(
           credentialKey("vellum", "platform_base_url"),
-        )) ?? "";
+        )).value ?? "";
     }
     if (!apiKey) {
       apiKey =
         (await getSecureKeyAsync(
           credentialKey("vellum", "assistant_api_key"),
-        )) ?? "";
+        )).value ?? "";
     }
     if (!assistantId) {
       assistantId =
@@ -63,7 +63,7 @@ export class VellumPlatformClient {
           await getSecureKeyAsync(
             credentialKey("vellum", "platform_assistant_id"),
           )
-        )?.trim() ?? "";
+        ).value?.trim() ?? "";
     }
 
     if (!baseUrl || !apiKey) return null;

--- a/assistant/src/providers/managed-proxy/context.ts
+++ b/assistant/src/providers/managed-proxy/context.ts
@@ -46,7 +46,7 @@ let _managedProxyEnabled = false;
 export async function resolveManagedProxyContext(): Promise<ManagedProxyContext> {
   const platformBaseUrl = getPlatformBaseUrl().replace(/\/+$/, "");
   const assistantApiKey =
-    (await getSecureKeyAsync(ASSISTANT_API_KEY_STORAGE_KEY)) ?? "";
+    (await getSecureKeyAsync(ASSISTANT_API_KEY_STORAGE_KEY)).value ?? "";
   const enabled = !!platformBaseUrl && !!assistantApiKey;
   _managedProxyEnabled = enabled;
 

--- a/assistant/src/runtime/channel-invite-transports/telegram.ts
+++ b/assistant/src/runtime/channel-invite-transports/telegram.ts
@@ -44,7 +44,7 @@ export async function ensureTelegramBotUsernameResolved(): Promise<void> {
     return; // Username and bot ID already cached in config
   }
 
-  const token = await getSecureKeyAsync(credentialKey("telegram", "bot_token"));
+  const { value: token } = await getSecureKeyAsync(credentialKey("telegram", "bot_token"));
   if (!token) return;
 
   try {

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -53,7 +53,7 @@ async function checkCredential(
   field: string,
   label: string,
 ): Promise<ReadinessCheckResult> {
-  const exists = !!(await getSecureKeyAsync(credentialKey(service, field)));
+  const exists = !!(await getSecureKeyAsync(credentialKey(service, field))).value;
   return check(
     name,
     exists,
@@ -143,8 +143,8 @@ const emailProbe: ChannelProbe = {
   channel: "email",
   async runLocalChecks(): Promise<ReadinessCheckResult[]> {
     const hasApiKey = !!(
-      (await getSecureKeyAsync("agentmail")) ||
-      (await getSecureKeyAsync(credentialKey("agentmail", "api_key")))
+      (await getSecureKeyAsync("agentmail")).value ||
+      (await getSecureKeyAsync(credentialKey("agentmail", "api_key"))).value
     );
     const invitePolicy = getChannelInvitePolicy("email");
     return [
@@ -166,8 +166,8 @@ const emailProbe: ChannelProbe = {
   async runRemoteChecks(): Promise<ReadinessCheckResult[]> {
     // Only worth checking if the API key is present
     const hasApiKey = !!(
-      (await getSecureKeyAsync("agentmail")) ||
-      (await getSecureKeyAsync(credentialKey("agentmail", "api_key")))
+      (await getSecureKeyAsync("agentmail")).value ||
+      (await getSecureKeyAsync(credentialKey("agentmail", "api_key"))).value
     );
     if (!hasApiKey) return [];
 

--- a/assistant/src/runtime/routes/integrations/slack/share.ts
+++ b/assistant/src/runtime/routes/integrations/slack/share.ts
@@ -30,7 +30,7 @@ const log = getLogger("slack-share");
 async function resolveSlackToken(): Promise<string | undefined> {
   const conn = getConnectionByProvider("integration:slack");
   return conn
-    ? await getSecureKeyAsync(`oauth_connection/${conn.id}/access_token`)
+    ? (await getSecureKeyAsync(`oauth_connection/${conn.id}/access_token`)).value
     : undefined;
 }
 

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -338,7 +338,7 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
       }
       // Check existence first — the broker always returns "deleted" even
       // for keys that don't exist, so we need a pre-check for 404 semantics.
-      const existing = await getSecureKeyAsync(name);
+      const { value: existing } = await getSecureKeyAsync(name);
       if (existing === undefined) {
         return httpError("NOT_FOUND", `API key not found: ${name}`, 404);
       }
@@ -372,7 +372,7 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
       const key = credentialKey(service, field);
       // Check existence first — the broker always returns "deleted" even
       // for keys that don't exist, so we need a pre-check for 404 semantics.
-      const existing = await getSecureKeyAsync(key);
+      const { value: existing } = await getSecureKeyAsync(key);
       if (existing === undefined) {
         return httpError("NOT_FOUND", `Credential not found: ${name}`, 404);
       }

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -177,7 +177,7 @@ async function handleOAuthConnectStart(body: {
     const app = getApp(conn.oauthAppId);
     if (app) {
       clientId = app.clientId;
-      clientSecret = await getSecureKeyAsync(app.clientSecretCredentialPath);
+      clientSecret = (await getSecureKeyAsync(app.clientSecretCredentialPath)).value;
     }
   }
 
@@ -187,9 +187,9 @@ async function handleOAuthConnectStart(body: {
     if (dbApp) {
       clientId = dbApp.clientId;
       if (!clientSecret) {
-        clientSecret = await getSecureKeyAsync(
+        clientSecret = (await getSecureKeyAsync(
           dbApp.clientSecretCredentialPath,
-        );
+        )).value;
       }
     }
   }

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -36,6 +36,21 @@ export type { DeleteResult } from "./credential-backend.js";
  */
 export type { SecureKeyBackend, SecureKeyDeleteResult };
 
+/**
+ * Result from a secure key lookup. Carries the secret value plus
+ * a flag indicating whether the primary backend was unreachable.
+ */
+export interface SecureKeyResult {
+  /** The secret value, or undefined if not found or backend unreachable. */
+  value: string | undefined;
+  /**
+   * True when the primary credential backend could not be reached.
+   * When true, `value` may be undefined even though the credential exists —
+   * it's just inaccessible right now.
+   */
+  unreachable: boolean;
+}
+
 const log = getLogger("secure-keys");
 
 let _keychain: CredentialBackend | undefined;
@@ -133,22 +148,32 @@ export async function listSecureKeysAsync(): Promise<string[]> {
  */
 export async function getSecureKeyAsync(
   account: string,
-): Promise<string | undefined> {
+): Promise<SecureKeyResult> {
   const backend = resolveBackend();
   const result = await backend.get(account);
-  if (result.value != null) return result.value;
 
-  // CES mode — no local fallback.
-  if (backend.name === "ces-http") return undefined;
-
-  // Legacy fallback: if primary backend is NOT the encrypted store,
-  // check the encrypted store for keys that haven't been migrated.
-  if (backend !== getEncryptedStoreBackend()) {
-    const fallback = await getEncryptedStoreBackend().get(account);
-    return fallback.value;
+  // Got a value from primary backend.
+  if (result.value != null) {
+    return { value: result.value, unreachable: false };
   }
 
-  return undefined;
+  // CES mode — no local fallback.
+  if (backend.name === "ces-http") {
+    return { value: undefined, unreachable: result.unreachable };
+  }
+
+  // Primary returned nothing — try the encrypted store fallback for
+  // legacy keys that haven't been migrated.
+  if (backend !== getEncryptedStoreBackend()) {
+    const fallback = await getEncryptedStoreBackend().get(account);
+    if (fallback.value != null) {
+      return { value: fallback.value, unreachable: false };
+    }
+    // Fallback also empty. Report unreachable only if primary was.
+    return { value: undefined, unreachable: result.unreachable };
+  }
+
+  return { value: undefined, unreachable: false };
 }
 
 /**
@@ -231,7 +256,7 @@ const PROVIDER_ENV_VARS: Record<string, string> =
 export async function getProviderKeyAsync(
   provider: string,
 ): Promise<string | undefined> {
-  const stored = await getSecureKeyAsync(provider);
+  const { value: stored } = await getSecureKeyAsync(provider);
   if (stored) return stored;
   const envVar = PROVIDER_ENV_VARS[provider];
   return envVar ? process.env[envVar] : undefined;

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -80,7 +80,7 @@ export class TokenExpiredError extends Error {
 // interface expected by @vellumai/credential-storage helpers.
 
 const secureKeyBackend: SecureKeyBackend = {
-  get: (key: string) => getSecureKeyAsync(key),
+  get: async (key: string) => (await getSecureKeyAsync(key)).value,
   set: (key: string, value: string) => setSecureKeyAsync(key, value),
   delete: async () => {
     // Not needed in this module — refresh persistence only writes tokens.
@@ -146,9 +146,9 @@ async function resolveRefreshConfig(
     );
   }
 
-  const secret = await getSecureKeyAsync(app.clientSecretCredentialPath);
+  const { value: secret } = await getSecureKeyAsync(app.clientSecretCredentialPath);
 
-  const refreshToken = await getSecureKeyAsync(
+  const { value: refreshToken } = await getSecureKeyAsync(
     oauthConnectionRefreshTokenPath(conn.id),
   );
 
@@ -290,7 +290,7 @@ export async function withValidToken<T>(
       ? getConnection(opts.connectionId)
       : getConnectionByProvider(service, opts);
   let token = conn
-    ? await getSecureKeyAsync(oauthConnectionAccessTokenPath(conn.id))
+    ? (await getSecureKeyAsync(oauthConnectionAccessTokenPath(conn.id))).value
     : undefined;
   if (!token || !conn) {
     throw new TokenExpiredError(

--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -217,7 +217,7 @@ export class CredentialBroker {
     // Deletion is deferred until after a successful fill so the value survives
     // transient failures (e.g. stale element, page navigation, Playwright timeout).
     const transient = this.transientValues.get(storageKey);
-    const value = transient?.value ?? (await getSecureKeyAsync(storageKey));
+    const value = transient?.value ?? (await getSecureKeyAsync(storageKey)).value;
     if (!value) {
       return {
         success: false,
@@ -302,7 +302,7 @@ export class CredentialBroker {
 
     const storageKey = credentialKey(request.service, request.field);
     const transient = this.transientValues.get(storageKey);
-    const value = transient?.value ?? (await getSecureKeyAsync(storageKey));
+    const value = transient?.value ?? (await getSecureKeyAsync(storageKey)).value;
     if (!value) {
       return {
         success: false,
@@ -385,7 +385,7 @@ export class CredentialBroker {
 
     // Fail-closed: verify the secret value actually exists in secure storage.
     // Without this, downstream proxy code would attempt unauthenticated requests.
-    const value = await getSecureKeyAsync(resolved.storageKey);
+    const { value } = await getSecureKeyAsync(resolved.storageKey);
     if (!value) {
       return {
         success: false,

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -852,9 +852,9 @@ class CredentialStoreTool implements Tool {
           if (dbApp) {
             if (!clientId) clientId = dbApp.clientId;
             if (!clientSecret) {
-              clientSecret = await getSecureKeyAsync(
+              clientSecret = (await getSecureKeyAsync(
                 dbApp.clientSecretCredentialPath,
-              );
+              )).value;
             }
           }
         }

--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -105,7 +105,7 @@ async function buildInjectedValue(
       tpl.composeWith.field,
     );
     if (!composed) return null;
-    const composedValue = await getSecureKeyAsync(composed.storageKey);
+    const { value: composedValue } = await getSecureKeyAsync(composed.storageKey);
     if (!composedValue) return null;
     value = `${value}${tpl.composeWith.separator}${composedValue}`;
   }
@@ -238,7 +238,7 @@ function buildSessionStartHooks(): SessionStartHooks {
             if (tpl.injectionType === "header" && tpl.headerName) {
               const resolved = resolveById(credId);
               if (!resolved) return req.headers;
-              const value = await getSecureKeyAsync(resolved.storageKey);
+              const { value } = await getSecureKeyAsync(resolved.storageKey);
               if (!value) return req.headers;
 
               const headerValue = await buildInjectedValue(tpl, value);
@@ -317,7 +317,7 @@ function buildSessionStartHooks(): SessionStartHooks {
             const { credentialId, template } = decision;
             const resolved = resolveById(credentialId);
             if (!resolved) return {};
-            const value = await getSecureKeyAsync(resolved.storageKey);
+            const { value } = await getSecureKeyAsync(resolved.storageKey);
             if (!value) return {};
 
             if (template.injectionType === "header" && template.headerName) {

--- a/assistant/src/workspace/migrations/006-services-config.ts
+++ b/assistant/src/workspace/migrations/006-services-config.ts
@@ -65,10 +65,10 @@ export const servicesConfigMigration: WorkspaceMigration = {
         }
       }
       if (!hasAnyUserKey) {
-        const apiKey = await getSecureKeyAsync(
+        const { value: apiKey } = await getSecureKeyAsync(
           credentialKey("vellum", "assistant_api_key"),
         );
-        const baseUrl = await getSecureKeyAsync(
+        const { value: baseUrl } = await getSecureKeyAsync(
           credentialKey("vellum", "platform_base_url"),
         );
         if (apiKey && baseUrl) {

--- a/assistant/src/workspace/provider-commit-message-generator.ts
+++ b/assistant/src/workspace/provider-commit-message-generator.ts
@@ -149,7 +149,7 @@ export class ProviderCommitMessageGenerator {
       );
       const keyChecks = await Promise.all(
         candidates.map(async (name) => {
-          const value = await getSecureKeyAsync(name);
+          const { value } = await getSecureKeyAsync(name);
           return typeof value === "string" && value.length > 0;
         }),
       );
@@ -172,7 +172,7 @@ export class ProviderCommitMessageGenerator {
 
     // Step 2b: API key preflight for the selected provider (skip keyless).
     if (!KEYLESS_PROVIDERS.has(selectedProviderName)) {
-      const providerApiKey = await getSecureKeyAsync(selectedProviderName);
+      const { value: providerApiKey } = await getSecureKeyAsync(selectedProviderName);
       if (!providerApiKey) {
         log.debug(
           {


### PR DESCRIPTION
## Summary
- Change getSecureKeyAsync return type from string | undefined to SecureKeyResult { value, unreachable }
- Update all ~35 production callers to destructure .value from the result
- Update reveal and inspect CLI commands to show 'Keychain broker is unreachable' when backend is down
- Update all ~12 test file mocks and add new tests for unreachable propagation
- getProviderKeyAsync still returns string | undefined — its 26+ callers are unaffected

Part of plan: cred-reveal-timeout-fix.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
