### PR TITLE
feat: expose upgrade controls in General settings, custom About panel, topology-aware menu

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -27,7 +27,7 @@ struct VellumAssistantApp: App {
                     appDelegate.showAboutPanel()
                 }
                 Button(appDelegate.updateManager.updateMenuItemTitle) {
-                    appDelegate.updateManager.checkForUpdates()
+                    appDelegate.checkForUpdates()
                 }
                 .disabled(!appDelegate.updateManager.updateMenuItemIsEnabled)
                 Divider()

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -399,6 +399,20 @@ extension AppDelegate {
     }
 
     @objc func checkForUpdates() {
+        // For Docker/managed topologies with a service group update available,
+        // navigate to Settings > General (where the Software Update card lives)
+        // instead of triggering Sparkle's update dialog.
+        if updateManager.isServiceGroupUpdateAvailable {
+            let assistants = LockfileAssistant.loadAll()
+            let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+            if let id = connectedId,
+               let assistant = assistants.first(where: { $0.assistantId == id }),
+               assistant.isDocker || assistant.isManaged {
+                showSettingsTab("General")
+                return
+            }
+        }
+        // Local topology (or no service group update): use Sparkle
         updateManager.checkForUpdates()
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -591,56 +591,30 @@ extension AppDelegate {
 extension AppDelegate {
 
     public func showAboutPanel() {
-        var options: [NSApplication.AboutPanelOptionKey: Any] = [:]
-
-        let creditsString = NSMutableAttributedString()
-
-        #if DEBUG
-        let bundlePath = Bundle.main.bundlePath
-
-        let headerAttributes: [NSAttributedString.Key: Any] = [
-            .font: NSFont.systemFont(ofSize: 11, weight: .semibold),
-            .foregroundColor: NSColor.systemOrange
-        ]
-        creditsString.append(NSAttributedString(string: "Local Development Build\n", attributes: headerAttributes))
-
-        let pathAttributes: [NSAttributedString.Key: Any] = [
-            .font: NSFont.monospacedSystemFont(ofSize: 10, weight: .regular),
-            .foregroundColor: NSColor.secondaryLabelColor
-        ]
-        creditsString.append(NSAttributedString(string: bundlePath, attributes: pathAttributes))
-        creditsString.append(NSAttributedString(string: "\n", attributes: pathAttributes))
-        #endif
-
-        if let commitSHA = Bundle.main.infoDictionary?["VellumCommitSHA"] as? String, !commitSHA.isEmpty {
-            let commitAttributes: [NSAttributedString.Key: Any] = [
-                .font: NSFont.monospacedSystemFont(ofSize: 10, weight: .regular),
-                .foregroundColor: NSColor.secondaryLabelColor
-            ]
-            let shortSHA = String(commitSHA.prefix(7))
-            creditsString.append(NSAttributedString(string: "Commit: \(shortSHA)\n", attributes: commitAttributes))
+        // Focus existing window if it's still open
+        if let existing = aboutWindow, existing.isVisible {
+            existing.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
         }
 
-        let archLabel: String
-        #if arch(arm64)
-        archLabel = "Apple Silicon (arm64)"
-        #elseif arch(x86_64)
-        archLabel = "Intel (x86_64)"
-        #else
-        archLabel = "Unknown architecture"
-        #endif
+        let aboutView = AboutVellumView()
+        let hostingController = NSHostingController(rootView: aboutView)
 
-        let archAttributes: [NSAttributedString.Key: Any] = [
-            .font: NSFont.systemFont(ofSize: 11, weight: .regular),
-            .foregroundColor: NSColor.secondaryLabelColor
-        ]
-        creditsString.append(NSAttributedString(string: archLabel, attributes: archAttributes))
+        let window = NSWindow(
+            contentRect: .zero,
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentViewController = hostingController
+        window.title = "About \(Self.appName)"
+        window.isReleasedWhenClosed = false
+        window.center()
 
-        options[.credits] = creditsString
-        options[.applicationName] = Self.appName
-
+        aboutWindow = window
+        window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
-        NSApp.orderFrontStandardAboutPanel(options: options)
     }
 
     /// Opens the settings panel in the main window.

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -78,6 +78,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var e2eStatusOverlayWindow: E2EStatusOverlayWindow?
 
     var onboardingWindow: OnboardingWindow?
+    var aboutWindow: NSWindow?
     var authWindow: NSWindow?
     public var authManager: AuthManager { services.authManager }
     public var mainWindow: MainWindow?

--- a/clients/macos/vellum-assistant/App/UpdateManager.swift
+++ b/clients/macos/vellum-assistant/App/UpdateManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Sparkle
+import VellumAssistantShared
 import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "UpdateManager")
@@ -17,9 +18,17 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
     @Published public private(set) var isDeferredUpdateReady = false
     @Published public private(set) var availableUpdateVersion: String?
 
+    /// Whether a newer service group release is available for Docker/managed topologies.
+    @Published public private(set) var isServiceGroupUpdateAvailable = false
+    /// The version string of the available service group update, if any.
+    @Published public private(set) var serviceGroupUpdateVersion: String?
+
     /// Called before the app is replaced — stop the daemon so the new version
     /// can launch its own bundled daemon cleanly.
     var onWillInstallUpdate: (() -> Void)?
+
+    /// Timer for periodic service group update checks (Docker/managed topologies).
+    private var serviceGroupCheckTimer: Timer?
 
     /// Lock-protected storage for the deferred install handler.  Written from
     /// any thread by the Sparkle delegate callback and read on MainActor by
@@ -45,6 +54,16 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
         } catch {
             log.error("Failed to start Sparkle updater: \(error.localizedDescription, privacy: .public)")
         }
+
+        // Run an initial service group update check and schedule periodic re-checks
+        // every hour (matching Sparkle's default automatic check interval).
+        Task { await checkServiceGroupUpdate() }
+        serviceGroupCheckTimer?.invalidate()
+        serviceGroupCheckTimer = Timer.scheduledTimer(withTimeInterval: 3600, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                await self?.checkServiceGroupUpdate()
+            }
+        }
     }
 
     /// Manually trigger "Check for Updates…" (shows UI).
@@ -60,18 +79,22 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
     // MARK: - Menu Item Helpers
 
     /// Context-aware title for the update menu item.
-    /// Returns "Update Available..." when an update is ready,
+    /// Returns "Update Available..." when a Sparkle update is ready,
+    /// "Update Available (vX.Y.Z)" when a service group update is available,
     /// "Check for Updates..." when a manual check can be triggered,
     /// or "Up to Date" when neither applies.
     public var updateMenuItemTitle: String {
         if isUpdateAvailable { return "Update Available..." }
+        if isServiceGroupUpdateAvailable, let v = serviceGroupUpdateVersion {
+            return "Update Available (\(v))"
+        }
         if canCheckForUpdates { return "Check for Updates..." }
         return "Up to Date"
     }
 
     /// Whether the update menu item should accept user interaction.
     public var updateMenuItemIsEnabled: Bool {
-        isUpdateAvailable || canCheckForUpdates
+        isUpdateAvailable || isServiceGroupUpdateAvailable || canCheckForUpdates
     }
 
     /// Whether an update has been downloaded and is waiting to be installed.
@@ -92,6 +115,100 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
         log.info("Installing deferred update now")
         onWillInstallUpdate?()
         handler()
+    }
+
+    // MARK: - Service Group Update Check
+
+    /// Checks whether a newer service group release is available for Docker/managed topologies.
+    /// For `.local` topology this is a no-op (Sparkle handles local app updates).
+    /// Failures are silently swallowed — the menu simply stays in "Check for Updates…" state.
+    func checkServiceGroupUpdate() async {
+        do {
+            // Resolve current topology from the lockfile
+            let assistants = LockfileAssistant.loadAll()
+            guard let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
+                  let assistant = assistants.first(where: { $0.assistantId == connectedId }) else {
+                clearServiceGroupFlags()
+                return
+            }
+
+            // Only check for Docker and managed topologies
+            guard assistant.isDocker || assistant.isManaged else {
+                clearServiceGroupFlags()
+                return
+            }
+
+            // Fetch the latest stable release from the platform API
+            let platformBase = AuthService.shared.baseURL
+            guard let releasesURL = URL(string: "\(platformBase)/v1/releases/?stable=true") else {
+                clearServiceGroupFlags()
+                return
+            }
+
+            var request = URLRequest(url: releasesURL)
+            request.httpMethod = "GET"
+            request.setValue("application/json", forHTTPHeaderField: "Accept")
+            if let token = await SessionTokenManager.getTokenAsync() {
+                request.setValue(token, forHTTPHeaderField: "X-Session-Token")
+            }
+            if let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") {
+                request.setValue(orgId, forHTTPHeaderField: "Vellum-Organization-Id")
+            }
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+                clearServiceGroupFlags()
+                return
+            }
+
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            let releases = try decoder.decode([AssistantRelease].self, from: data)
+            guard let latestRelease = releases.first else {
+                clearServiceGroupFlags()
+                return
+            }
+
+            // Fetch the current service group version from healthz
+            let (decoded, _): (DaemonHealthz?, _) = try await GatewayHTTPClient.get(
+                path: "assistants/\(connectedId)/healthz",
+                timeout: 10
+            ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
+
+            guard let currentVersion = decoded?.version, !currentVersion.isEmpty else {
+                clearServiceGroupFlags()
+                return
+            }
+
+            // Compare versions
+            guard let latestParsed = VersionCompat.parse(latestRelease.version),
+                  let currentParsed = VersionCompat.parse(currentVersion) else {
+                clearServiceGroupFlags()
+                return
+            }
+
+            let isNewer: Bool = {
+                if latestParsed.major != currentParsed.major { return latestParsed.major > currentParsed.major }
+                if latestParsed.minor != currentParsed.minor { return latestParsed.minor > currentParsed.minor }
+                return latestParsed.patch > currentParsed.patch
+            }()
+
+            if isNewer {
+                isServiceGroupUpdateAvailable = true
+                serviceGroupUpdateVersion = latestRelease.version
+            } else {
+                clearServiceGroupFlags()
+            }
+        } catch {
+            // Failures silently clear the flags — no error state in the menu.
+            clearServiceGroupFlags()
+        }
+    }
+
+    /// Resets service group update flags to their default (no update available) state.
+    private func clearServiceGroupFlags() {
+        isServiceGroupUpdateAvailable = false
+        serviceGroupUpdateVersion = nil
     }
 
     // MARK: - SPUUpdaterDelegate

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -471,7 +471,7 @@ struct MainWindowView: View {
             }
             WindowDragArea()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-            if updateManager.isUpdateAvailable {
+            if updateManager.isUpdateAvailable || updateManager.isServiceGroupUpdateAvailable {
                 VButton(
                     label: updateManager.isDeferredUpdateReady ? "Restart to update" : "Update",
                     leftIcon: VIcon.arrowUp.rawValue,
@@ -482,11 +482,12 @@ struct MainWindowView: View {
                     if updateManager.isDeferredUpdateReady {
                         NSApp.terminate(nil)
                     } else {
-                        updateManager.checkForUpdates()
+                        AppDelegate.shared?.checkForUpdates()
                     }
                 }
                 .transition(.opacity.combined(with: .scale(scale: 0.9)))
                 .animation(VAnimation.fast, value: updateManager.isUpdateAvailable)
+                .animation(VAnimation.fast, value: updateManager.isServiceGroupUpdateAvailable)
             }
             if windowState.isConversationVisible {
                 // Temporary chat toggle — always visible on private conversations (so users can exit temp chat),

--- a/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Custom About Vellum panel that replaces the native macOS About panel.
+/// Shows the app icon, client version, service group version with topology
+/// label, commit SHA, architecture, and a "Check for Updates..." button.
+@MainActor
+struct AboutVellumView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var healthz: DaemonHealthz?
+    @State private var lockfileAssistants: [LockfileAssistant] = []
+    @State private var selectedAssistantId: String = ""
+
+    var body: some View {
+        VStack(spacing: VSpacing.lg) {
+            // App Icon
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .frame(width: 80, height: 80)
+
+            // App Name
+            Text("Vellum")
+                .font(VFont.title)
+                .foregroundColor(VColor.contentEmphasized)
+
+            // Client Version
+            if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+                let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+                Text("Version \(version)" + (build.map { " (\($0))" } ?? ""))
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentSecondary)
+            }
+
+            Divider()
+
+            // Service Group Version with topology label
+            serviceGroupRow
+
+            Divider()
+
+            // Commit SHA
+            if let commitSHA = Bundle.main.infoDictionary?["VellumCommitSHA"] as? String, !commitSHA.isEmpty {
+                HStack(spacing: VSpacing.xs) {
+                    Text("Commit")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                    Text(String(commitSHA.prefix(7)))
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.contentSecondary)
+                        .textSelection(.enabled)
+                }
+            }
+
+            // Architecture
+            architectureLabel
+
+            // Debug build info
+            #if DEBUG
+            VStack(spacing: VSpacing.xs) {
+                Text("Local Development Build")
+                    .font(VFont.captionMedium)
+                    .foregroundColor(VColor.systemMidStrong)
+                Text(Bundle.main.bundlePath)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.contentTertiary)
+                    .lineLimit(2)
+                    .truncationMode(.middle)
+            }
+            #endif
+
+            Spacer()
+                .frame(height: VSpacing.sm)
+
+            // Check for Updates button
+            VButton(label: "Check for Updates...", style: .outlined) {
+                AppDelegate.shared?.showSettingsTab("General")
+                dismiss()
+            }
+        }
+        .frame(width: 320)
+        .padding(VSpacing.xxl)
+        .multilineTextAlignment(.center)
+        .onAppear {
+            lockfileAssistants = LockfileAssistant.loadAll()
+            selectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
+            Task { await fetchHealthz() }
+        }
+    }
+
+    // MARK: - Service Group Row
+
+    @ViewBuilder
+    private var serviceGroupRow: some View {
+        HStack(spacing: VSpacing.xs) {
+            Text("Service Group")
+                .font(VFont.caption)
+                .foregroundColor(VColor.contentTertiary)
+
+            if let version = healthz?.version, !version.isEmpty {
+                Text(version)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.contentDefault)
+                    .textSelection(.enabled)
+
+                if let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }) {
+                    let topo: AssistantTopology = assistant.isDocker ? .docker
+                        : assistant.isManaged ? .managed
+                        : assistant.cloud.lowercased() == "local" ? .local
+                        : .remote
+                    Text("(\(topologyLabel(topo)))")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                }
+            } else {
+                Text("Not connected")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentTertiary)
+            }
+        }
+    }
+
+    // MARK: - Architecture Label
+
+    private var architectureLabel: some View {
+        let label: String = {
+            #if arch(arm64)
+            return "Apple Silicon"
+            #elseif arch(x86_64)
+            return "Intel"
+            #else
+            return "Unknown architecture"
+            #endif
+        }()
+        return Text(label)
+            .font(VFont.caption)
+            .foregroundColor(VColor.contentTertiary)
+    }
+
+    // MARK: - Topology Label
+
+    private func topologyLabel(_ topology: AssistantTopology) -> String {
+        switch topology {
+        case .docker: return "Docker"
+        case .managed: return "Managed"
+        case .local: return "Local"
+        case .remote: return "Remote"
+        }
+    }
+
+    // MARK: - Fetch Healthz
+
+    private func fetchHealthz() async {
+        guard !selectedAssistantId.isEmpty else { return }
+        do {
+            let (decoded, _): (DaemonHealthz?, _) = try await GatewayHTTPClient.get(
+                path: "assistants/\(selectedAssistantId)/healthz",
+                timeout: 10
+            ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
+            healthz = decoded ?? DaemonHealthz()
+        } catch {
+            healthz = DaemonHealthz()
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
@@ -6,8 +6,6 @@ import VellumAssistantShared
 /// label, commit SHA, architecture, and a "Check for Updates..." button.
 @MainActor
 struct AboutVellumView: View {
-    @Environment(\.dismiss) private var dismiss
-
     @State private var healthz: DaemonHealthz?
     @State private var lockfileAssistants: [LockfileAssistant] = []
     @State private var selectedAssistantId: String = ""
@@ -74,8 +72,8 @@ struct AboutVellumView: View {
 
             // Check for Updates button
             VButton(label: "Check for Updates...", style: .outlined) {
+                AppDelegate.shared?.aboutWindow?.close()
                 AppDelegate.shared?.showSettingsTab("General")
-                dismiss()
             }
         }
         .frame(width: 320)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -58,25 +58,11 @@ struct SettingsDeveloperTab: View {
     @State private var showingRestartConfirmation: Bool = false
     @State private var isRestarting: Bool = false
 
-    // -- Inline upgrade state --
-    @State private var isUpgradingInline = false
-    @State private var showingInlineUpgradeConfirmation = false
-    @State private var inlineUpgradeError: String?
-    @State private var inlineUpgradeSuccess: String?
-
     // -- Revoke API key state --
     @State private var showingRevokeApiKeyConfirmation: Bool = false
     @State private var isRevokingApiKey: Bool = false
     @State private var revokeApiKeyStatus: String?
     @State private var revokeApiKeyDismissTask: Task<Void, Never>?
-
-    // -- Docker operation progress state --
-    @State private var isDockerOperationInProgress = false
-    @State private var dockerOperationLabel: String = ""
-
-    // -- Sparkle update state (local topology) --
-    @State private var sparkleUpdateAvailable: Bool = false
-    @State private var sparkleUpdateVersion: String?
 
     // -- Sentry testing state --
     @State private var lastSentryStatus: String?
@@ -125,21 +111,6 @@ struct SettingsDeveloperTab: View {
                 daemonClient: daemonClient,
                 isManaged: lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId })?.isManaged ?? false
             )
-            // Upgrade
-            if let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }) {
-                let topo: AssistantTopology = assistant.isDocker ? .docker
-                    : assistant.isManaged ? .managed
-                    : assistant.cloud.lowercased() == "local" ? .local
-                    : .remote
-                AssistantUpgradeSection(
-                    currentVersion: healthz?.version,
-                    topology: topo,
-                    isDockerOperationInProgress: $isDockerOperationInProgress,
-                    dockerOperationLabel: $dockerOperationLabel,
-                    sparkleUpdateAvailable: sparkleUpdateAvailable,
-                    sparkleUpdateVersion: sparkleUpdateVersion
-                )
-            }
             // Hatch New Assistant
             hatchNewAssistantSection
             // Retire Assistant
@@ -214,14 +185,6 @@ struct SettingsDeveloperTab: View {
             // Sentry setup
             isSentryEnabled = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
                 ?? true
-
-            // Sparkle update state (local topology)
-            sparkleUpdateAvailable = AppDelegate.shared?.updateManager.isUpdateAvailable ?? false
-            sparkleUpdateVersion = AppDelegate.shared?.updateManager.availableUpdateVersion
-        }
-        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-            sparkleUpdateAvailable = AppDelegate.shared?.updateManager.isUpdateAvailable ?? false
-            sparkleUpdateVersion = AppDelegate.shared?.updateManager.availableUpdateVersion
         }
         .alert("Retire Assistant", isPresented: $showingRetireConfirmation) {
             Button("Cancel", role: .cancel) {}
@@ -240,14 +203,6 @@ struct SettingsDeveloperTab: View {
             } else {
                 Text("This will stop the assistant, remove local data, and return to initial setup. This action cannot be undone.")
             }
-        }
-        .alert("Upgrade Assistant", isPresented: $showingInlineUpgradeConfirmation) {
-            Button("Cancel", role: .cancel) {}
-            Button("Upgrade") {
-                Task { await performInlineUpgrade() }
-            }
-        } message: {
-            Text("Upgrade the assistant to match the desktop app version? The assistant will be briefly unavailable during the upgrade.")
         }
         .alert("Restart Assistant", isPresented: $showingRestartConfirmation) {
             Button("Cancel", role: .cancel) {}
@@ -278,22 +233,6 @@ struct SettingsDeveloperTab: View {
                     .font(VFont.bodyMedium)
                     .foregroundColor(VColor.contentDefault)
                 Text("The assistant will be briefly unavailable.")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.contentTertiary)
-            }
-            .padding(VSpacing.xxl)
-            .frame(minWidth: 260)
-            .interactiveDismissDisabled()
-        }
-        .sheet(isPresented: $isDockerOperationInProgress) {
-            VStack(spacing: VSpacing.lg) {
-                ProgressView()
-                    .controlSize(.regular)
-                    .progressViewStyle(.circular)
-                Text(dockerOperationLabel)
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(VColor.contentDefault)
-                Text("This may take a minute. The assistant will be briefly unavailable.")
                     .font(VFont.caption)
                     .foregroundColor(VColor.contentTertiary)
             }
@@ -443,23 +382,7 @@ struct SettingsDeveloperTab: View {
                 .foregroundColor(VColor.contentTertiary)
                 .frame(width: 100, alignment: .leading)
 
-            if let daemonClient {
-                let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId })
-                let topo: AssistantTopology = assistant?.isDocker == true ? .docker
-                    : assistant?.isManaged == true ? .managed
-                    : assistant?.cloud.lowercased() == "local" ? .local
-                    : .remote
-                DeveloperUpdateProgressRow(
-                    daemonClient: daemonClient,
-                    effectiveVersion: effectiveVersion,
-                    isVersionIncompatible: isVersionIncompatible,
-                    assistantVersionBehind: assistantVersionBehind,
-                    isUpgradingInline: isUpgradingInline,
-                    isUpgradeSectionActive: isDockerOperationInProgress,
-                    topology: topo,
-                    onUpgradeTapped: { showingInlineUpgradeConfirmation = true }
-                )
-            } else if let version = effectiveVersion {
+            if let version = effectiveVersion {
                 Text(version)
                     .font(VFont.mono)
                     .foregroundColor(isVersionIncompatible ? VColor.systemNegativeStrong : VColor.contentDefault)
@@ -482,18 +405,6 @@ struct SettingsDeveloperTab: View {
                     .font(VFont.mono)
                     .foregroundColor(VColor.primaryBase)
             }
-        }
-
-        if let error = inlineUpgradeError {
-            Text(error)
-                .font(VFont.caption)
-                .foregroundColor(VColor.systemNegativeStrong)
-        }
-
-        if let success = inlineUpgradeSuccess {
-            Text(success)
-                .font(VFont.caption)
-                .foregroundColor(VColor.systemPositiveStrong)
         }
 
         if let healthz {
@@ -538,47 +449,6 @@ struct SettingsDeveloperTab: View {
             return String(format: "%.1f GB", mb / 1024.0)
         }
         return String(format: "%.0f MB", mb)
-    }
-
-    private func performInlineUpgrade() async {
-        inlineUpgradeError = nil
-        inlineUpgradeSuccess = nil
-        isUpgradingInline = true
-        defer { isUpgradingInline = false }
-
-        let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId })
-
-        if assistant?.isDocker == true {
-            dockerOperationLabel = "Upgrading assistant..."
-            isDockerOperationInProgress = true
-            defer { isDockerOperationInProgress = false }
-            guard let cli = AppDelegate.shared?.vellumCli else {
-                inlineUpgradeError = "CLI not available"
-                return
-            }
-            do {
-                try await cli.upgrade(name: selectedAssistantId)
-                inlineUpgradeSuccess = "Upgrade complete."
-                await fetchHealthz()
-            } catch {
-                inlineUpgradeError = "Upgrade failed: \(error.localizedDescription)"
-            }
-        } else {
-            do {
-                let response = try await GatewayHTTPClient.post(path: "assistants/upgrade")
-                if response.isSuccess {
-                    inlineUpgradeSuccess = "Upgrade initiated. The assistant may be briefly unavailable."
-                    try? await Task.sleep(nanoseconds: 3_000_000_000)
-                    await fetchHealthz()
-                } else {
-                    inlineUpgradeError = "Upgrade failed (HTTP \(response.statusCode))"
-                }
-            } catch let error as GatewayHTTPClient.ClientError {
-                inlineUpgradeError = error.localizedDescription
-            } catch {
-                inlineUpgradeError = "Upgrade failed: \(error.localizedDescription)"
-            }
-        }
     }
 
     private func fetchHealthz() async {
@@ -1362,56 +1232,3 @@ private struct DeveloperDaemonStatusRows: View {
         }
     }
 }
-
-// MARK: - Update Progress Row (Developer Tab)
-
-/// Extracted sub-view that uses `@ObservedObject` to subscribe to
-/// `DaemonClient.isUpdateInProgress` and `updateTargetVersion` changes.
-/// The parent (`healthzInfoRows`) passes in a non-optional `DaemonClient`
-/// via `if let`, which is the standard SwiftUI pattern for observing
-/// optional ObservableObjects.
-private struct DeveloperUpdateProgressRow: View {
-    @ObservedObject var daemonClient: DaemonClient
-
-    let effectiveVersion: String?
-    let isVersionIncompatible: Bool
-    let assistantVersionBehind: Bool
-    let isUpgradingInline: Bool
-    let isUpgradeSectionActive: Bool
-    let topology: AssistantTopology
-    let onUpgradeTapped: () -> Void
-
-    var body: some View {
-        if daemonClient.isUpdateInProgress {
-            ProgressView()
-                .controlSize(.small)
-            Text("Updating to \(daemonClient.updateTargetVersion ?? "...")...")
-                .font(VFont.body)
-                .foregroundColor(VColor.systemMidStrong)
-        } else if let version = effectiveVersion {
-            Text(version)
-                .font(VFont.mono)
-                .foregroundColor(isVersionIncompatible ? VColor.systemNegativeStrong : VColor.contentDefault)
-                .textSelection(.enabled)
-
-            if assistantVersionBehind {
-                if topology == .docker || topology == .managed {
-                    if isUpgradingInline {
-                        ProgressView()
-                            .controlSize(.small)
-                    } else {
-                        VButton(label: "Upgrade", style: .primary) {
-                            onUpgradeTapped()
-                        }
-                        .disabled(isUpgradingInline || isUpgradeSectionActive)
-                    }
-                }
-            }
-        } else {
-            Text("Not available")
-                .font(VFont.body)
-                .foregroundColor(VColor.contentTertiary)
-        }
-    }
-}
-

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -91,6 +91,7 @@ struct SettingsGeneralTab: View {
     // MARK: - Software Update
 
     private func fetchHealthz() async {
+        guard !selectedAssistantId.isEmpty else { return }
         do {
             let (decoded, _): (DaemonHealthz?, _) = try await GatewayHTTPClient.get(
                 path: "assistants/\(selectedAssistantId)/healthz",

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -13,6 +13,26 @@ struct SettingsGeneralTab: View {
 
     @State private var showingPairingQR: Bool = false
 
+    // -- Software Update state --
+    @State private var healthz: DaemonHealthz?
+    @State private var isDockerOperationInProgress = false
+    @State private var dockerOperationLabel: String = ""
+    @State private var sparkleUpdateAvailable: Bool = false
+    @State private var sparkleUpdateVersion: String?
+    @State private var lockfileAssistants: [LockfileAssistant] = []
+    @State private var selectedAssistantId: String = ""
+
+    /// Derive the topology for the currently selected assistant.
+    private var topology: AssistantTopology {
+        guard let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }) else {
+            return .local
+        }
+        return assistant.isDocker ? .docker
+            : assistant.isManaged ? .managed
+            : assistant.cloud.lowercased() == "local" ? .local
+            : .remote
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             accountSection
@@ -20,16 +40,65 @@ struct SettingsGeneralTab: View {
                 mobilePairingCard
             }
             SettingsAppearanceTab(store: store)
+            if !lockfileAssistants.isEmpty {
+                AssistantUpgradeSection(
+                    currentVersion: healthz?.version,
+                    topology: topology,
+                    isDockerOperationInProgress: $isDockerOperationInProgress,
+                    dockerOperationLabel: $dockerOperationLabel,
+                    sparkleUpdateAvailable: sparkleUpdateAvailable,
+                    sparkleUpdateVersion: sparkleUpdateVersion
+                )
+            }
         }
         .onAppear {
             Task { await authManager.checkSession() }
             store.refreshApprovedDevices()
+            lockfileAssistants = LockfileAssistant.loadAll()
+            selectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
+            sparkleUpdateAvailable = AppDelegate.shared?.updateManager.isUpdateAvailable ?? false
+            sparkleUpdateVersion = AppDelegate.shared?.updateManager.availableUpdateVersion
+            Task { await fetchHealthz() }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            sparkleUpdateAvailable = AppDelegate.shared?.updateManager.isUpdateAvailable ?? false
+            sparkleUpdateVersion = AppDelegate.shared?.updateManager.availableUpdateVersion
         }
         .sheet(isPresented: $showingPairingQR) {
             PairingQRCodeSheet(
                 gatewayUrl: store.resolvedIosGatewayUrl,
                 daemonClient: daemonClient
             )
+        }
+        .sheet(isPresented: $isDockerOperationInProgress) {
+            VStack(spacing: VSpacing.lg) {
+                ProgressView()
+                    .controlSize(.regular)
+                    .progressViewStyle(.circular)
+                Text(dockerOperationLabel)
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.contentDefault)
+                Text("This may take a minute. The assistant will be briefly unavailable.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+            }
+            .padding(VSpacing.xxl)
+            .frame(minWidth: 260)
+            .interactiveDismissDisabled()
+        }
+    }
+
+    // MARK: - Software Update
+
+    private func fetchHealthz() async {
+        do {
+            let (decoded, _): (DaemonHealthz?, _) = try await GatewayHTTPClient.get(
+                path: "assistants/\(selectedAssistantId)/healthz",
+                timeout: 10
+            ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
+            healthz = decoded ?? DaemonHealthz()
+        } catch {
+            healthz = DaemonHealthz()
         }
     }
 


### PR DESCRIPTION
## Summary
Move upgrade controls from the hidden Developer tab to user-facing surfaces so all users can discover and use the update functionality.

- **Settings > General**: New "Software Update" card showing service group version, upgrade/rollback controls, and version picker for Docker and managed topologies
- **About Vellum**: Custom SwiftUI About panel showing both client and service group versions with topology label, plus "Check for Updates..." link to Settings
- **Menu bar**: Topology-aware update item that checks platform API for Docker/managed service group updates (Sparkle behavior unchanged for local)
- **Developer tab**: Removed all upgrade controls (version picker, inline upgrade button, Docker progress sheet) — now read-only version display

## PRs merged into feature branch
- #20297: feat: add Software Update card to Settings > General tab
- #20299: feat: custom About Vellum panel with service group version and update link
- #20305: feat: topology-aware update menu item for Docker and managed topologies
- #20309: refactor: remove upgrade section and inline upgrade button from Developer tab
- #20321: fix: route all update actions through topology-aware checkForUpdates
- #20322: fix: close About window properly and guard empty assistant ID in General tab

## Self-review result
Integration review found 4 gaps, all fixed:
1. SwiftUI Commands menu bypassed topology-aware routing
2. `dismiss()` was a no-op in NSWindow context for About panel
3. Main window Update pill button didn't surface service group updates
4. Missing empty-ID guard in SettingsGeneralTab.fetchHealthz()

Part of plan: upgrade-ux-general-tab.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
