### PR TITLE
fix: use VIconView and .foregroundStyle() in Docker modal timeout

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -91,15 +91,14 @@ struct SettingsGeneralTab: View {
         .sheet(isPresented: $isDockerOperationInProgress) {
             VStack(spacing: VSpacing.lg) {
                 if dockerOperationTimedOut {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .font(.system(size: 28))
-                        .foregroundColor(VColor.systemMidStrong)
+                    VIconView(.triangleAlert, size: 28)
+                        .foregroundStyle(VColor.systemMidStrong)
                     Text("This is taking longer than expected")
                         .font(VFont.bodyMedium)
-                        .foregroundColor(VColor.contentDefault)
+                        .foregroundStyle(VColor.contentDefault)
                     Text(dockerOperationLabel)
                         .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                     VButton(label: "Dismiss", style: .outlined) {
                         isDockerOperationInProgress = false
                     }
@@ -109,10 +108,10 @@ struct SettingsGeneralTab: View {
                         .progressViewStyle(.circular)
                     Text(dockerOperationLabel)
                         .font(VFont.bodyMedium)
-                        .foregroundColor(VColor.contentDefault)
+                        .foregroundStyle(VColor.contentDefault)
                     Text("This may take a minute. The assistant will be briefly unavailable.")
                         .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                 }
             }
             .padding(VSpacing.xxl)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for spicy-discovering-moon.md.

**Gap:** Image(systemName:) and .foregroundColor() in Docker modal timeout
**What was expected:** VIconView and .foregroundStyle() per AGENTS.md
**What was found:** Image(systemName:) and .foregroundColor() in new timeout code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
