### PR TITLE
feat: add Comparable conformance to ParsedVersion for centralized version comparison

### DIFF
--- a/clients/shared/Utilities/VersionCompat.swift
+++ b/clients/shared/Utilities/VersionCompat.swift
@@ -1,10 +1,16 @@
 import Foundation
 
 /// Parsed semantic version components.
-public struct ParsedVersion {
+public struct ParsedVersion: Equatable, Comparable {
     public let major: Int
     public let minor: Int
     public let patch: Int
+
+    public static func < (lhs: ParsedVersion, rhs: ParsedVersion) -> Bool {
+        if lhs.major != rhs.major { return lhs.major < rhs.major }
+        if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
+        return lhs.patch < rhs.patch
+    }
 }
 
 public enum VersionCompat {


### PR DESCRIPTION
## Summary
- Add Equatable and Comparable conformance to ParsedVersion
- Centralizes version comparison logic used across ~6 files

Part of plan: svc-grp-update-ux-4.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
