### PR TITLE
Add Share submenu to image context menu

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -135,13 +135,14 @@ private enum ImageActions {
             Label { Text("Open in Preview") } icon: { VIconView(.eye, size: 12) }
         }
 
-        Divider()
-
         // Query sharing services using the lightweight thumbnail image to
         // keep the view builder fast. Full-res decode is deferred to when
         // the user actually picks a service.
+        // NSSharingService.sharingServices is deprecated in macOS 13 but has
+        // no functional replacement for custom share UI (see AppSharePanelView).
         let services = NSSharingService.sharingServices(forItems: [image])
         if !services.isEmpty {
+            Divider()
             Menu {
                 ForEach(Array(services.enumerated()), id: \.offset) { _, service in
                     Button {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -135,6 +135,43 @@ private enum ImageActions {
             Label { Text("Open in Preview") } icon: { VIconView(.eye, size: 12) }
         }
 
+        Divider()
+
+        // Query sharing services using the lightweight thumbnail image to
+        // keep the view builder fast. Full-res decode is deferred to when
+        // the user actually picks a service.
+        let services = NSSharingService.sharingServices(forItems: [image])
+        if !services.isEmpty {
+            Menu {
+                ForEach(Array(services.enumerated()), id: \.offset) { _, service in
+                    Button {
+                        // Defer full-res decode to action time (off the render path)
+                        let itemToShare: NSImage = {
+                            if let base64Data, !base64Data.isEmpty,
+                               let decoded = Data(base64Encoded: base64Data), !decoded.isEmpty,
+                               let fullRes = NSImage(data: decoded) {
+                                return fullRes
+                            }
+                            return image
+                        }()
+                        service.perform(withItems: [itemToShare])
+                    } label: {
+                        if let serviceImage = service.image {
+                            Label {
+                                Text(service.title)
+                            } icon: {
+                                Image(nsImage: serviceImage)
+                            }
+                        } else {
+                            Text(service.title)
+                        }
+                    }
+                }
+            } label: {
+                Label { Text("Share") } icon: { VIconView(.share, size: 12) }
+            }
+        }
+
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -72,9 +72,10 @@ private enum ImageActions {
         }
     }
 
-    /// Writes the image to a temporary file and opens it in the default app (Preview).
+    /// Writes the image to a temporary file and returns the file URL.
     /// Prefers `base64Data` (full resolution), falling back to PNG-encoding the NSImage.
-    static func openInPreview(_ image: NSImage, filename: String, base64Data: String? = nil) {
+    /// Returns nil if the image could not be written.
+    static func writeTempFile(_ image: NSImage, filename: String, base64Data: String? = nil) -> URL? {
         let tempDir = FileManager.default.temporaryDirectory
         let sanitized = (filename as NSString).lastPathComponent
         let fallbackName = sanitized.isEmpty ? "image.png" : sanitized
@@ -101,13 +102,19 @@ private enum ImageActions {
         }
         let fileURL = tempDir.appendingPathComponent(fileName)
 
-        guard let fileData else { return }
+        guard let fileData else { return nil }
         do {
             try fileData.write(to: fileURL)
-            NSWorkspace.shared.open(fileURL)
+            return fileURL
         } catch {
-            // Silently fail — not critical
+            return nil
         }
+    }
+
+    /// Writes the image to a temporary file and opens it in the default app (Preview).
+    static func openInPreview(_ image: NSImage, filename: String, base64Data: String? = nil) {
+        guard let fileURL = writeTempFile(image, filename: filename, base64Data: base64Data) else { return }
+        NSWorkspace.shared.open(fileURL)
     }
 
     /// Builds a SwiftUI context menu with Copy, Save As, and Open in Preview actions.
@@ -135,41 +142,37 @@ private enum ImageActions {
             Label { Text("Open in Preview") } icon: { VIconView(.eye, size: 12) }
         }
 
-        // Query sharing services using the lightweight thumbnail image to
-        // keep the view builder fast. Full-res decode is deferred to when
-        // the user actually picks a service.
+        // Write a temp file for sharing — NSSharingService.sharingServices
+        // returns far more services (AirDrop, Messages, Mail, etc.) when given
+        // a file URL vs a raw NSImage. The temp file write is lightweight
+        // (thumbnail image) to keep the view builder fast. Full-res file is
+        // written at action time when the user picks a service.
         // NSSharingService.sharingServices is deprecated in macOS 13 but has
         // no functional replacement for custom share UI (see AppSharePanelView).
-        let services = NSSharingService.sharingServices(forItems: [image])
-        if !services.isEmpty {
-            Divider()
-            Menu {
-                ForEach(Array(services.enumerated()), id: \.offset) { _, service in
-                    Button {
-                        // Defer full-res decode to action time (off the render path)
-                        let itemToShare: NSImage = {
-                            if let base64Data, !base64Data.isEmpty,
-                               let decoded = Data(base64Encoded: base64Data), !decoded.isEmpty,
-                               let fullRes = NSImage(data: decoded) {
-                                return fullRes
+        if let tempURL = writeTempFile(image, filename: filename) {
+            let services = NSSharingService.sharingServices(forItems: [tempURL])
+            if !services.isEmpty {
+                Divider()
+                Menu {
+                    ForEach(Array(services.enumerated()), id: \.offset) { _, service in
+                        Button {
+                            // Write full-res file at action time, then share
+                            if let fullResURL = writeTempFile(image, filename: filename, base64Data: base64Data) {
+                                service.perform(withItems: [fullResURL])
+                            } else {
+                                service.perform(withItems: [tempURL])
                             }
-                            return image
-                        }()
-                        service.perform(withItems: [itemToShare])
-                    } label: {
-                        if let serviceImage = service.image {
+                        } label: {
                             Label {
                                 Text(service.title)
                             } icon: {
-                                Image(nsImage: serviceImage)
+                                Image(nsImage: service.image)
                             }
-                        } else {
-                            Text(service.title)
                         }
                     }
+                } label: {
+                    Label { Text("Share") } icon: { VIconView(.share, size: 12) }
                 }
-            } label: {
-                Label { Text("Share") } icon: { VIconView(.share, size: 12) }
             }
         }
 


### PR DESCRIPTION
## Summary
Adds a Share submenu to the image right-click context menu using inline `NSSharingService` items. Each available system sharing service (AirDrop, Messages, Mail, Notes, etc.) is rendered as a button with its native icon inside a submenu — stays within the context menu lifecycle, unlike the previous `NSSharingServicePicker` approach which didn't work.

## Changes
- Added `Menu("Share")` submenu to `ImageActions.contextMenuItems` with inline `NSSharingService` buttons
- Services queried using the lightweight thumbnail image (fast, on render path)
- Full-res base64 decode deferred to button action time (off render path)
- Submenu hidden when no sharing services are available

## Milestone PRs (merged into feature branch)
- #20277: M1: Add Share submenu to image context menu

## Project issue
Closes #20275

## Test plan
- [ ] Right-click an image in chat — verify Share submenu appears with system services
- [ ] Click a sharing service (e.g., AirDrop, Messages) — verify it launches correctly
- [ ] Verify other context menu items (Copy, Save As, Open in Preview) still work
- [ ] Verify no UI lag when opening context menu on large images
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
