### PR TITLE
feat: show toast notifications for update success, rollback, and timeout

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -679,6 +679,11 @@ struct MainWindowView: View {
             .onReceive(connectionManager.$isConnected) { connected in
                 handleDaemonConnectionChange(connected)
             }
+            .onReceive(connectionManager.$lastUpdateOutcome) { outcome in
+                guard let outcome else { return }
+                handleUpdateOutcome(outcome)
+                connectionManager.clearLastUpdateOutcome()
+            }
             .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
                 refreshWindowAPIStatus(isConnected: connectionManager.isConnected, isAuthenticated: isAuthenticated)
             }
@@ -799,6 +804,43 @@ struct MainWindowView: View {
             withAnimation(VAnimation.standard) {
                 showDaemonLoading = false
             }
+        }
+    }
+
+    private func handleUpdateOutcome(_ outcome: UpdateOutcome) {
+        switch outcome.result {
+        case .succeeded(let version):
+            windowState.showToast(
+                message: "Assistant updated to \(version)",
+                style: .success,
+                autoDismissDelay: 8
+            )
+        case .rolledBack(_, let to):
+            windowState.showToast(
+                message: "Update failed — rolled back to \(to)",
+                style: .warning,
+                autoDismissDelay: 10
+            )
+        case .timedOut:
+            windowState.showToast(
+                message: "Update may not have completed. Check Settings for current version.",
+                style: .warning,
+                primaryAction: VToastAction(label: "Open Settings") {
+                    settingsStore.pendingSettingsTab = .general
+                    windowState.selection = .panel(.settings)
+                },
+                autoDismissDelay: 15
+            )
+        case .failed:
+            windowState.showToast(
+                message: "Update failed. Check Settings for details.",
+                style: .error,
+                primaryAction: VToastAction(label: "Open Settings") {
+                    settingsStore.pendingSettingsTab = .general
+                    windowState.selection = .panel(.settings)
+                },
+                autoDismissDelay: 15
+            )
         }
     }
 

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -233,6 +233,11 @@ public final class GatewayConnectionManager: ObservableObject {
         currentModel = nil
     }
 
+    /// Clears the last update outcome after the UI has consumed it.
+    public func clearLastUpdateOutcome() {
+        lastUpdateOutcome = nil
+    }
+
     // MARK: - Health Check (via GatewayHTTPClient)
 
     private func performHealthCheck() async throws {


### PR DESCRIPTION
## Summary
- Add .onReceive observer for connectionManager.$lastUpdateOutcome in MainWindowView
- Show success/warning/error toasts based on update outcome (succeeded, rolled back, timed out, failed)
- Success toast auto-dismisses after 8s; failure/timeout toasts persist 10-15s with Settings navigation
- Add clearLastUpdateOutcome() public method to GatewayConnectionManager for UI consumption

Part of plan: svc-grp-update-bugs-and-ux.md (PR 14 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
