### PR TITLE
Fix iOS build: remove nil passed to non-optional json parameter

### DIFF
--- a/clients/ios/Views/Settings/TwilioSettingsSection.swift
+++ b/clients/ios/Views/Settings/TwilioSettingsSection.swift
@@ -346,7 +346,7 @@ struct TwilioSettingsSection: View {
                 if !provisionCountry.isEmpty { body["country"] = provisionCountry }
                 let response = try await GatewayHTTPClient.post(
                     path: "assistants/{assistantId}/integrations/twilio/numbers/provision",
-                    json: body.isEmpty ? nil : body
+                    json: body
                 )
                 if response.isSuccess, let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any] {
                     let success = applyTwilioResponse(json, applyPhoneNumber: true)


### PR DESCRIPTION
## Summary
- Fix Swift compile error `'nil' cannot be used in context expecting type '[String : Any]'` in `TwilioSettingsSection.swift:349`
- The `GatewayHTTPClient.post(path:json:)` overload takes a non-optional `[String: Any]` — passing `nil` via a ternary broke the iOS build
- Changed to always pass `body` (which may be an empty dict `[:]`) since that's valid JSON

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23369829758/job/67991171607
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
