### PR TITLE
fix: centralize VELLUM_PLATFORM_URL and update dev default to dev-platform.vellum.ai

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -45,6 +45,7 @@ import {
   stopLocalProcesses,
 } from "../lib/local";
 import { maybeStartNgrokTunnel } from "../lib/ngrok";
+import { getPlatformUrl } from "../lib/platform-client";
 import { httpHealthCheck } from "../lib/http-client";
 import { detectOrphanedProcesses } from "../lib/orphan-detection";
 import { isProcessAlive, stopProcess } from "../lib/process";
@@ -100,7 +101,7 @@ export async function buildStartupScript(
   instanceName: string,
   cloud: RemoteHost,
 ): Promise<string> {
-  const platformUrl = process.env.VELLUM_PLATFORM_URL ?? "https://vellum.ai";
+  const platformUrl = getPlatformUrl();
   const logPath =
     cloud === "custom"
       ? "/tmp/vellum-startup.log"

--- a/cli/src/lib/gcp.ts
+++ b/cli/src/lib/gcp.ts
@@ -11,6 +11,7 @@ import {
 } from "./constants";
 import type { Species } from "./constants";
 import { leaseGuardianToken } from "./guardian-token";
+import { getPlatformUrl } from "./platform-client";
 import { generateInstanceName } from "./random-name";
 import { exec, execOutput } from "./step-runner";
 
@@ -640,7 +641,7 @@ export async function hatchGcp(
           species === "vellum" &&
           (await checkCurlFailure(instanceName, project, zone, account))
         ) {
-          const installScriptUrl = `${process.env.VELLUM_PLATFORM_URL ?? "https://vellum.ai"}/install.sh`;
+          const installScriptUrl = `${getPlatformUrl()}/install.sh`;
           console.log(
             `\ud83d\udd04 Detected install script curl failure for ${installScriptUrl}, attempting recovery...`,
           );

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -723,7 +723,7 @@ done
 
 # Default VELLUM_PLATFORM_URL for `run` builds (local dev against dev platform)
 if [ "$CMD" = "run" ] && [ -z "${VELLUM_PLATFORM_URL:-}" ]; then
-    export VELLUM_PLATFORM_URL="https://dev-assistant.vellum.ai"
+    export VELLUM_PLATFORM_URL="https://platform-assistant.vellum.ai"
 fi
 
 # Always regenerate Info.plist (fast, depends on env vars like DISPLAY_VERSION)

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -721,9 +721,15 @@ for SPM_BUNDLE in "$BIN_PATH"/*.bundle; do
     fi
 done
 
-# Default VELLUM_PLATFORM_URL for `run` builds (local dev against dev platform)
-if [ "$CMD" = "run" ] && [ -z "${VELLUM_PLATFORM_URL:-}" ]; then
-    export VELLUM_PLATFORM_URL="https://platform-assistant.vellum.ai"
+# Default VELLUM_PLATFORM_URL — single source of truth for the platform URL.
+# VellumCli.swift no longer hardcodes a fallback; it relies on this being
+# embedded into Info.plist via LSEnvironment below.
+if [ -z "${VELLUM_PLATFORM_URL:-}" ]; then
+    if [ "$CMD" = "run" ]; then
+        export VELLUM_PLATFORM_URL="https://platform-assistant.vellum.ai"
+    else
+        export VELLUM_PLATFORM_URL="https://vellum.ai"
+    fi
 fi
 
 # Always regenerate Info.plist (fast, depends on env vars like DISPLAY_VERSION)

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -723,7 +723,7 @@ done
 
 # Default VELLUM_PLATFORM_URL for `run` builds (local dev against dev platform)
 if [ "$CMD" = "run" ] && [ -z "${VELLUM_PLATFORM_URL:-}" ]; then
-    export VELLUM_PLATFORM_URL="https://platform-assistant.vellum.ai"
+    export VELLUM_PLATFORM_URL="https://dev-platform.vellum.ai"
 fi
 
 # Always regenerate Info.plist (fast, depends on env vars like DISPLAY_VERSION)

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -721,15 +721,9 @@ for SPM_BUNDLE in "$BIN_PATH"/*.bundle; do
     fi
 done
 
-# Default VELLUM_PLATFORM_URL — single source of truth for the platform URL.
-# VellumCli.swift no longer hardcodes a fallback; it relies on this being
-# embedded into Info.plist via LSEnvironment below.
-if [ -z "${VELLUM_PLATFORM_URL:-}" ]; then
-    if [ "$CMD" = "run" ]; then
-        export VELLUM_PLATFORM_URL="https://platform-assistant.vellum.ai"
-    else
-        export VELLUM_PLATFORM_URL="https://vellum.ai"
-    fi
+# Default VELLUM_PLATFORM_URL for `run` builds (local dev against dev platform)
+if [ "$CMD" = "run" ] && [ -z "${VELLUM_PLATFORM_URL:-}" ]; then
+    export VELLUM_PLATFORM_URL="https://platform-assistant.vellum.ai"
 fi
 
 # Always regenerate Info.plist (fast, depends on env vars like DISPLAY_VERSION)

--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -449,7 +449,7 @@ final class VellumCli {
 
         if env["VELLUM_PLATFORM_URL"] == nil {
             #if DEBUG
-            env["VELLUM_PLATFORM_URL"] = "https://dev-assistant.vellum.ai"
+            env["VELLUM_PLATFORM_URL"] = "https://platform-assistant.vellum.ai"
             #else
             env["VELLUM_PLATFORM_URL"] = "https://vellum.ai"
             #endif

--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -447,14 +447,6 @@ final class VellumCli {
 
         var env = Self.makeBaseEnvironment()
 
-        if env["VELLUM_PLATFORM_URL"] == nil {
-            #if DEBUG
-            env["VELLUM_PLATFORM_URL"] = "https://platform-assistant.vellum.ai"
-            #else
-            env["VELLUM_PLATFORM_URL"] = "https://vellum.ai"
-            #endif
-        }
-
         for (envVar, value) in config.providerApiKeys where !value.isEmpty {
             env[envVar] = value
         }

--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -447,6 +447,10 @@ final class VellumCli {
 
         var env = Self.makeBaseEnvironment()
 
+        if env["VELLUM_PLATFORM_URL"] == nil {
+            env["VELLUM_PLATFORM_URL"] = "https://dev-platform.vellum.ai"
+        }
+
         for (envVar, value) in config.providerApiKeys where !value.isEmpty {
             env[envVar] = value
         }

--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -448,7 +448,11 @@ final class VellumCli {
         var env = Self.makeBaseEnvironment()
 
         if env["VELLUM_PLATFORM_URL"] == nil {
+            #if DEBUG
             env["VELLUM_PLATFORM_URL"] = "https://dev-platform.vellum.ai"
+            #else
+            env["VELLUM_PLATFORM_URL"] = "https://platform.vellum.ai"
+            #endif
         }
 
         for (envVar, value) in config.providerApiKeys where !value.isEmpty {


### PR DESCRIPTION
## Summary
- Update macOS app platform URL defaults: debug → `https://dev-platform.vellum.ai`, release → `https://platform.vellum.ai`
- Update `build.sh` dev default from `https://dev-assistant.vellum.ai` to `https://dev-platform.vellum.ai`
- Replace inline `VELLUM_PLATFORM_URL` fallbacks in `hatch.ts` and `gcp.ts` with the centralized `getPlatformUrl()` helper (also fixes incorrect `vellum.ai` fallback → `platform.vellum.ai`)

## Original prompt
update env["VELLUM_PLATFORM_URL"] = "https://dev-assistant.vellum.ai" to be env["VELLUM_PLATFORM_URL"] = "https://platform-assistant.vellum.ai"