### PR TITLE
fix: replace raw Color.black with VColor.auxBlack in MemoriesPanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -102,7 +102,7 @@ struct MemoriesPanel: View {
         }
         .overlay {
             if let item = selectedItem {
-                Color.black.opacity(0.3)
+                VColor.auxBlack.opacity(0.3)
                     .ignoresSafeArea()
                     .onTapGesture {
                         withAnimation(VAnimation.fast) { selectedItem = nil }


### PR DESCRIPTION
## Summary
- Replace `Color.black.opacity(0.3)` with `VColor.auxBlack.opacity(0.3)` in `MemoriesPanel.swift` to fix the design token guard CI failure

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23364488615/job/67975349502
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
