### PR TITLE
Remove httpPort from daemon_status, rename to AssistantStatusMessage

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -9,7 +9,6 @@
         "@anthropic-ai/sdk": "^0.78.0",
         "@google/genai": "^1.40.0",
         "@modelcontextprotocol/sdk": "^1.15.1",
-        "@msgpack/msgpack": "^3.1.3",
         "@qdrant/js-client-rest": "^1.16.2",
         "@resvg/resvg-js": "^2.6.2",
         "@sentry/node": "^10.38.0",
@@ -152,8 +151,6 @@
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
-
-    "@msgpack/msgpack": ["@msgpack/msgpack@3.1.3", "", {}, "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -32,7 +32,6 @@
     "@anthropic-ai/sdk": "^0.78.0",
     "@google/genai": "^1.40.0",
     "@modelcontextprotocol/sdk": "^1.15.1",
-    "@msgpack/msgpack": "^3.1.3",
     "@qdrant/js-client-rest": "^1.16.2",
     "@resvg/resvg-js": "^2.6.2",
     "@sentry/node": "^10.38.0",

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -847,7 +847,7 @@ export async function runDaemon(): Promise<void> {
         server.broadcast(msg as ServerMessage),
       );
       initSlashPairingContext(runtimeHttp.getPairingStore());
-      server.setHttpPort(httpPort);
+      server.broadcastStatus();
       log.info(
         { port: httpPort, hostname },
         "Daemon startup: runtime HTTP server listening",

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -223,7 +223,6 @@ export interface PongMessage {
 
 export interface DaemonStatusMessage {
   type: "daemon_status";
-  httpPort?: number;
   version?: string;
   keyFingerprint?: string;
 }

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -221,8 +221,8 @@ export interface PongMessage {
   type: "pong";
 }
 
-export interface DaemonStatusMessage {
-  type: "daemon_status";
+export interface AssistantStatusMessage {
+  type: "assistant_status";
   version?: string;
   keyFingerprint?: string;
 }
@@ -418,7 +418,7 @@ export type _ConversationsClientMessages =
 export type _ConversationsServerMessages =
   | AuthResult
   | PongMessage
-  | DaemonStatusMessage
+  | AssistantStatusMessage
   | GenerationCancelled
   | GenerationHandoff
   | ModelInfo

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -251,7 +251,6 @@ export class DaemonServer {
   private conversationOptions = new Map<string, ConversationCreateOptions>();
   private conversationCreating = new Map<string, Promise<Conversation>>();
   private sharedRequestTimestamps: number[] = [];
-  private httpPort: number | undefined;
   private unsubscribeContactChange: (() => void) | null = null;
   private evictor: ConversationEvictor;
   private _hubChain: Promise<void> = Promise.resolve();
@@ -654,11 +653,9 @@ export class DaemonServer {
 
   // ── Conversation management ──────────────────────────────────────────────
 
-  setHttpPort(port: number): void {
-    this.httpPort = port;
+  broadcastStatus(): void {
     this.broadcast({
       type: "daemon_status",
-      httpPort: port,
       version: daemonVersion,
       keyFingerprint: getSigningKeyFingerprint(),
     });

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -655,7 +655,7 @@ export class DaemonServer {
 
   broadcastStatus(): void {
     this.broadcast({
-      type: "daemon_status",
+      type: "assistant_status",
       version: daemonVersion,
       keyFingerprint: getSigningKeyFingerprint(),
     });

--- a/assistant/src/runtime/auth/token-service.ts
+++ b/assistant/src/runtime/auth/token-service.ts
@@ -289,7 +289,7 @@ export function isSigningKeyInitialized(): boolean {
 
 /**
  * Returns a short hex fingerprint of the current signing key.
- * Used by daemon_status to let clients detect instance switches.
+ * Used by assistant_status to let clients detect instance switches.
  */
 export function getSigningKeyFingerprint(): string {
   return createHash("sha256")

--- a/clients/macos/vellum-assistant/ComputerUse/HostCuExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/HostCuExecutor.swift
@@ -32,7 +32,7 @@ enum HostCuExecutor {
         on client: GatewayConnectionManager,
         overlayProvider: @escaping @MainActor (_ conversationId: String, _ request: HostCuRequest) -> HostCuSessionProxy? = { _, _ in nil }
     ) {
-        // No-op: host CU requests are handled via DaemonStatus.subscribe() in AppDelegate.
+        // No-op: host CU requests are handled via EventStreamClient.subscribe() in AppDelegate.
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -326,7 +326,7 @@ struct SettingsDeveloperTab: View {
             }
 
             if let connectionManager {
-                DeveloperDaemonStatusRows(connectionManager: connectionManager)
+                DeveloperStatusRows(connectionManager: connectionManager)
             }
 
             healthzInfoRows
@@ -1190,7 +1190,7 @@ struct SettingsDeveloperTab: View {
 
 // MARK: - Daemon Status Rows (Developer Tab)
 
-private struct DeveloperDaemonStatusRows: View {
+private struct DeveloperStatusRows: View {
     @ObservedObject var connectionManager: GatewayConnectionManager
 
     var body: some View {

--- a/clients/macos/vellum-assistant/Security/KeychainBrokerServer.swift
+++ b/clients/macos/vellum-assistant/Security/KeychainBrokerServer.swift
@@ -178,7 +178,7 @@ final class KeychainBrokerServer {
 
     // MARK: - Receive Loop
 
-    /// Newline-delimited JSON receive loop matching the DaemonConnection pattern.
+    /// Newline-delimited JSON receive loop.
     private func receiveData(on conn: NWConnection) {
         conn.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self, weak conn] content, _, isComplete, error in
             guard let self, let conn else { return }

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -6,9 +6,7 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 /// Client that manages an SSE connection to the assistant runtime and broadcasts
 /// parsed `ServerMessage` values to multiple independent subscribers.
 ///
-/// Replaces the SSE portion of `HTTPTransport` and the broadcast portion of
-/// `GatewayConnectionManager`. Backed by `GatewayHTTPClient.stream()` for authenticated
-/// SSE connections.
+/// Backed by `GatewayHTTPClient.stream()` for authenticated SSE connections.
 @MainActor
 public final class EventStreamClient {
 

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -16,7 +16,7 @@ private struct HealthzVersionResponse: Decodable {
 @MainActor
 public final class GatewayConnectionManager: ObservableObject {
 
-    // MARK: - Published State (formerly on DaemonStatus)
+    // MARK: - Published State
 
     @Published public var isConnected: Bool = false
     @Published public var isConnecting: Bool = false
@@ -338,7 +338,7 @@ public final class GatewayConnectionManager: ObservableObject {
     // MARK: - SSE Message Pre-Processing
 
     private func handleServerMessage(_ message: ServerMessage) {
-        if case .daemonStatus(let status) = message {
+        if case .assistantStatus(let status) = message {
             if let version = status.version {
                 assistantVersion = version
                 checkVersionCompatibility(assistantVersion: version)

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -1253,15 +1253,13 @@ public struct CuComplete: Codable, Sendable {
     }
 }
 
-public struct DaemonStatusMessage: Codable, Sendable {
+public struct AssistantStatusMessage: Codable, Sendable {
     public let type: String
-    public let httpPort: Double?
     public let version: String?
     public let keyFingerprint: String?
 
-    public init(type: String, httpPort: Double? = nil, version: String? = nil, keyFingerprint: String? = nil) {
+    public init(type: String, version: String? = nil, keyFingerprint: String? = nil) {
         self.type = type
-        self.httpPort = httpPort
         self.version = version
         self.keyFingerprint = keyFingerprint
     }

--- a/clients/shared/Network/HostToolExecutor.swift
+++ b/clients/shared/Network/HostToolExecutor.swift
@@ -5,9 +5,6 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 
 /// Standalone executor for host tool requests (bash commands, file operations).
 /// These run locally on macOS and post results back via `HostProxyClient`.
-///
-/// Extracted from `HTTPTransport` — these operations are self-contained and
-/// don't need transport state.
 public enum HostToolExecutor {
 
     // MARK: - Host Bash Execution

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2410,7 +2410,11 @@ public enum ServerMessage: Decodable, Sendable {
         case "get_signing_identity":
             let message = try GetSigningIdentityRequest(from: decoder)
             self = .getSigningIdentity(message)
+        case "assistant_status":
+            let message = try AssistantStatusMessage(from: decoder)
+            self = .assistantStatus(message)
         case "daemon_status":
+            // Legacy: old assistants may still emit "daemon_status". Remove for v1.0.0.
             let message = try AssistantStatusMessage(from: decoder)
             self = .assistantStatus(message)
         case "publish_page_response":

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2091,7 +2091,7 @@ public enum ServerMessage: Decodable, Sendable {
     case documentSaveResponse(DocumentSaveResponseMessage)
     case documentLoadResponse(DocumentLoadResponseMessage)
     case documentListResponse(DocumentListResponseMessage)
-    case daemonStatus(DaemonStatusMessage)
+    case assistantStatus(AssistantStatusMessage)
     case openUrl(OpenUrlMessage)
     case navigateSettings(NavigateSettings)
     case integrationListResponse(IntegrationListResponse)
@@ -2411,8 +2411,8 @@ public enum ServerMessage: Decodable, Sendable {
             let message = try GetSigningIdentityRequest(from: decoder)
             self = .getSigningIdentity(message)
         case "daemon_status":
-            let message = try DaemonStatusMessage(from: decoder)
-            self = .daemonStatus(message)
+            let message = try AssistantStatusMessage(from: decoder)
+            self = .assistantStatus(message)
         case "publish_page_response":
             let message = try PublishPageResponseMessage(from: decoder)
             self = .publishPageResponse(message)


### PR DESCRIPTION
## Summary

**Server:**
- Remove `httpPort` from `DaemonStatusMessage` interface — clients no longer need the daemon's HTTP port (everything routes through `GatewayHTTPClient`)
- Rename `setHttpPort()` → `broadcastStatus()` on DaemonServer

**Client:**
- Rename `DaemonStatusMessage` → `AssistantStatusMessage`
- Rename `.daemonStatus` enum case → `.assistantStatus`
- Remove `httpPort` from the generated type
- Rename `DeveloperDaemonStatusRows` → `DeveloperStatusRows`
- Clean up stale comments referencing `DaemonConnection`, `DaemonStatus`, `HTTPTransport`

Net: **-11 lines** across 11 files (server + client)

## Test plan

- [x] `swift build` passes
- [x] `swift test` — all 156 tests pass
- [ ] Verify daemon starts and broadcasts status without httpPort

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
