### PR TITLE
Remove instanceDir from GatewayConnectionManager

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -67,8 +67,7 @@ extension AppDelegate {
         guard let assistant, assistant.isRemote else {
             // Local assistant or no assistant.
             let conversationKey = assistant?.assistantId ?? UUID().uuidString
-            let instanceDir = assistant?.instanceDir
-            services.reconfigureConnection(instanceDir: instanceDir, conversationKey: conversationKey)
+            services.reconfigureConnection(conversationKey: conversationKey)
             log.info("Configured local assistant")
             return
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -53,7 +53,7 @@ extension NSApplication {
 extension AppDelegate {
 
     func currentUserAppsDirectory() -> URL {
-        let env = connectionManager.instanceDir.map { ["BASE_DATA_DIR": $0] }
+        let env = LockfileAssistant.connectedInstanceDir().map { ["BASE_DATA_DIR": $0] }
         return VellumAppSchemeHandler.resolveUserAppsDirectory(environment: env)
     }
 

--- a/clients/macos/vellum-assistant/App/AppServices.swift
+++ b/clients/macos/vellum-assistant/App/AppServices.swift
@@ -19,10 +19,7 @@ public final class AppServices {
     )
 
     /// Reconfigure the connection for a new assistant.
-    func reconfigureConnection(instanceDir: String? = nil, conversationKey: String? = nil) {
-        connectionManager.reconfigure(
-            instanceDir: instanceDir,
-            conversationKey: conversationKey
-        )
+    func reconfigureConnection(conversationKey: String? = nil) {
+        connectionManager.reconfigure(conversationKey: conversationKey)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -806,7 +806,7 @@ struct MainWindowView: View {
             if let path = notification.userInfo?["userAppsDirectoryPath"] as? String, !path.isEmpty {
                 windowState.activeDynamicUserAppsDirectory = URL(fileURLWithPath: path, isDirectory: true)
             } else {
-                let env = connectionManager.instanceDir.map { ["BASE_DATA_DIR": $0] }
+                let env = LockfileAssistant.connectedInstanceDir().map { ["BASE_DATA_DIR": $0] }
                 windowState.activeDynamicUserAppsDirectory = VellumAppSchemeHandler.resolveUserAppsDirectory(environment: env)
             }
             if let surface = windowState.activeDynamicParsedSurface,
@@ -821,7 +821,7 @@ struct MainWindowView: View {
             // send a fresh ui_surface_show via SSE with the full payload.
             let reopenId = ref.appId ?? ref.surfaceId
             windowState.selection = .app(reopenId)
-            let env = connectionManager.instanceDir.map { ["BASE_DATA_DIR": $0] }
+            let env = LockfileAssistant.connectedInstanceDir().map { ["BASE_DATA_DIR": $0] }
             windowState.activeDynamicUserAppsDirectory = VellumAppSchemeHandler.resolveUserAppsDirectory(environment: env)
             Task { await AppsClient.openAppAndDispatchSurface(id: reopenId, connectionManager: connectionManager, eventStreamClient: eventStreamClient) }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -26,7 +26,7 @@ struct IdentityPanel: View {
 
     /// Whether the BOOTSTRAP.md first-run ritual is still in progress.
     private var isBootstrapActive: Bool {
-        let base = connectionManager.instanceDir ?? NSHomeDirectory()
+        let base = LockfileAssistant.connectedInstanceDir() ?? NSHomeDirectory()
         return FileManager.default.fileExists(atPath: base + "/.vellum/workspace/BOOTSTRAP.md")
     }
 

--- a/clients/macos/vellum-assistantTests/AppServicesDaemonClientReconfigureTests.swift
+++ b/clients/macos/vellum-assistantTests/AppServicesDaemonClientReconfigureTests.swift
@@ -9,20 +9,12 @@ final class AppServicesConnectionReconfigureTests: XCTestCase {
         let services = AppServices()
         let originalIdentity = ObjectIdentifier(services.connectionManager)
 
-        services.reconfigureConnection(instanceDir: "/tmp/test", conversationKey: "key")
+        services.reconfigureConnection(conversationKey: "key")
 
         XCTAssertEqual(
             ObjectIdentifier(services.connectionManager), originalIdentity,
             "reconfigureConnection must preserve GatewayConnectionManager object identity"
         )
-    }
-
-    func testReconfigureUpdatesInstanceDir() {
-        let services = AppServices()
-
-        services.reconfigureConnection(instanceDir: "/tmp/test-instance", conversationKey: "new-key")
-
-        XCTAssertEqual(services.connectionManager.instanceDir, "/tmp/test-instance")
     }
 
     func testSettingsStoreRetainsWorkingConnectionAfterReconfigure() {

--- a/clients/macos/vellum-assistantTests/DaemonClientReconfigureTests.swift
+++ b/clients/macos/vellum-assistantTests/DaemonClientReconfigureTests.swift
@@ -17,43 +17,33 @@ final class GatewayConnectionManagerReconfigureTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - Object identity preservation
-
-    func testResetPreservesObjectIdentity() {
+    func testReconfigurePreservesObjectIdentity() {
         let originalIdentity = ObjectIdentifier(client!)
-        client.reconfigure(instanceDir: "/tmp/test")
+        client.reconfigure(conversationKey: "test-key")
         XCTAssertEqual(ObjectIdentifier(client!), originalIdentity,
             "reconfigure must preserve object identity")
     }
 
-    func testResetUpdatesInstanceDir() {
-        client.reconfigure(instanceDir: "/tmp/test-instance")
-        XCTAssertEqual(client.instanceDir, "/tmp/test-instance")
-    }
-
-    func testResetClearsConnectionState() {
+    func testReconfigureClearsConnectionState() {
         client.currentModel = "claude-3"
-
-        client.reconfigure(instanceDir: nil)
-
+        client.reconfigure()
         XCTAssertNil(client.currentModel)
         XCTAssertNil(client.assistantVersion)
         XCTAssertNil(client.latestMemoryStatus)
         XCTAssertFalse(client.isConnected)
     }
 
-    func testResetSetsIsConnectedToFalse() {
+    func testReconfigureSetsIsConnectedToFalse() {
         client.isConnected = true
-        client.reconfigure(instanceDir: nil)
+        client.reconfigure()
         XCTAssertFalse(client.isConnected)
     }
 
-    func testWeakReferencesSurviveReset() {
+    func testWeakReferencesSurviveReconfigure() {
         weak var weakClient = client
         _ = { weakClient = nil }
-
         XCTAssertNotNil(weakClient)
-        client.reconfigure(instanceDir: nil)
+        client.reconfigure()
         XCTAssertNotNil(weakClient)
         XCTAssertTrue(weakClient === client)
     }

--- a/clients/macos/vellum-assistantTests/RecordingManagerSwitchBindingTests.swift
+++ b/clients/macos/vellum-assistantTests/RecordingManagerSwitchBindingTests.swift
@@ -10,7 +10,7 @@ final class RecordingManagerSwitchBindingTests: XCTestCase {
         let recordingManager = RecordingManager(connectionManager: client)
 
         // Reset published state (simulating assistant switch)
-        client.reconfigure(instanceDir: nil)
+        client.reconfigure()
 
         // The recording manager should still be able to send status
         // messages through the (reconfigured) daemon client. We verify

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -31,9 +31,6 @@ public final class GatewayConnectionManager: ObservableObject {
     @Published public var currentModel: String?
     @Published public var latestModelInfo: ModelInfoMessage?
 
-    /// Instance directory for the connected assistant.
-    public var instanceDir: String?
-
     /// Whether the transport has authenticated successfully.
     var isAuthenticated = false
 
@@ -143,7 +140,7 @@ public final class GatewayConnectionManager: ObservableObject {
             }
 
             if let wakeHandler, isLocal {
-                let reachable = await HealthCheckClient.isReachable(instanceDir: instanceDir)
+                let reachable = await HealthCheckClient.isReachable()
                 if !reachable {
                     log.info("connect: gateway unreachable — attempting auto-wake before retry")
                     do {
@@ -196,14 +193,13 @@ public final class GatewayConnectionManager: ObservableObject {
 
     /// Reconfigure connection parameters for a new assistant.
     /// Callers must call `connect()` after reconfiguring.
-    public func reconfigure(instanceDir: String?, conversationKey: String? = nil) {
+    public func reconfigure(conversationKey: String? = nil) {
         self.conversationKey = conversationKey
         #if os(macOS)
         autoWakeTask?.cancel()
         autoWakeTask = nil
         #endif
         disconnect()
-        self.instanceDir = instanceDir
         isAuthenticated = false
         refreshTask?.cancel()
         refreshTask = nil
@@ -462,7 +458,7 @@ public final class GatewayConnectionManager: ObservableObject {
         autoWakeTask = Task { @MainActor [weak self] in
             guard let self else { return }
 
-            let reachable = await HealthCheckClient.isReachable(instanceDir: self.instanceDir)
+            let reachable = await HealthCheckClient.isReachable()
             guard !reachable else {
                 self.lastAutoWakeAttempt = nil
                 return

--- a/clients/shared/Network/HealthCheckClient.swift
+++ b/clients/shared/Network/HealthCheckClient.swift
@@ -70,13 +70,5 @@ public enum HealthCheckClient {
         }
     }
 
-    /// Check whether the assistant matching the given instance directory is reachable.
-    public static func isReachable(instanceDir: String?, timeout: TimeInterval = 3) async -> Bool {
-        if let instanceDir,
-           let assistant = LockfileAssistant.loadAll().first(where: { $0.instanceDir == instanceDir }) {
-            return await isReachable(for: assistant, timeout: timeout)
-        }
-        return await isReachable(timeout: timeout)
-    }
     #endif
 }

--- a/clients/shared/Network/LockfileAssistant.swift
+++ b/clients/shared/Network/LockfileAssistant.swift
@@ -194,6 +194,12 @@ public struct LockfileAssistant {
         loadAll().first { $0.assistantId == name }
     }
 
+    /// Resolve the instance directory for the currently connected assistant.
+    public static func connectedInstanceDir() -> String? {
+        guard let id = UserDefaults.standard.string(forKey: "connectedAssistantId") else { return nil }
+        return loadByName(id)?.instanceDir
+    }
+
     /// Creates or refreshes a managed entry for the given `assistantId`.
     /// Existing entries keep their original `hatchedAt` value but have the
     /// managed runtime URL refreshed so sign-in follows the current platform.


### PR DESCRIPTION
## Summary

Remove `instanceDir` from `GatewayConnectionManager` — file path resolution belongs to the lockfile, not the connection manager.

- Remove `instanceDir` property from GatewayConnectionManager
- Remove `instanceDir` parameter from `reconfigure()` and `AppServices.reconfigureConnection()`
- Consumers that need instance directory use `LockfileAssistant.connectedInstanceDir()` (new helper)
- Auto-wake `HealthCheckClient` calls use the no-arg overload

Net: **-20 lines**

## Test plan

- [x] `swift build` passes
- [x] `swift test` — all 156 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
