### PR TITLE
fix: update stale AGENTS.md reference to moved README section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ The full test suite is large and will hang or timeout if run unscoped. **Never r
 
 ## Keep Docs Up to Date
 
-- **README**: When modifying slash commands in `.claude/commands/`, update the README's "Slash Commands" section to match.
+- **Internal reference**: When modifying slash commands in `.claude/commands/`, update the "Claude Code Workflow" section in `docs/internal-reference.md` to match.
 - **Architecture**: When introducing, removing, or significantly modifying a service/module/data flow, update `ARCHITECTURE.md` and impacted domain docs. Mermaid diagrams must reflect current architecture.
 - **AGENTS.md**: When a PR establishes a new mandatory pattern or architectural constraint, update `AGENTS.md`. Only for project-wide rules — use code comments for module-scoped patterns.
 


### PR DESCRIPTION
## Summary
Fixes stale instruction in AGENTS.md after slash command docs moved to docs/internal-reference.md.

**Gap:** AGENTS.md tells contributors to update README's Slash Commands section, but that section now lives in docs/internal-reference.md
**What was expected:** AGENTS.md points to the correct file
**What was found:** AGENTS.md referenced README instead of docs/internal-reference.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
