### PR TITLE
chore: add MIT license and dependency license guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,15 @@ cd assistant && bun test src/path/to/changed.test.ts  # Run tests
 cd assistant && bun run lint         # Lint
 ```
 
+## Dependencies
+
+This project is licensed under MIT. All dependencies must have MIT-compatible licenses (MIT, Apache-2.0, ISC, BSD-2-Clause, BSD-3-Clause, Unlicense, or similar permissive licenses). Do not add dependencies with copyleft licenses (GPL, AGPL, LGPL, SSPL, EUPL) or proprietary/restrictive licenses without explicit approval.
+
+When adding a new dependency:
+1. Check its license in the package's `package.json` or LICENSE file.
+2. Dual-licensed packages (e.g. "MIT OR GPL-3.0") are acceptable — we use them under the MIT-compatible option.
+3. If unsure about compatibility, flag it in the PR for review.
+
 ## Testing
 
 The full test suite is large and will hang or timeout if run unscoped. **Never run `bun test` without specifying file paths.**

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Vellum AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@vellumai/assistant",
   "version": "0.5.6",
+  "license": "MIT",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"

--- a/credential-executor/package.json
+++ b/credential-executor/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@vellumai/credential-executor",
   "version": "0.5.6",
+  "license": "MIT",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@vellumai/vellum-gateway",
   "version": "0.5.6",
+  "license": "MIT",
   "type": "module",
   "exports": {
     "./twilio/verify": "./src/twilio/verify.ts",

--- a/meta/package.json
+++ b/meta/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vellum",
   "version": "0.5.6",
+  "license": "MIT",
   "description": "Install the full Vellum stack locally",
   "bin": {
     "vellum": "./bin/vellum.js",

--- a/packages/ces-contracts/package.json
+++ b/packages/ces-contracts/package.json
@@ -2,6 +2,7 @@
   "name": "@vellumai/ces-contracts",
   "version": "0.0.1",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/credential-storage/package.json
+++ b/packages/credential-storage/package.json
@@ -2,6 +2,7 @@
   "name": "@vellumai/credential-storage",
   "version": "0.0.1",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"

--- a/packages/egress-proxy/package.json
+++ b/packages/egress-proxy/package.json
@@ -2,6 +2,7 @@
   "name": "@vellumai/egress-proxy",
   "version": "0.0.1",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@vellumai/scripts",
   "private": true,
+  "license": "MIT",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0"
   }


### PR DESCRIPTION
## Summary
- Add MIT LICENSE file with Vellum AI copyright
- Add `"license": "MIT"` to all workspace package.json files
- Add dependency license compatibility guidance to AGENTS.md

Part of plan: mit-license-setup.md (PR 1 of 1, combined)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
