### PR TITLE
Remove requestConfirmation callback from ToolContext interface and setup

### DIFF
--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -23,7 +23,6 @@ import {
 import { isAllowDecision } from "../permissions/types.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
 import type { TrustClass } from "../runtime/actor-trust-resolver.js";
-import { getEffectiveMode } from "../runtime/conversation-approval-overrides.js";
 import { coreAppProxyTools } from "../tools/apps/definitions.js";
 import { registerConversationSender } from "../tools/browser/browser-screencast.js";
 import type { ToolExecutor } from "../tools/executor.js";
@@ -233,110 +232,6 @@ export function createToolExecutor(
           params.allowedTools,
           params.allowedDomains,
         );
-      },
-      requestConfirmation: async (req) => {
-        // Check trust store before prompting
-        const existingRule = findHighestPriorityRule(
-          "cc:" + req.toolName,
-          [req.toolName, `cc:${req.toolName}`, "cc:*"],
-          ctx.workingDir,
-        );
-        if (existingRule && existingRule.decision !== "ask") {
-          return {
-            decision:
-              existingRule.decision === "allow"
-                ? ("allow" as const)
-                : ("deny" as const),
-          };
-        }
-        // Auto-approve sub-tool confirmations when a temporary approval
-        // override is active for this conversation (guardian only).
-        const guardianTrust = ctx.trustContext?.trustClass ?? "unknown";
-        if (
-          guardianTrust === "guardian" &&
-          getEffectiveMode(ctx.conversationId) !== undefined
-        ) {
-          return { decision: "allow" as const };
-        }
-        const allowlistOptions = [
-          {
-            label: `cc:${req.toolName}`,
-            description: `Claude Code ${req.toolName}`,
-            pattern: `cc:${req.toolName}`,
-          },
-          {
-            label: "cc:*",
-            description: "All Claude Code sub-tools",
-            pattern: "cc:*",
-          },
-        ];
-        const scopeOptions = generateScopeOptions(ctx.workingDir);
-        const response = await prompter.prompt(
-          `cc:${req.toolName}`,
-          req.input,
-          req.riskLevel,
-          allowlistOptions,
-          scopeOptions,
-          undefined,
-          undefined,
-          ctx.conversationId,
-          req.executionTarget,
-          undefined,
-          undefined,
-          undefined,
-          toolUseId,
-        );
-        if (
-          (response.decision === "always_allow" ||
-            response.decision === "always_allow_high_risk") &&
-          response.selectedPattern &&
-          response.selectedScope
-        ) {
-          log.info(
-            {
-              toolName: "cc:" + req.toolName,
-              pattern: response.selectedPattern,
-              scope: response.selectedScope,
-              highRisk: response.decision === "always_allow_high_risk",
-            },
-            "Persisting always-allow trust rule",
-          );
-          addRule(
-            "cc:" + req.toolName,
-            response.selectedPattern,
-            response.selectedScope,
-            "allow",
-            100,
-            response.decision === "always_allow_high_risk"
-              ? { allowHighRisk: true }
-              : undefined,
-          );
-        }
-        if (
-          response.decision === "always_deny" &&
-          response.selectedPattern &&
-          response.selectedScope
-        ) {
-          log.info(
-            {
-              toolName: "cc:" + req.toolName,
-              pattern: response.selectedPattern,
-              scope: response.selectedScope,
-            },
-            "Persisting always-deny trust rule",
-          );
-          addRule(
-            "cc:" + req.toolName,
-            response.selectedPattern,
-            response.selectedScope,
-            "deny",
-          );
-        }
-        return {
-          decision: isAllowDecision(response.decision)
-            ? ("allow" as const)
-            : ("deny" as const),
-        };
       },
     };
 

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -118,14 +118,6 @@ export interface ToolContext {
   proxyToolResolver?: ProxyToolResolver;
   /** When set, only tools in this set may execute. Tools outside the set are blocked with an error. */
   allowedToolNames?: Set<string>;
-  /** Request user confirmation for a sub-tool operation (used by claude_code tool). */
-  requestConfirmation?: (req: {
-    toolName: string;
-    input: Record<string, unknown>;
-    riskLevel: string;
-    executionTarget?: ExecutionTarget;
-    principal?: string;
-  }) => Promise<{ decision: "allow" | "deny" }>;
   /** Prompt the user for a secret value via native SecureField UI. */
   requestSecret?: (params: {
     service: string;


### PR DESCRIPTION
## Summary
- Remove requestConfirmation property from ToolContext interface in types.ts
- Remove the entire requestConfirmation callback implementation from conversation-tool-setup.ts
- Clean up any unused imports

Part of plan: rm-claude-agent-sdk.md (PR 7 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
