### PR TITLE
Add workspace migration 014 to migrate encrypted store credentials to keychain

### DIFF
--- a/assistant/src/__tests__/workspace-migration-014-migrate-credentials-to-keychain.test.ts
+++ b/assistant/src/__tests__/workspace-migration-014-migrate-credentials-to-keychain.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+const isAvailableFn = mock((): boolean => true);
+const brokerSetFn = mock(
+  async (
+    _account: string,
+    _value: string,
+  ): Promise<{ status: string; code?: string; message?: string }> => ({
+    status: "ok",
+  }),
+);
+const createBrokerClientFn = mock(() => ({
+  isAvailable: isAvailableFn,
+  set: brokerSetFn,
+}));
+
+const listKeysFn = mock((): string[] => []);
+const getKeyFn = mock((_account: string): string | undefined => undefined);
+const deleteKeyFn = mock(
+  (_account: string): "deleted" | "not-found" | "error" => "deleted",
+);
+
+// ---------------------------------------------------------------------------
+// Mock modules — before importing module under test
+//
+// The logger is mocked with a silent Proxy to suppress pino output in tests.
+// The broker client and encrypted store are mocked to control migration
+// behavior without touching real keychain or filesystem state.
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../security/keychain-broker-client.js", () => ({
+  createBrokerClient: createBrokerClientFn,
+}));
+
+mock.module("../security/encrypted-store.js", () => ({
+  listKeys: listKeysFn,
+  getKey: getKeyFn,
+  deleteKey: deleteKeyFn,
+}));
+
+// Import after mocking
+import { migrateCredentialsToKeychainMigration } from "../workspace/migrations/014-migrate-credentials-to-keychain.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_DIR = "/mock-home/.vellum/workspace";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("014-migrate-credentials-to-keychain migration", () => {
+  beforeEach(() => {
+    isAvailableFn.mockClear();
+    brokerSetFn.mockClear();
+    createBrokerClientFn.mockClear();
+    listKeysFn.mockClear();
+    getKeyFn.mockClear();
+    deleteKeyFn.mockClear();
+
+    // Defaults: mac production build
+    process.env.VELLUM_DESKTOP_APP = "1";
+    delete process.env.VELLUM_DEV;
+
+    isAvailableFn.mockReturnValue(true);
+    brokerSetFn.mockResolvedValue({ status: "ok" });
+    listKeysFn.mockReturnValue([]);
+    getKeyFn.mockReturnValue(undefined);
+    deleteKeyFn.mockReturnValue("deleted");
+  });
+
+  test("has correct migration id", () => {
+    expect(migrateCredentialsToKeychainMigration.id).toBe(
+      "014-migrate-credentials-to-keychain",
+    );
+  });
+
+  test("skips when VELLUM_DESKTOP_APP is not set", async () => {
+    delete process.env.VELLUM_DESKTOP_APP;
+
+    await migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR);
+
+    expect(createBrokerClientFn).not.toHaveBeenCalled();
+    expect(listKeysFn).not.toHaveBeenCalled();
+  });
+
+  test("skips when VELLUM_DESKTOP_APP is not '1'", async () => {
+    process.env.VELLUM_DESKTOP_APP = "0";
+
+    await migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR);
+
+    expect(createBrokerClientFn).not.toHaveBeenCalled();
+  });
+
+  test("skips when VELLUM_DEV=1", async () => {
+    process.env.VELLUM_DEV = "1";
+
+    await migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR);
+
+    expect(createBrokerClientFn).not.toHaveBeenCalled();
+    expect(listKeysFn).not.toHaveBeenCalled();
+  });
+
+  test("skips when broker is not available", async () => {
+    isAvailableFn.mockReturnValue(false);
+
+    await migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR);
+
+    // Should not proceed to list or migrate keys
+    expect(listKeysFn).not.toHaveBeenCalled();
+    expect(brokerSetFn).not.toHaveBeenCalled();
+  });
+
+  test("no-ops when encrypted store has no keys", async () => {
+    listKeysFn.mockReturnValue([]);
+
+    await migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR);
+
+    expect(brokerSetFn).not.toHaveBeenCalled();
+    expect(deleteKeyFn).not.toHaveBeenCalled();
+  });
+
+  test("successfully migrates keys from encrypted store to keychain", async () => {
+    listKeysFn.mockReturnValue(["account-a", "account-b"]);
+    getKeyFn.mockImplementation((account: string) => {
+      if (account === "account-a") return "secret-a";
+      if (account === "account-b") return "secret-b";
+      return undefined;
+    });
+    brokerSetFn.mockResolvedValue({ status: "ok" });
+
+    await migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR);
+
+    // Should have called broker.set for each key
+    expect(brokerSetFn).toHaveBeenCalledTimes(2);
+    expect(brokerSetFn).toHaveBeenCalledWith("account-a", "secret-a");
+    expect(brokerSetFn).toHaveBeenCalledWith("account-b", "secret-b");
+
+    // Should have deleted each key from encrypted store after successful migration
+    expect(deleteKeyFn).toHaveBeenCalledTimes(2);
+    expect(deleteKeyFn).toHaveBeenCalledWith("account-a");
+    expect(deleteKeyFn).toHaveBeenCalledWith("account-b");
+  });
+
+  test("continues on individual key failure and migrates others", async () => {
+    listKeysFn.mockReturnValue(["fail-key", "ok-key"]);
+    getKeyFn.mockImplementation((account: string) => {
+      if (account === "fail-key") return "fail-secret";
+      if (account === "ok-key") return "ok-secret";
+      return undefined;
+    });
+    brokerSetFn.mockImplementation(async (account: string) => {
+      if (account === "fail-key") {
+        return {
+          status: "rejected" as const,
+          code: "UNKNOWN",
+          message: "broker rejected",
+        };
+      }
+      return { status: "ok" as const };
+    });
+
+    await migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR);
+
+    // fail-key should NOT have been deleted (broker rejected it)
+    expect(deleteKeyFn).not.toHaveBeenCalledWith("fail-key");
+
+    // ok-key should have been migrated and deleted
+    expect(brokerSetFn).toHaveBeenCalledWith("ok-key", "ok-secret");
+    expect(deleteKeyFn).toHaveBeenCalledWith("ok-key");
+    expect(deleteKeyFn).toHaveBeenCalledTimes(1);
+  });
+
+  test("handles getKey returning undefined for a listed key", async () => {
+    listKeysFn.mockReturnValue(["ghost-key", "real-key"]);
+    getKeyFn.mockImplementation((account: string) => {
+      if (account === "ghost-key") return undefined;
+      if (account === "real-key") return "real-secret";
+      return undefined;
+    });
+    brokerSetFn.mockResolvedValue({ status: "ok" });
+
+    await migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR);
+
+    // ghost-key should not be sent to broker or deleted
+    expect(brokerSetFn).not.toHaveBeenCalledWith(
+      "ghost-key",
+      expect.anything(),
+    );
+    expect(deleteKeyFn).not.toHaveBeenCalledWith("ghost-key");
+
+    // real-key should be migrated
+    expect(brokerSetFn).toHaveBeenCalledWith("real-key", "real-secret");
+    expect(deleteKeyFn).toHaveBeenCalledWith("real-key");
+  });
+
+  test("handles broker unreachable status for individual keys", async () => {
+    listKeysFn.mockReturnValue(["key-1"]);
+    getKeyFn.mockReturnValue("secret-1");
+    brokerSetFn.mockResolvedValue({ status: "unreachable" });
+
+    await migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR);
+
+    // Should not delete when broker is unreachable
+    expect(deleteKeyFn).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/workspace/migrations/014-migrate-credentials-to-keychain.ts
+++ b/assistant/src/workspace/migrations/014-migrate-credentials-to-keychain.ts
@@ -1,0 +1,71 @@
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("workspace-migrations");
+
+export const migrateCredentialsToKeychainMigration: WorkspaceMigration = {
+  id: "014-migrate-credentials-to-keychain",
+  description:
+    "Copy encrypted store credentials to keychain for single-backend migration",
+
+  async run(_workspaceDir: string): Promise<void> {
+    // Only run on mac production builds (desktop app, non-dev).
+    if (
+      process.env.VELLUM_DESKTOP_APP !== "1" ||
+      process.env.VELLUM_DEV === "1"
+    ) {
+      return;
+    }
+
+    const { createBrokerClient } =
+      await import("../../security/keychain-broker-client.js");
+    const client = createBrokerClient();
+
+    if (!client.isAvailable()) {
+      log.warn(
+        "Keychain broker not available — skipping credential migration to keychain",
+      );
+      return;
+    }
+
+    const { listKeys, getKey, deleteKey } =
+      await import("../../security/encrypted-store.js");
+
+    const accounts = listKeys();
+    if (accounts.length === 0) {
+      return;
+    }
+
+    let migratedCount = 0;
+    let failedCount = 0;
+
+    for (const account of accounts) {
+      const value = getKey(account);
+      if (value === undefined) {
+        log.warn(
+          { account },
+          "Failed to read key from encrypted store — skipping",
+        );
+        failedCount++;
+        continue;
+      }
+
+      const result = await client.set(account, value);
+      if (result.status === "ok") {
+        deleteKey(account);
+        migratedCount++;
+      } else {
+        log.warn(
+          { account, status: result.status },
+          "Failed to write key to keychain — skipping",
+        );
+        failedCount++;
+      }
+    }
+
+    log.info(
+      { migratedCount, failedCount },
+      "Credential migration to keychain complete",
+    );
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -10,6 +10,7 @@ import { appDirRenameMigration } from "./010-app-dir-rename.js";
 import { backfillInstallationIdMigration } from "./011-backfill-installation-id.js";
 import { renameConversationDiskViewDirsMigration } from "./012-rename-conversation-disk-view-dirs.js";
 import { repairConversationDiskViewMigration } from "./013-repair-conversation-disk-view.js";
+import { migrateCredentialsToKeychainMigration } from "./014-migrate-credentials-to-keychain.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -31,4 +32,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   renameConversationDiskViewDirsMigration,
   repairConversationDiskViewMigration,
   migrateToWorkspaceVolumeMigration,
+  migrateCredentialsToKeychainMigration,
 ];


### PR DESCRIPTION
## Summary
- Adds migration 014 that copies encrypted store credentials to keychain on mac production builds
- Migration is best-effort: skips keys that fail to migrate, logs warnings for broker unavailability
- Includes comprehensive tests covering all skip conditions and migration scenarios

Part of plan: single-credential-backend.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
