### PR TITLE
Add sidebarToggleShortcut property to SettingsStore and UserDefaults

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -54,6 +54,12 @@ extension UserDefaults {
     @objc dynamic var quickInputHotkeyKeyCode: Int {
         return integer(forKey: "quickInputHotkeyKeyCode")
     }
+    @objc dynamic var sidebarToggleShortcut: String {
+        if UserDefaults.standard.object(forKey: "sidebarToggleShortcut") == nil {
+            return "cmd+\\"
+        }
+        return string(forKey: "sidebarToggleShortcut") ?? ""
+    }
 }
 
 // MARK: - Input Monitors

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -79,6 +79,7 @@ public final class SettingsStore: ObservableObject {
     @Published var globalHotkeyShortcut: String
     @Published var quickInputHotkeyShortcut: String
     @Published var quickInputHotkeyKeyCode: Int
+    @Published var sidebarToggleShortcut: String
     @Published var cmdEnterToSend: Bool
 
     // MARK: - Media Embed Settings
@@ -413,6 +414,11 @@ public final class SettingsStore: ObservableObject {
         }
         let storedQIKeyCode = UserDefaults.standard.object(forKey: "quickInputHotkeyKeyCode") as? Int
         self.quickInputHotkeyKeyCode = storedQIKeyCode ?? kVK_ANSI_Slash
+        if UserDefaults.standard.object(forKey: "sidebarToggleShortcut") == nil {
+            self.sidebarToggleShortcut = "cmd+\\"
+        } else {
+            self.sidebarToggleShortcut = UserDefaults.standard.string(forKey: "sidebarToggleShortcut") ?? ""
+        }
 
         // Load media embed settings from workspace config
         let mediaSettings = Self.loadMediaEmbedSettings(from: configPath)
@@ -527,6 +533,11 @@ public final class SettingsStore: ObservableObject {
         $quickInputHotkeyKeyCode
             .dropFirst()
             .sink { value in UserDefaults.standard.set(value, forKey: "quickInputHotkeyKeyCode") }
+            .store(in: &cancellables)
+
+        $sidebarToggleShortcut
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "sidebarToggleShortcut") }
             .store(in: &cancellables)
 
         // Mirror GatewayConnectionManager's trust-rules-open flag so views can disable their buttons


### PR DESCRIPTION
## Summary
- Add @Published sidebarToggleShortcut property to SettingsStore with default cmd+backslash
- Add UserDefaults loading logic and Combine persistence binding
- Add KVO-observable UserDefaults extension property for reactive observation

Part of plan: sidebar-collapse-keyboard-shortcut.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
