### PR TITLE
feat: add getSecureKeyResultAsync for richer credential lookup results

### DIFF
--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -75,6 +75,7 @@ import {
   _resetBackend,
   deleteSecureKeyAsync,
   getSecureKeyAsync,
+  getSecureKeyResultAsync,
   listSecureKeysAsync,
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
@@ -466,6 +467,61 @@ describe("secure-keys", () => {
 
       const keys = await listSecureKeysAsync();
       expect(keys).toEqual([]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getSecureKeyResultAsync — richer result with unreachable flag
+  // -----------------------------------------------------------------------
+  describe("getSecureKeyResultAsync", () => {
+    test("returns unreachable true when broker errors", async () => {
+      mockBrokerAvailable = true;
+      mockBrokerGetError = true;
+      _resetBackend();
+
+      const result = await getSecureKeyResultAsync("api-key");
+      expect(result.value).toBeUndefined();
+      expect(result.unreachable).toBe(true);
+    });
+
+    test("returns value and unreachable false on success", async () => {
+      mockBrokerAvailable = true;
+      _resetBackend();
+
+      mockBrokerStore.set("api-key", "broker-value");
+      const result = await getSecureKeyResultAsync("api-key");
+      expect(result.value).toBe("broker-value");
+      expect(result.unreachable).toBe(false);
+    });
+
+    test("falls back to encrypted store when broker is unreachable", async () => {
+      mockBrokerAvailable = true;
+      mockBrokerGetError = true;
+      _resetBackend();
+
+      encryptedStore.setKey("legacy-key", "legacy-value");
+      const result = await getSecureKeyResultAsync("legacy-key");
+      expect(result.value).toBe("legacy-value");
+      expect(result.unreachable).toBe(false);
+    });
+
+    test("propagates unreachable when broker errors and encrypted store also missing", async () => {
+      mockBrokerAvailable = true;
+      mockBrokerGetError = true;
+      _resetBackend();
+
+      const result = await getSecureKeyResultAsync("missing-key");
+      expect(result.value).toBeUndefined();
+      expect(result.unreachable).toBe(true);
+    });
+
+    test("returns unreachable false in dev mode (encrypted store backend)", async () => {
+      process.env.VELLUM_DEV = "1";
+      _resetBackend();
+
+      const result = await getSecureKeyResultAsync("missing-key");
+      expect(result.value).toBeUndefined();
+      expect(result.unreachable).toBe(false);
     });
   });
 });

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -36,6 +36,11 @@ export type { DeleteResult } from "./credential-backend.js";
  */
 export type { SecureKeyBackend, SecureKeyDeleteResult };
 
+export interface SecureKeyResult {
+  value: string | undefined;
+  unreachable: boolean;
+}
+
 const log = getLogger("secure-keys");
 
 let _keychain: CredentialBackend | undefined;
@@ -125,30 +130,53 @@ export async function listSecureKeysAsync(): Promise<string[]> {
 // ---------------------------------------------------------------------------
 
 /**
- * Retrieve a secret from secure storage. Reads from the primary backend
- * first. In CES mode, the sidecar is the single source of truth — no
- * local fallback. In local mode, if the primary backend is the keychain,
- * falls back to the encrypted store for legacy keys that haven't been
- * migrated.
+ * Retrieve a secret from secure storage with richer result metadata.
+ *
+ * Returns both the value (if found) and whether the backend was
+ * unreachable. Callers that need to distinguish "not found" from
+ * "backend down" should use this instead of `getSecureKeyAsync`.
+ *
+ * Reads from the primary backend first. In CES mode, the sidecar is
+ * the single source of truth — no local fallback. In local mode, if
+ * the primary backend is the keychain, falls back to the encrypted
+ * store for legacy keys that haven't been migrated.
  */
-export async function getSecureKeyAsync(
+export async function getSecureKeyResultAsync(
   account: string,
-): Promise<string | undefined> {
+): Promise<SecureKeyResult> {
   const backend = resolveBackend();
   const result = await backend.get(account);
-  if (result.value != null) return result.value;
+  if (result.value != null) {
+    return { value: result.value, unreachable: false };
+  }
 
-  // CES mode — no local fallback.
-  if (backend.name === "ces-http") return undefined;
+  // CES mode — the sidecar is the single source of truth, no local fallback.
+  if (backend.name === "ces-http") {
+    return { value: undefined, unreachable: result.unreachable };
+  }
 
   // Legacy fallback: if primary backend is NOT the encrypted store,
   // check the encrypted store for keys that haven't been migrated.
   if (backend !== getEncryptedStoreBackend()) {
     const fallback = await getEncryptedStoreBackend().get(account);
-    return fallback.value;
+    if (fallback.value != null) {
+      return { value: fallback.value, unreachable: false };
+    }
+    return { value: undefined, unreachable: result.unreachable };
   }
 
-  return undefined;
+  return { value: undefined, unreachable: false };
+}
+
+/**
+ * Retrieve a secret from secure storage. Convenience wrapper over
+ * `getSecureKeyResultAsync` that returns only the value.
+ */
+export async function getSecureKeyAsync(
+  account: string,
+): Promise<string | undefined> {
+  const result = await getSecureKeyResultAsync(account);
+  return result.value;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add SecureKeyResult type and getSecureKeyResultAsync wrapper function
- Refactor getSecureKeyAsync to delegate to the new function
- No changes to existing callers — getSecureKeyAsync still returns string | undefined
- Add tests for unreachable propagation

Part of plan: cred-reveal-timeout-fix-v2.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
