### PR TITLE
fix: use checkForUpdatesInBackground in checkForUpdatesAsync to avoid dialog

### DIFF
--- a/clients/macos/vellum-assistant/App/UpdateManager.swift
+++ b/clients/macos/vellum-assistant/App/UpdateManager.swift
@@ -81,7 +81,7 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
     /// `updaterDidNotFindUpdate` fires.  Falls back to the current
     /// `isUpdateAvailable` state after `timeout` seconds so callers never hang.
     func checkForUpdatesAsync(timeout: TimeInterval = 5.0) async -> Bool {
-        updaterController.checkForUpdates(nil)
+        updaterController.updater.checkForUpdatesInBackground()
 
         return await withTaskGroup(of: Bool.self) { group in
             // Race: delegate callback vs timeout


### PR DESCRIPTION
## Summary
- Replace checkForUpdates(nil) with checkForUpdatesInBackground() in checkForUpdatesAsync
- Background check fires delegate callbacks without showing interactive dialog
- Interactive checkForUpdates() method left unchanged for menu bar use

Part of plan: spicy-discovering-moon.md (PR 2 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
