### PR TITLE
Populate Help menu with docs, Discord, and feedback links

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -63,6 +63,13 @@ struct VellumAssistantApp: App {
                 }
             }
             CommandGroup(replacing: .help) {
+                Button("Vellum Help") {
+                    NSWorkspace.shared.open(URL(string: "https://vellum.ai/docs")!)
+                }
+                Button("Community") {
+                    NSWorkspace.shared.open(URL(string: "https://discord.gg/BbVhBYHPP3")!)
+                }
+                Divider()
                 Button("Share Feedback") {
                     appDelegate.sendLogsToSentry()
                 }


### PR DESCRIPTION
## Summary
- Added "Vellum Help" item linking to https://vellum.ai/docs and "Community" item linking to the Discord server
- Replaces the default macOS help search bar which was non-functional (no Apple Help Book registered)
- Share Feedback remains below a divider since it's an action (sends logs) rather than a navigation link
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
