### PR TITLE
Remove dual-store read fallback, list merge, and dual-delete from secure-keys

### DIFF
--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -181,7 +181,7 @@ describe("secure-keys", () => {
   });
 
   // -----------------------------------------------------------------------
-  // Reads: primary backend first, legacy fallback to encrypted store
+  // Reads: primary backend only, no fallback
   // -----------------------------------------------------------------------
   describe("reads with broker available", () => {
     test("getSecureKeyAsync reads from broker (primary backend)", async () => {
@@ -195,7 +195,7 @@ describe("secure-keys", () => {
       expect(mockBrokerGetCalled).toBe(true);
     });
 
-    test("getSecureKeyAsync falls back to encrypted store for legacy keys", async () => {
+    test("getSecureKeyAsync does not fall back to encrypted store", async () => {
       process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       _resetBackend();
@@ -204,8 +204,8 @@ describe("secure-keys", () => {
       encryptedStore.setKey("legacy-key", "legacy-value");
 
       const result = await getSecureKeyAsync("legacy-key");
-      expect(result).toBe("legacy-value");
-      // Broker was checked first (returned nothing), then encrypted store
+      expect(result).toBeUndefined();
+      // Broker was checked (returned nothing), no fallback to encrypted store
       expect(mockBrokerGetCalled).toBe(true);
     });
 
@@ -325,10 +325,10 @@ describe("secure-keys", () => {
   });
 
   // -----------------------------------------------------------------------
-  // Delete always attempts both stores
+  // Delete — single backend only
   // -----------------------------------------------------------------------
-  describe("delete attempts both stores", () => {
-    test("deleteSecureKeyAsync removes from both stores when broker available", async () => {
+  describe("delete from single backend", () => {
+    test("deleteSecureKeyAsync removes from broker store only when broker available", async () => {
       process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       _resetBackend();
@@ -339,7 +339,6 @@ describe("secure-keys", () => {
       const result = await deleteSecureKeyAsync("api-key");
       expect(result).toBe("deleted");
       expect(mockBrokerStore.has("api-key")).toBe(false);
-      expect(encryptedStore.getKey("api-key")).toBeUndefined();
     });
 
     test("deleteSecureKeyAsync returns deleted when only encrypted store has key", async () => {
@@ -358,13 +357,12 @@ describe("secure-keys", () => {
       _resetBackend();
 
       mockBrokerStore.set("api-key", "broker-value");
-      encryptedStore.setKey("api-key", "encrypted-value");
 
       const result = await deleteSecureKeyAsync("api-key");
       expect(result).toBe("error");
     });
 
-    test("deleteSecureKeyAsync in dev mode still attempts both stores", async () => {
+    test("deleteSecureKeyAsync in dev mode deletes from encrypted store only", async () => {
       process.env.VELLUM_DEV = "1";
       process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
@@ -375,7 +373,8 @@ describe("secure-keys", () => {
 
       const result = await deleteSecureKeyAsync("api-key");
       expect(result).toBe("deleted");
-      expect(mockBrokerStore.has("api-key")).toBe(false);
+      // Dev mode resolves to encrypted store — broker should NOT be touched
+      expect(mockBrokerStore.has("api-key")).toBe(true);
       expect(encryptedStore.getKey("api-key")).toBeUndefined();
     });
 
@@ -390,7 +389,7 @@ describe("secure-keys", () => {
   // Legacy read fallback
   // -----------------------------------------------------------------------
   describe("legacy read fallback", () => {
-    test("returns encrypted store value when broker has no key (legacy migration)", async () => {
+    test("does not fall back to encrypted store for legacy keys", async () => {
       process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       _resetBackend();
@@ -400,7 +399,7 @@ describe("secure-keys", () => {
       encryptedStore.setKey("legacy-account", "legacy-secret");
 
       const result = await getSecureKeyAsync("legacy-account");
-      expect(result).toBe("legacy-secret");
+      expect(result).toBeUndefined();
     });
 
     test("does not fall back to encrypted store when already using encrypted store backend", async () => {
@@ -440,10 +439,10 @@ describe("secure-keys", () => {
   });
 
   // -----------------------------------------------------------------------
-  // listSecureKeysAsync — merged/deduplicated key listing
+  // listSecureKeysAsync — single-backend key listing
   // -----------------------------------------------------------------------
   describe("listSecureKeysAsync", () => {
-    test("returns merged, deduplicated keys when broker is primary and encrypted store has legacy keys", async () => {
+    test("returns only broker keys when broker is primary (no encrypted store merge)", async () => {
       process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       _resetBackend();
@@ -452,16 +451,16 @@ describe("secure-keys", () => {
       mockBrokerStore.set("broker-key-1", "val1");
       mockBrokerStore.set("shared-key", "broker-val");
 
-      // Encrypted store has legacy keys (some overlapping)
+      // Encrypted store has legacy keys — should NOT be included
       encryptedStore.setKey("legacy-key-1", "val2");
       encryptedStore.setKey("shared-key", "enc-val");
 
       const keys = await listSecureKeysAsync();
       expect(keys).toContain("broker-key-1");
-      expect(keys).toContain("legacy-key-1");
       expect(keys).toContain("shared-key");
-      // Should be exactly 3 unique keys (no duplicates)
-      expect(keys.length).toBe(3);
+      expect(keys).not.toContain("legacy-key-1");
+      // Should be exactly 2 keys (broker only)
+      expect(keys.length).toBe(2);
     });
 
     test("returns only encrypted store keys when broker is unavailable", async () => {
@@ -509,22 +508,6 @@ describe("secure-keys", () => {
       expect(keys.length).toBe(2);
     });
 
-    test("deduplicates keys that exist in both stores", async () => {
-      process.env.VELLUM_DESKTOP_APP = "1";
-      mockBrokerAvailable = true;
-      _resetBackend();
-
-      // Same key in both stores
-      mockBrokerStore.set("api-key", "broker-val");
-      encryptedStore.setKey("api-key", "enc-val");
-
-      const keys = await listSecureKeysAsync();
-      expect(keys).toContain("api-key");
-      // Only one copy, not two
-      expect(keys.length).toBe(1);
-      expect(keys.filter((k) => k === "api-key").length).toBe(1);
-    });
-
     test("returns empty array when both stores are empty", async () => {
       process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
@@ -561,7 +544,7 @@ describe("secure-keys", () => {
       expect(result.unreachable).toBe(false);
     });
 
-    test("falls back to encrypted store when broker is unreachable", async () => {
+    test("returns unreachable when broker errors, does not fall back", async () => {
       process.env.VELLUM_DESKTOP_APP = "1";
       mockBrokerAvailable = true;
       mockBrokerGetError = true;
@@ -569,8 +552,8 @@ describe("secure-keys", () => {
 
       encryptedStore.setKey("legacy-key", "legacy-value");
       const result = await getSecureKeyResultAsync("legacy-key");
-      expect(result.value).toBe("legacy-value");
-      expect(result.unreachable).toBe(false);
+      expect(result.value).toBeUndefined();
+      expect(result.unreachable).toBe(true);
     });
 
     test("propagates unreachable when broker errors and encrypted store also missing", async () => {

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -1,5 +1,5 @@
 /**
- * Unified secure key storage — single-writer routing through CredentialBackend
+ * Unified secure key storage — single-backend routing through CredentialBackend
  * adapters.
  *
  * Backend selection (`resolveBackendAsync`) is the single async decision point:
@@ -10,9 +10,8 @@
  *     rather than silently writing to a different store.
  *   - Dev mode or non-desktop topology: encrypted file store always.
  *
- * Writes go to exactly one backend (no dual-writing). Reads in keychain mode
- * fall back to the encrypted store for keys that haven't been migrated yet.
- * Deletes clean up both stores regardless of mode.
+ * All operations (reads, writes, lists, deletes) go to exactly one backend.
+ * There are no cross-backend fallbacks or merges.
  */
 
 import type {
@@ -131,35 +130,17 @@ async function doResolveBackend(): Promise<CredentialBackend> {
 }
 
 /**
- * List all account names across both backends (async).
+ * List all account names from the resolved backend (async).
  *
- * In CES mode, only the CES backend is queried — there are no local stores.
- *
- * When the primary backend is the keychain, this merges keys from the keychain
- * and the encrypted store (for legacy keys that haven't been migrated). The
- * result is deduplicated. When the primary backend is already the encrypted
- * store, only that store is queried.
+ * Queries exactly one backend — no cross-store merge.
  */
 export async function listSecureKeysAsync(): Promise<string[]> {
   const backend = await resolveBackendAsync();
-  const primaryKeys = await backend.list();
-
-  // CES mode — the sidecar is the single source of truth, no local merge.
-  if (backend.name === "ces-http") return primaryKeys;
-
-  // If primary backend is NOT the encrypted store, also check
-  // the encrypted store for legacy keys that haven't been migrated.
-  if (backend !== getEncryptedStoreBackend()) {
-    const encKeys = await getEncryptedStoreBackend().list();
-    const merged = new Set([...primaryKeys, ...encKeys]);
-    return Array.from(merged);
-  }
-
-  return primaryKeys;
+  return backend.list();
 }
 
 // ---------------------------------------------------------------------------
-// Async CRUD — single-writer routing
+// Async CRUD — single-backend routing
 // ---------------------------------------------------------------------------
 
 /**
@@ -169,10 +150,7 @@ export async function listSecureKeysAsync(): Promise<string[]> {
  * unreachable. Callers that need to distinguish "not found" from
  * "backend down" should use this instead of `getSecureKeyAsync`.
  *
- * Reads from the primary backend first. In CES mode, the sidecar is
- * the single source of truth — no local fallback. In local mode, if
- * the primary backend is the keychain, falls back to the encrypted
- * store for legacy keys that haven't been migrated.
+ * Reads from exactly one backend — no cross-store fallback.
  */
 export async function getSecureKeyResultAsync(
   account: string,
@@ -182,23 +160,7 @@ export async function getSecureKeyResultAsync(
   if (result.value != null) {
     return { value: result.value, unreachable: false };
   }
-
-  // CES mode — the sidecar is the single source of truth, no local fallback.
-  if (backend.name === "ces-http") {
-    return { value: undefined, unreachable: result.unreachable };
-  }
-
-  // Legacy fallback: if primary backend is NOT the encrypted store,
-  // check the encrypted store for keys that haven't been migrated.
-  if (backend !== getEncryptedStoreBackend()) {
-    const fallback = await getEncryptedStoreBackend().get(account);
-    if (fallback.value != null) {
-      return { value: fallback.value, unreachable: false };
-    }
-    return { value: undefined, unreachable: result.unreachable };
-  }
-
-  return { value: undefined, unreachable: false };
+  return { value: undefined, unreachable: result.unreachable };
 }
 
 /**
@@ -234,38 +196,13 @@ export async function setSecureKeyAsync(
 /**
  * Delete a secret from secure storage.
  *
- * In containerized mode with CES, deletion is routed exclusively through the
- * CES backend — there are no local stores to clean up.
- *
- * In local mode, always attempts deletion on both the keychain backend (if
- * available) and the encrypted store backend, regardless of routing mode.
- * This cleans up legacy data from both stores.
+ * Deletes from exactly one backend — no cross-store cleanup.
  */
 export async function deleteSecureKeyAsync(
   account: string,
 ): Promise<DeleteResult> {
   const backend = await resolveBackendAsync();
-
-  // In CES mode, the sidecar is the only store — no local cleanup needed.
-  if (backend.name === "ces-http") {
-    return backend.delete(account);
-  }
-
-  const keychain = getKeychainBackend();
-  const enc = getEncryptedStoreBackend();
-
-  let keychainResult: DeleteResult = "not-found";
-  if (keychain.isAvailable()) {
-    keychainResult = await keychain.delete(account);
-  }
-
-  const encResult = await enc.delete(account);
-
-  // Return "error" if either errored
-  if (keychainResult === "error" || encResult === "error") return "error";
-  // Return "deleted" if either deleted
-  if (keychainResult === "deleted" || encResult === "deleted") return "deleted";
-  return "not-found";
+  return backend.delete(account);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Simplifies getSecureKeyResultAsync to read from exactly one backend with no encrypted store fallback
- Simplifies listSecureKeysAsync to query exactly one backend with no merge
- Simplifies deleteSecureKeyAsync to delete from exactly one backend with no dual-delete
- Updates all affected tests to reflect single-backend behavior

Part of plan: single-credential-backend.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
