### PR TITLE
fix: clear Share Feedback button when upgrade succeeds

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -433,6 +433,7 @@ struct AssistantUpgradeSection: View {
         do {
             try await cli.upgrade(name: name, version: version)
             successMessage = isRollback ? "Rollback complete." : "Update complete."
+            showFeedbackOption = false
             await loadReleasesQuietly()
             if successMessage != nil { errorMessage = nil }
         } catch let error as VellumCli.CLIError {
@@ -460,6 +461,7 @@ struct AssistantUpgradeSection: View {
                 successMessage = isRollback
                     ? "Rollback initiated. The assistant may be briefly unavailable."
                     : "Update initiated. The assistant may be briefly unavailable."
+                showFeedbackOption = false
                 // Refresh releases to update UI without clearing success message
                 await loadReleasesQuietly()
                 // Clear any error from the releases fetch so it doesn't appear alongside the success


### PR DESCRIPTION
## Summary
- Clear showFeedbackOption after successful Docker upgrade
- Clear showFeedbackOption after successful managed upgrade
- Feedback button still shows on failure paths

Part of plan: spicy-discovering-moon.md (PR 6 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
