### PR TITLE
feat: show "taking longer than expected" after expected downtime elapses

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -43,6 +43,8 @@ struct AssistantUpgradeSection: View {
     @State private var hasCheckedForUpdates = false
     @State private var checkedSparkleAvailable: Bool?
     @State private var checkedSparkleVersion: String?
+    @State private var isTakingLongerThanExpected = false
+    @State private var escalationTask: Task<Void, Never>?
 
     private var latestRelease: AssistantRelease? {
         availableReleases.first
@@ -328,15 +330,32 @@ struct AssistantUpgradeSection: View {
                 HStack(spacing: VSpacing.sm) {
                     ProgressView()
                         .controlSize(.small)
-                    Text("Assistant is updating...")
+                    Text(isTakingLongerThanExpected
+                        ? "Taking longer than expected. The assistant may still be updating..."
+                        : "Assistant is updating...")
                         .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(isTakingLongerThanExpected ? VColor.systemMidStrong : VColor.contentTertiary)
                 }
             }
         }
         .task { await loadReleases() }
         .onChange(of: currentVersion) { _, _ in
             Task { await loadReleasesQuietly() }
+        }
+        .onChange(of: isServiceGroupUpdateInProgress) { _, inProgress in
+            if inProgress {
+                isTakingLongerThanExpected = false
+                escalationTask = Task {
+                    try? await Task.sleep(nanoseconds: 90 * 1_000_000_000)
+                    if !Task.isCancelled {
+                        isTakingLongerThanExpected = true
+                    }
+                }
+            } else {
+                escalationTask?.cancel()
+                escalationTask = nil
+                isTakingLongerThanExpected = false
+            }
         }
         .alert(isRollback ? "Roll Back Assistant" : "Update Assistant", isPresented: $showingUpgradeConfirmation) {
             Button("Cancel", role: .cancel) {}


### PR DESCRIPTION
## Summary
- Add escalation timer state properties
- Show 'Taking longer than expected' message after 90 seconds of update
- Clear escalation state on update completion or new attempt

Part of plan: spicy-discovering-moon.md (PR 9 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
