### PR TITLE
feat: add migration to extract feature flags from config to protected directory

### DIFF
--- a/assistant/src/workspace/migrations/016-extract-feature-flags-to-protected.ts
+++ b/assistant/src/workspace/migrations/016-extract-feature-flags-to-protected.ts
@@ -1,0 +1,70 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import { getRootDir } from "../../util/platform.js";
+import type { WorkspaceMigration } from "./types.js";
+
+export const extractFeatureFlagsToProtectedMigration: WorkspaceMigration = {
+  id: "016-extract-feature-flags-to-protected",
+  description:
+    "Move assistantFeatureFlagValues from config.json to ~/.vellum/protected/feature-flags.json",
+
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return; // Malformed config — skip
+    }
+
+    const flagValues = config.assistantFeatureFlagValues as
+      | Record<string, boolean>
+      | undefined;
+    if (
+      !flagValues ||
+      typeof flagValues !== "object" ||
+      Object.keys(flagValues).length === 0
+    ) {
+      return; // Nothing to migrate
+    }
+
+    // Write feature flags to protected directory
+    const protectedDir = join(getRootDir(), "protected");
+    mkdirSync(protectedDir, { recursive: true });
+
+    const featureFlagsPath = join(protectedDir, "feature-flags.json");
+    const featureFlagsContent = JSON.stringify(
+      { version: 1, values: flagValues },
+      null,
+      2,
+    );
+
+    const tmpFeatureFlagsPath = featureFlagsPath + ".tmp";
+    writeFileSync(tmpFeatureFlagsPath, featureFlagsContent + "\n", "utf-8");
+    chmodSync(tmpFeatureFlagsPath, 0o600);
+    renameSync(tmpFeatureFlagsPath, featureFlagsPath);
+
+    // Remove assistantFeatureFlagValues from config.json
+    delete config.assistantFeatureFlagValues;
+
+    const tmpConfigPath = configPath + ".tmp";
+    writeFileSync(
+      tmpConfigPath,
+      JSON.stringify(config, null, 2) + "\n",
+      "utf-8",
+    );
+    renameSync(tmpConfigPath, configPath);
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -11,6 +11,7 @@ import { backfillInstallationIdMigration } from "./011-backfill-installation-id.
 import { renameConversationDiskViewDirsMigration } from "./012-rename-conversation-disk-view-dirs.js";
 import { repairConversationDiskViewMigration } from "./013-repair-conversation-disk-view.js";
 import { migrateCredentialsToKeychainMigration } from "./015-migrate-credentials-to-keychain.js";
+import { extractFeatureFlagsToProtectedMigration } from "./016-extract-feature-flags-to-protected.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -33,4 +34,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   repairConversationDiskViewMigration,
   migrateToWorkspaceVolumeMigration,
   migrateCredentialsToKeychainMigration,
+  extractFeatureFlagsToProtectedMigration,
 ];


### PR DESCRIPTION
## Summary
- Adds workspace migration to move `assistantFeatureFlagValues` from config.json to `~/.vellum/protected/feature-flags.json`
- Uses atomic write pattern (temp + rename) for both writes
- No-op if no flag values exist
- Registers migration in the migration registry

Part of plan: expressive-brewing-scroll.md (PR 6 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
