### PR TITLE
fix: defer avatar fetch until gateway is ready to prevent reset on launch

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -463,9 +463,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         }
 
         setupDaemonClient(isFirstLaunch: isFirstLaunch)
-        // Reload avatar after reconnecting so that logout→re-login cycles
-        // repopulate the dock icon (resetForDisconnect clears it on logout).
-        AvatarAppearanceManager.shared.reloadAvatar()
         setupMenuBar()
         setupFileMenu()
         patchAppMenuTitles()
@@ -517,6 +514,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 let ready = await awaitDaemonReady(timeout: 15)
 
                 if ready {
+                    // Gateway is healthy — reload the avatar now so it
+                    // reflects the user's saved image instead of the
+                    // bundled Vellum logo.
+                    AvatarAppearanceManager.shared.reloadAvatar()
+
                     // Record lifecycle telemetry events (fire-and-forget).
                     Task { await self.telemetryClient.recordLifecycleEvent("hatch") }
                     Task { await self.telemetryClient.recordLifecycleEvent("app_open") }
@@ -553,6 +555,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             Task {
                 let ready = await awaitDaemonReady(timeout: 10)
                 if ready {
+                    // Gateway is healthy — reload the avatar so
+                    // logout→re-login cycles repopulate the dock icon.
+                    AvatarAppearanceManager.shared.reloadAvatar()
                     await self.telemetryClient.recordLifecycleEvent("app_open")
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -133,10 +133,10 @@ final class AvatarAppearanceManager {
             IdentityInfo.load()?.name,
             fallback: "V"
         )
-        Task { [weak self] in
-            await self?.fetchAvatarViaHTTP()
-            await self?.fetchTraitsViaHTTP()
-        }
+        // Avatar is fetched later via reloadAvatar() once the gateway is
+        // confirmed ready. Fetching here would race the daemon startup and
+        // clear the avatar to nil on connection-refused, falling back to the
+        // bundled Vellum logo.
         updateDockLabel()
 
         // Fire-and-forget: fetch character component definitions via the


### PR DESCRIPTION
## Summary
- Removed premature avatar HTTP fetch from `AvatarAppearanceManager.start()` which fired before the gateway existed, causing connection-refused errors that cleared the avatar to nil
- Removed `reloadAvatar()` from `proceedToApp()` which ran synchronously before the async daemon hatch completed
- Added `reloadAvatar()` inside both `awaitDaemonReady` success blocks (first-launch and non-first-launch paths) so the avatar is only fetched after the gateway is confirmed healthy

## Original prompt
Fix the avatar reset bug: reload the avatar after the daemon/gateway are confirmed ready, not before. The root cause is that `reloadAvatar()` is called at `AppDelegate.swift:467` synchronously right after `setupDaemonClient()`, but the daemon hatch runs in an async Task (non-blocking), so the gateway isn't ready yet when the avatar fetch happens. Both the early `start()` call and the `proceedToApp()` `reloadAvatar()` fail because the gateway isn't listening. The fix should move the avatar reload to after `awaitDaemonReady()` succeeds, so the gateway is confirmed healthy before fetching.