### PR TITLE
fix: cancel escalationTask on view disappear in AssistantUpgradeSection

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -357,6 +357,10 @@ struct AssistantUpgradeSection: View {
                 isTakingLongerThanExpected = false
             }
         }
+        .onDisappear {
+            escalationTask?.cancel()
+            escalationTask = nil
+        }
         .alert(isRollback ? (topology == .managed ? "Downgrade Assistant" : "Roll Back Assistant") : "Update Assistant", isPresented: $showingUpgradeConfirmation) {
             Button("Cancel", role: .cancel) {}
             Button(isRollback ? (topology == .managed ? "Downgrade" : "Roll Back") : "Update") {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for spicy-discovering-moon.md.

**Gap:** Missing .onDisappear cancellation for escalationTask
**What was expected:** Tasks started in onChange should be cancelled when the view disappears
**What was found:** escalationTask never cancelled on view disappear
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
