### PR TITLE
fix: correct Fish Audio S2 WebSocket protocol

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -556,10 +556,10 @@ export class CallController {
 
     const synthesizeAndPlay = async (text: string): Promise<void> => {
       if (!this.isCurrentRun(runVersion)) return;
-      if (!fishSession) {
-        fishSession = await FishAudioSession.create(config.fishAudio);
-        this.activeFishSession = fishSession;
-      }
+      // Fish Audio S2 requires a stop event to emit FinishEvent, which
+      // closes the session. Create a fresh session for each sentence.
+      fishSession = await FishAudioSession.create(config.fishAudio);
+      this.activeFishSession = fishSession;
       const audioBuffer = await fishSession.synthesize(text);
       const format = config.fishAudio.format ?? "mp3";
       const audioId = storeAudio(audioBuffer, format as "mp3" | "wav" | "opus");

--- a/assistant/src/calls/fish-audio-client.ts
+++ b/assistant/src/calls/fish-audio-client.ts
@@ -14,14 +14,14 @@ const log = getLogger("fish-audio-client");
 interface StartEvent {
   event: "start";
   request: {
+    text?: string;
     reference_id?: string;
     format?: string;
     sample_rate?: number;
     chunk_length?: number;
     normalize?: boolean;
     latency?: string;
-    streaming?: boolean;
-    speed?: number;
+    prosody?: { speed?: number; volume?: number };
   };
 }
 
@@ -93,7 +93,7 @@ export class FishAudioSession {
         {
           headers: {
             Authorization: `Bearer ${apiKey}`,
-            model: "speech-01",
+            model: "s1",
           },
         } as unknown as string[],
       );
@@ -104,11 +104,15 @@ export class FishAudioSession {
         const startEvent: StartEvent = {
           event: "start",
           request: {
+            text: "",
             reference_id: config.referenceId || undefined,
             format: config.format,
             chunk_length: config.chunkLength,
-            speed: config.speed,
-            streaming: true,
+            latency: "balanced",
+            prosody:
+              config.speed !== 1.0
+                ? { speed: config.speed }
+                : undefined,
           },
         };
 
@@ -132,8 +136,9 @@ export class FishAudioSession {
 
   /**
    * Send text for synthesis and wait for the complete audio response.
-   * Sends a TextEvent followed by a FlushEvent, then collects AudioEvent
-   * chunks until a FinishEvent is received.
+   * Sends TextEvent + FlushEvent + StopEvent, then collects AudioEvent
+   * chunks until FinishEvent. Fish Audio S2 only emits FinishEvent after
+   * a StopEvent, so each synthesize() call terminates the session.
    */
   synthesize(text: string): Promise<Buffer> {
     if (this.closed) {
@@ -159,7 +164,12 @@ export class FishAudioSession {
       const flushEvent: FlushEvent = { event: "flush" };
       this.ws.send(encode(flushEvent));
 
-      log.debug({ textLength: text.length }, "Sent text for synthesis");
+      // Fish Audio S2 only sends FinishEvent after receiving StopEvent.
+      // This closes the session, so a new session is needed for the next sentence.
+      const stopEvent: StopEvent = { event: "stop" };
+      this.ws.send(encode(stopEvent));
+
+      log.debug({ textLength: text.length }, "Sent text+flush+stop for synthesis");
     });
   }
 


### PR DESCRIPTION
## Summary
- Fix model header from `speech-01` to `s1` (the correct Fish Audio S2 model ID)
- Send `stop` event after `text`+`flush` — Fish Audio S2 only emits `FinishEvent` after receiving `StopEvent`, so without it the synthesis promise hangs forever
- Create a fresh WebSocket session per sentence since `stop` terminates the session
- Fix `speed` config to use `prosody: { speed }` (Fish Audio nests it under prosody, not top-level)
- Add `text: ""` and `latency: "balanced"` to StartEvent per API docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
