### PR TITLE
fix: show SSE-driven update progress indicator for Docker topology alongside managed

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -326,7 +326,7 @@ struct AssistantUpgradeSection: View {
                     .foregroundColor(VColor.systemPositiveStrong)
             }
 
-            if isServiceGroupUpdateInProgress && !isUpgrading && topology == .managed {
+            if isServiceGroupUpdateInProgress && !isUpgrading && (topology == .managed || topology == .docker) {
                 HStack(spacing: VSpacing.sm) {
                     ProgressView()
                         .controlSize(.small)


### PR DESCRIPTION
## Summary
- Include Docker topology in SSE-driven update progress display
- Shows 'Assistant is updating...' indicator after modal dismiss

Part of plan: svc-grp-update-ux-3.md (PR 7 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
