### PR TITLE
fix: use correct health check path in GatewayConnectionManager

### DIFF
--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -194,7 +194,7 @@ public final class GatewayConnectionManager {
     private func performHealthCheck() async throws {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/healthz",
+                path: "health",
                 timeout: 10
             )
 

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -193,8 +193,10 @@ public final class GatewayConnectionManager {
 
     private func performHealthCheck() async throws {
         do {
+            let isManaged = (try? GatewayHTTPClient.isConnectionManaged()) ?? false
+            let healthPath = isManaged ? "assistants/{assistantId}/health" : "health"
             let response = try await GatewayHTTPClient.get(
-                path: "health",
+                path: healthPath,
                 timeout: 10
             )
 


### PR DESCRIPTION
The health check was hitting /v1/assistants/{assistantId}/healthz which returns 404. The correct gateway-proxied daemon health endpoint is /v1/health. This was broken in #20372 when health checks were moved from HTTPTransport to GatewayHTTPClient.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
