### PR TITLE
fix: show neutral "Selected:" label when version picker matches current version

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -217,7 +217,7 @@ struct AssistantUpgradeSection: View {
 
                 if !availableReleases.isEmpty && topology != .remote && topology != .local {
                     HStack(spacing: VSpacing.sm) {
-                        Text(isRollback ? (topology == .managed ? "Downgrade to:" : "Roll back to:") : "Update to:")
+                        Text(!upgradeAvailable ? "Selected:" : isRollback ? (topology == .managed ? "Downgrade to:" : "Roll back to:") : "Update to:")
                             .font(VFont.caption)
                             .foregroundColor(VColor.contentTertiary)
                         Picker("", selection: Binding<String>(


### PR DESCRIPTION
## Summary
- Show 'Selected:' when picker version matches current
- Prevents misleading 'Update to:' label when no upgrade is available

Part of plan: svc-grp-update-ux-4.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
