### PR TITLE
Fix iOS build: remove obsolete DaemonClient(connectionManager:) calls

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -65,10 +65,9 @@ final class ClientProvider: ObservableObject {
         )
         newCM.recoveryPlatform = prevPlatform
         newCM.recoveryDeviceId = prevDeviceId
-        let newClient = DaemonClient(connectionManager: newCM)
-        newClient.instanceDir = config.instanceDir
+        newCM.instanceDir = config.instanceDir
         self.connectionManager = newCM
-        self.client = newClient
+        self.client = newCM
         self.clientGeneration &+= 1
         self.isConnected = false
         bindCombineBridge()
@@ -118,12 +117,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     override init() {
         let cm = GatewayConnectionManager()
         let config = DaemonConfig.fromUserDefaults()
-        let client = DaemonClient(connectionManager: cm)
-        client.instanceDir = config.instanceDir
+        cm.instanceDir = config.instanceDir
         cm.reconfigure(
             instanceDir: config.instanceDir
         )
-        self.clientProvider = ClientProvider(connectionManager: cm, client: client)
+        self.clientProvider = ClientProvider(connectionManager: cm, client: cm)
         super.init()
     }
 


### PR DESCRIPTION
## Summary
- `DaemonClient` is now a typealias for `GatewayConnectionManager` (parameterless init), but `AppDelegate.swift` still called `DaemonClient(connectionManager:)` at two sites
- Removed the separate `DaemonClient` instantiation and use the `GatewayConnectionManager` instance directly as both connection manager and client

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23379419360/job/68016437724
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
