### PR TITLE
perf: fix scroll-up rainbow spinner by moving snapshotDebounceTask off @State

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -72,6 +72,9 @@ extension EnvironmentValues {
     /// comparisons and visibility boundary detection — never read during
     /// body evaluation for rendering, so mutations do not trigger re-renders.
     var avatarTargetY: CGFloat = .infinity
+    /// Debounced task for transcript snapshot updates, coalescing rapid scroll
+    /// events into a single snapshot capture per 150ms window.
+    var snapshotDebounceTask: Task<Void, Never>?
 }
 
 struct MessageListView: View {
@@ -211,9 +214,6 @@ struct MessageListView: View {
     @State private var isAvatarVisible: Bool = false
     @State private var avatarDisplayY: CGFloat = .infinity
     @State private var avatarSmoothingTask: Task<Void, Never>?
-    /// Debounced task for transcript snapshot updates, coalescing rapid scroll
-    /// events into a single snapshot capture per 150ms window.
-    @State private var snapshotDebounceTask: Task<Void, Never>?
     @State private var hasPlayedTailEntryAnimation = false
     /// Non-reactive scroll tracking state (dead-zone guards, smoothing).
     /// Stored on a class so mutations never trigger body re-evaluations.
@@ -728,8 +728,8 @@ struct MessageListView: View {
     /// events into a single snapshot per 150ms window, avoiding O(n) tool-call
     /// scans on every scroll tick.
     private func scheduleTranscriptSnapshot() {
-        snapshotDebounceTask?.cancel()
-        snapshotDebounceTask = Task { @MainActor in
+        scrollTracking.snapshotDebounceTask?.cancel()
+        scrollTracking.snapshotDebounceTask = Task { @MainActor in
             try? await Task.sleep(for: .milliseconds(150))
             guard !Task.isCancelled else { return }
             updateTranscriptSnapshot()
@@ -1355,8 +1355,8 @@ struct MessageListView: View {
                 avatarSmoothingTask = nil
                 highlightDismissTask?.cancel()
                 highlightDismissTask = nil
-                snapshotDebounceTask?.cancel()
-                snapshotDebounceTask = nil
+                scrollTracking.snapshotDebounceTask?.cancel()
+                scrollTracking.snapshotDebounceTask = nil
                 highlightedMessageId = nil
                 // Cancel any active pin session to prevent the coordinator's
                 // sessionTask from calling scrollTo on a stale ScrollViewProxy.
@@ -1521,8 +1521,8 @@ struct MessageListView: View {
                 expandSuppressionTask = nil
                 avatarSmoothingTask?.cancel()
                 avatarSmoothingTask = nil
-                snapshotDebounceTask?.cancel()
-                snapshotDebounceTask = nil
+                scrollTracking.snapshotDebounceTask?.cancel()
+                scrollTracking.snapshotDebounceTask = nil
                 paginationTask?.cancel()
                 paginationTask = nil
                 isPaginationInFlight = false


### PR DESCRIPTION
## Summary
Fix rainbow spinner (beach ball) lag when scrolling up in the chat by moving `snapshotDebounceTask` from `@State` to the non-reactive `ScrollTrackingState` class. Previously, `scheduleTranscriptSnapshot()` reassigned this `@State Task` on every scroll tick that passed the 2pt dead-zone, triggering unnecessary `MessageListView.body` re-evaluations with O(N) `precomputedState` scans — even though nothing about the messages changed.

## Changes
- Added `snapshotDebounceTask` property to `ScrollTrackingState` class (non-reactive, follows existing pattern)
- Removed `@State private var snapshotDebounceTask` from `MessageListView`
- Updated all references (`scheduleTranscriptSnapshot`, `onDisappear`, `onChange(of: conversationId)`) to use `scrollTracking.snapshotDebounceTask`

## Milestone PRs (merged into feature branch)
- #20378: perf: move snapshotDebounceTask off @State to prevent scroll-triggered body re-evals

## Project issue
Closes #20376

## Test plan
- [ ] Open a long conversation with many messages
- [ ] Scroll up — verify no rainbow spinner / reduced lag
- [ ] Verify auto-scroll-to-bottom still works when receiving new messages
- [ ] Verify pagination still loads older messages when scrolling to top
- [ ] Verify transcript snapshots still fire (check diagnostics store)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
