### PR TITLE
fix: show "keychain broker unreachable" instead of "credential not found" in reveal/inspect

### DIFF
--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -12,6 +12,7 @@ import type { CredentialMetadata } from "../tools/credentials/metadata-store.js"
 let secureKeyStore = new Map<string, string>();
 let metadataStore: CredentialMetadata[] = [];
 let idCounter = 0;
+let mockBrokerUnreachable = false;
 
 function nextUUID(): string {
   idCounter += 1;
@@ -45,6 +46,12 @@ mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (account: string): Promise<string | undefined> => {
     return secureKeyStore.get(account);
   },
+  getSecureKeyResultAsync: async (
+    account: string,
+  ): Promise<{ value: string | undefined; unreachable: boolean }> => ({
+    value: secureKeyStore.get(account),
+    unreachable: mockBrokerUnreachable,
+  }),
   _resetBackend: (): void => {},
 }));
 
@@ -264,6 +271,7 @@ describe("assistant credentials CLI", () => {
     secureKeyStore = new Map();
     metadataStore = [];
     idCounter = 0;
+    mockBrokerUnreachable = false;
     disconnectOAuthProviderCalls = [];
     disconnectOAuthProviderResult = "not-found";
     process.exitCode = 0;
@@ -870,6 +878,42 @@ describe("assistant credentials CLI", () => {
       expect(parsed.hasSecret).toBe(false);
       expect(parsed.scrubbedValue).toBe("(not set)");
     });
+
+    test("shows broker unreachable when metadata exists but broker is down", async () => {
+      seedMetadataOnly("twilio", "account_sid");
+      mockBrokerUnreachable = true;
+
+      const result = await runCli([
+        "inspect",
+        "--service",
+        "twilio",
+        "--field",
+        "account_sid",
+        "--json",
+      ]);
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.scrubbedValue).toBe("(broker unreachable)");
+      expect(parsed.brokerUnreachable).toBe(true);
+    });
+
+    test("shows unreachable error when no metadata and broker is down", async () => {
+      mockBrokerUnreachable = true;
+
+      const result = await runCli([
+        "inspect",
+        "--service",
+        "nonexistent",
+        "--field",
+        "field",
+        "--json",
+      ]);
+      expect(result.exitCode).toBe(1);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("Keychain broker is unreachable");
+    });
   });
 
   // =========================================================================
@@ -968,6 +1012,40 @@ describe("assistant credentials CLI", () => {
       const parsed = JSON.parse(result.stdout);
       expect(parsed.ok).toBe(false);
       expect(parsed.error).toContain("not found");
+    });
+
+    test("returns unreachable error when broker is down", async () => {
+      mockBrokerUnreachable = true;
+
+      const result = await runCli([
+        "reveal",
+        "--service",
+        "twilio",
+        "--field",
+        "auth_token",
+        "--json",
+      ]);
+      expect(result.exitCode).toBe(1);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("Keychain broker is unreachable");
+    });
+
+    test("returns credential-not-found when broker is up", async () => {
+      mockBrokerUnreachable = false;
+
+      const result = await runCli([
+        "reveal",
+        "--service",
+        "twilio",
+        "--field",
+        "nonexistent",
+        "--json",
+      ]);
+      expect(result.exitCode).toBe(1);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toBe("Credential not found");
     });
   });
 

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -15,6 +15,7 @@ import { credentialKey } from "../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
   getSecureKeyAsync,
+  getSecureKeyResultAsync,
   setSecureKeyAsync,
 } from "../../security/secure-keys.js";
 import {
@@ -608,10 +609,19 @@ Examples:
             return;
           }
 
-          const secret = await getSecureKeyAsync(storageKey);
+          const { value: secret, unreachable } =
+            await getSecureKeyResultAsync(storageKey);
 
           if (!metadata && (secret == null || secret.length === 0)) {
-            writeOutput(cmd, { ok: false, error: "Credential not found" });
+            if (unreachable) {
+              writeOutput(cmd, {
+                ok: false,
+                error:
+                  "Keychain broker is unreachable — is the macOS app running?",
+              });
+            } else {
+              writeOutput(cmd, { ok: false, error: "Credential not found" });
+            }
             process.exitCode = 1;
             return;
           }
@@ -646,10 +656,21 @@ Examples:
 
           const connection = safeGetConnectionByProvider(metadata.service);
           const output = buildCredentialOutput(metadata, secret, connection);
+
+          if (unreachable && (secret == null || secret.length === 0)) {
+            output.scrubbedValue = "(broker unreachable)";
+            output.brokerUnreachable = true;
+          }
+
           writeOutput(cmd, output);
 
           if (!shouldOutputJson(cmd)) {
             printCredentialHuman(output);
+            if (unreachable && (secret == null || secret.length === 0)) {
+              log.info(
+                "    \u26A0 Keychain broker unreachable — secret may exist but cannot be retrieved",
+              );
+            }
           }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
@@ -725,10 +746,19 @@ Examples:
             return;
           }
 
-          const secret = await getSecureKeyAsync(storageKey);
+          const { value: secret, unreachable } =
+            await getSecureKeyResultAsync(storageKey);
 
           if (secret == null || secret.length === 0) {
-            writeOutput(cmd, { ok: false, error: "Credential not found" });
+            if (unreachable) {
+              writeOutput(cmd, {
+                ok: false,
+                error:
+                  "Keychain broker is unreachable — is the macOS app running?",
+              });
+            } else {
+              writeOutput(cmd, { ok: false, error: "Credential not found" });
+            }
             process.exitCode = 1;
             return;
           }


### PR DESCRIPTION
## Summary
- Update reveal and inspect commands to use getSecureKeyResultAsync
- Show 'Keychain broker is unreachable' instead of misleading 'Credential not found'
- When inspect has metadata but broker is down, show (broker unreachable) in scrubbed value
- Add tests for all unreachable error paths

Part of plan: cred-reveal-timeout-fix-v2.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
