### PR TITLE
refactor: add CredentialGetResult type to distinguish unreachable from not-found

### DIFF
--- a/assistant/src/security/ces-credential-client.ts
+++ b/assistant/src/security/ces-credential-client.ts
@@ -16,7 +16,11 @@
  */
 
 import { getLogger } from "../util/logger.js";
-import type { CredentialBackend, DeleteResult } from "./credential-backend.js";
+import type {
+  CredentialBackend,
+  CredentialGetResult,
+  DeleteResult,
+} from "./credential-backend.js";
 
 const log = getLogger("ces-credential-client");
 
@@ -79,26 +83,26 @@ export class CesCredentialBackend implements CredentialBackend {
     return !!getBaseUrl() && !!getServiceToken();
   }
 
-  async get(account: string): Promise<string | undefined> {
+  async get(account: string): Promise<CredentialGetResult> {
     try {
       const res = await cesRequest(
         "GET",
         `/v1/credentials/${encodeURIComponent(account)}`,
       );
-      if (!res) return undefined;
-      if (res.status === 404) return undefined;
+      if (!res) return { value: undefined, unreachable: true };
+      if (res.status === 404) return { value: undefined, unreachable: false };
       if (!res.ok) {
         log.warn(
           { account, status: res.status },
           "CES credential get returned non-OK status",
         );
-        return undefined;
+        return { value: undefined, unreachable: true };
       }
       const data = (await res.json()) as { value?: string };
-      return data.value;
+      return { value: data.value, unreachable: false };
     } catch (err) {
       log.warn({ err, account }, "CES credential get threw unexpectedly");
-      return undefined;
+      return { value: undefined, unreachable: true };
     }
   }
 

--- a/assistant/src/security/credential-backend.ts
+++ b/assistant/src/security/credential-backend.ts
@@ -18,6 +18,12 @@ const log = getLogger("credential-backend");
 /** Result of a delete operation — distinguishes success, not-found, and error. */
 export type DeleteResult = "deleted" | "not-found" | "error";
 
+/** Result of a get operation — distinguishes unreachable from not-found. */
+export interface CredentialGetResult {
+  value: string | undefined;
+  unreachable: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // Interface
 // ---------------------------------------------------------------------------
@@ -29,8 +35,8 @@ export interface CredentialBackend {
   /** Whether this backend is currently reachable. Sync and cheap. */
   isAvailable(): boolean;
 
-  /** Retrieve a secret. Returns undefined if not found or on error. */
-  get(account: string): Promise<string | undefined>;
+  /** Retrieve a secret. Returns a result distinguishing unreachable from not-found. */
+  get(account: string): Promise<CredentialGetResult>;
 
   /** Store a secret. Returns true on success. */
   set(account: string, value: string): Promise<boolean>;
@@ -59,7 +65,7 @@ export class KeychainBackend implements CredentialBackend {
     return this.client.isAvailable();
   }
 
-  async get(account: string): Promise<string | undefined> {
+  async get(account: string): Promise<CredentialGetResult> {
     try {
       const result = await this.client.get(account);
       if (result == null) {
@@ -71,14 +77,14 @@ export class KeychainBackend implements CredentialBackend {
           );
           lastUnreachableWarnMs = now;
         }
-        return undefined;
+        return { value: undefined, unreachable: true };
       }
       lastUnreachableWarnMs = 0; // Reset so next outage is logged immediately
-      if (!result.found) return undefined;
-      return result.value;
+      if (!result.found) return { value: undefined, unreachable: false };
+      return { value: result.value, unreachable: false };
     } catch (err) {
       log.warn({ err, account }, "Keychain get threw unexpectedly");
-      return undefined;
+      return { value: undefined, unreachable: true };
     }
   }
 
@@ -135,11 +141,11 @@ export class EncryptedStoreBackend implements CredentialBackend {
     return true;
   }
 
-  async get(account: string): Promise<string | undefined> {
+  async get(account: string): Promise<CredentialGetResult> {
     try {
-      return encryptedStore.getKey(account);
+      return { value: encryptedStore.getKey(account), unreachable: false };
     } catch {
-      return undefined;
+      return { value: undefined, unreachable: false };
     }
   }
 

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -136,7 +136,7 @@ export async function getSecureKeyAsync(
 ): Promise<string | undefined> {
   const backend = resolveBackend();
   const result = await backend.get(account);
-  if (result != null) return result;
+  if (result.value != null) return result.value;
 
   // CES mode — no local fallback.
   if (backend.name === "ces-http") return undefined;
@@ -144,7 +144,8 @@ export async function getSecureKeyAsync(
   // Legacy fallback: if primary backend is NOT the encrypted store,
   // check the encrypted store for keys that haven't been migrated.
   if (backend !== getEncryptedStoreBackend()) {
-    return await getEncryptedStoreBackend().get(account);
+    const fallback = await getEncryptedStoreBackend().get(account);
+    return fallback.value;
   }
 
   return undefined;


### PR DESCRIPTION
## Summary
- Introduce CredentialGetResult type with value and unreachable fields
- Update CredentialBackend interface and all three implementations
- Update secure-keys.ts to handle new return type internally

Part of plan: cred-reveal-timeout-fix-v2.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
