### PR TITLE
fix: feedback form — empty email edge case + ReasonCard accessibility

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
@@ -72,7 +72,7 @@ struct LogReportFormView: View {
     // MARK: - Sections
 
     private var shouldShowEmail: Bool {
-        authManager.currentUser?.email == nil
+        authManager.currentUser?.email?.isEmpty != false
     }
 
     private var reasonCards: some View {
@@ -194,6 +194,7 @@ private struct ReasonCard: View {
                             .stroke(isSelected ? VColor.primaryBase : VColor.borderBase, lineWidth: 1.5)
                             .frame(width: 16, height: 16)
                     )
+                    .accessibilityHidden(true)
             }
             .padding(.horizontal, VSpacing.md)
             .padding(.vertical, VSpacing.sm)
@@ -207,5 +208,6 @@ private struct ReasonCard: View {
             )
         }
         .buttonStyle(.plain)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 }


### PR DESCRIPTION
## Summary
- Treat empty-string auth email same as nil in `shouldShowEmail` so the email field is shown when auth email is blank (prevents unsubmittable form)
- Add `.accessibilityAddTraits(.isSelected)` to ReasonCard and `.accessibilityHidden(true)` to decorative radio circle, matching VSegmentedControl/VToggle patterns

## Original prompt
Address PR review feedback from Codex and Devin on #20311
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
