### PR TITLE
fix: use atomic write-to-temp-then-rename for lockfile persistence

### DIFF
--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { randomBytes } from "crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
 import { homedir } from "os";
 import { join } from "path";
 
@@ -124,7 +132,16 @@ function readLockfile(): LockfileData {
 
 function writeLockfile(data: LockfileData): void {
   const lockfilePath = join(getLockfileDir(), ".vellum.lock.json");
-  writeFileSync(lockfilePath, JSON.stringify(data, null, 2) + "\n");
+  const tmpPath = `${lockfilePath}.${randomBytes(4).toString("hex")}.tmp`;
+  try {
+    writeFileSync(tmpPath, JSON.stringify(data, null, 2) + "\n");
+    renameSync(tmpPath, lockfilePath);
+  } catch (err) {
+    try {
+      unlinkSync(tmpPath);
+    } catch {}
+    throw err;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace direct writeFileSync with write-to-temp-then-rename pattern for lockfile persistence
- Prevents lockfile corruption from partial writes during crashes
- Cleans up temp files on error

Part of plan: svc-grp-update-bugs-and-ux.md (PR 2 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
