### PR TITLE
Fix iOS build: add recovery credential forwarding to DaemonStatus

### DIFF
--- a/clients/shared/Network/DaemonStatus.swift
+++ b/clients/shared/Network/DaemonStatus.swift
@@ -265,6 +265,18 @@ public final class DaemonStatus: ObservableObject, DaemonStatusProtocol {
             break
         }
     }
+
+    // MARK: - Recovery Credentials (forwarded to GatewayConnectionManager)
+
+    public var recoveryPlatform: String? {
+        get { _connectionManager?.recoveryPlatform }
+        set { _connectionManager?.recoveryPlatform = newValue }
+    }
+
+    public var recoveryDeviceId: String? {
+        get { _connectionManager?.recoveryDeviceId }
+        set { _connectionManager?.recoveryDeviceId = newValue }
+    }
 }
 
 // MARK: - Backward Compatibility


### PR DESCRIPTION
## Summary
- The recent `DaemonStatus` → `EventStreamClient` migration moved `recoveryPlatform` and `recoveryDeviceId` to `GatewayConnectionManager` but didn't add forwarding computed properties on `DaemonStatus`
- This broke iOS compilation since `WorkspaceFileSheet` and `AppDelegate` access these properties via `DaemonClient` (typealias for `DaemonStatus`)
- Adds forwarding computed properties that delegate to the private `_connectionManager` reference

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23378565027/job/68014397140
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
