### PR TITLE
fix: remove 'Getting some ideas...' loading text from chat empty state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -154,16 +154,8 @@ struct ChatEmptyStateView: View {
             .padding(.horizontal, VSpacing.lg)
             .frame(maxWidth: VSpacing.chatBubbleMaxWidth)
             .padding(.top, VSpacing.xxl)
-            .opacity(visible ? 1 : 0)
-            .offset(y: visible ? 0 : 10)
-        } else if conversationStartersLoading {
-            Text("Getting some ideas\u{2026}")
-                .font(VFont.caption)
-                .foregroundColor(VColor.contentTertiary)
-                .frame(maxWidth: VSpacing.chatBubbleMaxWidth)
-                .padding(.top, VSpacing.xxl)
-                .opacity(visible ? 1 : 0)
-                .offset(y: visible ? 0 : 10)
+            .transition(.opacity.combined(with: .offset(y: 10)))
+            .animation(.easeOut(duration: 0.4), value: conversationStarters.isEmpty)
         }
     }
 


### PR DESCRIPTION
## Summary
- Removed the "Getting some ideas…" loading text shown while conversation starters are fetching
- Conversation starter pills now fade in with a smooth opacity + offset transition once they arrive
- Cleaner empty state experience with no intermediate loading indicator
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
