### PR TITLE
M1: Add Share submenu to image context menu

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -137,34 +137,39 @@ private enum ImageActions {
 
         Divider()
 
-        Menu {
-            let shareImage: NSImage = {
-                if let base64Data, !base64Data.isEmpty,
-                   let decoded = Data(base64Encoded: base64Data), !decoded.isEmpty,
-                   let fullRes = NSImage(data: decoded) {
-                    return fullRes
-                } else {
-                    return image
-                }
-            }()
-            let services = NSSharingService.sharingServices(forItems: [shareImage])
-            ForEach(Array(services.enumerated()), id: \.offset) { _, service in
-                Button {
-                    service.perform(withItems: [shareImage])
-                } label: {
-                    if let serviceImage = service.image {
-                        Label {
+        // Query sharing services using the lightweight thumbnail image to
+        // keep the view builder fast. Full-res decode is deferred to when
+        // the user actually picks a service.
+        let services = NSSharingService.sharingServices(forItems: [image])
+        if !services.isEmpty {
+            Menu {
+                ForEach(Array(services.enumerated()), id: \.offset) { _, service in
+                    Button {
+                        // Defer full-res decode to action time (off the render path)
+                        let itemToShare: NSImage = {
+                            if let base64Data, !base64Data.isEmpty,
+                               let decoded = Data(base64Encoded: base64Data), !decoded.isEmpty,
+                               let fullRes = NSImage(data: decoded) {
+                                return fullRes
+                            }
+                            return image
+                        }()
+                        service.perform(withItems: [itemToShare])
+                    } label: {
+                        if let serviceImage = service.image {
+                            Label {
+                                Text(service.title)
+                            } icon: {
+                                Image(nsImage: serviceImage)
+                            }
+                        } else {
                             Text(service.title)
-                        } icon: {
-                            Image(nsImage: serviceImage)
                         }
-                    } else {
-                        Text(service.title)
                     }
                 }
+            } label: {
+                Label { Text("Share") } icon: { VIconView(.share, size: 12) }
             }
-        } label: {
-            Label { Text("Share") } icon: { VIconView(.share, size: 12) }
         }
 
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -135,6 +135,38 @@ private enum ImageActions {
             Label { Text("Open in Preview") } icon: { VIconView(.eye, size: 12) }
         }
 
+        Divider()
+
+        Menu {
+            let shareImage: NSImage = {
+                if let base64Data, !base64Data.isEmpty,
+                   let decoded = Data(base64Encoded: base64Data), !decoded.isEmpty,
+                   let fullRes = NSImage(data: decoded) {
+                    return fullRes
+                } else {
+                    return image
+                }
+            }()
+            let services = NSSharingService.sharingServices(forItems: [shareImage])
+            ForEach(Array(services.enumerated()), id: \.offset) { _, service in
+                Button {
+                    service.perform(withItems: [shareImage])
+                } label: {
+                    if let serviceImage = service.image {
+                        Label {
+                            Text(service.title)
+                        } icon: {
+                            Image(nsImage: serviceImage)
+                        }
+                    } else {
+                        Text(service.title)
+                    }
+                }
+            }
+        } label: {
+            Label { Text("Share") } icon: { VIconView(.share, size: 12) }
+        }
+
     }
 }
 


### PR DESCRIPTION
## Summary
- Part of #20275. Adds a Share submenu to the image right-click context menu using `NSSharingService.sharingServices(forItems:)`
- Each available sharing service (AirDrop, Messages, Mail, Notes, etc.) is rendered as a Button inside a Menu submenu
- Uses full-res image from base64Data when available, consistent with Copy Image behavior

## Test plan
- [ ] Right-click an image in a chat bubble and verify the Share submenu appears after a divider below "Open in Preview"
- [ ] Verify the Share submenu lists system sharing services (AirDrop, Messages, Mail, etc.) with their icons
- [ ] Click a sharing service and verify it triggers the appropriate share action
- [ ] Verify sharing uses full-res image when base64Data is available (not the thumbnail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
