### PR TITLE
fix: remove redundant isCheckingForUpdates = true in About window docker/managed case

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
@@ -263,7 +263,6 @@ struct AboutVellumView: View {
 
         case .docker, .managed:
             // Docker/managed: check platform API and show result inline
-            isCheckingForUpdates = true
             defer { isCheckingForUpdates = false }
 
             await AppDelegate.shared?.updateManager.checkServiceGroupUpdate()


### PR DESCRIPTION
## Summary
- Remove duplicate isCheckingForUpdates = true in docker/managed case
- Already set before the switch statement

Part of plan: svc-grp-update-ux-3.md (PR 6 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
