### PR TITLE
Return Sentry event ID from MetricKitManager.sendManualReport completion handler

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/CrashReportView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CrashReportView.swift
@@ -123,7 +123,7 @@ struct CrashReportView: View {
 
             // Await completion so UI confirms delivery only after flush finishes.
             await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-                MetricKitManager.sendManualReport(event, attachments: attachments) {
+                MetricKitManager.sendManualReport(event, attachments: attachments) { _ in
                     continuation.resume()
                 }
             }

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -170,15 +170,15 @@ enum LogExporter {
                 ? MetricKitManager.brainDSN
                 : nil
 
-            await withCheckedContinuation { continuation in
+            let _: SentryId? = await withCheckedContinuation { (continuation: CheckedContinuation<SentryId?, Never>) in
                 MetricKitManager.sendManualReport(
                     event,
                     attachments: [attachment],
                     userFeedback: feedback,
                     dsn: dsn
-                ) {
+                ) { eventId in
                     try? FileManager.default.removeItem(at: archiveURL)
-                    continuation.resume()
+                    continuation.resume(returning: eventId)
                 }
             }
 

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -79,7 +79,7 @@ import os
         attachments: [Attachment] = [],
         userFeedback: UserFeedbackData? = nil,
         dsn: String? = nil,
-        completion: (@Sendable () -> Void)? = nil
+        completion: (@Sendable (SentryId?) -> Void)? = nil
     ) {
         sentrySerialQueue.async {
             let targetDSN = dsn ?? macosDSN
@@ -178,7 +178,7 @@ import os
                 // SDK was disabled before we started it — close the temp session.
                 SentrySDK.close()
             }
-            completion?()
+            completion?(eventId)
         }
     }
 


### PR DESCRIPTION
## Summary
- Change MetricKitManager.sendManualReport completion handler from () -> Void to (SentryId?) -> Void
- Pass through the event ID captured by SentrySDK.capture(event:) to the completion handler
- Update LogExporter and all other callers to accept the new signature

Part of plan: feedback-ingest.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
