### PR TITLE
fix: allow one embed probe job when Qdrant breaker cooldown elapses

### DIFF
--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -4,7 +4,10 @@ import { v4 as uuid } from "uuid";
 import { getLogger } from "../util/logger.js";
 import { truncate } from "../util/truncate.js";
 import { getDb, rawAll, rawChanges } from "./db.js";
-import { isQdrantBreakerOpen } from "./qdrant-circuit-breaker.js";
+import {
+  isQdrantBreakerOpen,
+  shouldAllowQdrantProbe,
+} from "./qdrant-circuit-breaker.js";
 import { memoryJobs } from "./schema.js";
 
 const log = getLogger("memory-jobs-store");
@@ -203,11 +206,22 @@ export function claimMemoryJobs(limit: number): MemoryJob[] {
 
   const remainingSlots = limit - nonEmbedCandidates.length;
 
-  // When the Qdrant circuit breaker is open, skip embed jobs entirely.
-  // They would just be claimed → fail → deferred, wasting CPU cycles.
-  const skipEmbedJobs = isQdrantBreakerOpen();
+  // When the Qdrant circuit breaker is open, skip embed jobs entirely —
+  // they would just be claimed → fail → deferred, wasting CPU cycles.
+  // Exception: if the cooldown has elapsed (breaker ready for half-open probe),
+  // allow exactly 1 embed job through so the breaker can self-heal.
+  const breakerOpen = isQdrantBreakerOpen();
+  const probeAllowed = breakerOpen && shouldAllowQdrantProbe();
+  const skipEmbedJobs = breakerOpen && !probeAllowed;
+  const embedLimit = probeAllowed ? 1 : remainingSlots;
+
   if (skipEmbedJobs && remainingSlots > 0) {
     log.debug("Skipping embed job claims — Qdrant circuit breaker is open");
+  }
+  if (probeAllowed && remainingSlots > 0) {
+    log.debug(
+      "Allowing 1 embed probe job — Qdrant circuit breaker cooldown elapsed",
+    );
   }
 
   const embedCandidates =
@@ -217,7 +231,7 @@ export function claimMemoryJobs(limit: number): MemoryJob[] {
           .from(memoryJobs)
           .where(and(pendingFilter, inArray(memoryJobs.type, EMBED_JOB_TYPES)))
           .orderBy(asc(memoryJobs.runAfter), asc(memoryJobs.createdAt))
-          .limit(remainingSlots)
+          .limit(embedLimit)
           .all()
       : [];
 

--- a/assistant/src/memory/qdrant-circuit-breaker.ts
+++ b/assistant/src/memory/qdrant-circuit-breaker.ts
@@ -101,6 +101,15 @@ export function isQdrantBreakerOpen(): boolean {
   return breakerState !== "closed";
 }
 
+/**
+ * Returns true when the breaker is open and the cooldown has elapsed,
+ * meaning the next call to `withQdrantBreaker` will transition to half-open.
+ * Use this to allow a single probe job through when embed jobs are otherwise skipped.
+ */
+export function shouldAllowQdrantProbe(): boolean {
+  return breakerState === "open" && Date.now() - openedAt >= COOLDOWN_MS;
+}
+
 /** @internal Test-only: reset circuit breaker state */
 export function _resetQdrantBreaker(): void {
   breakerState = "closed";


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for cpu-churn-hot-loop-fixes.md.

**Gap:** Circuit breaker cannot self-heal when only embed jobs are pending
**What was expected:** Breaker should close when Qdrant recovers
**What was found:** Embed jobs are never claimed when breaker is open, blocking the probe mechanism
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
