### PR TITLE
fix: satisfy no-null-check lint rule in schedule-routes

### DIFF
--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -302,7 +302,7 @@ export function scheduleRouteDefinitions(deps: {
       policyKey: "schedules",
       handler: async ({ req, params }) => {
         const body: unknown = await req.json();
-        if (typeof body !== "object" || body === null || Array.isArray(body)) {
+        if (typeof body !== "object" || !body || Array.isArray(body)) {
           return httpError("BAD_REQUEST", "Request body must be a JSON object", 400);
         }
         return handleUpdateSchedule(params.id, body as Record<string, unknown>);


### PR DESCRIPTION
## Summary
- Replace `=== null` with `!body` in the PATCH `/schedules/:id` handler to satisfy the `no-restricted-syntax` lint rule
- Semantically equivalent: the only falsy value with `typeof "object"` is `null`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23360892674/job/67963585051
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
