### PR TITLE
fix: update 36 test file mocks for SecureKeyResult return type

### DIFF
--- a/assistant/src/__tests__/avatar-e2e.test.ts
+++ b/assistant/src/__tests__/avatar-e2e.test.ts
@@ -45,8 +45,10 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async (name: string) =>
-    name === "gemini" ? mockGeminiKey : null,
+  getSecureKeyAsync: async (name: string) => ({
+    value: name === "gemini" ? mockGeminiKey : undefined,
+    unreachable: false,
+  }),
   getProviderKeyAsync: async (provider: string) =>
     provider === "gemini" ? mockGeminiKey : undefined,
 }));

--- a/assistant/src/__tests__/browser-fill-credential.test.ts
+++ b/assistant/src/__tests__/browser-fill-credential.test.ts
@@ -58,7 +58,10 @@ let mockGetSecureKey: ReturnType<typeof mock>;
 let mockGetCredentialMetadata: ReturnType<typeof mock>;
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async (...args: unknown[]) => mockGetSecureKey(...args),
+  getSecureKeyAsync: async (...args: unknown[]) => {
+    const raw = await mockGetSecureKey(...args);
+    return { value: raw ?? undefined, unreachable: false };
+  },
   setSecureKeyAsync: async () => true,
   deleteSecureKeyAsync: async () => "deleted",
   listSecureKeysAsync: async () => [],

--- a/assistant/src/__tests__/call-domain.test.ts
+++ b/assistant/src/__tests__/call-domain.test.ts
@@ -114,7 +114,7 @@ mock.module("../calls/twilio-provider.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async () => null,
+  getSecureKeyAsync: async () => ({ value: undefined, unreachable: false }),
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -103,7 +103,7 @@ mock.module("../calls/twilio-config.js", () => ({
 
 // Mock secure keys
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async () => null,
+  getSecureKeyAsync: async () => ({ value: undefined, unreachable: false }),
 }));
 
 mock.module("../calls/voice-ingress-preflight.js", () => ({

--- a/assistant/src/__tests__/channel-readiness-routes.test.ts
+++ b/assistant/src/__tests__/channel-readiness-routes.test.ts
@@ -47,7 +47,10 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async (key: string) => mockSecureKeys[key] ?? null,
+  getSecureKeyAsync: async (key: string) => ({
+    value: mockSecureKeys[key],
+    unreachable: false,
+  }),
 }));
 
 mock.module("../email/service.js", () => ({

--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -47,7 +47,10 @@ mock.module("../email/service.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async (key: string) => mockSecureKeys[key] ?? null,
+  getSecureKeyAsync: async (key: string) => ({
+    value: mockSecureKeys[key],
+    unreachable: false,
+  }),
 }));
 
 mock.module("../runtime/channel-invite-transports/whatsapp.js", () => ({

--- a/assistant/src/__tests__/claude-code-skill-regression.test.ts
+++ b/assistant/src/__tests__/claude-code-skill-regression.test.ts
@@ -54,8 +54,10 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async (name: string) =>
-    name === "anthropic" ? "fake-anthropic-key" : null,
+  getSecureKeyAsync: async (name: string) => ({
+    value: name === "anthropic" ? "fake-anthropic-key" : undefined,
+    unreachable: false,
+  }),
   getProviderKeyAsync: async (provider: string) =>
     provider === "anthropic" ? "fake-anthropic-key" : undefined,
 }));

--- a/assistant/src/__tests__/claude-code-tool-profiles.test.ts
+++ b/assistant/src/__tests__/claude-code-tool-profiles.test.ts
@@ -38,8 +38,10 @@ mock.module("../config/loader.js", () => ({
 
 // Mock secure-keys — provide a fake Anthropic API key
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async (name: string) =>
-    name === "anthropic" ? "fake-anthropic-key" : null,
+  getSecureKeyAsync: async (name: string) => ({
+    value: name === "anthropic" ? "fake-anthropic-key" : undefined,
+    unreachable: false,
+  }),
   getProviderKeyAsync: async (provider: string) =>
     provider === "anthropic" ? "fake-anthropic-key" : undefined,
 }));

--- a/assistant/src/__tests__/credential-security-e2e.test.ts
+++ b/assistant/src/__tests__/credential-security-e2e.test.ts
@@ -63,7 +63,10 @@ mock.module("../security/secure-keys.js", () => {
     return "not-found" as const;
   };
   return {
-    getSecureKeyAsync: async (key: string) => storedKeys.get(key) ?? undefined,
+    getSecureKeyAsync: async (key: string) => ({
+      value: storedKeys.get(key),
+      unreachable: false,
+    }),
     setSecureKeyAsync: async (key: string, value: string) =>
       syncSet(key, value),
     deleteSecureKeyAsync: async (key: string) => syncDelete(key),

--- a/assistant/src/__tests__/integration-status.test.ts
+++ b/assistant/src/__tests__/integration-status.test.ts
@@ -9,7 +9,10 @@ let mockTwilioAccountSid: string | undefined;
 const connectedProviders = new Set<string>();
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async (account: string) => secureKeyValues.get(account),
+  getSecureKeyAsync: async (account: string) => ({
+    value: secureKeyValues.get(account),
+    unreachable: false,
+  }),
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/invite-routes-http.test.ts
+++ b/assistant/src/__tests__/invite-routes-http.test.ts
@@ -26,7 +26,7 @@ mock.module("../util/logger.js", () => ({
 // Prevent ensureTelegramBotUsernameResolved() from reading real credentials
 // and calling the Telegram API.
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async () => undefined,
+  getSecureKeyAsync: async () => ({ value: undefined, unreachable: false }),
   setSecureKeyAsync: async () => {},
   deleteSecureKeyAsync: async () => {},
 }));

--- a/assistant/src/__tests__/log-export-workspace.test.ts
+++ b/assistant/src/__tests__/log-export-workspace.test.ts
@@ -58,7 +58,7 @@ mock.module("../util/logger.js", () => ({
 
 // Mock getSecureKeyAsync to avoid keychain access during tests
 mock.module("../util/secure-keys.js", () => ({
-  getSecureKeyAsync: async () => undefined,
+  getSecureKeyAsync: async () => ({ value: undefined, unreachable: false }),
 }));
 
 import { initializeDb, resetDb } from "../memory/db.js";

--- a/assistant/src/__tests__/managed-credential-catalog-cli.test.ts
+++ b/assistant/src/__tests__/managed-credential-catalog-cli.test.ts
@@ -35,12 +35,13 @@ mock.module("../config/env.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async (key: string) => {
-    if (key === credentialKey("vellum", "assistant_api_key")) {
-      return mockAssistantApiKey;
-    }
-    return null;
-  },
+  getSecureKeyAsync: async (key: string) => ({
+    value:
+      key === credentialKey("vellum", "assistant_api_key")
+        ? mockAssistantApiKey
+        : undefined,
+    unreachable: false,
+  }),
 }));
 
 // Mock global fetch

--- a/assistant/src/__tests__/managed-proxy-context.test.ts
+++ b/assistant/src/__tests__/managed-proxy-context.test.ts
@@ -19,12 +19,13 @@ mock.module("../config/env.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async (key: string) => {
-    if (key === credentialKey("vellum", "assistant_api_key")) {
-      return mockAssistantApiKey;
-    }
-    return null;
-  },
+  getSecureKeyAsync: async (key: string) => ({
+    value:
+      key === credentialKey("vellum", "assistant_api_key")
+        ? mockAssistantApiKey
+        : undefined,
+    unreachable: false,
+  }),
 }));
 
 import {

--- a/assistant/src/__tests__/mcp-client-auth.test.ts
+++ b/assistant/src/__tests__/mcp-client-auth.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, jest, mock, test } from "bun:test";
 
 // Mock secure-keys so McpOAuthProvider doesn't try to access the keychain
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: jest.fn().mockResolvedValue(null),
+  getSecureKeyAsync: jest
+    .fn()
+    .mockResolvedValue({ value: undefined, unreachable: false }),
   setSecureKeyAsync: jest.fn().mockResolvedValue(true),
   deleteSecureKeyAsync: jest.fn().mockResolvedValue("deleted"),
 }));

--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -40,10 +40,10 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async (account: string) => {
-    if (account === "gemini") return mockApiKey;
-    return undefined;
-  },
+  getSecureKeyAsync: async (account: string) => ({
+    value: account === "gemini" ? mockApiKey : undefined,
+    unreachable: false,
+  }),
   getProviderKeyAsync: async (provider: string) => {
     if (provider === "gemini") return mockApiKey;
     return undefined;

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -154,7 +154,10 @@ mock.module("../oauth/oauth-store.js", () => ({
 
 // Stub out transitive dependencies that token-manager would normally pull in
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async (account: string) => mockGetSecureKey(account),
+  getSecureKeyAsync: async (account: string) => ({
+    value: await mockGetSecureKey(account),
+    unreachable: false,
+  }),
   setSecureKeyAsync: async () => true,
   deleteSecureKeyAsync: async (account: string) => {
     if (secureKeyStore.has(account)) {

--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -34,7 +34,10 @@ mock.module("../security/secure-keys.js", () => ({
   deleteSecureKeyAsync: mockDeleteSecureKeyAsync,
   setSecureKeyAsync: mockSetSecureKeyAsync,
   getSecureKeyAsync: (account: string) =>
-    Promise.resolve(secureKeyValues.get(account)),
+    Promise.resolve({
+      value: secureKeyValues.get(account),
+      unreachable: false,
+    }),
 }));
 
 import { eq } from "drizzle-orm";

--- a/assistant/src/__tests__/provider-commit-message-generator.test.ts
+++ b/assistant/src/__tests__/provider-commit-message-generator.test.ts
@@ -10,7 +10,10 @@ import type { CommitContext } from "../workspace/commit-message-provider.js";
 // ---------------------------------------------------------------------------
 let mockSecureKeys: Record<string, string> = {};
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async (name: string) => mockSecureKeys[name] ?? undefined,
+  getSecureKeyAsync: async (name: string) => ({
+    value: mockSecureKeys[name],
+    unreachable: false,
+  }),
   setSecureKeyAsync: async () => true,
   deleteSecureKeyAsync: async () => "deleted" as const,
 }));

--- a/assistant/src/__tests__/provider-fail-open-selection.test.ts
+++ b/assistant/src/__tests__/provider-fail-open-selection.test.ts
@@ -21,12 +21,13 @@ mock.module("../config/env.js", () => ({
 const actualSecureKeys = await import("../security/secure-keys.js");
 mock.module("../security/secure-keys.js", () => ({
   ...actualSecureKeys,
-  getSecureKeyAsync: async (key: string) => {
-    if (key === credentialKey("vellum", "assistant_api_key")) {
-      return mockAssistantApiKey || null;
-    }
-    return mockProviderKeys[key] ?? null;
-  },
+  getSecureKeyAsync: async (key: string) => ({
+    value:
+      key === credentialKey("vellum", "assistant_api_key")
+        ? mockAssistantApiKey || undefined
+        : (mockProviderKeys[key] ?? undefined),
+    unreachable: false,
+  }),
 }));
 
 import type { ProvidersConfig } from "../providers/registry.js";

--- a/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
@@ -46,12 +46,13 @@ mock.module("../config/env.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async (key: string) => {
-    if (key === credentialKey("vellum", "assistant_api_key")) {
-      return mockAssistantApiKey;
-    }
-    return mockProviderKeys[key] ?? null;
-  },
+  getSecureKeyAsync: async (key: string) => ({
+    value:
+      key === credentialKey("vellum", "assistant_api_key")
+        ? mockAssistantApiKey
+        : (mockProviderKeys[key] ?? undefined),
+    unreachable: false,
+  }),
 }));
 
 import type { ProvidersConfig } from "../providers/registry.js";

--- a/assistant/src/__tests__/provider-registry-ollama.test.ts
+++ b/assistant/src/__tests__/provider-registry-ollama.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, mock, test } from "bun:test";
 const actualSecureKeys = await import("../security/secure-keys.js");
 mock.module("../security/secure-keys.js", () => ({
   ...actualSecureKeys,
-  getSecureKeyAsync: async () => undefined,
+  getSecureKeyAsync: async () => ({ value: undefined, unreachable: false }),
 }));
 
 import {

--- a/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
+++ b/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
@@ -32,7 +32,10 @@ let secureKeyValues = new Map<string, string | undefined>();
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: (account: string) =>
-    Promise.resolve(secureKeyValues.get(account)),
+    Promise.resolve({
+      value: secureKeyValues.get(account),
+      unreachable: false,
+    }),
   setSecureKeyAsync: () => Promise.resolve(true),
   deleteSecureKeyAsync: () => Promise.resolve("deleted"),
   listSecureKeysAsync: async () => [],

--- a/assistant/src/__tests__/secret-onetime-send.test.ts
+++ b/assistant/src/__tests__/secret-onetime-send.test.ts
@@ -62,7 +62,10 @@ mock.module("../security/secure-keys.js", () => {
     return "not-found" as const;
   };
   return {
-    getSecureKeyAsync: async (key: string) => storedKeys.get(key) ?? undefined,
+    getSecureKeyAsync: async (key: string) => ({
+      value: storedKeys.get(key),
+      unreachable: false,
+    }),
     setSecureKeyAsync: async (key: string, value: string) =>
       syncSet(key, value),
     deleteSecureKeyAsync: async (key: string) => syncDelete(key),

--- a/assistant/src/__tests__/secret-routes-managed-proxy.test.ts
+++ b/assistant/src/__tests__/secret-routes-managed-proxy.test.ts
@@ -80,7 +80,10 @@ mock.module("../logfire.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async (key: string) => secureKeyStore[key],
+  getSecureKeyAsync: async (key: string) => ({
+    value: secureKeyStore[key],
+    unreachable: false,
+  }),
   setSecureKeyAsync: async (key: string, value: string) => {
     secureKeyStore[key] = value;
     return true;

--- a/assistant/src/__tests__/slack-messaging-token-resolution.test.ts
+++ b/assistant/src/__tests__/slack-messaging-token-resolution.test.ts
@@ -5,7 +5,12 @@ import type { OAuthConnection } from "../oauth/connection.js";
 // ── Mocks ───────────────────────────────────────────────────────────────────
 
 const getSecureKeyAsyncMock = mock(
-  async (_key: string): Promise<string | null> => null,
+  async (
+    _key: string,
+  ): Promise<{ value: string | undefined; unreachable: boolean }> => ({
+    value: undefined,
+    unreachable: false,
+  }),
 );
 const isProviderConnectedMock = mock(
   async (_service: string): Promise<boolean> => false,
@@ -80,7 +85,10 @@ registerMessagingProvider(telegramBotMessagingProvider);
 
 function resetAllMocks() {
   getSecureKeyAsyncMock.mockReset();
-  getSecureKeyAsyncMock.mockImplementation(async () => null);
+  getSecureKeyAsyncMock.mockImplementation(async () => ({
+    value: undefined,
+    unreachable: false,
+  }));
   isProviderConnectedMock.mockReset();
   isProviderConnectedMock.mockImplementation(async () => false);
   resolveOAuthConnectionMock.mockReset();
@@ -100,18 +108,26 @@ describe("Slack messaging token resolution", () => {
 
   describe("slackProvider.isConnected()", () => {
     test("returns true when slack_channel bot token exists in credential store", async () => {
-      getSecureKeyAsyncMock.mockImplementation(async (key: string) =>
-        key === "credential/slack_channel/bot_token" ? "xoxb-bot-token" : null,
-      );
+      getSecureKeyAsyncMock.mockImplementation(async (key: string) => ({
+        value:
+          key === "credential/slack_channel/bot_token"
+            ? "xoxb-bot-token"
+            : undefined,
+        unreachable: false,
+      }));
 
       expect(await slackProvider.isConnected!()).toBe(true);
     });
 
     test("returns true even if slack_channel connection row is missing (backfill failure resilience)", async () => {
       // Bot token exists but no connection row — isConnected should still return true
-      getSecureKeyAsyncMock.mockImplementation(async (key: string) =>
-        key === "credential/slack_channel/bot_token" ? "xoxb-bot-token" : null,
-      );
+      getSecureKeyAsyncMock.mockImplementation(async (key: string) => ({
+        value:
+          key === "credential/slack_channel/bot_token"
+            ? "xoxb-bot-token"
+            : undefined,
+        unreachable: false,
+      }));
       // No getConnectionByProvider call expected — Slack adapter checks token first
 
       expect(await slackProvider.isConnected!()).toBe(true);
@@ -119,7 +135,10 @@ describe("Slack messaging token resolution", () => {
 
     test("returns true when only integration:slack has active OAuth connection (backwards compat)", async () => {
       // No bot token
-      getSecureKeyAsyncMock.mockImplementation(async () => null);
+      getSecureKeyAsyncMock.mockImplementation(async () => ({
+        value: undefined,
+        unreachable: false,
+      }));
       // But OAuth provider is connected
       isProviderConnectedMock.mockImplementation(async (service: string) =>
         service === "integration:slack" ? true : false,
@@ -129,7 +148,10 @@ describe("Slack messaging token resolution", () => {
     });
 
     test("returns false when neither credential path exists", async () => {
-      getSecureKeyAsyncMock.mockImplementation(async () => null);
+      getSecureKeyAsyncMock.mockImplementation(async () => ({
+        value: undefined,
+        unreachable: false,
+      }));
       isProviderConnectedMock.mockImplementation(async () => false);
 
       expect(await slackProvider.isConnected!()).toBe(false);
@@ -140,20 +162,26 @@ describe("Slack messaging token resolution", () => {
 
   describe("slackProvider.resolveConnection()", () => {
     test("returns bot token string when Socket Mode credentials exist", async () => {
-      getSecureKeyAsyncMock.mockImplementation(async (key: string) =>
-        key === "credential/slack_channel/bot_token"
-          ? "xoxb-socket-token"
-          : null,
-      );
+      getSecureKeyAsyncMock.mockImplementation(async (key: string) => ({
+        value:
+          key === "credential/slack_channel/bot_token"
+            ? "xoxb-socket-token"
+            : undefined,
+        unreachable: false,
+      }));
 
       const result = await slackProvider.resolveConnection!();
       expect(result).toBe("xoxb-socket-token");
     });
 
     test("returns bot token string even without a slack_channel connection row (token-only resilience)", async () => {
-      getSecureKeyAsyncMock.mockImplementation(async (key: string) =>
-        key === "credential/slack_channel/bot_token" ? "xoxb-token-only" : null,
-      );
+      getSecureKeyAsyncMock.mockImplementation(async (key: string) => ({
+        value:
+          key === "credential/slack_channel/bot_token"
+            ? "xoxb-token-only"
+            : undefined,
+        unreachable: false,
+      }));
       // No connection row — resolveConnection should still return the token
 
       const result = await slackProvider.resolveConnection!();
@@ -161,7 +189,10 @@ describe("Slack messaging token resolution", () => {
     });
 
     test("returns OAuthConnection when only OAuth integration:slack credentials exist (backwards compat)", async () => {
-      getSecureKeyAsyncMock.mockImplementation(async () => null);
+      getSecureKeyAsyncMock.mockImplementation(async () => ({
+        value: undefined,
+        unreachable: false,
+      }));
       const oauthConn = {
         accessToken: "xoxp-oauth-token",
       } as unknown as OAuthConnection;
@@ -176,7 +207,10 @@ describe("Slack messaging token resolution", () => {
     });
 
     test("throws when no credentials exist at all (no Socket Mode, no OAuth)", async () => {
-      getSecureKeyAsyncMock.mockImplementation(async () => null);
+      getSecureKeyAsyncMock.mockImplementation(async () => ({
+        value: undefined,
+        unreachable: false,
+      }));
       resolveOAuthConnectionMock.mockImplementation(async () => {
         throw new Error("No OAuth connection found for integration:slack");
       });
@@ -191,16 +225,23 @@ describe("Slack messaging token resolution", () => {
 
   describe("getProviderConnection()", () => {
     test("returns bot token string for Slack when Socket Mode credentials exist", async () => {
-      getSecureKeyAsyncMock.mockImplementation(async (key: string) =>
-        key === "credential/slack_channel/bot_token" ? "xoxb-conn-token" : null,
-      );
+      getSecureKeyAsyncMock.mockImplementation(async (key: string) => ({
+        value:
+          key === "credential/slack_channel/bot_token"
+            ? "xoxb-conn-token"
+            : undefined,
+        unreachable: false,
+      }));
 
       const result = await getProviderConnection(slackProvider);
       expect(result).toBe("xoxb-conn-token");
     });
 
     test("returns OAuthConnection for Slack when only OAuth credentials exist (backwards compat)", async () => {
-      getSecureKeyAsyncMock.mockImplementation(async () => null);
+      getSecureKeyAsyncMock.mockImplementation(async () => ({
+        value: undefined,
+        unreachable: false,
+      }));
       const oauthConn = {
         accessToken: "xoxp-oauth-token",
       } as unknown as OAuthConnection;
@@ -211,7 +252,10 @@ describe("Slack messaging token resolution", () => {
     });
 
     test("throws when no Slack credentials exist", async () => {
-      getSecureKeyAsyncMock.mockImplementation(async () => null);
+      getSecureKeyAsyncMock.mockImplementation(async () => ({
+        value: undefined,
+        unreachable: false,
+      }));
       resolveOAuthConnectionMock.mockImplementation(async () => {
         throw new Error("No OAuth connection found");
       });
@@ -225,9 +269,11 @@ describe("Slack messaging token resolution", () => {
       // Telegram has isConnected but no resolveConnection.
       // When isConnected returns true, getProviderConnection returns ""
       getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
-        if (key === "credential/telegram/bot_token") return "bot-token";
-        if (key === "credential/telegram/webhook_secret") return "secret";
-        return null;
+        if (key === "credential/telegram/bot_token")
+          return { value: "bot-token", unreachable: false };
+        if (key === "credential/telegram/webhook_secret")
+          return { value: "secret", unreachable: false };
+        return { value: undefined, unreachable: false };
       });
       getConnectionByProviderMock.mockImplementation((provider: string) =>
         provider === "telegram" ? { status: "active" } : undefined,
@@ -259,9 +305,13 @@ describe("Slack messaging token resolution", () => {
   describe("resolveProvider() multi-platform behavior", () => {
     test('throws "Multiple platforms connected" when both Gmail and Slack (Socket Mode) are connected and no platform is specified', async () => {
       // Slack connected via Socket Mode
-      getSecureKeyAsyncMock.mockImplementation(async (key: string) =>
-        key === "credential/slack_channel/bot_token" ? "xoxb-token" : null,
-      );
+      getSecureKeyAsyncMock.mockImplementation(async (key: string) => ({
+        value:
+          key === "credential/slack_channel/bot_token"
+            ? "xoxb-token"
+            : undefined,
+        unreachable: false,
+      }));
       // Gmail connected via OAuth
       isProviderConnectedMock.mockImplementation(async (service: string) =>
         service === "integration:google" ? true : false,
@@ -273,9 +323,13 @@ describe("Slack messaging token resolution", () => {
     });
 
     test("auto-selects Slack when it is the only connected provider", async () => {
-      getSecureKeyAsyncMock.mockImplementation(async (key: string) =>
-        key === "credential/slack_channel/bot_token" ? "xoxb-only" : null,
-      );
+      getSecureKeyAsyncMock.mockImplementation(async (key: string) => ({
+        value:
+          key === "credential/slack_channel/bot_token"
+            ? "xoxb-only"
+            : undefined,
+        unreachable: false,
+      }));
       isProviderConnectedMock.mockImplementation(async () => false);
 
       const provider = await resolveProvider();
@@ -283,7 +337,10 @@ describe("Slack messaging token resolution", () => {
     });
 
     test("auto-selects Gmail when it is the only connected provider (no Slack credentials)", async () => {
-      getSecureKeyAsyncMock.mockImplementation(async () => null);
+      getSecureKeyAsyncMock.mockImplementation(async () => ({
+        value: undefined,
+        unreachable: false,
+      }));
       isProviderConnectedMock.mockImplementation(async (service: string) =>
         service === "integration:google" ? true : false,
       );
@@ -297,9 +354,13 @@ describe("Slack messaging token resolution", () => {
 
   describe("getConnectedProviders()", () => {
     test("includes Slack when connected via Socket Mode (slack_channel)", async () => {
-      getSecureKeyAsyncMock.mockImplementation(async (key: string) =>
-        key === "credential/slack_channel/bot_token" ? "xoxb-token" : null,
-      );
+      getSecureKeyAsyncMock.mockImplementation(async (key: string) => ({
+        value:
+          key === "credential/slack_channel/bot_token"
+            ? "xoxb-token"
+            : undefined,
+        unreachable: false,
+      }));
       isProviderConnectedMock.mockImplementation(async () => false);
 
       const connected = await getConnectedProviders();
@@ -308,7 +369,10 @@ describe("Slack messaging token resolution", () => {
     });
 
     test("excludes Slack when no bot token exists", async () => {
-      getSecureKeyAsyncMock.mockImplementation(async () => null);
+      getSecureKeyAsyncMock.mockImplementation(async () => ({
+        value: undefined,
+        unreachable: false,
+      }));
       isProviderConnectedMock.mockImplementation(async () => false);
 
       const connected = await getConnectedProviders();

--- a/assistant/src/__tests__/slack-share-routes.test.ts
+++ b/assistant/src/__tests__/slack-share-routes.test.ts
@@ -6,7 +6,10 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const secureKeyValues = new Map<string, string>();
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async (key: string) => secureKeyValues.get(key),
+  getSecureKeyAsync: async (key: string) => ({
+    value: secureKeyValues.get(key),
+    unreachable: false,
+  }),
   setSecureKeyAsync: async () => {},
 }));
 

--- a/assistant/src/__tests__/swarm-conversation-integration.test.ts
+++ b/assistant/src/__tests__/swarm-conversation-integration.test.ts
@@ -69,7 +69,10 @@ const mockTestProvider = {
 };
 let mockAnthropicKey: string | undefined = "test-api-key";
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async () => mockAnthropicKey,
+  getSecureKeyAsync: async () => ({
+    value: mockAnthropicKey,
+    unreachable: false,
+  }),
   getProviderKeyAsync: async () => mockAnthropicKey,
 }));
 

--- a/assistant/src/__tests__/swarm-recursion.test.ts
+++ b/assistant/src/__tests__/swarm-recursion.test.ts
@@ -80,7 +80,10 @@ const mockProvider = {
   },
 };
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async () => "test-api-key",
+  getSecureKeyAsync: async () => ({
+    value: "test-api-key",
+    unreachable: false,
+  }),
   getProviderKeyAsync: async () => "test-api-key",
 }));
 

--- a/assistant/src/__tests__/swarm-tool.test.ts
+++ b/assistant/src/__tests__/swarm-tool.test.ts
@@ -75,7 +75,10 @@ const mockProvider = {
   },
 };
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async () => "test-api-key",
+  getSecureKeyAsync: async () => ({
+    value: "test-api-key",
+    unreachable: false,
+  }),
   getProviderKeyAsync: async () => "test-api-key",
 }));
 

--- a/assistant/src/__tests__/telegram-bot-username-resolution.test.ts
+++ b/assistant/src/__tests__/telegram-bot-username-resolution.test.ts
@@ -38,7 +38,10 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async (_keyId: string) => mockSecureKey,
+  getSecureKeyAsync: async (_keyId: string) => ({
+    value: mockSecureKey,
+    unreachable: false,
+  }),
 }));
 
 // Suppress logger output during tests

--- a/assistant/src/__tests__/telegram-config.test.ts
+++ b/assistant/src/__tests__/telegram-config.test.ts
@@ -33,8 +33,10 @@ mock.module("../daemon/handlers/shared.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async (account: string) =>
-    secureKeyStore[account] ?? undefined,
+  getSecureKeyAsync: async (account: string) => ({
+    value: secureKeyStore[account],
+    unreachable: false,
+  }),
   setSecureKeyAsync: async (account: string, value: string) => {
     secureKeyStore[account] = value;
     return true;

--- a/assistant/src/__tests__/twilio-config.test.ts
+++ b/assistant/src/__tests__/twilio-config.test.ts
@@ -13,7 +13,10 @@ mock.module("../util/logger.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async (key: string) => mockSecureKeys[key] ?? null,
+  getSecureKeyAsync: async (key: string) => ({
+    value: mockSecureKeys[key],
+    unreachable: false,
+  }),
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/twilio-provider.test.ts
+++ b/assistant/src/__tests__/twilio-provider.test.ts
@@ -42,9 +42,11 @@ mock.module("../config/loader.js", () => ({
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (key: string) => {
-    if (key === credentialKey("twilio", "auth_token")) return mockAuthToken;
-    if (key === credentialKey("twilio", "account_sid")) return mockAccountSid;
-    return undefined;
+    if (key === credentialKey("twilio", "auth_token"))
+      return { value: mockAuthToken, unreachable: false };
+    if (key === credentialKey("twilio", "account_sid"))
+      return { value: mockAccountSid, unreachable: false };
+    return { value: undefined, unreachable: false };
   },
 }));
 

--- a/assistant/src/__tests__/workspace-migration-006-services-config.test.ts
+++ b/assistant/src/__tests__/workspace-migration-006-services-config.test.ts
@@ -15,7 +15,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../security/secure-keys.js", () => ({
   getProviderKeyAsync: async () => null,
-  getSecureKeyAsync: async () => null,
+  getSecureKeyAsync: async () => ({ value: undefined, unreachable: false }),
 }));
 
 import { servicesConfigMigration } from "../workspace/migrations/006-services-config.js";

--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -36,7 +36,10 @@ mock.module("./oauth-store.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async () => mockAccessToken,
+  getSecureKeyAsync: async () => ({
+    value: mockAccessToken,
+    unreachable: false,
+  }),
 }));
 
 mock.module("../config/loader.js", () => ({


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for cred-reveal-timeout-fix.md.

**Gap:** 36 test files mock getSecureKeyAsync with old return type
**What was expected:** All test mocks should return { value, unreachable } objects
**What was found:** 36 test files still return raw string/null/undefined
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
