### PR TITLE
fix: update ConversationForkIOSTests for DaemonClient refactor

### DIFF
--- a/clients/ios/Tests/ConversationForkIOSTests.swift
+++ b/clients/ios/Tests/ConversationForkIOSTests.swift
@@ -133,7 +133,7 @@ final class ConversationForkIOSTests: XCTestCase {
                 )
             ]
         )
-        daemonClient.onConversationListResponse?(response)
+        store.handleConversationListResponse(response)
 
         let refreshed = store.conversations.first(where: { $0.conversationId == "conv-thread" })
         XCTAssertNil(refreshed?.forkParent)


### PR DESCRIPTION
## Summary
- Update `ConversationForkIOSTests.testConversationListRefreshClearsStaleForkParentFromCachedConversation` to use `store.handleConversationListResponse(response)` instead of the removed `daemonClient.onConversationListResponse?(response)` callback
- Mirrors the same fix applied to `ConversationLifecycleIOSTests` in 6b6fd25

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23361183039/job/67964605725
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
