### PR TITLE
fix: update iOS conversation lifecycle tests for DaemonClient refactor

### DIFF
--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -589,7 +589,7 @@ class IOSConversationStore: ObservableObject {
         }
     }
 
-    private func handleConversationListResponse(_ response: ConversationListResponseMessage) {
+    func handleConversationListResponse(_ response: ConversationListResponseMessage) {
         // Discard responses from a previous connection.  The daemon does not echo a
         // request ID, so within a single connection all responses are accepted in order.
         // Reconnect-era staleness is detected via the generation counter: when the

--- a/clients/ios/Tests/ConversationLifecycleIOSTests.swift
+++ b/clients/ios/Tests/ConversationLifecycleIOSTests.swift
@@ -267,7 +267,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
             ],
         ]])
 
-        daemonClient.onConversationListResponse?(response)
+        store.handleConversationListResponse(response)
 
         guard let storedConversation = store.conversations.first(where: { $0.conversationId == "connected-session-1" }) else {
             XCTFail("Expected connected conversation")
@@ -319,7 +319,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
             ],
         ]])
 
-        daemonClient.onConversationListResponse?(response)
+        store.handleConversationListResponse(response)
 
         XCTAssertEqual(store.conversations.count, 1)
         guard let updatedConversation = store.conversations.first else {
@@ -352,7 +352,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
             ],
         ]])
 
-        daemonClient.onConversationListResponse?(response)
+        store.handleConversationListResponse(response)
         guard let storedConversation = store.conversations.first(where: { $0.conversationId == "connected-session-2" }) else {
             XCTFail("Expected unread connected conversation")
             return
@@ -386,14 +386,9 @@ final class ConversationLifecycleIOSTests: XCTestCase {
 
     func testOpeningAlreadySeenConnectedConversationDoesNotEmitSignal() {
         let daemonClient = DaemonClient()
-        var sentSignals: [ConversationSeenSignal] = []
-        daemonClient.sendOverride = { message in
-            if let signal = message as? ConversationSeenSignal {
-                sentSignals.append(signal)
-            }
-        }
+        let mockListClient = MockConversationListClient()
 
-        let store = IOSConversationStore(daemonClient: daemonClient)
+        let store = IOSConversationStore(daemonClient: daemonClient, conversationListClient: mockListClient)
         let response = makeConversationListResponse(conversations: [[
             "id": "connected-session-3",
             "title": "Seen conversation",
@@ -406,7 +401,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
             ],
         ]])
 
-        daemonClient.onConversationListResponse?(response)
+        store.handleConversationListResponse(response)
         guard let storedConversation = store.conversations.first(where: { $0.conversationId == "connected-session-3" }) else {
             XCTFail("Expected connected conversation")
             return
@@ -414,7 +409,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
 
         store.markConversationSeenIfNeeded(conversationLocalId: storedConversation.id)
 
-        XCTAssertTrue(sentSignals.isEmpty)
+        XCTAssertTrue(mockListClient.sentSeenSignals.isEmpty)
         XCTAssertFalse(store.conversations.first(where: { $0.id == storedConversation.id })?.hasUnseenLatestAssistantMessage ?? true)
     }
 
@@ -435,7 +430,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
             ],
         ]])
 
-        daemonClient.onConversationListResponse?(response)
+        store.handleConversationListResponse(response)
         guard let storedConversation = store.conversations.first(where: { $0.conversationId == "connected-session-4" }) else {
             XCTFail("Expected connected conversation")
             return
@@ -484,7 +479,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
             ],
         ]])
 
-        daemonClient.onConversationListResponse?(response)
+        store.handleConversationListResponse(response)
         guard let storedConversation = store.conversations.first(where: { $0.conversationId == "connected-session-5" }) else {
             XCTFail("Expected unread connected conversation")
             return
@@ -514,7 +509,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
             ],
         ]])
 
-        daemonClient.onConversationListResponse?(response)
+        store.handleConversationListResponse(response)
         guard let storedConversation = store.conversations.first(where: { $0.conversationId == "connected-session-unread-failure" }) else {
             XCTFail("Expected connected conversation")
             return
@@ -547,7 +542,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
             ],
         ]])
 
-        daemonClient.onConversationListResponse?(response)
+        store.handleConversationListResponse(response)
         guard let storedConversation = store.conversations.first(where: { $0.conversationId == "connected-session-6" }) else {
             XCTFail("Expected connected conversation")
             return
@@ -574,7 +569,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
             ],
         ]])
 
-        daemonClient.onConversationListResponse?(response)
+        store.handleConversationListResponse(response)
         guard let storedConversation = store.conversations.first(where: { $0.conversationId == "connected-session-live-assistant" }) else {
             XCTFail("Expected connected conversation")
             return
@@ -628,7 +623,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
                 "lastSeenAssistantMessageAt": 4_000,
             ],
         ]])
-        daemonClient.onConversationListResponse?(initialResponse)
+        store.handleConversationListResponse(initialResponse)
 
         guard let storedConversation = store.conversations.first(where: { $0.conversationId == "connected-session-refresh-seen" }) else {
             XCTFail("Expected connected conversation")
@@ -648,7 +643,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
                 "lastSeenAssistantMessageAt": 4_000,
             ],
         ]])
-        daemonClient.onConversationListResponse?(staleResponse)
+        store.handleConversationListResponse(staleResponse)
 
         XCTAssertFalse(
             store.conversations.first(where: { $0.conversationId == "connected-session-refresh-seen" })?.hasUnseenLatestAssistantMessage ?? true
@@ -670,7 +665,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
                 "lastSeenAssistantMessageAt": 5_000,
             ],
         ]])
-        daemonClient.onConversationListResponse?(initialResponse)
+        store.handleConversationListResponse(initialResponse)
 
         guard let storedConversation = store.conversations.first(where: { $0.conversationId == "connected-session-refresh-unread" }) else {
             XCTFail("Expected connected conversation")
@@ -690,7 +685,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
                 "lastSeenAssistantMessageAt": 5_000,
             ],
         ]])
-        daemonClient.onConversationListResponse?(staleResponse)
+        store.handleConversationListResponse(staleResponse)
 
         XCTAssertTrue(
             store.conversations.first(where: { $0.conversationId == "connected-session-refresh-unread" })?.hasUnseenLatestAssistantMessage ?? false
@@ -719,7 +714,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
             ],
         ])
 
-        daemonClient.onConversationListResponse?(response)
+        store.handleConversationListResponse(response)
         guard let conversation = store.conversations.first(where: { $0.conversationId == "connected-session-unpinned" }) else {
             XCTFail("Expected unpinned connected conversation")
             return
@@ -766,14 +761,14 @@ final class ConversationLifecycleIOSTests: XCTestCase {
             ],
         ])
 
-        daemonClient.onConversationListResponse?(response)
+        store.handleConversationListResponse(response)
         guard let conversation = store.conversations.first(where: { $0.conversationId == "connected-session-unpinned" }) else {
             XCTFail("Expected unpinned connected conversation")
             return
         }
 
         store.pinConversation(conversation)
-        daemonClient.onConversationListResponse?(response)
+        store.handleConversationListResponse(response)
 
         guard let updatedConversation = store.conversations.first(where: { $0.id == conversation.id }) else {
             XCTFail("Expected updated conversation")
@@ -808,7 +803,7 @@ final class ConversationLifecycleIOSTests: XCTestCase {
             ],
         ])
 
-        daemonClient.onConversationListResponse?(response)
+        store.handleConversationListResponse(response)
         guard let conversation = store.conversations.first(where: { $0.conversationId == "connected-session-first" }) else {
             XCTFail("Expected pinned connected conversation")
             return


### PR DESCRIPTION
## Summary
- Made `IOSConversationStore.handleConversationListResponse` internal (was private) so tests can inject conversation list responses directly via `@testable import`
- Replaced all `daemonClient.onConversationListResponse?(response)` calls with `store.handleConversationListResponse(response)` across 17 test sites
- Replaced `daemonClient.sendOverride` usage with `MockConversationListClient` pattern in `testOpeningAlreadySeenConnectedConversationDoesNotEmitSignal`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23360871965/job/67963504772
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
