### PR TITLE
feat: custom About Vellum panel with service group version and update link

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -591,56 +591,30 @@ extension AppDelegate {
 extension AppDelegate {
 
     public func showAboutPanel() {
-        var options: [NSApplication.AboutPanelOptionKey: Any] = [:]
-
-        let creditsString = NSMutableAttributedString()
-
-        #if DEBUG
-        let bundlePath = Bundle.main.bundlePath
-
-        let headerAttributes: [NSAttributedString.Key: Any] = [
-            .font: NSFont.systemFont(ofSize: 11, weight: .semibold),
-            .foregroundColor: NSColor.systemOrange
-        ]
-        creditsString.append(NSAttributedString(string: "Local Development Build\n", attributes: headerAttributes))
-
-        let pathAttributes: [NSAttributedString.Key: Any] = [
-            .font: NSFont.monospacedSystemFont(ofSize: 10, weight: .regular),
-            .foregroundColor: NSColor.secondaryLabelColor
-        ]
-        creditsString.append(NSAttributedString(string: bundlePath, attributes: pathAttributes))
-        creditsString.append(NSAttributedString(string: "\n", attributes: pathAttributes))
-        #endif
-
-        if let commitSHA = Bundle.main.infoDictionary?["VellumCommitSHA"] as? String, !commitSHA.isEmpty {
-            let commitAttributes: [NSAttributedString.Key: Any] = [
-                .font: NSFont.monospacedSystemFont(ofSize: 10, weight: .regular),
-                .foregroundColor: NSColor.secondaryLabelColor
-            ]
-            let shortSHA = String(commitSHA.prefix(7))
-            creditsString.append(NSAttributedString(string: "Commit: \(shortSHA)\n", attributes: commitAttributes))
+        // Focus existing window if it's still open
+        if let existing = aboutWindow, existing.isVisible {
+            existing.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
         }
 
-        let archLabel: String
-        #if arch(arm64)
-        archLabel = "Apple Silicon (arm64)"
-        #elseif arch(x86_64)
-        archLabel = "Intel (x86_64)"
-        #else
-        archLabel = "Unknown architecture"
-        #endif
+        let aboutView = AboutVellumView()
+        let hostingController = NSHostingController(rootView: aboutView)
 
-        let archAttributes: [NSAttributedString.Key: Any] = [
-            .font: NSFont.systemFont(ofSize: 11, weight: .regular),
-            .foregroundColor: NSColor.secondaryLabelColor
-        ]
-        creditsString.append(NSAttributedString(string: archLabel, attributes: archAttributes))
+        let window = NSWindow(
+            contentRect: .zero,
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentViewController = hostingController
+        window.title = "About \(Self.appName)"
+        window.isReleasedWhenClosed = false
+        window.center()
 
-        options[.credits] = creditsString
-        options[.applicationName] = Self.appName
-
+        aboutWindow = window
+        window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
-        NSApp.orderFrontStandardAboutPanel(options: options)
     }
 
     /// Opens the settings panel in the main window.

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -78,6 +78,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var e2eStatusOverlayWindow: E2EStatusOverlayWindow?
 
     var onboardingWindow: OnboardingWindow?
+    var aboutWindow: NSWindow?
     var authWindow: NSWindow?
     public var authManager: AuthManager { services.authManager }
     public var mainWindow: MainWindow?

--- a/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Custom About Vellum panel that replaces the native macOS About panel.
+/// Shows the app icon, client version, service group version with topology
+/// label, commit SHA, architecture, and a "Check for Updates..." button.
+@MainActor
+struct AboutVellumView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var healthz: DaemonHealthz?
+    @State private var lockfileAssistants: [LockfileAssistant] = []
+    @State private var selectedAssistantId: String = ""
+
+    var body: some View {
+        VStack(spacing: VSpacing.lg) {
+            // App Icon
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .frame(width: 80, height: 80)
+
+            // App Name
+            Text("Vellum")
+                .font(VFont.title)
+                .foregroundColor(VColor.contentEmphasized)
+
+            // Client Version
+            if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+                let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+                Text("Version \(version)" + (build.map { " (\($0))" } ?? ""))
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentSecondary)
+            }
+
+            Divider()
+
+            // Service Group Version with topology label
+            serviceGroupRow
+
+            Divider()
+
+            // Commit SHA
+            if let commitSHA = Bundle.main.infoDictionary?["VellumCommitSHA"] as? String, !commitSHA.isEmpty {
+                HStack(spacing: VSpacing.xs) {
+                    Text("Commit")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                    Text(String(commitSHA.prefix(7)))
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.contentSecondary)
+                        .textSelection(.enabled)
+                }
+            }
+
+            // Architecture
+            architectureLabel
+
+            // Debug build info
+            #if DEBUG
+            VStack(spacing: VSpacing.xs) {
+                Text("Local Development Build")
+                    .font(VFont.captionMedium)
+                    .foregroundColor(VColor.systemMidStrong)
+                Text(Bundle.main.bundlePath)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.contentTertiary)
+                    .lineLimit(2)
+                    .truncationMode(.middle)
+            }
+            #endif
+
+            Spacer()
+                .frame(height: VSpacing.sm)
+
+            // Check for Updates button
+            VButton(label: "Check for Updates...", style: .outlined) {
+                AppDelegate.shared?.showSettingsTab("General")
+                dismiss()
+            }
+        }
+        .frame(width: 320)
+        .padding(VSpacing.xxl)
+        .multilineTextAlignment(.center)
+        .onAppear {
+            lockfileAssistants = LockfileAssistant.loadAll()
+            selectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
+            Task { await fetchHealthz() }
+        }
+    }
+
+    // MARK: - Service Group Row
+
+    @ViewBuilder
+    private var serviceGroupRow: some View {
+        HStack(spacing: VSpacing.xs) {
+            Text("Service Group")
+                .font(VFont.caption)
+                .foregroundColor(VColor.contentTertiary)
+
+            if let version = healthz?.version, !version.isEmpty {
+                Text(version)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.contentDefault)
+                    .textSelection(.enabled)
+
+                if let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }) {
+                    let topo: AssistantTopology = assistant.isDocker ? .docker
+                        : assistant.isManaged ? .managed
+                        : assistant.cloud.lowercased() == "local" ? .local
+                        : .remote
+                    Text("(\(topologyLabel(topo)))")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                }
+            } else {
+                Text("Not connected")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentTertiary)
+            }
+        }
+    }
+
+    // MARK: - Architecture Label
+
+    private var architectureLabel: some View {
+        let label: String = {
+            #if arch(arm64)
+            return "Apple Silicon"
+            #elseif arch(x86_64)
+            return "Intel"
+            #else
+            return "Unknown architecture"
+            #endif
+        }()
+        return Text(label)
+            .font(VFont.caption)
+            .foregroundColor(VColor.contentTertiary)
+    }
+
+    // MARK: - Topology Label
+
+    private func topologyLabel(_ topology: AssistantTopology) -> String {
+        switch topology {
+        case .docker: return "Docker"
+        case .managed: return "Managed"
+        case .local: return "Local"
+        case .remote: return "Remote"
+        }
+    }
+
+    // MARK: - Fetch Healthz
+
+    private func fetchHealthz() async {
+        guard !selectedAssistantId.isEmpty else { return }
+        do {
+            let (decoded, _): (DaemonHealthz?, _) = try await GatewayHTTPClient.get(
+                path: "assistants/\(selectedAssistantId)/healthz",
+                timeout: 10
+            ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
+            healthz = decoded ?? DaemonHealthz()
+        } catch {
+            healthz = DaemonHealthz()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Replace native macOS About panel with a custom SwiftUI window
- Shows both client version and service group version with topology label
- Includes Check for Updates button that navigates to Settings > General

Part of plan: upgrade-ux-general-tab.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
