### PR TITLE
Convert resolveBackend to async with VELLUM_DESKTOP_APP gate and broker wait

### DIFF
--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -103,8 +103,9 @@ describe("secure-keys", () => {
     mockBrokerGetCalled = false;
     mockBrokerSetCalled = false;
 
-    // Ensure VELLUM_DEV is NOT set so broker tests work by default
+    // Ensure VELLUM_DEV and VELLUM_DESKTOP_APP are NOT set so broker tests work by default
     delete process.env.VELLUM_DEV;
+    delete process.env.VELLUM_DESKTOP_APP;
 
     if (existsSync(TEST_DIR)) {
       rmSync(TEST_DIR, { recursive: true });
@@ -117,6 +118,7 @@ describe("secure-keys", () => {
     _setStorePath(null);
     _resetBackend();
     delete process.env.VELLUM_DEV;
+    delete process.env.VELLUM_DESKTOP_APP;
   });
 
   afterAll(() => {
@@ -154,6 +156,7 @@ describe("secure-keys", () => {
   // -----------------------------------------------------------------------
   describe("single-writer with broker available", () => {
     test("setSecureKeyAsync writes to broker only (not encrypted store)", async () => {
+      process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       _resetBackend();
 
@@ -166,6 +169,7 @@ describe("secure-keys", () => {
     });
 
     test("setSecureKeyAsync returns false on broker set error", async () => {
+      process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       mockBrokerSetError = true;
       _resetBackend();
@@ -181,6 +185,7 @@ describe("secure-keys", () => {
   // -----------------------------------------------------------------------
   describe("reads with broker available", () => {
     test("getSecureKeyAsync reads from broker (primary backend)", async () => {
+      process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       _resetBackend();
 
@@ -191,6 +196,7 @@ describe("secure-keys", () => {
     });
 
     test("getSecureKeyAsync falls back to encrypted store for legacy keys", async () => {
+      process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       _resetBackend();
 
@@ -204,6 +210,7 @@ describe("secure-keys", () => {
     });
 
     test("getSecureKeyAsync returns undefined when neither store has the key", async () => {
+      process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       _resetBackend();
 
@@ -211,6 +218,7 @@ describe("secure-keys", () => {
     });
 
     test("getSecureKeyAsync returns broker value even when encrypted store also has a value", async () => {
+      process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       _resetBackend();
 
@@ -269,10 +277,59 @@ describe("secure-keys", () => {
   });
 
   // -----------------------------------------------------------------------
+  // VELLUM_DESKTOP_APP gating — keychain backend selection
+  // -----------------------------------------------------------------------
+  describe("VELLUM_DESKTOP_APP gating", () => {
+    test("uses keychain when VELLUM_DESKTOP_APP=1 and broker available", async () => {
+      process.env.VELLUM_DESKTOP_APP = "1";
+      mockBrokerAvailable = true;
+      _resetBackend();
+
+      const result = await setSecureKeyAsync("api-key", "new-value");
+      expect(result).toBe(true);
+      // Value is in the broker store (keychain backend)
+      expect(mockBrokerStore.get("api-key")).toBe("new-value");
+      // Value should NOT be in the encrypted store
+      expect(encryptedStore.getKey("api-key")).toBeUndefined();
+    });
+
+    test(
+      "still resolves to keychain when VELLUM_DESKTOP_APP=1 and broker unavailable",
+      async () => {
+        process.env.VELLUM_DESKTOP_APP = "1";
+        mockBrokerAvailable = false;
+        mockBrokerGetError = true;
+        _resetBackend();
+
+        // Backend resolves to keychain even though broker is unavailable.
+        // Operations will report unreachable rather than falling back to encrypted store.
+        const result = await getSecureKeyResultAsync("api-key");
+        expect(result.value).toBeUndefined();
+        expect(result.unreachable).toBe(true);
+      },
+      { timeout: 10_000 },
+    );
+
+    test("non-desktop topology uses encrypted store even when broker is available", async () => {
+      // VELLUM_DESKTOP_APP is NOT set
+      mockBrokerAvailable = true;
+      _resetBackend();
+
+      const result = await setSecureKeyAsync("api-key", "new-value");
+      expect(result).toBe(true);
+      // Value is in the encrypted store (not broker)
+      expect(encryptedStore.getKey("api-key")).toBe("new-value");
+      // Broker should NOT have been used
+      expect(mockBrokerSetCalled).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // Delete always attempts both stores
   // -----------------------------------------------------------------------
   describe("delete attempts both stores", () => {
     test("deleteSecureKeyAsync removes from both stores when broker available", async () => {
+      process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       _resetBackend();
 
@@ -295,6 +352,7 @@ describe("secure-keys", () => {
     });
 
     test("deleteSecureKeyAsync returns error when broker delete fails", async () => {
+      process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       mockBrokerDelError = true;
       _resetBackend();
@@ -308,6 +366,7 @@ describe("secure-keys", () => {
 
     test("deleteSecureKeyAsync in dev mode still attempts both stores", async () => {
       process.env.VELLUM_DEV = "1";
+      process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       _resetBackend();
 
@@ -332,6 +391,7 @@ describe("secure-keys", () => {
   // -----------------------------------------------------------------------
   describe("legacy read fallback", () => {
     test("returns encrypted store value when broker has no key (legacy migration)", async () => {
+      process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       _resetBackend();
 
@@ -362,6 +422,7 @@ describe("secure-keys", () => {
   // -----------------------------------------------------------------------
   describe("stale-value prevention", () => {
     test("setSecureKeyAsync failure does not corrupt broker store", async () => {
+      process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       _resetBackend();
 
@@ -383,6 +444,7 @@ describe("secure-keys", () => {
   // -----------------------------------------------------------------------
   describe("listSecureKeysAsync", () => {
     test("returns merged, deduplicated keys when broker is primary and encrypted store has legacy keys", async () => {
+      process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       _resetBackend();
 
@@ -434,6 +496,7 @@ describe("secure-keys", () => {
     });
 
     test("returns broker-only keys when encrypted store is empty", async () => {
+      process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       _resetBackend();
 
@@ -447,6 +510,7 @@ describe("secure-keys", () => {
     });
 
     test("deduplicates keys that exist in both stores", async () => {
+      process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       _resetBackend();
 
@@ -462,6 +526,7 @@ describe("secure-keys", () => {
     });
 
     test("returns empty array when both stores are empty", async () => {
+      process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       _resetBackend();
 
@@ -475,6 +540,7 @@ describe("secure-keys", () => {
   // -----------------------------------------------------------------------
   describe("getSecureKeyResultAsync", () => {
     test("returns unreachable true when broker errors", async () => {
+      process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       mockBrokerGetError = true;
       _resetBackend();
@@ -485,6 +551,7 @@ describe("secure-keys", () => {
     });
 
     test("returns value and unreachable false on success", async () => {
+      process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       _resetBackend();
 
@@ -495,6 +562,7 @@ describe("secure-keys", () => {
     });
 
     test("falls back to encrypted store when broker is unreachable", async () => {
+      process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       mockBrokerGetError = true;
       _resetBackend();
@@ -506,6 +574,7 @@ describe("secure-keys", () => {
     });
 
     test("propagates unreachable when broker errors and encrypted store also missing", async () => {
+      process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       mockBrokerGetError = true;
       _resetBackend();

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -2,10 +2,13 @@
  * Unified secure key storage — single-writer routing through CredentialBackend
  * adapters.
  *
- * Backend selection (`resolveBackend`) is the single decision point:
+ * Backend selection (`resolveBackendAsync`) is the single async decision point:
  *   - Containerized (IS_CONTAINERIZED + CES_CREDENTIAL_URL set): CES HTTP client.
- *   - Production (VELLUM_DEV unset or "0"): keychain backend when available.
- *   - Dev mode (VELLUM_DEV=1): encrypted file store always.
+ *   - Desktop app (VELLUM_DESKTOP_APP=1, non-dev): keychain backend always,
+ *     with up to 5 s wait for the broker socket to appear. Even if the broker
+ *     never becomes available, we commit to keychain so operations fail visibly
+ *     rather than silently writing to a different store.
+ *   - Dev mode or non-desktop topology: encrypted file store always.
  *
  * Writes go to exactly one backend (no dual-writing). Reads in keychain mode
  * fall back to the encrypted store for keys that haven't been migrated yet.
@@ -43,9 +46,13 @@ export interface SecureKeyResult {
 
 const log = getLogger("secure-keys");
 
+const BROKER_WAIT_INTERVAL_MS = 500;
+const BROKER_WAIT_MAX_ATTEMPTS = 10; // 5 seconds total
+
 let _keychain: CredentialBackend | undefined;
 let _encryptedStore: CredentialBackend | undefined;
 let _resolvedBackend: CredentialBackend | undefined;
+let _resolvePromise: Promise<CredentialBackend> | undefined;
 
 function getKeychainBackend(): CredentialBackend {
   if (!_keychain) _keychain = createKeychainBackend();
@@ -57,43 +64,69 @@ function getEncryptedStoreBackend(): CredentialBackend {
   return _encryptedStore;
 }
 
+async function waitForBrokerAvailability(): Promise<boolean> {
+  const keychain = getKeychainBackend();
+  for (let i = 0; i < BROKER_WAIT_MAX_ATTEMPTS; i++) {
+    if (keychain.isAvailable()) return true;
+    await new Promise((r) => setTimeout(r, BROKER_WAIT_INTERVAL_MS));
+  }
+  return false;
+}
+
 /**
- * Resolve the primary credential backend for this process.
+ * Resolve the primary credential backend for this process (async).
  *
  * Priority:
  *   1. Containerized + CES_CREDENTIAL_URL → CES HTTP client (skip keychain
  *      and encrypted store entirely — the sidecar owns credential storage).
- *   2. Production (VELLUM_DEV unset or "0") → keychain when available.
- *   3. Dev mode (VELLUM_DEV=1) → encrypted file store always.
+ *   2. Desktop app (VELLUM_DESKTOP_APP=1, non-dev) → keychain always, with
+ *      up to 5 s wait for the broker socket. Even if the broker never becomes
+ *      available, we commit to keychain so operations fail visibly.
+ *   3. Dev mode or non-desktop topology → encrypted file store always.
  *
  * Once resolved, the backend does not change during the process lifetime.
  * Call `_resetBackend()` in tests to clear the cached resolution.
  */
-function resolveBackend(): CredentialBackend {
-  if (!_resolvedBackend) {
-    if (getIsContainerized() && process.env.CES_CREDENTIAL_URL) {
-      const ces = createCesCredentialBackend();
-      if (ces.isAvailable()) {
-        _resolvedBackend = ces;
-      } else {
-        log.warn(
-          "CES_CREDENTIAL_URL is set but CES backend is not available — " +
-            "falling back to local credential store",
-        );
-      }
-    }
-
-    if (!_resolvedBackend) {
-      if (
-        process.env.VELLUM_DEV !== "1" &&
-        getKeychainBackend().isAvailable()
-      ) {
-        _resolvedBackend = getKeychainBackend();
-      } else {
-        _resolvedBackend = getEncryptedStoreBackend();
-      }
-    }
+async function resolveBackendAsync(): Promise<CredentialBackend> {
+  if (_resolvedBackend) return _resolvedBackend;
+  if (!_resolvePromise) {
+    _resolvePromise = doResolveBackend();
   }
+  return _resolvePromise;
+}
+
+async function doResolveBackend(): Promise<CredentialBackend> {
+  // 1. Containerized + CES (unchanged)
+  if (getIsContainerized() && process.env.CES_CREDENTIAL_URL) {
+    const ces = createCesCredentialBackend();
+    if (ces.isAvailable()) {
+      _resolvedBackend = ces;
+      return ces;
+    }
+    log.warn(
+      "CES_CREDENTIAL_URL is set but CES backend is not available — " +
+        "falling back to local credential store",
+    );
+  }
+
+  // 2. Mac production: wait for keychain broker, commit to it even if
+  //    the wait times out (operations will fail with unreachable errors).
+  if (
+    process.env.VELLUM_DESKTOP_APP === "1" &&
+    process.env.VELLUM_DEV !== "1"
+  ) {
+    const available = await waitForBrokerAvailability();
+    if (!available) {
+      log.warn(
+        "Keychain broker not available after waiting — credential operations will fail until the Vellum app is restarted",
+      );
+    }
+    _resolvedBackend = getKeychainBackend();
+    return _resolvedBackend;
+  }
+
+  // 3. Dev mode or non-desktop topology
+  _resolvedBackend = getEncryptedStoreBackend();
   return _resolvedBackend;
 }
 
@@ -108,7 +141,7 @@ function resolveBackend(): CredentialBackend {
  * store, only that store is queried.
  */
 export async function listSecureKeysAsync(): Promise<string[]> {
-  const backend = resolveBackend();
+  const backend = await resolveBackendAsync();
   const primaryKeys = await backend.list();
 
   // CES mode — the sidecar is the single source of truth, no local merge.
@@ -144,7 +177,7 @@ export async function listSecureKeysAsync(): Promise<string[]> {
 export async function getSecureKeyResultAsync(
   account: string,
 ): Promise<SecureKeyResult> {
-  const backend = resolveBackend();
+  const backend = await resolveBackendAsync();
   const result = await backend.get(account);
   if (result.value != null) {
     return { value: result.value, unreachable: false };
@@ -187,7 +220,7 @@ export async function setSecureKeyAsync(
   account: string,
   value: string,
 ): Promise<boolean> {
-  const backend = resolveBackend();
+  const backend = await resolveBackendAsync();
   const ok = await backend.set(account, value);
   if (!ok) {
     log.warn(
@@ -211,7 +244,7 @@ export async function setSecureKeyAsync(
 export async function deleteSecureKeyAsync(
   account: string,
 ): Promise<DeleteResult> {
-  const backend = resolveBackend();
+  const backend = await resolveBackendAsync();
 
   // In CES mode, the sidecar is the only store — no local cleanup needed.
   if (backend.name === "ces-http") {
@@ -295,4 +328,5 @@ export function _resetBackend(): void {
   _keychain = undefined;
   _encryptedStore = undefined;
   _resolvedBackend = undefined;
+  _resolvePromise = undefined;
 }


### PR DESCRIPTION
## Summary
- Converts resolveBackend from sync to async with caching promise to prevent redundant resolution
- Gates keychain backend on VELLUM_DESKTOP_APP=1, with 5-second broker wait for socket availability
- Non-desktop topologies always use encrypted store regardless of broker availability

Part of plan: single-credential-backend.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
