### PR TITLE
fix: make checkForUpdates() public to fix macOS build

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -398,7 +398,7 @@ extension AppDelegate {
         mainWindow?.windowState.selection = .panel(.apps)
     }
 
-    @objc func checkForUpdates() {
+    @objc public func checkForUpdates() {
         // For Docker/managed topologies with a service group update available,
         // navigate to Settings > General (where the Software Update card lives)
         // instead of triggering Sparkle's update dialog.


### PR DESCRIPTION
## Summary
- `checkForUpdates()` in `AppDelegate+MenuBar.swift` was missing the `public` access modifier, causing a build error when called from `VellumAssistantApp.swift` (a different module)
- All other `AppDelegate` methods called from `VellumAssistantApp.swift` (`showAboutPanel`, `sendLogsToSentry`, `performUninstall`, `performLogout`) are already `public`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23363416199/job/67971987941