### PR TITLE
M1: Add tooltips to message hover action buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -429,6 +429,7 @@ struct ChatBubble: View {
                 .buttonStyle(.plain)
                 .pointerCursor()
                 .accessibilityLabel(showCopyConfirmation ? "Copied" : "Copy message")
+                .nativeTooltip(showCopyConfirmation ? "Copied" : "Copy")
                 .animation(VAnimation.fast, value: showCopyConfirmation)
             }
             if !isUser && hasCopyableText && isTTSEnabled && message.daemonMessageId != nil {
@@ -446,6 +447,7 @@ struct ChatBubble: View {
                 .buttonStyle(.plain)
                 .pointerCursor()
                 .accessibilityLabel("Report message")
+                .nativeTooltip("Report")
             }
             if let onForkFromMessage, let daemonMessageId = message.daemonMessageId, !message.isStreaming {
                 Button {
@@ -459,6 +461,7 @@ struct ChatBubble: View {
                 .buttonStyle(.plain)
                 .pointerCursor()
                 .accessibilityLabel("Fork from here")
+                .nativeTooltip("Fork from here")
             }
             if showInspectButton, !isUser, let daemonMsgId = message.daemonMessageId {
                 Button {
@@ -472,6 +475,7 @@ struct ChatBubble: View {
                 .buttonStyle(.plain)
                 .pointerCursor()
                 .accessibilityLabel("Inspect LLM context")
+                .nativeTooltip("Inspect")
             }
         }
     }
@@ -514,7 +518,7 @@ struct ChatBubble: View {
             .buttonStyle(.plain)
             .pointerCursor()
             .accessibilityLabel("Play as audio")
-            .help(audioPlayer.error ?? "Play as audio")
+            .nativeTooltip(audioPlayer.error ?? "Read aloud")
         }
     }
 


### PR DESCRIPTION
Part of #20263

- Copy button: "Copy" / "Copied"
- TTS button: "Read aloud"
- Report button: "Report"
- Fork button: "Fork from here"
- Inspect button: "Inspect"

Uses .nativeTooltip() for consistency with other tooltips in the codebase.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
