### PR TITLE
fix: renumber migration from 014 to 015 to avoid prefix collision

### DIFF
--- a/assistant/src/__tests__/workspace-migration-015-migrate-credentials-to-keychain.test.ts
+++ b/assistant/src/__tests__/workspace-migration-015-migrate-credentials-to-keychain.test.ts
@@ -50,7 +50,7 @@ mock.module("../security/encrypted-store.js", () => ({
 }));
 
 // Import after mocking
-import { migrateCredentialsToKeychainMigration } from "../workspace/migrations/014-migrate-credentials-to-keychain.js";
+import { migrateCredentialsToKeychainMigration } from "../workspace/migrations/015-migrate-credentials-to-keychain.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -62,7 +62,7 @@ const WORKSPACE_DIR = "/mock-home/.vellum/workspace";
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("014-migrate-credentials-to-keychain migration", () => {
+describe("015-migrate-credentials-to-keychain migration", () => {
   beforeEach(() => {
     isAvailableFn.mockClear();
     brokerSetFn.mockClear();
@@ -84,7 +84,7 @@ describe("014-migrate-credentials-to-keychain migration", () => {
 
   test("has correct migration id", () => {
     expect(migrateCredentialsToKeychainMigration.id).toBe(
-      "014-migrate-credentials-to-keychain",
+      "015-migrate-credentials-to-keychain",
     );
   });
 

--- a/assistant/src/workspace/migrations/015-migrate-credentials-to-keychain.ts
+++ b/assistant/src/workspace/migrations/015-migrate-credentials-to-keychain.ts
@@ -4,7 +4,7 @@ import type { WorkspaceMigration } from "./types.js";
 const log = getLogger("workspace-migrations");
 
 export const migrateCredentialsToKeychainMigration: WorkspaceMigration = {
-  id: "014-migrate-credentials-to-keychain",
+  id: "015-migrate-credentials-to-keychain",
   description:
     "Copy encrypted store credentials to keychain for single-backend migration",
 

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -10,7 +10,7 @@ import { appDirRenameMigration } from "./010-app-dir-rename.js";
 import { backfillInstallationIdMigration } from "./011-backfill-installation-id.js";
 import { renameConversationDiskViewDirsMigration } from "./012-rename-conversation-disk-view-dirs.js";
 import { repairConversationDiskViewMigration } from "./013-repair-conversation-disk-view.js";
-import { migrateCredentialsToKeychainMigration } from "./014-migrate-credentials-to-keychain.js";
+import { migrateCredentialsToKeychainMigration } from "./015-migrate-credentials-to-keychain.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for single-credential-backend.md.

**Gap:** Duplicate 014 migration ID prefix
**What was expected:** Unique sequential prefix (015)
**What was found:** Both migrate-credentials-to-keychain and migrate-to-workspace-volume used 014 prefix
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
