### PR TITLE
Add tooltip to truncated action descriptions

### DIFF
--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -101,6 +101,7 @@ public struct ToolCallChip: View {
                         .foregroundColor(toolCall.isError ? VColor.systemNegativeStrong : VColor.contentDefault)
                         .lineLimit(1)
                         .truncationMode(.tail)
+                        .help(toolCall.actionDescription)
 
                     // Status indicator
                     if !toolCall.isComplete {


### PR DESCRIPTION
## Summary
- Add `.help()` modifier to the action description `Text` in `ToolCallChip` so that hovering over a truncated step description shows the full text in a macOS tooltip.

## Original prompt
When this action description is truncated like this, mousing over it should give me a tooltip with the full text