### PR TITLE
Add "Skill" memory kind to Intelligence tab

### DIFF
--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -154,7 +154,7 @@ async function searchItemsSemantic(
     const sparse = generateSparseEmbedding(query);
     const sparseVector = { indices: sparse.indices, values: sparse.values };
 
-    // Build Qdrant filter — items only, exclude capability kind and sentinel
+    // Build Qdrant filter — items only, exclude sentinel
     const mustConditions: Array<Record<string, unknown>> = [
       { key: "target_type", match: { value: "item" } },
     ];
@@ -168,7 +168,6 @@ async function searchItemsSemantic(
     const filter = {
       must: mustConditions,
       must_not: [
-        { key: "kind", match: { value: "capability" } },
         { key: "_meta", match: { value: true } },
       ],
     };
@@ -262,7 +261,6 @@ export async function handleListMemoryItems(url: URL): Promise<Response> {
       // in-depth against stale Qdrant payloads leaking deleted/mismatched rows.
       const hydrationConditions = [
         inArray(memoryItems.id, pageIds),
-        ne(memoryItems.kind, "capability"),
       ];
       if (statusParam && statusParam !== "all") {
         hydrationConditions.push(eq(memoryItems.status, statusParam));
@@ -300,8 +298,6 @@ export async function handleListMemoryItems(url: URL): Promise<Response> {
 
   // ── SQL path (default or fallback) ──────────────────────────────────
   const conditions = [];
-  // Hide system-managed capability memories (skill announcements) from the UI
-  conditions.push(ne(memoryItems.kind, "capability"));
   if (statusParam && statusParam !== "all") {
     conditions.push(eq(memoryItems.status, statusParam));
   }

--- a/clients/shared/Features/Memory/MemoryKindStyle.swift
+++ b/clients/shared/Features/Memory/MemoryKindStyle.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// The six memory kinds with display metadata (label, color, icon).
+/// Memory kinds with display metadata (label, color, icon).
 public enum MemoryKind: String, CaseIterable, Identifiable, Sendable {
     case identity
     case preference
@@ -8,11 +8,17 @@ public enum MemoryKind: String, CaseIterable, Identifiable, Sendable {
     case decision
     case constraint
     case event
+    case capability
 
     public var id: String { rawValue }
 
     /// Capitalised display label for the kind.
-    public var label: String { rawValue.capitalized }
+    public var label: String {
+        switch self {
+        case .capability: return "Skill"
+        default: return rawValue.capitalized
+        }
+    }
 
     /// Distinct fun-palette color for each kind.
     public var color: Color {
@@ -23,6 +29,7 @@ public enum MemoryKind: String, CaseIterable, Identifiable, Sendable {
         case .decision:   return VColor.funYellow
         case .constraint: return VColor.funCoral
         case .event:      return VColor.funPink
+        case .capability: return VColor.funRed
         }
     }
 
@@ -35,6 +42,7 @@ public enum MemoryKind: String, CaseIterable, Identifiable, Sendable {
         case .decision:   return VIcon.gitBranch.rawValue
         case .constraint: return VIcon.shield.rawValue
         case .event:      return VIcon.calendar.rawValue
+        case .capability: return VIcon.zap.rawValue
         }
     }
 }


### PR DESCRIPTION
## Summary
- Remove the `kind != capability` filter from all three query paths (Qdrant, SQL, hydration) in the memory items API
- Add `capability` case to `MemoryKind` Swift enum with display label "Skill", `funRed` color, and `zap` icon
- Skill (capability) memories now appear alongside other memory kinds in both macOS and iOS Intelligence tabs

## Original prompt
remove the filtering on capability
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
