### PR TITLE
feat: add skipDisclosure parameter to call_start tool

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -119,6 +119,8 @@ export class CallController {
   private task: string | null;
   /** True when the call session was created via the inbound path (no outbound task). */
   private isInbound: boolean;
+  /** When true, the disclosure announcement is skipped for this call. */
+  private skipDisclosure: boolean;
   /** Instructions queued while an LLM turn is in-flight or during pending guardian input */
   private pendingInstructions: string[] = [];
   /** Ensures the call opener is triggered at most once per call. */
@@ -170,9 +172,10 @@ export class CallController {
     this.assistantId = opts?.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
     this.trustContext = opts?.trustContext ?? null;
 
-    // Resolve the conversation ID from the call session
+    // Resolve the conversation ID and skipDisclosure from the call session
     const session = getCallSession(callSessionId);
     this.conversationId = session?.conversationId ?? callSessionId;
+    this.skipDisclosure = session?.skipDisclosure ?? false;
 
     this.startDurationTimer();
     this.resetSilenceTimer();
@@ -673,6 +676,7 @@ export class CallController {
         trustContext: this.trustContext ?? undefined,
         isInbound: this.isInbound,
         task: this.task,
+        skipDisclosure: this.skipDisclosure,
         onTextDelta,
         onComplete,
         onError,

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -85,6 +85,7 @@ export type StartCallInput = {
   conversationId: string;
   assistantId?: string;
   callerIdentityMode?: "assistant_number" | "user_number";
+  skipDisclosure?: boolean;
 };
 
 export type CancelCallInput = {
@@ -364,6 +365,7 @@ export async function startCall(
     context: callContext,
     conversationId,
     callerIdentityMode,
+    skipDisclosure,
     assistantId = DAEMON_INTERNAL_ASSISTANT_ID,
   } = input;
 
@@ -440,6 +442,7 @@ export async function startCall(
       task: callContext ? `${task}\n\nContext: ${callContext}` : task,
       callerIdentityMode: identityResult.mode,
       callerIdentitySource: identityResult.source,
+      skipDisclosure,
       initiatedFromConversationId: conversationId,
     });
     sessionId = session.id;

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -41,6 +41,10 @@ const parseCallSession = createRowMapper<
   inviteGuardianName: "inviteGuardianName",
   callerIdentityMode: "callerIdentityMode",
   callerIdentitySource: "callerIdentitySource",
+  skipDisclosure: {
+    from: "skipDisclosure",
+    transform: (v: unknown) => v === 1,
+  },
   initiatedFromConversationId: "initiatedFromConversationId",
   startedAt: "startedAt",
   endedAt: "endedAt",
@@ -87,11 +91,13 @@ export function createCallSession(opts: {
   inviteGuardianName?: string;
   callerIdentityMode?: string;
   callerIdentitySource?: string;
+  skipDisclosure?: boolean;
   initiatedFromConversationId?: string;
 }): CallSession {
   const db = getDb();
   const now = Date.now();
-  const session = {
+  const skipDisclosure = opts.skipDisclosure ?? false;
+  const row = {
     id: uuid(),
     conversationId: opts.conversationId,
     provider: opts.provider,
@@ -106,6 +112,7 @@ export function createCallSession(opts: {
     inviteGuardianName: opts.inviteGuardianName ?? null,
     callerIdentityMode: opts.callerIdentityMode ?? null,
     callerIdentitySource: opts.callerIdentitySource ?? null,
+    skipDisclosure: skipDisclosure ? 1 : 0,
     initiatedFromConversationId: opts.initiatedFromConversationId ?? null,
     startedAt: null,
     endedAt: null,
@@ -113,8 +120,8 @@ export function createCallSession(opts: {
     createdAt: now,
     updatedAt: now,
   };
-  db.insert(callSessions).values(session).run();
-  return session;
+  db.insert(callSessions).values(row).run();
+  return { ...row, skipDisclosure };
 }
 
 export function getCallSession(id: string): CallSession | null {

--- a/assistant/src/calls/types.ts
+++ b/assistant/src/calls/types.ts
@@ -75,6 +75,7 @@ export interface CallSession {
   inviteGuardianName: string | null;
   callerIdentityMode: string | null;
   callerIdentitySource: string | null;
+  skipDisclosure: boolean;
   initiatedFromConversationId?: string | null;
   startedAt: number | null;
   endedAt: number | null;

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -95,6 +95,8 @@ export interface VoiceTurnOptions {
   isInbound: boolean;
   /** The outbound call task, if any. */
   task?: string | null;
+  /** When true, skip the disclosure announcement for this call. */
+  skipDisclosure?: boolean;
   /** Called for each streaming text token from the agent loop. */
   onTextDelta: (text: string) => void;
   /** Called when the agent loop completes a full response. */
@@ -128,9 +130,11 @@ function buildVoiceCallControlPrompt(opts: {
   isInbound: boolean;
   task?: string | null;
   isCallerGuardian?: boolean;
+  skipDisclosure?: boolean;
 }): string {
   const config = getConfig();
-  const disclosureEnabled = config.calls?.disclosure?.enabled === true;
+  const disclosureEnabled =
+    config.calls?.disclosure?.enabled === true && !opts.skipDisclosure;
   const disclosureText = config.calls?.disclosure?.text?.trim();
   const disclosureRule =
     disclosureEnabled && disclosureText
@@ -286,6 +290,7 @@ export async function startVoiceTurn(
     isInbound: opts.isInbound,
     task: opts.task,
     isCallerGuardian,
+    skipDisclosure: opts.skipDisclosure,
   });
 
   // Get or create the conversation

--- a/assistant/src/config/bundled-skills/phone-calls/TOOLS.json
+++ b/assistant/src/config/bundled-skills/phone-calls/TOOLS.json
@@ -26,6 +26,10 @@
             "enum": ["assistant_number", "user_number"],
             "description": "Which phone number to use as the caller ID. assistant_number uses the AI assistant's Twilio number; user_number uses the user's verified personal number."
           },
+          "skip_disclosure": {
+            "type": "boolean",
+            "description": "Skip the disclosure announcement at the start of the call. Set to true when calling someone who already knows who you are (e.g. your guardian, a family member, or a close contact)."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -41,6 +41,7 @@ import {
   migrateBackfillUsageCacheAccounting,
   migrateCallSessionInviteMetadata,
   migrateCallSessionMode,
+  migrateCallSessionSkipDisclosure,
   migrateCanonicalGuardianDeliveriesDestinationIndex,
   migrateCanonicalGuardianRequesterChatId,
   migrateCapabilityCardColumns,
@@ -491,6 +492,9 @@ export function initializeDb(): void {
 
   // 86. Drop simplified-memory tables and reducer checkpoint columns
   migrateDropSimplifiedMemory(database);
+
+  // 87. Add skip_disclosure column to call_sessions for per-call disclosure control
+  migrateCallSessionSkipDisclosure(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/190-call-session-skip-disclosure.ts
+++ b/assistant/src/memory/migrations/190-call-session-skip-disclosure.ts
@@ -1,0 +1,15 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Add skip_disclosure column to call_sessions so outbound calls can
+ * skip the disclosure announcement on a per-call basis.
+ */
+export function migrateCallSessionSkipDisclosure(database: DrizzleDb): void {
+  try {
+    database.run(
+      /*sql*/ `ALTER TABLE call_sessions ADD COLUMN skip_disclosure INTEGER NOT NULL DEFAULT 0`,
+    );
+  } catch {
+    /* already exists */
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -128,6 +128,7 @@ export { migrateConversationForkLineage } from "./183-add-conversation-fork-line
 export { migrateLlmRequestLogProvider } from "./184-llm-request-log-provider.js";
 export { migrateScheduleQuietFlag } from "./188-schedule-quiet-flag.js";
 export { migrateDropSimplifiedMemory } from "./189-drop-simplified-memory.js";
+export { migrateCallSessionSkipDisclosure } from "./190-call-session-skip-disclosure.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/calls.ts
+++ b/assistant/src/memory/schema/calls.ts
@@ -27,6 +27,7 @@ export const callSessions = sqliteTable(
     inviteGuardianName: text("invite_guardian_name"),
     callerIdentityMode: text("caller_identity_mode"),
     callerIdentitySource: text("caller_identity_source"),
+    skipDisclosure: integer("skip_disclosure").notNull().default(0),
     initiatedFromConversationId: text("initiated_from_conversation_id"),
     startedAt: integer("started_at"),
     endedAt: integer("ended_at"),

--- a/assistant/src/tools/calls/call-start.ts
+++ b/assistant/src/tools/calls/call-start.ts
@@ -46,6 +46,7 @@ export async function executeCallStart(
       | "assistant_number"
       | "user_number"
       | undefined,
+    skipDisclosure: input.skip_disclosure === true,
   });
 
   if (!result.ok) {


### PR DESCRIPTION
## Summary
- Adds optional `skip_disclosure` boolean to the `call_start` tool input schema
- When true, skips the disclosure announcement at the start of the call
- Tool description guides the LLM to use this when calling someone who knows who you are
- Falls back to "Begin the conversation naturally." when disclosure is skipped
- Adds `skip_disclosure` column to `call_sessions` DB table with migration
- Threads the flag through: tool executor -> startCall -> CallSession -> CallController -> startVoiceTurn -> buildVoiceCallControlPrompt

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All relevant tests pass (voice-session-bridge, call-controller, call-store, call-start-guardian-guard, config-schema)
- [x] Pre-existing failures confirmed unrelated (17 failures exist with and without changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)