### PR TITLE
fix: center conversation title in top bar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -431,48 +431,6 @@ struct MainWindowView: View {
             }
             WindowDragArea()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-            if windowState.isConversationVisible {
-                ConversationTitleActionsControl(
-                    presentation: conversationHeaderPresentation,
-                    onCopy: { copyActiveConversationToClipboard(); dismissConversationDrawer() },
-                    onForkConversation: {
-                        Task {
-                            await conversationManager.forkActiveConversation()
-                            await MainActor.run {
-                                dismissConversationDrawer()
-                            }
-                        }
-                    },
-                    onPin: {
-                        guard let id = conversationManager.activeConversationId else { return }
-                        conversationManager.pinConversation(id: id)
-                        dismissConversationDrawer()
-                    },
-                    onUnpin: {
-                        guard let id = conversationManager.activeConversationId else { return }
-                        conversationManager.unpinConversation(id: id)
-                        dismissConversationDrawer()
-                    },
-                    onArchive: {
-                        guard let id = conversationManager.activeConversationId else { return }
-                        conversationManager.archiveConversation(id: id)
-                        dismissConversationDrawer()
-                    },
-                    onRename: { startRenameActiveConversation(); dismissConversationDrawer() },
-                    onOpenForkParent: { openForkParentConversation() },
-                    showDrawer: $showConversationActionsDrawer
-                )
-                .background(GeometryReader { proxy in
-                    Color.clear.onAppear {
-                        conversationTitleFrame = proxy.frame(in: .named("coreLayout"))
-                    }
-                    .onChange(of: proxy.frame(in: .named("coreLayout"))) { _, newFrame in
-                        conversationTitleFrame = newFrame
-                    }
-                })
-            }
-            WindowDragArea()
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
             if updateManager.isUpdateAvailable || updateManager.isServiceGroupUpdateAvailable {
                 VButton(
                     label: updateManager.isDeferredUpdateReady
@@ -513,6 +471,48 @@ struct MainWindowView: View {
         }
         .padding(.leading, trafficLightPadding)
         .padding(.trailing, VSpacing.lg)
+        .overlay {
+            if windowState.isConversationVisible {
+                ConversationTitleActionsControl(
+                    presentation: conversationHeaderPresentation,
+                    onCopy: { copyActiveConversationToClipboard(); dismissConversationDrawer() },
+                    onForkConversation: {
+                        Task {
+                            await conversationManager.forkActiveConversation()
+                            await MainActor.run {
+                                dismissConversationDrawer()
+                            }
+                        }
+                    },
+                    onPin: {
+                        guard let id = conversationManager.activeConversationId else { return }
+                        conversationManager.pinConversation(id: id)
+                        dismissConversationDrawer()
+                    },
+                    onUnpin: {
+                        guard let id = conversationManager.activeConversationId else { return }
+                        conversationManager.unpinConversation(id: id)
+                        dismissConversationDrawer()
+                    },
+                    onArchive: {
+                        guard let id = conversationManager.activeConversationId else { return }
+                        conversationManager.archiveConversation(id: id)
+                        dismissConversationDrawer()
+                    },
+                    onRename: { startRenameActiveConversation(); dismissConversationDrawer() },
+                    onOpenForkParent: { openForkParentConversation() },
+                    showDrawer: $showConversationActionsDrawer
+                )
+                .background(GeometryReader { proxy in
+                    Color.clear.onAppear {
+                        conversationTitleFrame = proxy.frame(in: .named("coreLayout"))
+                    }
+                    .onChange(of: proxy.frame(in: .named("coreLayout"))) { _, newFrame in
+                        conversationTitleFrame = newFrame
+                    }
+                })
+            }
+        }
         .frame(height: 48)
         .background(VColor.surfaceOverlay)
     }


### PR DESCRIPTION
## Summary
- Move `ConversationTitleActionsControl` from inline in the HStack (between two flex `WindowDragArea` spacers) to an `.overlay` on the full toolbar frame
- This ensures the title is always horizontally centered in the toolbar regardless of how many buttons are on the left vs right side
- The two `WindowDragArea` spacers are consolidated into one since they no longer need to flank the title

## Original prompt
The conversation title no longer seems to be centered in the top bar, but it should be. It appears to be shifted/off-center. Look at the screenshot the user provided - the "Generating title..." text with the dropdown chevron in the top toolbar bar is not horizontally centered in the available space (between the left navigation buttons and the right edge of the window). Fix the CSS/layout so the title is properly centered in the top bar.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
