### PR TITLE
fix: use VersionCompat.parse for update success detection instead of string equality

### DIFF
--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -321,12 +321,26 @@ public final class GatewayConnectionManager: ObservableObject {
         }
     }
 
+    // MARK: - Version Comparison
+
+    /// Compare two version strings using parsed semver components so that
+    /// prefix differences (e.g. "v1.2.3" vs "1.2.3") are ignored.
+    private func versionsMatch(_ a: String, _ b: String) -> Bool {
+        guard let parsedA = VersionCompat.parse(a),
+              let parsedB = VersionCompat.parse(b) else {
+            return a == b
+        }
+        return parsedA.major == parsedB.major
+            && parsedA.minor == parsedB.minor
+            && parsedA.patch == parsedB.patch
+    }
+
     // MARK: - Version Change Handling
 
     private func handleDaemonVersionChanged(_ newVersion: String) {
         checkVersionCompatibility(assistantVersion: newVersion)
         if isUpdateInProgress {
-            if newVersion == updateTargetVersion {
+            if let target = updateTargetVersion, versionsMatch(newVersion, target) {
                 log.info("Health check confirmed update completed — now running \(newVersion, privacy: .public)")
                 lastUpdateOutcome = UpdateOutcome(result: .succeeded(version: newVersion), timestamp: Date())
             } else {
@@ -364,7 +378,7 @@ public final class GatewayConnectionManager: ObservableObject {
                 assistantVersion = version
                 checkVersionCompatibility(assistantVersion: version)
                 if self.isUpdateInProgress {
-                    if version == self.updateTargetVersion {
+                    if let target = self.updateTargetVersion, self.versionsMatch(version, target) {
                         log.info("Planned update completed — now running \(version, privacy: .public)")
                         self.lastUpdateOutcome = UpdateOutcome(result: .succeeded(version: version), timestamp: Date())
                     } else {


### PR DESCRIPTION
## Summary
- Add versionsMatch() helper using VersionCompat.parse to compare versions ignoring v-prefix
- Replace string equality checks in handleDaemonVersionChanged and assistantStatus handler
- Ensure .serviceGroupUpdateComplete always overwrites lastUpdateOutcome

Part of plan: spicy-discovering-moon.md (PR 1 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
