### PR TITLE
fix: credential reveal timeout when keychain broker unavailable (v2)

### DIFF
--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -12,6 +12,7 @@ import type { CredentialMetadata } from "../tools/credentials/metadata-store.js"
 let secureKeyStore = new Map<string, string>();
 let metadataStore: CredentialMetadata[] = [];
 let idCounter = 0;
+let mockBrokerUnreachable = false;
 
 function nextUUID(): string {
   idCounter += 1;
@@ -45,6 +46,12 @@ mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (account: string): Promise<string | undefined> => {
     return secureKeyStore.get(account);
   },
+  getSecureKeyResultAsync: async (
+    account: string,
+  ): Promise<{ value: string | undefined; unreachable: boolean }> => ({
+    value: secureKeyStore.get(account),
+    unreachable: mockBrokerUnreachable,
+  }),
   _resetBackend: (): void => {},
 }));
 
@@ -264,6 +271,7 @@ describe("assistant credentials CLI", () => {
     secureKeyStore = new Map();
     metadataStore = [];
     idCounter = 0;
+    mockBrokerUnreachable = false;
     disconnectOAuthProviderCalls = [];
     disconnectOAuthProviderResult = "not-found";
     process.exitCode = 0;
@@ -870,6 +878,42 @@ describe("assistant credentials CLI", () => {
       expect(parsed.hasSecret).toBe(false);
       expect(parsed.scrubbedValue).toBe("(not set)");
     });
+
+    test("shows broker unreachable when metadata exists but broker is down", async () => {
+      seedMetadataOnly("twilio", "account_sid");
+      mockBrokerUnreachable = true;
+
+      const result = await runCli([
+        "inspect",
+        "--service",
+        "twilio",
+        "--field",
+        "account_sid",
+        "--json",
+      ]);
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.scrubbedValue).toBe("(broker unreachable)");
+      expect(parsed.brokerUnreachable).toBe(true);
+    });
+
+    test("shows unreachable error when no metadata and broker is down", async () => {
+      mockBrokerUnreachable = true;
+
+      const result = await runCli([
+        "inspect",
+        "--service",
+        "nonexistent",
+        "--field",
+        "field",
+        "--json",
+      ]);
+      expect(result.exitCode).toBe(1);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("Keychain broker is unreachable");
+    });
   });
 
   // =========================================================================
@@ -968,6 +1012,40 @@ describe("assistant credentials CLI", () => {
       const parsed = JSON.parse(result.stdout);
       expect(parsed.ok).toBe(false);
       expect(parsed.error).toContain("not found");
+    });
+
+    test("returns unreachable error when broker is down", async () => {
+      mockBrokerUnreachable = true;
+
+      const result = await runCli([
+        "reveal",
+        "--service",
+        "twilio",
+        "--field",
+        "auth_token",
+        "--json",
+      ]);
+      expect(result.exitCode).toBe(1);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("Keychain broker is unreachable");
+    });
+
+    test("returns credential-not-found when broker is up", async () => {
+      mockBrokerUnreachable = false;
+
+      const result = await runCli([
+        "reveal",
+        "--service",
+        "twilio",
+        "--field",
+        "nonexistent",
+        "--json",
+      ]);
+      expect(result.exitCode).toBe(1);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toBe("Credential not found");
     });
   });
 

--- a/assistant/src/__tests__/keychain-broker-client.test.ts
+++ b/assistant/src/__tests__/keychain-broker-client.test.ts
@@ -537,8 +537,8 @@ describe("keychain-broker-client", () => {
       writeFileSync(SOCKET_PATH, "");
       expect(client.isAvailable()).toBe(false);
 
-      // Advance time past the first cooldown (30s)
-      fakeNow += 30_001;
+      // Advance time past the first cooldown (5s)
+      fakeNow += 5_001;
       expect(client.isAvailable()).toBe(true);
 
       // Now start a real broker and verify the client reconnects
@@ -558,8 +558,8 @@ describe("keychain-broker-client", () => {
       const client = createBrokerClient();
       await client.ping();
 
-      // Advance past first cooldown (30s)
-      fakeNow += 30_001;
+      // Advance past first cooldown (5s)
+      fakeNow += 5_001;
 
       // Start broker — reconnection should succeed and reset counters
       const broker = createMockBroker();
@@ -578,15 +578,15 @@ describe("keychain-broker-client", () => {
       rmSync(SOCKET_PATH, { force: true });
 
       // This new failure should start from the beginning of the cooldown
-      // schedule (30s), not escalated.
+      // schedule (5s), not escalated.
       await client.ping();
 
-      // Verify cooldown is back to 30s (not 60s)
+      // Verify cooldown is back to 5s (not 15s)
       writeFileSync(SOCKET_PATH, "");
       expect(client.isAvailable()).toBe(false);
 
-      // 30s should be enough to clear cooldown
-      fakeNow += 30_001;
+      // 5s should be enough to clear cooldown
+      fakeNow += 5_001;
       expect(client.isAvailable()).toBe(true);
     }, 15_000);
 
@@ -594,21 +594,47 @@ describe("keychain-broker-client", () => {
       const client = createBrokerClient();
 
       // First failure round: two attempts (first + immediate retry) ->
-      // consecutiveFailures=2, cooldown index = max(2-2,0) = 0 -> 30s.
+      // consecutiveFailures=2, cooldown index = max(2-2,0) = 0 -> 5s.
       await client.ping();
 
       writeFileSync(SOCKET_PATH, "");
       expect(client.isAvailable()).toBe(false);
 
-      // 30s should clear the first cooldown
-      fakeNow += 30_001;
+      // 5s should clear the first cooldown
+      fakeNow += 5_001;
       expect(client.isAvailable()).toBe(true);
 
       // Remove socket to trigger another failure. After cooldown elapses,
       // ensureConnected clears unavailableSince and tries connect().
       // This failure increments consecutiveFailures to 3 (no immediate retry
       // since consecutiveFailures > 1 after increment).
-      // Cooldown index = max(3-2,0) = 1 -> 60s.
+      // Cooldown index = max(3-2,0) = 1 -> 15s.
+      rmSync(SOCKET_PATH, { force: true });
+      await client.ping();
+
+      writeFileSync(SOCKET_PATH, "");
+      expect(client.isAvailable()).toBe(false);
+
+      fakeNow += 5_001;
+      expect(client.isAvailable()).toBe(false); // 5s not enough
+
+      fakeNow += 10_000; // total 15_001ms since this cooldown started
+      expect(client.isAvailable()).toBe(true);
+
+      // Another failure -> consecutiveFailures=4, index = max(4-2,0) = 2 -> 30s
+      rmSync(SOCKET_PATH, { force: true });
+      await client.ping();
+
+      writeFileSync(SOCKET_PATH, "");
+      expect(client.isAvailable()).toBe(false);
+
+      fakeNow += 15_001;
+      expect(client.isAvailable()).toBe(false);
+
+      fakeNow += 15_000; // total 30_001ms
+      expect(client.isAvailable()).toBe(true);
+
+      // Another failure -> consecutiveFailures=5, index = max(5-2,0) = 3 -> 60s
       rmSync(SOCKET_PATH, { force: true });
       await client.ping();
 
@@ -616,12 +642,12 @@ describe("keychain-broker-client", () => {
       expect(client.isAvailable()).toBe(false);
 
       fakeNow += 30_001;
-      expect(client.isAvailable()).toBe(false); // 30s not enough
+      expect(client.isAvailable()).toBe(false);
 
-      fakeNow += 30_000; // total 60_001ms since this cooldown started
+      fakeNow += 30_000; // total 60_001ms
       expect(client.isAvailable()).toBe(true);
 
-      // Another failure -> consecutiveFailures=4, index = max(4-2,0) = 2 -> 120s (2min)
+      // Another failure -> consecutiveFailures=6, index = min(max(6-2,0), 4) = 4 -> 300s (5min)
       rmSync(SOCKET_PATH, { force: true });
       await client.ping();
 
@@ -631,23 +657,10 @@ describe("keychain-broker-client", () => {
       fakeNow += 60_001;
       expect(client.isAvailable()).toBe(false);
 
-      fakeNow += 60_000; // total 120_001ms
+      fakeNow += 240_000; // total 300_001ms
       expect(client.isAvailable()).toBe(true);
 
-      // Another failure -> consecutiveFailures=5, index = max(5-2,0) = 3 -> 300s (5min)
-      rmSync(SOCKET_PATH, { force: true });
-      await client.ping();
-
-      writeFileSync(SOCKET_PATH, "");
-      expect(client.isAvailable()).toBe(false);
-
-      fakeNow += 120_001;
-      expect(client.isAvailable()).toBe(false);
-
-      fakeNow += 180_000; // total 300_001ms
-      expect(client.isAvailable()).toBe(true);
-
-      // Another failure -> consecutiveFailures=6, index = min(max(6-2,0), 3) = 3 -> 300s (capped)
+      // Another failure -> consecutiveFailures=7, index = min(max(7-2,0), 4) = 4 -> 300s (capped)
       rmSync(SOCKET_PATH, { force: true });
       await client.ping();
 
@@ -655,6 +668,132 @@ describe("keychain-broker-client", () => {
       expect(client.isAvailable()).toBe(false);
 
       fakeNow += 300_001;
+      expect(client.isAvailable()).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Connect timeout
+  // -----------------------------------------------------------------------
+  describe("connect timeout", () => {
+    let stopFn: (() => Promise<void>) | null = null;
+
+    beforeEach(() => {
+      writeFileSync(TOKEN_PATH, TEST_TOKEN);
+    });
+
+    afterEach(async () => {
+      if (stopFn) {
+        await stopFn();
+        stopFn = null;
+      }
+    });
+
+    test("rejects connect within 3 seconds when broker is unresponsive", async () => {
+      // Create a server that accepts connections but never responds
+      // (simulates an unresponsive broker process).
+      const activeConns = new Set<import("node:net").Socket>();
+      const server = createServer((conn) => {
+        activeConns.add(conn);
+        conn.on("close", () => activeConns.delete(conn));
+        // Accept connection but do nothing — no data, no close
+      });
+      await new Promise<void>((resolve) => {
+        server.listen(SOCKET_PATH, () => resolve());
+      });
+      stopFn = () =>
+        new Promise<void>((resolve) => {
+          for (const conn of activeConns) conn.destroy();
+          activeConns.clear();
+          server.close(() => resolve());
+        });
+
+      const client = createBrokerClient();
+      const start = Date.now();
+      const result = await client.ping();
+      const elapsed = Date.now() - start;
+
+      // Should return null (graceful fallback) and not hang indefinitely.
+      // The connect timeout is 3s; allow some slack but it should be well
+      // under 10s (the old behavior would hang for REQUEST_TIMEOUT_MS * retries).
+      expect(result).toBeNull();
+      expect(elapsed).toBeLessThan(10_000);
+    }, 15_000);
+
+    test("successful connect clears the connect timer", async () => {
+      // Normal broker that responds to pings — verifies the timer is cleared
+      // and doesn't fire after a successful connection.
+      const broker = createMockBroker();
+      broker.setHandler(() => ({ ok: true, result: { pong: true } }));
+      await broker.start();
+      stopFn = () => broker.stop();
+
+      const client = createBrokerClient();
+      const result = await client.ping();
+      expect(result).toEqual({ pong: true });
+
+      // Wait a bit past the connect timeout to ensure no stale timer fires
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Client should still work fine
+      const result2 = await client.ping();
+      expect(result2).toEqual({ pong: true });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Reduced initial cooldown
+  // -----------------------------------------------------------------------
+  describe("reduced initial cooldown", () => {
+    const originalDateNow = Date.now;
+    let fakeNow: number;
+
+    beforeEach(() => {
+      fakeNow = originalDateNow.call(Date);
+      Date.now = () => fakeNow;
+      writeFileSync(TOKEN_PATH, TEST_TOKEN);
+    });
+
+    afterEach(() => {
+      Date.now = originalDateNow;
+    });
+
+    test("first cooldown is 5 seconds, not 30 seconds", async () => {
+      const client = createBrokerClient();
+
+      // Trigger two connection failures (first + immediate retry)
+      await client.ping();
+
+      writeFileSync(SOCKET_PATH, "");
+
+      // Should still be in cooldown at 4 seconds
+      fakeNow += 4_000;
+      expect(client.isAvailable()).toBe(false);
+
+      // Should be available after 5 seconds
+      fakeNow += 1_001;
+      expect(client.isAvailable()).toBe(true);
+    });
+
+    test("second cooldown is 15 seconds", async () => {
+      const client = createBrokerClient();
+
+      // First failure round -> cooldown 5s
+      await client.ping();
+
+      // Clear first cooldown
+      fakeNow += 5_001;
+
+      // Second failure -> cooldown 15s
+      await client.ping();
+
+      writeFileSync(SOCKET_PATH, "");
+      expect(client.isAvailable()).toBe(false);
+
+      fakeNow += 14_000;
+      expect(client.isAvailable()).toBe(false);
+
+      fakeNow += 1_001;
       expect(client.isAvailable()).toBe(true);
     });
   });

--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -75,6 +75,7 @@ import {
   _resetBackend,
   deleteSecureKeyAsync,
   getSecureKeyAsync,
+  getSecureKeyResultAsync,
   listSecureKeysAsync,
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
@@ -466,6 +467,61 @@ describe("secure-keys", () => {
 
       const keys = await listSecureKeysAsync();
       expect(keys).toEqual([]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getSecureKeyResultAsync — richer result with unreachable flag
+  // -----------------------------------------------------------------------
+  describe("getSecureKeyResultAsync", () => {
+    test("returns unreachable true when broker errors", async () => {
+      mockBrokerAvailable = true;
+      mockBrokerGetError = true;
+      _resetBackend();
+
+      const result = await getSecureKeyResultAsync("api-key");
+      expect(result.value).toBeUndefined();
+      expect(result.unreachable).toBe(true);
+    });
+
+    test("returns value and unreachable false on success", async () => {
+      mockBrokerAvailable = true;
+      _resetBackend();
+
+      mockBrokerStore.set("api-key", "broker-value");
+      const result = await getSecureKeyResultAsync("api-key");
+      expect(result.value).toBe("broker-value");
+      expect(result.unreachable).toBe(false);
+    });
+
+    test("falls back to encrypted store when broker is unreachable", async () => {
+      mockBrokerAvailable = true;
+      mockBrokerGetError = true;
+      _resetBackend();
+
+      encryptedStore.setKey("legacy-key", "legacy-value");
+      const result = await getSecureKeyResultAsync("legacy-key");
+      expect(result.value).toBe("legacy-value");
+      expect(result.unreachable).toBe(false);
+    });
+
+    test("propagates unreachable when broker errors and encrypted store also missing", async () => {
+      mockBrokerAvailable = true;
+      mockBrokerGetError = true;
+      _resetBackend();
+
+      const result = await getSecureKeyResultAsync("missing-key");
+      expect(result.value).toBeUndefined();
+      expect(result.unreachable).toBe(true);
+    });
+
+    test("returns unreachable false in dev mode (encrypted store backend)", async () => {
+      process.env.VELLUM_DEV = "1";
+      _resetBackend();
+
+      const result = await getSecureKeyResultAsync("missing-key");
+      expect(result.value).toBeUndefined();
+      expect(result.unreachable).toBe(false);
     });
   });
 });

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -15,6 +15,7 @@ import { credentialKey } from "../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
   getSecureKeyAsync,
+  getSecureKeyResultAsync,
   setSecureKeyAsync,
 } from "../../security/secure-keys.js";
 import {
@@ -608,10 +609,19 @@ Examples:
             return;
           }
 
-          const secret = await getSecureKeyAsync(storageKey);
+          const { value: secret, unreachable } =
+            await getSecureKeyResultAsync(storageKey);
 
           if (!metadata && (secret == null || secret.length === 0)) {
-            writeOutput(cmd, { ok: false, error: "Credential not found" });
+            if (unreachable) {
+              writeOutput(cmd, {
+                ok: false,
+                error:
+                  "Keychain broker is unreachable — is the macOS app running?",
+              });
+            } else {
+              writeOutput(cmd, { ok: false, error: "Credential not found" });
+            }
             process.exitCode = 1;
             return;
           }
@@ -646,10 +656,21 @@ Examples:
 
           const connection = safeGetConnectionByProvider(metadata.service);
           const output = buildCredentialOutput(metadata, secret, connection);
+
+          if (unreachable && (secret == null || secret.length === 0)) {
+            output.scrubbedValue = "(broker unreachable)";
+            output.brokerUnreachable = true;
+          }
+
           writeOutput(cmd, output);
 
           if (!shouldOutputJson(cmd)) {
             printCredentialHuman(output);
+            if (unreachable && (secret == null || secret.length === 0)) {
+              log.info(
+                "    \u26A0 Keychain broker unreachable — secret may exist but cannot be retrieved",
+              );
+            }
           }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
@@ -725,10 +746,19 @@ Examples:
             return;
           }
 
-          const secret = await getSecureKeyAsync(storageKey);
+          const { value: secret, unreachable } =
+            await getSecureKeyResultAsync(storageKey);
 
           if (secret == null || secret.length === 0) {
-            writeOutput(cmd, { ok: false, error: "Credential not found" });
+            if (unreachable) {
+              writeOutput(cmd, {
+                ok: false,
+                error:
+                  "Keychain broker is unreachable — is the macOS app running?",
+              });
+            } else {
+              writeOutput(cmd, { ok: false, error: "Credential not found" });
+            }
             process.exitCode = 1;
             return;
           }

--- a/assistant/src/security/ces-credential-client.ts
+++ b/assistant/src/security/ces-credential-client.ts
@@ -16,7 +16,11 @@
  */
 
 import { getLogger } from "../util/logger.js";
-import type { CredentialBackend, DeleteResult } from "./credential-backend.js";
+import type {
+  CredentialBackend,
+  CredentialGetResult,
+  DeleteResult,
+} from "./credential-backend.js";
 
 const log = getLogger("ces-credential-client");
 
@@ -79,26 +83,26 @@ export class CesCredentialBackend implements CredentialBackend {
     return !!getBaseUrl() && !!getServiceToken();
   }
 
-  async get(account: string): Promise<string | undefined> {
+  async get(account: string): Promise<CredentialGetResult> {
     try {
       const res = await cesRequest(
         "GET",
         `/v1/credentials/${encodeURIComponent(account)}`,
       );
-      if (!res) return undefined;
-      if (res.status === 404) return undefined;
+      if (!res) return { value: undefined, unreachable: true };
+      if (res.status === 404) return { value: undefined, unreachable: false };
       if (!res.ok) {
         log.warn(
           { account, status: res.status },
           "CES credential get returned non-OK status",
         );
-        return undefined;
+        return { value: undefined, unreachable: true };
       }
       const data = (await res.json()) as { value?: string };
-      return data.value;
+      return { value: data.value, unreachable: false };
     } catch (err) {
       log.warn({ err, account }, "CES credential get threw unexpectedly");
-      return undefined;
+      return { value: undefined, unreachable: true };
     }
   }
 

--- a/assistant/src/security/credential-backend.ts
+++ b/assistant/src/security/credential-backend.ts
@@ -18,6 +18,12 @@ const log = getLogger("credential-backend");
 /** Result of a delete operation — distinguishes success, not-found, and error. */
 export type DeleteResult = "deleted" | "not-found" | "error";
 
+/** Result of a get operation — distinguishes unreachable from not-found. */
+export interface CredentialGetResult {
+  value: string | undefined;
+  unreachable: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // Interface
 // ---------------------------------------------------------------------------
@@ -29,8 +35,8 @@ export interface CredentialBackend {
   /** Whether this backend is currently reachable. Sync and cheap. */
   isAvailable(): boolean;
 
-  /** Retrieve a secret. Returns undefined if not found or on error. */
-  get(account: string): Promise<string | undefined>;
+  /** Retrieve a secret. Returns a result distinguishing unreachable from not-found. */
+  get(account: string): Promise<CredentialGetResult>;
 
   /** Store a secret. Returns true on success. */
   set(account: string, value: string): Promise<boolean>;
@@ -59,7 +65,7 @@ export class KeychainBackend implements CredentialBackend {
     return this.client.isAvailable();
   }
 
-  async get(account: string): Promise<string | undefined> {
+  async get(account: string): Promise<CredentialGetResult> {
     try {
       const result = await this.client.get(account);
       if (result == null) {
@@ -71,14 +77,14 @@ export class KeychainBackend implements CredentialBackend {
           );
           lastUnreachableWarnMs = now;
         }
-        return undefined;
+        return { value: undefined, unreachable: true };
       }
       lastUnreachableWarnMs = 0; // Reset so next outage is logged immediately
-      if (!result.found) return undefined;
-      return result.value;
+      if (!result.found) return { value: undefined, unreachable: false };
+      return { value: result.value, unreachable: false };
     } catch (err) {
       log.warn({ err, account }, "Keychain get threw unexpectedly");
-      return undefined;
+      return { value: undefined, unreachable: true };
     }
   }
 
@@ -135,11 +141,11 @@ export class EncryptedStoreBackend implements CredentialBackend {
     return true;
   }
 
-  async get(account: string): Promise<string | undefined> {
+  async get(account: string): Promise<CredentialGetResult> {
     try {
-      return encryptedStore.getKey(account);
+      return { value: encryptedStore.getKey(account), unreachable: false };
     } catch {
-      return undefined;
+      return { value: undefined, unreachable: false };
     }
   }
 

--- a/assistant/src/security/keychain-broker-client.ts
+++ b/assistant/src/security/keychain-broker-client.ts
@@ -24,9 +24,10 @@ import { getRootDir } from "../util/platform.js";
 const log = getLogger("keychain-broker-client");
 
 const REQUEST_TIMEOUT_MS = 5_000;
+const CONNECT_TIMEOUT_MS = 3_000;
 
-/** Cooldown periods (ms) after consecutive connection failures: 30s, 60s, 2min, 5min, then cap at 5min. */
-const RECONNECT_COOLDOWN_MS = [30_000, 60_000, 120_000, 300_000];
+/** Cooldown periods (ms) after consecutive connection failures: 5s, 15s, 30s, 60s, 5min, then cap at 5min. */
+const RECONNECT_COOLDOWN_MS = [5_000, 15_000, 30_000, 60_000, 300_000];
 
 // ---------------------------------------------------------------------------
 // Types
@@ -191,7 +192,13 @@ export function createBrokerClient(): KeychainBrokerClient {
 
       const sock = createConnection({ path: socketPath });
 
+      const connectTimer = setTimeout(() => {
+        sock.destroy();
+        reject(new Error("Connect timeout"));
+      }, CONNECT_TIMEOUT_MS);
+
       sock.on("connect", () => {
+        clearTimeout(connectTimer);
         socket = sock;
         consecutiveFailures = 0;
         unavailableSince = null;
@@ -199,6 +206,7 @@ export function createBrokerClient(): KeychainBrokerClient {
       });
 
       sock.on("error", (err) => {
+        clearTimeout(connectTimer);
         log.warn({ err }, "Keychain broker socket error");
         cleanupSocket();
         reject(err);

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -136,7 +136,7 @@ export async function getSecureKeyAsync(
 ): Promise<string | undefined> {
   const backend = resolveBackend();
   const result = await backend.get(account);
-  if (result != null) return result;
+  if (result.value != null) return result.value;
 
   // CES mode — no local fallback.
   if (backend.name === "ces-http") return undefined;
@@ -144,7 +144,8 @@ export async function getSecureKeyAsync(
   // Legacy fallback: if primary backend is NOT the encrypted store,
   // check the encrypted store for keys that haven't been migrated.
   if (backend !== getEncryptedStoreBackend()) {
-    return await getEncryptedStoreBackend().get(account);
+    const fallback = await getEncryptedStoreBackend().get(account);
+    return fallback.value;
   }
 
   return undefined;

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -36,6 +36,11 @@ export type { DeleteResult } from "./credential-backend.js";
  */
 export type { SecureKeyBackend, SecureKeyDeleteResult };
 
+export interface SecureKeyResult {
+  value: string | undefined;
+  unreachable: boolean;
+}
+
 const log = getLogger("secure-keys");
 
 let _keychain: CredentialBackend | undefined;
@@ -125,30 +130,53 @@ export async function listSecureKeysAsync(): Promise<string[]> {
 // ---------------------------------------------------------------------------
 
 /**
- * Retrieve a secret from secure storage. Reads from the primary backend
- * first. In CES mode, the sidecar is the single source of truth — no
- * local fallback. In local mode, if the primary backend is the keychain,
- * falls back to the encrypted store for legacy keys that haven't been
- * migrated.
+ * Retrieve a secret from secure storage with richer result metadata.
+ *
+ * Returns both the value (if found) and whether the backend was
+ * unreachable. Callers that need to distinguish "not found" from
+ * "backend down" should use this instead of `getSecureKeyAsync`.
+ *
+ * Reads from the primary backend first. In CES mode, the sidecar is
+ * the single source of truth — no local fallback. In local mode, if
+ * the primary backend is the keychain, falls back to the encrypted
+ * store for legacy keys that haven't been migrated.
  */
-export async function getSecureKeyAsync(
+export async function getSecureKeyResultAsync(
   account: string,
-): Promise<string | undefined> {
+): Promise<SecureKeyResult> {
   const backend = resolveBackend();
   const result = await backend.get(account);
-  if (result.value != null) return result.value;
+  if (result.value != null) {
+    return { value: result.value, unreachable: false };
+  }
 
-  // CES mode — no local fallback.
-  if (backend.name === "ces-http") return undefined;
+  // CES mode — the sidecar is the single source of truth, no local fallback.
+  if (backend.name === "ces-http") {
+    return { value: undefined, unreachable: result.unreachable };
+  }
 
   // Legacy fallback: if primary backend is NOT the encrypted store,
   // check the encrypted store for keys that haven't been migrated.
   if (backend !== getEncryptedStoreBackend()) {
     const fallback = await getEncryptedStoreBackend().get(account);
-    return fallback.value;
+    if (fallback.value != null) {
+      return { value: fallback.value, unreachable: false };
+    }
+    return { value: undefined, unreachable: result.unreachable };
   }
 
-  return undefined;
+  return { value: undefined, unreachable: false };
+}
+
+/**
+ * Retrieve a secret from secure storage. Convenience wrapper over
+ * `getSecureKeyResultAsync` that returns only the value.
+ */
+export async function getSecureKeyAsync(
+  account: string,
+): Promise<string | undefined> {
+  const result = await getSecureKeyResultAsync(account);
+  return result.value;
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes `assistant credentials reveal` silently hanging when the keychain broker is unavailable. Uses a wrapper approach (`getSecureKeyResultAsync`) that keeps `getSecureKeyAsync` unchanged — zero changes to its 48+ callers.

## Changes
1. **Connect timeout**: 3-second timeout on keychain broker socket connection (was unbounded OS timeout)
2. **Reduced cooldown**: Initial reconnect cooldown reduced from 30s to 5s
3. **Richer result types**: `CredentialBackend.get()` returns `CredentialGetResult { value, unreachable }`, new `getSecureKeyResultAsync()` wraps this for callers that need the signal
4. **Better error messages**: `reveal` and `inspect` commands show "Keychain broker is unreachable" when broker is down
5. **Zero blast radius**: `getSecureKeyAsync` still returns `string | undefined` — no existing callers changed

## PRs merged into feature branch
- #20308: fix: add connect timeout to keychain broker socket + reduce initial cooldown
- #20306: refactor: add CredentialGetResult type to distinguish unreachable from not-found
- #20319: feat: add getSecureKeyResultAsync for richer credential lookup results
- #20326: fix: show "keychain broker unreachable" instead of "credential not found" in reveal/inspect

Part of plan: cred-reveal-timeout-fix-v2.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
