### PR TITLE
fix: update broken Remote Access link in macOS README

### DIFF
--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -413,7 +413,7 @@ Logging/
 
 ## Remote Assistant
 
-The app supports connecting to a remote assistant process over HTTP. Configure a remote assistant entry in the lockfile with its `runtimeUrl` and optional `bearerToken`, or use managed mode to connect through the Vellum platform. See the [Remote Access](../../README.md#remote-access) section in the root README.
+The app supports connecting to a remote assistant process over HTTP. Configure a remote assistant entry in the lockfile with its `runtimeUrl` and optional `bearerToken`, or use managed mode to connect through the Vellum platform. See the [Remote Access](../../docs/internal-reference.md#remote-access) section in the internal reference documentation.
 
 ---
 


### PR DESCRIPTION
## Summary
Fixes broken link after README content was moved to docs/internal-reference.md.

**Gap:** Broken #remote-access anchor in clients/macos/README.md
**What was expected:** Link points to valid location
**What was found:** Link pointed to ../../README.md#remote-access which no longer exists
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
