### PR TITLE
refactor: use "Downgrade" instead of "Roll Back" for managed topology

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -208,7 +208,7 @@ struct AssistantUpgradeSection: View {
 
                 if !availableReleases.isEmpty && topology != .remote && topology != .local {
                     HStack(spacing: VSpacing.sm) {
-                        Text(isRollback ? "Roll back to:" : "Update to:")
+                        Text(isRollback ? (topology == .managed ? "Downgrade to:" : "Roll back to:") : "Update to:")
                             .font(VFont.caption)
                             .foregroundColor(VColor.contentTertiary)
                         Picker("", selection: Binding<String>(
@@ -276,8 +276,8 @@ struct AssistantUpgradeSection: View {
                     // Docker and managed get the upgrade button
                     VButton(
                         label: isUpgrading
-                            ? (isRollback ? "Rolling back..." : "Updating...")
-                            : (isRollback ? "Roll Back" : "Update Now"),
+                            ? (isRollback ? (topology == .managed ? "Downgrading..." : "Rolling back...") : "Updating...")
+                            : (isRollback ? (topology == .managed ? "Downgrade" : "Roll Back") : "Update Now"),
                         style: isRollback ? .outlined : .primary
                     ) {
                         showingUpgradeConfirmation = true
@@ -300,7 +300,7 @@ struct AssistantUpgradeSection: View {
                 HStack(spacing: VSpacing.sm) {
                     ProgressView()
                         .controlSize(.small)
-                    Text(isUpgrading ? (isRollback ? "Rolling back assistant..." : "Updating assistant...") : "Checking for updates...")
+                    Text(isUpgrading ? (isRollback ? (topology == .managed ? "Downgrading assistant..." : "Rolling back assistant...") : "Updating assistant...") : "Checking for updates...")
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)
                 }
@@ -338,14 +338,16 @@ struct AssistantUpgradeSection: View {
         .onChange(of: currentVersion) { _, _ in
             Task { await loadReleasesQuietly() }
         }
-        .alert(isRollback ? "Roll Back Assistant" : "Update Assistant", isPresented: $showingUpgradeConfirmation) {
+        .alert(isRollback ? (topology == .managed ? "Downgrade Assistant" : "Roll Back Assistant") : "Update Assistant", isPresented: $showingUpgradeConfirmation) {
             Button("Cancel", role: .cancel) {}
-            Button(isRollback ? "Roll Back" : "Update") {
+            Button(isRollback ? (topology == .managed ? "Downgrade" : "Roll Back") : "Update") {
                 Task { await performUpgrade() }
             }
         } message: {
             if isRollback {
-                Text("Roll back to version \(effectiveSelectedVersion ?? "unknown")? The assistant will be briefly unavailable.")
+                Text(topology == .managed
+                     ? "Downgrade to version \(effectiveSelectedVersion ?? "unknown")? The assistant will be briefly unavailable."
+                     : "Roll back to version \(effectiveSelectedVersion ?? "unknown")? The assistant will be briefly unavailable.")
             } else {
                 Text("Update to version \(effectiveSelectedVersion ?? "latest")? The assistant will be briefly unavailable during the update.")
             }
@@ -458,21 +460,21 @@ struct AssistantUpgradeSection: View {
             let response = try await GatewayHTTPClient.post(path: "assistants/upgrade", json: body)
             if response.isSuccess {
                 successMessage = isRollback
-                    ? "Rollback initiated. The assistant may be briefly unavailable."
+                    ? "Downgrade initiated. The assistant may be briefly unavailable."
                     : "Update initiated. The assistant may be briefly unavailable."
                 // Refresh releases to update UI without clearing success message
                 await loadReleasesQuietly()
                 // Clear any error from the releases fetch so it doesn't appear alongside the success
                 if successMessage != nil { errorMessage = nil }
             } else {
-                errorMessage = "\(isRollback ? "Rollback" : "Update") failed (HTTP \(response.statusCode))"
+                errorMessage = "\(isRollback ? "Downgrade" : "Update") failed (HTTP \(response.statusCode))"
                 showFeedbackOption = true
             }
         } catch let error as GatewayHTTPClient.ClientError {
-            errorMessage = "Unable to start \(isRollback ? "rollback" : "update"): \(error.localizedDescription)"
+            errorMessage = "Unable to start \(isRollback ? "downgrade" : "update"): \(error.localizedDescription)"
             showFeedbackOption = true
         } catch {
-            errorMessage = "\(isRollback ? "Rollback" : "Update") failed: \(error.localizedDescription)"
+            errorMessage = "\(isRollback ? "Downgrade" : "Update") failed: \(error.localizedDescription)"
             showFeedbackOption = true
         }
     }


### PR DESCRIPTION
## Summary
- Use 'Downgrade' terminology for managed topology when selecting an older version
- Keep 'Roll Back' for Docker topology (unchanged)
- Update version picker label, button text, confirmation dialog title and message

Part of plan: spicy-discovering-moon.md (PR 10 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
