### PR TITLE
Partition audio attachments into their own bucket in ChatBubble

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -542,6 +542,14 @@ struct ChatBubble: View {
                     }
                 }
 
+                if !partitioned.audios.isEmpty {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        ForEach(partitioned.audios) { attachment in
+                            fileAttachmentChip(attachment)
+                        }
+                    }
+                }
+
                 if !partitioned.files.isEmpty {
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         ForEach(partitioned.files) { attachment in

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -407,23 +407,26 @@ extension ChatBubble {
         return "Sent \(count) attachments"
     }
 
-    /// Partitions attachments into image, video, and file buckets without
+    /// Partitions attachments into image, video, audio, and file buckets without
     /// performing any image decoding — decoding happens asynchronously in
     /// AttachmentImageGrid to keep NSImage(data:) off the layout path.
-    var partitionedAttachments: (images: [ChatAttachment], videos: [ChatAttachment], files: [ChatAttachment]) {
+    var partitionedAttachments: (images: [ChatAttachment], videos: [ChatAttachment], audios: [ChatAttachment], files: [ChatAttachment]) {
         var images: [ChatAttachment] = []
         var videos: [ChatAttachment] = []
+        var audios: [ChatAttachment] = []
         var files: [ChatAttachment] = []
         for attachment in message.attachments {
             if attachment.mimeType.hasPrefix("image/") {
                 images.append(attachment)
             } else if attachment.mimeType.hasPrefix("video/") {
                 videos.append(attachment)
+            } else if attachment.mimeType.hasPrefix("audio/") {
+                audios.append(attachment)
             } else {
                 files.append(attachment)
             }
         }
-        return (images, videos, files)
+        return (images, videos, audios, files)
     }
 
     func attachmentImageGrid(_ images: [ChatAttachment]) -> some View {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -317,6 +317,13 @@ extension ChatBubble {
                 }
             }
         }
+        if !partitioned.audios.isEmpty {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                ForEach(partitioned.audios) { attachment in
+                    fileAttachmentChip(attachment)
+                }
+            }
+        }
         if !partitioned.files.isEmpty {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
                 ForEach(partitioned.files) { attachment in


### PR DESCRIPTION
## Summary
- Add an `audios` bucket to `partitionedAttachments` alongside images, videos, and files
- Audio attachments (mp3, wav, m4a, etc.) are now partitioned separately from generic file attachments
- Temporarily render audio attachments as file chips until the inline player view lands in a follow-up PR

Part of plan: inline-audio-playback.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
