### PR TITLE
fix: consume unconsumed update outcome when main window appears

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -793,6 +793,14 @@ struct MainWindowView: View {
         }
         eventStreamClient.startSSE()
         daemonStartupError = AppDelegate.shared?.daemonStartupError
+
+        // Show toast for update outcomes emitted while the main window was not visible.
+        // The onReceive handler for lastUpdateOutcome covers outcomes arriving while
+        // the view is live; this catches any that were missed in between.
+        if let outcome = connectionManager.lastUpdateOutcome {
+            handleUpdateOutcome(outcome)
+            connectionManager.clearLastUpdateOutcome()
+        }
     }
 
     private func observeDaemonStartupErrors() async {


### PR DESCRIPTION
## Summary
- Check for unconsumed lastUpdateOutcome in handleCoreLayoutAppear
- Shows toast for outcomes emitted while window was hidden

Part of plan: svc-grp-update-ux-3.md (PR 11 of 14)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
