### PR TITLE
Fix Developer settings nav item spacing to match Preferences

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -351,14 +351,15 @@ struct SettingsPanel: View {
                     selectedTab = tab
                 }
             }
-            Spacer()
+            Spacer(minLength: VSpacing.sm)
             if isDeveloperEnabled {
-                Divider()
+                VColor.surfaceBase
+                    .frame(height: 1)
+                    .padding(.vertical, SidebarLayoutMetrics.dividerVerticalPadding)
                     .padding(.trailing, VSpacing.md)
                 SettingsNavRow(tab: .developer, isSelected: selectedTab == .developer) {
                     selectedTab = .developer
                 }
-                .padding(.bottom, VSpacing.sm)
             }
         }
         .padding(.top, VSpacing.lg)


### PR DESCRIPTION
## Summary
- Replace the SwiftUI `Divider()` above the Developer settings nav item with the same styled divider used by the Preferences sidebar row (`VColor.surfaceBase` 1pt line with `SidebarLayoutMetrics.dividerVerticalPadding`)
- Use `Spacer(minLength: VSpacing.sm)` to match the Preferences pattern
- Remove the extra `.padding(.bottom, VSpacing.sm)` on the Developer row for consistent spacing

## Original prompt
Clean up the padding around the Developer side nav item in macOS settings to match how Preferences is styled in the main sidebar.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
