### PR TITLE
fix: forward VELLUM_DESKTOP_APP to daemon env whitelist

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -933,6 +933,7 @@ export async function startLocalDaemon(
         "USER",
         "LANG",
         "VELLUM_DEBUG",
+        "VELLUM_DESKTOP_APP",
       ]) {
         if (process.env[key]) {
           daemonEnv[key] = process.env[key]!;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for single-credential-backend.md.

**Gap:** VELLUM_DESKTOP_APP not forwarded in daemon env whitelist
**What was expected:** Daemon process should see VELLUM_DESKTOP_APP=1 when set by macOS app
**What was found:** The env whitelist in cli/src/lib/local.ts did not include VELLUM_DESKTOP_APP
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
