### PR TITLE
fix: clean up stale diagnostics export references

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1604,7 +1604,7 @@ public struct ChatMessage: Identifiable, Equatable {
     public var conversationError: ConversationError?
     /// The daemon's persisted message ID, populated from history responses.
     /// Nil for freshly streamed messages that haven't been loaded from history.
-    /// Used for anchoring diagnostics exports so the daemon can locate the message.
+    /// Used for fork-from-message, inspect LLM context, TTS, and other daemon-anchored actions.
     public var daemonMessageId: String?
     /// When true, this message is a subagent notification (e.g. completed/failed/aborted)
     /// reconstructed from history. It should be hidden from the chat UI since the

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -640,8 +640,8 @@ extension ChatViewModel {
             // Flush any buffered streaming text before finalizing the message.
             flushStreamingBuffer()
             flushPartialOutputBuffer()
-            // Backfill the daemon's persisted message ID so diagnostics exports
-            // can anchor to it without requiring a history reload.
+            // Backfill the daemon's persisted message ID so fork, inspect,
+            // TTS, and other daemon-anchored actions work without a history reload.
             if let messageId = complete.messageId,
                let msgId = currentAssistantMessageId,
                let idx = messages.firstIndex(where: { $0.id == msgId }) {
@@ -1001,8 +1001,8 @@ extension ChatViewModel {
             // Keep isSending = true — daemon is handing off to next queued message
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
-                // Backfill the daemon's persisted message ID so diagnostics exports
-                // can anchor to it without requiring a history reload.
+                // Backfill the daemon's persisted message ID so fork, inspect,
+                // TTS, and other daemon-anchored actions work without a history reload.
                 if let messageId = handoff.messageId {
                     messages[index].daemonMessageId = messageId
                 }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2901,9 +2901,9 @@ public final class ChatViewModel: ObservableObject {
                 )
             }
 
-            // Store the daemon's persisted message ID so diagnostics exports can
-            // anchor to it. This is the database ID from the daemon, not the
-            // client-side UUID.
+            // Store the daemon's persisted message ID so fork, inspect, TTS,
+            // and other daemon-anchored actions can locate it. This is the
+            // database ID from the daemon, not the client-side UUID.
             chatMsg.daemonMessageId = item.id
 
             // Preserve truncation flag so the UI can offer on-demand rehydration.

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -1279,32 +1279,6 @@ public struct DeleteQueuedMessage: Codable, Sendable {
     }
 }
 
-public struct DiagnosticsExportRequest: Codable, Sendable {
-    public let type: String
-    public let conversationId: String
-    public let anchorMessageId: String?
-
-    public init(type: String, conversationId: String, anchorMessageId: String? = nil) {
-        self.type = type
-        self.conversationId = conversationId
-        self.anchorMessageId = anchorMessageId
-    }
-}
-
-public struct DiagnosticsExportResponse: Codable, Sendable {
-    public let type: String
-    public let success: Bool
-    public let filePath: String?
-    public let error: String?
-
-    public init(type: String, success: Bool, filePath: String? = nil, error: String? = nil) {
-        self.type = type
-        self.success = success
-        self.filePath = filePath
-        self.error = error
-    }
-}
-
 public struct DictationContext: Codable, Sendable {
     public let bundleIdentifier: String
     public let appName: String


### PR DESCRIPTION
## Summary
- Update 4 comments that still referenced diagnostics exports to reflect actual uses of daemonMessageId (fork, inspect, TTS)
- Remove dead DiagnosticsExportRequest and DiagnosticsExportResponse from GeneratedAPITypes.swift

Follow-up cleanup for remove-report-message.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
