### PR TITLE
feat: show actionable error guidance and "Share Feedback" option for update failures

### DIFF
--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -59,10 +59,22 @@ struct DaemonStartupError {
 @MainActor
 final class VellumCli {
 
+    /// Structured error emitted by the CLI for upgrade/rollback failures.
+    ///
+    /// The CLI writes a `CLI_ERROR:{...}` JSON line to stderr when a command
+    /// fails with a categorised error. This struct captures the parsed fields
+    /// so the UI can display actionable guidance instead of raw stderr.
+    struct CliError {
+        let category: String
+        let message: String
+        let detail: String?
+    }
+
     enum CLIError: LocalizedError {
         case binaryNotFound
         case executionFailed(String)
         case daemonStartupFailed(DaemonStartupError)
+        case structuredError(CliError)
 
         var errorDescription: String? {
             switch self {
@@ -72,6 +84,8 @@ final class VellumCli {
                 return "CLI command failed: \(message)"
             case .daemonStartupFailed(let error):
                 return "Assistant startup failed: \(error.message)"
+            case .structuredError(let cliError):
+                return "CLI command failed: \(cliError.message)"
             }
         }
     }
@@ -371,6 +385,9 @@ final class VellumCli {
 
         if status != 0 {
             log.error("CLI upgrade failed with exit code \(status, privacy: .public): \(stderr, privacy: .private)")
+            if let cliError = Self.parseCliError(from: stderr) {
+                throw CLIError.structuredError(cliError)
+            }
             throw CLIError.executionFailed(stderr)
         }
         log.info("CLI upgrade completed successfully for '\(name, privacy: .public)'")
@@ -388,6 +405,9 @@ final class VellumCli {
 
         if status != 0 {
             log.error("CLI rollback failed with exit code \(status, privacy: .public): \(stderr, privacy: .private)")
+            if let cliError = Self.parseCliError(from: stderr) {
+                throw CLIError.structuredError(cliError)
+            }
             throw CLIError.executionFailed(stderr)
         }
         log.info("CLI rollback completed successfully for '\(name, privacy: .public)'")
@@ -694,6 +714,25 @@ final class VellumCli {
         let message = json["message"] as? String ?? "Unknown startup error"
         let detail = json["detail"] as? String
         return DaemonStartupError(category: category, message: message, detail: detail)
+    }
+
+    /// Parse a `CliError` from the CLI's stderr output.
+    ///
+    /// Scans for the last line starting with `CLI_ERROR:` and decodes the
+    /// trailing JSON payload. Returns `nil` when no marker is found.
+    static func parseCliError(from stderr: String) -> CliError? {
+        let lines = stderr.components(separatedBy: "\n")
+        guard let errorLine = lines.last(where: { $0.hasPrefix("CLI_ERROR:") }) else { return nil }
+        let json = String(errorLine.dropFirst("CLI_ERROR:".count))
+        guard let data = json.data(using: .utf8),
+              let parsed = try? JSONDecoder().decode(CliErrorPayload.self, from: data) else { return nil }
+        return CliError(category: parsed.error, message: parsed.message, detail: parsed.detail)
+    }
+
+    private struct CliErrorPayload: Decodable {
+        let error: String
+        let message: String
+        let detail: String?
     }
 
     /// Send SIGTERM to a process identified by a PID file. Does not wait for

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -38,6 +38,7 @@ struct AssistantUpgradeSection: View {
     @State private var errorMessage: String?
     @State private var successMessage: String?
     @State private var showingUpgradeConfirmation = false
+    @State private var showFeedbackOption = false
     @State private var isCheckingLocal = false
     @State private var hasCheckedForUpdates = false
     @State private var checkedSparkleAvailable: Bool?
@@ -311,6 +312,12 @@ struct AssistantUpgradeSection: View {
                     .foregroundColor(VColor.systemNegativeStrong)
             }
 
+            if showFeedbackOption {
+                VButton(label: "Share Feedback", style: .outlined) {
+                    AppDelegate.shared?.showLogReportWindow(reason: .somethingBroken)
+                }
+            }
+
             if let success = successMessage {
                 Text(success)
                     .font(VFont.caption)
@@ -428,6 +435,17 @@ struct AssistantUpgradeSection: View {
             successMessage = isRollback ? "Rollback complete." : "Update complete."
             await loadReleasesQuietly()
             if successMessage != nil { errorMessage = nil }
+        } catch let error as VellumCli.CLIError {
+            switch error {
+            case .structuredError(let cliError):
+                errorMessage = guidanceForError(cliError)
+                showFeedbackOption = true
+            case .executionFailed(let stderr):
+                errorMessage = "Update failed: \(stderr)"
+                showFeedbackOption = true
+            default:
+                errorMessage = "Update failed: \(error.localizedDescription)"
+            }
         } catch {
             errorMessage = "\(isRollback ? "Rollback" : "Update") failed: \(error.localizedDescription)"
         }
@@ -448,11 +466,14 @@ struct AssistantUpgradeSection: View {
                 if successMessage != nil { errorMessage = nil }
             } else {
                 errorMessage = "\(isRollback ? "Rollback" : "Update") failed (HTTP \(response.statusCode))"
+                showFeedbackOption = true
             }
         } catch let error as GatewayHTTPClient.ClientError {
             errorMessage = "Unable to start \(isRollback ? "rollback" : "update"): \(error.localizedDescription)"
+            showFeedbackOption = true
         } catch {
             errorMessage = "\(isRollback ? "Rollback" : "Update") failed: \(error.localizedDescription)"
+            showFeedbackOption = true
         }
     }
 
@@ -481,6 +502,32 @@ struct AssistantUpgradeSection: View {
     private func clearMessages() {
         errorMessage = nil
         successMessage = nil
+        showFeedbackOption = false
+    }
+
+    private func guidanceForError(_ error: VellumCli.CliError) -> String {
+        switch error.category {
+        case "DOCKER_NOT_RUNNING":
+            return "Docker doesn't appear to be running. Start Docker Desktop and try again."
+        case "IMAGE_PULL_FAILED":
+            return "Failed to download the update. Check your internet connection and try again."
+        case "READINESS_TIMEOUT":
+            return "The assistant didn't start up in time. Check Docker Desktop for container status, or try rolling back."
+        case "ROLLBACK_FAILED":
+            return "Rollback failed. Check Docker Desktop for container status."
+        case "ROLLBACK_NO_STATE":
+            return "No previous version available to roll back to."
+        case "AUTH_FAILED":
+            return "Authentication failed. Try signing out and back in from Settings."
+        case "NETWORK_ERROR":
+            return "Couldn't reach the update server. Check your internet connection."
+        case "PLATFORM_API_ERROR":
+            return "The platform returned an error. Try again in a few minutes."
+        case "ASSISTANT_NOT_FOUND":
+            return "Could not find the assistant. Make sure it's still configured."
+        default:
+            return "Something went wrong. Share feedback to send logs to the team."
+        }
     }
 
 }


### PR DESCRIPTION
## Summary
- Add CLI_ERROR parsing to VellumCli.swift for structured error extraction from stderr
- Map error categories to user-facing guidance messages in AssistantUpgradeSection
- Show "Share Feedback" button alongside error messages for quick log report submission
- Clear feedback option state when messages are cleared

Part of plan: svc-grp-update-bugs-and-ux.md (PR 15 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
