### PR TITLE
feat: increase Fish Audio MP3 bitrate to 192kbps

### DIFF
--- a/assistant/src/calls/fish-audio-client.ts
+++ b/assistant/src/calls/fish-audio-client.ts
@@ -18,6 +18,7 @@ interface StartEvent {
     reference_id?: string;
     format?: string;
     sample_rate?: number;
+    mp3_bitrate?: number;
     chunk_length?: number;
     normalize?: boolean;
     latency?: string;
@@ -122,6 +123,7 @@ export class FishAudioSession {
             text: "",
             reference_id: config.referenceId || undefined,
             format: config.format,
+            mp3_bitrate: 192,
             chunk_length: config.chunkLength,
             latency: "balanced",
             prosody:


### PR DESCRIPTION
## Summary
- Adds mp3_bitrate: 192 to the Fish Audio S2 StartEvent request
- Higher bitrate reduces compression artifacts in phone call audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)