### PR TITLE
Render audio attachments with inline player in ChatBubble

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -543,9 +543,9 @@ struct ChatBubble: View {
                 }
 
                 if !partitioned.audios.isEmpty {
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
                         ForEach(partitioned.audios) { attachment in
-                            fileAttachmentChip(attachment)
+                            InlineAudioAttachmentView(attachment: attachment, resolveHttpPort: resolveHttpPort)
                         }
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -318,9 +318,9 @@ extension ChatBubble {
             }
         }
         if !partitioned.audios.isEmpty {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
                 ForEach(partitioned.audios) { attachment in
-                    fileAttachmentChip(attachment)
+                    InlineAudioAttachmentView(attachment: attachment, resolveHttpPort: resolveHttpPort)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Replace temporary file-chip rendering of audio attachments with InlineAudioAttachmentView
- Audio files (mp3, wav, m4a, etc.) now play inline in chat with play/pause, progress bar, seek, and download
- Applied in both standard and interleaved content rendering paths

Part of plan: inline-audio-playback.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
