### PR TITLE
fix: prevent starting a second Docker upgrade while one is already running

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -1,6 +1,9 @@
 import Foundation
+import os
 import SwiftUI
 import VellumAssistantShared
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AssistantUpgrade")
 
 /// Topology classification for upgrade UI behavior.
 enum AssistantTopology {
@@ -45,6 +48,7 @@ struct AssistantUpgradeSection: View {
     @State private var checkedSparkleVersion: String?
     @State private var isTakingLongerThanExpected = false
     @State private var escalationTask: Task<Void, Never>?
+    @State private var dockerUpgradeTask: Task<Void, Never>?
 
     private var latestRelease: AssistantRelease? {
         availableReleases.first
@@ -360,6 +364,8 @@ struct AssistantUpgradeSection: View {
         .onDisappear {
             escalationTask?.cancel()
             escalationTask = nil
+            dockerUpgradeTask?.cancel()
+            dockerUpgradeTask = nil
         }
         .alert(isRollback ? (topology == .managed ? "Downgrade Assistant" : "Roll Back Assistant") : "Update Assistant", isPresented: $showingUpgradeConfirmation) {
             Button("Cancel", role: .cancel) {}
@@ -431,13 +437,22 @@ struct AssistantUpgradeSection: View {
     }
 
     private func performUpgrade() async {
+        guard dockerUpgradeTask == nil else {
+            log.warning("Upgrade already in progress — ignoring duplicate request")
+            return
+        }
+
         clearMessages()
         isUpgrading = true
         defer { isUpgrading = false }
 
         switch topology {
         case .docker:
-            await performDockerUpgrade()
+            dockerUpgradeTask = Task {
+                await performDockerUpgrade()
+                dockerUpgradeTask = nil
+            }
+            await dockerUpgradeTask?.value
         case .managed:
             await performManagedUpgrade()
         case .local, .remote:


### PR DESCRIPTION
## Summary
- Add dockerUpgradeTask state to track running CLI operation
- Guard performUpgrade() against concurrent Docker operations
- Task reference cleared on completion

Part of plan: svc-grp-update-ux-3.md (PR 3 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
