### PR TITLE
fix: run workspace migrations before backfilling manual token connections

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -159,9 +159,19 @@ export async function runDaemon(): Promise<void> {
     initializeDb();
     // Seed well-known OAuth provider configurations (insert-if-not-exists)
     seedOAuthProviders();
+    log.info("Daemon startup: DB initialized");
+
+    await runWorkspaceMigrations(getWorkspaceDir(), WORKSPACE_MIGRATIONS);
+    log.info("Daemon startup: workspace migrations complete");
+
     // Backfill oauth_connection rows for manual-token providers (Telegram,
     // Slack channel) that already have keychain credentials from before the
     // oauth_connection migration. Safe to call on every startup.
+    //
+    // Must run AFTER workspace migrations so that migration 014 (which copies
+    // encrypted-store credentials to the keychain) has already executed.
+    // Otherwise syncManualTokenConnection sees no keychain credentials and
+    // incorrectly removes existing connection rows.
     try {
       await backfillManualTokenConnections();
     } catch (err) {
@@ -170,10 +180,6 @@ export async function runDaemon(): Promise<void> {
         "Manual-token connection backfill failed — continuing startup",
       );
     }
-    log.info("Daemon startup: DB initialized");
-
-    await runWorkspaceMigrations(getWorkspaceDir(), WORKSPACE_MIGRATIONS);
-    log.info("Daemon startup: workspace migrations complete");
 
     // Now that workspace migrations have run (including 003-seed-device-id
     // which may copy the legacy installationId into device.json), it is safe


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for single-credential-backend.md.

**Gap:** Startup ordering — backfillManualTokenConnections reads credentials before migration 014 copies them to keychain
**What was expected:** Workspace migrations should run before credential reads
**What was found:** backfillManualTokenConnections() ran before runWorkspaceMigrations() in lifecycle.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
