### PR TITLE
feat: add async Sparkle update check to replace hardcoded 2-second sleep

### DIFF
--- a/clients/macos/vellum-assistant/App/UpdateManager.swift
+++ b/clients/macos/vellum-assistant/App/UpdateManager.swift
@@ -76,6 +76,32 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
         updaterController.updater.canCheckForUpdates
     }
 
+    /// Trigger a background update check and wait for Sparkle's delegate to
+    /// report a result, returning as soon as `didFindValidUpdate` or
+    /// `updaterDidNotFindUpdate` fires.  Falls back to the current
+    /// `isUpdateAvailable` state after `timeout` seconds so callers never hang.
+    func checkForUpdatesAsync(timeout: TimeInterval = 5.0) async -> Bool {
+        updaterController.checkForUpdates(nil)
+
+        return await withTaskGroup(of: Bool.self) { group in
+            // Race: delegate callback vs timeout
+            group.addTask { @MainActor [weak self] in
+                guard let self else { return false }
+                for await value in self.$isUpdateAvailable.values.dropFirst() {
+                    return value
+                }
+                return false
+            }
+            group.addTask { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                return self?.isUpdateAvailable ?? false
+            }
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
+        }
+    }
+
     // MARK: - Menu Item Helpers
 
     /// Context-aware title for the update menu item.


### PR DESCRIPTION
## Summary
- Add checkForUpdatesAsync() method to UpdateManager that races Sparkle delegate callback against a timeout
- Returns immediately when Sparkle reports result instead of hardcoded 2-second sleep
- Falls back to current state after 5-second timeout

Part of plan: svc-grp-update-bugs-and-ux.md (PR 7 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
