### PR TITLE
feat: add managed services billing info banner to Models & Services tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -413,6 +413,38 @@ struct SettingsPanel: View {
 
     private var integrationsContent: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
+            // Managed services billing info banner
+            HStack(spacing: VSpacing.sm) {
+                VIconView(.info, size: 14)
+                    .foregroundColor(VColor.primaryBase)
+
+                Text("Managed services are metered and deducted from your Vellum account balance.")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentSecondary)
+
+                Button {
+                    NSWorkspace.shared.open(URL(string: "https://vellum.ai/docs/pricing")!)
+                } label: {
+                    HStack(spacing: 4) {
+                        Text("View pricing")
+                            .underline()
+                        VIconView(.arrowUpRight, size: 10)
+                    }
+                    .font(VFont.body)
+                    .foregroundColor(VColor.primaryBase)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(VColor.surfaceBase)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(VColor.borderBase, lineWidth: 1)
+            )
+
             // ANTHROPIC / INFERENCE
             InferenceServiceCard(
                 store: store,


### PR DESCRIPTION
## Summary
- Add an always-visible info banner at the top of the Models & Services settings tab
- Banner communicates that managed services are metered and deducted from the user's Vellum account balance
- Includes a "View pricing" link that opens https://vellum.ai/docs/pricing in the default browser
- Uses existing design system tokens (VColor, VSpacing, VRadius, VFont, VIcon) for consistent styling

## Original prompt
Add an info banner at the top of the Models & Services settings page that links to https://vellum.ai/docs/pricing and communicates that using managed services requires a Vellum platform account, may cost money, and deducts from your Vellum balance.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
