### PR TITLE
docs: add CONTRIBUTING.md and SECURITY.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+Thank you for your interest in Vellum Assistant!
+
+We are not currently accepting external contributions. This may change in the future, but for now:
+
+- **Bug reports**: Feel free to [open an issue](https://github.com/vellum-ai/vellum-assistant/issues) if you find a bug.
+- **Feature requests**: We welcome ideas — please [open an issue](https://github.com/vellum-ai/vellum-assistant/issues) describing your use case.
+- **Pull requests**: Please do not submit PRs — they will be closed. If you have a fix you'd like to suggest, describe it in an issue instead.
+- **Security vulnerabilities**: Please report these privately. See [SECURITY.md](SECURITY.md) for details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Vellum Assistant, please report it responsibly. **Do not open a public GitHub issue.**
+
+Email **security@vellum.ai** with:
+- A description of the vulnerability
+- Steps to reproduce
+- The potential impact
+- Any suggested fix (optional)
+
+We will acknowledge receipt within 48 hours and aim to provide a resolution timeline within 5 business days.
+
+## Scope
+
+This policy covers the code in this repository, including:
+- The assistant runtime (`assistant/`)
+- The gateway (`gateway/`)
+- The CLI (`cli/`)
+- Native clients (`clients/`)
+- The credential execution service (`credential-executor/`)
+
+## Security Model
+
+For details on Vellum Assistant's security architecture — including sandboxing, credential storage, permission modes, and trust rules — see the [Security Architecture documentation](assistant/docs/architecture/security.md).


### PR DESCRIPTION
## Summary
- Add CONTRIBUTING.md explaining we are not accepting external contributions
- Add SECURITY.md with responsible disclosure policy (security@vellum.ai)

Part of plan: oss-docs-readme.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
