### PR TITLE
feat: show version mismatch banner at the top of the main window

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -582,9 +582,43 @@ struct MainWindowView: View {
                 .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
                 .padding(.top, VSpacing.sm)
                 .animation(VAnimation.fast, value: windowState.needsInferenceApiKey)
+            } else if daemonClient.versionMismatch {
+                ChatConversationErrorToast(
+                    message: versionMismatchMessage,
+                    icon: .triangleAlert,
+                    accentColor: VColor.systemMidStrong,
+                    actionLabel: "Update in Settings",
+                    onAction: {
+                        settingsStore.pendingSettingsTab = .general
+                        windowState.selection = .panel(.settings)
+                    }
+                )
+                .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
+                .padding(.top, VSpacing.sm)
+                .animation(VAnimation.fast, value: daemonClient.versionMismatch)
             }
         }
         .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    /// Contextual message for version mismatch: tells user which side is behind.
+    private var versionMismatchMessage: String {
+        guard let daemonVersion = daemonClient.daemonVersion,
+              let clientVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+              let daemonParsed = VersionCompat.parse(daemonVersion),
+              let clientParsed = VersionCompat.parse(clientVersion) else {
+            return "Your app and assistant versions don't match."
+        }
+        let daemonBehind: Bool = {
+            if daemonParsed.major != clientParsed.major { return daemonParsed.major < clientParsed.major }
+            if daemonParsed.minor != clientParsed.minor { return daemonParsed.minor < clientParsed.minor }
+            return daemonParsed.patch < clientParsed.patch
+        }()
+        if daemonBehind {
+            return "Your assistant (\(daemonVersion)) doesn't match this app (\(clientVersion)). Upgrade to avoid issues."
+        } else {
+            return "Your app (\(clientVersion)) is older than the assistant (\(daemonVersion)). Update the app."
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Add a version mismatch banner to the main window using the same `ChatConversationErrorToast` pattern as the API key banner
- Shows when client and service group major.minor versions differ, with contextual message showing both versions
- "Update in Settings" button deep-links to Settings > General where the Assistant Version card has upgrade controls
- Lower priority than the API key banner (only shows when no API key issue or conversation error is active)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
