### PR TITLE
fix: restore try/catch around Qdrant client init in lifecycle

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -385,32 +385,39 @@ export async function runDaemon(): Promise<void> {
       }
 
       if (qdrantStarted) {
-        const embeddingSelection = await selectEmbeddingBackend(config);
-        const embeddingModel = embeddingSelection.backend
-          ? `${embeddingSelection.backend.provider}:${embeddingSelection.backend.model}:sparse-v${SPARSE_EMBEDDING_VERSION}`
-          : undefined;
-        const qdrantClient = initQdrantClient({
-          url: qdrantUrl,
-          collection: config.memory.qdrant.collection,
-          vectorSize: config.memory.qdrant.vectorSize,
-          onDisk: config.memory.qdrant.onDisk,
-          quantization: config.memory.qdrant.quantization,
-          embeddingModel,
-        });
+        try {
+          const embeddingSelection = await selectEmbeddingBackend(config);
+          const embeddingModel = embeddingSelection.backend
+            ? `${embeddingSelection.backend.provider}:${embeddingSelection.backend.model}:sparse-v${SPARSE_EMBEDDING_VERSION}`
+            : undefined;
+          const qdrantClient = initQdrantClient({
+            url: qdrantUrl,
+            collection: config.memory.qdrant.collection,
+            vectorSize: config.memory.qdrant.vectorSize,
+            onDisk: config.memory.qdrant.onDisk,
+            quantization: config.memory.qdrant.quantization,
+            embeddingModel,
+          });
 
-        // Eagerly ensure the collection exists so we detect migrations
-        // (unnamed→named vectors, dimension/model changes) at startup.
-        // If a destructive migration occurred, enqueue a rebuild_index job
-        // to re-embed all memory items from the SQLite cache.
-        const { migrated } = await qdrantClient.ensureCollection();
-        if (migrated) {
-          enqueueMemoryJob("rebuild_index", {});
-          log.info(
-            "Qdrant collection was migrated — enqueued rebuild_index job",
+          // Eagerly ensure the collection exists so we detect migrations
+          // (unnamed→named vectors, dimension/model changes) at startup.
+          // If a destructive migration occurred, enqueue a rebuild_index job
+          // to re-embed all memory items from the SQLite cache.
+          const { migrated } = await qdrantClient.ensureCollection();
+          if (migrated) {
+            enqueueMemoryJob("rebuild_index", {});
+            log.info(
+              "Qdrant collection was migrated — enqueued rebuild_index job",
+            );
+          }
+
+          log.info("Qdrant vector store initialized");
+        } catch (err) {
+          log.warn(
+            { err },
+            "Qdrant client initialization failed — memory features will be degraded",
           );
         }
-
-        log.info("Qdrant vector store initialized");
       }
 
       log.info("Daemon startup: starting memory worker");


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for cpu-churn-hot-loop-fixes.md.

**Gap:** Missing try/catch around Qdrant client initialization
**What was expected:** Memory worker always starts even if Qdrant client init fails
**What was found:** Exception from selectEmbeddingBackend/ensureCollection skips startMemoryJobsWorker
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
