### PR TITLE
Update registry.test.ts, conversation-skill-tools.test.ts, and credential-security-invariants.test.ts

### DIFF
--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -1721,58 +1721,6 @@ describe("bundled skill: gmail", () => {
   });
 });
 
-describe("bundled skill: claude-code", () => {
-  let sessionState: Map<string, string>;
-
-  beforeEach(() => {
-    mockCatalog = [];
-    mockManifests = {};
-    mockRegisteredTools = new Map();
-    mockUnregisteredSkillIds = [];
-    mockSkillRefCount = new Map();
-    mockSkillRefCount = new Map();
-    mockVersionHashes = {};
-    mockVersionHashErrors = new Set();
-    sessionState = new Map<string, string>();
-  });
-
-  test("claude-code skill activation registers claude_code in allowedToolNames", () => {
-    mockCatalog = [
-      makeSkill("claude-code", "/path/to/bundled-skills/claude-code"),
-    ];
-    mockManifests = { "claude-code": makeManifest(["claude_code"]) };
-
-    const history: Message[] = [
-      ...skillLoadMessages('<loaded_skill id="claude-code" />'),
-    ];
-
-    const result = projectSkillTools(history, {
-      previouslyActiveSkillIds: sessionState,
-    });
-
-    expect(result.toolDefinitions).toEqual([]);
-    expect(result.allowedToolNames).toEqual(new Set(["claude_code"]));
-  });
-
-  test("claude_code tool is absent when claude-code skill is not active", () => {
-    mockCatalog = [
-      makeSkill("claude-code", "/path/to/bundled-skills/claude-code"),
-    ];
-    mockManifests = { "claude-code": makeManifest(["claude_code"]) };
-
-    const history: Message[] = [
-      { role: "user", content: [{ type: "text", text: "Hello" }] },
-    ];
-
-    const result = projectSkillTools(history, {
-      previouslyActiveSkillIds: sessionState,
-    });
-
-    expect(result.toolDefinitions).toHaveLength(0);
-    expect(result.allowedToolNames.has("claude_code")).toBe(false);
-  });
-});
-
 // ---------------------------------------------------------------------------
 // Bundled skill: app-builder
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -239,7 +239,6 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "cli/commands/oauth/connections.ts", // CLI OAuth connection delete (legacy credential cleanup)
       "oauth/manual-token-connection.ts", // manual-token provider backfill (keychain credential existence check)
       "cli/commands/doctor.ts", // CLI diagnostic API key verification via secure storage
-      "swarm/backend-claude-code.ts", // Claude Code swarm backend API key lookup
       "workspace/provider-commit-message-generator.ts", // commit message generation provider key lookup
       "config/bundled-skills/transcribe/tools/transcribe-media.ts", // transcription tool API key lookup
       "config/bundled-skills/image-studio/tools/media-generate-image.ts", // image generation tool API key lookup
@@ -251,7 +250,6 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "media/avatar-router.ts", // avatar generation API key lookup
       "memory/embedding-backend.ts", // embedding backend API key lookup
       "daemon/providers-setup.ts", // provider initialization API key lookup
-      "tools/claude-code/claude-code.ts", // Claude Code tool API key lookup
       "workspace/migrations/006-services-config.ts", // services config migration reads provider API keys
       "cli/commands/avatar.ts", // CLI avatar generation API key lookup
       "config/bundled-skills/slack/tools/shared.ts", // Slack skill bot token lookup

--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -173,12 +173,6 @@ describe("baseline characterization: hardcoded tool loading", () => {
       expect(eagerModuleToolNames).not.toContain(name);
     }
   });
-
-  test("claude_code is NOT in global registry after initializeTools()", async () => {
-    await initializeTools();
-    const tool = getTool("claude_code");
-    expect(tool).toBeUndefined();
-  });
 });
 
 describe("baseline characterization: core app tool surface", () => {


### PR DESCRIPTION
## Summary
- Remove claude_code test case from registry.test.ts
- Remove bundled skill: claude-code describe block from conversation-skill-tools.test.ts
- Remove claude-code allowlist entries from credential-security-invariants.test.ts

Part of plan: rm-claude-agent-sdk.md (PR 9 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
