### PR TITLE
feat: stream-and-play for Fish Audio TTS

### DIFF
--- a/assistant/src/calls/audio-store.test.ts
+++ b/assistant/src/calls/audio-store.test.ts
@@ -28,7 +28,10 @@ describe("audio-store", () => {
       const id = storeAudio(buf, "mp3");
       const result = getAudio(id);
       expect(result).not.toBeNull();
-      expect(result!.buffer).toEqual(buf);
+      expect(result!.type).toBe("buffer");
+      if (result!.type === "buffer") {
+        expect(result!.buffer).toEqual(buf);
+      }
       expect(result!.contentType).toBe("audio/mpeg");
     });
 

--- a/assistant/src/calls/audio-store.ts
+++ b/assistant/src/calls/audio-store.ts
@@ -6,7 +6,17 @@ interface AudioEntry {
   expiresAt: number;
 }
 
+interface StreamingAudioEntry {
+  contentType: string;
+  expiresAt: number;
+  chunks: Uint8Array[];
+  totalBytes: number;
+  complete: boolean;
+  subscribers: Set<ReadableStreamDefaultController<Uint8Array>>;
+}
+
 const store = new Map<string, AudioEntry>();
+const streamingStore = new Map<string, StreamingAudioEntry>();
 const MAX_STORE_BYTES = 50 * 1024 * 1024; // 50MB cap
 const TTL_MS = 60_000; // 60 seconds
 
@@ -23,28 +33,148 @@ export function storeAudio(
     if (oldest) removeEntry(oldest);
   }
   const id = randomUUID();
-  const contentType =
-    format === "mp3"
-      ? "audio/mpeg"
-      : format === "wav"
-        ? "audio/wav"
-        : "audio/opus";
+  const contentType = contentTypeForFormat(format);
   store.set(id, { buffer, contentType, expiresAt: Date.now() + TTL_MS });
   currentBytes += buffer.length;
   return id;
 }
 
-export function getAudio(
-  id: string,
-): { buffer: Buffer; contentType: string } | null {
+// ---------------------------------------------------------------------------
+// Streaming entries — audio is pushed chunk-by-chunk while being served
+// ---------------------------------------------------------------------------
+
+export interface StreamingAudioHandle {
+  audioId: string;
+  push: (chunk: Uint8Array) => void;
+  finalize: () => void;
+}
+
+export function createStreamingEntry(
+  format: "mp3" | "wav" | "opus",
+): StreamingAudioHandle {
   evictExpired();
+  const id = randomUUID();
+  const contentType = contentTypeForFormat(format);
+  const entry: StreamingAudioEntry = {
+    contentType,
+    expiresAt: Date.now() + TTL_MS,
+    chunks: [],
+    totalBytes: 0,
+    complete: false,
+    subscribers: new Set(),
+  };
+  streamingStore.set(id, entry);
+
+  return {
+    audioId: id,
+    push(chunk: Uint8Array) {
+      entry.chunks.push(chunk);
+      entry.totalBytes += chunk.byteLength;
+      for (const controller of entry.subscribers) {
+        try {
+          controller.enqueue(chunk);
+        } catch {
+          entry.subscribers.delete(controller);
+        }
+      }
+    },
+    finalize() {
+      entry.complete = true;
+      for (const controller of entry.subscribers) {
+        try {
+          controller.close();
+        } catch {
+          // Already closed
+        }
+      }
+      entry.subscribers.clear();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Retrieval — handles both regular and streaming entries
+// ---------------------------------------------------------------------------
+
+export type AudioResult =
+  | { type: "buffer"; buffer: Buffer; contentType: string }
+  | { type: "stream"; stream: ReadableStream<Uint8Array>; contentType: string };
+
+export function getAudio(id: string): AudioResult | null {
+  evictExpired();
+
+  // Check streaming store first
+  const streamingEntry = streamingStore.get(id);
+  if (streamingEntry) {
+    if (Date.now() > streamingEntry.expiresAt) {
+      streamingStore.delete(id);
+      return null;
+    }
+
+    if (streamingEntry.complete) {
+      // Synthesis finished — serve the complete buffer
+      const merged = mergeChunks(streamingEntry.chunks);
+      return {
+        type: "buffer",
+        buffer: Buffer.from(merged),
+        contentType: streamingEntry.contentType,
+      };
+    }
+
+    // Still streaming — return a ReadableStream that replays existing
+    // chunks and subscribes for future ones.
+    let ctrl: ReadableStreamDefaultController<Uint8Array>;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        ctrl = controller;
+        for (const chunk of streamingEntry.chunks) {
+          controller.enqueue(chunk);
+        }
+        if (streamingEntry.complete) {
+          controller.close();
+        } else {
+          streamingEntry.subscribers.add(controller);
+        }
+      },
+      cancel() {
+        streamingEntry.subscribers.delete(ctrl);
+      },
+    });
+
+    return { type: "stream", stream, contentType: streamingEntry.contentType };
+  }
+
+  // Check regular store
   const entry = store.get(id);
   if (!entry) return null;
   if (Date.now() > entry.expiresAt) {
     removeEntry(id);
     return null;
   }
-  return { buffer: entry.buffer, contentType: entry.contentType };
+  return { type: "buffer", buffer: entry.buffer, contentType: entry.contentType };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function contentTypeForFormat(format: "mp3" | "wav" | "opus"): string {
+  return format === "mp3"
+    ? "audio/mpeg"
+    : format === "wav"
+      ? "audio/wav"
+      : "audio/opus";
+}
+
+function mergeChunks(chunks: Uint8Array[]): Uint8Array {
+  const totalLength = chunks.reduce((sum, c) => sum + c.byteLength, 0);
+  const merged = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return merged;
 }
 
 function removeEntry(id: string): void {
@@ -59,5 +189,17 @@ function evictExpired(): void {
   const now = Date.now();
   for (const [id, entry] of store) {
     if (now > entry.expiresAt) removeEntry(id);
+  }
+  for (const [id, entry] of streamingStore) {
+    if (now > entry.expiresAt) {
+      for (const controller of entry.subscribers) {
+        try {
+          controller.close();
+        } catch {
+          // noop
+        }
+      }
+      streamingStore.delete(id);
+    }
   }
 }

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -24,7 +24,7 @@ import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { mintDaemonDeliveryToken } from "../runtime/auth/token-service.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
 import { getLogger } from "../util/logger.js";
-import { storeAudio } from "./audio-store.js";
+import { createStreamingEntry } from "./audio-store.js";
 import {
   getMaxCallDurationMs,
   getSilenceTimeoutMs,
@@ -567,15 +567,19 @@ export class CallController {
           fishSession = await FishAudioSession.create(config.fishAudio);
           this.activeFishSession = fishSession;
         }
-        const audioBuffer = await fishSession.synthesize(text);
         const format = config.fishAudio.format ?? "mp3";
-        const audioId = storeAudio(
-          audioBuffer,
+        const handle = createStreamingEntry(
           format as "mp3" | "wav" | "opus",
         );
         const baseUrl = getPublicBaseUrl(config);
-        const url = `${baseUrl}/v1/audio/${audioId}`;
+        const url = `${baseUrl}/v1/audio/${handle.audioId}`;
+        // Send the play URL to Twilio immediately — before synthesis
+        // completes. Twilio will fetch the audio while Fish Audio is
+        // still streaming chunks, eliminating the idle-timeout wait
+        // from the critical path.
         this.relay.sendPlayUrl(url);
+        await fishSession.synthesize(text, (chunk) => handle.push(chunk));
+        handle.finalize();
       } catch (err) {
         log.error(
           { err, textLength: text.length },

--- a/assistant/src/calls/fish-audio-client.ts
+++ b/assistant/src/calls/fish-audio-client.ts
@@ -22,6 +22,7 @@ interface StartEvent {
     chunk_length?: number;
     normalize?: boolean;
     latency?: string;
+    temperature?: number;
     prosody?: { speed?: number; volume?: number };
   };
 }
@@ -73,6 +74,7 @@ interface PendingSynthesis {
   reject: (error: Error) => void;
   idleTimer: ReturnType<typeof setTimeout> | null;
   firstChunkReceived: boolean;
+  onChunk?: (chunk: Uint8Array) => void;
 }
 
 export class FishAudioSession {
@@ -125,7 +127,9 @@ export class FishAudioSession {
             format: config.format,
             mp3_bitrate: 192,
             chunk_length: config.chunkLength,
+            normalize: true,
             latency: config.latency,
+            temperature: 1.0,
             prosody:
               config.speed !== 1.0 ? { speed: config.speed } : undefined,
           },
@@ -156,7 +160,10 @@ export class FishAudioSession {
    * server has finished streaming audio for this text. The session remains
    * alive for subsequent calls.
    */
-  synthesize(text: string): Promise<Buffer> {
+  synthesize(
+    text: string,
+    onChunk?: (chunk: Uint8Array) => void,
+  ): Promise<Buffer> {
     if (this.closed) {
       return Promise.reject(new Error("FishAudioSession is closed"));
     }
@@ -176,6 +183,7 @@ export class FishAudioSession {
         reject,
         idleTimer: null,
         firstChunkReceived: false,
+        onChunk,
       };
 
       const textEvent: TextEvent = { event: "text", text };
@@ -323,6 +331,7 @@ export class FishAudioSession {
         if (this.pending) {
           this.pending.chunks.push(msg.audio);
           this.pending.firstChunkReceived = true;
+          this.pending.onChunk?.(msg.audio);
           // Reset idle timer — more audio may follow. The first chunk
           // cancels the initial FIRST_CHUNK_TIMEOUT and switches to the
           // shorter IDLE_TIMEOUT for inter-chunk gaps.

--- a/assistant/src/runtime/routes/audio-routes.ts
+++ b/assistant/src/runtime/routes/audio-routes.ts
@@ -14,15 +14,26 @@ import { httpError } from "../http-errors.js";
 /**
  * Handle GET /v1/audio/:audioId.
  *
- * Returns the audio buffer with its stored Content-Type on hit,
- * or a 404 when the audioId is unknown or expired.
+ * Returns the audio with its stored Content-Type. For complete audio,
+ * includes Content-Length for efficient playback. For in-progress
+ * streaming entries, uses chunked transfer encoding.
  */
 export function handleGetAudio(audioId: string): Response {
   const entry = getAudio(audioId);
   if (!entry) {
     return httpError("NOT_FOUND", "Audio not found", 404);
   }
-  return new Response(new Uint8Array(entry.buffer), {
+  if (entry.type === "buffer") {
+    return new Response(new Uint8Array(entry.buffer), {
+      status: 200,
+      headers: {
+        "Content-Type": entry.contentType,
+        "Content-Length": entry.buffer.length.toString(),
+      },
+    });
+  }
+  // Streaming — Content-Length unknown, chunked transfer encoding
+  return new Response(entry.stream, {
     status: 200,
     headers: { "Content-Type": entry.contentType },
   });

--- a/gateway/src/http/routes/audio-proxy.ts
+++ b/gateway/src/http/routes/audio-proxy.ts
@@ -46,9 +46,16 @@ export function createAudioProxyHandler(config: GatewayConfig) {
       });
     }
 
+    const headers: Record<string, string> = {
+      "Content-Type": response.headers.get("Content-Type") ?? "application/octet-stream",
+    };
+    const contentLength = response.headers.get("Content-Length");
+    if (contentLength) {
+      headers["Content-Length"] = contentLength;
+    }
     return new Response(response.body, {
       status: response.status,
-      headers: { "Content-Type": response.headers.get("Content-Type") ?? "application/octet-stream" },
+      headers,
     });
   }
 


### PR DESCRIPTION
## Summary
- Rearchitects Fish Audio TTS to send the play URL to Twilio *before* synthesis completes — Twilio fetches audio while Fish Audio is still streaming chunks, removing the idle timeout from the critical path
- Adds streaming audio store entries with ReadableStream support: chunks are pushed to subscribers (HTTP responses) as they arrive from Fish Audio
- Adds Content-Length header to complete audio responses and passes it through the gateway proxy for better Twilio playback behavior
- Adds `normalize: true` and `temperature: 1.0` to Fish Audio StartEvent for consistent audio output
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
