### PR TITLE
Fix audio attachments getting application/octet-stream MIME type

### DIFF
--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -76,6 +76,15 @@ const EXTENSION_MIME_MAP: Record<string, string> = {
   js: "text/javascript",
   ts: "text/typescript",
 
+  // Audio
+  mp3: "audio/mpeg",
+  wav: "audio/wav",
+  ogg: "audio/ogg",
+  flac: "audio/flac",
+  aac: "audio/aac",
+  m4a: "audio/x-m4a",
+  opus: "audio/opus",
+
   // Video
   mp4: "video/mp4",
   webm: "video/webm",

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -37,6 +37,7 @@ import {
   migrateAssistantContactMetadata,
   migrateBackfillContactInteractionStats,
   migrateBackfillGuardianPrincipalId,
+  migrateBackfillAudioAttachmentMimeTypes,
   migrateBackfillInlineAttachmentsToDisk,
   migrateBackfillUsageCacheAccounting,
   migrateCallSessionInviteMetadata,
@@ -495,6 +496,9 @@ export function initializeDb(): void {
 
   // 87. Add skip_disclosure column to call_sessions for per-call disclosure control
   migrateCallSessionSkipDisclosure(database);
+
+  // 88. Backfill correct MIME types for audio attachments stored as application/octet-stream
+  migrateBackfillAudioAttachmentMimeTypes(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/191-backfill-audio-attachment-mime-types.ts
+++ b/assistant/src/memory/migrations/191-backfill-audio-attachment-mime-types.ts
@@ -1,0 +1,51 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+/**
+ * Backfill MIME types for audio attachments that were stored with
+ * "application/octet-stream" because the EXTENSION_MIME_MAP was
+ * missing audio format entries.
+ *
+ * Updates mime_type based on the file extension in original_filename.
+ */
+
+const AUDIO_EXT_MIME: Record<string, string> = {
+  mp3: "audio/mpeg",
+  wav: "audio/wav",
+  ogg: "audio/ogg",
+  flac: "audio/flac",
+  aac: "audio/aac",
+  m4a: "audio/x-m4a",
+  opus: "audio/opus",
+};
+
+export function migrateBackfillAudioAttachmentMimeTypes(
+  database: DrizzleDb,
+): void {
+  withCrashRecovery(
+    database,
+    "migration_backfill_audio_attachment_mime_types_v1",
+    () => {
+      const raw = getSqliteFrom(database);
+
+      for (const [ext, mime] of Object.entries(AUDIO_EXT_MIME)) {
+        const pattern = `%.${ext}`;
+        const result = raw
+          .query(
+            `UPDATE attachments
+             SET mime_type = ?, kind = 'document'
+             WHERE lower(original_filename) LIKE ?
+               AND mime_type = 'application/octet-stream'`,
+          )
+          .run(mime, pattern);
+
+        if ((result as { changes?: number }).changes) {
+          console.log(
+            `Backfilled ${(result as { changes: number }).changes} .${ext} attachments → ${mime}`,
+          );
+        }
+      }
+    },
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -129,6 +129,7 @@ export { migrateLlmRequestLogProvider } from "./184-llm-request-log-provider.js"
 export { migrateScheduleQuietFlag } from "./188-schedule-quiet-flag.js";
 export { migrateDropSimplifiedMemory } from "./189-drop-simplified-memory.js";
 export { migrateCallSessionSkipDisclosure } from "./190-call-session-skip-disclosure.js";
+export { migrateBackfillAudioAttachmentMimeTypes } from "./191-backfill-audio-attachment-mime-types.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -241,6 +241,12 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Rename checkpoint keys from thread_starters: to conversation_starters: prefix so renamed code paths find existing generation state",
   },
+  {
+    key: "migration_backfill_audio_attachment_mime_types_v1",
+    version: 36,
+    description:
+      "Backfill correct MIME types for audio attachments stored as application/octet-stream due to missing extension map entries",
+  },
 ];
 
 export interface MigrationValidationResult {


### PR DESCRIPTION
## Summary
- Add audio format entries (mp3, wav, ogg, flac, aac, m4a, opus) to `EXTENSION_MIME_MAP` in `assistant-attachments.ts` so new audio attachments get the correct `audio/*` MIME type instead of `application/octet-stream`
- Add DB migration (191) to backfill existing audio attachments stored with incorrect MIME type, fixing inline playback for previously-sent audio files