### PR TITLE
Remove stale daemonPort from HealthCheckClientTests

### DIFF
--- a/clients/macos/vellum-assistantTests/HealthCheckClientTests.swift
+++ b/clients/macos/vellum-assistantTests/HealthCheckClientTests.swift
@@ -58,7 +58,7 @@ final class HealthCheckClientTests: XCTestCase {
             instanceId: nil,
             hatchedAt: nil,
             baseDataDir: nil,
-            daemonPort: nil,
+
             gatewayPort: gatewayPort,
             instanceDir: nil
         )
@@ -188,7 +188,7 @@ final class HealthCheckClientTests: XCTestCase {
             instanceId: nil,
             hatchedAt: nil,
             baseDataDir: nil,
-            daemonPort: nil,
+
             gatewayPort: nil,
             instanceDir: nil
         )
@@ -207,7 +207,7 @@ final class HealthCheckClientTests: XCTestCase {
             instanceId: nil,
             hatchedAt: nil,
             baseDataDir: nil,
-            daemonPort: nil,
+
             gatewayPort: nil,
             instanceDir: nil
         )
@@ -226,7 +226,7 @@ final class HealthCheckClientTests: XCTestCase {
             instanceId: nil,
             hatchedAt: nil,
             baseDataDir: nil,
-            daemonPort: nil,
+
             gatewayPort: nil,
             instanceDir: nil
         )


### PR DESCRIPTION
## Summary
- Remove `daemonPort: nil` from all `LockfileAssistant` initializer calls in `HealthCheckClientTests.swift`
- Fixes macOS test compilation failure caused by the removal of `daemonPort` from `LockfileAssistant` in #20384

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23369829816/job/67991179316
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
