### PR TITLE
Fix flaky ChatBottomPinCoordinator test timing on CI

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
@@ -651,8 +651,10 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
 
         coordinator.requestPin(reason: .messageCount, conversationId: convId)
 
-        // Wait for retries to process.
-        try await Task.sleep(nanoseconds: 300_000_000)
+        // Wait for retries to process. Use a generous timeout because
+        // @MainActor Task scheduling on CI runners can be much slower than
+        // the 50ms retry interval would suggest.
+        try await Task.sleep(nanoseconds: 1_000_000_000)
 
         // Session should have completed successfully once geometry appeared.
         XCTAssertNil(coordinator.activeSession,


### PR DESCRIPTION
## Summary
- Increased sleep duration in `testGeometryBecomingAvailableMidSessionCompletesPin` from 300ms to 1s to account for slow `@MainActor` Task scheduling on CI runners
- The test needs 3 retry attempts at 50ms intervals (~100ms theoretical), but CI scheduling overhead caused only 2 retries to complete within 300ms

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23378565024/job/68014405807