### PR TITLE
fix: show "Unavailable" for service group version when healthz fetch fails

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -31,6 +31,9 @@ struct AssistantUpgradeSection: View {
     /// Whether a service group update is in progress (managed topology).
     var isServiceGroupUpdateInProgress: Bool = false
 
+    /// Whether the healthz fetch has completed (regardless of success/failure).
+    var healthzLoaded: Bool = false
+
     @State private var availableReleases: [AssistantRelease] = []
     @State private var selectedVersion: String?
     @State private var isLoadingReleases = false
@@ -150,7 +153,7 @@ struct AssistantUpgradeSection: View {
                                 .font(VFont.mono)
                                 .foregroundColor(isVersionIncompatible ? VColor.systemNegativeStrong : VColor.contentDefault)
                         } else {
-                            Text("Loading...")
+                            Text(healthzLoaded ? "Unavailable" : "Loading...")
                                 .font(VFont.caption)
                                 .foregroundColor(VColor.contentTertiary)
                         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -25,6 +25,7 @@ struct SettingsGeneralTab: View {
     @State private var selectedAssistantId: String = ""
     @State private var dockerOperationTimedOut = false
     @State private var dockerOperationTimeoutTask: Task<Void, Never>?
+    @State private var healthzLoaded = false
 
     /// Publisher for reactive observation of connectionManager's isUpdateInProgress.
     /// Falls back to a single `false` emission when connectionManager is nil.
@@ -57,7 +58,8 @@ struct SettingsGeneralTab: View {
                     dockerOperationLabel: $dockerOperationLabel,
                     sparkleUpdateAvailable: sparkleUpdateAvailable,
                     sparkleUpdateVersion: sparkleUpdateVersion,
-                    isServiceGroupUpdateInProgress: isServiceGroupUpdateInProgress
+                    isServiceGroupUpdateInProgress: isServiceGroupUpdateInProgress,
+                    healthzLoaded: healthzLoaded
                 )
             }
             if MacOSClientFeatureFlagManager.shared.isEnabled("mobile_pairing_enabled") {
@@ -147,6 +149,7 @@ struct SettingsGeneralTab: View {
         } catch {
             healthz = DaemonHealthz()
         }
+        healthzLoaded = true
     }
 
     // MARK: - Mobile Pairing


### PR DESCRIPTION
## Summary
- Add healthzLoaded state to track when healthz fetch completes
- Show 'Unavailable' instead of perpetual 'Loading...' when version is nil

Part of plan: svc-grp-update-ux-3.md (PR 9 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
