### PR TITLE
Cut over connect/disconnect/reconfigure to GatewayConnectionManager

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -192,7 +192,7 @@ extension AppDelegate {
                 let cleared = await LocalAssistantBootstrapService.clearDaemonCredentials()
                 if !cleared {
                     log.warning("Credential cleanup incomplete — stopping daemon to prevent stale managed credential state")
-                    daemonClient.disconnect()
+                    connectionManager.disconnect()
                     vellumCli.stop(name: connectedAssistantId)
                 }
             }
@@ -443,7 +443,7 @@ extension AppDelegate {
 
         // 2. Disconnect transport — leave the old daemon running so it stays
         //    awake and can be switched back to without a cold start.
-        daemonClient.disconnect()
+        connectionManager.disconnect()
         // Reset dock icon to default before loading the new assistant's avatar
         AvatarAppearanceManager.shared.resetForDisconnect()
         // Close and recreate the main window to reset conversation state
@@ -561,7 +561,7 @@ extension AppDelegate {
                 }
                 // Retire failed but user chose Force Remove — stop the daemon
                 // before cleaning up local state.
-                daemonClient.disconnect()
+                connectionManager.disconnect()
                 vellumCli.stop(name: name)
                 self.removeLockfileEntry(assistantId: name)
             }
@@ -570,7 +570,7 @@ extension AppDelegate {
             // The retire CLI already stopped the daemon process; an
             // additional vellumCli.stop() here would block the main
             // thread and always fail because the process is already gone.
-            daemonClient.disconnect()
+            connectionManager.disconnect()
         } else {
             vellumCli.stop(name: assistantName)
         }
@@ -617,7 +617,7 @@ extension AppDelegate {
         UserDefaults.standard.removeObject(forKey: "lastActivePanel")
         UserDefaults.standard.removeObject(forKey: "managedServiceModesInitialized")
 
-        daemonClient.disconnect()
+        connectionManager.disconnect()
         actorTokenBootstrapTask?.cancel()
         actorTokenBootstrapTask = nil
         ActorTokenManager.deleteToken()
@@ -670,7 +670,7 @@ extension AppDelegate {
 
         hasSetupApp = false
         hasSetupDaemon = false
-        daemonClient.disconnect()
+        connectionManager.disconnect()
         UserDefaults.standard.removeObject(forKey: "user.profile")
 
         // Dev builds may have a custom bundle name (e.g. "Jarvis.app").
@@ -721,7 +721,7 @@ extension AppDelegate {
             }
 
             // Stop any remaining daemon processes.
-            daemonClient.disconnect()
+            connectionManager.disconnect()
             vellumCli.stop()
 
             // Move the app bundle to the Trash.

--- a/clients/macos/vellum-assistant/App/AppDelegate+Conversations.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Conversations.swift
@@ -27,7 +27,7 @@ extension AppDelegate {
             if !daemonClient.isConnected {
                 log.info("Daemon not connected, attempting to connect before session start")
                 do {
-                    try await daemonClient.connect()
+                    try await connectionManager.connect()
                     self.setupAmbientAgent()
                 } catch {
                     log.error("Failed to connect to daemon: \(error.localizedDescription)")

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -260,7 +260,7 @@ extension AppDelegate {
             if !daemonClient.isConnected && !connectionManager.isConnecting {
                 log.info("setupDaemonClient: calling connect()")
                 do {
-                    try await daemonClient.connect()
+                    try await connectionManager.connect()
                     log.info("setupDaemonClient: connect() succeeded, isConnected=\(self.daemonClient.isConnected)")
                 } catch {
                     log.error("Failed to connect to daemon during setup: \(error)")

--- a/clients/macos/vellum-assistant/App/AppServices.swift
+++ b/clients/macos/vellum-assistant/App/AppServices.swift
@@ -25,6 +25,13 @@ public final class AppServices {
 
     /// Reconfigure the connection for a new assistant.
     func reconfigureDaemonClient(config: DaemonConfig) {
-        daemonClient.reconfigure(config: config)
+        let conversationKey: String?
+        if case .http(_, _, let key) = config.transport { conversationKey = key } else { conversationKey = nil }
+        connectionManager.reconfigure(
+            instanceDir: config.instanceDir,
+            isRuntimeFlat: config.transportMetadata.routeMode == .runtimeFlat,
+            conversationKey: conversationKey
+        )
+        daemonClient.resetConnectionState(instanceDir: config.instanceDir)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1137,7 +1137,7 @@ struct MainWindowView: View {
             }
             // Reconnect the daemon client after a successful restart
             if !appDelegate.daemonClient.isConnected && !appDelegate.connectionManager.isConnecting {
-                try? await appDelegate.daemonClient.connect()
+                try? await appDelegate.connectionManager.connect()
             }
         }
     }

--- a/clients/macos/vellum-assistantTests/DaemonClientReconfigureTests.swift
+++ b/clients/macos/vellum-assistantTests/DaemonClientReconfigureTests.swift
@@ -19,121 +19,44 @@ final class DaemonClientReconfigureTests: XCTestCase {
 
     // MARK: - Object identity preservation
 
-    func testReconfigurePreservesObjectIdentity() {
+    func testResetPreservesObjectIdentity() {
         let originalIdentity = ObjectIdentifier(client!)
-
-        let newConfig = DaemonConfig(transport: .http(
-            baseURL: "http://localhost:9999",
-            bearerToken: "test-token",
-            conversationKey: "test-key"
-        ))
-        client.reconfigure(config: newConfig)
-
+        client.resetConnectionState(instanceDir: "/tmp/test")
         XCTAssertEqual(ObjectIdentifier(client!), originalIdentity,
-            "Reconfigure must preserve DaemonClient object identity")
+            "resetConnectionState must preserve object identity")
     }
 
-    func testReconfigureUpdatesInstanceDir() {
-        let newConfig = DaemonConfig(transport: .http(
-            baseURL: "http://localhost:9999",
-            bearerToken: "new-token",
-            conversationKey: "new-key"
-        ), instanceDir: "/tmp/test-instance")
-        client.reconfigure(config: newConfig)
-
-        XCTAssertEqual(client.instanceDir, "/tmp/test-instance",
-            "instanceDir should be updated after reconfigure")
+    func testResetUpdatesInstanceDir() {
+        client.resetConnectionState(instanceDir: "/tmp/test-instance")
+        XCTAssertEqual(client.instanceDir, "/tmp/test-instance")
     }
 
-    func testReconfigureResetsConnectionState() {
-        // Simulate some connection state
+    func testResetClearsConnectionState() {
         client.httpPort = 7821
         client.currentModel = "claude-3"
 
-        let newConfig = DaemonConfig(transport: .http(
-            baseURL: "http://localhost:9999",
-            bearerToken: nil,
-            conversationKey: "key"
-        ))
-        client.reconfigure(config: newConfig)
+        client.resetConnectionState()
 
-        XCTAssertNil(client.httpPort, "httpPort should be reset after reconfigure")
-        XCTAssertNil(client.currentModel, "currentModel should be reset after reconfigure")
-        XCTAssertNil(client.daemonVersion, "daemonVersion should be reset after reconfigure")
-        XCTAssertNil(client.latestMemoryStatus, "latestMemoryStatus should be reset after reconfigure")
-        XCTAssertFalse(client.isConnected, "isConnected should be false after reconfigure")
+        XCTAssertNil(client.httpPort)
+        XCTAssertNil(client.currentModel)
+        XCTAssertNil(client.daemonVersion)
+        XCTAssertNil(client.latestMemoryStatus)
+        XCTAssertFalse(client.isConnected)
     }
 
-    func testReconfigurePreservesIsConnectedAsFalse() {
+    func testResetSetsIsConnectedToFalse() {
         client.isConnected = true
-
-        let newConfig = DaemonConfig(transport: .http(
-            baseURL: "http://localhost:9999",
-            bearerToken: nil,
-            conversationKey: "key"
-        ))
-        client.reconfigure(config: newConfig)
-
-        // After reconfigure, isConnected should be reset to false
-        XCTAssertFalse(client.isConnected, "isConnected should be false after reconfigure")
+        client.resetConnectionState()
+        XCTAssertFalse(client.isConnected)
     }
 
-    func testReconfigureBetweenHTTPEndpoints() {
-        // Start with default config
-        XCTAssertNil(client.instanceDir)
-
-        // Reconfigure to a different HTTP endpoint with instanceDir
-        let httpConfig = DaemonConfig(transport: .http(
-            baseURL: "http://remote-host:8080",
-            bearerToken: "bearer-123",
-            conversationKey: "conv-key"
-        ), instanceDir: "/tmp/remote-instance")
-        client.reconfigure(config: httpConfig)
-
-        XCTAssertEqual(client.instanceDir, "/tmp/remote-instance",
-            "instanceDir should reflect the new config after reconfigure")
-    }
-
-    func testMultipleReconfiguresPreserveIdentity() {
-        let originalIdentity = ObjectIdentifier(client!)
-
-        // First reconfigure
-        client.reconfigure(config: DaemonConfig(transport: .http(
-            baseURL: "http://host-1:8080",
-            bearerToken: nil,
-            conversationKey: "key-1"
-        )))
-        XCTAssertEqual(ObjectIdentifier(client!), originalIdentity)
-
-        // Second reconfigure
-        client.reconfigure(config: DaemonConfig(transport: .http(
-            baseURL: "http://host-2:8080",
-            bearerToken: nil,
-            conversationKey: "key-2"
-        )))
-        XCTAssertEqual(ObjectIdentifier(client!), originalIdentity)
-
-        // Third reconfigure back to default
-        client.reconfigure(config: .default)
-        XCTAssertEqual(ObjectIdentifier(client!), originalIdentity)
-    }
-
-    // MARK: - Weak reference survival
-
-    func testWeakReferencesSurviveReconfigure() {
-        // Simulate what RecordingManager does: hold a weak reference
+    func testWeakReferencesSurviveReset() {
         weak var weakClient = client
-        _ = { weakClient = nil }  // prevent "never mutated" warning; not called
+        _ = { weakClient = nil }
 
-        XCTAssertNotNil(weakClient, "Weak reference should be non-nil before reconfigure")
-
-        client.reconfigure(config: DaemonConfig(transport: .http(
-            baseURL: "http://localhost:9999",
-            bearerToken: nil,
-            conversationKey: "key"
-        )))
-
-        XCTAssertNotNil(weakClient, "Weak reference should survive reconfigure (same object)")
-        XCTAssertTrue(weakClient === client, "Weak reference should point to the same object")
+        XCTAssertNotNil(weakClient)
+        client.resetConnectionState()
+        XCTAssertNotNil(weakClient)
+        XCTAssertTrue(weakClient === client)
     }
 }

--- a/clients/macos/vellum-assistantTests/RecordingManagerSwitchBindingTests.swift
+++ b/clients/macos/vellum-assistantTests/RecordingManagerSwitchBindingTests.swift
@@ -9,12 +9,8 @@ final class RecordingManagerSwitchBindingTests: XCTestCase {
         let client = DaemonClient()
         let recordingManager = RecordingManager(daemonClient: client)
 
-        // Reconfigure the client in place (simulating assistant switch)
-        client.reconfigure(config: DaemonConfig(transport: .http(
-            baseURL: "http://new-assistant:8080",
-            bearerToken: "token",
-            conversationKey: "key"
-        )))
+        // Reset published state (simulating assistant switch)
+        client.resetConnectionState()
 
         // The recording manager should still be able to send status
         // messages through the (reconfigured) daemon client. We verify

--- a/clients/shared/Network/DaemonStatus.swift
+++ b/clients/shared/Network/DaemonStatus.swift
@@ -134,26 +134,24 @@ public final class DaemonStatus: ObservableObject, DaemonStatusProtocol {
     public convenience init(config: DaemonConfig = .default) {
         let cm = GatewayConnectionManager()
         self.init(connectionManager: cm)
-        self.currentConfig = config
         self.instanceDir = config.instanceDir
+        let conversationKey: String?
+        if case .http(_, _, let key) = config.transport { conversationKey = key } else { conversationKey = nil }
         cm.reconfigure(
             instanceDir: config.instanceDir,
-            isRuntimeFlat: config.transportMetadata.routeMode == .runtimeFlat
+            isRuntimeFlat: config.transportMetadata.routeMode == .runtimeFlat,
+            conversationKey: conversationKey
         )
     }
 
     // MARK: - Connection (forwarding)
 
-    /// Current config — stored only so `connect()` can extract the conversation key.
-    private var currentConfig: DaemonConfig?
-
     public func connect() async throws {
-        guard let cm = _connectionManager,
-              case .http(_, _, let conversationKey) = currentConfig?.transport else {
-            log.info("connect: no HTTP transport configured, skipping")
+        guard let cm = _connectionManager else {
+            log.info("connect: no connection manager")
             return
         }
-        try await cm.connectImpl(cancelAutoWake: true, conversationKey: conversationKey)
+        try await cm.connect()
     }
 
     public func disconnect() {
@@ -163,15 +161,9 @@ public final class DaemonStatus: ObservableObject, DaemonStatusProtocol {
         latestMemoryStatus = nil
     }
 
-    /// Reconfigure the transport in place without replacing object identity.
-    public func reconfigure(config newConfig: DaemonConfig) {
-        currentConfig = newConfig
-        instanceDir = newConfig.instanceDir
-        _connectionManager?.reconfigure(
-            instanceDir: newConfig.instanceDir,
-            isRuntimeFlat: newConfig.transportMetadata.routeMode == .runtimeFlat
-        )
-        // Reset connection-specific published state
+    /// Reset connection-specific published state after a reconfigure or disconnect.
+    public func resetConnectionState(instanceDir: String? = nil) {
+        self.instanceDir = instanceDir
         isConnected = false
         httpPort = nil
         daemonVersion = nil

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -89,9 +89,7 @@ public final class GatewayConnectionManager {
         try await connectImpl(cancelAutoWake: true)
     }
 
-    /// Connect using a conversation key for host tool filtering.
-    /// Call `reconfigure()` first to set instance directory and route mode.
-    func connectImpl(cancelAutoWake: Bool, conversationKey: String? = nil) async throws {
+    func connectImpl(cancelAutoWake: Bool) async throws {
         disconnectInternal(cancelAutoWake: cancelAutoWake)
 
         isConnecting = true
@@ -171,9 +169,13 @@ public final class GatewayConnectionManager {
 
     // MARK: - Reconfigure
 
+    /// Conversation key for host tool filtering, set during reconfigure.
+    private var conversationKey: String?
+
     /// Reconfigure connection parameters for a new assistant.
     /// Callers must call `connect()` after reconfiguring.
-    public func reconfigure(instanceDir: String?, isRuntimeFlat: Bool) {
+    public func reconfigure(instanceDir: String?, isRuntimeFlat: Bool, conversationKey: String? = nil) {
+        self.conversationKey = conversationKey
         #if os(macOS)
         autoWakeTask?.cancel()
         autoWakeTask = nil


### PR DESCRIPTION
## Summary

macOS callers now call `connectionManager.connect()`/`disconnect()`/`reconfigure()` directly instead of going through `daemonClient`.

- Remove `reconfigure()` from DaemonStatus, replace with `resetConnectionState()` for published state reset
- `connect()`/`disconnect()` remain on DaemonStatus for iOS/ChatViewModel protocol callers only
- Store `conversationKey` on GatewayConnectionManager during `reconfigure()` so `connect()` can use it
- Remove `currentConfig` from DaemonStatus
- AppServices calls `connectionManager.reconfigure()` + `daemonClient.resetConnectionState()` separately
- AppDelegate auth lifecycle calls `connectionManager.disconnect()` directly

Net: **-80 lines** across 9 files

## Test plan

- [x] `swift build` passes
- [x] `swift test` — all 156 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
