### PR TITLE
Suppress drop zone overlay for internal image drags

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -3,6 +3,12 @@ import SwiftUI
 import UniformTypeIdentifiers
 import VellumAssistantShared
 
+/// Posted when an image drag begins from within the chat UI.
+/// ChatView observes this to suppress the drop zone overlay for internal drags.
+extension Notification.Name {
+    static let internalImageDragStarted = Notification.Name("com.vellum.internalImageDragStarted")
+}
+
 // MARK: - Image Context Menu Actions
 
 /// Standalone helper for image context menu actions used by both
@@ -196,6 +202,7 @@ private struct InlineToolCallImageView: View {
                 ImageActions.contextMenuItems(image: image, filename: "image.png")
             }
             .onDrag {
+                NotificationCenter.default.post(name: .internalImageDragStarted, object: nil)
                 let provider = NSItemProvider()
                 if let tiff = image.tiffRepresentation,
                    let rep = NSBitmapImageRep(data: tiff),
@@ -205,7 +212,7 @@ private struct InlineToolCallImageView: View {
                         return nil
                     }
                 }
-                provider.suggestedName = "image.png"
+                provider.suggestedName = "image"
                 return provider
             }
             .pointerCursor()
@@ -283,6 +290,7 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                                 )
                             }
                             .onDrag {
+                                NotificationCenter.default.post(name: .internalImageDragStarted, object: nil)
                                 let provider = NSItemProvider()
                                 let hasBase64 = !attachment.data.isEmpty
 
@@ -320,11 +328,8 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                                 }
                                 // Force .png extension when falling back to PNG encoding
                                 let filename = attachment.filename
-                                if hasBase64 {
-                                    provider.suggestedName = filename
-                                } else {
-                                    provider.suggestedName = (filename as NSString).deletingPathExtension + ".png"
-                                }
+                                // Strip extension — Finder appends it from the UTType
+                                provider.suggestedName = (filename as NSString).deletingPathExtension
                                 return provider
                             }
                             .pointerCursor()

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -127,7 +127,8 @@ struct ChatView: View {
     @State private var isNearBottom = true
     @State private var isDropTargeted = false
     @State private var isDraggingInternalImage = false
-    @State private var dragEndMonitor: Any?
+    @State private var dragEndLocalMonitor: Any?
+    @State private var dragEndGlobalMonitor: Any?
     @State private var containerWidth: CGFloat = 0
 
     // MARK: - In-Chat Search (Cmd+F)
@@ -403,18 +404,12 @@ struct ChatView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .internalImageDragStarted)) { _ in
             isDraggingInternalImage = true
-            // Install a one-shot mouse-up monitor to detect when the drag ends,
-            // regardless of where the drop lands (chat, Finder, Desktop, or cancel).
-            if dragEndMonitor == nil {
-                dragEndMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { event in
-                    isDraggingInternalImage = false
-                    if let monitor = dragEndMonitor {
-                        NSEvent.removeMonitor(monitor)
-                        dragEndMonitor = nil
-                    }
-                    return event
-                }
-            }
+            // Install one-shot monitors to detect when the drag ends.
+            // NSDraggingSession consumes the drag-ending mouse-up internally,
+            // so a single local monitor misses drops on external apps.
+            // Global monitor catches mouse-up in other apps (Finder, Desktop).
+            // Local monitor catches mouse-up within our app (cancel + release).
+            installDragEndMonitors()
         }
         .onChange(of: shouldShowSkeleton, initial: true) { _, shouldShow in
             skeletonDebounceTask?.cancel()
@@ -427,6 +422,9 @@ struct ChatView: View {
             } else {
                 showSkeleton = false
             }
+        }
+        .onDisappear {
+            removeDragEndMonitors()
         }
     }
 
@@ -485,6 +483,39 @@ struct ChatView: View {
         }
     }
 
+    // MARK: - Internal Drag Detection
+
+    /// Installs one-shot global + local mouse-up monitors to detect drag-end.
+    /// Global monitor catches drops on external apps (Finder, Desktop).
+    /// Local monitor catches in-app mouse-up (post-cancel click, etc.).
+    /// Both are removed after firing once.
+    private func installDragEndMonitors() {
+        removeDragEndMonitors()
+
+        dragEndGlobalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseUp) { [self] _ in
+            isDraggingInternalImage = false
+            removeDragEndMonitors()
+        }
+
+        dragEndLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { [self] event in
+            isDraggingInternalImage = false
+            removeDragEndMonitors()
+            return event
+        }
+    }
+
+    /// Removes both drag-end monitors if installed.
+    private func removeDragEndMonitors() {
+        if let monitor = dragEndGlobalMonitor {
+            NSEvent.removeMonitor(monitor)
+            dragEndGlobalMonitor = nil
+        }
+        if let monitor = dragEndLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            dragEndLocalMonitor = nil
+        }
+    }
+
     /// Handle dropped items — supports both file URLs and raw image data.
     /// File URLs are preferred (preserves original filenames); raw image data
     /// is used as a fallback for providers without a backing file (e.g. screenshot
@@ -499,6 +530,7 @@ struct ChatView: View {
         // assistant-rendered image to Finder/Desktop, not uploading it back.
         if isDraggingInternalImage {
             isDraggingInternalImage = false
+            removeDragEndMonitors()
             return false
         }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -126,6 +126,8 @@ struct ChatView: View {
 
     @State private var isNearBottom = true
     @State private var isDropTargeted = false
+    @State private var isDraggingInternalImage = false
+    @State private var dragEndMonitor: Any?
     @State private var containerWidth: CGFloat = 0
 
     // MARK: - In-Chat Search (Cmd+F)
@@ -321,8 +323,8 @@ struct ChatView: View {
             }
             .animation(VAnimation.fast, value: btwResponse != nil)
 
-            // Drop target overlay
-            if isDropTargeted {
+            // Drop target overlay — hidden for internal image drags
+            if isDropTargeted && !isDraggingInternalImage {
                 RoundedRectangle(cornerRadius: VRadius.lg)
                     .stroke(VColor.primaryBase, style: StrokeStyle(lineWidth: 2, dash: [8, 4]))
                     .background(
@@ -398,6 +400,21 @@ struct ChatView: View {
                 return
             }
             activateSearch()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .internalImageDragStarted)) { _ in
+            isDraggingInternalImage = true
+            // Install a one-shot mouse-up monitor to detect when the drag ends,
+            // regardless of where the drop lands (chat, Finder, Desktop, or cancel).
+            if dragEndMonitor == nil {
+                dragEndMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { event in
+                    isDraggingInternalImage = false
+                    if let monitor = dragEndMonitor {
+                        NSEvent.removeMonitor(monitor)
+                        dragEndMonitor = nil
+                    }
+                    return event
+                }
+            }
         }
         .onChange(of: shouldShowSkeleton, initial: true) { _, shouldShow in
             skeletonDebounceTask?.cancel()
@@ -477,6 +494,13 @@ struct ChatView: View {
         // reset reliably when AppKit's NSDraggingDestination (e.g. the
         // NSTextView inside the composer) intercepts the drag session.
         isDropTargeted = false
+
+        // Reject drops from internal image drags — the user is dragging an
+        // assistant-rendered image to Finder/Desktop, not uploading it back.
+        if isDraggingInternalImage {
+            isDraggingInternalImage = false
+            return false
+        }
 
         // Signal loading immediately so the "Processing…" chip appears without
         // waiting for NSItemProvider async callbacks to resolve.


### PR DESCRIPTION
## Summary
- Suppress the "Drop files here" overlay when dragging assistant-rendered images within the chat — the user is dragging to Finder/Desktop, not uploading back to the assistant
- Reject internal image drops in the handleDrop handler so they don't appear in the composer
- Fix double `.png` extension on dragged files (e.g., `image.png.png` → `image.png`)

## How it works
- Image `.onDrag` closures post a `Notification` when drag starts
- `ChatView` listens for it and sets `isDraggingInternalImage = true`
- An `NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp)` monitor clears the flag when the drag ends (regardless of where the drop lands)
- The drop overlay is conditionally hidden: `isDropTargeted && !isDraggingInternalImage`
- `handleDrop` returns `false` early for internal drags
- External file drops from Finder/other apps are completely unaffected

## Test plan
- [ ] Drag an assistant-rendered image over the chat — drop zone overlay should NOT appear
- [ ] Drop an internal image on the chat — should NOT be processed/attached
- [ ] Drag an internal image to Desktop/Finder — should create file as `image.png` (not `image.png.png`)
- [ ] Drag a file from Finder onto the chat — drop zone SHOULD appear and file SHOULD be attached
- [ ] Drag an image from another app onto the chat — should work normally
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
