### PR TITLE
Add configurable keyboard shortcut to toggle sidebar

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -303,7 +303,7 @@ extension AppDelegate {
                   event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else {
                 return event
             }
-            let current = UserDefaults.standard.bool(forKey: "sidebarExpanded")
+            let current = (UserDefaults.standard.object(forKey: "sidebarExpanded") as? Bool) ?? true
             UserDefaults.standard.set(!current, forKey: "sidebarExpanded")
             return nil
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -76,15 +76,17 @@ extension AppDelegate {
         registerCmdKMonitor()
         registerCmdNMonitor()
 
-        globalHotkeyObserver = Publishers.Merge3(
+        globalHotkeyObserver = Publishers.Merge4(
             UserDefaults.standard.publisher(for: \.globalHotkeyShortcut).map { _ in () },
             UserDefaults.standard.publisher(for: \.quickInputHotkeyShortcut).map { _ in () },
-            UserDefaults.standard.publisher(for: \.quickInputHotkeyKeyCode).map { _ in () }
+            UserDefaults.standard.publisher(for: \.quickInputHotkeyKeyCode).map { _ in () },
+            UserDefaults.standard.publisher(for: \.sidebarToggleShortcut).map { _ in () }
         )
         .debounce(for: .milliseconds(100), scheduler: RunLoop.main)
         .sink { [weak self] _ in
             self?.registerGlobalHotkeyMonitor()
             self?.registerQuickInputMonitor()
+            self?.registerSidebarToggleMonitor()
         }
     }
 
@@ -177,6 +179,10 @@ extension AppDelegate {
         if let monitor = zoomLocalMonitor {
             NSEvent.removeMonitor(monitor)
             zoomLocalMonitor = nil
+        }
+        if let monitor = sidebarToggleLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            sidebarToggleLocalMonitor = nil
         }
     }
 
@@ -272,6 +278,36 @@ extension AppDelegate {
             }
         }
         navLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+    }
+
+    /// Registers a local event monitor to toggle the sidebar collapsed/expanded
+    /// state when the configured shortcut (default: Cmd+\) is pressed.
+    /// The shortcut is read dynamically from UserDefaults so it can be
+    /// reconfigured without restarting.
+    func registerSidebarToggleMonitor() {
+        if let existing = sidebarToggleLocalMonitor {
+            NSEvent.removeMonitor(existing)
+            sidebarToggleLocalMonitor = nil
+        }
+
+        let shortcut = UserDefaults.standard.string(forKey: "sidebarToggleShortcut") ?? "cmd+\\"
+        guard !shortcut.isEmpty else { return }
+
+        let (targetModifiers, targetKey) = ShortcutHelper.parseShortcut(shortcut)
+
+        let handler: (NSEvent) -> NSEvent? = { [weak self] event in
+            guard self?.isBootstrapping != true,
+                  self?.mainWindow?.isVisible == true else { return event }
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            guard mods == targetModifiers,
+                  event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else {
+                return event
+            }
+            let current = UserDefaults.standard.bool(forKey: "sidebarExpanded")
+            UserDefaults.standard.set(!current, forKey: "sidebarExpanded")
+            return nil
+        }
+        sidebarToggleLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
     }
 
     /// Registers Cmd+=/Cmd+-/Cmd+0 as local shortcuts for window zoom.

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -298,7 +298,7 @@ extension AppDelegate {
         let handler: (NSEvent) -> NSEvent? = { [weak self] event in
             guard self?.isBootstrapping != true,
                   self?.mainWindow?.isVisible == true else { return event }
-            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask).subtracting(.numericPad)
             guard mods == targetModifiers,
                   event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else {
                 return event

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -54,6 +54,12 @@ extension UserDefaults {
     @objc dynamic var quickInputHotkeyKeyCode: Int {
         return integer(forKey: "quickInputHotkeyKeyCode")
     }
+    @objc dynamic var sidebarToggleShortcut: String {
+        if UserDefaults.standard.object(forKey: "sidebarToggleShortcut") == nil {
+            return "cmd+\\"
+        }
+        return string(forKey: "sidebarToggleShortcut") ?? ""
+    }
 }
 
 // MARK: - Input Monitors

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -53,6 +53,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var cmdNLocalMonitor: Any?
     var navLocalMonitor: Any?
     var zoomLocalMonitor: Any?
+    var sidebarToggleLocalMonitor: Any?
     public let services = AppServices()
     let vellumCli = VellumCli()
     public let updateManager = UpdateManager()
@@ -481,6 +482,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         stripHelpMenuSearchField()
         registerNavigationMonitor()
         registerZoomMonitor()
+        registerSidebarToggleMonitor()
         setupHotKey()
         setupEscapeMonitor()
         setupVoiceInput()

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -29,6 +29,7 @@ struct MainWindowView: View {
     @State private var preTemporaryChatConversationId: UUID?
 
     @AppStorage("sidebarExpanded") var sidebarExpanded: Bool = true
+    @AppStorage("sidebarToggleShortcut") private var sidebarToggleShortcut: String = "cmd+\\"
     /// True when the sidebar was auto-collapsed by entering an app panel.
     /// Used to distinguish automatic collapse from manual user collapse so
     /// we only re-expand the sidebar on app exit when it was our doing.
@@ -377,6 +378,13 @@ struct MainWindowView: View {
         return false
     }
 
+    private var sidebarTooltip: String {
+        let label = sidebarExpanded ? "Collapse sidebar" : "Expand sidebar"
+        guard !sidebarToggleShortcut.isEmpty else { return label }
+        let display = ShortcutHelper.displayString(for: sidebarToggleShortcut)
+        return "\(label) (\(display))"
+    }
+
     /// Daemon loading overlay extracted to reduce type-checker pressure on `coreLayoutView`.
     @ViewBuilder
     private var daemonLoadingOverlayIfNeeded: some View {
@@ -405,7 +413,7 @@ struct MainWindowView: View {
     private var topBarView: some View {
         HStack(spacing: VSpacing.sm) {
             if !isSettingsOpen {
-                VButton(label: "Sidebar", iconOnly: VIcon.panelLeft.rawValue, style: .ghost, tooltip: sidebarExpanded ? "Collapse sidebar" : "Expand sidebar") {
+                VButton(label: "Sidebar", iconOnly: VIcon.panelLeft.rawValue, style: .ghost, tooltip: sidebarTooltip) {
                     withAnimation(VAnimation.panel) {
                         sidebarExpanded.toggle()
                     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -293,7 +293,7 @@ struct SettingsAppearanceTab: View {
                 HStack {
                     Text("Toggle sidebar")
                         .font(VFont.body)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                     Spacer()
                     if isRecordingSidebarToggle, let display = recordingDisplayString, !display.isEmpty {
                         VShortcutTag(display)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -10,6 +10,7 @@ struct SettingsAppearanceTab: View {
     @State private var isVideoDomainsExpanded: Bool = false
     @State private var isRecordingGlobalHotkey = false
     @State private var isRecordingQuickInputHotkey = false
+    @State private var isRecordingSidebarToggle = false
     @State private var isRecordingVoiceInput = false
     @State private var shortcutMonitor: Any?
     @State private var flagsMonitor: Any?
@@ -288,6 +289,39 @@ struct SettingsAppearanceTab: View {
 
                 SettingsDivider()
 
+                // Toggle sidebar (configurable)
+                HStack {
+                    Text("Toggle sidebar")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentSecondary)
+                    Spacer()
+                    if isRecordingSidebarToggle, let display = recordingDisplayString, !display.isEmpty {
+                        VShortcutTag(display)
+                    } else {
+                        VShortcutTag(ShortcutHelper.displayString(for: store.sidebarToggleShortcut))
+                    }
+
+                    if isRecordingSidebarToggle {
+                        VButton(label: "Press shortcut...", style: .outlined) {
+                            stopRecording()
+                        }
+                    } else {
+                        HStack(spacing: VSpacing.sm) {
+                            VButton(label: "Record", style: .outlined) {
+                                startRecordingSidebarToggle()
+                            }
+                            if !store.sidebarToggleShortcut.isEmpty {
+                                VButton(label: "Unbind", style: .outlined) {
+                                    store.sidebarToggleShortcut = ""
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical, VSpacing.md)
+
+                SettingsDivider()
+
                 VToggle(
                     isOn: Binding(
                         get: { store.cmdEnterToSend },
@@ -483,6 +517,13 @@ struct SettingsAppearanceTab: View {
         isRecordingQuickInputHotkey = true
     }
 
+    private func startRecordingSidebarToggle() {
+        startRecordingShortcut { shortcut, _ in
+            store.sidebarToggleShortcut = shortcut
+        }
+        isRecordingSidebarToggle = true
+    }
+
     /// Shared recording logic. The callback receives the shortcut string and the raw NSEvent key code.
     private func startRecordingShortcut(onRecord: @escaping (String, UInt16) -> Void) {
         stopRecording()
@@ -526,6 +567,7 @@ struct SettingsAppearanceTab: View {
     private func stopRecording() {
         isRecordingGlobalHotkey = false
         isRecordingQuickInputHotkey = false
+        isRecordingSidebarToggle = false
         recordingDisplayString = nil
         if let monitor = shortcutMonitor {
             NSEvent.removeMonitor(monitor)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -79,6 +79,7 @@ public final class SettingsStore: ObservableObject {
     @Published var globalHotkeyShortcut: String
     @Published var quickInputHotkeyShortcut: String
     @Published var quickInputHotkeyKeyCode: Int
+    @Published var sidebarToggleShortcut: String
     @Published var cmdEnterToSend: Bool
 
     // MARK: - Media Embed Settings
@@ -413,6 +414,11 @@ public final class SettingsStore: ObservableObject {
         }
         let storedQIKeyCode = UserDefaults.standard.object(forKey: "quickInputHotkeyKeyCode") as? Int
         self.quickInputHotkeyKeyCode = storedQIKeyCode ?? kVK_ANSI_Slash
+        if UserDefaults.standard.object(forKey: "sidebarToggleShortcut") == nil {
+            self.sidebarToggleShortcut = "cmd+\\"
+        } else {
+            self.sidebarToggleShortcut = UserDefaults.standard.string(forKey: "sidebarToggleShortcut") ?? ""
+        }
 
         // Load media embed settings from workspace config
         let mediaSettings = Self.loadMediaEmbedSettings(from: configPath)
@@ -527,6 +533,11 @@ public final class SettingsStore: ObservableObject {
         $quickInputHotkeyKeyCode
             .dropFirst()
             .sink { value in UserDefaults.standard.set(value, forKey: "quickInputHotkeyKeyCode") }
+            .store(in: &cancellables)
+
+        $sidebarToggleShortcut
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "sidebarToggleShortcut") }
             .store(in: &cancellables)
 
         // Mirror GatewayConnectionManager's trust-rules-open flag so views can disable their buttons


### PR DESCRIPTION
## Summary
Add a configurable keyboard shortcut (default: Cmd+\) to toggle the sidebar collapsed/expanded state. The shortcut appears in the sidebar button tooltip and is fully configurable (record/unbind) in the Keyboard Shortcuts section of Settings > General > Appearance.

## PRs merged into feature branch
- #20493: Add sidebarToggleShortcut property to SettingsStore and UserDefaults
- #20494: Register Cmd+\ local event monitor to toggle sidebar
- #20495: Display sidebar toggle keyboard shortcut in the sidebar button tooltip
- #20496: Add configurable sidebar toggle shortcut row in Settings > Appearance

## Self-review result
PASS after 1 remediation round fixing 2 gaps:
- #20513: Fix sidebarExpanded default mismatch (UserDefaults.bool returns false for absent keys vs @AppStorage default of true)
- Fix: Use foregroundStyle instead of deprecated foregroundColor for sidebar toggle label

Part of plan: sidebar-collapse-keyboard-shortcut.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
