### PR TITLE
fix: replace hardcoded 2-second Sparkle sleeps with async observation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
@@ -239,14 +239,16 @@ struct AboutVellumView: View {
 
         switch topology {
         case .local:
-            // Local: trigger Sparkle and show result inline after a brief wait
-            AppDelegate.shared?.updateManager.checkForUpdates()
-            try? await Task.sleep(nanoseconds: 2_000_000_000)
-            let sparkleAvailable = AppDelegate.shared?.updateManager.isUpdateAvailable ?? false
-            if sparkleAvailable, let version = AppDelegate.shared?.updateManager.availableUpdateVersion {
-                updateCheckResult = .updateAvailable(version: version)
+            // Local: trigger Sparkle and wait for delegate callback (up to 5s timeout)
+            if let manager = AppDelegate.shared?.updateManager {
+                let sparkleAvailable = await manager.checkForUpdatesAsync()
+                if sparkleAvailable, let version = manager.availableUpdateVersion {
+                    updateCheckResult = .updateAvailable(version: version)
+                } else {
+                    updateCheckResult = .upToDate
+                }
             } else {
-                updateCheckResult = .upToDate
+                updateCheckResult = .error
             }
             isCheckingForUpdates = false
 

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -262,10 +262,11 @@ struct AssistantUpgradeSection: View {
                     ) {
                         Task {
                             isCheckingLocal = true
-                            AppDelegate.shared?.updateManager.checkForUpdates()
-                            try? await Task.sleep(nanoseconds: 2_000_000_000)
-                            checkedSparkleAvailable = AppDelegate.shared?.updateManager.isUpdateAvailable ?? false
-                            checkedSparkleVersion = AppDelegate.shared?.updateManager.availableUpdateVersion
+                            if let manager = AppDelegate.shared?.updateManager {
+                                let available = await manager.checkForUpdatesAsync()
+                                checkedSparkleAvailable = available
+                                checkedSparkleVersion = manager.availableUpdateVersion
+                            }
                             hasCheckedForUpdates = true
                             isCheckingLocal = false
                         }


### PR DESCRIPTION
## Summary
- Replace Task.sleep(2s) in AssistantUpgradeSection with checkForUpdatesAsync()
- Replace Task.sleep(2s) in AboutVellumWindow with checkForUpdatesAsync()
- UI now responds immediately when Sparkle reports result, with 5-second timeout fallback

Part of plan: svc-grp-update-bugs-and-ux.md (PR 11 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
