### PR TITLE
fix: use "downgraded" for managed topology in rollback toast

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -847,8 +847,18 @@ struct MainWindowView: View {
                 autoDismissDelay: 8
             )
         case .rolledBack(_, let to):
+            let verb: String = {
+                let assistants = LockfileAssistant.loadAll()
+                let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+                if let id = connectedId,
+                   let assistant = assistants.first(where: { $0.assistantId == id }),
+                   assistant.isManaged {
+                    return "downgraded"
+                }
+                return "rolled back"
+            }()
             windowState.showToast(
-                message: "Update failed — rolled back to \(to)",
+                message: "Update failed — \(verb) to \(to)",
                 style: .warning,
                 autoDismissDelay: 10
             )


### PR DESCRIPTION
## Summary
- Look up assistant topology in rollback toast handler
- Use 'downgraded' for managed, 'rolled back' for Docker

Part of plan: svc-grp-update-ux-4.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
