### PR TITLE
docs: document that versionsMatch intentionally ignores prerelease suffixes

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
@@ -31,7 +31,10 @@ struct AboutVellumView: View {
             : .remote
     }
 
-    /// Whether the client and service group versions match.
+    /// Whether the client and service-group versions are semantically equal
+    /// (major.minor.patch). Pre-release suffixes (e.g., `-beta.1`) are
+    /// intentionally ignored — only the release triple matters for the
+    /// "versions match" checkmark in the About window.
     private var versionsMatch: Bool {
         guard let sgVersion = healthz?.version, !sgVersion.isEmpty,
               let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,


### PR DESCRIPTION
## Summary
- Add doc comment to versionsMatch explaining prerelease suffix behavior

Part of plan: svc-grp-update-ux-3.md (PR 14 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
