### PR TITLE
fix: route Vellum Cloud through consent screen before managed bootstrap

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -234,14 +234,8 @@ struct APIKeyStepView: View {
             state.cloudProvider = state.selectedHostingMode.rawValue
         }
 
-        if isAuthenticated && state.selectedHostingMode == .vellumCloud {
-            // Platform-hosted: trigger managed bootstrap directly
-            onHatchManaged?()
-            return
-        }
-
         if isAuthenticated {
-            // Authenticated user selecting Local: skip API key, advance to consent step
+            // Authenticated user: skip API key entry, advance to consent step
             state.selectedProvider = "anthropic"
             state.selectedModel = "claude-opus-4-6"
             saveModelToConfig("claude-opus-4-6")

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -7,6 +7,9 @@ struct ImproveExperienceStepView: View {
     /// Whether the user arrived here by skipping step 2 (API key entry).
     /// Captured at init so it reflects the navigation path, not live auth state.
     var skippedAPIKeyEntry: Bool = false
+    /// Optional override for what happens after the user accepts ToS.
+    /// When provided, called instead of the default `state.isHatching = true`.
+    var onAccepted: (() -> Void)?
 
     @State private var showTitle = false
     @State private var showContent = false
@@ -125,7 +128,11 @@ struct ImproveExperienceStepView: View {
             MetricKitManager.closeSentry()
         }
 
-        state.isHatching = true
+        if let onAccepted {
+            onAccepted()
+        } else {
+            state.isHatching = true
+        }
     }
 
     private func goBack() {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -120,7 +120,15 @@ struct OnboardingFlowView: View {
                             case 2:
                                 APIKeyEntryStepView(state: state)
                             case 3:
-                                ImproveExperienceStepView(state: state, skippedAPIKeyEntry: state.skippedAPIKeyEntry)
+                                ImproveExperienceStepView(
+                                    state: state,
+                                    skippedAPIKeyEntry: state.skippedAPIKeyEntry,
+                                    onAccepted: state.selectedHostingMode == .vellumCloud ? {
+                                        Task {
+                                            await performManagedBootstrap()
+                                        }
+                                    } : nil
+                                )
                             default:
                                 EmptyView()
                             }


### PR DESCRIPTION
## Summary
- Vellum Cloud users now see the consent screen (ImproveExperienceStepView) before managed bootstrap starts, ensuring explicit ToS acceptance
- Added `onAccepted` closure to `ImproveExperienceStepView` — when provided, called instead of `state.isHatching = true` after the user accepts
- `OnboardingFlowView` passes `performManagedBootstrap()` as `onAccepted` when the selected hosting mode is Vellum Cloud
- Removed the direct `onHatchManaged` call from `APIKeyStepView.handleContinue()` — Vellum Cloud now follows the same authenticated-user path (skip API key, advance to consent)

## Original prompt
When an authenticated user picks Vellum Cloud with platform_hosted_enabled on, this branch jumps straight into managed bootstrap instead of advancing to ImproveExperienceStepView. Fix so users must accept ToS before managed bootstrap.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
