### PR TITLE
fix: add loading state and deferred status for local Check for Updates

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
@@ -69,10 +69,8 @@ struct AboutVellumView: View {
                 serviceGroupRow
             }
 
-            // Update check result (Docker/managed only)
-            if topology != .local {
-                updateCheckResultView
-            }
+            // Update check result
+            updateCheckResultView
 
             Divider()
 
@@ -148,7 +146,15 @@ struct AboutVellumView: View {
 
     @ViewBuilder
     private var updateCheckResultView: some View {
-        if let result = updateCheckResult {
+        if isCheckingForUpdates {
+            HStack(spacing: VSpacing.sm) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Checking for updates...")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+            }
+        } else if let result = updateCheckResult {
             switch result {
             case .upToDate:
                 HStack(spacing: VSpacing.xs) {
@@ -229,11 +235,20 @@ struct AboutVellumView: View {
 
     private func performUpdateCheck() async {
         updateCheckResult = nil
+        isCheckingForUpdates = true
 
         switch topology {
         case .local:
-            // Local: delegate to Sparkle which handles its own UI
+            // Local: trigger Sparkle and show result inline after a brief wait
             AppDelegate.shared?.updateManager.checkForUpdates()
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            let sparkleAvailable = AppDelegate.shared?.updateManager.isUpdateAvailable ?? false
+            if sparkleAvailable, let version = AppDelegate.shared?.updateManager.availableUpdateVersion {
+                updateCheckResult = .updateAvailable(version: version)
+            } else {
+                updateCheckResult = .upToDate
+            }
+            isCheckingForUpdates = false
 
         case .docker, .managed:
             // Docker/managed: check platform API and show result inline

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -35,6 +35,8 @@ struct AssistantUpgradeSection: View {
     @State private var errorMessage: String?
     @State private var successMessage: String?
     @State private var showingUpgradeConfirmation = false
+    @State private var isCheckingLocal = false
+    @State private var hasCheckedForUpdates = false
 
     private var latestRelease: AssistantRelease? {
         availableReleases.first
@@ -142,13 +144,23 @@ struct AssistantUpgradeSection: View {
                                 .font(VFont.mono)
                                 .foregroundColor(VColor.primaryBase)
                         }
-                    } else if !sparkleUpdateAvailable {
+                    } else if hasCheckedForUpdates && !sparkleUpdateAvailable {
                         HStack(spacing: VSpacing.xs) {
                             VIconView(.circleCheck, size: 12)
                                 .foregroundColor(VColor.systemPositiveStrong)
                             Text("You are on the latest version.")
                                 .font(VFont.caption)
                                 .foregroundColor(VColor.systemPositiveStrong)
+                        }
+                    }
+
+                    if isCheckingLocal {
+                        HStack(spacing: VSpacing.sm) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("Checking for updates...")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.contentTertiary)
                         }
                     }
                 }
@@ -203,8 +215,20 @@ struct AssistantUpgradeSection: View {
 
             HStack(spacing: VSpacing.md) {
                 if topology == .local {
-                    VButton(label: "Check for Updates", style: .outlined) {
-                        AppDelegate.shared?.updateManager.checkForUpdates()
+                    VButton(
+                        label: isCheckingLocal ? "Checking..." : "Check for Updates",
+                        style: .outlined,
+                        isDisabled: isCheckingLocal
+                    ) {
+                        Task {
+                            isCheckingLocal = true
+                            AppDelegate.shared?.updateManager.checkForUpdates()
+                            try? await Task.sleep(nanoseconds: 2_000_000_000)
+                            sparkleUpdateAvailable = AppDelegate.shared?.updateManager.isUpdateAvailable ?? false
+                            sparkleUpdateVersion = AppDelegate.shared?.updateManager.availableUpdateVersion
+                            hasCheckedForUpdates = true
+                            isCheckingLocal = false
+                        }
                     }
                 } else if topology != .remote {
                     // Docker and managed get the upgrade button


### PR DESCRIPTION
## Summary
- Add loading state ("Checking..." button + spinner) when clicking "Check for Updates" on local topology in both Settings card and About panel
- Defer "You are on the latest version" message until after the user actively checks (no longer shows on load)
- About panel shows inline loading spinner and result for all topologies including local
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
