### PR TITLE
fix: prioritize .processing over .toolsCompleteThinking in AssistantProgressView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -225,16 +225,18 @@ struct AssistantProgressView: View {
             return .toolRunning
         }
 
+        // All tools done, model composing response (daemon sent activity_state "thinking").
+        // Check this before toolsCompleteThinking so the "Processing results" label
+        // is shown instead of the stale last-tool label during extended thinking gaps.
+        if derived.allComplete && isProcessing {
+            return .processing
+        }
+
         // All tools done but message still streaming with no text yet — more tools
         // may come. Show active "Thinking" state rather than premature "Completed N steps".
         // Once text appears, fall through to .complete (which shows warning icon if denied).
         if derived.allComplete && isStreaming && !hasText {
             return .toolsCompleteThinking
-        }
-
-        // All tools done, model composing response
-        if derived.allComplete && isProcessing {
-            return .processing
         }
 
         // All done — either message finished (!isStreaming && !isProcessing) or


### PR DESCRIPTION
## Summary
- Swaps the phase priority in AssistantProgressView so .processing is checked before .toolsCompleteThinking
- When the daemon signals 'thinking' after tools complete, the UI now shows 'Processing results' instead of the stale last-tool label
- The .toolsCompleteThinking phase still serves as a fallback for the brief sub-second gap before the activity state arrives

Part of plan: progress-phase-priority-fix.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
