### PR TITLE
feat: make Fish Audio latency mode configurable

### DIFF
--- a/assistant/src/calls/fish-audio-client.ts
+++ b/assistant/src/calls/fish-audio-client.ts
@@ -18,6 +18,7 @@ interface StartEvent {
     reference_id?: string;
     format?: string;
     sample_rate?: number;
+    mp3_bitrate?: number;
     chunk_length?: number;
     normalize?: boolean;
     latency?: string;
@@ -122,8 +123,9 @@ export class FishAudioSession {
             text: "",
             reference_id: config.referenceId || undefined,
             format: config.format,
+            mp3_bitrate: 192,
             chunk_length: config.chunkLength,
-            latency: "balanced",
+            latency: config.latency,
             prosody:
               config.speed !== 1.0 ? { speed: config.speed } : undefined,
           },

--- a/assistant/src/config/schemas/fish-audio.ts
+++ b/assistant/src/config/schemas/fish-audio.ts
@@ -19,6 +19,14 @@ export const FishAudioConfigSchema = z
       })
       .default("mp3")
       .describe("Output audio format"),
+    latency: z
+      .enum(["normal", "balanced"], {
+        error: "fishAudio.latency must be one of: normal, balanced",
+      })
+      .default("normal")
+      .describe(
+        "Latency/quality tradeoff for Fish Audio S2 synthesis. 'normal' prioritizes lower latency; 'balanced' trades latency for higher quality.",
+      ),
     speed: z
       .number({ error: "fishAudio.speed must be a number" })
       .min(0.5, "fishAudio.speed must be >= 0.5")


### PR DESCRIPTION
## Summary
- Adds latency field to Fish Audio config schema with options: normal, balanced (default: normal)
- Previously hardcoded as balanced — now reads from config
- Normal mode prioritizes lower latency for phone calls
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
