### PR TITLE
Reorder settings sidebar nav and rename Account card

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -14,14 +14,10 @@ enum SettingsTab: String {
 
     /// Primary tabs shown in the main nav list (excludes feature-flagged bottom tabs).
     static func primaryTabs(billingEnabled: Bool = false, soundsEnabled: Bool = true, schedulesEnabled: Bool = false) -> [SettingsTab] {
-        var tabs: [SettingsTab] = [.general]
-        var middle: [SettingsTab] = [.voice]
-        if soundsEnabled { middle.append(.sounds) }
-        middle.append(contentsOf: [.modelsAndServices, .permissionsAndPrivacy])
-        tabs.append(contentsOf: middle)
-        if billingEnabled {
-            tabs.append(.billing)
-        }
+        var tabs: [SettingsTab] = [.general, .modelsAndServices, .voice]
+        if soundsEnabled { tabs.append(.sounds) }
+        if billingEnabled { tabs.append(.billing) }
+        tabs.append(.permissionsAndPrivacy)
         tabs.append(.archivedConversations)
         if schedulesEnabled { tabs.append(.schedules) }
         return tabs

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -149,7 +149,7 @@ struct SettingsGeneralTab: View {
 
     private var accountSection: some View {
         SettingsCard(
-            title: "Account",
+            title: "Vellum Platform",
             subtitle: authManager.currentUser?.email ?? authManager.currentUser?.display ?? "Log in to your account"
         ) {
             if authManager.isLoading {


### PR DESCRIPTION
## Summary
- Reorder the settings sidebar navigation to: General, Models & Services, Voice, Sounds, Billing, Permissions & Privacy
- Rename the "Account" card on the General tab to "Vellum Platform"

## Original prompt
Lets make some improvements to these macos settings uis.

1. Lets reorder the settings side nav so that it's:
General
Models & Services
Voice
Sounds
Billing
Permissions & Privacy

2. Lets rename this card from "Account" to "Vellum Platform"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
