### PR TITLE
refactor: remove Check for Updates menu items from app menu and status bar

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -26,10 +26,6 @@ struct VellumAssistantApp: App {
                 Button("About \(appName)") {
                     appDelegate.showAboutPanel()
                 }
-                Button(appDelegate.updateManager.updateMenuItemTitle) {
-                    appDelegate.checkForUpdates()
-                }
-                .disabled(!appDelegate.updateManager.updateMenuItemIsEnabled)
                 Divider()
                 Button("Share Feedback") {
                     appDelegate.sendLogsToSentry()

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -285,14 +285,6 @@ extension AppDelegate {
         newChatItem.image = VIcon.messageCirclePlus.nsImage(size: 16)
         menu.addItem(newChatItem)
 
-        menu.addItem(NSMenuItem.separator())
-
-        let updateItem = NSMenuItem(title: updateManager.updateMenuItemTitle, action: #selector(checkForUpdates), keyEquivalent: "")
-        updateItem.target = self
-        updateItem.isEnabled = updateManager.updateMenuItemIsEnabled
-        updateItem.image = VIcon.circleArrowDown.nsImage(size: 16)
-        menu.addItem(updateItem)
-
         if MacOSClientFeatureFlagManager.shared.isEnabled("developer_menu_items_enabled") {
             menu.addItem(NSMenuItem.separator())
 

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -37,6 +37,8 @@ struct AssistantUpgradeSection: View {
     @State private var showingUpgradeConfirmation = false
     @State private var isCheckingLocal = false
     @State private var hasCheckedForUpdates = false
+    @State private var checkedSparkleAvailable: Bool?
+    @State private var checkedSparkleVersion: String?
 
     private var latestRelease: AssistantRelease? {
         availableReleases.first
@@ -135,7 +137,9 @@ struct AssistantUpgradeSection: View {
             // Update status
             VStack(alignment: .leading, spacing: VSpacing.sm) {
                 if topology == .local {
-                    if sparkleUpdateAvailable, let updateVersion = sparkleUpdateVersion {
+                    let effectiveAvailable = checkedSparkleAvailable ?? sparkleUpdateAvailable
+                    let effectiveVersion = checkedSparkleVersion ?? sparkleUpdateVersion
+                    if effectiveAvailable, let updateVersion = effectiveVersion {
                         HStack(spacing: VSpacing.sm) {
                             Text("Update available:")
                                 .font(VFont.caption)
@@ -144,7 +148,7 @@ struct AssistantUpgradeSection: View {
                                 .font(VFont.mono)
                                 .foregroundColor(VColor.primaryBase)
                         }
-                    } else if hasCheckedForUpdates && !sparkleUpdateAvailable {
+                    } else if hasCheckedForUpdates && !effectiveAvailable {
                         HStack(spacing: VSpacing.xs) {
                             VIconView(.circleCheck, size: 12)
                                 .foregroundColor(VColor.systemPositiveStrong)
@@ -224,8 +228,8 @@ struct AssistantUpgradeSection: View {
                             isCheckingLocal = true
                             AppDelegate.shared?.updateManager.checkForUpdates()
                             try? await Task.sleep(nanoseconds: 2_000_000_000)
-                            sparkleUpdateAvailable = AppDelegate.shared?.updateManager.isUpdateAvailable ?? false
-                            sparkleUpdateVersion = AppDelegate.shared?.updateManager.availableUpdateVersion
+                            checkedSparkleAvailable = AppDelegate.shared?.updateManager.isUpdateAvailable ?? false
+                            checkedSparkleVersion = AppDelegate.shared?.updateManager.availableUpdateVersion
                             hasCheckedForUpdates = true
                             isCheckingLocal = false
                         }


### PR DESCRIPTION
## Summary
- Remove the "Check for Updates" / "Up to Date" menu item from the status bar dropdown
- Remove the "Check for Updates" / "Update Available" button from the Vellum app menu
- Fix build error: use @State properties for Sparkle state mutation in async Task closure
- Updates are now handled exclusively from the About panel and Settings > General
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
