### PR TITLE
fix: clear service group update pill when SSE reports successful update

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -841,6 +841,7 @@ struct MainWindowView: View {
     private func handleUpdateOutcome(_ outcome: UpdateOutcome) {
         switch outcome.result {
         case .succeeded(let version):
+            AppDelegate.shared?.updateManager.clearServiceGroupFlags()
             windowState.showToast(
                 message: "Assistant updated to \(version)",
                 style: .success,


### PR DESCRIPTION
## Summary
- Call clearServiceGroupFlags() in handleUpdateOutcome for .succeeded case
- Ensures update pill disappears immediately on SSE success

Part of plan: svc-grp-update-ux-4.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
