### PR TITLE
fix: log deferral warnings at milestones instead of every deferral

### DIFF
--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -243,8 +243,8 @@ export function completeMemoryJob(id: string): void {
 
 /** Max times a job can be deferred before it is marked as failed. */
 const MAX_DEFERRALS = 50;
-/** Warn when deferrals reach 80% of the limit. */
-const DEFER_WARNING_THRESHOLD = Math.floor(MAX_DEFERRALS * 0.8);
+/** Log warnings at these milestone counts to avoid flooding logs. */
+const DEFERRAL_WARN_MILESTONES = [40, 45];
 /** Base delay in ms for deferred jobs (grows with exponential backoff). */
 const DEFER_BASE_DELAY_MS = 30_000;
 /** Maximum delay cap for deferred jobs (5 minutes). */
@@ -286,7 +286,9 @@ export function deferMemoryJob(id: string): "deferred" | "failed" {
     return "failed";
   }
 
-  if (deferrals >= DEFER_WARNING_THRESHOLD) {
+  // Log at milestones only (40, 45) to avoid flooding logs.
+  // At 50, the job fails via the check above, so 40 and 45 are the warnings.
+  if (DEFERRAL_WARN_MILESTONES.includes(deferrals)) {
     log.warn(
       { jobId: id, type: row.type, deferrals, max: MAX_DEFERRALS },
       "Job approaching max deferral limit",


### PR DESCRIPTION
## Summary
- Replace threshold-based deferral warnings (logged at deferrals 40-49) with milestone-based (40, 45 only)
- Reduces log spam from ~10 warnings per stuck job to 2
- No change to the failure behavior at deferral 50

Part of plan: cpu-churn-hot-loop-fixes.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
