### PR TITLE
Rename AppDelegate+DaemonSetup, remove hatch logic

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -2,7 +2,7 @@ import AppKit
 import VellumAssistantShared
 import os
 
-private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AppDelegate+DaemonSetup")
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AppDelegate+ConnectionSetup")
 
 extension AppDelegate {
 
@@ -77,15 +77,15 @@ extension AppDelegate {
         log.info("Configured remote assistant \(assistant.assistantId, privacy: .public)")
     }
 
-    // MARK: - Daemon Client Setup
+    // MARK: - Gateway Connection Setup
 
-    func setupGatewayConnectionManager(isFirstLaunch: Bool = false) {
+    func setupGatewayConnectionManager() {
         guard !hasSetupDaemon else { return }
         hasSetupDaemon = true
 
         let assistant = loadAssistantFromLockfile()
 
-        // Start the keychain broker before the daemon so it is listening
+        // Start the keychain broker before the gateway so it is listening
         // when the daemon process launches and reads the socket path.
         #if !DEBUG
         keychainBroker = KeychainBrokerServer()
@@ -112,139 +112,32 @@ extension AppDelegate {
         rebindConnectionStatusObserver()
 
         // Subscribe to SSE event stream for UI event routing.
-        // Replaces individual onX callbacks — each event type is handled
-        // in a single switch statement.
-        startDaemonEventSubscription()
-
+        startEventSubscription()
 
         Task {
-            if !isCurrentAssistantRemote {
-                // If the hatching step already started the gateway (e.g. `vellum-cli hatch --remote local`),
-                // skip the CLI hatch to avoid spawning a duplicate gateway process.
-                // Require BOTH lockfile and healthy gateway — a stale lockfile with an unhealthy
-                // gateway falls through to the normal hatch path.
-                let lockfileExists = self.lockfileHasAssistants()
-                var gatewayHealthy = false
-                if lockfileExists {
-                    if isFirstLaunch {
-                        // Retry window: gateway may still be starting from onboarding hatch
-                        for _ in 0..<3 {
-                            if await isGatewayHealthy() { gatewayHealthy = true; break }
-                            try? await Task.sleep(nanoseconds: 1_000_000_000)
-                        }
-                    } else {
-                        // Non-first-launch: single check, no retry delay
-                        gatewayHealthy = await isGatewayHealthy()
-                    }
-                }
-
-                if lockfileExists && gatewayHealthy {
-                    log.info("Lockfile and gateway already present — skipping CLI hatch to avoid duplicate gateway")
-                } else {
-                    // On first launch post-onboarding, use daemonOnly: false so the CLI
-                    // creates a lockfile entry AND starts the gateway. On subsequent
-                    // launches, daemonOnly: true prevents duplicates — gateway restart
-                    // is handled separately below to avoid tearing down the daemon on
-                    // transient gateway failures.
-                    let needsLockfileEntry = isFirstLaunch && !lockfileExists
-                    let daemonOnly = !needsLockfileEntry
-                    // Pass the selected assistant ID so the gateway starts
-                    // with the correct default assistant (not a random name).
-                    let assistantName = assistant?.assistantId
-                    // Clear any stale startup error from a previous hatch attempt
-                    // so a successful hatch doesn't leave a non-nil error in app state.
-                    self.daemonStartupError = nil
-                    do {
-                        try await vellumCli.hatch(name: assistantName, daemonOnly: daemonOnly)
-                    } catch let error as VellumCli.CLIError {
-                        switch error {
-                        case .daemonStartupFailed(let startupError):
-                            log.error("Daemon startup failed [\(startupError.category, privacy: .public)]: \(startupError.message, privacy: .private)")
-                            self.daemonStartupError = startupError
-                            MetricKitManager.reportDaemonStartupFailure(startupError)
-                        default:
-                            log.error("Failed to hatch assistant during daemon setup: \(error)")
-                        }
-                        if needsLockfileEntry {
-                            log.info("Full hatch failed on first launch — retrying daemon-only as fallback")
-                            do {
-                                try await vellumCli.hatch(name: assistantName, daemonOnly: true)
-                                self.daemonStartupError = nil
-                            } catch {
-                                log.error("Fallback daemon-only hatch also failed: \(error)")
-                            }
-                        }
-                    } catch {
-                        log.error("Failed to hatch assistant during daemon setup: \(error)")
-                        if needsLockfileEntry {
-                            log.info("Full hatch failed on first launch — retrying daemon-only as fallback")
-                            do {
-                                try await vellumCli.hatch(name: assistantName, daemonOnly: true)
-                                self.daemonStartupError = nil
-                            } catch {
-                                log.error("Fallback daemon-only hatch also failed: \(error)")
-                            }
-                        }
-                    }
-                    if needsLockfileEntry {
-                        _ = self.loadAssistantFromLockfile()
-                    }
-
-                    // Gateway died between app launches — attempt to restart it
-                    // separately from the daemon. If gateway startup fails, recover
-                    // the daemon so the user can still interact (just without gateway).
-                    if !needsLockfileEntry && !gatewayHealthy {
-                        log.info("Gateway unhealthy — attempting separate restart")
-                        do {
-                            try await vellumCli.hatch(name: assistantName, daemonOnly: false)
-                        } catch {
-                            log.warning("Gateway restart failed — recovering daemon: \(error)")
-                            // The full hatch may have torn down the daemon during
-                            // cleanup; re-hatch daemon-only so the user isn't left
-                            // with nothing.
-                            do {
-                                try await vellumCli.hatch(name: assistantName, daemonOnly: true)
-                            } catch {
-                                log.error("Daemon recovery after gateway failure also failed: \(error)")
-                            }
-                        }
-                    }
-                }
-            }
             // Import guardian token from CLI file before connecting, so the
-            // health check has valid credentials in the Keychain. On first
-            // launch ensureActorCredentials() runs later in proceedToApp()
-            // as a separate Task — this ensures the token is available in
-            // time for connect()'s health check.
+            // health check has valid credentials in the Keychain.
             if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
                !ActorTokenManager.hasToken {
                 _ = GuardianTokenFileReader.importIfAvailable(assistantId: assistantId)
             }
 
-            // Skip connect if the bootstrap retry coordinator already connected
-            // or has a connect in flight (hatch can take a long time; the
-            // coordinator connects independently). Checking isConnecting
-            // prevents tearing down the coordinator's in-flight HTTP connection
-            // via disconnectInternal().
             if !connectionManager.isConnected && !connectionManager.isConnecting {
                 log.info("setupGatewayConnectionManager: calling connect()")
                 do {
                     try await connectionManager.connect()
                     log.info("setupGatewayConnectionManager: connect() succeeded, isConnected=\(self.connectionManager.isConnected)")
                 } catch {
-                    log.error("Failed to connect to daemon during setup: \(error)")
+                    log.error("Failed to connect during setup: \(error)")
                 }
             } else {
                 log.info("setupGatewayConnectionManager: skipping connect() — isConnected=\(self.connectionManager.isConnected), isConnecting=\(self.connectionManager.isConnecting)")
             }
-            // Once connected, start ambient agent if it was waiting for daemon
+
             if connectionManager.isConnected {
                 setupAmbientAgent()
                 refreshAppsCache()
                 refreshSkillsCache()
-                // Sync privacy config now that the gateway is reachable:
-                // close Sentry if diagnostics are disabled, and sync both
-                // keys to the daemon.
                 syncPrivacyConfig()
             }
         }
@@ -252,10 +145,9 @@ extension AppDelegate {
 
     // MARK: - SSE Event Subscription
 
-    /// Subscribe to the daemon event stream and dispatch events to their handlers.
-    /// Replaces the ~20 individual onX callback assignments that were previously set
-    /// on GatewayConnectionManager. Each event type is handled in a single switch statement.
-    private func startDaemonEventSubscription() {
+    /// Subscribe to the event stream and dispatch events to their handlers.
+    /// Each event type is handled in a single switch statement.
+    private func startEventSubscription() {
         Task { @MainActor [weak self] in
             guard let self else { return }
             let stream = self.eventStreamClient.subscribe()

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -139,9 +139,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var lastNotificationPermissionToastAtMs: Double = 0
 
     /// Structured error from the most recent daemon startup failure.
-    /// Populated by `setupGatewayConnectionManager()` when `hatch()` throws a
-    /// `CLIError.daemonStartupFailed`. Read by the UI to show a
-    /// contextual error view instead of a generic failure message.
+    /// Read by the UI to show a contextual error view instead of a
+    /// generic failure message.
     @Published var daemonStartupError: DaemonStartupError?
 
     /// Whether the current assistant runs remotely (cloud != "local").
@@ -462,7 +461,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             hasSetupDaemon = false
         }
 
-        setupGatewayConnectionManager(isFirstLaunch: isFirstLaunch)
+        setupGatewayConnectionManager()
         setupMenuBar()
         setupFileMenu()
         patchAppMenuTitles()


### PR DESCRIPTION
## Summary
- Renames `AppDelegate+DaemonSetup.swift` to `AppDelegate+ConnectionSetup.swift` to reflect that the desktop now orchestrates gateway connections, not direct daemon access
- Removes the hatch/re-hatch logic from `setupGatewayConnectionManager()` — hatches should only originate from the setup modal
- Renames `startDaemonEventSubscription()` to `startEventSubscription()`
- Removes the now-unused `isFirstLaunch` parameter from `setupGatewayConnectionManager()`

## Test plan
- [ ] Verify macOS app launches and connects to an already-running assistant without attempting a re-hatch
- [ ] Verify onboarding flow still hatches correctly (hatch originates from setup modal)
- [ ] Verify auto-wake still works for local assistants when gateway goes down
- [ ] Verify SSE event stream subscription still works (notifications, surfaces, host tools, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
