### PR TITLE
fix: add showFeedbackOption = true to Docker upgrade generic catch block

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -493,6 +493,7 @@ struct AssistantUpgradeSection: View {
             }
         } catch {
             errorMessage = "\(isRollback ? "Roll back" : "Update") failed: \(error.localizedDescription)"
+            showFeedbackOption = true
         }
     }
 


### PR DESCRIPTION
## Summary
- Add showFeedbackOption = true to generic catch in performDockerUpgrade
- Ensures Share Feedback button appears for all error paths

Part of plan: svc-grp-update-ux-4.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
