### PR TITLE
Remove DaemonConfig from GatewayConnectionManager

### DIFF
--- a/clients/ios/Views/Settings/TwilioSettingsSection.swift
+++ b/clients/ios/Views/Settings/TwilioSettingsSection.swift
@@ -245,14 +245,10 @@ struct TwilioSettingsSection: View {
         applyPhoneNumber: Bool = false,
         applyNumbers: Bool = false
     ) async -> Bool {
-        guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") else {
-            errorMessage = "No connected assistant"
-            return false
-        }
-
         // Strip leading "/v1/" if present — GatewayHTTPClient prepends /v1/ automatically.
+        // Use {assistantId} placeholder — GatewayHTTPClient resolves it for all connection modes.
         let trimmedPath = path.hasPrefix("/v1/") ? String(path.dropFirst(4)) : path
-        let gatewayPath = "assistants/\(assistantId)/\(trimmedPath)"
+        let gatewayPath = "assistants/{assistantId}/\(trimmedPath)"
 
         let bodyData: Data?
         if let body {

--- a/clients/ios/Views/Settings/TwilioSettingsSection.swift
+++ b/clients/ios/Views/Settings/TwilioSettingsSection.swift
@@ -237,18 +237,7 @@ struct TwilioSettingsSection: View {
         .presentationDetents([.medium])
     }
 
-    // MARK: - HTTP Endpoint Resolution
-
-    /// Resolve the gateway base URL and bearer token for Twilio HTTP calls.
-    private func resolveHTTPEndpoint() -> (baseURL: String, bearerToken: String?)? {
-        guard let daemon = clientProvider.client as? DaemonClient else { return nil }
-        if case .http(let baseURL, let bearerToken, _) = daemon.config.transport {
-            return (baseURL, bearerToken)
-        }
-        return nil
-    }
-
-    /// Perform a Twilio HTTP request and apply the response.
+    /// Perform a Twilio HTTP request via GatewayHTTPClient and apply the response.
     private func performHTTPRequest(
         method: String,
         path: String,
@@ -256,36 +245,43 @@ struct TwilioSettingsSection: View {
         applyPhoneNumber: Bool = false,
         applyNumbers: Bool = false
     ) async -> Bool {
-        guard let endpoint = resolveHTTPEndpoint(),
-              let url = URL(string: "\(endpoint.baseURL)\(path)") else {
-            errorMessage = "No HTTP endpoint available"
+        guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") else {
+            errorMessage = "No connected assistant"
             return false
         }
 
-        var request = URLRequest(url: url)
-        request.httpMethod = method
-        request.timeoutInterval = 30
-        // Use the JWT access token as the sole Authorization bearer.
-        // Falls back to the legacy runtime bearer token if no JWT is available.
-        if let accessToken = ActorTokenManager.getToken(), !accessToken.isEmpty {
-            request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-        } else if let token = endpoint.bearerToken, !token.isEmpty {
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        }
+        // Strip leading "/v1/" if present — GatewayHTTPClient prepends /v1/ automatically.
+        let trimmedPath = path.hasPrefix("/v1/") ? String(path.dropFirst(4)) : path
+        let gatewayPath = "assistants/\(assistantId)/\(trimmedPath)"
+
+        let bodyData: Data?
         if let body {
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+            bodyData = try? JSONSerialization.data(withJSONObject: body)
+        } else {
+            bodyData = nil
         }
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
-            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
-                let errorBody = String(data: data, encoding: .utf8) ?? "Request failed"
+            let response: GatewayHTTPClient.Response
+            switch method {
+            case "GET":
+                response = try await GatewayHTTPClient.get(path: gatewayPath)
+            case "POST":
+                response = try await GatewayHTTPClient.post(path: gatewayPath, body: bodyData)
+            case "DELETE":
+                response = try await GatewayHTTPClient.delete(path: gatewayPath, body: bodyData)
+            default:
+                errorMessage = "Unsupported HTTP method"
+                return false
+            }
+
+            guard response.isSuccess else {
+                let errorBody = String(data: response.data, encoding: .utf8) ?? "Request failed"
                 errorMessage = errorBody
                 return false
             }
 
-            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            guard let json = try JSONSerialization.jsonObject(with: response.data) as? [String: Any] else {
                 errorMessage = "Invalid JSON response"
                 return false
             }

--- a/clients/ios/Views/Settings/TwilioSettingsSection.swift
+++ b/clients/ios/Views/Settings/TwilioSettingsSection.swift
@@ -237,77 +237,27 @@ struct TwilioSettingsSection: View {
         .presentationDetents([.medium])
     }
 
-    /// Perform a Twilio HTTP request via GatewayHTTPClient and apply the response.
-    private func performHTTPRequest(
-        method: String,
-        path: String,
-        body: [String: Any]? = nil,
-        applyPhoneNumber: Bool = false,
-        applyNumbers: Bool = false
-    ) async -> Bool {
-        // Strip leading "/v1/" if present — GatewayHTTPClient prepends /v1/ automatically.
-        // Use {assistantId} placeholder — GatewayHTTPClient resolves it for all connection modes.
-        let trimmedPath = path.hasPrefix("/v1/") ? String(path.dropFirst(4)) : path
-        let gatewayPath = "assistants/{assistantId}/\(trimmedPath)"
-
-        let bodyData: Data?
-        if let body {
-            bodyData = try? JSONSerialization.data(withJSONObject: body)
-        } else {
-            bodyData = nil
-        }
-
-        do {
-            let response: GatewayHTTPClient.Response
-            switch method {
-            case "GET":
-                response = try await GatewayHTTPClient.get(path: gatewayPath)
-            case "POST":
-                response = try await GatewayHTTPClient.post(path: gatewayPath, body: bodyData)
-            case "DELETE":
-                response = try await GatewayHTTPClient.delete(path: gatewayPath, body: bodyData)
-            default:
-                errorMessage = "Unsupported HTTP method"
-                return false
-            }
-
-            guard response.isSuccess else {
-                let errorBody = String(data: response.data, encoding: .utf8) ?? "Request failed"
-                errorMessage = errorBody
-                return false
-            }
-
-            guard let json = try JSONSerialization.jsonObject(with: response.data) as? [String: Any] else {
-                errorMessage = "Invalid JSON response"
-                return false
-            }
-
-            let success = json["success"] as? Bool ?? false
-            if success {
-                hasCredentials = json["hasCredentials"] as? Bool ?? false
-                if !hasCredentials {
-                    phoneNumber = nil
-                    availableNumbers = []
-                } else {
-                    if applyPhoneNumber || json["phoneNumber"] != nil {
-                        phoneNumber = json["phoneNumber"] as? String
-                    }
-                    if applyNumbers {
-                        availableNumbers = Self.decodeTwilioNumbers(from: json["numbers"])
-                    } else if json["numbers"] != nil {
-                        availableNumbers = Self.decodeTwilioNumbers(from: json["numbers"])
-                    }
-                }
-                errorMessage = nil
-                return true
-            } else {
-                errorMessage = json["error"] as? String ?? "Unknown error"
-                return false
-            }
-        } catch {
-            errorMessage = error.localizedDescription
+    /// Apply a successful Twilio response JSON to local state.
+    private func applyTwilioResponse(_ json: [String: Any], applyPhoneNumber: Bool = false, applyNumbers: Bool = false) -> Bool {
+        let success = json["success"] as? Bool ?? false
+        guard success else {
+            errorMessage = json["error"] as? String ?? "Unknown error"
             return false
         }
+        hasCredentials = json["hasCredentials"] as? Bool ?? false
+        if !hasCredentials {
+            phoneNumber = nil
+            availableNumbers = []
+        } else {
+            if applyPhoneNumber || json["phoneNumber"] != nil {
+                phoneNumber = json["phoneNumber"] as? String
+            }
+            if applyNumbers || json["numbers"] != nil {
+                availableNumbers = Self.decodeTwilioNumbers(from: json["numbers"])
+            }
+        }
+        errorMessage = nil
+        return true
     }
 
     /// Decode the `numbers` array from the Twilio HTTP response JSON.
@@ -332,11 +282,16 @@ struct TwilioSettingsSection: View {
         isLoading = true
         errorMessage = nil
         Task {
-            await performHTTPRequest(
-                method: "GET",
-                path: "/v1/integrations/twilio/config",
-                applyPhoneNumber: true
-            )
+            do {
+                let response = try await GatewayHTTPClient.get(path: "assistants/{assistantId}/integrations/twilio/config")
+                if response.isSuccess, let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any] {
+                    _ = applyTwilioResponse(json, applyPhoneNumber: true)
+                } else {
+                    errorMessage = String(data: response.data, encoding: .utf8) ?? "Request failed"
+                }
+            } catch {
+                errorMessage = error.localizedDescription
+            }
             isLoading = false
         }
     }
@@ -345,14 +300,18 @@ struct TwilioSettingsSection: View {
         isClearing = true
         errorMessage = nil
         Task {
-            let success = await performHTTPRequest(
-                method: "DELETE",
-                path: "/v1/integrations/twilio/credentials"
-            )
-            isClearing = false
-            if success {
-                availableNumbers = []
+            do {
+                let response = try await GatewayHTTPClient.delete(path: "assistants/{assistantId}/integrations/twilio/credentials")
+                if response.isSuccess, let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any] {
+                    let success = applyTwilioResponse(json)
+                    if success { availableNumbers = [] }
+                } else {
+                    errorMessage = String(data: response.data, encoding: .utf8) ?? "Request failed"
+                }
+            } catch {
+                errorMessage = error.localizedDescription
             }
+            isClearing = false
         }
     }
 
@@ -360,15 +319,20 @@ struct TwilioSettingsSection: View {
         isLoadingNumbers = true
         errorMessage = nil
         Task {
-            let success = await performHTTPRequest(
-                method: "GET",
-                path: "/v1/integrations/twilio/numbers",
-                applyNumbers: true
-            )
-            isLoadingNumbers = false
-            if success && availableNumbers.isEmpty {
-                errorMessage = "No numbers found on this Twilio account."
+            do {
+                let response = try await GatewayHTTPClient.get(path: "assistants/{assistantId}/integrations/twilio/numbers")
+                if response.isSuccess, let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any] {
+                    let success = applyTwilioResponse(json, applyNumbers: true)
+                    if success && availableNumbers.isEmpty {
+                        errorMessage = "No numbers found on this Twilio account."
+                    }
+                } else {
+                    errorMessage = String(data: response.data, encoding: .utf8) ?? "Request failed"
+                }
+            } catch {
+                errorMessage = error.localizedDescription
             }
+            isLoadingNumbers = false
         }
     }
 
@@ -376,24 +340,32 @@ struct TwilioSettingsSection: View {
         isProvisioning = true
         errorMessage = nil
         Task {
-            var body: [String: Any] = [:]
-            if !provisionAreaCode.isEmpty { body["areaCode"] = provisionAreaCode }
-            if !provisionCountry.isEmpty { body["country"] = provisionCountry }
-            let success = await performHTTPRequest(
-                method: "POST",
-                path: "/v1/integrations/twilio/numbers/provision",
-                body: body.isEmpty ? nil : body,
-                applyPhoneNumber: true
-            )
-            isProvisioning = false
-            if success {
-                showProvisionSheet = false
-                provisionAreaCode = ""
-                // Refresh the number list to include the newly provisioned number
-                listNumbers()
-            } else {
+            do {
+                var body: [String: Any] = [:]
+                if !provisionAreaCode.isEmpty { body["areaCode"] = provisionAreaCode }
+                if !provisionCountry.isEmpty { body["country"] = provisionCountry }
+                let response = try await GatewayHTTPClient.post(
+                    path: "assistants/{assistantId}/integrations/twilio/numbers/provision",
+                    json: body.isEmpty ? nil : body
+                )
+                if response.isSuccess, let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any] {
+                    let success = applyTwilioResponse(json, applyPhoneNumber: true)
+                    if success {
+                        showProvisionSheet = false
+                        provisionAreaCode = ""
+                        listNumbers()
+                    } else {
+                        showProvisionSheet = false
+                    }
+                } else {
+                    errorMessage = String(data: response.data, encoding: .utf8) ?? "Request failed"
+                    showProvisionSheet = false
+                }
+            } catch {
+                errorMessage = error.localizedDescription
                 showProvisionSheet = false
             }
+            isProvisioning = false
         }
     }
 
@@ -402,12 +374,19 @@ struct TwilioSettingsSection: View {
         assigningNumber = number
         errorMessage = nil
         Task {
-            await performHTTPRequest(
-                method: "POST",
-                path: "/v1/integrations/twilio/numbers/assign",
-                body: ["phoneNumber": number],
-                applyPhoneNumber: true
-            )
+            do {
+                let response = try await GatewayHTTPClient.post(
+                    path: "assistants/{assistantId}/integrations/twilio/numbers/assign",
+                    json: ["phoneNumber": number]
+                )
+                if response.isSuccess, let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any] {
+                    _ = applyTwilioResponse(json, applyPhoneNumber: true)
+                } else {
+                    errorMessage = String(data: response.data, encoding: .utf8) ?? "Request failed"
+                }
+            } catch {
+                errorMessage = error.localizedDescription
+            }
             isAssigning = false
             assigningNumber = nil
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -53,7 +53,7 @@ extension NSApplication {
 extension AppDelegate {
 
     func currentUserAppsDirectory() -> URL {
-        let env = daemonClient.config.instanceDir.map { ["BASE_DATA_DIR": $0] }
+        let env = daemonClient.instanceDir.map { ["BASE_DATA_DIR": $0] }
         return VellumAppSchemeHandler.resolveUserAppsDirectory(environment: env)
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -770,7 +770,7 @@ struct MainWindowView: View {
             if let path = notification.userInfo?["userAppsDirectoryPath"] as? String, !path.isEmpty {
                 windowState.activeDynamicUserAppsDirectory = URL(fileURLWithPath: path, isDirectory: true)
             } else {
-                let env = daemonClient.config.instanceDir.map { ["BASE_DATA_DIR": $0] }
+                let env = daemonClient.instanceDir.map { ["BASE_DATA_DIR": $0] }
                 windowState.activeDynamicUserAppsDirectory = VellumAppSchemeHandler.resolveUserAppsDirectory(environment: env)
             }
             if let surface = windowState.activeDynamicParsedSurface,
@@ -785,7 +785,7 @@ struct MainWindowView: View {
             // send a fresh ui_surface_show via SSE with the full payload.
             let reopenId = ref.appId ?? ref.surfaceId
             windowState.selection = .app(reopenId)
-            let env = daemonClient.config.instanceDir.map { ["BASE_DATA_DIR": $0] }
+            let env = daemonClient.instanceDir.map { ["BASE_DATA_DIR": $0] }
             windowState.activeDynamicUserAppsDirectory = VellumAppSchemeHandler.resolveUserAppsDirectory(environment: env)
             Task { await AppsClient.openAppAndDispatchSurface(id: reopenId, daemonClient: daemonClient) }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -26,7 +26,7 @@ struct IdentityPanel: View {
 
     /// Whether the BOOTSTRAP.md first-run ritual is still in progress.
     private var isBootstrapActive: Bool {
-        let base = daemonClient.config.instanceDir ?? NSHomeDirectory()
+        let base = daemonClient.instanceDir ?? NSHomeDirectory()
         return FileManager.default.fileExists(atPath: base + "/.vellum/workspace/BOOTSTRAP.md")
     }
 

--- a/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
+++ b/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
@@ -68,11 +68,7 @@ final class DebugStateWriter {
         let daemonClient = appDelegate.services.daemonClient
         let conversationManager = appDelegate.mainWindow?.conversationManager
 
-        let transport: String
-        switch daemonClient.config.transport {
-        case .http:
-            transport = "http"
-        }
+        let transport = daemonClient.isConnected ? "connected" : "disconnected"
 
         let daemonState = DebugSnapshot.DaemonState(
             isConnected: daemonClient.isConnected,

--- a/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
+++ b/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
@@ -68,13 +68,10 @@ final class DebugStateWriter {
         let daemonClient = appDelegate.services.daemonClient
         let conversationManager = appDelegate.mainWindow?.conversationManager
 
-        let transport = daemonClient.isConnected ? "connected" : "disconnected"
-
         let daemonState = DebugSnapshot.DaemonState(
             isConnected: daemonClient.isConnected,
             isConnecting: daemonClient.isConnecting,
-            daemonVersion: daemonClient.daemonVersion,
-            transport: transport
+            daemonVersion: daemonClient.daemonVersion
         )
 
         let conversationSnapshots: [DebugSnapshot.ConversationInfo] = (conversationManager?.conversations ?? []).map { conversation in
@@ -156,7 +153,6 @@ struct DebugSnapshot: Codable {
         let isConnected: Bool
         let isConnecting: Bool
         let daemonVersion: String?
-        let transport: String
     }
 
     struct ConversationsState: Codable {

--- a/clients/macos/vellum-assistantTests/AppServicesDaemonClientReconfigureTests.swift
+++ b/clients/macos/vellum-assistantTests/AppServicesDaemonClientReconfigureTests.swift
@@ -27,21 +27,18 @@ final class AppServicesDaemonClientReconfigureTests: XCTestCase {
         )
     }
 
-    func testReconfigureUpdatesTransport() {
+    func testReconfigureUpdatesInstanceDir() {
         let services = AppServices()
 
         let httpConfig = DaemonConfig(transport: .http(
             baseURL: "http://remote:8080",
             bearerToken: "new-token",
             conversationKey: "new-key"
-        ))
+        ), instanceDir: "/tmp/test-instance")
         services.reconfigureDaemonClient(config: httpConfig)
 
-        if case .http(let baseURL, _, _) = services.daemonClient.config.transport {
-            XCTAssertEqual(baseURL, "http://remote:8080")
-        } else {
-            XCTFail("Expected HTTP transport after reconfigure")
-        }
+        XCTAssertEqual(services.daemonClient.instanceDir, "/tmp/test-instance",
+            "instanceDir should be updated after reconfigure via AppServices")
     }
 
     func testSettingsStoreRetainsWorkingDaemonClientAfterReconfigure() {

--- a/clients/macos/vellum-assistantTests/DaemonClientReconfigureTests.swift
+++ b/clients/macos/vellum-assistantTests/DaemonClientReconfigureTests.swift
@@ -33,19 +33,16 @@ final class DaemonClientReconfigureTests: XCTestCase {
             "Reconfigure must preserve DaemonClient object identity")
     }
 
-    func testReconfigureUpdatesConfig() {
+    func testReconfigureUpdatesInstanceDir() {
         let newConfig = DaemonConfig(transport: .http(
             baseURL: "http://localhost:9999",
             bearerToken: "new-token",
             conversationKey: "new-key"
-        ))
+        ), instanceDir: "/tmp/test-instance")
         client.reconfigure(config: newConfig)
 
-        if case .http(let baseURL, _, _) = client.config.transport {
-            XCTAssertEqual(baseURL, "http://localhost:9999")
-        } else {
-            XCTFail("Expected HTTP transport after reconfigure")
-        }
+        XCTAssertEqual(client.instanceDir, "/tmp/test-instance",
+            "instanceDir should be updated after reconfigure")
     }
 
     func testReconfigureResetsConnectionState() {
@@ -82,24 +79,19 @@ final class DaemonClientReconfigureTests: XCTestCase {
     }
 
     func testReconfigureBetweenHTTPEndpoints() {
-        // Start with default HTTP config
-        XCTAssertNotNil(client.config)
+        // Start with default config
+        XCTAssertNil(client.instanceDir)
 
-        // Reconfigure to a different HTTP endpoint
+        // Reconfigure to a different HTTP endpoint with instanceDir
         let httpConfig = DaemonConfig(transport: .http(
             baseURL: "http://remote-host:8080",
             bearerToken: "bearer-123",
             conversationKey: "conv-key"
-        ))
+        ), instanceDir: "/tmp/remote-instance")
         client.reconfigure(config: httpConfig)
 
-        if case .http(let baseURL, let token, let key) = client.config.transport {
-            XCTAssertEqual(baseURL, "http://remote-host:8080")
-            XCTAssertEqual(token, "bearer-123")
-            XCTAssertEqual(key, "conv-key")
-        } else {
-            XCTFail("Expected HTTP transport after reconfigure")
-        }
+        XCTAssertEqual(client.instanceDir, "/tmp/remote-instance",
+            "instanceDir should reflect the new config after reconfigure")
     }
 
     func testMultipleReconfiguresPreserveIdentity() {

--- a/clients/macos/vellum-assistantTests/DebugStateWriterTests.swift
+++ b/clients/macos/vellum-assistantTests/DebugStateWriterTests.swift
@@ -54,9 +54,7 @@ struct DebugStateWriterTests {
             daemon: DebugSnapshot.DaemonState(
                 isConnected: true,
                 isConnecting: false,
-                daemonVersion: "1.0.0",
-                transport: "http"
-            ),
+                daemonVersion: "1.0.0"            ),
             conversations: DebugSnapshot.ConversationsState(
                 activeConversationId: conversationId,
                 count: 1,
@@ -176,9 +174,7 @@ struct DebugStateWriterTests {
             daemon: DebugSnapshot.DaemonState(
                 isConnected: true,
                 isConnecting: false,
-                daemonVersion: "1.0.0",
-                transport: "http"
-            ),
+                daemonVersion: "1.0.0"            ),
             conversations: DebugSnapshot.ConversationsState(
                 activeConversationId: UUID().uuidString,
                 count: 0,
@@ -262,9 +258,7 @@ struct DebugStateWriterTests {
             daemon: DebugSnapshot.DaemonState(
                 isConnected: true,
                 isConnecting: false,
-                daemonVersion: nil,
-                transport: "http"
-            ),
+                daemonVersion: nil            ),
             conversations: DebugSnapshot.ConversationsState(
                 activeConversationId: conversationId,
                 count: 1,
@@ -418,9 +412,7 @@ struct DebugStateWriterTests {
             daemon: DebugSnapshot.DaemonState(
                 isConnected: true,
                 isConnecting: false,
-                daemonVersion: "2.0.0",
-                transport: "http"
-            ),
+                daemonVersion: "2.0.0"            ),
             conversations: DebugSnapshot.ConversationsState(
                 activeConversationId: conversationId,
                 count: 1,
@@ -552,9 +544,7 @@ struct DebugStateWriterTests {
             daemon: DebugSnapshot.DaemonState(
                 isConnected: true,
                 isConnecting: false,
-                daemonVersion: "1.0.0",
-                transport: "http"
-            ),
+                daemonVersion: "1.0.0"            ),
             conversations: DebugSnapshot.ConversationsState(
                 activeConversationId: conversationId,
                 count: 1,

--- a/clients/shared/Network/DaemonStatus.swift
+++ b/clients/shared/Network/DaemonStatus.swift
@@ -102,10 +102,9 @@ public final class DaemonStatus: ObservableObject, DaemonStatusProtocol {
         set { connectionManager.isConnecting = newValue }
     }
 
-    /// Current daemon connection configuration.
-    public var config: DaemonConfig {
-        connectionManager.config
-    }
+    /// Instance directory for the connected assistant. Used by consumers
+    /// that need to resolve file paths (e.g. workspace, identity).
+    public var instanceDir: String?
 
     /// Platform identifier for automatic 401 re-bootstrap.
     public var recoveryPlatform: String? {
@@ -127,10 +126,10 @@ public final class DaemonStatus: ObservableObject, DaemonStatusProtocol {
 
     // MARK: - Init
 
-    public init(config: DaemonConfig = .default) {
+    public init() {
         let esc = EventStreamClient()
         self.eventStreamClient = esc
-        self.connectionManager = GatewayConnectionManager(config: config, eventStreamClient: esc)
+        self.connectionManager = GatewayConnectionManager(eventStreamClient: esc)
 
         // Wire the pre-processor so state is updated before subscribers see messages
         esc.messagePreProcessor = { [weak self] message in
@@ -223,7 +222,11 @@ public final class DaemonStatus: ObservableObject, DaemonStatusProtocol {
     // MARK: - Connection (forwarding)
 
     public func connect() async throws {
-        try await connectionManager.connect()
+        guard case .http(_, _, let conversationKey) = currentConfig?.transport else {
+            log.info("connect: no HTTP transport configured, skipping")
+            return
+        }
+        try await connectionManager.connectImpl(cancelAutoWake: true, conversationKey: conversationKey)
     }
 
     public func disconnect() {
@@ -235,7 +238,12 @@ public final class DaemonStatus: ObservableObject, DaemonStatusProtocol {
 
     /// Reconfigure the transport in place without replacing object identity.
     public func reconfigure(config newConfig: DaemonConfig) {
-        connectionManager.reconfigure(config: newConfig)
+        currentConfig = newConfig
+        instanceDir = newConfig.instanceDir
+        connectionManager.reconfigure(
+            instanceDir: newConfig.instanceDir,
+            isRuntimeFlat: newConfig.transportMetadata.routeMode == .runtimeFlat
+        )
         // Reset connection-specific published state
         isConnected = false
         httpPort = nil
@@ -248,6 +256,10 @@ public final class DaemonStatus: ObservableObject, DaemonStatusProtocol {
         latestMemoryStatus = nil
         currentModel = nil
     }
+
+    /// Current config — stored only so `connect()` can extract the conversation key.
+    /// Will be removed when DaemonStatus is deleted.
+    private var currentConfig: DaemonConfig?
 
     // MARK: - Version Compatibility
 

--- a/clients/shared/Network/DaemonStatus.swift
+++ b/clients/shared/Network/DaemonStatus.swift
@@ -126,10 +126,18 @@ public final class DaemonStatus: ObservableObject, DaemonStatusProtocol {
 
     // MARK: - Init
 
-    public init() {
+    public init(config: DaemonConfig = .default) {
         let esc = EventStreamClient()
         self.eventStreamClient = esc
         self.connectionManager = GatewayConnectionManager(eventStreamClient: esc)
+
+        // Extract fields from initial config
+        self.currentConfig = config
+        self.instanceDir = config.instanceDir
+        self.connectionManager.reconfigure(
+            instanceDir: config.instanceDir,
+            isRuntimeFlat: config.transportMetadata.routeMode == .runtimeFlat
+        )
 
         // Wire the pre-processor so state is updated before subscribers see messages
         esc.messagePreProcessor = { [weak self] message in

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -19,38 +19,31 @@ public final class GatewayConnectionManager {
 
     // MARK: - Connection State
 
-    /// Current connection configuration.
-    public private(set) var config: DaemonConfig
-
     /// Whether a connection attempt is in flight.
     public var isConnecting: Bool = false
 
     /// Whether the transport has authenticated successfully.
     var isAuthenticated = false
 
+    /// Instance directory for HealthCheckClient reachability checks (auto-wake).
+    /// Set during `reconfigure()`.
+    private var instanceDir: String?
+
+    /// Whether auto-wake should be attempted on disconnect.
+    /// Only applies to runtimeFlat mode (local assistants).
+    private var isRuntimeFlat: Bool = false
+
     // MARK: - Health Check
 
-    /// Periodic health check task.
     private var healthCheckTask: Task<Void, Never>?
-
-    /// Health check interval in seconds.
     private let healthCheckInterval: TimeInterval = 15.0
-
-    /// Whether the gateway is reachable (health check passes).
     private(set) var isConnected: Bool = false
-
-    /// The daemon's self-reported version from the most recent health check.
     private(set) var daemonVersion: String?
-
-    /// Whether we should attempt to reconnect on disconnect.
     private var shouldReconnect = true
 
     /// Whether a planned service group update is in progress.
-    /// Accelerates health check polling for faster reconnection.
     var isUpdateInProgress: Bool = false
 
-    /// Update the in-progress flag and restart the health-check loop when
-    /// transitioning to `true`.
     func setUpdateInProgress(_ value: Bool) {
         let wasInProgress = isUpdateInProgress
         isUpdateInProgress = value
@@ -61,19 +54,12 @@ public final class GatewayConnectionManager {
 
     // MARK: - 401 Recovery
 
-    /// In-flight refresh task for coalescing concurrent 401 handlers.
     private var refreshTask: Task<Void, Never>?
 
     // MARK: - Auto-Wake
 
-    /// Optional closure invoked when a connection attempt fails because the daemon process
-    /// is not alive. The macOS app sets this to call `vellumCli.wake(name:)`.
     public var wakeHandler: (@MainActor @Sendable () async throws -> Void)?
-
-    /// Platform identifier for automatic 401 re-bootstrap (e.g. "macos", "ios").
     public var recoveryPlatform: String?
-
-    /// Device identifier for automatic 401 re-bootstrap.
     public var recoveryDeviceId: String?
 
     #if os(macOS)
@@ -83,24 +69,17 @@ public final class GatewayConnectionManager {
 
     // MARK: - Callbacks
 
-    /// Called when health-check-driven connection state changes.
     var onConnectionStateChanged: ((_ connected: Bool) -> Void)?
-
-    /// Called when the daemon version changes during a health check.
     var onDaemonVersionChanged: ((_ newVersion: String) -> Void)?
-
-    /// Called when a health check 401 needs to emit an auth error to the UI.
     var onAuthError: ((_ message: ServerMessage) -> Void)?
 
     // MARK: - Dependencies
 
-    /// Event stream client — starts/stops SSE and registers conversation IDs.
     private let eventStreamClient: EventStreamClient
 
     // MARK: - Init
 
-    init(config: DaemonConfig, eventStreamClient: EventStreamClient) {
-        self.config = config
+    init(eventStreamClient: EventStreamClient) {
         self.eventStreamClient = eventStreamClient
     }
 
@@ -110,19 +89,14 @@ public final class GatewayConnectionManager {
         try await connectImpl(cancelAutoWake: true)
     }
 
-    func connectImpl(cancelAutoWake: Bool) async throws {
+    /// Connect using a conversation key for host tool filtering.
+    /// Call `reconfigure()` first to set instance directory and route mode.
+    func connectImpl(cancelAutoWake: Bool, conversationKey: String? = nil) async throws {
         disconnectInternal(cancelAutoWake: cancelAutoWake)
 
         isConnecting = true
 
-        guard case .http(_, _, let conversationKey) = config.transport else {
-            isConnecting = false
-            log.info("connect: non-HTTP transport, skipping")
-            return
-        }
-
-        // Register the conversation key for host tool filtering
-        if !conversationKey.isEmpty {
+        if let conversationKey, !conversationKey.isEmpty {
             eventStreamClient.registerConversationId(conversationKey)
         }
 
@@ -145,8 +119,8 @@ public final class GatewayConnectionManager {
                 throw error
             }
 
-            if let wakeHandler, config.transportMetadata.routeMode == .runtimeFlat {
-                let reachable = await HealthCheckClient.isReachable(instanceDir: config.instanceDir)
+            if let wakeHandler, isRuntimeFlat {
+                let reachable = await HealthCheckClient.isReachable(instanceDir: instanceDir)
                 if !reachable {
                     log.info("connect: gateway unreachable — attempting auto-wake before retry")
                     do {
@@ -197,13 +171,16 @@ public final class GatewayConnectionManager {
 
     // MARK: - Reconfigure
 
-    public func reconfigure(config newConfig: DaemonConfig) {
+    /// Reconfigure connection parameters for a new assistant.
+    /// Callers must call `connect()` after reconfiguring.
+    public func reconfigure(instanceDir: String?, isRuntimeFlat: Bool) {
         #if os(macOS)
         autoWakeTask?.cancel()
         autoWakeTask = nil
         #endif
         disconnect()
-        self.config = newConfig
+        self.instanceDir = instanceDir
+        self.isRuntimeFlat = isRuntimeFlat
         isAuthenticated = false
         refreshTask?.cancel()
         refreshTask = nil
@@ -214,7 +191,6 @@ public final class GatewayConnectionManager {
 
     // MARK: - Health Check (via GatewayHTTPClient)
 
-    /// Run a single health check via GatewayHTTPClient.
     private func performHealthCheck() async throws {
         do {
             let response = try await GatewayHTTPClient.get(
@@ -225,14 +201,14 @@ public final class GatewayConnectionManager {
             guard response.isSuccess else {
                 if response.statusCode == 401 {
                     handleAuthenticationFailure()
-                    if config.transportMetadata.routeMode == .platformAssistantProxy {
+                    let isManaged = (try? GatewayHTTPClient.isConnectionManaged()) ?? false
+                    if isManaged {
                         shouldReconnect = false
                     }
                 }
                 throw ConnectionError.healthCheckFailed
             }
 
-            // Extract daemon version from response body
             if let decoded = try? JSONDecoder().decode(HealthzVersionResponse.self, from: response.data) {
                 if let newVersion = decoded.version, newVersion != daemonVersion {
                     daemonVersion = newVersion
@@ -261,7 +237,6 @@ public final class GatewayConnectionManager {
         }
     }
 
-    /// Periodically poll healthz to maintain connection status.
     private func startHealthCheckLoop() {
         healthCheckTask?.cancel()
 
@@ -288,7 +263,8 @@ public final class GatewayConnectionManager {
     // MARK: - 401 Recovery
 
     private func handleAuthenticationFailure() {
-        if config.transportMetadata.routeMode == .platformAssistantProxy {
+        let isManaged = (try? GatewayHTTPClient.isConnectionManaged()) ?? false
+        if isManaged {
             log.warning("401 in managed mode — session token may be expired")
             onAuthError?(.conversationError(ConversationErrorMessage(
                 conversationId: "",
@@ -300,7 +276,6 @@ public final class GatewayConnectionManager {
             return
         }
 
-        // Coalesce concurrent 401 handlers
         guard refreshTask == nil else { return }
 
         refreshTask = Task { @MainActor [weak self] in
@@ -343,9 +318,7 @@ public final class GatewayConnectionManager {
     private static let autoWakeCooldown: TimeInterval = 60.0
 
     private func autoWakeIfDaemonDied() {
-        guard let wakeHandler,
-              config.transportMetadata.routeMode == .runtimeFlat
-        else { return }
+        guard let wakeHandler, isRuntimeFlat else { return }
 
         if let last = lastAutoWakeAttempt,
            Date().timeIntervalSince(last) < Self.autoWakeCooldown {
@@ -358,7 +331,7 @@ public final class GatewayConnectionManager {
         autoWakeTask = Task { @MainActor [weak self] in
             guard let self else { return }
 
-            let reachable = await HealthCheckClient.isReachable(instanceDir: self.config.instanceDir)
+            let reachable = await HealthCheckClient.isReachable(instanceDir: self.instanceDir)
             guard !reachable else {
                 self.lastAutoWakeAttempt = nil
                 return
@@ -404,14 +377,11 @@ public final class GatewayConnectionManager {
 
     public enum ConnectionError: Error, LocalizedError {
         case healthCheckFailed
-        case invalidURL
 
         public var errorDescription: String? {
             switch self {
             case .healthCheckFailed:
                 return "Gateway health check failed"
-            case .invalidURL:
-                return "Invalid gateway URL"
             }
         }
     }


### PR DESCRIPTION
## Summary

- Remove `DaemonConfig` property from `GatewayConnectionManager` — it only needed `instanceDir` and `routeMode`
- `reconfigure()` now takes `instanceDir: String?` and `isRuntimeFlat: Bool` instead of a full `DaemonConfig`
- Managed-mode detection uses `GatewayHTTPClient.isConnectionManaged()` instead of reading config
- `DaemonStatus` exposes `instanceDir` directly (replaces `config.instanceDir` for consumers)
- Migrate `TwilioSettingsSection` from manual URLRequest construction to `GatewayHTTPClient`
- Remove stale `config.transport` references from consumer code and tests

Net: **-37 lines** (92 added, 129 removed across 9 files)

## Test plan

- [x] `swift build` passes
- [x] `swift test` — all 156 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
