### PR TITLE
fix: center conversation title above chat content area

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -511,6 +511,12 @@ struct MainWindowView: View {
                         conversationTitleFrame = newFrame
                     }
                 })
+                // Shift the title right so it centers above the chat content area
+                // (not the full window). Content starts after outer padding (16) +
+                // sidebar + spacing (16), so its center is offset from the window
+                // center by (sidebarWidth + 16) / 2.
+                .offset(x: isSettingsOpen ? 0 : ((sidebarExpanded ? sidebarExpandedWidth : sidebarCollapsedWidth) + 16) / 2)
+                .animation(VAnimation.panel, value: sidebarExpanded)
             }
         }
         .frame(height: 48)


### PR DESCRIPTION
## Summary
- Add horizontal offset to the toolbar title overlay so it centers above the chat content area rather than the full window width
- The offset is computed as `(sidebarWidth + 16) / 2` which accounts for the outer padding and sidebar width in the content layout below
- Animates smoothly with sidebar expand/collapse using `VAnimation.panel`

## Original prompt
The conversation title should be centered above the chat conversation itself, aligned with the "Yesterday at 3:27 PM" timestamp, not centered in the full window width.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
