### PR TITLE
Add log warning when feedback archive file cannot be read

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -287,6 +287,8 @@ enum LogExporter {
             body.append("Content-Type: application/gzip\r\n\r\n".data(using: .utf8)!)
             body.append(archiveData)
             body.append("\r\n".data(using: .utf8)!)
+        } else {
+            log.warning("Failed to read archive at \(archiveURL.path) — submitting feedback without logs")
         }
 
         // Final boundary


### PR DESCRIPTION
## Summary
- Add a `log.warning` when the archive file can't be read during platform feedback upload, so we have visibility into submissions that arrive without logs

## Original prompt
lets add that log warning
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
