### PR TITLE
fix: use foregroundStyle and VSpacing.xs in managed services banner

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -398,7 +398,7 @@ extension AppDelegate {
         mainWindow?.windowState.selection = .panel(.apps)
     }
 
-    @objc func checkForUpdates() {
+    @objc public func checkForUpdates() {
         // For Docker/managed topologies with a service group update available,
         // navigate to Settings > General (where the Software Update card lives)
         // instead of triggering Sparkle's update dialog.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -416,22 +416,22 @@ struct SettingsPanel: View {
             // Managed services billing info banner
             HStack(spacing: VSpacing.sm) {
                 VIconView(.info, size: 14)
-                    .foregroundColor(VColor.primaryBase)
+                    .foregroundStyle(VColor.primaryBase)
 
                 Text("Managed services are metered and deducted from your Vellum account balance.")
                     .font(VFont.body)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
 
                 Button {
                     NSWorkspace.shared.open(URL(string: "https://vellum.ai/docs/pricing")!)
                 } label: {
-                    HStack(spacing: 4) {
+                    HStack(spacing: VSpacing.xs) {
                         Text("View pricing")
                             .underline()
                         VIconView(.arrowUpRight, size: 10)
                     }
                     .font(VFont.body)
-                    .foregroundColor(VColor.primaryBase)
+                    .foregroundStyle(VColor.primaryBase)
                 }
                 .buttonStyle(.plain)
             }


### PR DESCRIPTION
## Summary
- Replace 3 instances of deprecated `.foregroundColor()` with `.foregroundStyle()` in the managed services info banner
- Replace hardcoded `spacing: 4` with `VSpacing.xs` design token
- Fix `checkForUpdates()` access level (`internal` -> `public`) to unblock Swift builds on main
- Addresses review feedback from #20331
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
