### PR TITLE
fix: remove claude_code references from root ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -284,7 +284,7 @@ subgraph "Text Q&A Session"
             SWARM_TOOL["swarm_delegate tool<br/>recursion guard"]
             ROUTER_PLAN["Router Planner<br/>LLM → DAG plan"]
             DAG_SCHED["DAG Scheduler<br/>topological order<br/>bounded concurrency"]
-            WORKER_POOL["Worker Pool<br/>claude_code backend<br/>role-scoped profiles"]
+            WORKER_POOL["Worker Pool<br/>role-scoped profiles"]
             SYNTH["Synthesizer<br/>LLM + markdown fallback"]
         end
 


### PR DESCRIPTION
## Summary
Remove stale claude_code backend reference from root ARCHITECTURE.md Mermaid diagram.

Part of rm-claude-agent-sdk plan review fixes (round 2).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
