### PR TITLE
Update keychain unreachable error messages to guide users to restart app

### DIFF
--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -617,7 +617,7 @@ Examples:
               writeOutput(cmd, {
                 ok: false,
                 error:
-                  "Keychain broker is unreachable — is the macOS app running?",
+                  "Keychain broker is unreachable — restart the Vellum app and accept the macOS Keychain prompt",
               });
             } else {
               writeOutput(cmd, { ok: false, error: "Credential not found" });
@@ -668,7 +668,7 @@ Examples:
             printCredentialHuman(output);
             if (unreachable && (secret == null || secret.length === 0)) {
               log.info(
-                "    \u26A0 Keychain broker unreachable — secret may exist but cannot be retrieved",
+                "    \u26A0 Keychain broker unreachable — restart the Vellum app and accept the macOS Keychain prompt to access credentials",
               );
             }
           }
@@ -754,7 +754,7 @@ Examples:
               writeOutput(cmd, {
                 ok: false,
                 error:
-                  "Keychain broker is unreachable — is the macOS app running?",
+                  "Keychain broker is unreachable — restart the Vellum app and accept the macOS Keychain prompt",
               });
             } else {
               writeOutput(cmd, { ok: false, error: "Credential not found" });

--- a/assistant/src/security/credential-backend.ts
+++ b/assistant/src/security/credential-backend.ts
@@ -71,10 +71,7 @@ export class KeychainBackend implements CredentialBackend {
       if (result == null) {
         const now = Date.now();
         if (now - lastUnreachableWarnMs >= UNREACHABLE_WARN_COOLDOWN_MS) {
-          log.warn(
-            { account },
-            "Keychain broker unreachable during get — falling back",
-          );
+          log.warn({ account }, "Keychain broker unreachable during get");
           lastUnreachableWarnMs = now;
         }
         return { value: undefined, unreachable: true };


### PR DESCRIPTION
## Summary
- Updates three CLI error messages for keychain broker unreachable to guide users to restart the Vellum app and accept the macOS Keychain prompt
- Removes 'falling back' language from internal log message in credential-backend.ts

Part of plan: single-credential-backend.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
