### PR TITLE
fix: route all update actions through topology-aware checkForUpdates

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -27,7 +27,7 @@ struct VellumAssistantApp: App {
                     appDelegate.showAboutPanel()
                 }
                 Button(appDelegate.updateManager.updateMenuItemTitle) {
-                    appDelegate.updateManager.checkForUpdates()
+                    appDelegate.checkForUpdates()
                 }
                 .disabled(!appDelegate.updateManager.updateMenuItemIsEnabled)
                 Divider()

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -471,7 +471,7 @@ struct MainWindowView: View {
             }
             WindowDragArea()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-            if updateManager.isUpdateAvailable {
+            if updateManager.isUpdateAvailable || updateManager.isServiceGroupUpdateAvailable {
                 VButton(
                     label: updateManager.isDeferredUpdateReady ? "Restart to update" : "Update",
                     leftIcon: VIcon.arrowUp.rawValue,
@@ -482,11 +482,12 @@ struct MainWindowView: View {
                     if updateManager.isDeferredUpdateReady {
                         NSApp.terminate(nil)
                     } else {
-                        updateManager.checkForUpdates()
+                        AppDelegate.shared?.checkForUpdates()
                     }
                 }
                 .transition(.opacity.combined(with: .scale(scale: 0.9)))
                 .animation(VAnimation.fast, value: updateManager.isUpdateAvailable)
+                .animation(VAnimation.fast, value: updateManager.isServiceGroupUpdateAvailable)
             }
             if windowState.isConversationVisible {
                 // Temporary chat toggle — always visible on private conversations (so users can exit temp chat),


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for upgrade-ux-general-tab.md.

**Gap 1:** SwiftUI Commands menu bypassed topology-aware routing — now calls appDelegate.checkForUpdates() instead of updateManager.checkForUpdates() directly
**Gap 3:** Main window Update pill button now checks isServiceGroupUpdateAvailable and routes through topology-aware checkForUpdates()
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
