### PR TITLE
fix: update stale migration number in lifecycle.ts comment (014 → 015)

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -168,7 +168,7 @@ export async function runDaemon(): Promise<void> {
     // Slack channel) that already have keychain credentials from before the
     // oauth_connection migration. Safe to call on every startup.
     //
-    // Must run AFTER workspace migrations so that migration 014 (which copies
+    // Must run AFTER workspace migrations so that migration 015 (which copies
     // encrypted-store credentials to the keychain) has already executed.
     // Otherwise syncManualTokenConnection sees no keychain credentials and
     // incorrectly removes existing connection rows.


### PR DESCRIPTION
## Summary
Updates comment referencing migration 014 to 015 after the renumber in PR #20468.

**Gap:** Stale migration number in lifecycle.ts comment
**Fix:** 014 → 015 in the ordering comment
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
