### PR TITLE
Rename ConnectionManager → GatewayConnectionManager

### DIFF
--- a/clients/shared/Network/DaemonStatus.swift
+++ b/clients/shared/Network/DaemonStatus.swift
@@ -18,7 +18,7 @@ public protocol DaemonStatusProtocol: AnyObject {
 /// Observable status of the assistant daemon connection. Publishes connection state,
 /// daemon version, model info, and other status properties derived from SSE events.
 ///
-/// Pure state object — connection lifecycle is managed by `ConnectionManager`,
+/// Pure state object — connection lifecycle is managed by `GatewayConnectionManager`,
 /// SSE and message broadcast by `EventStreamClient`. This class wires the three
 /// together and reacts to events by updating `@Published` properties.
 @MainActor
@@ -92,7 +92,7 @@ public final class DaemonStatus: ObservableObject, DaemonStatusProtocol {
     public let eventStreamClient: EventStreamClient
 
     /// Connection lifecycle manager (health checks, auto-wake, transport).
-    public let connectionManager: ConnectionManager
+    public let connectionManager: GatewayConnectionManager
 
     // MARK: - Forwarding accessors (backward compat)
 
@@ -135,7 +135,7 @@ public final class DaemonStatus: ObservableObject, DaemonStatusProtocol {
     public init(config: DaemonConfig = .default) {
         let esc = EventStreamClient()
         self.eventStreamClient = esc
-        self.connectionManager = ConnectionManager(config: config, eventStreamClient: esc)
+        self.connectionManager = GatewayConnectionManager(config: config, eventStreamClient: esc)
 
         // Wire the pre-processor so state is updated before subscribers see messages
         esc.messagePreProcessor = { [weak self] message in
@@ -156,7 +156,7 @@ public final class DaemonStatus: ObservableObject, DaemonStatusProtocol {
             #endif
         }
 
-        // Wire ConnectionManager callbacks to update DaemonStatus state.
+        // Wire GatewayConnectionManager callbacks to update DaemonStatus state.
         connectionManager.onConnectionStateChanged = { [weak self] connected in
             guard let self else { return }
             self.isConnected = connected

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -1,16 +1,16 @@
 import Foundation
 import os
 
-private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ConnectionManager")
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "GatewayConnectionManager")
 
-/// Manages the HTTP transport connection lifecycle: connect, disconnect,
+/// Manages the gateway connection lifecycle: connect, disconnect,
 /// reconfigure, auto-wake, and bearer token updates.
 ///
 /// Owns `HTTPTransport` (health checks) and coordinates with `EventStreamClient`
 /// (SSE start/stop). Does NOT own published state — `DaemonStatus` observes
 /// this manager's callbacks to update its `@Published` properties.
 @MainActor
-public final class ConnectionManager {
+public final class GatewayConnectionManager {
 
     // MARK: - Transport
 


### PR DESCRIPTION
## Summary

- Rename `ConnectionManager` → `GatewayConnectionManager` to reflect that this manager handles the gateway connection lifecycle
- As the architecture moves toward gateway-only connections (no direct daemon runtime contact), the name aligns with the target state
- Pure rename — no logic changes

Stacked on #20204.

## Test plan

- [x] `swift build` passes
- [x] `swift test` — all 156 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
