### PR TITLE
fix: add broker availability wait loop to migration and throw on timeout

### DIFF
--- a/assistant/src/__tests__/workspace-migration-014-migrate-credentials-to-keychain.test.ts
+++ b/assistant/src/__tests__/workspace-migration-014-migrate-credentials-to-keychain.test.ts
@@ -114,14 +114,42 @@ describe("014-migrate-credentials-to-keychain migration", () => {
     expect(listKeysFn).not.toHaveBeenCalled();
   });
 
-  test("skips when broker is not available", async () => {
+  test("throws when broker is not available after max retry attempts", async () => {
     isAvailableFn.mockReturnValue(false);
 
-    await migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR);
+    await expect(
+      migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR),
+    ).rejects.toThrow(
+      "Keychain broker not available after waiting — credential migration will be retried on next startup",
+    );
+
+    // Should have retried isAvailable multiple times
+    expect(isAvailableFn.mock.calls.length).toBeGreaterThan(1);
 
     // Should not proceed to list or migrate keys
     expect(listKeysFn).not.toHaveBeenCalled();
     expect(brokerSetFn).not.toHaveBeenCalled();
+  });
+
+  test("succeeds when broker becomes available after retry", async () => {
+    // Broker unavailable for first 3 calls, then available
+    let callCount = 0;
+    isAvailableFn.mockImplementation(() => {
+      callCount++;
+      return callCount > 3;
+    });
+    listKeysFn.mockReturnValue(["retry-key"]);
+    getKeyFn.mockReturnValue("retry-secret");
+    brokerSetFn.mockResolvedValue({ status: "ok" });
+
+    await migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR);
+
+    // Should have called isAvailable 4 times (3 false + 1 true)
+    expect(isAvailableFn).toHaveBeenCalledTimes(4);
+
+    // Should have proceeded with migration
+    expect(brokerSetFn).toHaveBeenCalledWith("retry-key", "retry-secret");
+    expect(deleteKeyFn).toHaveBeenCalledWith("retry-key");
   });
 
   test("no-ops when encrypted store has no keys", async () => {

--- a/assistant/src/workspace/migrations/014-migrate-credentials-to-keychain.ts
+++ b/assistant/src/workspace/migrations/014-migrate-credentials-to-keychain.ts
@@ -3,6 +3,9 @@ import type { WorkspaceMigration } from "./types.js";
 
 const log = getLogger("workspace-migrations");
 
+const BROKER_WAIT_INTERVAL_MS = 500;
+const BROKER_WAIT_MAX_ATTEMPTS = 10; // 5 seconds total
+
 export const migrateCredentialsToKeychainMigration: WorkspaceMigration = {
   id: "014-migrate-credentials-to-keychain",
   description:
@@ -21,11 +24,22 @@ export const migrateCredentialsToKeychainMigration: WorkspaceMigration = {
       await import("../../security/keychain-broker-client.js");
     const client = createBrokerClient();
 
-    if (!client.isAvailable()) {
-      log.warn(
-        "Keychain broker not available — skipping credential migration to keychain",
+    // Wait for the broker to become available (up to 5 seconds), matching
+    // the retry strategy in secure-keys.ts waitForBrokerAvailability().
+    let brokerAvailable = false;
+    for (let i = 0; i < BROKER_WAIT_MAX_ATTEMPTS; i++) {
+      if (client.isAvailable()) {
+        brokerAvailable = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, BROKER_WAIT_INTERVAL_MS));
+    }
+
+    if (!brokerAvailable) {
+      throw new Error(
+        "Keychain broker not available after waiting — credential migration " +
+          "will be retried on next startup",
       );
-      return;
     }
 
     const { listKeys, getKey, deleteKey } =


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for single-credential-backend.md.

**Gap:** Migration silently marks itself complete when broker is unavailable
**What was expected:** Migration should wait for broker and throw on timeout to allow retry
**What was found:** Single isAvailable() check with no retry, silently returning on failure
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
