### PR TITLE
fix: show informative message for remote topology in About window update check

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
@@ -5,6 +5,7 @@ import VellumAssistantShared
 private enum UpdateCheckResult {
     case upToDate
     case updateAvailable(version: String)
+    case notAvailable(String)
     case error
 }
 
@@ -179,6 +180,14 @@ struct AboutVellumView: View {
                         AppDelegate.shared?.showSettingsTab("General")
                     }
                 }
+            case .notAvailable(let message):
+                HStack(spacing: VSpacing.xs) {
+                    VIconView(.info, size: 12)
+                        .foregroundStyle(VColor.contentTertiary)
+                    Text(message)
+                        .font(VFont.caption)
+                        .foregroundStyle(VColor.contentTertiary)
+                }
             case .error:
                 Text("Could not check for updates.")
                     .font(VFont.caption)
@@ -271,8 +280,8 @@ struct AboutVellumView: View {
             }
 
         case .remote:
-            // Remote: no automatic update mechanism
-            break
+            updateCheckResult = .notAvailable("Automatic updates are not available for remote deployments.")
+            isCheckingForUpdates = false
         }
     }
 


### PR DESCRIPTION
## Summary
- Add .notAvailable(String) case to UpdateCheckResult enum
- Show informative message for remote topology instead of silent no-op
- Display info icon with tertiary-styled message text

Part of plan: spicy-discovering-moon.md (PR 4 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
