### PR TITLE
fix: use direct Sparkle call for app-behind banner instead of topology-aware routing

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -630,7 +630,7 @@ struct MainWindowView: View {
                         accentColor: VColor.systemMidStrong,
                         actionLabel: "Check for App Update",
                         onAction: {
-                            AppDelegate.shared?.checkForUpdates()
+                            AppDelegate.shared?.updateManager.checkForUpdates()
                         }
                     )
                     .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }


### PR DESCRIPTION
## Summary
- Revert app-behind banner action to call updateManager.checkForUpdates() directly
- Sparkle is always correct for updating the app, regardless of assistant topology

Part of plan: svc-grp-update-ux-3.md (PR 2 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
