### PR TITLE
fix: use default-aware read for sidebarExpanded to match @AppStorage default

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -303,7 +303,7 @@ extension AppDelegate {
                   event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else {
                 return event
             }
-            let current = UserDefaults.standard.bool(forKey: "sidebarExpanded")
+            let current = (UserDefaults.standard.object(forKey: "sidebarExpanded") as? Bool) ?? true
             UserDefaults.standard.set(!current, forKey: "sidebarExpanded")
             return nil
         }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for sidebar-collapse-keyboard-shortcut.md.

**Gap:** sidebarExpanded default mismatch causes first toggle to be a no-op
**What was expected:** First Cmd+\ press should toggle the sidebar from its visible expanded state
**What was found:** UserDefaults.bool(forKey:) returns false for absent keys, but @AppStorage defaults to true
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
