### PR TITLE
fix: use correct Update/Rollback terminology in CLIError catch cases

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -441,10 +441,10 @@ struct AssistantUpgradeSection: View {
                 errorMessage = guidanceForError(cliError)
                 showFeedbackOption = true
             case .executionFailed(let stderr):
-                errorMessage = "Update failed: \(stderr)"
+                errorMessage = "\(isRollback ? "Rollback" : "Update") failed: \(stderr)"
                 showFeedbackOption = true
             default:
-                errorMessage = "Update failed: \(error.localizedDescription)"
+                errorMessage = "\(isRollback ? "Rollback" : "Update") failed: \(error.localizedDescription)"
             }
         } catch {
             errorMessage = "\(isRollback ? "Rollback" : "Update") failed: \(error.localizedDescription)"


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for svc-grp-update-bugs-and-ux.md.

**Gap:** performDockerUpgrade error messages hard-code Update even during rollback
**What was expected:** Error messages should say Rollback when isRollback is true
**What was found:** CLIError catch cases always said Update failed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
