### PR TITLE
fix: change failed-update toast text from "Check Settings for details" to actionable message

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -856,7 +856,7 @@ struct MainWindowView: View {
             )
         case .failed:
             windowState.showToast(
-                message: "Update failed. Check Settings for details.",
+                message: "Update failed. Try again from Settings.",
                 style: .error,
                 primaryAction: VToastAction(label: "Open Settings") {
                     settingsStore.pendingSettingsTab = .general


### PR DESCRIPTION
## Summary
- Change misleading 'Check Settings for details' to 'Try again from Settings'
- Settings doesn't display SSE failure details; new text is actionable

Part of plan: svc-grp-update-ux-3.md (PR 8 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
