### PR TITLE
fix: import guardian token before connect() to prevent first-launch auth race

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -252,6 +252,16 @@ extension AppDelegate {
                     }
                 }
             }
+            // Import guardian token from CLI file before connecting, so the
+            // health check has valid credentials in the Keychain. On first
+            // launch ensureActorCredentials() runs later in proceedToApp()
+            // as a separate Task — this ensures the token is available in
+            // time for connect()'s health check.
+            if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
+               !ActorTokenManager.hasToken {
+                _ = GuardianTokenFileReader.importIfAvailable(assistantId: assistantId)
+            }
+
             // Skip connect if the bootstrap retry coordinator already connected
             // or has a connect in flight (hatch can take a long time; the
             // coordinator connects independently). Checking isConnecting


### PR DESCRIPTION
## Summary
Fix a race condition introduced in #20372 where `setupDaemonClient()` calls `connect()` before `ensureActorCredentials()` has imported the guardian token into the Keychain. On first launch, the health check fires with no auth header, gets 401 from the gateway, and `connect()` fails with `ConnectionError.healthCheckFailed`.

## Changes
- Import the guardian token via `GuardianTokenFileReader.importIfAvailable()` right before `connect()` in `setupDaemonClient()`'s Task body, guarded by `!ActorTokenManager.hasToken` so it's a no-op on subsequent launches

## Milestone PRs (merged into feature branch)
- #20389: fix: import guardian token before connect() to prevent first-launch auth race

## Project issue
Closes #20387

## Test plan
- [ ] Delete `~/.vellum/`, `~/.vellum.lock.json`, `~/.config/vellum/` for clean state
- [ ] Hatch via CLI: `vellum-cli hatch -d --name test-local`
- [ ] Launch app — should connect to daemon on first attempt without timeout
- [ ] Restart app — should still connect (token already in Keychain)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
