### PR TITLE
feat: switch Fish Audio to REST API with s2-pro model

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -45,7 +45,7 @@ import {
   updateCallSession,
 } from "./call-store.js";
 import { finalizeCall } from "./finalize-call.js";
-import { FishAudioSession } from "./fish-audio-client.js";
+import { synthesizeWithFishAudio } from "./fish-audio-client.js";
 import { sendGuardianExpiryNotices } from "./guardian-action-sweep.js";
 import { dispatchGuardianQuestion } from "./guardian-dispatch.js";
 import type { RelayConnection } from "./relay-server.js";
@@ -67,19 +67,6 @@ import {
 } from "./voice-session-bridge.js";
 
 const log = getLogger("call-controller");
-
-const SENTENCE_END_RE = /[.!?]\s+/;
-function splitAtSentenceBoundary(
-  text: string,
-): { complete: string; remainder: string } | undefined {
-  const match = SENTENCE_END_RE.exec(text);
-  if (!match) return undefined;
-  const splitIdx = match.index + match[0].length;
-  return {
-    complete: text.slice(0, splitIdx).trim(),
-    remainder: text.slice(splitIdx),
-  };
-}
 
 type ControllerState = "idle" | "processing" | "speaking";
 
@@ -152,7 +139,7 @@ export class CallController {
    */
   private guardianUnavailableForCall = false;
   /** Active Fish Audio session — tracked so interrupt handling can close it. */
-  private activeFishSession: FishAudioSession | null = null;
+  private activeFishAbort: AbortController | null = null;
 
   constructor(
     callSessionId: string,
@@ -364,9 +351,9 @@ export class CallController {
     this.abortCurrentTurn();
     this.llmRunVersion++;
     // Cancel in-flight Fish Audio synthesis on barge-in
-    if (this.activeFishSession) {
-      this.activeFishSession.close();
-      this.activeFishSession = null;
+    if (this.activeFishAbort) {
+      this.activeFishAbort.abort();
+      this.activeFishAbort = null;
     }
     // Explicitly terminate the in-progress TTS turn so the relay can
     // immediately hand control back to the caller after barge-in.
@@ -398,9 +385,9 @@ export class CallController {
     this.pendingInstructions = [];
     this.llmRunVersion++;
     this.abortCurrentTurn();
-    if (this.activeFishSession) {
-      this.activeFishSession.close();
-      this.activeFishSession = null;
+    if (this.activeFishAbort) {
+      this.activeFishAbort.abort();
+      this.activeFishAbort = null;
     }
     this.currentTurnPromise = null;
     unregisterCallController(this.callSessionId);
@@ -553,44 +540,6 @@ export class CallController {
     // tokens for ElevenLabs TTS.
     const config = loadConfig();
     const useFishAudio = isFishAudioTts(config);
-    let fishSession: FishAudioSession | null = null;
-    let sentenceBuffer = "";
-    let fishSynthesisChain: Promise<void> = Promise.resolve();
-
-    const synthesizeAndPlay = async (text: string): Promise<void> => {
-      if (!this.isCurrentRun(runVersion)) return;
-      try {
-        // Reuse the session across sentences — a single WebSocket
-        // connection for the entire call turn avoids rate-limit
-        // rejections from rapid reconnection.
-        if (!fishSession || fishSession.closed) {
-          fishSession = await FishAudioSession.create(config.fishAudio);
-          this.activeFishSession = fishSession;
-        }
-        const format = config.fishAudio.format ?? "mp3";
-        const handle = createStreamingEntry(
-          format as "mp3" | "wav" | "opus",
-        );
-        const baseUrl = getPublicBaseUrl(config);
-        const url = `${baseUrl}/v1/audio/${handle.audioId}`;
-        // Send the play URL to Twilio immediately — before synthesis
-        // completes. Twilio will fetch the audio while Fish Audio is
-        // still streaming chunks, eliminating the idle-timeout wait
-        // from the critical path.
-        this.relay.sendPlayUrl(url);
-        await fishSession.synthesize(text, (chunk) => handle.push(chunk));
-        handle.finalize();
-      } catch (err) {
-        log.error(
-          { err, textLength: text.length },
-          "Fish Audio synthesis failed for sentence — skipping",
-        );
-        // Reset session so next sentence tries a fresh connection.
-        fishSession = null;
-        // Don't re-throw: skip this sentence rather than crashing the
-        // entire daemon with an unhandled rejection.
-      }
-    };
 
     // Buffer incoming tokens so we can strip control markers ([ASK_GUARDIAN:...], [END_CALL])
     // before they reach TTS. We hold text whenever an unmatched '[' appears, since it
@@ -598,20 +547,14 @@ export class CallController {
     let ttsBuffer = "";
     let fullResponseText = "";
 
+    // When using Fish Audio, we accumulate all text and synthesize
+    // the complete response at the end of the turn (better prosody).
+    let fishAudioTextBuffer = "";
+
     /** Emit a chunk of safe text to the appropriate TTS backend. */
     const emitSafeChunk = (safeText: string): void => {
       if (useFishAudio) {
-        sentenceBuffer += safeText;
-        let split: ReturnType<typeof splitAtSentenceBoundary>;
-        while (
-          (split = splitAtSentenceBoundary(sentenceBuffer)) !== undefined
-        ) {
-          const sentence = split.complete;
-          fishSynthesisChain = fishSynthesisChain.then(() =>
-            synthesizeAndPlay(sentence),
-          );
-          sentenceBuffer = split.remainder;
-        }
+        fishAudioTextBuffer += safeText;
       } else {
         this.relay.sendTextToken(safeText, false);
       }
@@ -724,20 +667,37 @@ export class CallController {
       emitSafeChunk(ttsBuffer);
     }
 
-    // When using Fish Audio, flush any remaining sentence buffer (even
-    // if it doesn't end with sentence-ending punctuation) and wait for
-    // all in-flight synthesis to finish before signaling end-of-turn.
-    if (useFishAudio) {
-      if (sentenceBuffer.trim().length > 0) {
-        fishSynthesisChain = fishSynthesisChain.then(() =>
-          synthesizeAndPlay(sentenceBuffer.trim()),
+    // When using Fish Audio, synthesize the complete response text in a
+    // single REST API call. The full text gives Fish Audio better context
+    // for prosody and intonation. Audio streams back via chunked transfer
+    // encoding and is forwarded to Twilio as it arrives.
+    if (useFishAudio && fishAudioTextBuffer.trim().length > 0) {
+      if (!this.isCurrentRun(runVersion)) return fullResponseText;
+      try {
+        const format = config.fishAudio.format ?? "mp3";
+        const handle = createStreamingEntry(format as "mp3" | "wav" | "opus");
+        const baseUrl = getPublicBaseUrl(config);
+        const url = `${baseUrl}/v1/audio/${handle.audioId}`;
+        this.relay.sendPlayUrl(url);
+        const abortController = new AbortController();
+        this.activeFishAbort = abortController;
+        await synthesizeWithFishAudio(
+          fishAudioTextBuffer.trim(),
+          config.fishAudio,
+          {
+            onChunk: (chunk) => handle.push(chunk),
+            signal: abortController.signal,
+          },
         );
-        sentenceBuffer = "";
-      }
-      await fishSynthesisChain;
-      if (this.activeFishSession) {
-        this.activeFishSession.close();
-        this.activeFishSession = null;
+        handle.finalize();
+        this.activeFishAbort = null;
+      } catch (err) {
+        this.activeFishAbort = null;
+        if (err instanceof DOMException && err.name === "AbortError") {
+          log.debug("Fish Audio synthesis aborted (barge-in)");
+        } else {
+          log.error({ err }, "Fish Audio synthesis failed — skipping");
+        }
       }
     }
 

--- a/assistant/src/calls/fish-audio-client.ts
+++ b/assistant/src/calls/fish-audio-client.ts
@@ -1,5 +1,3 @@
-import { decode, encode } from "@msgpack/msgpack";
-
 import type { FishAudioConfig } from "../config/schemas/fish-audio.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
@@ -8,373 +6,97 @@ import { getLogger } from "../util/logger.js";
 const log = getLogger("fish-audio-client");
 
 // ---------------------------------------------------------------------------
-// Fish Audio S2 WebSocket MessagePack protocol types
+// Fish Audio REST API (POST /v1/tts)
 // ---------------------------------------------------------------------------
 
-interface StartEvent {
-  event: "start";
-  request: {
-    text?: string;
-    reference_id?: string;
-    format?: string;
-    sample_rate?: number;
-    mp3_bitrate?: number;
-    chunk_length?: number;
-    normalize?: boolean;
-    latency?: string;
-    temperature?: number;
-    prosody?: { speed?: number; volume?: number };
-  };
-}
-
-interface TextEvent {
-  event: "text";
-  text: string;
-}
-
-interface FlushEvent {
-  event: "flush";
-}
-
-interface StopEvent {
-  event: "stop";
-}
-
-interface AudioEvent {
-  event: "audio";
-  audio: Uint8Array;
-}
-
-interface FinishEvent {
-  event: "finish";
-  reason: string;
-}
-
-type InboundEvent = AudioEvent | FinishEvent;
-
-// ---------------------------------------------------------------------------
-// FishAudioSession — persistent session for an entire call
-// ---------------------------------------------------------------------------
-
-/**
- * Fish Audio S2 streams audio chunks after receiving text + flush, but does
- * NOT send a FinishEvent until a StopEvent is sent (which terminates the
- * session). To keep a single session alive across multiple sentences, we
- * detect synthesis completion by an idle timeout: once the first audio chunk
- * arrives, if no more chunks arrive within IDLE_TIMEOUT_MS we consider that
- * sentence done. A separate FIRST_CHUNK_TIMEOUT_MS guards against the server
- * never responding at all.
- */
-const IDLE_TIMEOUT_MS = 800;
-const FIRST_CHUNK_TIMEOUT_MS = 10_000;
-
-interface PendingSynthesis {
-  chunks: Uint8Array[];
-  resolve: (buffer: Buffer) => void;
-  reject: (error: Error) => void;
-  idleTimer: ReturnType<typeof setTimeout> | null;
-  firstChunkReceived: boolean;
+interface SynthesizeOptions {
   onChunk?: (chunk: Uint8Array) => void;
+  signal?: AbortSignal;
 }
-
-export class FishAudioSession {
-  private ws: WebSocket;
-  private pending: PendingSynthesis | null = null;
-  closed = false;
-
-  private constructor(ws: WebSocket) {
-    this.ws = ws;
-    this.setupHandlers();
-  }
-
-  /**
-   * Open a WebSocket connection to Fish Audio S2 and send the initial
-   * StartEvent with the provided configuration. The session stays alive
-   * for multiple synthesize() calls until close() is called.
-   */
-  static async create(config: FishAudioConfig): Promise<FishAudioSession> {
-    const apiKey = await getSecureKeyAsync(
-      credentialKey("fish-audio", "api_key"),
-    );
-    if (!apiKey) {
-      throw new Error(
-        "Fish Audio API key not configured. Store it via: assistant credentials set --service fish-audio --field api_key <key>",
-      );
-    }
-
-    return new Promise<FishAudioSession>((resolve, reject) => {
-      // Bun's WebSocket supports headers in its options object, but the
-      // constructor overload may not be visible when lib.dom types are
-      // loaded. Cast through unknown to use the Bun-specific signature.
-      const ws = new WebSocket(
-        "wss://api.fish.audio/v1/tts/live",
-        {
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-            model: "s1",
-          },
-        } as unknown as string[],
-      );
-
-      ws.binaryType = "arraybuffer";
-
-      ws.addEventListener("open", () => {
-        const startEvent: StartEvent = {
-          event: "start",
-          request: {
-            text: "",
-            reference_id: config.referenceId || undefined,
-            format: config.format,
-            mp3_bitrate: 192,
-            chunk_length: config.chunkLength,
-            normalize: true,
-            latency: config.latency,
-            temperature: 1.0,
-            prosody:
-              config.speed !== 1.0 ? { speed: config.speed } : undefined,
-          },
-        };
-
-        ws.send(encode(startEvent));
-        log.info(
-          { referenceId: config.referenceId, format: config.format },
-          "Fish Audio session started",
-        );
-
-        const session = new FishAudioSession(ws);
-        resolve(session);
-      });
-
-      ws.addEventListener("error", (ev) => {
-        const errorMsg =
-          ev instanceof ErrorEvent ? ev.message : "WebSocket connection failed";
-        reject(new Error(`Fish Audio WebSocket error: ${errorMsg}`));
-      });
-    });
-  }
-
-  /**
-   * Send text for synthesis and wait for the complete audio response.
-   * Sends TextEvent + FlushEvent, then collects AudioEvent chunks until
-   * an idle timeout (no new chunks for IDLE_TIMEOUT_MS) indicates the
-   * server has finished streaming audio for this text. The session remains
-   * alive for subsequent calls.
-   */
-  synthesize(
-    text: string,
-    onChunk?: (chunk: Uint8Array) => void,
-  ): Promise<Buffer> {
-    if (this.closed) {
-      return Promise.reject(new Error("FishAudioSession is closed"));
-    }
-
-    if (this.pending) {
-      return Promise.reject(
-        new Error(
-          "A synthesis is already in progress. Wait for it to complete before starting another.",
-        ),
-      );
-    }
-
-    return new Promise<Buffer>((resolve, reject) => {
-      this.pending = {
-        chunks: [],
-        resolve,
-        reject,
-        idleTimer: null,
-        firstChunkReceived: false,
-        onChunk,
-      };
-
-      const textEvent: TextEvent = { event: "text", text };
-      this.ws.send(encode(textEvent));
-
-      const flushEvent: FlushEvent = { event: "flush" };
-      this.ws.send(encode(flushEvent));
-
-      // Start a long initial timer — if no audio chunk arrives at all
-      // within FIRST_CHUNK_TIMEOUT_MS, reject. Once the first chunk
-      // arrives, we switch to the shorter idle timeout.
-      this.pending.idleTimer = setTimeout(() => {
-        if (this.pending && !this.pending.firstChunkReceived) {
-          this.rejectPending(
-            new Error("Fish Audio did not respond with audio within timeout"),
-          );
-        }
-      }, FIRST_CHUNK_TIMEOUT_MS);
-
-      log.debug({ textLength: text.length }, "Sent text+flush for synthesis");
-    });
-  }
-
-  /**
-   * Close the WebSocket session gracefully.
-   */
-  close(): void {
-    if (this.closed) return;
-    this.closed = true;
-
-    this.clearIdleTimer();
-
-    // If there's a pending synthesis, resolve it with whatever we have
-    // rather than rejecting — the audio collected so far is still usable.
-    if (this.pending) {
-      this.resolvePending();
-    }
-
-    try {
-      const closeEvent: StopEvent = { event: "stop" };
-      this.ws.send(encode(closeEvent));
-    } catch {
-      // WebSocket may already be closed
-    }
-
-    this.ws.close();
-    log.debug("Fish Audio session closed");
-  }
-
-  // -------------------------------------------------------------------------
-  // Internal
-  // -------------------------------------------------------------------------
-
-  private resetIdleTimer(): void {
-    if (this.pending?.idleTimer) {
-      clearTimeout(this.pending.idleTimer);
-    }
-    if (this.pending) {
-      this.pending.idleTimer = setTimeout(() => {
-        // No audio chunk received within the idle window — synthesis is done.
-        this.resolvePending();
-      }, IDLE_TIMEOUT_MS);
-    }
-  }
-
-  private clearIdleTimer(): void {
-    if (this.pending?.idleTimer) {
-      clearTimeout(this.pending.idleTimer);
-      this.pending.idleTimer = null;
-    }
-  }
-
-  private resolvePending(): void {
-    if (!this.pending) return;
-    const { chunks, resolve } = this.pending;
-    this.clearIdleTimer();
-    this.pending = null;
-    const totalLength = chunks.reduce((sum, c) => sum + c.byteLength, 0);
-    const merged = new Uint8Array(totalLength);
-    let offset = 0;
-    for (const chunk of chunks) {
-      merged.set(chunk, offset);
-      offset += chunk.byteLength;
-    }
-    log.debug({ bytes: totalLength }, "Synthesis complete (idle timeout)");
-    resolve(Buffer.from(merged));
-  }
-
-  private setupHandlers(): void {
-    this.ws.addEventListener("message", (ev) => {
-      try {
-        const data =
-          ev.data instanceof ArrayBuffer
-            ? new Uint8Array(ev.data)
-            : new Uint8Array(ev.data as ArrayBuffer);
-
-        const decoded = decode(data) as InboundEvent;
-        this.handleMessage(decoded);
-      } catch (err) {
-        log.error({ err }, "Failed to decode Fish Audio message");
-        this.rejectPending(
-          new Error(
-            `Failed to decode Fish Audio message: ${err instanceof Error ? err.message : String(err)}`,
-          ),
-        );
-      }
-    });
-
-    this.ws.addEventListener("error", (ev) => {
-      const errorMsg =
-        ev instanceof ErrorEvent ? ev.message : "WebSocket error";
-      log.error({ error: errorMsg }, "Fish Audio WebSocket error");
-      this.rejectPending(new Error(`Fish Audio WebSocket error: ${errorMsg}`));
-    });
-
-    this.ws.addEventListener("close", (ev) => {
-      this.closed = true;
-      if (this.pending) {
-        // If we have audio chunks, resolve with what we have rather than
-        // rejecting — partial audio is better than no audio.
-        if (this.pending.chunks.length > 0) {
-          log.warn(
-            { code: ev.code },
-            "Fish Audio WebSocket closed with buffered audio — resolving with partial data",
-          );
-          this.resolvePending();
-        } else {
-          log.warn(
-            { code: ev.code, reason: ev.reason },
-            "Fish Audio WebSocket closed with pending synthesis (no audio)",
-          );
-          this.rejectPending(
-            new Error(
-              `Fish Audio WebSocket closed unexpectedly (code: ${ev.code})`,
-            ),
-          );
-        }
-      }
-    });
-  }
-
-  private handleMessage(msg: InboundEvent): void {
-    switch (msg.event) {
-      case "audio": {
-        if (this.pending) {
-          this.pending.chunks.push(msg.audio);
-          this.pending.firstChunkReceived = true;
-          this.pending.onChunk?.(msg.audio);
-          // Reset idle timer — more audio may follow. The first chunk
-          // cancels the initial FIRST_CHUNK_TIMEOUT and switches to the
-          // shorter IDLE_TIMEOUT for inter-chunk gaps.
-          this.resetIdleTimer();
-        }
-        break;
-      }
-      case "finish": {
-        // FinishEvent arrives after StopEvent (session teardown). In
-        // persistent-session mode we don't send stop between sentences,
-        // so this only fires during close(). Resolve if still pending.
-        this.resolvePending();
-        break;
-      }
-    }
-  }
-
-  private rejectPending(error: Error): void {
-    if (this.pending) {
-      const { reject } = this.pending;
-      this.clearIdleTimer();
-      this.pending = null;
-      reject(error);
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Convenience function
-// ---------------------------------------------------------------------------
 
 /**
- * Synthesize text to audio using Fish Audio S2 in a single call.
- * Opens a session, synthesizes the text, and closes the session.
+ * Synthesize text to audio using the Fish Audio REST API with the s2-pro
+ * model. Streams audio chunks via the optional `onChunk` callback as they
+ * arrive from the server's chunked transfer-encoded response. Returns the
+ * complete audio buffer when the response finishes.
+ *
+ * Pass an `AbortSignal` to cancel in-flight synthesis (e.g. on barge-in).
  */
 export async function synthesizeWithFishAudio(
   text: string,
   config: FishAudioConfig,
+  options?: SynthesizeOptions,
 ): Promise<Buffer> {
-  const session = await FishAudioSession.create(config);
-  try {
-    return await session.synthesize(text);
-  } finally {
-    session.close();
+  const apiKey = await getSecureKeyAsync(
+    credentialKey("fish-audio", "api_key"),
+  );
+  if (!apiKey) {
+    throw new Error(
+      "Fish Audio API key not configured. Store it via: assistant credentials set --service fish-audio --field api_key <key>",
+    );
   }
+
+  const body = {
+    text,
+    reference_id: config.referenceId || undefined,
+    model: "s2-pro",
+    format: config.format,
+    mp3_bitrate: 192,
+    chunk_length: config.chunkLength,
+    normalize: true,
+    latency: config.latency,
+    temperature: 1.0,
+    prosody: config.speed !== 1.0 ? { speed: config.speed } : undefined,
+  };
+
+  log.info(
+    {
+      referenceId: config.referenceId,
+      format: config.format,
+      textLength: text.length,
+    },
+    "Starting Fish Audio synthesis",
+  );
+
+  const response = await fetch("https://api.fish.audio/v1/tts", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+    signal: options?.signal,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Fish Audio API error (${response.status}): ${errorText}`);
+  }
+
+  if (!response.body) {
+    throw new Error("Fish Audio API returned no body");
+  }
+
+  const chunks: Uint8Array[] = [];
+  const reader = response.body.getReader();
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) {
+      chunks.push(value);
+      options?.onChunk?.(value);
+    }
+  }
+
+  const totalLength = chunks.reduce((sum, c) => sum + c.byteLength, 0);
+  const merged = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  log.debug({ bytes: totalLength }, "Fish Audio synthesis complete");
+  return Buffer.from(merged);
 }


### PR DESCRIPTION
## Summary
- Replaces WebSocket live streaming API (`wss://api.fish.audio/v1/tts/live`, model `s1`) with REST API (`POST /v1/tts`, model `s2-pro`) for higher quality synthesis
- Synthesizes the full LLM response in one API call instead of sentence-by-sentence — Fish Audio gets complete text context for better prosody, and the idle-timeout heuristic is eliminated entirely
- Simplifies fish-audio-client.ts from a 360-line WebSocket/MessagePack session class to a ~100-line streaming HTTP function with AbortSignal support for barge-in
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
