### PR TITLE
fix: enforce update timeout to prevent stuck isUpdateInProgress state

### DIFF
--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -288,6 +288,15 @@ public final class GatewayConnectionManager: ObservableObject {
                 } catch {
                     log.warning("Periodic health check failed: \(error.localizedDescription)")
                 }
+
+                // Check for update timeout
+                if self.isUpdateInProgress, let expiresAt = self.updateExpiresAt, Date() > expiresAt {
+                    log.warning("Update timed out — clearing isUpdateInProgress after deadline passed")
+                    self.isUpdateInProgress = false
+                    self.updateTargetVersion = nil
+                    self.updateExpiresAt = nil
+                    self.eventStreamClient.resetSSEReconnectDelay()
+                }
             }
         }
     }
@@ -367,9 +376,9 @@ public final class GatewayConnectionManager: ObservableObject {
 
         switch message {
         case .serviceGroupUpdateStarting(let msg):
-            self.isUpdateInProgress = true
             self.updateTargetVersion = msg.targetVersion
             self.updateExpiresAt = Date().addingTimeInterval(msg.expectedDowntimeSeconds * 2)
+            setUpdateInProgress(true)
             log.info("Service group update starting — target: \(msg.targetVersion, privacy: .public), expected downtime: \(msg.expectedDowntimeSeconds)s")
         case .serviceGroupUpdateComplete:
             self.isUpdateInProgress = false


### PR DESCRIPTION
## Summary
- Add timeout check in health check loop to clear stale isUpdateInProgress after expectedDowntimeSeconds * 2
- Fix serviceGroupUpdateStarting handler to use setUpdateInProgress(true) for immediate health check restart
- Prevents indefinitely stuck update state

Part of plan: svc-grp-update-bugs-and-ux.md (PR 5 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
