### PR TITLE
fix: add UNSUPPORTED_TOPOLOGY case to upgrade error guidance

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -525,6 +525,8 @@ struct AssistantUpgradeSection: View {
             return "The platform returned an error. Try again in a few minutes."
         case "ASSISTANT_NOT_FOUND":
             return "Could not find the assistant. Make sure it's still configured."
+        case "UNSUPPORTED_TOPOLOGY":
+            return "This assistant type doesn't support automatic updates. Update your infrastructure manually."
         default:
             return "Something went wrong. Share feedback to send logs to the team."
         }


### PR DESCRIPTION
## Summary
- Add UNSUPPORTED_TOPOLOGY case to guidanceForError switch statement
- Shows specific guidance message instead of generic fallback

Part of plan: spicy-discovering-moon.md (PR 5 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
