### PR TITLE
fix: use correct health check path in GatewayConnectionManager

### DIFF
--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -193,8 +193,10 @@ public final class GatewayConnectionManager {
 
     private func performHealthCheck() async throws {
         do {
+            let isManaged = (try? GatewayHTTPClient.isConnectionManaged()) ?? false
+            let healthPath = isManaged ? "assistants/{assistantId}/health" : "health"
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/healthz",
+                path: healthPath,
                 timeout: 10
             )
 


### PR DESCRIPTION
## Summary
Fix the health check path in `GatewayConnectionManager.performHealthCheck()`. The refactor in #20372 changed health checks to use `GatewayHTTPClient`, which prepends `/v1/` to all paths. The path `assistants/{assistantId}/healthz` resolved to `/v1/assistants/{id}/healthz` — a 404. The correct endpoint is `/v1/health` for local connections and `/v1/assistants/{assistantId}/health` for managed (cloud-hosted) connections.

## Changes
- Use `"health"` for local connections, `"assistants/{assistantId}/health"` for managed connections
- Conditionally select path based on `GatewayHTTPClient.isConnectionManaged()`

## Test plan
- [ ] Local assistant: health check hits `/v1/health` → 200
- [ ] App connects to daemon on first launch
- [ ] Managed assistant: health check hits `/v1/assistants/{id}/health` (platform proxy routes correctly)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
