### PR TITLE
fix: move no-backend error before planning in swarm delegate

### DIFF
--- a/assistant/src/tools/swarm/delegate.ts
+++ b/assistant/src/tools/swarm/delegate.ts
@@ -1,17 +1,7 @@
 import { getConfig } from "../../config/loader.js";
 import { RiskLevel } from "../../permissions/types.js";
-import { getFailoverProvider } from "../../providers/registry.js";
 import type { ToolDefinition } from "../../providers/types.js";
-import { resolveSwarmLimits } from "../../swarm/limits.js";
-import { generatePlan } from "../../swarm/router-planner.js";
-import { getLogger } from "../../util/logger.js";
-import { truncate } from "../../util/truncate.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
-
-const log = getLogger("swarm-delegate");
-
-/** Tracks active swarm conversations to prevent nested invocation per-conversation. */
-const activeConversations = new Set<string>();
 
 export const swarmDelegateTool: Tool = {
   name: "swarm_delegate",
@@ -49,13 +39,9 @@ export const swarmDelegateTool: Tool = {
   },
 
   async execute(
-    input: Record<string, unknown>,
-    context: ToolContext,
+    _input: Record<string, unknown>,
+    _context: ToolContext,
   ): Promise<ToolExecutionResult> {
-    const objective = input.objective as string;
-    const extraContext = input.context as string | undefined;
-    const maxWorkersOverride = input.max_workers as number | undefined;
-
     // Check if swarm is enabled
     const config = getConfig();
     if (!config.swarm.enabled) {
@@ -66,77 +52,10 @@ export const swarmDelegateTool: Tool = {
       };
     }
 
-    // Early abort check
-    if (context.signal?.aborted) {
-      return { content: "Cancelled", isError: true };
-    }
-
-    // Recursion guard - scoped to conversation so independent conversations are not blocked
-    const conversationKey = context.conversationId;
-    if (activeConversations.has(conversationKey)) {
-      return {
-        content:
-          "Error: A swarm is already executing in this conversation. Nested swarm invocation is not allowed.",
-        isError: true,
-      };
-    }
-
-    activeConversations.add(conversationKey);
-    try {
-      const limits = resolveSwarmLimits({
-        maxWorkers: maxWorkersOverride ?? config.swarm.maxWorkers,
-        maxTasks: config.swarm.maxTasks,
-        maxRetriesPerTask: config.swarm.maxRetriesPerTask,
-        workerTimeoutSec: config.swarm.workerTimeoutSec,
-        roleTimeoutsSec: config.swarm.roleTimeoutsSec,
-      });
-
-      // Generate plan
-      context.onOutput?.("Planning task decomposition...\n");
-      const planProvider = getFailoverProvider(
-        config.services.inference.provider,
-        config.providerOrder,
-      );
-      const plan = await generatePlan({
-        objective: extraContext
-          ? `${objective}\n\nContext: ${extraContext}`
-          : objective,
-        provider: planProvider,
-        modelIntent: config.swarm.plannerModelIntent,
-        limits,
-      });
-
-      context.onOutput?.(`Plan: ${plan.tasks.length} tasks\n`);
-      for (const task of plan.tasks) {
-        context.onOutput?.(
-          `  - [${task.role}] ${task.id}: ${truncate(task.objective, 80)}\n`,
-        );
-      }
-      context.onOutput?.("\nExecuting...\n");
-
-      if (context.signal?.aborted) {
-        return { content: "Cancelled before execution", isError: true };
-      }
-
-      return {
-        content:
-          "Swarm orchestration is currently unavailable: no worker backend is configured.",
-        isError: true,
-      };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      log.error({ err }, "Swarm execution failed");
-      return {
-        content: `Swarm error: ${message}`,
-        isError: true,
-      };
-    } finally {
-      activeConversations.delete(conversationKey);
-    }
+    return {
+      content:
+        "Swarm orchestration is currently unavailable: no worker backend is configured.",
+      isError: true,
+    };
   },
 };
-
-/** Clear all active conversations - only for testing. */
-export function _resetSwarmActive(): void {
-  activeConversations.clear();
-}


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rm-claude-agent-sdk.md.

**Gap:** swarm_delegate wastes LLM tokens on planning before returning unavailable error
**What was expected:** Error return should happen before the planning phase
**What was found:** Planning and LLM calls execute before the error return
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
