### PR TITLE
fix: VersionCompat.parse handles dotted pre-release versions and uppercase V prefix

### DIFF
--- a/clients/shared/Utilities/VersionCompat.swift
+++ b/clients/shared/Utilities/VersionCompat.swift
@@ -9,17 +9,14 @@ public struct ParsedVersion {
 
 public enum VersionCompat {
     /// Parse a version string into major.minor.patch components.
-    /// Handles optional `v` prefix (e.g., "v1.2.3" or "1.2.3").
+    /// Handles optional `v`/`V` prefix (e.g., "v1.2.3", "V1.2.3", or "1.2.3").
     /// Returns nil if the string cannot be parsed.
     public static func parse(_ version: String) -> ParsedVersion? {
-        let cleaned = version.hasPrefix("v") ? String(version.dropFirst()) : version
-        // Strip pre-release/build metadata from each segment
-        let segments = cleaned.split(separator: ".").map { segment -> String in
-            let s = String(segment)
-            if let dashIdx = s.firstIndex(of: "-") { return String(s[..<dashIdx]) }
-            if let plusIdx = s.firstIndex(of: "+") { return String(s[..<plusIdx]) }
-            return s
-        }
+        let cleaned = (version.hasPrefix("v") || version.hasPrefix("V")) ? String(version.dropFirst()) : version
+        // Strip pre-release (-beta.1) and build metadata (+build.123) before splitting on dots
+        let withoutPreRelease = cleaned.split(separator: "-", maxSplits: 1).first.map(String.init) ?? cleaned
+        let withoutBuild = withoutPreRelease.split(separator: "+", maxSplits: 1).first.map(String.init) ?? withoutPreRelease
+        let segments = withoutBuild.split(separator: ".").map(String.init)
         let components = segments.compactMap { Int($0) }
         guard components.count >= 2, components.count <= 3 else { return nil }
         return ParsedVersion(


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for svc-grp-update-bugs-and-ux.md.

**Gap:** VersionCompat.parse breaks on dotted pre-release versions and uppercase V prefix
**What was expected:** Versions like 1.2.3-beta.1 and V1.2.3 should parse correctly
**What was found:** parse returns nil for dotted pre-release and wrong values for uppercase V
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
