### PR TITLE
fix: back off worker poll interval when no jobs are claimable

### DIFF
--- a/assistant/src/__tests__/memory-jobs-worker-backoff.test.ts
+++ b/assistant/src/__tests__/memory-jobs-worker-backoff.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for adaptive poll interval backoff in the memory jobs worker.
+ *
+ * Verifies that when no jobs are claimable, the poll interval doubles each
+ * tick (1.5s -> 3s -> 6s -> ... -> 30s cap), and resets to 1.5s when work
+ * is found.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+// ── Mocks (must precede imports of tested module) ──────────────────
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => "/tmp/test-backoff",
+  isMacOS: () => false,
+  isLinux: () => true,
+  isWindows: () => false,
+  getPidPath: () => "/tmp/test-backoff/test.pid",
+  getDbPath: () => "/tmp/test-backoff/test.db",
+  getLogPath: () => "/tmp/test-backoff/test.log",
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Mock config — memory disabled so runMemoryJobsOnce returns 0 immediately
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    memory: { enabled: false },
+  }),
+  loadConfig: () => ({
+    memory: { enabled: false },
+  }),
+}));
+
+// Mock jobs-store (accesses DB)
+mock.module("../memory/jobs-store.js", () => ({
+  resetRunningJobsToPending: () => 0,
+  claimMemoryJobs: () => [],
+  completeMemoryJob: () => {},
+  deferMemoryJob: () => "deferred",
+  failMemoryJob: () => {},
+  failStalledJobs: () => 0,
+  enqueueCleanupStaleSupersededItemsJob: () => null,
+  enqueuePruneOldConversationsJob: () => null,
+}));
+
+// Mock db.js (rawRun used in sweepStaleItems)
+mock.module("../memory/db.js", () => ({
+  rawRun: () => 0,
+}));
+
+import {
+  POLL_INTERVAL_MAX_MS,
+  POLL_INTERVAL_MIN_MS,
+  startMemoryJobsWorker,
+} from "../memory/jobs-worker.js";
+
+describe("memory jobs worker adaptive poll interval", () => {
+  test("exports expected poll interval constants", () => {
+    expect(POLL_INTERVAL_MIN_MS).toBe(1_500);
+    expect(POLL_INTERVAL_MAX_MS).toBe(30_000);
+  });
+
+  test("backoff sequence doubles from min to max then caps", () => {
+    // Verify the math: starting at 1500, doubling each step, capped at 30000
+    const intervals: number[] = [];
+    let current = POLL_INTERVAL_MIN_MS;
+    for (let i = 0; i < 10; i++) {
+      intervals.push(current);
+      current = Math.min(current * 2, POLL_INTERVAL_MAX_MS);
+    }
+    expect(intervals).toEqual([
+      1_500, // tick 1
+      3_000, // tick 2
+      6_000, // tick 3
+      12_000, // tick 4
+      24_000, // tick 5
+      30_000, // tick 6 (capped)
+      30_000, // stays capped
+      30_000,
+      30_000,
+      30_000,
+    ]);
+  });
+
+  test("worker schedules setTimeout with increasing intervals when idle", async () => {
+    const timeoutDelays: number[] = [];
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+
+    // Collect pending timer callbacks so we can fire them manually
+    const pendingCallbacks: Array<() => void> = [];
+
+    globalThis.setTimeout = ((fn: () => void, delay?: number) => {
+      if (delay !== undefined && delay >= POLL_INTERVAL_MIN_MS) {
+        timeoutDelays.push(delay);
+        pendingCallbacks.push(fn);
+      }
+      return 999 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout;
+    globalThis.clearTimeout = (() => {}) as typeof clearTimeout;
+
+    try {
+      const worker = startMemoryJobsWorker();
+
+      // Wait for the initial tick() promise to settle
+      await new Promise((resolve) => originalSetTimeout(resolve, 20));
+
+      // Fire pending timer callbacks to advance through the backoff sequence.
+      // Each callback triggers tick() which is async, so we await a microtask
+      // after each to let the promise chain settle and schedule the next timer.
+      for (let i = 0; i < 6; i++) {
+        const cb = pendingCallbacks.shift();
+        if (cb) {
+          cb();
+          await new Promise((resolve) => originalSetTimeout(resolve, 20));
+        }
+      }
+
+      worker.stop();
+
+      // We should have captured several setTimeout calls with increasing delays
+      expect(timeoutDelays.length).toBeGreaterThanOrEqual(4);
+
+      // Intervals should be non-decreasing (backoff)
+      for (let i = 1; i < timeoutDelays.length; i++) {
+        expect(timeoutDelays[i]).toBeGreaterThanOrEqual(timeoutDelays[i - 1]!);
+      }
+
+      // All intervals within bounds
+      for (const delay of timeoutDelays) {
+        expect(delay).toBeGreaterThanOrEqual(POLL_INTERVAL_MIN_MS);
+        expect(delay).toBeLessThanOrEqual(POLL_INTERVAL_MAX_MS);
+      }
+
+      // Should eventually reach the cap
+      expect(timeoutDelays[timeoutDelays.length - 1]).toBe(
+        POLL_INTERVAL_MAX_MS,
+      );
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
+    }
+  });
+});

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -44,6 +44,9 @@ import { QdrantCircuitOpenError } from "./qdrant-circuit-breaker.js";
 
 const log = getLogger("memory-jobs-worker");
 
+export const POLL_INTERVAL_MIN_MS = 1_500;
+export const POLL_INTERVAL_MAX_MS = 30_000;
+
 export interface MemoryJobsWorker {
   runOnce(): Promise<number>;
   stop(): void;
@@ -57,12 +60,24 @@ export function startMemoryJobsWorker(): MemoryJobsWorker {
 
   let stopped = false;
   let tickRunning = false;
+  let timer: ReturnType<typeof setTimeout>;
+  let currentIntervalMs = POLL_INTERVAL_MIN_MS;
 
   const tick = async () => {
     if (stopped || tickRunning) return;
     tickRunning = true;
     try {
-      await runMemoryJobsOnce({ enableScheduledCleanup: true });
+      const processed = await runMemoryJobsOnce({
+        enableScheduledCleanup: true,
+      });
+      if (processed > 0) {
+        currentIntervalMs = POLL_INTERVAL_MIN_MS;
+      } else {
+        currentIntervalMs = Math.min(
+          currentIntervalMs * 2,
+          POLL_INTERVAL_MAX_MS,
+        );
+      }
     } catch (err) {
       log.error({ err }, "Memory worker tick failed");
     } finally {
@@ -70,11 +85,19 @@ export function startMemoryJobsWorker(): MemoryJobsWorker {
     }
   };
 
-  const timer = setInterval(() => {
-    void tick();
-  }, 1500);
-  timer.unref();
-  void tick();
+  const scheduleTick = () => {
+    if (stopped) return;
+    timer = setTimeout(() => {
+      void tick().then(() => {
+        if (!stopped) scheduleTick();
+      });
+    }, currentIntervalMs);
+    (timer as NodeJS.Timeout).unref?.();
+  };
+
+  void tick().then(() => {
+    if (!stopped) scheduleTick();
+  });
 
   return {
     async runOnce(): Promise<number> {
@@ -82,7 +105,7 @@ export function startMemoryJobsWorker(): MemoryJobsWorker {
     },
     stop(): void {
       stopped = true;
-      clearInterval(timer);
+      clearTimeout(timer);
     },
   };
 }


### PR DESCRIPTION
## Summary
- Replace fixed 1.5s setInterval with adaptive setTimeout-based polling
- When no jobs are claimable, interval doubles: 1.5s → 3s → 6s → ... → 30s (capped)
- Resets to 1.5s immediately when work is found

Part of plan: cpu-churn-hot-loop-fixes.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
