### PR TITLE
fix: use topology-aware checkForUpdates in app-behind banner

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -624,7 +624,7 @@ struct MainWindowView: View {
                         accentColor: VColor.systemMidStrong,
                         actionLabel: "Check for App Update",
                         onAction: {
-                            AppDelegate.shared?.updateManager.checkForUpdates()
+                            AppDelegate.shared?.checkForUpdates()
                         }
                     )
                     .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for spicy-discovering-moon.md.

**Gap:** Direct updateManager.checkForUpdates() bypasses topology routing
**What was expected:** Use centralized AppDelegate.checkForUpdates() for topology-aware routing
**What was found:** Direct Sparkle call via updateManager.checkForUpdates()
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
