### PR TITLE
feat: add platform_hosted_enabled feature flag for Vellum Cloud hosting

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -91,7 +91,7 @@ struct APIKeyStepView: View {
     private func chipLabel(for mode: OnboardingState.HostingMode) -> String? {
         switch mode {
         case .vellumCloud:
-            if state.skippedAuth { return "Requires Account" }
+            if !isAuthenticated || state.skippedAuth { return "Requires Account" }
             return platformHostedEnabled ? nil : "Coming Soon"
         case .docker:
             return userHostedEnabled ? nil : "Coming Soon"
@@ -212,7 +212,7 @@ struct APIKeyStepView: View {
 
     private var canContinue: Bool {
         if state.selectedHostingMode == .vellumCloud {
-            return platformHostedEnabled && !state.skippedAuth
+            return platformHostedEnabled && isAuthenticated && !state.skippedAuth
         }
         return true
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -234,13 +234,8 @@ struct APIKeyStepView: View {
             state.cloudProvider = state.selectedHostingMode.rawValue
         }
 
-        if isAuthenticated && state.selectedHostingMode == .vellumCloud {
-            // Platform-hosted: trigger managed bootstrap directly
-            onHatchManaged?()
-            return
-        }
-
         if isAuthenticated {
+            // Authenticated user: skip API key entry, advance to consent step
             state.selectedProvider = "anthropic"
             state.selectedModel = "claude-opus-4-6"
             state.skippedAPIKeyEntry = true

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -14,6 +14,10 @@ struct APIKeyStepView: View {
         MacOSClientFeatureFlagManager.shared.isEnabled("user_hosted_enabled")
     }
 
+    private var platformHostedEnabled: Bool {
+        MacOSClientFeatureFlagManager.shared.isEnabled("platform_hosted_enabled")
+    }
+
     var body: some View {
         Text("Hosting")
             .font(.system(size: 32, weight: .regular, design: .serif))
@@ -87,7 +91,8 @@ struct APIKeyStepView: View {
     private func chipLabel(for mode: OnboardingState.HostingMode) -> String? {
         switch mode {
         case .vellumCloud:
-            return state.skippedAuth ? "Requires Account" : "Coming Soon"
+            if state.skippedAuth { return "Requires Account" }
+            return platformHostedEnabled ? nil : "Coming Soon"
         case .docker:
             return userHostedEnabled ? nil : "Coming Soon"
         default:
@@ -206,7 +211,10 @@ struct APIKeyStepView: View {
     // MARK: - Helpers
 
     private var canContinue: Bool {
-        state.selectedHostingMode != .vellumCloud
+        if state.selectedHostingMode == .vellumCloud {
+            return platformHostedEnabled && !state.skippedAuth
+        }
+        return true
     }
 
     private var continueButtonTitle: String {
@@ -224,6 +232,12 @@ struct APIKeyStepView: View {
             state.cloudProvider = OnboardingState.HostingMode.docker.rawValue
         } else {
             state.cloudProvider = state.selectedHostingMode.rawValue
+        }
+
+        if isAuthenticated && state.selectedHostingMode == .vellumCloud {
+            // Platform-hosted: trigger managed bootstrap directly
+            onHatchManaged?()
+            return
         }
 
         if isAuthenticated {

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -7,6 +7,9 @@ struct ImproveExperienceStepView: View {
     /// Whether the user arrived here by skipping step 2 (API key entry).
     /// Captured at init so it reflects the navigation path, not live auth state.
     var skippedAPIKeyEntry: Bool = false
+    /// Optional override for what happens after the user accepts ToS.
+    /// When provided, called instead of the default `state.isHatching = true`.
+    var onAccepted: (() -> Void)?
 
     @State private var showTitle = false
     @State private var showContent = false
@@ -125,7 +128,11 @@ struct ImproveExperienceStepView: View {
             MetricKitManager.closeSentry()
         }
 
-        state.isHatching = true
+        if let onAccepted {
+            onAccepted()
+        } else {
+            state.isHatching = true
+        }
     }
 
     private func goBack() {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -120,7 +120,15 @@ struct OnboardingFlowView: View {
                             case 2:
                                 APIKeyEntryStepView(state: state)
                             case 3:
-                                ImproveExperienceStepView(state: state, skippedAPIKeyEntry: state.skippedAPIKeyEntry)
+                                ImproveExperienceStepView(
+                                    state: state,
+                                    skippedAPIKeyEntry: state.skippedAPIKeyEntry,
+                                    onAccepted: state.selectedHostingMode == .vellumCloud ? {
+                                        Task {
+                                            await performManagedBootstrap()
+                                        }
+                                    } : nil
+                                )
                             default:
                                 EmptyView()
                             }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -18,6 +18,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "platform-hosted-enabled",
+      "scope": "macos",
+      "key": "platform_hosted_enabled",
+      "label": "Platform Hosted Assistants",
+      "description": "Enable the Vellum Cloud hosting option on the Hosting screen",
+      "defaultEnabled": false
+    },
+    {
       "id": "contacts",
       "scope": "assistant",
       "key": "feature_flags.contacts.enabled",


### PR DESCRIPTION
## Summary
- Added `platform-hosted-enabled` feature flag (scope: `macos`, key: `platform_hosted_enabled`, default: off) to the feature flag registry
- When enabled, the Vellum Cloud option on the Hosting screen becomes selectable (removes "Coming Soon" chip) for authenticated users
- Authenticated users selecting Vellum Cloud trigger the managed bootstrap flow via `onHatchManaged`

## Original prompt
--safe add a new feature flag for enabling platform hosted assistants and when this flag is on, the Vellum Cloud option should be enabled on the Hosting screen. the default value should be off
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
