### PR TITLE
fix: wrap clearSigningKeyBootstrapLock in try/catch during rollback

### DIFF
--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -18,7 +18,10 @@ import {
   stopContainers,
 } from "../lib/docker";
 import type { ServiceName } from "../lib/docker";
-import { loadBootstrapSecret, saveBootstrapSecret } from "../lib/guardian-token";
+import {
+  loadBootstrapSecret,
+  saveBootstrapSecret,
+} from "../lib/guardian-token";
 import {
   broadcastUpgradeEvent,
   captureContainerEnv,
@@ -223,7 +226,14 @@ export async function rollback(): Promise<void> {
   await migrateCesSecurityFiles(res, (msg) => console.log(msg));
 
   console.log("🔑 Clearing signing key bootstrap lock...");
-  await clearSigningKeyBootstrapLock(res);
+  try {
+    await clearSigningKeyBootstrapLock(res);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `⚠️  Failed to clear signing key bootstrap lock (${message}), continuing...`,
+    );
+  }
 
   console.log("🚀 Starting containers with previous version...");
   await startContainers(


### PR DESCRIPTION
## Summary
- Wrap clearSigningKeyBootstrapLock call in rollback.ts with try/catch to prevent rollback abort on failure
- Logs a warning and continues to startContainers, matching the pattern in upgrade.ts

Part of plan: svc-grp-update-bugs-and-ux.md (PR 1 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
