### PR TITLE
Match settings nav bottom padding to left padding

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -363,7 +363,7 @@ struct SettingsPanel: View {
             }
         }
         .padding(.top, VSpacing.lg)
-        .padding(.bottom, VSpacing.md)
+        .padding(.bottom, VSpacing.xl)
         .padding(.trailing, VSpacing.sm)
     }
 


### PR DESCRIPTION
## Summary
- Change settings nav bottom padding from `VSpacing.md` to `VSpacing.xl` to match the leading padding on the outer container, giving the Developer row equal spacing on all sides

## Original prompt
Make the settings nav bottom padding match the left padding amount.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
