### PR TITLE
fix: remove stale CLAUDE_CODE_ENTRYPOINT mention from CLI comment

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -905,7 +905,7 @@ export async function startLocalDaemon(
 
       // Build a minimal environment for the daemon. When launched from the
       // macOS app the CLI inherits a huge environment (XPC_SERVICE_NAME,
-      // __CFBundleIdentifier, CLAUDE_CODE_ENTRYPOINT, etc.) that can cause
+      // __CFBundleIdentifier, etc.) that can cause
       // the daemon to take 50+ seconds to start instead of ~1s.
       const home = homedir();
       const bunBinDir = join(home, ".bun", "bin");


### PR DESCRIPTION
## Summary
Remove stale CLAUDE_CODE_ENTRYPOINT from a code comment in cli/src/lib/local.ts.

Part of rm-claude-agent-sdk plan review fixes (round 2).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
