### PR TITLE
fix: use surfaceOverlay for confirmation dismissed pill background

### DIFF
--- a/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
@@ -128,7 +128,7 @@ public struct ConfirmationSurfaceView: View {
         .padding(.vertical, VSpacing.sm)
         .background(
             RoundedRectangle(cornerRadius: VRadius.md)
-                .fill(VColor.surfaceBase.opacity(0.5))
+                .fill(VColor.surfaceOverlay.opacity(0.5))
         )
     }
 }


### PR DESCRIPTION
## Summary
- Change the dismissed confirmation card pill background from `VColor.surfaceBase` to `VColor.surfaceOverlay` (both at 0.5 opacity)

## Original prompt
update it to be surfaceoverlay
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
