### PR TITLE
feat: polish upgrade UX — rename to Assistant Version, in-place About panel updates, routing fixes

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -309,11 +309,6 @@ extension AppDelegate {
 
         menu.addItem(NSMenuItem.separator())
 
-        let feedbackItem = NSMenuItem(title: "Send Feedback...", action: #selector(sendLogsToSentry), keyEquivalent: "")
-        feedbackItem.target = self
-        feedbackItem.image = VIcon.messageCircle.nsImage(size: 16)
-        menu.addItem(feedbackItem)
-
         let settingsItem = NSMenuItem(title: "Settings...", action: #selector(showSettingsWindow(_:)), keyEquivalent: ",")
         settingsItem.target = self
         settingsItem.image = VIcon.settings.nsImage(size: 16)
@@ -404,20 +399,18 @@ extension AppDelegate {
     }
 
     @objc public func checkForUpdates() {
-        // For Docker/managed topologies with a service group update available,
-        // navigate to Settings > General (where the Software Update card lives)
-        // instead of triggering Sparkle's update dialog.
-        if updateManager.isServiceGroupUpdateAvailable {
-            let assistants = LockfileAssistant.loadAll()
-            let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
-            if let id = connectedId,
-               let assistant = assistants.first(where: { $0.assistantId == id }),
-               assistant.isDocker || assistant.isManaged {
-                showSettingsTab("General")
-                return
-            }
+        // Docker/managed topologies: always navigate to Settings > General
+        // where the Software Update card lives and auto-loads releases.
+        // Sparkle is only relevant for local topology.
+        let assistants = LockfileAssistant.loadAll()
+        let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+        if let id = connectedId,
+           let assistant = assistants.first(where: { $0.assistantId == id }),
+           assistant.isDocker || assistant.isManaged {
+            showSettingsTab("General")
+            return
         }
-        // Local topology (or no service group update): use Sparkle
+        // Local topology: use Sparkle
         updateManager.checkForUpdates()
     }
 
@@ -505,7 +498,7 @@ extension AppDelegate {
 
         let hostingController = NSHostingController(rootView: view)
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 480, height: 560),
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 420),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -609,6 +609,9 @@ extension AppDelegate {
         )
         window.contentViewController = hostingController
         window.title = "About \(Self.appName)"
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
+        window.backgroundColor = NSColor(VColor.surfaceBase)
         window.isReleasedWhenClosed = false
         window.center()
 

--- a/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
@@ -1,14 +1,47 @@
 import SwiftUI
 import VellumAssistantShared
 
+/// Result of an in-place update check in the About panel.
+private enum UpdateCheckResult {
+    case upToDate
+    case updateAvailable(version: String)
+    case error
+}
+
 /// Custom About Vellum panel that replaces the native macOS About panel.
 /// Shows the app icon, client version, service group version with topology
-/// label, commit SHA, architecture, and a "Check for Updates..." button.
+/// label, commit SHA, architecture, and an in-place "Check for Updates" button.
 @MainActor
 struct AboutVellumView: View {
     @State private var healthz: DaemonHealthz?
     @State private var lockfileAssistants: [LockfileAssistant] = []
     @State private var selectedAssistantId: String = ""
+    @State private var isCheckingForUpdates = false
+    @State private var updateCheckResult: UpdateCheckResult?
+
+    /// The current assistant's topology.
+    private var topology: AssistantTopology {
+        guard let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }) else {
+            return .local
+        }
+        return assistant.isDocker ? .docker
+            : assistant.isManaged ? .managed
+            : assistant.cloud.lowercased() == "local" ? .local
+            : .remote
+    }
+
+    /// Whether the client and service group versions match.
+    private var versionsMatch: Bool {
+        guard let sgVersion = healthz?.version, !sgVersion.isEmpty,
+              let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+              let sgParsed = VersionCompat.parse(sgVersion),
+              let appParsed = VersionCompat.parse(appVersion) else {
+            return false
+        }
+        return sgParsed.major == appParsed.major
+            && sgParsed.minor == appParsed.minor
+            && sgParsed.patch == appParsed.patch
+    }
 
     var body: some View {
         VStack(spacing: VSpacing.lg) {
@@ -30,28 +63,21 @@ struct AboutVellumView: View {
                     .foregroundColor(VColor.contentSecondary)
             }
 
-            Divider()
-
-            // Service Group Version with topology label
-            serviceGroupRow
-
-            Divider()
-
-            // Commit SHA
-            if let commitSHA = Bundle.main.infoDictionary?["VellumCommitSHA"] as? String, !commitSHA.isEmpty {
-                HStack(spacing: VSpacing.xs) {
-                    Text("Commit")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
-                    Text(String(commitSHA.prefix(7)))
-                        .font(VFont.mono)
-                        .foregroundColor(VColor.contentSecondary)
-                        .textSelection(.enabled)
-                }
+            // Service Group Version — only for non-local topologies
+            if topology != .local {
+                Divider()
+                serviceGroupRow
             }
 
-            // Architecture
-            architectureLabel
+            // Update check result (Docker/managed only)
+            if topology != .local {
+                updateCheckResultView
+            }
+
+            Divider()
+
+            // Metadata: commit SHA + architecture in a compact single line
+            metadataRow
 
             // Debug build info
             #if DEBUG
@@ -67,18 +93,19 @@ struct AboutVellumView: View {
             }
             #endif
 
-            Spacer()
-                .frame(height: VSpacing.sm)
-
-            // Check for Updates button
-            VButton(label: "Check for Updates...", style: .outlined) {
-                AppDelegate.shared?.aboutWindow?.close()
-                AppDelegate.shared?.showSettingsTab("General")
+            // Check for Updates button — handles check in-place
+            VButton(
+                label: isCheckingForUpdates ? "Checking..." : "Check for Updates",
+                style: .outlined,
+                isDisabled: isCheckingForUpdates
+            ) {
+                Task { await performUpdateCheck() }
             }
         }
         .frame(width: 320)
         .padding(VSpacing.xxl)
         .multilineTextAlignment(.center)
+        .background(VColor.surfaceBase)
         .onAppear {
             lockfileAssistants = LockfileAssistant.loadAll()
             selectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
@@ -101,38 +128,90 @@ struct AboutVellumView: View {
                     .foregroundColor(VColor.contentDefault)
                     .textSelection(.enabled)
 
-                if let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }) {
-                    let topo: AssistantTopology = assistant.isDocker ? .docker
-                        : assistant.isManaged ? .managed
-                        : assistant.cloud.lowercased() == "local" ? .local
-                        : .remote
-                    Text("(\(topologyLabel(topo)))")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
+                Text("(\(topologyLabel(topology)))")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+
+                if versionsMatch {
+                    VIconView(.circleCheck, size: 14)
+                        .foregroundColor(VColor.systemPositiveStrong)
                 }
             } else {
                 Text("Not connected")
-                    .font(VFont.body)
+                    .font(VFont.caption)
                     .foregroundColor(VColor.contentTertiary)
             }
         }
     }
 
-    // MARK: - Architecture Label
+    // MARK: - Update Check Result
 
-    private var architectureLabel: some View {
-        let label: String = {
+    @ViewBuilder
+    private var updateCheckResultView: some View {
+        if let result = updateCheckResult {
+            switch result {
+            case .upToDate:
+                HStack(spacing: VSpacing.xs) {
+                    VIconView(.circleCheck, size: 12)
+                        .foregroundColor(VColor.systemPositiveStrong)
+                    Text("You are on the latest version.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.systemPositiveStrong)
+                }
+            case .updateAvailable(let version):
+                VStack(spacing: VSpacing.sm) {
+                    HStack(spacing: VSpacing.xs) {
+                        Text("Update available:")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentTertiary)
+                        Text(version)
+                            .font(VFont.mono)
+                            .foregroundColor(VColor.primaryBase)
+                    }
+                    VButton(label: "Update in Settings", style: .outlined) {
+                        AppDelegate.shared?.aboutWindow?.close()
+                        AppDelegate.shared?.showSettingsTab("General")
+                    }
+                }
+            case .error:
+                Text("Could not check for updates.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.systemNegativeStrong)
+            }
+        }
+    }
+
+    // MARK: - Metadata Row (commit + architecture)
+
+    @ViewBuilder
+    private var metadataRow: some View {
+        let archLabel: String = {
             #if arch(arm64)
             return "Apple Silicon"
             #elseif arch(x86_64)
             return "Intel"
             #else
-            return "Unknown architecture"
+            return "Unknown"
             #endif
         }()
-        return Text(label)
-            .font(VFont.caption)
-            .foregroundColor(VColor.contentTertiary)
+
+        let commitSHA = Bundle.main.infoDictionary?["VellumCommitSHA"] as? String
+        let hasCommit = commitSHA != nil && !commitSHA!.isEmpty
+
+        HStack(spacing: VSpacing.xs) {
+            if hasCommit {
+                Text(String(commitSHA!.prefix(7)))
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.contentTertiary)
+                    .textSelection(.enabled)
+                Text("\u{00B7}")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+            }
+            Text(archLabel)
+                .font(VFont.caption)
+                .foregroundColor(VColor.contentTertiary)
+        }
     }
 
     // MARK: - Topology Label
@@ -143,6 +222,40 @@ struct AboutVellumView: View {
         case .managed: return "Managed"
         case .local: return "Local"
         case .remote: return "Remote"
+        }
+    }
+
+    // MARK: - Update Check
+
+    private func performUpdateCheck() async {
+        updateCheckResult = nil
+
+        switch topology {
+        case .local:
+            // Local: delegate to Sparkle which handles its own UI
+            AppDelegate.shared?.updateManager.checkForUpdates()
+
+        case .docker, .managed:
+            // Docker/managed: check platform API and show result inline
+            isCheckingForUpdates = true
+            defer { isCheckingForUpdates = false }
+
+            await AppDelegate.shared?.updateManager.checkServiceGroupUpdate()
+
+            if let updateManager = AppDelegate.shared?.updateManager {
+                if updateManager.isServiceGroupUpdateAvailable,
+                   let version = updateManager.serviceGroupUpdateVersion {
+                    updateCheckResult = .updateAvailable(version: version)
+                } else {
+                    updateCheckResult = .upToDate
+                }
+            } else {
+                updateCheckResult = .error
+            }
+
+        case .remote:
+            // Remote: no automatic update mechanism
+            break
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -70,24 +70,68 @@ struct AssistantUpgradeSection: View {
         return targetParsed.patch < currentParsed.patch
     }
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text(isRollback ? "Roll Back" : "Upgrade")
-                .font(VFont.sectionTitle)
-                .foregroundColor(VColor.contentDefault)
+    /// Human-readable label for the current topology.
+    private var topologySubtitle: String {
+        switch topology {
+        case .local: return "Local"
+        case .docker: return "Docker"
+        case .managed: return "Managed"
+        case .remote: return "Remote"
+        }
+    }
 
+    /// The client app version from the bundle (always available).
+    private var appVersion: String? {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    }
+
+    var body: some View {
+        SettingsCard(title: "Assistant Version", subtitle: topologySubtitle) {
+            // Version info — always visible
             VStack(alignment: .leading, spacing: VSpacing.sm) {
-                if let current = currentVersion, !current.isEmpty {
+                if topology == .local {
+                    // Local: app and service group are bundled, show single version
+                    if let version = appVersion {
+                        HStack(spacing: VSpacing.sm) {
+                            Text("Version:")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.contentTertiary)
+                            Text(version)
+                                .font(VFont.mono)
+                                .foregroundColor(VColor.contentDefault)
+                        }
+                    }
+                } else {
+                    // Docker/managed/remote: show both app and service group versions
+                    if let version = appVersion {
+                        HStack(spacing: VSpacing.sm) {
+                            Text("App version:")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.contentTertiary)
+                            Text(version)
+                                .font(VFont.mono)
+                                .foregroundColor(VColor.contentDefault)
+                        }
+                    }
                     HStack(spacing: VSpacing.sm) {
-                        Text("Current version:")
+                        Text("Service group:")
                             .font(VFont.caption)
                             .foregroundColor(VColor.contentTertiary)
-                        Text(current)
-                            .font(VFont.mono)
-                            .foregroundColor(VColor.contentDefault)
+                        if let sgVersion = currentVersion, !sgVersion.isEmpty {
+                            Text(sgVersion)
+                                .font(VFont.mono)
+                                .foregroundColor(VColor.contentDefault)
+                        } else {
+                            Text("Loading...")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.contentTertiary)
+                        }
                     }
                 }
+            }
 
+            // Update status
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
                 if topology == .local {
                     if sparkleUpdateAvailable, let updateVersion = sparkleUpdateVersion {
                         HStack(spacing: VSpacing.sm) {
@@ -98,10 +142,14 @@ struct AssistantUpgradeSection: View {
                                 .font(VFont.mono)
                                 .foregroundColor(VColor.primaryBase)
                         }
-                    } else if !sparkleUpdateAvailable && currentVersion != nil {
-                        Text("You are on the latest version.")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.systemPositiveStrong)
+                    } else if !sparkleUpdateAvailable {
+                        HStack(spacing: VSpacing.xs) {
+                            VIconView(.circleCheck, size: 12)
+                                .foregroundColor(VColor.systemPositiveStrong)
+                            Text("You are on the latest version.")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.systemPositiveStrong)
+                        }
                     }
                 }
 
@@ -125,11 +173,15 @@ struct AssistantUpgradeSection: View {
                 }
 
                 if !upgradeAvailable && !isLoadingReleases && !availableReleases.isEmpty && topology != .local {
-                    Text(selectedVersion == nil
-                         ? "You are on the latest version."
-                         : "You are already on this version.")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.systemPositiveStrong)
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.circleCheck, size: 12)
+                            .foregroundColor(VColor.systemPositiveStrong)
+                        Text(selectedVersion == nil
+                             ? "You are on the latest version."
+                             : "You are already on this version.")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.systemPositiveStrong)
+                    }
                 }
 
                 if availableReleases.isEmpty && !isLoadingReleases && errorMessage == nil && topology != .local {
@@ -151,7 +203,7 @@ struct AssistantUpgradeSection: View {
 
             HStack(spacing: VSpacing.md) {
                 if topology == .local {
-                    VButton(label: "Check for App Updates", style: .outlined) {
+                    VButton(label: "Check for Updates", style: .outlined) {
                         AppDelegate.shared?.updateManager.checkForUpdates()
                     }
                 } else if topology != .remote {
@@ -200,9 +252,6 @@ struct AssistantUpgradeSection: View {
                     .foregroundColor(VColor.systemPositiveStrong)
             }
         }
-        .padding(VSpacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(background: VColor.surfaceOverlay)
         .task { await loadReleases() }
         .onChange(of: currentVersion) { _, _ in
             Task { await loadReleasesQuietly() }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -36,10 +36,6 @@ struct SettingsGeneralTab: View {
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             accountSection
-            if MacOSClientFeatureFlagManager.shared.isEnabled("mobile_pairing_enabled") {
-                mobilePairingCard
-            }
-            SettingsAppearanceTab(store: store)
             if !lockfileAssistants.isEmpty {
                 AssistantUpgradeSection(
                     currentVersion: healthz?.version,
@@ -50,6 +46,10 @@ struct SettingsGeneralTab: View {
                     sparkleUpdateVersion: sparkleUpdateVersion
                 )
             }
+            if MacOSClientFeatureFlagManager.shared.isEnabled("mobile_pairing_enabled") {
+                mobilePairingCard
+            }
+            SettingsAppearanceTab(store: store)
         }
         .onAppear {
             Task { await authManager.checkSession() }


### PR DESCRIPTION
## Summary
Followup changes that were pushed to the feature branch after #20325 was merged:

- Rename card from "Software Update" to "Assistant Version", reposition between Account and Mobile in General tab
- About panel: in-place update check (local triggers Sparkle, Docker/managed shows result inline with "Update in Settings" deep-link), hide Service Group row for local topology, fix text sizes, transparent titlebar
- Route Docker/managed to Settings by topology (not update availability), fix checkForUpdates() access level to public
- Always show version info in the card (app version from Bundle.main, not just healthz)
- Checkmark icons on "up to date" status messages
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
