### PR TITLE
fix: address integration review feedback from svc-grp-update plan

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -479,11 +479,13 @@ struct MainWindowView: View {
                         ? "Restart to update"
                         : (connectionManager.versionMismatch ? "Compatibility update" : "Update"),
                     leftIcon: VIcon.arrowUp.rawValue,
-                    style: connectionManager.versionMismatch ? .outlined : .primary,
+                    style: updateManager.isDeferredUpdateReady ? .primary : (connectionManager.versionMismatch ? .outlined : .primary),
                     size: .pill,
-                    tooltip: connectionManager.versionMismatch
-                        ? "Your assistant version doesn't match this app"
-                        : (updateManager.isDeferredUpdateReady ? "Restart to install the latest version" : "A new version is available")
+                    tooltip: updateManager.isDeferredUpdateReady
+                        ? "Restart to install the latest version"
+                        : (connectionManager.versionMismatch
+                            ? "Your assistant version doesn't match this app"
+                            : "A new version is available")
                 ) {
                     if updateManager.isDeferredUpdateReady {
                         NSApp.terminate(nil)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -1,3 +1,4 @@
+import Combine
 import SwiftUI
 import VellumAssistantShared
 
@@ -19,8 +20,18 @@ struct SettingsGeneralTab: View {
     @State private var dockerOperationLabel: String = ""
     @State private var sparkleUpdateAvailable: Bool = false
     @State private var sparkleUpdateVersion: String?
+    @State private var isServiceGroupUpdateInProgress = false
     @State private var lockfileAssistants: [LockfileAssistant] = []
     @State private var selectedAssistantId: String = ""
+
+    /// Publisher for reactive observation of connectionManager's isUpdateInProgress.
+    /// Falls back to a single `false` emission when connectionManager is nil.
+    private var updateInProgressPublisher: AnyPublisher<Bool, Never> {
+        if let cm = connectionManager {
+            return cm.$isUpdateInProgress.eraseToAnyPublisher()
+        }
+        return Just(false).eraseToAnyPublisher()
+    }
 
     /// Derive the topology for the currently selected assistant.
     private var topology: AssistantTopology {
@@ -44,7 +55,7 @@ struct SettingsGeneralTab: View {
                     dockerOperationLabel: $dockerOperationLabel,
                     sparkleUpdateAvailable: sparkleUpdateAvailable,
                     sparkleUpdateVersion: sparkleUpdateVersion,
-                    isServiceGroupUpdateInProgress: connectionManager?.isUpdateInProgress ?? false
+                    isServiceGroupUpdateInProgress: isServiceGroupUpdateInProgress
                 )
             }
             if MacOSClientFeatureFlagManager.shared.isEnabled("mobile_pairing_enabled") {
@@ -61,6 +72,9 @@ struct SettingsGeneralTab: View {
             sparkleUpdateAvailable = AppDelegate.shared?.updateManager.isUpdateAvailable ?? false
             sparkleUpdateVersion = AppDelegate.shared?.updateManager.availableUpdateVersion
             Task { await fetchHealthz() }
+        }
+        .onReceive(updateInProgressPublisher) { inProgress in
+            isServiceGroupUpdateInProgress = inProgress
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             sparkleUpdateAvailable = AppDelegate.shared?.updateManager.isUpdateAvailable ?? false

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -334,7 +334,8 @@ public final class GatewayConnectionManager: ObservableObject {
                 lastUpdateOutcome = UpdateOutcome(result: .rolledBack(from: updateTargetVersion ?? "unknown", to: newVersion), timestamp: Date())
             }
             isUpdateInProgress = false
-            updateTargetVersion = nil
+            // Preserve updateTargetVersion — only the authoritative
+            // .serviceGroupUpdateComplete SSE event or timeout clears it.
             updateExpiresAt = nil
             eventStreamClient.resetSSEReconnectDelay()
         }
@@ -371,7 +372,8 @@ public final class GatewayConnectionManager: ObservableObject {
                         self.lastUpdateOutcome = UpdateOutcome(result: .rolledBack(from: self.updateTargetVersion ?? "unknown", to: version), timestamp: Date())
                     }
                     self.isUpdateInProgress = false
-                    self.updateTargetVersion = nil
+                    // Preserve updateTargetVersion — only the authoritative
+                    // .serviceGroupUpdateComplete SSE event or timeout clears it.
                     self.updateExpiresAt = nil
                     self.eventStreamClient.resetSSEReconnectDelay()
                 }

--- a/clients/shared/Utilities/VersionCompat.swift
+++ b/clients/shared/Utilities/VersionCompat.swift
@@ -18,7 +18,9 @@ public enum VersionCompat {
         let withoutBuild = withoutPreRelease.split(separator: "+", maxSplits: 1).first.map(String.init) ?? withoutPreRelease
         let segments = withoutBuild.split(separator: ".").map(String.init)
         let components = segments.compactMap { Int($0) }
-        guard components.count >= 2, components.count <= 3 else { return nil }
+        // Fail-fast if any segment was non-numeric (compactMap silently drops them)
+        guard components.count == segments.count,
+              components.count >= 2, components.count <= 3 else { return nil }
         return ParsedVersion(
             major: components[0],
             minor: components[1],


### PR DESCRIPTION
## Summary
- **VersionCompat.parse**: add guard that `components.count == segments.count` so `compactMap` doesn't silently drop non-numeric segments (e.g. malformed versions like `1.foo.3`)
- **SettingsGeneralTab**: make `isServiceGroupUpdateInProgress` reactive via `@State` + `.onReceive` publisher instead of passing a static snapshot — the "Assistant is updating..." indicator now updates in real time
- **GatewayConnectionManager**: fix race condition where health check / `.assistantStatus` paths cleared `updateTargetVersion` before the authoritative `.serviceGroupUpdateComplete` SSE event could read it — only `.serviceGroupUpdateComplete` and timeout now clear `updateTargetVersion`
- **MainWindowView**: fix Update pill button `style` and `tooltip` to prioritize `isDeferredUpdateReady` over `versionMismatch`, matching the existing label priority

## Original prompt
these fixes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
