### PR TITLE
fix: remove stale VELLUM_CLAUDE_CODE_DEPTH from env-registry

### DIFF
--- a/assistant/src/config/env-registry.ts
+++ b/assistant/src/config/env-registry.ts
@@ -72,7 +72,6 @@ export function getWorkspaceDirOverride(): string | undefined {
 const KNOWN_VELLUM_VARS = new Set([
   "VELLUM_ASSISTANT_NAME",
   "VELLUM_AWS_ROLE_ARN",
-  "VELLUM_CLAUDE_CODE_DEPTH",
   "VELLUM_CUSTOM_QR_CODE_PATH",
   "VELLUM_DAEMON_AUTOSTART",
   "VELLUM_DAEMON_NOAUTH",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rm-claude-agent-sdk.md.

**Gap:** Stale VELLUM_CLAUDE_CODE_DEPTH entry in env-registry
**What was expected:** All references to Claude Code should be removed
**What was found:** env-registry.ts still listed the dead env var
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
