### PR TITLE
fix: close About window properly and guard empty assistant ID in General tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
@@ -6,8 +6,6 @@ import VellumAssistantShared
 /// label, commit SHA, architecture, and a "Check for Updates..." button.
 @MainActor
 struct AboutVellumView: View {
-    @Environment(\.dismiss) private var dismiss
-
     @State private var healthz: DaemonHealthz?
     @State private var lockfileAssistants: [LockfileAssistant] = []
     @State private var selectedAssistantId: String = ""
@@ -74,8 +72,8 @@ struct AboutVellumView: View {
 
             // Check for Updates button
             VButton(label: "Check for Updates...", style: .outlined) {
+                AppDelegate.shared?.aboutWindow?.close()
                 AppDelegate.shared?.showSettingsTab("General")
-                dismiss()
             }
         }
         .frame(width: 320)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -91,6 +91,7 @@ struct SettingsGeneralTab: View {
     // MARK: - Software Update
 
     private func fetchHealthz() async {
+        guard !selectedAssistantId.isEmpty else { return }
         do {
             let (decoded, _): (DaemonHealthz?, _) = try await GatewayHTTPClient.get(
                 path: "assistants/\(selectedAssistantId)/healthz",


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for upgrade-ux-general-tab.md.

**Gap 2:** AboutVellumView dismiss() was a no-op in NSWindow context — now uses AppDelegate.shared?.aboutWindow?.close()
**Gap 4:** SettingsGeneralTab.fetchHealthz() now guards against empty selectedAssistantId
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
