### PR TITLE
fix: clear update-available pill immediately after successful upgrade

### DIFF
--- a/clients/macos/vellum-assistant/App/UpdateManager.swift
+++ b/clients/macos/vellum-assistant/App/UpdateManager.swift
@@ -232,7 +232,7 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
     }
 
     /// Resets service group update flags to their default (no update available) state.
-    private func clearServiceGroupFlags() {
+    func clearServiceGroupFlags() {
         isServiceGroupUpdateAvailable = false
         serviceGroupUpdateVersion = nil
     }

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -433,6 +433,7 @@ struct AssistantUpgradeSection: View {
         do {
             try await cli.upgrade(name: name, version: version)
             successMessage = isRollback ? "Rollback complete." : "Update complete."
+            AppDelegate.shared?.updateManager.clearServiceGroupFlags()
             await loadReleasesQuietly()
             if successMessage != nil { errorMessage = nil }
         } catch let error as VellumCli.CLIError {
@@ -460,6 +461,7 @@ struct AssistantUpgradeSection: View {
                 successMessage = isRollback
                     ? "Rollback initiated. The assistant may be briefly unavailable."
                     : "Update initiated. The assistant may be briefly unavailable."
+                AppDelegate.shared?.updateManager.clearServiceGroupFlags()
                 // Refresh releases to update UI without clearing success message
                 await loadReleasesQuietly()
                 // Clear any error from the releases fetch so it doesn't appear alongside the success


### PR DESCRIPTION
## Summary
- Make clearServiceGroupFlags() internal instead of private in UpdateManager
- Call clearServiceGroupFlags() after successful Docker upgrade
- Call clearServiceGroupFlags() after successful managed upgrade

Part of plan: spicy-discovering-moon.md (PR 3 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
