### PR TITLE
feat: show progress indicator for managed upgrades, clean up remote "Check for Updates"

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -28,6 +28,9 @@ struct AssistantUpgradeSection: View {
     /// The version Sparkle would upgrade to (local topology only).
     var sparkleUpdateVersion: String?
 
+    /// Whether a service group update is in progress (managed topology).
+    var isServiceGroupUpdateInProgress: Bool = false
+
     @State private var availableReleases: [AssistantRelease] = []
     @State private var selectedVersion: String?
     @State private var isLoadingReleases = false
@@ -280,7 +283,7 @@ struct AssistantUpgradeSection: View {
                     .disabled(!upgradeAvailable || isUpgrading)
                 }
 
-                if topology != .local {
+                if topology != .local && topology != .remote {
                     VButton(
                         label: isLoadingReleases ? "Checking..." : "Check for Updates",
                         style: .outlined
@@ -311,6 +314,16 @@ struct AssistantUpgradeSection: View {
                 Text(success)
                     .font(VFont.caption)
                     .foregroundColor(VColor.systemPositiveStrong)
+            }
+
+            if isServiceGroupUpdateInProgress && !isUpgrading && topology == .managed {
+                HStack(spacing: VSpacing.sm) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Assistant is updating...")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                }
             }
         }
         .task { await loadReleases() }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -43,7 +43,8 @@ struct SettingsGeneralTab: View {
                     isDockerOperationInProgress: $isDockerOperationInProgress,
                     dockerOperationLabel: $dockerOperationLabel,
                     sparkleUpdateAvailable: sparkleUpdateAvailable,
-                    sparkleUpdateVersion: sparkleUpdateVersion
+                    sparkleUpdateVersion: sparkleUpdateVersion,
+                    isServiceGroupUpdateInProgress: connectionManager?.isUpdateInProgress ?? false
                 )
             }
             if MacOSClientFeatureFlagManager.shared.isEnabled("mobile_pairing_enabled") {


### PR DESCRIPTION
## Summary
- Add managed topology progress indicator showing "Assistant is updating..." during service group updates
- Hide "Check for Updates" button for remote topology (no actionable output)
- Pass isServiceGroupUpdateInProgress from SettingsGeneralTab to AssistantUpgradeSection

Part of plan: svc-grp-update-bugs-and-ux.md (PR 9 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
