### PR TITLE
Simplify Feedback Form UI

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -486,7 +486,7 @@ extension AppDelegate {
 
         let hostingController = NSHostingController(rootView: view)
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 480, height: 680),
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 420),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false

--- a/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
@@ -42,10 +42,9 @@ struct LogReportFormView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
-            header
-            reasonList
+            reasonDropdown
             messageField
-            logAttachmentSection
+            logAttachmentRow
             emailField
             Spacer(minLength: 0)
             actionRow
@@ -71,34 +70,21 @@ struct LogReportFormView: View {
 
     // MARK: - Sections
 
-    private var header: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xxs) {
-            Text("Share Feedback")
-                .font(VFont.headline)
-                .foregroundColor(VColor.contentDefault)
-            Text("Let us know what's going on.")
-                .font(VFont.caption)
-                .foregroundColor(VColor.contentSecondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-    }
-
-    private var reasonList: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xs) {
-            ForEach(LogReportReason.allCases) { reason in
-                ReasonRow(
-                    reason: reason,
-                    isSelected: selectedReason == reason,
-                    action: { selectedReason = reason }
-                )
-            }
-        }
+    private var reasonDropdown: some View {
+        VDropdown(
+            "Category",
+            placeholder: "Select a category\u{2026}",
+            selection: $selectedReason,
+            options: LogReportReason.allCases.map { (label: $0.displayName, value: Optional($0)) },
+            emptyValue: .some(nil),
+            optionIcon: { $0.flatMap { .resolve($0.icon) } }
+        )
     }
 
     private var messageField: some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
             Text("What happened?")
-                .font(VFont.caption)
+                .font(VFont.inputLabel)
                 .foregroundColor(VColor.contentSecondary)
             VTextEditor(
                 placeholder: "Describe what happened...",
@@ -111,60 +97,45 @@ struct LogReportFormView: View {
     }
 
     private var emailField: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xs) {
-            Text("Email")
-                .font(VFont.caption)
-                .foregroundColor(VColor.contentSecondary)
-            VTextField(
-                placeholder: "you@example.com",
-                text: $email,
-                leadingIcon: VIcon.mail.rawValue
-            )
-            .focused($focusedField, equals: .email)
-        }
+        VTextField(
+            "Email",
+            placeholder: "you@example.com",
+            text: $email,
+            leadingIcon: VIcon.mail.rawValue
+        )
+        .focused($focusedField, equals: .email)
     }
 
     @ViewBuilder
-    private var logAttachmentSection: some View {
+    private var logAttachmentRow: some View {
         if selectedReason != .featureRequest {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                HStack(spacing: VSpacing.md) {
-                    Toggle(isOn: Binding(
-                        get: { includeLogs },
-                        set: { newValue in
-                            includeLogs = newValue
-                            hasManuallyToggledLogs = true
-                        }
-                    )) {
-                        Text("Include diagnostic logs")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.contentDefault)
+            HStack(spacing: VSpacing.sm) {
+                Toggle(isOn: Binding(
+                    get: { includeLogs },
+                    set: { newValue in
+                        includeLogs = newValue
+                        hasManuallyToggledLogs = true
                     }
-                    .toggleStyle(.checkbox)
+                )) {
+                    Text("Include diagnostic logs")
+                        .font(VFont.body)
+                }
+                .toggleStyle(.checkbox)
 
-                    if includeLogs {
-                        Picker("", selection: $logTimeRange) {
-                            ForEach(LogTimeRange.allCases) { range in
-                                Text(range.displayName).tag(range)
-                            }
+                if includeLogs {
+                    Picker("", selection: $logTimeRange) {
+                        ForEach(LogTimeRange.allCases) { range in
+                            Text(range.displayName).tag(range)
                         }
-                        .pickerStyle(.menu)
-                        .frame(width: 130)
                     }
-
-                    Spacer()
+                    .pickerStyle(.menu)
+                    .frame(width: 130)
                 }
 
-                Text("Logs include conversation messages and app diagnostics but never passwords or credentials.")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.contentTertiary)
-                    .fixedSize(horizontal: false, vertical: true)
+                VInfoTooltip("Logs include conversation messages and app diagnostics but never passwords or credentials.")
+
+                Spacer()
             }
-            .padding(VSpacing.md)
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .fill(VColor.surfaceActive.opacity(0.3))
-            )
         }
     }
 
@@ -191,48 +162,5 @@ struct LogReportFormView: View {
                 ))
             }
         }
-    }
-}
-
-// MARK: - Reason Row
-
-private struct ReasonRow: View {
-    let reason: LogReportReason
-    let isSelected: Bool
-    let action: () -> Void
-
-    @State private var isHovered = false
-
-    var body: some View {
-        Button(action: action) {
-            HStack(spacing: VSpacing.md) {
-                VIconView(.resolve(reason.icon), size: 14)
-                    .foregroundColor(isSelected ? VColor.primaryBase : VColor.contentSecondary)
-                Text(reason.displayName)
-                    .font(VFont.body)
-                    .foregroundColor(isSelected ? VColor.contentDefault : VColor.contentSecondary)
-                Spacer()
-                if isSelected {
-                    VIconView(.circleCheck, size: 14)
-                        .foregroundColor(VColor.primaryBase)
-                }
-            }
-            .padding(.horizontal, VSpacing.md)
-            .padding(.vertical, VSpacing.sm)
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .fill(isSelected ? VColor.surfaceActive : (isHovered ? VColor.surfaceActive.opacity(0.5) : Color.clear))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .stroke(isSelected ? VColor.primaryBase.opacity(0.5) : Color.clear, lineWidth: 1)
-            )
-            .contentShape(RoundedRectangle(cornerRadius: VRadius.md))
-        }
-        .buttonStyle(.plain)
-        .onHover { hovering in isHovered = hovering }
-        .pointerCursor()
-        .accessibilityLabel(reason.displayName)
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 }


### PR DESCRIPTION
## Summary
- Replace 6-row reason list with a single VDropdown, shrinking ~240pt to ~32pt
- Collapse bordered log attachment card into a single compact row with VInfoTooltip
- Remove redundant header (window title already says 'Share Feedback')
- Use built-in label parameters on design system inputs for consistency
- Reduce window height from 680pt to 420pt

Part of plan: simplify-feedback-form.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
