### PR TITLE
Cut over command palette search from daemon port to GatewayHTTPClient

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -365,14 +365,6 @@ extension AppDelegate {
             self?.mainWindow?.windowState.showMemory(id: memoryId)
         }
 
-        // Wire runtime HTTP resolver for server search
-        window.runtimeHTTPResolver = {
-            let port = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"]
-                .flatMap(Int.init) ?? 7821
-            guard let jwt = ActorTokenManager.getToken(), !jwt.isEmpty else { return nil }
-            return ("http://localhost:\(port)", jwt)
-        }
-
         window.show()
         commandPaletteWindow = window
     }

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import VellumAssistantShared
 
 /// State management for the command palette (CMD+K).
 @MainActor
@@ -23,9 +24,6 @@ final class CommandPaletteViewModel {
 
     /// Deep search task that runs after fast results arrive.
     private var deepSearchTask: Task<Void, Never>?
-
-    /// Base URL and token resolver for runtime HTTP calls.
-    var runtimeHTTPResolver: (() -> (baseURL: String, token: String)?)?
 
     /// Filtered actions based on the current query.
     var filteredActions: [CommandPaletteAction] {
@@ -164,32 +162,21 @@ final class CommandPaletteViewModel {
     }
 
     private func performSearch(query: String, deep: Bool) async -> GlobalSearchResults {
-        guard let resolver = runtimeHTTPResolver,
-              let http = resolver() else {
-            return .empty
-        }
-
-        let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
-        var urlString = "\(http.baseURL)/v1/search/global?q=\(encoded)&limit=10"
+        var params = ["q": query, "limit": "10"]
         if deep {
-            urlString += "&deep=true&categories=memories"
+            params["deep"] = "true"
+            params["categories"] = "memories"
         }
-        guard let url = URL(string: urlString) else {
-            return .empty
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(http.token)", forHTTPHeaderField: "Authorization")
-        request.timeoutInterval = deep ? 10 : 5
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200 else {
+            let (decoded, response): (GlobalSearchResponse?, _) = try await GatewayHTTPClient.get(
+                path: "assistants/{assistantId}/search/global",
+                params: params,
+                timeout: deep ? 10 : 5
+            )
+            guard response.isSuccess, let decoded else {
                 return .empty
             }
-            let decoded = try JSONDecoder().decode(GlobalSearchResponse.self, from: data)
             return decoded.results
         } catch {
             return .empty

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteWindow.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteWindow.swift
@@ -34,9 +34,6 @@ final class CommandPaletteWindow {
     /// Recent conversations to show in the palette.
     var recentItems: [CommandPaletteRecentItem] = []
 
-    /// Resolver for runtime HTTP base URL and bearer token.
-    var runtimeHTTPResolver: (() -> (baseURL: String, token: String)?)?
-
     func show() {
         let panel = makePanel()
         centerOnScreen(panel)
@@ -55,8 +52,6 @@ final class CommandPaletteWindow {
         viewModel.reset()
         viewModel.actions = actions
         viewModel.recentItems = recentItems
-        viewModel.runtimeHTTPResolver = runtimeHTTPResolver
-
         let view = CommandPaletteView(
             viewModel: viewModel,
             onDismiss: { [weak self] in


### PR DESCRIPTION
## Summary
- Replace `runtimeHTTPResolver` closure (which read `RUNTIME_HTTP_PORT` env var to build a `localhost:{port}` URL) with `GatewayHTTPClient.get` in `CommandPaletteViewModel.performSearch`
- Remove the `runtimeHTTPResolver` property from `CommandPaletteViewModel`, `CommandPaletteWindow`, and the wiring in `AppDelegate+InputMonitors`
- Net -36/+10 lines — eliminates manual URL construction, auth header injection, and the daemon port dependency

## Test plan
- [ ] Open command palette (CMD+K), type a query, verify search results appear
- [ ] Verify deep search (memory results) still loads after initial results

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
