### PR TITLE
fix: narrow categorizeUpgradeError not-found matcher to image-pull-specific errors

### DIFF
--- a/cli/src/lib/cli-error.ts
+++ b/cli/src/lib/cli-error.ts
@@ -59,9 +59,10 @@ export function categorizeUpgradeError(err: unknown): CliErrorCategory {
   }
 
   if (
-    msg.includes("manifest") ||
+    msg.includes("manifest unknown") ||
+    msg.includes("manifest not found") ||
     msg.includes("pull access denied") ||
-    msg.includes("not found")
+    msg.includes("repository does not exist")
   ) {
     return "IMAGE_PULL_FAILED";
   }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for svc-grp-update-bugs-and-ux.md.

**Gap:** categorizeUpgradeError not found matcher is overly broad
**What was expected:** Only image-pull-related not-found errors should map to IMAGE_PULL_FAILED
**What was found:** Any error containing not found was classified as IMAGE_PULL_FAILED
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
