### PR TITLE
Add tooltips to message hover action buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -429,7 +429,7 @@ struct ChatBubble: View {
                 .buttonStyle(.plain)
                 .pointerCursor()
                 .accessibilityLabel(showCopyConfirmation ? "Copied" : "Copy message")
-                .nativeTooltip(showCopyConfirmation ? "Copied" : "Copy")
+                .vTooltip(showCopyConfirmation ? "Copied" : "Copy")
                 .animation(VAnimation.fast, value: showCopyConfirmation)
             }
             if !isUser && hasCopyableText && isTTSEnabled && message.daemonMessageId != nil {
@@ -447,7 +447,7 @@ struct ChatBubble: View {
                 .buttonStyle(.plain)
                 .pointerCursor()
                 .accessibilityLabel("Report message")
-                .nativeTooltip("Report")
+                .vTooltip("Report")
             }
             if let onForkFromMessage, let daemonMessageId = message.daemonMessageId, !message.isStreaming {
                 Button {
@@ -461,7 +461,7 @@ struct ChatBubble: View {
                 .buttonStyle(.plain)
                 .pointerCursor()
                 .accessibilityLabel("Fork from here")
-                .nativeTooltip("Fork from here")
+                .vTooltip("Fork from here")
             }
             if showInspectButton, !isUser, let daemonMsgId = message.daemonMessageId {
                 Button {
@@ -475,7 +475,7 @@ struct ChatBubble: View {
                 .buttonStyle(.plain)
                 .pointerCursor()
                 .accessibilityLabel("Inspect LLM context")
-                .nativeTooltip("Inspect")
+                .vTooltip("Inspect")
             }
         }
     }
@@ -518,7 +518,7 @@ struct ChatBubble: View {
             .buttonStyle(.plain)
             .pointerCursor()
             .accessibilityLabel("Play as audio")
-            .nativeTooltip(audioPlayer.error ?? "Read aloud")
+            .vTooltip(audioPlayer.error ?? "Read aloud")
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -429,7 +429,7 @@ struct ChatBubble: View {
                 .buttonStyle(.plain)
                 .pointerCursor()
                 .accessibilityLabel(showCopyConfirmation ? "Copied" : "Copy message")
-                .vTooltip(showCopyConfirmation ? "Copied" : "Copy")
+                .vTooltip(showCopyConfirmation ? "Copied" : "Copy", edge: .bottom)
                 .animation(VAnimation.fast, value: showCopyConfirmation)
             }
             if !isUser && hasCopyableText && isTTSEnabled && message.daemonMessageId != nil {
@@ -447,7 +447,7 @@ struct ChatBubble: View {
                 .buttonStyle(.plain)
                 .pointerCursor()
                 .accessibilityLabel("Report message")
-                .vTooltip("Report")
+                .vTooltip("Report", edge: .bottom)
             }
             if let onForkFromMessage, let daemonMessageId = message.daemonMessageId, !message.isStreaming {
                 Button {
@@ -461,7 +461,7 @@ struct ChatBubble: View {
                 .buttonStyle(.plain)
                 .pointerCursor()
                 .accessibilityLabel("Fork from here")
-                .vTooltip("Fork from here")
+                .vTooltip("Fork from here", edge: .bottom)
             }
             if showInspectButton, !isUser, let daemonMsgId = message.daemonMessageId {
                 Button {
@@ -475,7 +475,7 @@ struct ChatBubble: View {
                 .buttonStyle(.plain)
                 .pointerCursor()
                 .accessibilityLabel("Inspect LLM context")
-                .vTooltip("Inspect")
+                .vTooltip("Inspect", edge: .bottom)
             }
         }
     }
@@ -518,7 +518,7 @@ struct ChatBubble: View {
             .buttonStyle(.plain)
             .pointerCursor()
             .accessibilityLabel("Play as audio")
-            .vTooltip(audioPlayer.error ?? "Read aloud")
+            .vTooltip(audioPlayer.error ?? "Read aloud", edge: .bottom)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -429,6 +429,7 @@ struct ChatBubble: View {
                 .buttonStyle(.plain)
                 .pointerCursor()
                 .accessibilityLabel(showCopyConfirmation ? "Copied" : "Copy message")
+                .nativeTooltip(showCopyConfirmation ? "Copied" : "Copy")
                 .animation(VAnimation.fast, value: showCopyConfirmation)
             }
             if !isUser && hasCopyableText && isTTSEnabled && message.daemonMessageId != nil {
@@ -446,6 +447,7 @@ struct ChatBubble: View {
                 .buttonStyle(.plain)
                 .pointerCursor()
                 .accessibilityLabel("Report message")
+                .nativeTooltip("Report")
             }
             if let onForkFromMessage, let daemonMessageId = message.daemonMessageId, !message.isStreaming {
                 Button {
@@ -459,6 +461,7 @@ struct ChatBubble: View {
                 .buttonStyle(.plain)
                 .pointerCursor()
                 .accessibilityLabel("Fork from here")
+                .nativeTooltip("Fork from here")
             }
             if showInspectButton, !isUser, let daemonMsgId = message.daemonMessageId {
                 Button {
@@ -472,6 +475,7 @@ struct ChatBubble: View {
                 .buttonStyle(.plain)
                 .pointerCursor()
                 .accessibilityLabel("Inspect LLM context")
+                .nativeTooltip("Inspect")
             }
         }
     }
@@ -514,7 +518,7 @@ struct ChatBubble: View {
             .buttonStyle(.plain)
             .pointerCursor()
             .accessibilityLabel("Play as audio")
-            .help(audioPlayer.error ?? "Play as audio")
+            .nativeTooltip(audioPlayer.error ?? "Read aloud")
         }
     }
 

--- a/clients/shared/DesignSystem/Gallery/Sections/ModifiersGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ModifiersGallerySection.swift
@@ -156,8 +156,8 @@ struct ModifiersGallerySection: View {
                 }
                 // MARK: - .vTooltip()
                 GallerySectionHeader(
-                    title: ".vTooltip(_:delay:)",
-                    description: "Fast floating tooltip (200ms default). Uses an NSPanel so it escapes clipping, never steals clicks, and works on any view — buttons, icons, text, containers. Falls back to .help() on non-macOS."
+                    title: ".vTooltip(_:edge:delay:)",
+                    description: "Fast floating tooltip (200ms default). Uses an NSPanel so it escapes clipping, never steals clicks, and works on any view — buttons, icons, text, containers. Supports edge placement (.top default, .bottom). Falls back to .help() on non-macOS."
                 )
 
                 VCard {
@@ -182,6 +182,18 @@ struct ModifiersGallerySection: View {
                                 .background(VColor.surfaceBase)
                                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                                 .vTooltip("Works on any view, not just buttons")
+                        }
+
+                        Text("Bottom edge placement:")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentSecondary)
+
+                        HStack(spacing: VSpacing.lg) {
+                            VButton(label: "Copy", iconOnly: VIcon.copy.rawValue, style: .ghost) {}
+                                .vTooltip("Copy message", edge: .bottom)
+
+                            VButton(label: "Fork", iconOnly: VIcon.gitBranch.rawValue, style: .ghost) {}
+                                .vTooltip("Fork from here", edge: .bottom)
                         }
                     }
                 }

--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -56,9 +56,9 @@ public extension View {
 /// ```
 public extension View {
     /// Attaches a floating tooltip that appears on hover after `delay` seconds.
-    func vTooltip(_ text: String, delay: TimeInterval = 0.2) -> some View {
+    func vTooltip(_ text: String, edge: Edge = .top, delay: TimeInterval = 0.2) -> some View {
         self.overlay(
-            VTooltipTracker(text: text, delay: delay)
+            VTooltipTracker(text: text, edge: edge, delay: delay)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .allowsHitTesting(false)
         )
@@ -70,17 +70,20 @@ public extension View {
 /// using AppKit's native coordinate conversion.
 private struct VTooltipTracker: NSViewRepresentable {
     let text: String
+    let edge: Edge
     let delay: TimeInterval
 
     func makeNSView(context: Context) -> VTooltipTrackerView {
         let view = VTooltipTrackerView()
         view.tooltipText = text
+        view.tooltipEdge = edge
         view.showDelay = delay
         return view
     }
 
     func updateNSView(_ nsView: VTooltipTrackerView, context: Context) {
         nsView.tooltipText = text
+        nsView.tooltipEdge = edge
         nsView.showDelay = delay
     }
 }
@@ -91,6 +94,7 @@ private struct VTooltipTracker: NSViewRepresentable {
 /// so it never interferes with interaction.
 private final class VTooltipTrackerView: NSView {
     var tooltipText: String = ""
+    var tooltipEdge: Edge = .top
     var showDelay: TimeInterval = 0.2
     private var showTimer: Timer?
     private var panel: NSPanel?
@@ -156,13 +160,14 @@ private final class VTooltipTrackerView: NSView {
 
         // Use AppKit's native coordinate conversion — works on any display
         let viewFrameInWindow = convert(bounds, to: nil)
+        let anchorY = tooltipEdge == .bottom ? viewFrameInWindow.minY : viewFrameInWindow.maxY
         let screenPoint = window.convertPoint(toScreen: NSPoint(
             x: viewFrameInWindow.midX,
-            y: viewFrameInWindow.maxY
+            y: anchorY
         ))
 
         let x = screenPoint.x - host.fittingSize.width / 2
-        let y = screenPoint.y + 4
+        let y = tooltipEdge == .bottom ? screenPoint.y - host.fittingSize.height - 4 : screenPoint.y + 4
         p.setFrameOrigin(NSPoint(x: x, y: y))
 
         p.alphaValue = 0
@@ -209,7 +214,7 @@ public extension View {
     }
 
     /// On non-macOS platforms, falls back to the standard `.help()` modifier.
-    func vTooltip(_ text: String, delay: TimeInterval = 0.2) -> some View {
+    func vTooltip(_ text: String, edge: Edge = .top, delay: TimeInterval = 0.2) -> some View {
         self.help(text)
     }
 }


### PR DESCRIPTION
## Summary
Adds descriptive tooltips to the 5 icon-only action buttons that appear when hovering over assistant messages in the chat.

## Changes
- `clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift`
  - Copy: "Copy" / "Copied"
  - TTS: "Read aloud" (or error message)
  - Report: "Report"
  - Fork: "Fork from here"
  - Inspect: "Inspect"

## Milestone PRs (merged into feature branch)
- #20268: M1: Add tooltips to message hover action buttons

## Project issue
Closes #20263

## Test plan
- [ ] Hover over an assistant message to reveal the action buttons
- [ ] Hover over each button and verify the tooltip appears
- [ ] Copy a message and verify tooltip changes to "Copied"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
