### PR TITLE
fix: increase test timeout for migration broker wait loop test

### DIFF
--- a/assistant/src/__tests__/workspace-migration-015-migrate-credentials-to-keychain.test.ts
+++ b/assistant/src/__tests__/workspace-migration-015-migrate-credentials-to-keychain.test.ts
@@ -114,22 +114,26 @@ describe("015-migrate-credentials-to-keychain migration", () => {
     expect(listKeysFn).not.toHaveBeenCalled();
   });
 
-  test("throws when broker is not available after max retry attempts", async () => {
-    isAvailableFn.mockReturnValue(false);
+  test(
+    "throws when broker is not available after max retry attempts",
+    async () => {
+      isAvailableFn.mockReturnValue(false);
 
-    await expect(
-      migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR),
-    ).rejects.toThrow(
-      "Keychain broker not available after waiting — credential migration will be retried on next startup",
-    );
+      await expect(
+        migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR),
+      ).rejects.toThrow(
+        "Keychain broker not available after waiting — credential migration will be retried on next startup",
+      );
 
-    // Should have retried isAvailable multiple times
-    expect(isAvailableFn.mock.calls.length).toBeGreaterThan(1);
+      // Should have retried isAvailable multiple times
+      expect(isAvailableFn.mock.calls.length).toBeGreaterThan(1);
 
-    // Should not proceed to list or migrate keys
-    expect(listKeysFn).not.toHaveBeenCalled();
-    expect(brokerSetFn).not.toHaveBeenCalled();
-  });
+      // Should not proceed to list or migrate keys
+      expect(listKeysFn).not.toHaveBeenCalled();
+      expect(brokerSetFn).not.toHaveBeenCalled();
+    },
+    { timeout: 10_000 },
+  );
 
   test("succeeds when broker becomes available after retry", async () => {
     // Broker unavailable for first 3 calls, then available


### PR DESCRIPTION
## Summary
Fixes migration test that races with the default 5s bun timeout due to the 5s broker wait loop.

**Gap:** Migration timeout test reliably fails
**Fix:** Add { timeout: 10_000 } to the broker-unavailable test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
