### PR TITLE
Refine Help menu labels, add UTM params, remove search bar

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -63,11 +63,11 @@ struct VellumAssistantApp: App {
                 }
             }
             CommandGroup(replacing: .help) {
-                Button("Vellum Help") {
-                    NSWorkspace.shared.open(URL(string: "https://vellum.ai/docs")!)
+                Button("Documentation") {
+                    NSWorkspace.shared.open(URL(string: "https://vellum.ai/docs?utm_source=macos-app&utm_medium=help-menu")!)
                 }
-                Button("Community") {
-                    NSWorkspace.shared.open(URL(string: "https://discord.gg/BbVhBYHPP3")!)
+                Button("Discord Community") {
+                    NSWorkspace.shared.open(URL(string: "https://www.vellum.ai/community?utm_source=macos-app&utm_medium=help-menu")!)
                 }
                 Divider()
                 Button("Share Feedback") {

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -252,6 +252,18 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         }
     }
 
+    /// Remove the system-provided search field from the Help menu.
+    /// macOS automatically inserts it for any menu registered as the app's
+    /// helpMenu, but it's non-functional without an Apple Help Book.
+    func stripHelpMenuSearchField() {
+        NSApp.helpMenu = nil
+        // SwiftUI may re-register the help menu after launch; retry on
+        // the next run-loop pass to catch late registration.
+        DispatchQueue.main.async {
+            NSApp.helpMenu = nil
+        }
+    }
+
     public func applicationDidFinishLaunching(_ notification: Notification) {
         // ── Single-instance guard ──────────────────────────────────────
         // If another copy of this app is already running (e.g. Sparkle
@@ -394,6 +406,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         // Set up menu bar and hotkeys early so they work regardless of auth state.
         setupMenuBar()
         patchAppMenuTitles()
+        stripHelpMenuSearchField()
         setupHotKey()
 
         // Install CLI symlinks early so they are available before the daemon
@@ -465,6 +478,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         setupMenuBar()
         setupFileMenu()
         patchAppMenuTitles()
+        stripHelpMenuSearchField()
         registerNavigationMonitor()
         registerZoomMonitor()
         setupHotKey()


### PR DESCRIPTION
## Summary
- Renamed menu items to "Documentation" and "Discord Community" for clarity
- Added `utm_source=macos-app&utm_medium=help-menu` tracking params to both links
- Removed the non-functional macOS Help menu search bar by clearing `NSApp.helpMenu` in AppDelegate (runs at launch and after `proceedToApp`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
