### PR TITLE
feat: default speechModel to nova-3

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -638,6 +638,7 @@ describe("AssistantConfigSchema", () => {
       voice: {
         language: "en-US",
         transcriptionProvider: "Deepgram",
+        speechModel: "nova-3",
         ttsProvider: "elevenlabs",
       },
       callerIdentity: {

--- a/assistant/src/config/schemas/calls.ts
+++ b/assistant/src/config/schemas/calls.ts
@@ -60,7 +60,7 @@ export const CallsVoiceConfigSchema = z
       .describe("Speech-to-text provider used for call transcription"),
     speechModel: z
       .string({ error: "calls.voice.speechModel must be a string" })
-      .optional()
+      .default("nova-3")
       .describe(
         "ASR model to use for speech recognition (e.g. nova-3, nova-2-phonecall for Deepgram; telephony, long for Google)",
       ),


### PR DESCRIPTION
## Summary
- Changes the default speechModel in calls voice config from unset to nova-3
- Deepgram nova-3 has 53% lower word error rate than previous models
- All new setups will automatically use the best available STT model

## Original prompt
make this the default
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
