### PR TITLE
fix: use reactive assistantVersion from connectionManager in Settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -49,7 +49,7 @@ struct SettingsGeneralTab: View {
             accountSection
             if !lockfileAssistants.isEmpty {
                 AssistantUpgradeSection(
-                    currentVersion: healthz?.version,
+                    currentVersion: connectionManager?.assistantVersion ?? healthz?.version,
                     topology: topology,
                     isDockerOperationInProgress: $isDockerOperationInProgress,
                     dockerOperationLabel: $dockerOperationLabel,


### PR DESCRIPTION
## Summary
- Prefer connectionManager.assistantVersion over healthz.version for real-time updates
- Fall back to healthz fetch when connectionManager is unavailable

Part of plan: spicy-discovering-moon.md (PR 8 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
