### PR TITLE
Add bottom padding to settings nav for Developer row

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -363,6 +363,7 @@ struct SettingsPanel: View {
             }
         }
         .padding(.top, VSpacing.lg)
+        .padding(.bottom, VSpacing.md)
         .padding(.trailing, VSpacing.sm)
     }
 


### PR DESCRIPTION
## Summary
- Add `.padding(.bottom, VSpacing.md)` to the settings nav VStack to match the `.padding(.vertical, VSpacing.md)` used by the main sidebar around Preferences
- This gives the Developer row proper breathing room from the bottom edge of the panel

## Original prompt
Fix the Developer settings nav item which looks cramped against the bottom edge — match the Preferences sidebar spacing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
