### PR TITLE
Improve File, Edit, and View menus to follow macOS conventions

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -82,7 +82,7 @@ struct VellumAssistantApp: App {
             // the menu system would consume the event even when the nav stack
             // is empty, breaking the event monitor's intentional pass-through
             // to the responder chain (e.g. text editors).
-            CommandGroup(replacing: .toolbar) {
+            CommandGroup(before: .toolbar) {
                 Button("Zoom In") {
                     appDelegate.performZoomIn()
                 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -111,14 +111,15 @@ extension AppDelegate {
         newChatItem.target = self
         fileMenu.addItem(newChatItem)
 
-        let markAllSeenItem = NSMenuItem(
-            title: "Mark All Conversations as Seen",
-            action: #selector(markAllConversationsSeen),
-            keyEquivalent: "k"
-        )
-        markAllSeenItem.keyEquivalentModifierMask = [.command, .shift]
-        markAllSeenItem.target = self
-        fileMenu.addItem(markAllSeenItem)
+        let currentConversationItem = NSMenuItem(title: "Current Conversation", action: #selector(openCurrentConversation), keyEquivalent: "")
+        currentConversationItem.target = self
+        fileMenu.addItem(currentConversationItem)
+
+        fileMenu.addItem(NSMenuItem.separator())
+
+        let closeItem = NSMenuItem(title: "Close Window", action: #selector(NSWindow.performClose(_:)), keyEquivalent: "w")
+        closeItem.keyEquivalentModifierMask = .command
+        fileMenu.addItem(closeItem)
 
         let fileMenuItem = NSMenuItem(title: "File", action: nil, keyEquivalent: "")
         fileMenuItem.submenu = fileMenu
@@ -127,6 +128,13 @@ extension AppDelegate {
         // Edit menu — provides Cmd+F "Find" so the shortcut works regardless of focus state.
         if mainMenu.indexOfItem(withTitle: "Edit") < 0 {
             let editMenu = NSMenu(title: "Edit")
+
+            // Standard undo/redo actions
+            editMenu.addItem(NSMenuItem(title: "Undo", action: Selector(("undo:")), keyEquivalent: "z"))
+            let redoItem = NSMenuItem(title: "Redo", action: Selector(("redo:")), keyEquivalent: "z")
+            redoItem.keyEquivalentModifierMask = [.command, .shift]
+            editMenu.addItem(redoItem)
+            editMenu.addItem(NSMenuItem.separator())
 
             // Standard edit actions so Cmd+C/V/X/A work in text fields
             editMenu.addItem(NSMenuItem(title: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x"))


### PR DESCRIPTION
## Summary
- **File menu**: Added "Current Conversation" and "Close Window" (⌘W), removed "Mark All Conversations as Seen" (still accessible from dock menu and sidebar)
- **Edit menu**: Added Undo (⌘Z) and Redo (⌘⇧Z) at the top for standard macOS discoverability
- **View menu**: Changed from `replacing: .toolbar` to `before: .toolbar` to preserve system-provided items like "Enter Full Screen"

## Original prompt
Implement macOS menu bar improvements across File, Edit, and View menus following platform best practices.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
