### PR TITLE
fix: catch Fish Audio synthesis errors to prevent daemon crash

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -556,16 +556,28 @@ export class CallController {
 
     const synthesizeAndPlay = async (text: string): Promise<void> => {
       if (!this.isCurrentRun(runVersion)) return;
-      // Fish Audio S2 requires a stop event to emit FinishEvent, which
-      // closes the session. Create a fresh session for each sentence.
-      fishSession = await FishAudioSession.create(config.fishAudio);
-      this.activeFishSession = fishSession;
-      const audioBuffer = await fishSession.synthesize(text);
-      const format = config.fishAudio.format ?? "mp3";
-      const audioId = storeAudio(audioBuffer, format as "mp3" | "wav" | "opus");
-      const baseUrl = getPublicBaseUrl(config);
-      const url = `${baseUrl}/v1/audio/${audioId}`;
-      this.relay.sendPlayUrl(url);
+      try {
+        // Fish Audio S2 requires a stop event to emit FinishEvent, which
+        // closes the session. Create a fresh session for each sentence.
+        fishSession = await FishAudioSession.create(config.fishAudio);
+        this.activeFishSession = fishSession;
+        const audioBuffer = await fishSession.synthesize(text);
+        const format = config.fishAudio.format ?? "mp3";
+        const audioId = storeAudio(
+          audioBuffer,
+          format as "mp3" | "wav" | "opus",
+        );
+        const baseUrl = getPublicBaseUrl(config);
+        const url = `${baseUrl}/v1/audio/${audioId}`;
+        this.relay.sendPlayUrl(url);
+      } catch (err) {
+        log.error(
+          { err, textLength: text.length },
+          "Fish Audio synthesis failed for sentence — skipping",
+        );
+        // Don't re-throw: skip this sentence rather than crashing the
+        // entire daemon with an unhandled rejection.
+      }
     };
 
     // Buffer incoming tokens so we can strip control markers ([ASK_GUARDIAN:...], [END_CALL])


### PR DESCRIPTION
## Summary
- Wrap `synthesizeAndPlay` in try/catch so failed WebSocket connections (e.g. HTTP 101 errors from rapid reconnection) log and skip the sentence instead of crashing the daemon with an unhandled promise rejection
- Previously, `Expected 101 status code` errors during per-sentence session creation propagated as unhandled rejections, triggering `[lifecycle] Unhandled promise rejection — initiating shutdown` and killing the call mid-sentence

## Original prompt
the current changes then rework it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
