### PR TITLE
Route feedback log archives to platform API, stop attaching to Sentry events

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -40,7 +40,8 @@ enum LogExporter {
         AppDelegate.shared?.isCurrentAssistantManaged == true
     }
 
-    /// Collects logs, archives them, and sends to Sentry as an attachment for developer debugging.
+    /// Collects logs, archives them, sends a lightweight Sentry event (no archive attachment),
+    /// and uploads the archive to the platform API for storage.
     /// Includes report metadata (reason, message) from the log report form.
     static func sendLogsToSentry(formData: LogReportFormData) {
         Task {
@@ -61,8 +62,8 @@ enum LogExporter {
                 return
             }
 
-            let archiveName = defaultArchiveName()
-            let attachment = Attachment(path: archiveURL.path, filename: archiveName)
+            // --- Phase 1: Lightweight Sentry event (no archive attachment) ---
+
             let event = Event(level: .info)
             let errorTitle: String
             switch formData.scope {
@@ -170,17 +171,31 @@ enum LogExporter {
                 ? MetricKitManager.brainDSN
                 : nil
 
-            let _: SentryId? = await withCheckedContinuation { (continuation: CheckedContinuation<SentryId?, Never>) in
+            // Send lightweight Sentry event (no archive attachment) and capture the event ID
+            // for linking to the platform API upload.
+            let sentryEventId: SentryId? = await withCheckedContinuation { (continuation: CheckedContinuation<SentryId?, Never>) in
                 MetricKitManager.sendManualReport(
                     event,
-                    attachments: [attachment],
+                    attachments: [],
                     userFeedback: feedback,
                     dsn: dsn
                 ) { eventId in
-                    try? FileManager.default.removeItem(at: archiveURL)
                     continuation.resume(returning: eventId)
                 }
             }
+
+            // --- Phase 2: Upload archive to platform API ---
+
+            await uploadFeedbackToPlatform(
+                archiveURL: archiveURL,
+                formData: formData,
+                sentryEventId: sentryEventId,
+                connectedAssistantId: connectedAssistantId,
+                connectedAssistant: connectedAssistantForTags
+            )
+
+            // Clean up the archive temp file after platform upload completes (or fails).
+            try? fileManager.removeItem(at: archiveURL)
 
             // Re-activate before showing the alert in case the app reverted
             // to .accessory policy after the log report window was dismissed.
@@ -191,6 +206,111 @@ enum LogExporter {
             alert.alertStyle = .informational
             alert.runModal()
         }
+    }
+
+    // MARK: - Platform Feedback Upload
+
+    /// Maps `LogReportReason` to the platform API's `FeedbackClassification` values.
+    private static func feedbackClassification(for reason: LogReportReason) -> String {
+        switch reason {
+        case .somethingBroken: return "something_broken"
+        case .appCrash: return "app_crash"
+        case .performanceIssue: return "performance"
+        case .connectionIssue: return "connection"
+        case .featureRequest: return "feature_request"
+        case .other: return "other"
+        }
+    }
+
+    /// Uploads the feedback archive and metadata to the platform API.
+    /// Errors are logged but not surfaced to the user — the Sentry event
+    /// was already captured successfully in Phase 1.
+    private static func uploadFeedbackToPlatform(
+        archiveURL: URL,
+        formData: LogReportFormData,
+        sentryEventId: SentryId?,
+        connectedAssistantId: String?,
+        connectedAssistant: LockfileAssistant?
+    ) async {
+        let baseURL = AuthService.shared.baseURL
+        guard let url = URL(string: "\(baseURL)/v1/feedback/") else {
+            log.warning("Failed to construct platform feedback URL")
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 60
+
+        // Add auth headers if the user is authenticated (managed assistant).
+        if let token = await SessionTokenManager.getTokenAsync() {
+            request.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        }
+        if let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId"), !orgId.isEmpty {
+            request.setValue(orgId, forHTTPHeaderField: "Vellum-Organization-Id")
+        }
+
+        // Build multipart/form-data body.
+        let boundary = UUID().uuidString
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+        var body = Data()
+
+        // Text fields
+        appendFormField(&body, boundary: boundary, name: "message", value: formData.message)
+        appendFormField(&body, boundary: boundary, name: "classification", value: feedbackClassification(for: formData.reason))
+        appendFormField(&body, boundary: boundary, name: "email", value: formData.email)
+
+        if let eventId = sentryEventId {
+            appendFormField(&body, boundary: boundary, name: "sentry_event_id", value: eventId.sentryIdString)
+        }
+
+        appendFormField(&body, boundary: boundary, name: "device_id", value: SentryDeviceInfo.deviceId)
+
+        if let clientVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+            appendFormField(&body, boundary: boundary, name: "client_version", value: clientVersion)
+        }
+
+        if let assistantVersion = connectedAssistant?.serviceGroupVersion {
+            appendFormField(&body, boundary: boundary, name: "assistant_version", value: assistantVersion)
+        }
+
+        if let assistantId = connectedAssistantId {
+            appendFormField(&body, boundary: boundary, name: "assistant_id", value: assistantId)
+        }
+
+        // File part — the tar.gz archive
+        if let archiveData = try? Data(contentsOf: archiveURL) {
+            let filename = defaultArchiveName()
+            body.append("--\(boundary)\r\n".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"logs_file\"; filename=\"\(filename)\"\r\n".data(using: .utf8)!)
+            body.append("Content-Type: application/gzip\r\n\r\n".data(using: .utf8)!)
+            body.append(archiveData)
+            body.append("\r\n".data(using: .utf8)!)
+        }
+
+        // Final boundary
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+
+        request.httpBody = body
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+                log.warning("Platform feedback upload failed with status \(http.statusCode)")
+            } else {
+                log.info("Platform feedback upload succeeded")
+            }
+        } catch {
+            log.warning("Platform feedback upload request failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Appends a simple text field to a multipart/form-data body.
+    private static func appendFormField(_ body: inout Data, boundary: String, name: String, value: String) {
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n".data(using: .utf8)!)
+        body.append("\(value)\r\n".data(using: .utf8)!)
     }
 
     // MARK: - Private

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -111,15 +111,6 @@ import os
                 SentryDeviceInfo.configureSentryScope()
             }
 
-            // Attach files to the scope before capturing the event.
-            if !attachments.isEmpty {
-                SentrySDK.configureScope { scope in
-                    for attachment in attachments {
-                        scope.addAttachment(attachment)
-                    }
-                }
-            }
-
             // Set reporter identity on the event so log reports are searchable
             // by email (user.email:foo@example.com) in Sentry. Only set for
             // manual reports where the user explicitly provided their email.
@@ -147,19 +138,11 @@ import os
                 SentrySDK.capture(feedback: feedback)
             }
 
-            // Clean up attachments so they don't leak into subsequent events.
-            if !attachments.isEmpty {
-                SentrySDK.configureScope { scope in
-                    scope.clearAttachments()
-                }
-            }
-
-            // Always flush when attachments are present so large files are
-            // delivered before the user quits the app. Use a longer timeout
-            // when attachments are present since companion archives (e.g.
-            // spindump .tar.gz) can be several MB on slow connections.
-            let flushTimeout: TimeInterval = attachments.isEmpty ? 5 : 15
-            SentrySDK.flush(timeout: flushTimeout)
+            // Flush to ensure the lightweight event is delivered before the
+            // app quits. Archives are no longer attached to Sentry events
+            // (they're uploaded to the platform API instead), so a short
+            // timeout is sufficient.
+            SentrySDK.flush(timeout: 5)
 
             // Clear reporter identity so it doesn't leak into subsequent events.
             if userFeedback != nil {


### PR DESCRIPTION
## Summary
- Stop attaching log archives to Sentry events (keep lightweight event capture for stack traces/breadcrumbs)
- Upload archives to platform API POST /v1/feedback/ as multipart/form-data
- Include all metadata: device_id, client_version, assistant_version, assistant_id, sentry_event_id
- Add auth headers (X-Session-Token, Vellum-Organization-Id) when available for managed users
- Graceful degradation: if platform upload fails, user still sees Feedback Sent

Part of plan: feedback-ingest.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
