### PR TITLE
fix: prefer connectionManager.assistantVersion in About window for consistency

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -592,7 +592,7 @@ extension AppDelegate {
             return
         }
 
-        let aboutView = AboutVellumView()
+        let aboutView = AboutVellumView(connectionManager: connectionManager)
         let hostingController = NSHostingController(rootView: aboutView)
 
         let window = NSWindow(

--- a/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
@@ -14,6 +14,8 @@ private enum UpdateCheckResult {
 /// label, commit SHA, architecture, and an in-place "Check for Updates" button.
 @MainActor
 struct AboutVellumView: View {
+    var connectionManager: GatewayConnectionManager?
+
     @State private var healthz: DaemonHealthz?
     @State private var lockfileAssistants: [LockfileAssistant] = []
     @State private var selectedAssistantId: String = ""
@@ -31,9 +33,15 @@ struct AboutVellumView: View {
             : .remote
     }
 
+    /// Resolved service group version — prefers the reactive connectionManager value,
+    /// falls back to the one-shot healthz fetch.
+    private var serviceVersion: String? {
+        connectionManager?.assistantVersion ?? healthz?.version
+    }
+
     /// Whether the client and service group versions match.
     private var versionsMatch: Bool {
-        guard let sgVersion = healthz?.version, !sgVersion.isEmpty,
+        guard let sgVersion = serviceVersion, !sgVersion.isEmpty,
               let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
               let sgParsed = VersionCompat.parse(sgVersion),
               let appParsed = VersionCompat.parse(appVersion) else {
@@ -121,7 +129,7 @@ struct AboutVellumView: View {
                 .font(VFont.caption)
                 .foregroundColor(VColor.contentTertiary)
 
-            if let version = healthz?.version, !version.isEmpty {
+            if let version = serviceVersion, !version.isEmpty {
                 Text(version)
                     .font(VFont.mono)
                     .foregroundColor(VColor.contentDefault)


### PR DESCRIPTION
## Summary
- Add connectionManager reference to About window view
- Prefer assistantVersion from connectionManager over standalone healthz fetch
- Ensures About window and Settings show consistent version

Part of plan: svc-grp-update-ux-3.md (PR 10 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
