### PR TITLE
Remove length cap from suggestion text generation

### DIFF
--- a/assistant/src/__tests__/suggestion-routes.test.ts
+++ b/assistant/src/__tests__/suggestion-routes.test.ts
@@ -2,8 +2,7 @@
  * Unit tests for the GET /v1/suggestion endpoint (handleGetSuggestion).
  *
  * Validates happy path, all null-return paths, caching, staleness check,
- * quote stripping, word-boundary truncation, empty response rejection,
- * and modelIntent verification.
+ * quote stripping, empty response rejection, and modelIntent verification.
  */
 
 import { describe, expect, mock, test } from "bun:test";
@@ -291,36 +290,6 @@ describe("GET /v1/suggestion", () => {
     const body = (await res.json()) as { suggestion: string };
 
     expect(body.suggestion).toBe("Sure, let's go!");
-  });
-
-  test("truncates long suggestions at word boundary", async () => {
-    // A 60-char string that will exceed the 50-char limit
-    const longText =
-      "This is a really long suggestion that goes well beyond fifty chars";
-    const provider = makeMockProvider(longText);
-    mockGetConfiguredProvider.mockImplementation(async () => provider);
-    mockGetConversationByKey.mockImplementation(() => ({
-      conversationId: "conv-test",
-    }));
-    mockGetMessages.mockImplementation(() => [
-      {
-        id: "msg-asst-1",
-        conversationId: "conv-test",
-        role: "assistant",
-        content: JSON.stringify([{ type: "text", text: "Hello there" }]),
-        createdAt: Date.now(),
-        metadata: null,
-      },
-    ]);
-
-    const url = makeUrl({ conversationKey: "test-key" });
-    const deps = makeDeps();
-    const res = await handleGetSuggestion(url, deps);
-    const body = (await res.json()) as { suggestion: string };
-
-    expect(body.suggestion.length).toBeLessThanOrEqual(50);
-    // Should end at a word boundary (no partial words)
-    expect(body.suggestion).not.toMatch(/\s$/);
   });
 
   test("rejects empty LLM response", async () => {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1234,12 +1234,12 @@ async function generateLlmSuggestion(
   const truncated =
     assistantText.length > 2000 ? assistantText.slice(-2000) : assistantText;
 
-  const prompt = `Given this assistant message, write a very short tab-complete suggestion (max 50 chars) the user could send next to keep the conversation going. Be casual, curious, or actionable — like a quick reply, not a formal request. Reply with ONLY the suggestion text.\n\nAssistant's message:\n${truncated}`;
+  const prompt = `Given this assistant message, write a very short tab-complete suggestion the user could send next to keep the conversation going. Be casual, curious, or actionable — like a quick reply, not a formal request. Reply with ONLY the suggestion text.\n\nAssistant's message:\n${truncated}`;
   const response = await provider.sendMessage(
     [{ role: "user", content: [{ type: "text", text: prompt }] }],
     [], // no tools
     undefined, // no system prompt
-    { config: { max_tokens: 40, modelIntent: "latency-optimized" } },
+    { config: { modelIntent: "latency-optimized" } },
   );
 
   const textBlock = response.content.find((b) => b.type === "text");
@@ -1251,7 +1251,7 @@ async function generateLlmSuggestion(
     return null;
   }
 
-  // Take first line only, then enforce the length cap
+  // Take first line only
   const firstLine = stripped.split("\n")[0].trim();
   if (!firstLine) {
     log.debug(
@@ -1260,22 +1260,7 @@ async function generateLlmSuggestion(
     );
     return null;
   }
-  if (firstLine.length <= 50) return firstLine;
-  // Truncate at last word boundary within 50 chars.
-  // Only strip the trailing partial word if the slice actually cut mid-word;
-  // if the character right after the cut is whitespace, the slice is already clean.
-  const sliced = firstLine.slice(0, 50);
-  const wordTruncated = (
-    /\s/.test(firstLine[50]) ? sliced : sliced.replace(/\s+\S*$/, "")
-  ).trim();
-  if (wordTruncated.length < 15) {
-    log.debug(
-      { rawLength: firstLine.length, truncatedLength: wordTruncated.length },
-      "Suggestion rejected: too short after word-boundary truncation",
-    );
-    return null;
-  }
-  return wordTruncated;
+  return firstLine;
 }
 
 export async function handleGetSuggestion(


### PR DESCRIPTION
## Summary
- Removed `max_tokens: 40` from the suggestion LLM call so the model isn't artificially cut short
- Removed the 50-char hard cap and word-boundary truncation logic from `generateLlmSuggestion`
- Removed `(max 50 chars)` instruction from the prompt — the model still gets "very short" guidance
- Removed the now-irrelevant truncation test

## Original prompt
remove the max_tokens and truncation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
