### PR TITLE
fix: surface broker unreachable state in credential inspect output

### DIFF
--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -655,9 +655,23 @@ Examples:
 
           const connection = safeGetConnectionByProvider(metadata.service);
           const output = buildCredentialOutput(metadata, secret, connection);
+
+          // When the keychain broker is unreachable and we have no secret,
+          // override the output to indicate the broker is down rather than
+          // misleadingly reporting "(not set)".
+          if (unreachable && (secret == null || secret.length === 0)) {
+            output.scrubbedValue = "(broker unreachable)";
+            output.brokerUnreachable = true;
+          }
+
           writeOutput(cmd, output);
 
           if (!shouldOutputJson(cmd)) {
+            if (unreachable && (secret == null || secret.length === 0)) {
+              log.warn(
+                "⚠ Keychain broker unreachable — secret may exist but cannot be retrieved",
+              );
+            }
             printCredentialHuman(output);
           }
         } catch (err) {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for cred-reveal-timeout-fix.md.

**Gap:** inspect command silently reports hasSecret: false when broker is unreachable
**What was expected:** User should be informed that the broker is unreachable
**What was found:** When metadata exists but broker is down, inspect shows (not set) with no indication
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
