### PR TITLE
fix: retry Qdrant startup with backoff for slow machines

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -355,8 +355,36 @@ export async function runDaemon(): Promise<void> {
       log.info({ qdrantUrl }, "Daemon startup: initializing Qdrant");
       const manager = new QdrantManager({ url: qdrantUrl });
       bgRefs.qdrantManager = manager;
-      try {
-        await manager.start();
+      const QDRANT_START_MAX_ATTEMPTS = 3;
+      let qdrantStarted = false;
+      for (let attempt = 1; attempt <= QDRANT_START_MAX_ATTEMPTS; attempt++) {
+        try {
+          await manager.start();
+          qdrantStarted = true;
+          break;
+        } catch (err) {
+          if (attempt < QDRANT_START_MAX_ATTEMPTS) {
+            const backoffMs = attempt * 5_000; // 5s, 10s
+            log.warn(
+              {
+                err,
+                attempt,
+                maxAttempts: QDRANT_START_MAX_ATTEMPTS,
+                backoffMs,
+              },
+              "Qdrant startup failed, retrying",
+            );
+            await Bun.sleep(backoffMs);
+          } else {
+            log.warn(
+              { err },
+              "Qdrant failed to start after all attempts — memory features will be unavailable",
+            );
+          }
+        }
+      }
+
+      if (qdrantStarted) {
         const embeddingSelection = await selectEmbeddingBackend(config);
         const embeddingModel = embeddingSelection.backend
           ? `${embeddingSelection.backend.provider}:${embeddingSelection.backend.model}:sparse-v${SPARSE_EMBEDDING_VERSION}`
@@ -383,11 +411,6 @@ export async function runDaemon(): Promise<void> {
         }
 
         log.info("Qdrant vector store initialized");
-      } catch (err) {
-        log.warn(
-          { err },
-          "Qdrant failed to start — memory features will be unavailable",
-        );
       }
 
       log.info("Daemon startup: starting memory worker");


### PR DESCRIPTION
## Summary
- Retry Qdrant startup up to 3 times with escalating backoff (5s, 10s)
- On slow machines (M1 MacBook Air), subsequent attempts succeed from warmed Qdrant state
- If all attempts fail, behavior is identical to before (warning logged, memory features disabled)
- Memory worker always starts regardless of Qdrant status

Part of plan: cpu-churn-hot-loop-fixes.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
