### PR TITLE
Clean up macOS app menu to follow platform conventions

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -26,20 +26,6 @@ struct VellumAssistantApp: App {
                 Button("About \(appName)") {
                     appDelegate.showAboutPanel()
                 }
-                Divider()
-                Button("Share Feedback") {
-                    appDelegate.sendLogsToSentry()
-                }
-                Divider()
-                Button("Uninstall \(appName)...") {
-                    appDelegate.performUninstall()
-                }
-                if appDelegate.authManager.isAuthenticated {
-                    Divider()
-                    Button("Sign Out") {
-                        appDelegate.performLogout()
-                    }
-                }
             }
             // Replace the auto-generated Hide/Quit items so they always
             // say "Vellum" instead of the bundle display name (which may
@@ -70,6 +56,16 @@ struct VellumAssistantApp: App {
                     appDelegate.showSettingsWindow(nil)
                 }
                 .keyboardShortcut(",", modifiers: .command)
+                if appDelegate.authManager.isAuthenticated {
+                    Button("Sign Out") {
+                        appDelegate.performLogout()
+                    }
+                }
+            }
+            CommandGroup(replacing: .help) {
+                Button("Share Feedback") {
+                    appDelegate.sendLogsToSentry()
+                }
             }
             // View menu: zoom shortcuts for discoverability.
             // The actual handling is done by event monitors (registerZoomMonitor)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -51,6 +51,7 @@ struct SettingsGeneralTab: View {
                 mobilePairingCard
             }
             SettingsAppearanceTab(store: store)
+            uninstallSection
         }
         .onAppear {
             Task { await authManager.checkSession() }
@@ -142,6 +143,19 @@ struct SettingsGeneralTab: View {
                 VButton(label: "Pair Device", leftIcon: VIcon.qrCode.rawValue, style: .primary) {
                     showingPairingQR = true
                 }
+            }
+        }
+    }
+
+    // MARK: - Uninstall
+
+    private var uninstallSection: some View {
+        SettingsCard(
+            title: "Uninstall",
+            subtitle: "Stops all assistants, archives your data, and moves Vellum to the Trash"
+        ) {
+            VButton(label: "Uninstall Vellum...", style: .danger) {
+                AppDelegate.shared?.performUninstall()
             }
         }
     }


### PR DESCRIPTION
## Summary
- Restructured the macOS app menu to follow standard platform conventions: About only in the info group, Settings + Sign Out grouped together, Share Feedback in the Help menu
- Moved Uninstall Vellum into Settings > General as a clearly described destructive action card, since it performs significant cleanup beyond just trashing the app (retires assistants, archives data, stops daemons)
- Removes non-standard menu items that made the app menu feel cluttered and unconventional
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
