### PR TITLE
fix: extract .value from getSecureKeyAsync in boolean checks

### DIFF
--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -47,12 +47,12 @@ export async function getSlackChannelConfig(): Promise<SlackChannelConfigResult>
     : undefined;
   await syncManualTokenConnection("slack_channel", accountInfo);
 
-  const hasBotToken = !!(await getSecureKeyAsync(
-    credentialKey("slack_channel", "bot_token"),
-  )).value;
-  const hasAppToken = !!(await getSecureKeyAsync(
-    credentialKey("slack_channel", "app_token"),
-  )).value;
+  const hasBotToken = !!(
+    await getSecureKeyAsync(credentialKey("slack_channel", "bot_token"))
+  ).value;
+  const hasAppToken = !!(
+    await getSecureKeyAsync(credentialKey("slack_channel", "app_token"))
+  ).value;
   const conn = getConnectionByProvider("slack_channel");
   const connected =
     !!(conn && conn.status === "active") && hasBotToken && hasAppToken;
@@ -97,12 +97,12 @@ export async function setSlackChannelConfig(
         user?: string;
       };
       if (!data.ok) {
-        const errHasBotToken = !!(await getSecureKeyAsync(
-          credentialKey("slack_channel", "bot_token"),
-        )).value;
-        const errHasAppToken = !!(await getSecureKeyAsync(
-          credentialKey("slack_channel", "app_token"),
-        )).value;
+        const errHasBotToken = !!(
+          await getSecureKeyAsync(credentialKey("slack_channel", "bot_token"))
+        ).value;
+        const errHasAppToken = !!(
+          await getSecureKeyAsync(credentialKey("slack_channel", "app_token"))
+        ).value;
         const errConn = getConnectionByProvider("slack_channel");
         return {
           success: false,
@@ -125,12 +125,12 @@ export async function setSlackChannelConfig(
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      const errHasBotToken = !!(await getSecureKeyAsync(
-        credentialKey("slack_channel", "bot_token"),
-      ));
-      const errHasAppToken = !!(await getSecureKeyAsync(
-        credentialKey("slack_channel", "app_token"),
-      ));
+      const errHasBotToken = !!(
+        await getSecureKeyAsync(credentialKey("slack_channel", "bot_token"))
+      ).value;
+      const errHasAppToken = !!(
+        await getSecureKeyAsync(credentialKey("slack_channel", "app_token"))
+      ).value;
       const errConn = getConnectionByProvider("slack_channel");
       return {
         success: false,
@@ -149,12 +149,12 @@ export async function setSlackChannelConfig(
       botToken,
     );
     if (!stored) {
-      const errHasBotToken = !!(await getSecureKeyAsync(
-        credentialKey("slack_channel", "bot_token"),
-      ));
-      const errHasAppToken = !!(await getSecureKeyAsync(
-        credentialKey("slack_channel", "app_token"),
-      ));
+      const errHasBotToken = !!(
+        await getSecureKeyAsync(credentialKey("slack_channel", "bot_token"))
+      ).value;
+      const errHasAppToken = !!(
+        await getSecureKeyAsync(credentialKey("slack_channel", "app_token"))
+      ).value;
       const errConn = getConnectionByProvider("slack_channel");
       return {
         success: false,
@@ -191,12 +191,12 @@ export async function setSlackChannelConfig(
   // Validate and store app token
   if (appToken) {
     if (!appToken.startsWith("xapp-")) {
-      const errHasBotToken = !!(await getSecureKeyAsync(
-        credentialKey("slack_channel", "bot_token"),
-      ));
-      const errHasAppToken = !!(await getSecureKeyAsync(
-        credentialKey("slack_channel", "app_token"),
-      ));
+      const errHasBotToken = !!(
+        await getSecureKeyAsync(credentialKey("slack_channel", "bot_token"))
+      ).value;
+      const errHasAppToken = !!(
+        await getSecureKeyAsync(credentialKey("slack_channel", "app_token"))
+      ).value;
       const errConn = getConnectionByProvider("slack_channel");
       return {
         success: false,
@@ -215,12 +215,12 @@ export async function setSlackChannelConfig(
       appToken,
     );
     if (!stored) {
-      const errHasBotToken = !!(await getSecureKeyAsync(
-        credentialKey("slack_channel", "bot_token"),
-      ));
-      const errHasAppToken = !!(await getSecureKeyAsync(
-        credentialKey("slack_channel", "app_token"),
-      ));
+      const errHasBotToken = !!(
+        await getSecureKeyAsync(credentialKey("slack_channel", "bot_token"))
+      ).value;
+      const errHasAppToken = !!(
+        await getSecureKeyAsync(credentialKey("slack_channel", "app_token"))
+      ).value;
       const errConn = getConnectionByProvider("slack_channel");
       return {
         success: false,
@@ -237,12 +237,12 @@ export async function setSlackChannelConfig(
     upsertCredentialMetadata("slack_channel", "app_token", {});
   }
 
-  const hasBotToken = !!(await getSecureKeyAsync(
-    credentialKey("slack_channel", "bot_token"),
-  )).value;
-  const hasAppToken = !!(await getSecureKeyAsync(
-    credentialKey("slack_channel", "app_token"),
-  )).value;
+  const hasBotToken = !!(
+    await getSecureKeyAsync(credentialKey("slack_channel", "bot_token"))
+  ).value;
+  const hasAppToken = !!(
+    await getSecureKeyAsync(credentialKey("slack_channel", "app_token"))
+  ).value;
 
   if (hasBotToken && !hasAppToken) {
     warning =
@@ -283,12 +283,12 @@ export async function clearSlackChannelConfig(): Promise<SlackChannelConfigResul
 
   if (r1 === "error" || r2 === "error") {
     // Check each key individually so partial deletions report accurate status.
-    const hasBotToken = !!(await getSecureKeyAsync(
-      credentialKey("slack_channel", "bot_token"),
-    ));
-    const hasAppToken = !!(await getSecureKeyAsync(
-      credentialKey("slack_channel", "app_token"),
-    ));
+    const hasBotToken = !!(
+      await getSecureKeyAsync(credentialKey("slack_channel", "bot_token"))
+    ).value;
+    const hasAppToken = !!(
+      await getSecureKeyAsync(credentialKey("slack_channel", "app_token"))
+    ).value;
     const conn = getConnectionByProvider("slack_channel");
     return {
       success: false,

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -75,12 +75,12 @@ export async function getTelegramConfig(): Promise<TelegramConfigResult> {
     "telegram",
     botUsername ? `@${botUsername}` : undefined,
   );
-  const hasBotToken = !!(await getSecureKeyAsync(
-    credentialKey("telegram", "bot_token"),
-  )).value;
-  const hasWebhookSecret = !!(await getSecureKeyAsync(
-    credentialKey("telegram", "webhook_secret"),
-  )).value;
+  const hasBotToken = !!(
+    await getSecureKeyAsync(credentialKey("telegram", "bot_token"))
+  ).value;
+  const hasWebhookSecret = !!(
+    await getSecureKeyAsync(credentialKey("telegram", "webhook_secret"))
+  ).value;
   const conn = getConnectionByProvider("telegram");
   const connected = !!(conn && conn.status === "active");
   const botId = getTelegramBotId();
@@ -182,9 +182,9 @@ export async function setTelegramConfig(
   invalidateConfigCache();
 
   // Ensure webhook secret exists (generate if missing)
-  let hasWebhookSecret = !!(await getSecureKeyAsync(
-    credentialKey("telegram", "webhook_secret"),
-  )).value;
+  let hasWebhookSecret = !!(
+    await getSecureKeyAsync(credentialKey("telegram", "webhook_secret"))
+  ).value;
   if (!hasWebhookSecret) {
     const { randomUUID } = await import("node:crypto");
     const webhookSecret = randomUUID();
@@ -280,12 +280,12 @@ export async function clearTelegramConfig(): Promise<TelegramConfigResult> {
 
   if (r1 === "error" || r2 === "error") {
     // Check each key individually so partial deletions report accurate status.
-    const hasBotToken = !!(await getSecureKeyAsync(
-      credentialKey("telegram", "bot_token"),
-    ));
-    const hasWebhookSecret = !!(await getSecureKeyAsync(
-      credentialKey("telegram", "webhook_secret"),
-    ));
+    const hasBotToken = !!(
+      await getSecureKeyAsync(credentialKey("telegram", "bot_token"))
+    ).value;
+    const hasWebhookSecret = !!(
+      await getSecureKeyAsync(credentialKey("telegram", "webhook_secret"))
+    ).value;
     return {
       success: false,
       hasBotToken,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for cred-reveal-timeout-fix.md.

**Gap:** 12 call sites use !!(await getSecureKeyAsync(...)) which always evaluates to true
**What was expected:** Should check .value for credential presence
**What was found:** Object return type makes !! always truthy, silently breaking credential presence checks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
