### PR TITLE
feat: emit structured CLI_ERROR from upgrade and rollback error paths

### DIFF
--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -22,6 +22,7 @@ import {
   loadBootstrapSecret,
   saveBootstrapSecret,
 } from "../lib/guardian-token";
+import { emitCliError, categorizeUpgradeError } from "../lib/cli-error.js";
 import {
   broadcastUpgradeEvent,
   captureContainerEnv,
@@ -56,6 +57,7 @@ function parseArgs(): { name: string | null } {
       name = arg;
     } else {
       console.error(`Error: Unknown option '${arg}'.`);
+      emitCliError("UNKNOWN", `Unknown option '${arg}'`);
       process.exit(1);
     }
   }
@@ -87,6 +89,10 @@ function resolveTargetAssistant(nameArg: string | null): AssistantEntry {
     const entry = findAssistantByName(nameArg);
     if (!entry) {
       console.error(`No assistant found with name '${nameArg}'.`);
+      emitCliError(
+        "ASSISTANT_NOT_FOUND",
+        `No assistant found with name '${nameArg}'.`,
+      );
       process.exit(1);
     }
     return entry;
@@ -102,11 +108,14 @@ function resolveTargetAssistant(nameArg: string | null): AssistantEntry {
   if (all.length === 1) return all[0];
 
   if (all.length === 0) {
-    console.error("No assistants found. Run 'vellum hatch' first.");
+    const msg = "No assistants found. Run 'vellum hatch' first.";
+    console.error(msg);
+    emitCliError("ASSISTANT_NOT_FOUND", msg);
   } else {
-    console.error(
-      "Multiple assistants found. Specify a name or set an active assistant with 'vellum use <name>'.",
-    );
+    const msg =
+      "Multiple assistants found. Specify a name or set an active assistant with 'vellum use <name>'.";
+    console.error(msg);
+    emitCliError("ASSISTANT_NOT_FOUND", msg);
   }
   process.exit(1);
 }
@@ -118,26 +127,29 @@ export async function rollback(): Promise<void> {
 
   // Only Docker assistants support rollback
   if (cloud !== "docker") {
-    console.error(
-      "Rollback is only supported for Docker assistants. For managed assistants, use the version picker to upgrade to the previous version.",
-    );
+    const msg =
+      "Rollback is only supported for Docker assistants. For managed assistants, use the version picker to upgrade to the previous version.";
+    console.error(msg);
+    emitCliError("UNSUPPORTED_TOPOLOGY", msg);
     process.exit(1);
   }
 
   // Verify rollback state exists
   if (!entry.previousServiceGroupVersion || !entry.previousContainerInfo) {
-    console.error(
-      "No rollback state available. Run `vellum upgrade` first to create a rollback point.",
-    );
+    const msg =
+      "No rollback state available. Run `vellum upgrade` first to create a rollback point.";
+    console.error(msg);
+    emitCliError("ROLLBACK_NO_STATE", msg);
     process.exit(1);
   }
 
   // Verify all three digest fields are present
   const prev = entry.previousContainerInfo;
   if (!prev.assistantDigest || !prev.gatewayDigest || !prev.cesDigest) {
-    console.error(
-      "Incomplete rollback state. Previous container digests are missing.",
-    );
+    const msg =
+      "Incomplete rollback state. Previous container digests are missing.";
+    console.error(msg);
+    emitCliError("ROLLBACK_NO_STATE", msg);
     process.exit(1);
   }
 
@@ -151,143 +163,158 @@ export async function rollback(): Promise<void> {
   const instanceName = entry.assistantId;
   const res = dockerResourceNames(instanceName);
 
-  console.log(
-    `🔄 Rolling back Docker assistant '${instanceName}' to ${entry.previousServiceGroupVersion}...\n`,
-  );
-
-  // Capture current container env
-  console.log("💾 Capturing existing container environment...");
-  const capturedEnv = await captureContainerEnv(res.assistantContainer);
-  console.log(
-    `   Captured ${Object.keys(capturedEnv).length} env var(s) from ${res.assistantContainer}\n`,
-  );
-
-  // Extract CES_SERVICE_TOKEN from captured env, or generate fresh one
-  const cesServiceToken =
-    capturedEnv["CES_SERVICE_TOKEN"] || randomBytes(32).toString("hex");
-
-  // Retrieve or generate a bootstrap secret for the gateway.
-  const loadedSecret = loadBootstrapSecret(instanceName);
-  const bootstrapSecret = loadedSecret || randomBytes(32).toString("hex");
-  if (!loadedSecret) {
-    saveBootstrapSecret(instanceName, bootstrapSecret);
-  }
-
-  // Build extra env vars, excluding keys managed by serviceDockerRunArgs
-  const envKeysSetByRunArgs = new Set([
-    "CES_SERVICE_TOKEN",
-    "VELLUM_ASSISTANT_NAME",
-    "RUNTIME_HTTP_HOST",
-    "PATH",
-  ]);
-  for (const envVar of ["ANTHROPIC_API_KEY", "VELLUM_PLATFORM_URL"]) {
-    if (process.env[envVar]) {
-      envKeysSetByRunArgs.add(envVar);
-    }
-  }
-  const extraAssistantEnv: Record<string, string> = {};
-  for (const [key, value] of Object.entries(capturedEnv)) {
-    if (!envKeysSetByRunArgs.has(key)) {
-      extraAssistantEnv[key] = value;
-    }
-  }
-
-  // Parse gateway port from entry's runtimeUrl, fall back to default
-  let gatewayPort = GATEWAY_INTERNAL_PORT;
   try {
-    const parsed = new URL(entry.runtimeUrl);
-    const port = parseInt(parsed.port, 10);
-    if (!isNaN(port)) {
-      gatewayPort = port;
-    }
-  } catch {
-    // use default
-  }
-
-  // Notify connected clients that a rollback is about to begin (best-effort)
-  console.log("📢 Notifying connected clients...");
-  await broadcastUpgradeEvent(entry.runtimeUrl, entry.assistantId, {
-    type: "starting",
-    targetVersion: entry.previousServiceGroupVersion,
-    expectedDowntimeSeconds: 60,
-  });
-  // Brief pause to allow SSE delivery before containers stop.
-  await new Promise((r) => setTimeout(r, 500));
-
-  console.log("🛑 Stopping existing containers...");
-  await stopContainers(res);
-  console.log("✅ Containers stopped\n");
-
-  // Run security file migrations and signing key cleanup
-  console.log("🔄 Migrating security files to gateway volume...");
-  await migrateGatewaySecurityFiles(res, (msg) => console.log(msg));
-
-  console.log("🔄 Migrating credential files to CES security volume...");
-  await migrateCesSecurityFiles(res, (msg) => console.log(msg));
-
-  console.log("🔑 Clearing signing key bootstrap lock...");
-  try {
-    await clearSigningKeyBootstrapLock(res);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    console.warn(
-      `⚠️  Failed to clear signing key bootstrap lock (${message}), continuing...`,
-    );
-  }
-
-  console.log("🚀 Starting containers with previous version...");
-  await startContainers(
-    {
-      bootstrapSecret,
-      cesServiceToken,
-      extraAssistantEnv,
-      gatewayPort,
-      imageTags: previousImageRefs,
-      instanceName,
-      res,
-    },
-    (msg) => console.log(msg),
-  );
-  console.log("✅ Containers started\n");
-
-  console.log("Waiting for assistant to become ready...");
-  const ready = await waitForReady(entry.runtimeUrl);
-
-  if (ready) {
-    // Capture new digests from the rolled-back containers
-    const newDigests = await captureImageRefs(res);
-
-    // Swap current/previous state to enable "rollback the rollback"
-    const updatedEntry: AssistantEntry = {
-      ...entry,
-      serviceGroupVersion: entry.previousServiceGroupVersion,
-      containerInfo: {
-        assistantImage: prev.assistantImage ?? previousImageRefs.assistant,
-        gatewayImage: prev.gatewayImage ?? previousImageRefs.gateway,
-        cesImage: prev.cesImage ?? previousImageRefs["credential-executor"],
-        assistantDigest: newDigests?.assistant,
-        gatewayDigest: newDigests?.gateway,
-        cesDigest: newDigests?.["credential-executor"],
-        networkName: res.network,
-      },
-      previousServiceGroupVersion: entry.serviceGroupVersion,
-      previousContainerInfo: entry.containerInfo,
-    };
-    saveAssistantEntry(updatedEntry);
-
-    // Notify clients that the rollback succeeded
-    await broadcastUpgradeEvent(entry.runtimeUrl, entry.assistantId, {
-      type: "complete",
-      installedVersion: entry.previousServiceGroupVersion,
-      success: true,
-    });
-
     console.log(
-      `\n✅ Docker assistant '${instanceName}' rolled back to ${entry.previousServiceGroupVersion}.`,
+      `🔄 Rolling back Docker assistant '${instanceName}' to ${entry.previousServiceGroupVersion}...\n`,
     );
-  } else {
-    console.error(`\n❌ Containers failed to become ready within the timeout.`);
-    console.log(`   Check logs with: docker logs -f ${res.assistantContainer}`);
+
+    // Capture current container env
+    console.log("💾 Capturing existing container environment...");
+    const capturedEnv = await captureContainerEnv(res.assistantContainer);
+    console.log(
+      `   Captured ${Object.keys(capturedEnv).length} env var(s) from ${res.assistantContainer}\n`,
+    );
+
+    // Extract CES_SERVICE_TOKEN from captured env, or generate fresh one
+    const cesServiceToken =
+      capturedEnv["CES_SERVICE_TOKEN"] || randomBytes(32).toString("hex");
+
+    // Retrieve or generate a bootstrap secret for the gateway.
+    const loadedSecret = loadBootstrapSecret(instanceName);
+    const bootstrapSecret = loadedSecret || randomBytes(32).toString("hex");
+    if (!loadedSecret) {
+      saveBootstrapSecret(instanceName, bootstrapSecret);
+    }
+
+    // Build extra env vars, excluding keys managed by serviceDockerRunArgs
+    const envKeysSetByRunArgs = new Set([
+      "CES_SERVICE_TOKEN",
+      "VELLUM_ASSISTANT_NAME",
+      "RUNTIME_HTTP_HOST",
+      "PATH",
+    ]);
+    for (const envVar of ["ANTHROPIC_API_KEY", "VELLUM_PLATFORM_URL"]) {
+      if (process.env[envVar]) {
+        envKeysSetByRunArgs.add(envVar);
+      }
+    }
+    const extraAssistantEnv: Record<string, string> = {};
+    for (const [key, value] of Object.entries(capturedEnv)) {
+      if (!envKeysSetByRunArgs.has(key)) {
+        extraAssistantEnv[key] = value;
+      }
+    }
+
+    // Parse gateway port from entry's runtimeUrl, fall back to default
+    let gatewayPort = GATEWAY_INTERNAL_PORT;
+    try {
+      const parsed = new URL(entry.runtimeUrl);
+      const port = parseInt(parsed.port, 10);
+      if (!isNaN(port)) {
+        gatewayPort = port;
+      }
+    } catch {
+      // use default
+    }
+
+    // Notify connected clients that a rollback is about to begin (best-effort)
+    console.log("📢 Notifying connected clients...");
+    await broadcastUpgradeEvent(entry.runtimeUrl, entry.assistantId, {
+      type: "starting",
+      targetVersion: entry.previousServiceGroupVersion,
+      expectedDowntimeSeconds: 60,
+    });
+    // Brief pause to allow SSE delivery before containers stop.
+    await new Promise((r) => setTimeout(r, 500));
+
+    console.log("🛑 Stopping existing containers...");
+    await stopContainers(res);
+    console.log("✅ Containers stopped\n");
+
+    // Run security file migrations and signing key cleanup
+    console.log("🔄 Migrating security files to gateway volume...");
+    await migrateGatewaySecurityFiles(res, (msg) => console.log(msg));
+
+    console.log("🔄 Migrating credential files to CES security volume...");
+    await migrateCesSecurityFiles(res, (msg) => console.log(msg));
+
+    console.log("🔑 Clearing signing key bootstrap lock...");
+    try {
+      await clearSigningKeyBootstrapLock(res);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `⚠️  Failed to clear signing key bootstrap lock (${message}), continuing...`,
+      );
+    }
+
+    console.log("🚀 Starting containers with previous version...");
+    await startContainers(
+      {
+        bootstrapSecret,
+        cesServiceToken,
+        extraAssistantEnv,
+        gatewayPort,
+        imageTags: previousImageRefs,
+        instanceName,
+        res,
+      },
+      (msg) => console.log(msg),
+    );
+    console.log("✅ Containers started\n");
+
+    console.log("Waiting for assistant to become ready...");
+    const ready = await waitForReady(entry.runtimeUrl);
+
+    if (ready) {
+      // Capture new digests from the rolled-back containers
+      const newDigests = await captureImageRefs(res);
+
+      // Swap current/previous state to enable "rollback the rollback"
+      const updatedEntry: AssistantEntry = {
+        ...entry,
+        serviceGroupVersion: entry.previousServiceGroupVersion,
+        containerInfo: {
+          assistantImage: prev.assistantImage ?? previousImageRefs.assistant,
+          gatewayImage: prev.gatewayImage ?? previousImageRefs.gateway,
+          cesImage: prev.cesImage ?? previousImageRefs["credential-executor"],
+          assistantDigest: newDigests?.assistant,
+          gatewayDigest: newDigests?.gateway,
+          cesDigest: newDigests?.["credential-executor"],
+          networkName: res.network,
+        },
+        previousServiceGroupVersion: entry.serviceGroupVersion,
+        previousContainerInfo: entry.containerInfo,
+      };
+      saveAssistantEntry(updatedEntry);
+
+      // Notify clients that the rollback succeeded
+      await broadcastUpgradeEvent(entry.runtimeUrl, entry.assistantId, {
+        type: "complete",
+        installedVersion: entry.previousServiceGroupVersion,
+        success: true,
+      });
+
+      console.log(
+        `\n✅ Docker assistant '${instanceName}' rolled back to ${entry.previousServiceGroupVersion}.`,
+      );
+    } else {
+      console.error(
+        `\n❌ Containers failed to become ready within the timeout.`,
+      );
+      console.log(
+        `   Check logs with: docker logs -f ${res.assistantContainer}`,
+      );
+      emitCliError(
+        "READINESS_TIMEOUT",
+        "Rolled-back containers failed to become ready within the timeout.",
+      );
+      process.exit(1);
+    }
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    console.error(`\n❌ Rollback failed: ${detail}`);
+    emitCliError(categorizeUpgradeError(err), "Rollback failed", detail);
     process.exit(1);
   }
 }

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -31,6 +31,7 @@ import {
   saveBootstrapSecret,
   loadGuardianToken,
 } from "../lib/guardian-token";
+import { emitCliError, categorizeUpgradeError } from "../lib/cli-error.js";
 import { exec, execOutput } from "../lib/step-runner";
 
 interface UpgradeArgs {
@@ -75,6 +76,7 @@ function parseArgs(): UpgradeArgs {
       const next = args[i + 1];
       if (!next || next.startsWith("-")) {
         console.error("Error: --version requires a value");
+        emitCliError("UNKNOWN", "--version requires a value");
         process.exit(1);
       }
       version = next;
@@ -83,6 +85,7 @@ function parseArgs(): UpgradeArgs {
       name = arg;
     } else {
       console.error(`Error: Unknown option '${arg}'.`);
+      emitCliError("UNKNOWN", `Unknown option '${arg}'`);
       process.exit(1);
     }
   }
@@ -114,6 +117,10 @@ function resolveTargetAssistant(nameArg: string | null): AssistantEntry {
     const entry = findAssistantByName(nameArg);
     if (!entry) {
       console.error(`No assistant found with name '${nameArg}'.`);
+      emitCliError(
+        "ASSISTANT_NOT_FOUND",
+        `No assistant found with name '${nameArg}'.`,
+      );
       process.exit(1);
     }
     return entry;
@@ -129,11 +136,14 @@ function resolveTargetAssistant(nameArg: string | null): AssistantEntry {
   if (all.length === 1) return all[0];
 
   if (all.length === 0) {
-    console.error("No assistants found. Run 'vellum hatch' first.");
+    const msg = "No assistants found. Run 'vellum hatch' first.";
+    console.error(msg);
+    emitCliError("ASSISTANT_NOT_FOUND", msg);
   } else {
-    console.error(
-      "Multiple assistants found. Specify a name or set an active assistant with 'vellum use <name>'.",
-    );
+    const msg =
+      "Multiple assistants found. Specify a name or set an active assistant with 'vellum use <name>'.";
+    console.error(msg);
+    emitCliError("ASSISTANT_NOT_FOUND", msg);
   }
   process.exit(1);
 }
@@ -284,9 +294,16 @@ async function upgradeDocker(
   );
 
   console.log("📦 Pulling new Docker images...");
-  await exec("docker", ["pull", imageTags.assistant]);
-  await exec("docker", ["pull", imageTags.gateway]);
-  await exec("docker", ["pull", imageTags["credential-executor"]]);
+  try {
+    await exec("docker", ["pull", imageTags.assistant]);
+    await exec("docker", ["pull", imageTags.gateway]);
+    await exec("docker", ["pull", imageTags["credential-executor"]]);
+  } catch (pullErr) {
+    const detail = pullErr instanceof Error ? pullErr.message : String(pullErr);
+    console.error(`\n❌ Failed to pull Docker images: ${detail}`);
+    emitCliError("IMAGE_PULL_FAILED", "Failed to pull Docker images", detail);
+    process.exit(1);
+  }
   console.log("✅ Docker images pulled\n");
 
   // Parse gateway port from entry's runtimeUrl, fall back to default
@@ -494,6 +511,10 @@ async function upgradeDocker(
           console.log(
             `\n⚠️  Rolled back to previous version. Upgrade to ${versionTag} failed.`,
           );
+          emitCliError(
+            "READINESS_TIMEOUT",
+            `Upgrade to ${versionTag} failed: containers did not become ready. Rolled back to previous version.`,
+          );
         } else {
           console.error(
             `\n❌ Rollback also failed. Manual intervention required.`,
@@ -501,20 +522,35 @@ async function upgradeDocker(
           console.log(
             `   Check logs with: docker logs -f ${res.assistantContainer}`,
           );
+          emitCliError(
+            "ROLLBACK_FAILED",
+            "Rollback also failed after readiness timeout. Manual intervention required.",
+          );
         }
       } catch (rollbackErr) {
-        console.error(
-          `\n❌ Rollback failed: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
-        );
+        const rollbackDetail =
+          rollbackErr instanceof Error
+            ? rollbackErr.message
+            : String(rollbackErr);
+        console.error(`\n❌ Rollback failed: ${rollbackDetail}`);
         console.error(`   Manual intervention required.`);
         console.log(
           `   Check logs with: docker logs -f ${res.assistantContainer}`,
+        );
+        emitCliError(
+          "ROLLBACK_FAILED",
+          "Auto-rollback failed after readiness timeout. Manual intervention required.",
+          rollbackDetail,
         );
       }
     } else {
       console.log(`   No previous images available for rollback.`);
       console.log(
         `   Check logs with: docker logs -f ${res.assistantContainer}`,
+      );
+      emitCliError(
+        "ROLLBACK_NO_STATE",
+        "Containers failed to become ready and no previous images available for rollback.",
       );
     }
 
@@ -537,9 +573,10 @@ async function upgradePlatform(
 
   const token = readPlatformToken();
   if (!token) {
-    console.error(
-      "Error: Not logged in. Run `vellum login --token <token>` first.",
-    );
+    const msg =
+      "Error: Not logged in. Run `vellum login --token <token>` first.";
+    console.error(msg);
+    emitCliError("AUTH_FAILED", msg);
     process.exit(1);
   }
 
@@ -577,6 +614,11 @@ async function upgradePlatform(
     console.error(
       `Error: Platform upgrade failed (${response.status}): ${text}`,
     );
+    emitCliError(
+      "PLATFORM_API_ERROR",
+      `Platform upgrade failed (${response.status})`,
+      text,
+    );
     await broadcastUpgradeEvent(entry.runtimeUrl, entry.assistantId, {
       type: "complete",
       installedVersion: entry.serviceGroupVersion ?? "unknown",
@@ -605,18 +647,25 @@ export async function upgrade(): Promise<void> {
   const entry = resolveTargetAssistant(name);
   const cloud = resolveCloud(entry);
 
-  if (cloud === "docker") {
-    await upgradeDocker(entry, version);
-    return;
+  try {
+    if (cloud === "docker") {
+      await upgradeDocker(entry, version);
+      return;
+    }
+
+    if (cloud === "vellum") {
+      await upgradePlatform(entry, version);
+      return;
+    }
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    console.error(`\n❌ Upgrade failed: ${detail}`);
+    emitCliError(categorizeUpgradeError(err), "Upgrade failed", detail);
+    process.exit(1);
   }
 
-  if (cloud === "vellum") {
-    await upgradePlatform(entry, version);
-    return;
-  }
-
-  console.error(
-    `Error: Upgrade is not supported for '${cloud}' assistants. Only 'docker' and 'vellum' assistants can be upgraded via the CLI.`,
-  );
+  const msg = `Error: Upgrade is not supported for '${cloud}' assistants. Only 'docker' and 'vellum' assistants can be upgraded via the CLI.`;
+  console.error(msg);
+  emitCliError("UNSUPPORTED_TOPOLOGY", msg);
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- Wire emitCliError into all process.exit(1) paths in upgrade.ts and rollback.ts
- Emit structured CLI_ERROR:{json} to stderr before exit for macOS app parsing
- Use categorizeUpgradeError for automatic error classification in catch blocks
- Preserve existing human-readable stderr output for terminal users

Part of plan: svc-grp-update-bugs-and-ux.md (PR 12 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
