### PR TITLE
fix: consolidate version parsing to use VersionCompat everywhere

### DIFF
--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -311,22 +311,11 @@ public final class GatewayConnectionManager: ObservableObject {
 
     // MARK: - Version Compatibility
 
-    private func parseMajorMinor(_ version: String) -> (Int, Int)? {
-        let cleaned = version.hasPrefix("v") ? String(version.dropFirst()) : version
-        let components = cleaned.split(separator: ".").compactMap { Int($0) }
-        guard components.count >= 2 else { return nil }
-        return (components[0], components[1])
-    }
-
     func checkVersionCompatibility(assistantVersion: String) {
-        guard let clientVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else {
-            return
-        }
-        guard let (daemonMajor, daemonMinor) = parseMajorMinor(assistantVersion),
-              let (clientMajor, clientMinor) = parseMajorMinor(clientVersion) else {
-            return
-        }
-        let mismatch = daemonMajor != clientMajor || daemonMinor != clientMinor
+        guard let clientVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else { return }
+        guard let daemon = VersionCompat.parseMajorMinor(assistantVersion),
+              let client = VersionCompat.parseMajorMinor(clientVersion) else { return }
+        let mismatch = daemon.major != client.major || daemon.minor != client.minor
         if mismatch != versionMismatch {
             versionMismatch = mismatch
         }

--- a/clients/shared/Utilities/VersionCompat.swift
+++ b/clients/shared/Utilities/VersionCompat.swift
@@ -12,32 +12,27 @@ public enum VersionCompat {
     /// Handles optional `v` prefix (e.g., "v1.2.3" or "1.2.3").
     /// Returns nil if the string cannot be parsed.
     public static func parse(_ version: String) -> ParsedVersion? {
-        var trimmed = version
-        if trimmed.first == "v" || trimmed.first == "V" {
-            trimmed.removeFirst()
+        let cleaned = version.hasPrefix("v") ? String(version.dropFirst()) : version
+        // Strip pre-release/build metadata from each segment
+        let segments = cleaned.split(separator: ".").map { segment -> String in
+            let s = String(segment)
+            if let dashIdx = s.firstIndex(of: "-") { return String(s[..<dashIdx]) }
+            if let plusIdx = s.firstIndex(of: "+") { return String(s[..<plusIdx]) }
+            return s
         }
+        let components = segments.compactMap { Int($0) }
+        guard components.count >= 2, components.count <= 3 else { return nil }
+        return ParsedVersion(
+            major: components[0],
+            minor: components[1],
+            patch: components.count > 2 ? components[2] : 0
+        )
+    }
 
-        let components = trimmed.split(separator: ".")
-        guard components.count >= 2, components.count <= 3 else {
-            return nil
-        }
-
-        guard let major = Int(components[0]),
-              let minor = Int(components[1]) else {
-            return nil
-        }
-
-        let patch: Int
-        if components.count == 3 {
-            guard let p = Int(components[2]) else {
-                return nil
-            }
-            patch = p
-        } else {
-            patch = 0
-        }
-
-        return ParsedVersion(major: major, minor: minor, patch: patch)
+    /// Extracts (major, minor) from a version string, stripping pre-release suffixes.
+    public static func parseMajorMinor(_ version: String) -> (major: Int, minor: Int)? {
+        guard let parsed = parse(version) else { return nil }
+        return (parsed.major, parsed.minor)
     }
 
     /// Check whether two version strings are compatible.


### PR DESCRIPTION
## Summary
- Add parseMajorMinor convenience method to VersionCompat for version comparison
- Harden VersionCompat.parse to strip pre-release/build metadata from version strings
- Remove duplicated private parseMajorMinor from GatewayConnectionManager in favor of shared VersionCompat

Part of plan: svc-grp-update-bugs-and-ux.md (PR 4 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
