### PR TITLE
Remove RUNTIME_HTTP_PORT pass-through from desktop app to CLI

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -115,16 +115,6 @@ extension AppDelegate {
         hasSetupDaemon = true
 
         let assistant = loadAssistantFromLockfile()
-        let launchEnvironment = ProcessInfo.processInfo.environment
-
-        // Ensure the daemon starts its runtime HTTP server so the
-        // gateway can proxy iOS traffic to it.
-        if let assistant, !assistant.isRemote {
-            let port = Int(launchEnvironment["RUNTIME_HTTP_PORT"] ?? "") ?? 7821
-            setenv("RUNTIME_HTTP_PORT", String(port), 1)
-        } else {
-            setenv("RUNTIME_HTTP_PORT", "7821", 1)
-        }
 
         // Start the keychain broker before the daemon so it is listening
         // when the daemon process launches and reads the socket path.

--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -97,7 +97,7 @@ final class VellumCli {
     /// child processes. Centralised so every call site stays in sync.
     nonisolated private static let forwardedEnvKeys: [String] = [
         "BASE_DATA_DIR",
-        "VELLUM_PLATFORM_URL", "RUNTIME_HTTP_PORT",
+        "VELLUM_PLATFORM_URL",
         "SENTRY_DSN", "TMPDIR", "USER", "LANG",
     ] + Array(providerEnvVars.values) + [
         // Cloud provider auth — needed by hatch and retire flows.
@@ -743,13 +743,6 @@ final class VellumCli {
                 proc.standardError = stderrPipe
 
                 var env = VellumCli.makeBaseEnvironment()
-                // Always forward RUNTIME_HTTP_PORT from getenv as a fallback
-                // (setenv may have been called after ProcessInfo was captured).
-                let fullEnv = ProcessInfo.processInfo.environment
-                if env["RUNTIME_HTTP_PORT"] == nil,
-                   let port = fullEnv["RUNTIME_HTTP_PORT"] ?? getenv("RUNTIME_HTTP_PORT").flatMap({ String(cString: $0) }) {
-                    env["RUNTIME_HTTP_PORT"] = port
-                }
                 // Fall back to credential storage for provider API keys
                 // when they're not in the process environment (e.g. app
                 // launched from Finder, not a terminal with env vars set).


### PR DESCRIPTION
## Summary
- Remove `setenv("RUNTIME_HTTP_PORT", ...)` from `AppDelegate+DaemonSetup.setupDaemonClient` — the CLI already defaults this to 7821 and overrides from lockfile resources
- Remove `RUNTIME_HTTP_PORT` from `VellumCli.forwardedEnvKeys` and the explicit `getenv` fallback in the CLI process launcher
- Port resolution is a backend concern; the desktop app shouldn't dictate it

## Test plan
- [ ] Hatch a local assistant — verify daemon starts on the correct port
- [ ] Switch between local assistants — verify gateway proxies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
