### PR TITLE
feat: add speechModel config for STT model selection

### DIFF
--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -49,6 +49,7 @@ export function generateTwiML(
   profile: {
     language: string;
     transcriptionProvider: string;
+    speechModel?: string;
     ttsProvider: string;
     voice: string;
   },
@@ -91,7 +92,7 @@ export function generateTwiML(
 ${greetingAttr}
       voice="${escapeXml(profile.voice)}"
       language="${escapeXml(profile.language)}"
-      transcriptionProvider="${escapeXml(profile.transcriptionProvider)}"
+      transcriptionProvider="${escapeXml(profile.transcriptionProvider)}"${profile.speechModel ? `\n      speechModel="${escapeXml(profile.speechModel)}"` : ""}
       ttsProvider="${escapeXml(profile.ttsProvider)}"
       interruptible="true"
       dtmfDetection="true"

--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -3,6 +3,7 @@ import { loadConfig } from "../config/loader.js";
 export interface VoiceQualityProfile {
   language: string;
   transcriptionProvider: string;
+  speechModel?: string;
   ttsProvider: string;
   voice: string;
 }
@@ -61,6 +62,7 @@ export function resolveVoiceQualityProfile(
   return {
     language: voice.language,
     transcriptionProvider: voice.transcriptionProvider,
+    speechModel: voice.speechModel,
     ttsProvider: fishAudio ? "Google" : "ElevenLabs",
     voice: fishAudio ? "" : buildElevenLabsVoiceSpec(cfg.elevenlabs),
   };

--- a/assistant/src/config/schemas/calls.ts
+++ b/assistant/src/config/schemas/calls.ts
@@ -58,6 +58,12 @@ export const CallsVoiceConfigSchema = z
       })
       .default("Deepgram")
       .describe("Speech-to-text provider used for call transcription"),
+    speechModel: z
+      .string({ error: "calls.voice.speechModel must be a string" })
+      .optional()
+      .describe(
+        "ASR model to use for speech recognition (e.g. nova-3, nova-2-phonecall for Deepgram; telephony, long for Google)",
+      ),
     ttsProvider: z
       .enum(VALID_TTS_PROVIDERS, {
         error: `calls.voice.ttsProvider must be one of: ${VALID_TTS_PROVIDERS.join(", ")}`,


### PR DESCRIPTION
## Summary
- Adds optional speechModel field to calls voice config schema
- Threads it through voice quality profile to TwiML generation
- Allows selecting ASR models like Deepgram nova-3/nova-2-phonecall or Google telephony
- Previously no model was specified, defaulting to provider's base model

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
