### PR TITLE
fix: call resetSSEReconnectDelay in all update-state-clearing paths

### DIFF
--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -351,6 +351,7 @@ public final class GatewayConnectionManager: ObservableObject {
                     self.isUpdateInProgress = false
                     self.updateTargetVersion = nil
                     self.updateExpiresAt = nil
+                    self.eventStreamClient.resetSSEReconnectDelay()
                 }
             }
             if let newFingerprint = status.keyFingerprint {
@@ -375,6 +376,7 @@ public final class GatewayConnectionManager: ObservableObject {
             self.isUpdateInProgress = false
             self.updateTargetVersion = nil
             self.updateExpiresAt = nil
+            self.eventStreamClient.resetSSEReconnectDelay()
         case .modelInfo(let msg):
             currentModel = msg.model
             latestModelInfo = msg


### PR DESCRIPTION
## Summary
- Add resetSSEReconnectDelay() call to assistantStatus handler after clearing update state
- Add resetSSEReconnectDelay() call to serviceGroupUpdateComplete handler
- Ensures SSE reconnect delay resets consistently regardless of which path detects update completion

Part of plan: svc-grp-update-bugs-and-ux.md (PR 6 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
