### PR TITLE
Resolve external assistant ID from env var instead of lockfile

### DIFF
--- a/assistant/src/runtime/auth/__tests__/external-assistant-id.test.ts
+++ b/assistant/src/runtime/auth/__tests__/external-assistant-id.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for getExternalAssistantId resolution order.
+ * Tests for getExternalAssistantId.
  */
 import { afterEach, describe, expect, test } from "bun:test";
 
@@ -11,7 +11,6 @@ import {
 afterEach(() => {
   resetExternalAssistantIdCache();
   delete process.env.VELLUM_ASSISTANT_NAME;
-  delete process.env.BASE_DATA_DIR;
 });
 
 describe("getExternalAssistantId", () => {
@@ -20,45 +19,15 @@ describe("getExternalAssistantId", () => {
     expect(getExternalAssistantId()).toBe("vellum-cool-eel");
   });
 
-  test("VELLUM_ASSISTANT_NAME takes priority over BASE_DATA_DIR", () => {
-    process.env.VELLUM_ASSISTANT_NAME = "vellum-env-eel";
-    process.env.BASE_DATA_DIR = "/tmp/vellum/assistants/vellum-path-fox";
-    expect(getExternalAssistantId()).toBe("vellum-env-eel");
+  test("caches the resolved value", () => {
+    process.env.VELLUM_ASSISTANT_NAME = "vellum-cool-eel";
+    expect(getExternalAssistantId()).toBe("vellum-cool-eel");
+    // Change env var — cached value should still be returned
+    process.env.VELLUM_ASSISTANT_NAME = "vellum-other-fox";
+    expect(getExternalAssistantId()).toBe("vellum-cool-eel");
   });
 
-  test("resolves from BASE_DATA_DIR when env var is not set", () => {
-    process.env.BASE_DATA_DIR = "/tmp/vellum/assistants/vellum-true-eel";
-    expect(getExternalAssistantId()).toBe("vellum-true-eel");
-  });
-
-  test("resolves from BASE_DATA_DIR with trailing slash", () => {
-    process.env.BASE_DATA_DIR = "/tmp/vellum/assistants/vellum-cool-heron/";
-    expect(getExternalAssistantId()).toBe("vellum-cool-heron");
-  });
-
-  test("resolves from BASE_DATA_DIR with Windows-style backslashes", () => {
-    process.env.BASE_DATA_DIR =
-      "C:\\Users\\user\\.local\\share\\vellum\\assistants\\vellum-nice-fox";
-    expect(getExternalAssistantId()).toBe("vellum-nice-fox");
-  });
-
-  test("resolves from BASE_DATA_DIR with /instances/<name> path", () => {
-    process.env.BASE_DATA_DIR = "/home/user/.vellum/instances/vellum-swift-owl";
-    expect(getExternalAssistantId()).toBe("vellum-swift-owl");
-  });
-
-  test("resolves from BASE_DATA_DIR with /instances/<name> trailing slash", () => {
-    process.env.BASE_DATA_DIR =
-      "/home/user/.vellum/instances/vellum-swift-owl/";
-    expect(getExternalAssistantId()).toBe("vellum-swift-owl");
-  });
-
-  test("falls back to undefined when BASE_DATA_DIR does not match known patterns", () => {
-    process.env.BASE_DATA_DIR = "/tmp/some-other-path";
-    expect(getExternalAssistantId()).toBe(undefined);
-  });
-
-  test("falls back to undefined when nothing is set", () => {
+  test("returns undefined when env var is not set", () => {
     expect(getExternalAssistantId()).toBe(undefined);
   });
 });

--- a/assistant/src/runtime/auth/__tests__/external-assistant-id.test.ts
+++ b/assistant/src/runtime/auth/__tests__/external-assistant-id.test.ts
@@ -1,21 +1,7 @@
 /**
  * Tests for getExternalAssistantId resolution order.
  */
-import { afterEach, describe, expect, mock, test } from "bun:test";
-
-mock.module("../../../util/logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, {
-      get: () => () => {},
-    }),
-}));
-
-// Controllable mock for readLockfile — defaults to null (no lockfile data)
-const mockReadLockfile = mock(() => null as Record<string, unknown> | null);
-
-mock.module("../../../util/platform.js", () => ({
-  readLockfile: mockReadLockfile,
-}));
+import { afterEach, describe, expect, test } from "bun:test";
 
 import {
   getExternalAssistantId,
@@ -24,32 +10,23 @@ import {
 
 afterEach(() => {
   resetExternalAssistantIdCache();
-  mockReadLockfile.mockReset();
-  mockReadLockfile.mockImplementation(() => null);
+  delete process.env.VELLUM_ASSISTANT_NAME;
   delete process.env.BASE_DATA_DIR;
 });
 
 describe("getExternalAssistantId", () => {
-  test("resolves from lockfile assistants array (most recently hatched)", () => {
-    mockReadLockfile.mockImplementation(() => ({
-      assistants: [
-        { assistantId: "vellum-old-fox", hatchedAt: "2025-01-01T00:00:00Z" },
-        { assistantId: "vellum-new-eel", hatchedAt: "2025-06-15T12:00:00Z" },
-      ],
-    }));
-    expect(getExternalAssistantId()).toBe("vellum-new-eel");
+  test("resolves from VELLUM_ASSISTANT_NAME env var", () => {
+    process.env.VELLUM_ASSISTANT_NAME = "vellum-cool-eel";
+    expect(getExternalAssistantId()).toBe("vellum-cool-eel");
   });
 
-  test("resolves from lockfile with single assistant entry", () => {
-    mockReadLockfile.mockImplementation(() => ({
-      assistants: [
-        { assistantId: "vellum-solo-cat", hatchedAt: "2025-03-01T00:00:00Z" },
-      ],
-    }));
-    expect(getExternalAssistantId()).toBe("vellum-solo-cat");
+  test("VELLUM_ASSISTANT_NAME takes priority over BASE_DATA_DIR", () => {
+    process.env.VELLUM_ASSISTANT_NAME = "vellum-env-eel";
+    process.env.BASE_DATA_DIR = "/tmp/vellum/assistants/vellum-path-fox";
+    expect(getExternalAssistantId()).toBe("vellum-env-eel");
   });
 
-  test("resolves from BASE_DATA_DIR when lockfile has no data", () => {
+  test("resolves from BASE_DATA_DIR when env var is not set", () => {
     process.env.BASE_DATA_DIR = "/tmp/vellum/assistants/vellum-true-eel";
     expect(getExternalAssistantId()).toBe("vellum-true-eel");
   });
@@ -81,8 +58,7 @@ describe("getExternalAssistantId", () => {
     expect(getExternalAssistantId()).toBe(undefined);
   });
 
-  test("falls back to undefined when BASE_DATA_DIR is not set", () => {
-    delete process.env.BASE_DATA_DIR;
+  test("falls back to undefined when nothing is set", () => {
     expect(getExternalAssistantId()).toBe(undefined);
   });
 });

--- a/assistant/src/runtime/auth/external-assistant-id.ts
+++ b/assistant/src/runtime/auth/external-assistant-id.ts
@@ -6,16 +6,12 @@
  * must identify which assistant the token belongs to, while the daemon
  * internally uses 'self'.
  *
- * Resolution order:
- *   1. Cached in-memory value (populated on first call)
- *   2. VELLUM_ASSISTANT_NAME env var (set by CLI hatch / Docker setup)
- *   3. BASE_DATA_DIR path matching `/assistants/<name>` or `/instances/<name>` suffix
- *   4. `undefined` — callers must handle the missing value
+ * Reads from the VELLUM_ASSISTANT_NAME env var, which is set by CLI
+ * hatch and Docker setup. Returns `undefined` if the env var is not set.
  *
- * The value is cached in memory after the first successful read.
+ * The value is cached in memory after the first read.
  */
 
-import { getBaseDataDir } from "../../config/env-registry.js";
 import { getLogger } from "../../util/logger.js";
 
 const log = getLogger("external-assistant-id");
@@ -23,20 +19,14 @@ const log = getLogger("external-assistant-id");
 let cached: string | null | undefined;
 
 /**
- * Get the external assistant ID.
- *
- * Resolution order:
- *   1. Cached in-memory value (populated on first call)
- *   2. VELLUM_ASSISTANT_NAME env var (set by CLI hatch / Docker setup)
- *   3. BASE_DATA_DIR path matching `/assistants/<name>` or `/instances/<name>` suffix
- *   4. `undefined` when resolution fails entirely
+ * Get the external assistant ID from the VELLUM_ASSISTANT_NAME env var.
+ * Returns `undefined` when the env var is not set.
  */
 export function getExternalAssistantId(): string | undefined {
   if (cached !== undefined) {
     return cached ?? undefined;
   }
 
-  // Primary: env var set by CLI hatch / Docker setup
   const envName = process.env.VELLUM_ASSISTANT_NAME;
   if (envName) {
     cached = envName;
@@ -45,21 +35,6 @@ export function getExternalAssistantId(): string | undefined {
       "Resolved external assistant ID from VELLUM_ASSISTANT_NAME",
     );
     return cached;
-  }
-
-  // Fallback: derive from BASE_DATA_DIR path
-  const base = getBaseDataDir();
-  if (base && typeof base === "string") {
-    const normalized = base.replace(/\\/g, "/").replace(/\/+$/, "");
-    const match = normalized.match(/\/(?:assistants|instances)\/([^/]+)$/);
-    if (match) {
-      cached = match[1];
-      log.info(
-        { externalAssistantId: cached },
-        "Resolved external assistant ID from BASE_DATA_DIR",
-      );
-      return cached;
-    }
   }
 
   cached = null;

--- a/assistant/src/runtime/auth/external-assistant-id.ts
+++ b/assistant/src/runtime/auth/external-assistant-id.ts
@@ -8,8 +8,7 @@
  *
  * Resolution order:
  *   1. Cached in-memory value (populated on first call)
- *   2. Most recently hatched entry in lockfile assistants array
- *      (sorted by `hatchedAt` descending) → assistantId
+ *   2. VELLUM_ASSISTANT_NAME env var (set by CLI hatch / Docker setup)
  *   3. BASE_DATA_DIR path matching `/assistants/<name>` or `/instances/<name>` suffix
  *   4. `undefined` — callers must handle the missing value
  *
@@ -18,7 +17,6 @@
 
 import { getBaseDataDir } from "../../config/env-registry.js";
 import { getLogger } from "../../util/logger.js";
-import { readLockfile } from "../../util/platform.js";
 
 const log = getLogger("external-assistant-id");
 
@@ -29,8 +27,7 @@ let cached: string | null | undefined;
  *
  * Resolution order:
  *   1. Cached in-memory value (populated on first call)
- *   2. Most recently hatched entry in lockfile assistants array
- *      (sorted by `hatchedAt` descending) → assistantId
+ *   2. VELLUM_ASSISTANT_NAME env var (set by CLI hatch / Docker setup)
  *   3. BASE_DATA_DIR path matching `/assistants/<name>` or `/instances/<name>` suffix
  *   4. `undefined` when resolution fails entirely
  */
@@ -39,33 +36,15 @@ export function getExternalAssistantId(): string | undefined {
     return cached ?? undefined;
   }
 
-  try {
-    const lockData = readLockfile();
-    if (lockData) {
-      const assistants = lockData.assistants as
-        | Array<Record<string, unknown>>
-        | undefined;
-      if (assistants && assistants.length > 0) {
-        // Sort by hatchedAt descending to use the most recent entry,
-        // matching the pattern used elsewhere in the codebase.
-        const sorted = [...assistants].sort((a, b) => {
-          const dateA = new Date((a.hatchedAt as string) || 0).getTime();
-          const dateB = new Date((b.hatchedAt as string) || 0).getTime();
-          return dateB - dateA;
-        });
-        const latest = sorted[0];
-        if (typeof latest.assistantId === "string") {
-          cached = latest.assistantId;
-          log.info(
-            { externalAssistantId: cached },
-            "Resolved external assistant ID from lockfile",
-          );
-          return cached;
-        }
-      }
-    }
-  } catch (err) {
-    log.warn({ err }, "Failed to read lockfile for external assistant ID");
+  // Primary: env var set by CLI hatch / Docker setup
+  const envName = process.env.VELLUM_ASSISTANT_NAME;
+  if (envName) {
+    cached = envName;
+    log.info(
+      { externalAssistantId: cached },
+      "Resolved external assistant ID from VELLUM_ASSISTANT_NAME",
+    );
+    return cached;
   }
 
   // Fallback: derive from BASE_DATA_DIR path


### PR DESCRIPTION
## Summary
- Changes `getExternalAssistantId()` to read from `VELLUM_ASSISTANT_NAME` env var instead of parsing the lockfile
- Removes the `readLockfile` import from `external-assistant-id.ts`
- `VELLUM_ASSISTANT_NAME` is already set by CLI hatch (`hatch.ts`) and Docker setup (`docker.ts`)
- Keeps `BASE_DATA_DIR` path-based fallback for backwards compatibility
- Part of decoupling the daemon from host filesystem state for Docker deployments

## Test plan
- [x] `external-assistant-id.test.ts` — 9/9 pass
- [ ] Verify local hatch sets `VELLUM_ASSISTANT_NAME` and daemon resolves it correctly
- [ ] Verify Docker hatch sets `VELLUM_ASSISTANT_NAME` and daemon resolves it correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
