### PR TITLE
Add Send Feedback option to status bar menu

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -309,6 +309,11 @@ extension AppDelegate {
 
         menu.addItem(NSMenuItem.separator())
 
+        let feedbackItem = NSMenuItem(title: "Send Feedback...", action: #selector(sendLogsToSentry), keyEquivalent: "")
+        feedbackItem.target = self
+        feedbackItem.image = VIcon.messageCircle.nsImage(size: 16)
+        menu.addItem(feedbackItem)
+
         let settingsItem = NSMenuItem(title: "Settings...", action: #selector(showSettingsWindow(_:)), keyEquivalent: ",")
         settingsItem.target = self
         settingsItem.image = VIcon.settings.nsImage(size: 16)


### PR DESCRIPTION
## Summary
- Adds a "Send Feedback..." item to the macOS status bar dropdown menu
- Reuses the existing `sendLogsToSentry()` action which opens the Share Feedback modal
- Placed in the bottom section of the menu, above Settings, with the `messageCircle` icon

## Original prompt
I want to add a "Send Feedback" option to this menu somewhere that opens the same modal as our other Share Feedback options
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
