### PR TITLE
docs: update keychain-broker architecture doc for single-backend changes

### DIFF
--- a/assistant/docs/architecture/keychain-broker.md
+++ b/assistant/docs/architecture/keychain-broker.md
@@ -1,14 +1,14 @@
 # macOS Keychain Broker Architecture
 
 **Status:** Accepted
-**Last Updated:** 2026-03-14
+**Last Updated:** 2026-03-21
 **Owners:** macOS client + assistant runtime
 
 ## Decision
 
 Embed the keychain broker in the macOS app process rather than running a standalone daemon. The app exposes SecItem keychain operations over a Unix domain socket to the assistant runtime and gateway. Debug builds skip the broker entirely (`#if !DEBUG` guard) so developers never see keychain authorization prompts during rebuilds.
 
-Credential storage is abstracted behind a `CredentialBackend` interface with two implementations: a keychain backend (backed by the broker) and an encrypted file store backend. Each process resolves a single primary backend at startup and uses single-writer semantics -- all writes go to the resolved backend only, with no dual-writing.
+Credential storage is abstracted behind a `CredentialBackend` interface with two implementations: a keychain backend (backed by the broker) and an encrypted file store backend. Each process resolves a single primary backend at startup via `resolveBackendAsync()` and uses single-writer semantics -- all writes go to the resolved backend only, with no dual-writing.
 
 ## Problem Statement
 
@@ -28,10 +28,10 @@ All credential storage operations are routed through the `CredentialBackend` int
 
 Two implementations exist:
 
-| Backend          | Backing store                                | When used                                                               |
-| ---------------- | -------------------------------------------- | ----------------------------------------------------------------------- |
-| Keychain backend | macOS Keychain via the broker UDS connection | Production app context (`VELLUM_DEV` is NOT `"1"`) and broker available |
-| Encrypted store  | `~/.vellum/protected/keys.enc` (AES-256-GCM) | `VELLUM_DEV=1`, broker unavailable, CLI-only, headless, CI              |
+| Backend          | Backing store                                | When used                                                                                                        |
+| ---------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Keychain backend | macOS Keychain via the broker UDS connection | Desktop app context (`VELLUM_DESKTOP_APP=1`, non-dev mode) — committed even if broker is temporarily unavailable |
+| Encrypted store  | `~/.vellum/protected/keys.enc` (AES-256-GCM) | Dev mode (`VELLUM_DEV=1`), non-desktop topology, CLI-only, headless, CI                                          |
 
 The interface is intentionally minimal to make adding future backends trivial -- e.g., Linux secret service (libsecret/D-Bus), 1Password CLI, or cloud KMS. A new backend only needs to implement the `CredentialBackend` interface and be wired into the backend resolution logic.
 
@@ -47,11 +47,11 @@ graph LR
     end
 
     subgraph "Backend Resolution"
-        RESOLVE{"resolveBackend()"}
+        RESOLVE{"resolveBackendAsync()"}
         KB["Keychain Backend"]
         EB["Encrypted Store Backend"]
-        RESOLVE -->|"VELLUM_DEV!=1<br/>+ broker available"| KB
-        RESOLVE -->|"VELLUM_DEV=1<br/>OR broker unavailable"| EB
+        RESOLVE -->|"VELLUM_DESKTOP_APP=1<br/>+ non-dev mode"| KB
+        RESOLVE -->|"dev mode<br/>OR non-desktop"| EB
     end
 
     KB -->|"UDS JSON"| SERVER
@@ -67,8 +67,9 @@ graph LR
 - **No auth bootstrap problem.** The app writes the broker auth token to disk before launching the daemon, so the daemon always has a valid token at startup.
 - **No keychain prompts on signed builds.** Items are stored with `kSecAttrAccessibleAfterFirstUnlock` under the `vellum-assistant` service name. A stable code-signing identity means macOS grants access without prompting after the first unlock.
 - **No keychain interaction on debug builds.** The entire `KeychainBrokerServer` is compiled out with `#if !DEBUG`, so development builds use the encrypted file store exclusively.
-- **Single-writer to resolved backend.** Each process resolves exactly one primary backend at startup. Writes go only to that backend. There is no dual-writing.
-- **Encrypted file store as permanent fallback.** CLI-only, headless, and development environments always have the encrypted store (`~/.vellum/protected/keys.enc`) available.
+- **Single-writer to resolved backend.** Each process resolves exactly one primary backend at startup via `resolveBackendAsync()`. Writes go only to that backend. There is no dual-writing.
+- **Commit to keychain even if broker unavailable.** In desktop app context, `resolveBackendAsync()` waits up to 5 seconds for the broker socket and then commits to the keychain backend regardless. Operations fail visibly rather than silently falling back to a different store, ensuring the user is prompted to restart the app.
+- **Encrypted file store for non-desktop contexts.** CLI-only, headless, and development environments always use the encrypted store (`~/.vellum/protected/keys.enc`).
 
 ## Components
 
@@ -85,7 +86,7 @@ graph LR
 | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `assistant/src/security/credential-backend.ts`     | `CredentialBackend` interface definition (`get`, `set`, `delete`, `list`) plus both adapter implementations: `KeychainBackend` (backed by the broker UDS client) and `EncryptedStoreBackend` (backed by `encrypted-store.ts` / `~/.vellum/protected/keys.enc`). Also exports factory functions `createKeychainBackend()` and `createEncryptedStoreBackend()`. |
 | `assistant/src/security/keychain-broker-client.ts` | Async UDS client for the runtime. Persistent socket connection, request/response correlation, auth token caching with auto-refresh on `UNAUTHORIZED`. Falls back gracefully (returns safe defaults, never throws).                                                                                                                                            |
-| `assistant/src/security/secure-keys.ts`            | Unified API surface. Resolves a single primary `CredentialBackend` at startup based on environment and broker availability. All writes go to the resolved backend only (single-writer). Reads check the primary backend first, with legacy fallback to the encrypted store for migration. Deletes clean up both stores to prevent stale keys.                 |
+| `assistant/src/security/secure-keys.ts`            | Unified API surface. Resolves a single primary `CredentialBackend` at startup via `resolveBackendAsync()` based on `VELLUM_DESKTOP_APP` and `VELLUM_DEV` environment variables. All operations (reads, writes, deletes) go to the resolved backend only — no cross-store fallbacks.                                                                           |
 | `gateway/src/credential-reader.ts`                 | Read-only credential reader. Tries broker via native async UDS connection (`node:net`), falls back to encrypted store. All public credential read functions are async.                                                                                                                                                                                        |
 
 ## Message Contract
@@ -192,18 +193,20 @@ XPC provides stronger caller identity guarantees via audit tokens and code requi
 
 ### Backend resolution
 
-At process startup, `secure-keys.ts` resolves a single primary `CredentialBackend` for the lifetime of the process:
+At process startup, `resolveBackendAsync()` in `secure-keys.ts` resolves a single primary `CredentialBackend` for the lifetime of the process:
 
-| Condition                                             | Resolved backend |
-| ----------------------------------------------------- | ---------------- |
-| `VELLUM_DEV` is NOT `"1"` **and** broker is available | Keychain backend |
-| `VELLUM_DEV=1` **or** broker is unavailable           | Encrypted store  |
+| Condition                                                             | Resolved backend |
+| --------------------------------------------------------------------- | ---------------- |
+| `VELLUM_DESKTOP_APP=1` **and** `VELLUM_DEV` is NOT `"1"`              | Keychain backend |
+| `VELLUM_DEV=1` **or** `VELLUM_DESKTOP_APP` is not `"1"` (non-desktop) | Encrypted store  |
+
+When the keychain backend is selected, `resolveBackendAsync()` waits up to 5 seconds for the broker socket to become available. If the broker does not appear in time, the process still commits to the keychain backend -- operations will fail with unreachable errors rather than silently falling back to the encrypted store. This ensures failures are visible and prompt the user to restart the app.
 
 Once resolved, the backend does not change during the process lifetime. There is no runtime switching between backends.
 
 ### Read strategy
 
-Reads go to the **primary backend first**. If the primary backend is the keychain backend and the key is not found, a legacy fallback read is attempted against the encrypted store. This fallback handles the migration period where keys written before the single-writer policy may still exist only in the encrypted store. When the primary backend is the encrypted store, there is no fallback -- the encrypted store is the sole source of truth.
+Reads go to the **resolved backend only**. There is no cross-store fallback -- the resolved backend is the sole source of truth.
 
 ### Write strategy
 
@@ -214,22 +217,27 @@ Writes go **only to the resolved primary backend**. There is no dual-writing. Th
 
 ### Delete strategy
 
-Deletes **always clean up both stores** regardless of the resolved backend. This ensures that stale keys do not linger in the non-primary store, which could cause unexpected reads through the legacy fallback path.
+Deletes go to the **resolved backend only**. There is no cross-store cleanup.
 
-### `VELLUM_DEV` environment variable
+### Environment-based gating
 
-Setting `VELLUM_DEV=1` forces the encrypted store as the sole backend, bypassing the keychain broker entirely even when the broker socket is available. This serves two purposes:
+Backend resolution uses two environment variables:
+
+- **`VELLUM_DESKTOP_APP=1`** — set by the macOS app when it launches the daemon. Signals that the process is running inside a desktop app context where the keychain broker is expected to be available.
+- **`VELLUM_DEV=1`** — forces the encrypted store as the sole backend, bypassing the keychain broker entirely even when `VELLUM_DESKTOP_APP=1` is set.
+
+The keychain backend is selected only when **both** conditions are met: `VELLUM_DESKTOP_APP=1` and `VELLUM_DEV` is not `"1"`. In all other cases (dev mode, CLI-only, headless, CI, non-desktop), the encrypted store is used.
+
+`VELLUM_DEV=1` serves two purposes:
 
 1. **Development ergonomics.** Developers running the daemon outside the macOS app context (e.g., `bun run` directly) avoid broker connectivity issues and keychain prompt noise.
 2. **Deterministic testing.** Tests and CI environments get predictable encrypted-store-only behavior without depending on macOS Keychain infrastructure.
-
-When `VELLUM_DEV` is not set or is set to any value other than `"1"`, backend resolution proceeds normally (broker availability check).
 
 ## Callsite Policy
 
 ### Async-only policy
 
-**All credential access uses the async functions** (`getSecureKeyAsync`, `setSecureKeyAsync`, `deleteSecureKeyAsync`). These route through the resolved `CredentialBackend`, with legacy fallback reads to the encrypted store when the keychain backend is primary. The migration from sync to async is complete: the sync variants (`getSecureKey`, `setSecureKey`, `deleteSecureKey`) have been deleted and no longer exist in the codebase.
+**All credential access uses the async functions** (`getSecureKeyAsync`, `setSecureKeyAsync`, `deleteSecureKeyAsync`). These route through the single resolved `CredentialBackend` with no cross-store fallbacks. The migration from sync to async is complete: the sync variants (`getSecureKey`, `setSecureKey`, `deleteSecureKey`) have been deleted and no longer exist in the codebase.
 
 ### Runtime request handlers (secret-routes, etc.)
 
@@ -245,13 +253,11 @@ The sync secure-key functions (`getSecureKey`, `setSecureKey`, `deleteSecureKey`
 
 ## Migration
 
-Existing encrypted store keys remain accessible through the legacy read fallback. When the keychain backend is the resolved primary, reads that miss in the keychain fall back to the encrypted store, so keys written before the single-writer policy are still reachable without a one-time migration step.
+A workspace migration (`014-migrate-credentials-to-keychain`) runs on startup in desktop app context (`VELLUM_DESKTOP_APP=1`, non-dev). It copies existing keys from the encrypted store into the keychain via the broker and removes the encrypted store copies. The migration waits up to 5 seconds for the broker to become available and throws if the broker never appears, so it will be retried on the next startup.
 
-Over time, as keys are re-written through normal credential update flows, they will be written only to the resolved primary backend. The legacy fallback read path will eventually become a no-op as all keys migrate naturally to the keychain.
+After migration completes, all operations go through the single resolved backend with no cross-store fallbacks.
 
-Deletes always clean up both stores, so stale keys in the non-primary store are removed as part of normal credential lifecycle operations.
-
-The old `keychain.ts` module (which called `/usr/bin/security` CLI directly) has been deleted. The old keychain-to-encrypted migration code has been removed. All keychain access now flows exclusively through the broker.
+The old `keychain.ts` module (which called `/usr/bin/security` CLI directly) has been deleted. All keychain access now flows exclusively through the broker.
 
 ## Extensibility
 


### PR DESCRIPTION
## Summary
Updates architecture documentation to reflect the single-credential-backend changes.

**Gap:** Architecture doc references outdated function name and decision logic
**Fix:** Updated resolveBackend → resolveBackendAsync, updated Mermaid diagram with VELLUM_DESKTOP_APP gating, removed fallback references
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
