### PR TITLE
Display sidebar toggle keyboard shortcut in the sidebar button tooltip

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -29,6 +29,7 @@ struct MainWindowView: View {
     @State private var preTemporaryChatConversationId: UUID?
 
     @AppStorage("sidebarExpanded") var sidebarExpanded: Bool = true
+    @AppStorage("sidebarToggleShortcut") private var sidebarToggleShortcut: String = "cmd+\\"
     /// True when the sidebar was auto-collapsed by entering an app panel.
     /// Used to distinguish automatic collapse from manual user collapse so
     /// we only re-expand the sidebar on app exit when it was our doing.
@@ -377,6 +378,13 @@ struct MainWindowView: View {
         return false
     }
 
+    private var sidebarTooltip: String {
+        let label = sidebarExpanded ? "Collapse sidebar" : "Expand sidebar"
+        guard !sidebarToggleShortcut.isEmpty else { return label }
+        let display = ShortcutHelper.displayString(for: sidebarToggleShortcut)
+        return "\(label) (\(display))"
+    }
+
     /// Daemon loading overlay extracted to reduce type-checker pressure on `coreLayoutView`.
     @ViewBuilder
     private var daemonLoadingOverlayIfNeeded: some View {
@@ -405,7 +413,7 @@ struct MainWindowView: View {
     private var topBarView: some View {
         HStack(spacing: VSpacing.sm) {
             if !isSettingsOpen {
-                VButton(label: "Sidebar", iconOnly: VIcon.panelLeft.rawValue, style: .ghost, tooltip: sidebarExpanded ? "Collapse sidebar" : "Expand sidebar") {
+                VButton(label: "Sidebar", iconOnly: VIcon.panelLeft.rawValue, style: .ghost, tooltip: sidebarTooltip) {
                     withAnimation(VAnimation.panel) {
                         sidebarExpanded.toggle()
                     }


### PR DESCRIPTION
## Summary
- Add @AppStorage for sidebarToggleShortcut in MainWindowView
- Add sidebarTooltip computed property that includes the shortcut display string
- Tooltip shows 'Collapse sidebar (⌘ \)' when expanded and 'Expand sidebar (⌘ \)' when collapsed

Part of plan: sidebar-collapse-keyboard-shortcut.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
