### PR TITLE
Remove claude-code import and registry entry from bundled-tool-registry.ts

### DIFF
--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -39,8 +39,6 @@ import * as browserWaitFor from "./bundled-skills/browser/tools/browser-wait-for
 import * as browserWaitForDownload from "./bundled-skills/browser/tools/browser-wait-for-download.js";
 // ── chatgpt-import ─────────────────────────────────────────────────────────────
 import * as chatgptImport from "./bundled-skills/chatgpt-import/tools/chatgpt-import.js";
-// ── claude-code ────────────────────────────────────────────────────────────────
-import * as claudeCode from "./bundled-skills/claude-code/tools/claude-code.js";
 // ── computer-use ───────────────────────────────────────────────────────────────
 import * as computerUseClick from "./bundled-skills/computer-use/tools/computer-use-click.js";
 import * as computerUseDone from "./bundled-skills/computer-use/tools/computer-use-done.js";
@@ -209,9 +207,6 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
 
   // chatgpt-import
   ["chatgpt-import:tools/chatgpt-import.ts", chatgptImport],
-
-  // claude-code
-  ["claude-code:tools/claude-code.ts", claudeCode],
 
   // computer-use
   ["computer-use:tools/computer-use-observe.ts", computerUseObserve],


### PR DESCRIPTION
## Summary
- Remove claude-code import and registry entry from bundled-tool-registry.ts

Part of plan: rm-claude-agent-sdk.md (PR 2 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
