### PR TITLE
Remove claude_code timeout special case from ToolExecutor

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -183,10 +183,6 @@ export class ToolExecutor {
         );
         // Buffer so the shell's own timeout fires first and handles cleanup
         toolTimeoutMs = (shellTimeoutSec + 5) * 1000;
-      } else if (name === "claude_code") {
-        // Claude Code spawns a subprocess that manages its own turn limits
-        // (maxTurns). Give it a generous timeout so it isn't killed mid-task.
-        toolTimeoutMs = 10 * 60 * 1000; // 10 minutes
       } else {
         const rawTimeoutSec = getConfig().timeouts.toolExecutionTimeoutSec;
         toolTimeoutMs = safeTimeoutMs(rawTimeoutSec);


### PR DESCRIPTION
## Summary
- Remove the claude_code-specific 10-minute timeout from executor.ts

Part of plan: rm-claude-agent-sdk.md (PR 6 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
