### PR TITLE
fix: trigger Sparkle check when app is behind instead of navigating to Settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -603,19 +603,34 @@ struct MainWindowView: View {
         if connectionManager.versionMismatch && !connectionManager.isUpdateInProgress {
             // Suppress when the "Update" pill already covers it (daemon behind + update available)
             if !(updateManager.isServiceGroupUpdateAvailable && isDaemonBehind) {
-                ChatConversationErrorToast(
-                    message: versionMismatchMessage,
-                    icon: .triangleAlert,
-                    accentColor: VColor.systemMidStrong,
-                    actionLabel: "Update in Settings",
-                    onAction: {
-                        settingsStore.pendingSettingsTab = .general
-                        windowState.selection = .panel(.settings)
-                    }
-                )
-                .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
-                .padding(.top, VSpacing.sm)
-                .animation(VAnimation.fast, value: connectionManager.versionMismatch)
+                if isDaemonBehind {
+                    ChatConversationErrorToast(
+                        message: versionMismatchMessage,
+                        icon: .triangleAlert,
+                        accentColor: VColor.systemMidStrong,
+                        actionLabel: "Update in Settings",
+                        onAction: {
+                            settingsStore.pendingSettingsTab = .general
+                            windowState.selection = .panel(.settings)
+                        }
+                    )
+                    .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
+                    .padding(.top, VSpacing.sm)
+                    .animation(VAnimation.fast, value: connectionManager.versionMismatch)
+                } else {
+                    ChatConversationErrorToast(
+                        message: versionMismatchMessage,
+                        icon: .triangleAlert,
+                        accentColor: VColor.systemMidStrong,
+                        actionLabel: "Check for App Update",
+                        onAction: {
+                            AppDelegate.shared?.updateManager.checkForUpdates()
+                        }
+                    )
+                    .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
+                    .padding(.top, VSpacing.sm)
+                    .animation(VAnimation.fast, value: connectionManager.versionMismatch)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Show different banner action based on isDaemonBehind state
- App-behind: 'Check for App Update' triggers interactive Sparkle dialog
- Assistant-behind: keeps existing 'Update in Settings' navigation

Part of plan: spicy-discovering-moon.md (PR 7 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
