### PR TITLE
fix: rate-limit keychain broker unreachable warnings

### DIFF
--- a/assistant/src/security/credential-backend.ts
+++ b/assistant/src/security/credential-backend.ts
@@ -46,6 +46,10 @@ export interface CredentialBackend {
 // KeychainBackend
 // ---------------------------------------------------------------------------
 
+/** Suppress repeated "unreachable" warnings — log at most once per 5 minutes. */
+const UNREACHABLE_WARN_COOLDOWN_MS = 5 * 60 * 1000;
+let lastUnreachableWarnMs = 0;
+
 export class KeychainBackend implements CredentialBackend {
   readonly name = "keychain";
 
@@ -59,12 +63,17 @@ export class KeychainBackend implements CredentialBackend {
     try {
       const result = await this.client.get(account);
       if (result == null) {
-        log.warn(
-          { account },
-          "Keychain broker unreachable during get — falling back",
-        );
+        const now = Date.now();
+        if (now - lastUnreachableWarnMs >= UNREACHABLE_WARN_COOLDOWN_MS) {
+          log.warn(
+            { account },
+            "Keychain broker unreachable during get — falling back",
+          );
+          lastUnreachableWarnMs = now;
+        }
         return undefined;
       }
+      lastUnreachableWarnMs = 0; // Reset so next outage is logged immediately
       if (!result.found) return undefined;
       return result.value;
     } catch (err) {


### PR DESCRIPTION
## Summary
- Throttle 'keychain broker unreachable' warnings to at most once per 5 minutes
- Reset throttle on successful broker response so next outage is always logged
- Eliminates hundreds of warning log lines per day when broker is down

Part of plan: cpu-churn-hot-loop-fixes.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
