### PR TITLE
refactor: update daemon feature flag resolver to read from protected directory

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -5,7 +5,7 @@
  * Covers:
  *   - Flag OFF blocks all exposure paths
  *   - Missing persisted value falls back to code default
- *   - New assistantFeatureFlagValues is the sole override mechanism
+ *   - Protected feature-flags.json is the sole override mechanism
  *   - Undeclared keys default to enabled
  */
 import {
@@ -120,8 +120,11 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
 }));
 
 const { buildSystemPrompt } = await import("../prompts/system-prompt.js");
-const { isAssistantFeatureFlagEnabled } =
-  await import("../config/assistant-feature-flags.js");
+const {
+  isAssistantFeatureFlagEnabled,
+  _setOverridesForTesting,
+  clearFeatureFlagOverridesCache,
+} = await import("../config/assistant-feature-flags.js");
 const { skillFlagKey } = await import("../config/skill-state.js");
 
 // ---------------------------------------------------------------------------
@@ -130,6 +133,7 @@ const { skillFlagKey } = await import("../config/skill-state.js");
 
 beforeEach(() => {
   mkdirSync(TEST_DIR, { recursive: true });
+  clearFeatureFlagOverridesCache();
   currentConfig = {
     services: {
       inference: {
@@ -148,6 +152,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  clearFeatureFlagOverridesCache();
   if (existsSync(TEST_DIR)) {
     rmSync(TEST_DIR, { recursive: true, force: true });
   }
@@ -198,11 +203,12 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
       "browser",
     );
 
+    _setOverridesForTesting({
+      [DECLARED_FLAG_KEY]: false,
+      "feature_flags.browser.enabled": true,
+    });
+
     currentConfig = {
-      assistantFeatureFlagValues: {
-        [DECLARED_FLAG_KEY]: false,
-        "feature_flags.browser.enabled": true,
-      },
       services: {
         inference: {
           mode: "your-own",
@@ -282,11 +288,12 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
       "email-channel",
     );
 
+    _setOverridesForTesting({
+      [DECLARED_FLAG_KEY]: false,
+      "feature_flags.email-channel.enabled": false,
+    });
+
     currentConfig = {
-      assistantFeatureFlagValues: {
-        [DECLARED_FLAG_KEY]: false,
-        "feature_flags.email-channel.enabled": false,
-      },
       services: {
         inference: {
           mode: "your-own",
@@ -311,7 +318,7 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
     expect(result).not.toContain("**email-channel**");
   });
 
-  test("assistantFeatureFlagValues overrides control visibility", () => {
+  test("file-based overrides control visibility", () => {
     createSkillOnDisk(
       DECLARED_SKILL_ID,
       "Contacts",
@@ -319,8 +326,9 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
       DECLARED_FLAG_ID,
     );
 
+    _setOverridesForTesting({ [DECLARED_FLAG_KEY]: true });
+
     currentConfig = {
-      assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: true },
       services: {
         inference: {
           mode: "your-own",
@@ -352,8 +360,9 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
       "browser",
     );
 
+    _setOverridesForTesting({ "feature_flags.browser.enabled": false });
+
     currentConfig = {
-      assistantFeatureFlagValues: { "feature_flags.browser.enabled": false },
       services: {
         inference: {
           mode: "your-own",
@@ -446,18 +455,16 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
 // ---------------------------------------------------------------------------
 
 describe("isAssistantFeatureFlagEnabled", () => {
-  test("reads from assistantFeatureFlagValues", () => {
-    const config = {
-      assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: true },
-    } as any;
+  test("reads from file-based overrides", () => {
+    _setOverridesForTesting({ [DECLARED_FLAG_KEY]: true });
+    const config = {} as any;
 
     expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(true);
   });
 
-  test("explicit false override in assistantFeatureFlagValues", () => {
-    const config = {
-      assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: false },
-    } as any;
+  test("explicit false override in file-based overrides", () => {
+    _setOverridesForTesting({ [DECLARED_FLAG_KEY]: false });
+    const config = {} as any;
 
     expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(
       false,
@@ -483,10 +490,9 @@ describe("isAssistantFeatureFlagEnabled", () => {
     ).toBe(true);
   });
 
-  test("undeclared flag respects persisted canonical override", () => {
-    const config = {
-      assistantFeatureFlagValues: { "feature_flags.browser.enabled": false },
-    } as any;
+  test("undeclared flag respects persisted override", () => {
+    _setOverridesForTesting({ "feature_flags.browser.enabled": false });
+    const config = {} as any;
 
     expect(
       isAssistantFeatureFlagEnabled("feature_flags.browser.enabled", config),
@@ -496,9 +502,8 @@ describe("isAssistantFeatureFlagEnabled", () => {
 
 describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
   test("resolves skill flag via canonical path", () => {
-    const config = {
-      assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: false },
-    } as any;
+    _setOverridesForTesting({ [DECLARED_FLAG_KEY]: false });
+    const config = {} as any;
 
     expect(
       isAssistantFeatureFlagEnabled(

--- a/assistant/src/__tests__/credential-execution-feature-gates.test.ts
+++ b/assistant/src/__tests__/credential-execution-feature-gates.test.ts
@@ -8,9 +8,13 @@
  *   behavior or existing feature flags.
  */
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import {
+  _setOverridesForTesting,
+  clearFeatureFlagOverridesCache,
+  isAssistantFeatureFlagEnabled,
+} from "../config/assistant-feature-flags.js";
 import type { AssistantConfig } from "../config/schema.js";
 import {
   CES_GRANT_AUDIT_FLAG_KEY,
@@ -25,15 +29,17 @@ import {
   isCesToolsEnabled,
 } from "../credential-execution/feature-gates.js";
 
+afterEach(() => {
+  clearFeatureFlagOverridesCache();
+});
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Create a minimal AssistantConfig with optional feature flag values. */
-function makeConfig(flagOverrides?: Record<string, boolean>): AssistantConfig {
-  return {
-    ...(flagOverrides ? { assistantFeatureFlagValues: flagOverrides } : {}),
-  } as AssistantConfig;
+/** Create a minimal AssistantConfig (flag overrides are now set via _setOverridesForTesting). */
+function makeConfig(): AssistantConfig {
+  return {} as AssistantConfig;
 }
 
 /** All CES flag keys for iteration. */
@@ -87,16 +93,16 @@ describe("CES flag key format", () => {
 // ---------------------------------------------------------------------------
 
 describe("CES flags default safely (all disabled)", () => {
-  const config = makeConfig();
-
   for (const { name, fn } of ALL_CES_PREDICATES) {
     test(`${name} returns false with no config overrides`, () => {
+      const config = makeConfig();
       expect(fn(config)).toBe(false);
     });
   }
 
   for (const key of ALL_CES_FLAG_KEYS) {
     test(`isAssistantFeatureFlagEnabled('${key}') returns false with no overrides`, () => {
+      const config = makeConfig();
       expect(isAssistantFeatureFlagEnabled(key, config)).toBe(false);
     });
   }
@@ -109,12 +115,14 @@ describe("CES flags default safely (all disabled)", () => {
 describe("CES flags can be enabled independently", () => {
   for (const { name, fn, key } of ALL_CES_PREDICATES) {
     test(`enabling ${key} makes ${name} return true`, () => {
-      const config = makeConfig({ [key]: true });
+      _setOverridesForTesting({ [key]: true });
+      const config = makeConfig();
       expect(fn(config)).toBe(true);
     });
 
     test(`enabling ${key} does not enable other CES flags`, () => {
-      const config = makeConfig({ [key]: true });
+      _setOverridesForTesting({ [key]: true });
+      const config = makeConfig();
       for (const { fn: otherFn, key: otherKey } of ALL_CES_PREDICATES) {
         if (otherKey === key) continue;
         expect(otherFn(config)).toBe(false);
@@ -130,7 +138,8 @@ describe("CES flags can be enabled independently", () => {
 describe("CES flags respect explicit false overrides", () => {
   for (const { name, fn, key } of ALL_CES_PREDICATES) {
     test(`${name} returns false when explicitly set to false`, () => {
-      const config = makeConfig({ [key]: false });
+      _setOverridesForTesting({ [key]: false });
+      const config = makeConfig();
       expect(fn(config)).toBe(false);
     });
   }
@@ -146,7 +155,8 @@ describe("CES flags do not affect unrelated flags", () => {
     for (const key of ALL_CES_FLAG_KEYS) {
       overrides[key] = true;
     }
-    const config = makeConfig(overrides);
+    _setOverridesForTesting(overrides);
+    const config = makeConfig();
 
     // browser defaults to true in the registry and should stay true
     expect(
@@ -159,7 +169,8 @@ describe("CES flags do not affect unrelated flags", () => {
     for (const key of ALL_CES_FLAG_KEYS) {
       overrides[key] = true;
     }
-    const config = makeConfig(overrides);
+    _setOverridesForTesting(overrides);
+    const config = makeConfig();
 
     // contacts defaults to true in the registry and should stay true
     expect(

--- a/assistant/src/__tests__/credential-execution-managed-contract.test.ts
+++ b/assistant/src/__tests__/credential-execution-managed-contract.test.ts
@@ -26,7 +26,16 @@
  * contracts — no real CES process or socket dependencies are needed.
  */
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  _setOverridesForTesting,
+  clearFeatureFlagOverridesCache,
+} from "../config/assistant-feature-flags.js";
+
+afterEach(() => {
+  clearFeatureFlagOverridesCache();
+});
 
 import {
   CES_PROTOCOL_VERSION,
@@ -58,11 +67,9 @@ import {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Create a minimal AssistantConfig with optional feature flag values. */
-function makeConfig(flagOverrides?: Record<string, boolean>): AssistantConfig {
-  return {
-    ...(flagOverrides ? { assistantFeatureFlagValues: flagOverrides } : {}),
-  } as AssistantConfig;
+/** Create a minimal AssistantConfig (flag overrides are now set via _setOverridesForTesting). */
+function makeConfig(): AssistantConfig {
+  return {} as AssistantConfig;
 }
 
 // ---------------------------------------------------------------------------
@@ -444,32 +451,36 @@ describe("feature-flag rollback safety", () => {
   });
 
   test("managed sidecar flag can be explicitly enabled", () => {
-    const config = makeConfig({
+    _setOverridesForTesting({
       "feature_flags.ces-managed-sidecar.enabled": true,
     });
+    const config = makeConfig();
     expect(isCesManagedSidecarEnabled(config)).toBe(true);
   });
 
   test("managed sidecar flag can be explicitly disabled", () => {
-    const config = makeConfig({
+    _setOverridesForTesting({
       "feature_flags.ces-managed-sidecar.enabled": false,
     });
+    const config = makeConfig();
     expect(isCesManagedSidecarEnabled(config)).toBe(false);
   });
 
   test("enabling managed sidecar does not enable CES tools", () => {
-    const config = makeConfig({
+    _setOverridesForTesting({
       "feature_flags.ces-managed-sidecar.enabled": true,
     });
+    const config = makeConfig();
     // CES tools flag should remain independently controlled
     expect(isCesToolsEnabled(config)).toBe(false);
   });
 
   test("disabling managed sidecar does not affect other CES flags", () => {
-    const config = makeConfig({
+    _setOverridesForTesting({
       "feature_flags.ces-managed-sidecar.enabled": false,
       "feature_flags.ces-tools.enabled": true,
     });
+    const config = makeConfig();
     expect(isCesToolsEnabled(config)).toBe(true);
   });
 });
@@ -480,10 +491,11 @@ describe("feature-flag rollback safety", () => {
 
 describe("process manager config wiring", () => {
   test("CesProcessManagerConfig accepts assistantConfig for flag gating", () => {
+    _setOverridesForTesting({
+      "feature_flags.ces-managed-sidecar.enabled": true,
+    });
     const config: CesProcessManagerConfig = {
-      assistantConfig: makeConfig({
-        "feature_flags.ces-managed-sidecar.enabled": true,
-      }),
+      assistantConfig: makeConfig(),
     };
     expect(config.assistantConfig).toBeDefined();
     expect(isCesManagedSidecarEnabled(config.assistantConfig!)).toBe(true);
@@ -491,16 +503,17 @@ describe("process manager config wiring", () => {
 
   test("CesProcessManagerConfig requires assistantConfig for feature-flag gate", () => {
     const config: CesProcessManagerConfig = {
-      assistantConfig: makeConfig({}),
+      assistantConfig: makeConfig(),
     };
     expect(config.assistantConfig).toBeDefined();
   });
 
   test("when flag is off, managed discovery is skipped", () => {
+    _setOverridesForTesting({
+      "feature_flags.ces-managed-sidecar.enabled": false,
+    });
     const config: CesProcessManagerConfig = {
-      assistantConfig: makeConfig({
-        "feature_flags.ces-managed-sidecar.enabled": false,
-      }),
+      assistantConfig: makeConfig(),
     };
     // The managed path should be gated
     expect(isCesManagedSidecarEnabled(config.assistantConfig!)).toBe(false);
@@ -513,9 +526,10 @@ describe("process manager config wiring", () => {
 
 describe("non-CES internal consumers intact when flag is off", () => {
   test("existing non-agent flows are unaffected by managed sidecar flag", () => {
-    const config = makeConfig({
+    _setOverridesForTesting({
       "feature_flags.ces-managed-sidecar.enabled": false,
     });
+    const config = makeConfig();
     expect(isCesManagedSidecarEnabled(config)).toBe(false);
   });
 

--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -846,12 +846,12 @@ describe("host_bash — proxy delegation", () => {
   });
 
   test("propagates VELLUM_UNTRUSTED_SHELL env to proxy under CES lockdown", async () => {
-    // Enable CES shell lockdown
-    const origFlags = (mockConfig as Record<string, unknown>)
-      .assistantFeatureFlagValues;
-    (mockConfig as Record<string, unknown>).assistantFeatureFlagValues = {
+    // Enable CES shell lockdown via the override cache
+    const { _setOverridesForTesting, clearFeatureFlagOverridesCache } =
+      await import("../config/assistant-feature-flags.js");
+    _setOverridesForTesting({
       "feature_flags.ces-shell-lockdown.enabled": true,
-    };
+    });
 
     try {
       const proxyResult: ToolExecutionResult = {
@@ -875,8 +875,7 @@ describe("host_bash — proxy delegation", () => {
       expect(calls.length).toBe(1);
       expect(calls[0].input.env).toEqual({ VELLUM_UNTRUSTED_SHELL: "1" });
     } finally {
-      (mockConfig as Record<string, unknown>).assistantFeatureFlagValues =
-        origFlags;
+      clearFeatureFlagOverridesCache();
     }
   });
 

--- a/assistant/src/__tests__/inline-skill-load-permissions.test.ts
+++ b/assistant/src/__tests__/inline-skill-load-permissions.test.ts
@@ -18,6 +18,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
+
 // ── Mock setup (must be before any imports from the project) ──────────────
 
 const testDir = mkdtempSync(join(tmpdir(), "inline-skill-perm-test-"));
@@ -46,7 +48,6 @@ interface TestConfig {
   permissions: { mode: "strict" | "workspace" };
   skills: { load: { extraDirs: string[] } };
   sandbox: { enabled: boolean };
-  assistantFeatureFlagValues?: Record<string, boolean>;
   [key: string]: unknown;
 }
 
@@ -54,9 +55,6 @@ const testConfig: TestConfig = {
   permissions: { mode: "workspace" },
   skills: { load: { extraDirs: [] } },
   sandbox: { enabled: true },
-  assistantFeatureFlagValues: {
-    "feature_flags.inline-skill-commands.enabled": true,
-  },
 };
 
 mock.module("../config/loader.js", () => ({
@@ -118,9 +116,9 @@ describe("inline-command skill_load permissions", () => {
     clearCache();
     testConfig.permissions = { mode: "workspace" };
     testConfig.skills = { load: { extraDirs: [] } };
-    testConfig.assistantFeatureFlagValues = {
+    _setOverridesForTesting({
       "feature_flags.inline-skill-commands.enabled": true,
-    };
+    });
     try {
       rmSync(join(testDir, "protected", "trust.json"));
     } catch {
@@ -352,9 +350,9 @@ describe("inline-command skill_load permissions", () => {
       writeDynamicSkill("dynamic-flag-off", "Dynamic Flag Off Skill");
 
       // Disable the feature flag
-      testConfig.assistantFeatureFlagValues = {
+      _setOverridesForTesting({
         "feature_flags.inline-skill-commands.enabled": false,
-      };
+      });
 
       const result = await check(
         "skill_load",

--- a/assistant/src/__tests__/skill-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags-integration.test.ts
@@ -5,9 +5,17 @@
  * parses it via the real frontmatter parser, and verifies that `skillFlagKey()`
  * returns the correct key and `resolveSkillStates()` correctly gates the skill.
  */
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import {
+  _setOverridesForTesting,
+  clearFeatureFlagOverridesCache,
+  isAssistantFeatureFlagEnabled,
+} from "../config/assistant-feature-flags.js";
+
+afterEach(() => {
+  clearFeatureFlagOverridesCache();
+});
 import type { AssistantConfig } from "../config/schema.js";
 import { resolveSkillStates, skillFlagKey } from "../config/skill-state.js";
 import type { SkillSummary } from "../config/skills.js";
@@ -150,12 +158,11 @@ describe("frontmatter feature-flag integration", () => {
   });
 
   test("resolveSkillStates includes skill with featureFlag when flag is ON", () => {
-    const skill = buildSkillSummary("contacts", SKILL_MD_WITH_FLAG)!;
-    const config = makeConfig({
-      assistantFeatureFlagValues: {
-        "feature_flags.contacts.enabled": true,
-      },
+    _setOverridesForTesting({
+      "feature_flags.contacts.enabled": true,
     });
+    const skill = buildSkillSummary("contacts", SKILL_MD_WITH_FLAG)!;
+    const config = makeConfig();
 
     const resolved = resolveSkillStates([skill], config);
     expect(resolved.length).toBe(1);
@@ -165,11 +172,10 @@ describe("frontmatter feature-flag integration", () => {
   test("resolveSkillStates never gates skill without featureFlag", () => {
     const skill = buildSkillSummary("plain-skill", SKILL_MD_WITHOUT_FLAG)!;
     // Even with an explicit false override for this skill ID, it should pass through
-    const config = makeConfig({
-      assistantFeatureFlagValues: {
-        "feature_flags.plain-skill.enabled": false,
-      },
+    _setOverridesForTesting({
+      "feature_flags.plain-skill.enabled": false,
     });
+    const config = makeConfig();
 
     const resolved = resolveSkillStates([skill], config);
     expect(resolved.length).toBe(1);
@@ -203,9 +209,8 @@ describe("frontmatter feature-flag integration", () => {
     expect(resolvedDefault[0].summary.id).toBe("contacts");
 
     // Step 6: With override disabled, skill is filtered out
-    const configOff = makeConfig({
-      assistantFeatureFlagValues: { [key!]: false },
-    });
+    _setOverridesForTesting({ [key!]: false });
+    const configOff = makeConfig();
     expect(isAssistantFeatureFlagEnabled(key!, configOff)).toBe(false);
 
     const resolvedOff = resolveSkillStates([skill], configOff);

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -1,9 +1,17 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import {
+  _setOverridesForTesting,
+  clearFeatureFlagOverridesCache,
+  isAssistantFeatureFlagEnabled,
+} from "../config/assistant-feature-flags.js";
 import type { AssistantConfig } from "../config/schema.js";
 import { resolveSkillStates, skillFlagKey } from "../config/skill-state.js";
 import type { SkillSummary } from "../config/skills.js";
+
+afterEach(() => {
+  clearFeatureFlagOverridesCache();
+});
 
 const DECLARED_FLAG_ID = "contacts";
 const DECLARED_FLAG_KEY = `feature_flags.${DECLARED_FLAG_ID}.enabled`;
@@ -92,9 +100,8 @@ describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
   });
 
   test("returns true when skill key is explicitly true", () => {
-    const config = makeConfig({
-      assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: true },
-    });
+    _setOverridesForTesting({ [DECLARED_FLAG_KEY]: true });
+    const config = makeConfig();
     expect(
       isAssistantFeatureFlagEnabled(
         skillFlagKey({ featureFlag: DECLARED_FLAG_ID })!,
@@ -104,9 +111,8 @@ describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
   });
 
   test("returns false when skill key is explicitly false", () => {
-    const config = makeConfig({
-      assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: false },
-    });
+    _setOverridesForTesting({ [DECLARED_FLAG_KEY]: false });
+    const config = makeConfig();
     expect(
       isAssistantFeatureFlagEnabled(
         skillFlagKey({ featureFlag: DECLARED_FLAG_ID })!,
@@ -128,11 +134,9 @@ describe("isAssistantFeatureFlagEnabled", () => {
     ).toBe(true);
   });
 
-  test("assistantFeatureFlagValues overrides registry default", () => {
-    const config = {
-      ...makeConfig(),
-      assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: false },
-    } as AssistantConfig;
+  test("file-based override overrides registry default", () => {
+    _setOverridesForTesting({ [DECLARED_FLAG_KEY]: false });
+    const config = makeConfig();
     expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(
       false,
     );
@@ -145,9 +149,8 @@ describe("isAssistantFeatureFlagEnabled", () => {
   });
 
   test("respects persisted overrides for undeclared keys", () => {
-    const config = makeConfig({
-      assistantFeatureFlagValues: { "feature_flags.browser.enabled": false },
-    });
+    _setOverridesForTesting({ "feature_flags.browser.enabled": false });
+    const config = makeConfig();
     expect(
       isAssistantFeatureFlagEnabled("feature_flags.browser.enabled", config),
     ).toBe(false);
@@ -168,16 +171,15 @@ describe("isAssistantFeatureFlagEnabled", () => {
 
 describe("resolveSkillStates with feature flags", () => {
   test("flag OFF skill does not appear in resolved list", () => {
+    _setOverridesForTesting({
+      [DECLARED_FLAG_KEY]: false,
+      "feature_flags.browser.enabled": true,
+    });
     const catalog = [
       makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID),
       makeSkill("browser", "bundled", "browser"),
     ];
-    const config = makeConfig({
-      assistantFeatureFlagValues: {
-        [DECLARED_FLAG_KEY]: false,
-        "feature_flags.browser.enabled": true,
-      },
-    });
+    const config = makeConfig();
 
     const resolved = resolveSkillStates(catalog, config);
     const ids = resolved.map((r) => r.summary.id);
@@ -187,16 +189,15 @@ describe("resolveSkillStates with feature flags", () => {
   });
 
   test("flag ON skill appears normally", () => {
+    _setOverridesForTesting({
+      [DECLARED_FLAG_KEY]: true,
+      "feature_flags.browser.enabled": true,
+    });
     const catalog = [
       makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID),
       makeSkill("browser", "bundled", "browser"),
     ];
-    const config = makeConfig({
-      assistantFeatureFlagValues: {
-        [DECLARED_FLAG_KEY]: true,
-        "feature_flags.browser.enabled": true,
-      },
-    });
+    const config = makeConfig();
 
     const resolved = resolveSkillStates(catalog, config);
     const ids = resolved.map((r) => r.summary.id);
@@ -227,9 +228,9 @@ describe("resolveSkillStates with feature flags", () => {
   });
 
   test("feature flag OFF takes precedence over user-enabled config entry", () => {
+    _setOverridesForTesting({ [DECLARED_FLAG_KEY]: false });
     const catalog = [makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID)];
     const config = makeConfig({
-      assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: false },
       skills: {
         entries: { [DECLARED_SKILL_ID]: { enabled: true } },
         load: { extraDirs: [], watch: true, watchDebounceMs: 250 },
@@ -253,18 +254,17 @@ describe("resolveSkillStates with feature flags", () => {
   });
 
   test("multiple skills with mixed flags — persisted overrides respected", () => {
+    _setOverridesForTesting({
+      [DECLARED_FLAG_KEY]: false,
+      "feature_flags.browser.enabled": true,
+      "feature_flags.deploy.enabled": false,
+    });
     const catalog = [
       makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID),
       makeSkill("browser", "bundled", "browser"),
       makeSkill("deploy", "bundled", "deploy"),
     ];
-    const config = makeConfig({
-      assistantFeatureFlagValues: {
-        [DECLARED_FLAG_KEY]: false,
-        "feature_flags.browser.enabled": true,
-        "feature_flags.deploy.enabled": false,
-      },
-    });
+    const config = makeConfig();
 
     const resolved = resolveSkillStates(catalog, config);
     const ids = resolved.map((r) => r.summary.id);
@@ -290,11 +290,10 @@ describe("resolveSkillStates with frontmatter featureFlag", () => {
     expect(resolved[0].summary.id).toBe(DECLARED_SKILL_ID);
   });
 
-  test("skill with featureFlag is included when config override enables it", () => {
+  test("skill with featureFlag is included when override enables it", () => {
+    _setOverridesForTesting({ [DECLARED_FLAG_KEY]: true });
     const catalog = [makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID)];
-    const config = makeConfig({
-      assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: true },
-    });
+    const config = makeConfig();
 
     const resolved = resolveSkillStates(catalog, config);
     const ids = resolved.map((r) => r.summary.id);
@@ -316,12 +315,11 @@ describe("resolveSkillStates with frontmatter featureFlag", () => {
     // This proves the implicit skillId→flag mapping is gone:
     // setting feature_flags.my-skill.enabled = false has no effect
     // when the skill itself does not declare a featureFlag.
-    const catalog = [makeSkill("my-skill")];
-    const config = makeConfig({
-      assistantFeatureFlagValues: {
-        "feature_flags.my-skill.enabled": false,
-      },
+    _setOverridesForTesting({
+      "feature_flags.my-skill.enabled": false,
     });
+    const catalog = [makeSkill("my-skill")];
+    const config = makeConfig();
 
     const resolved = resolveSkillStates(catalog, config);
     const ids = resolved.map((r) => r.summary.id);

--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -7,6 +7,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import {
+  _setOverridesForTesting,
+  clearFeatureFlagOverridesCache,
+} from "../config/assistant-feature-flags.js";
+
 const TEST_DIR = join(
   tmpdir(),
   `vellum-skill-load-flag-test-${crypto.randomUUID()}`,
@@ -113,9 +118,11 @@ describe("skill_load feature flag enforcement", () => {
   beforeEach(() => {
     mkdirSync(join(TEST_DIR, "skills"), { recursive: true });
     currentConfig = {};
+    clearFeatureFlagOverridesCache();
   });
 
   afterEach(() => {
+    clearFeatureFlagOverridesCache();
     if (existsSync(TEST_DIR)) {
       rmSync(TEST_DIR, { recursive: true, force: true });
     }
@@ -133,9 +140,7 @@ describe("skill_load feature flag enforcement", () => {
       `- ${DECLARED_SKILL_ID}\n`,
     );
 
-    currentConfig = {
-      assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: false },
-    };
+    _setOverridesForTesting({ [DECLARED_FLAG_KEY]: false });
 
     const result = await executeSkillLoad({ skill: DECLARED_SKILL_ID });
 
@@ -156,9 +161,7 @@ describe("skill_load feature flag enforcement", () => {
       `- ${DECLARED_SKILL_ID}\n`,
     );
 
-    currentConfig = {
-      assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: true },
-    };
+    _setOverridesForTesting({ [DECLARED_FLAG_KEY]: true });
 
     const result = await executeSkillLoad({ skill: DECLARED_SKILL_ID });
 
@@ -178,9 +181,7 @@ describe("skill_load feature flag enforcement", () => {
       `- ${DECLARED_SKILL_ID}\n`,
     );
 
-    currentConfig = {
-      assistantFeatureFlagValues: {},
-    };
+    // No overrides — uses registry defaults
 
     const result = await executeSkillLoad({ skill: DECLARED_SKILL_ID });
 

--- a/assistant/src/__tests__/skill-load-inline-command.test.ts
+++ b/assistant/src/__tests__/skill-load-inline-command.test.ts
@@ -21,6 +21,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
+
 // ── Test directory ────────────────────────────────────────────────────────────
 
 const TEST_DIR = mkdtempSync(
@@ -127,7 +129,6 @@ interface TestConfig {
   permissions: { mode: "strict" | "workspace" };
   skills: { load: { extraDirs: string[] } };
   sandbox: { enabled: boolean };
-  assistantFeatureFlagValues?: Record<string, boolean>;
   [key: string]: unknown;
 }
 
@@ -135,9 +136,6 @@ const testConfig: TestConfig = {
   permissions: { mode: "workspace" },
   skills: { load: { extraDirs: [] } },
   sandbox: { enabled: true },
-  assistantFeatureFlagValues: {
-    "feature_flags.inline-skill-commands.enabled": true,
-  },
 };
 
 mock.module("../config/loader.js", () => ({
@@ -215,9 +213,9 @@ describe("skill_load inline command expansion", () => {
     }));
 
     // Enable the feature flag
-    testConfig.assistantFeatureFlagValues = {
+    _setOverridesForTesting({
       "feature_flags.inline-skill-commands.enabled": true,
-    };
+    });
     testConfig.skills = { load: { extraDirs: [] } };
   });
 
@@ -316,9 +314,9 @@ describe("skill_load inline command expansion", () => {
 
   describe("feature flag disabled", () => {
     test("returns error when flag is off and skill has inline commands", async () => {
-      testConfig.assistantFeatureFlagValues = {
+      _setOverridesForTesting({
         "feature_flags.inline-skill-commands.enabled": false,
-      };
+      });
 
       writeSkill(
         "flagged-off-skill",
@@ -337,9 +335,9 @@ describe("skill_load inline command expansion", () => {
     });
 
     test("plain skill still loads when flag is off", async () => {
-      testConfig.assistantFeatureFlagValues = {
+      _setOverridesForTesting({
         "feature_flags.inline-skill-commands.enabled": false,
-      };
+      });
 
       writeSkill(
         "plain-flag-off",

--- a/assistant/src/__tests__/skill-load-inline-includes.test.ts
+++ b/assistant/src/__tests__/skill-load-inline-includes.test.ts
@@ -23,6 +23,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
+
 // ── Test directory ────────────────────────────────────────────────────────────
 
 const TEST_DIR = mkdtempSync(
@@ -129,7 +131,6 @@ interface TestConfig {
   permissions: { mode: "strict" | "workspace" };
   skills: { load: { extraDirs: string[] } };
   sandbox: { enabled: boolean };
-  assistantFeatureFlagValues?: Record<string, boolean>;
   [key: string]: unknown;
 }
 
@@ -137,9 +138,6 @@ const testConfig: TestConfig = {
   permissions: { mode: "workspace" },
   skills: { load: { extraDirs: [] } },
   sandbox: { enabled: true },
-  assistantFeatureFlagValues: {
-    "feature_flags.inline-skill-commands.enabled": true,
-  },
 };
 
 mock.module("../config/loader.js", () => ({
@@ -225,9 +223,9 @@ describe("skill_load inline command expansion for included skills", () => {
     }));
 
     // Enable the feature flag
-    testConfig.assistantFeatureFlagValues = {
+    _setOverridesForTesting({
       "feature_flags.inline-skill-commands.enabled": true,
-    };
+    });
     testConfig.skills = { load: { extraDirs: [] } };
   });
 
@@ -575,9 +573,9 @@ describe("skill_load inline command expansion for included skills", () => {
 
   describe("feature flag disabled for included skills", () => {
     test("skill_load returns error when child has inline commands and flag is off", async () => {
-      testConfig.assistantFeatureFlagValues = {
+      _setOverridesForTesting({
         "feature_flags.inline-skill-commands.enabled": false,
-      };
+      });
 
       writeSkill(
         "child-flag-off",

--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -5,7 +5,8 @@
  * `meta/feature-flags/feature-flag-registry.json` and resolves the effective
  * enabled/disabled state for each declared assistant-scope flag by consulting
  * (in priority order):
- *   1. `config.assistantFeatureFlagValues[key]`  (explicit override)
+ *   1. Override values from `~/.vellum/protected/feature-flags.json` (local)
+ *      or via the gateway HTTP API (Docker/containerized)
  *   2. defaults registry `defaultEnabled`         (for declared keys)
  *   3. `true`                                     (for undeclared keys)
  *
@@ -14,8 +15,10 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
+import { getBaseDataDir, getIsContainerized } from "./env-registry.js";
 import type { AssistantConfig } from "./schema.js";
 
 // ---------------------------------------------------------------------------
@@ -106,6 +109,178 @@ function parseRegistryToDefaults(parsed: unknown): FeatureFlagDefaultsRegistry {
 }
 
 // ---------------------------------------------------------------------------
+// Override loading — reads from protected directory or gateway HTTP
+// ---------------------------------------------------------------------------
+
+/**
+ * Module-level cache of feature flag override values. Populated lazily on
+ * first access, invalidated by `clearFeatureFlagOverridesCache()`.
+ */
+let cachedOverrides: Record<string, boolean> | null = null;
+
+/**
+ * File format for `~/.vellum/protected/feature-flags.json`, matching the
+ * gateway's feature-flag-store.ts schema.
+ */
+interface FeatureFlagFileData {
+  version: 1;
+  values: Record<string, boolean>;
+}
+
+/**
+ * Resolve the path to the feature flag overrides file.
+ *
+ * Docker: `GATEWAY_SECURITY_DIR/feature-flags.json`
+ * Local:  `~/.vellum/protected/feature-flags.json`
+ *
+ * Uses `BASE_DATA_DIR` when set (multi-instance mode) so per-instance
+ * feature flag files are correctly scoped.
+ */
+function getFeatureFlagOverridesPath(): string {
+  const securityDir = process.env.GATEWAY_SECURITY_DIR;
+  if (securityDir) {
+    return join(securityDir, "feature-flags.json");
+  }
+  const root = join(getBaseDataDir() || homedir(), ".vellum");
+  return join(root, "protected", "feature-flags.json");
+}
+
+/**
+ * Load override values from the protected feature-flags.json file.
+ * Returns an empty record if the file doesn't exist or is malformed.
+ */
+function loadOverridesFromFile(): Record<string, boolean> {
+  const path = getFeatureFlagOverridesPath();
+  if (!existsSync(path)) return {};
+
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const data = JSON.parse(raw) as FeatureFlagFileData;
+    if (data.version !== 1) return {};
+    if (
+      data.values &&
+      typeof data.values === "object" &&
+      !Array.isArray(data.values)
+    ) {
+      return { ...data.values };
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Load override values from the gateway via synchronous HTTP call.
+ *
+ * Follows the trust-client pattern: uses `Bun.spawnSync` + `curl` to make
+ * a blocking GET request to the gateway's feature-flags endpoint. The
+ * gateway returns `{ flags: Array<{ key, enabled, ... }> }` and we extract
+ * just the key → enabled map.
+ */
+function loadOverridesFromGateway(): Record<string, boolean> {
+  try {
+    // Lazy-import to avoid circular dependency and keep this module
+    // importable from bootstrap code when not in containerized mode.
+    const { getGatewayInternalBaseUrl } =
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require("./env.js") as typeof import("./env.js");
+    const { mintEdgeRelayToken } =
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require("../runtime/auth/token-service.js") as typeof import("../runtime/auth/token-service.js");
+
+    const url = `${getGatewayInternalBaseUrl()}/v1/feature-flags`;
+    const token = mintEdgeRelayToken();
+
+    const proc = Bun.spawnSync(
+      [
+        "curl",
+        "-s",
+        "-S",
+        "-X",
+        "GET",
+        "--max-time",
+        "10",
+        "-H",
+        `Authorization: Bearer ${token}`,
+        "-H",
+        "Accept: application/json",
+        "-w",
+        "\n%{http_code}",
+        url,
+      ],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+
+    if (proc.exitCode !== 0) return {};
+
+    const output = proc.stdout.toString().trim();
+    const lastNewline = output.lastIndexOf("\n");
+    const responseBody = lastNewline >= 0 ? output.slice(0, lastNewline) : "";
+    const statusCode = parseInt(
+      lastNewline >= 0 ? output.slice(lastNewline + 1) : output,
+      10,
+    );
+
+    if (statusCode < 200 || statusCode >= 300) return {};
+    if (!responseBody) return {};
+
+    const parsed = JSON.parse(responseBody) as {
+      flags?: Array<{ key: string; enabled: boolean }>;
+    };
+    if (!Array.isArray(parsed.flags)) return {};
+
+    const result: Record<string, boolean> = {};
+    for (const entry of parsed.flags) {
+      if (typeof entry.key === "string" && typeof entry.enabled === "boolean") {
+        result[entry.key] = entry.enabled;
+      }
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Load overrides from the appropriate source based on runtime mode.
+ * Results are cached at module level.
+ */
+function loadOverrides(): Record<string, boolean> {
+  if (cachedOverrides != null) return cachedOverrides;
+
+  cachedOverrides = getIsContainerized()
+    ? loadOverridesFromGateway()
+    : loadOverridesFromFile();
+
+  return cachedOverrides;
+}
+
+/**
+ * Invalidate the cached override values so the next call to
+ * `isAssistantFeatureFlagEnabled` re-reads from the source.
+ *
+ * Called by the config watcher when the feature-flags file changes.
+ */
+export function clearFeatureFlagOverridesCache(): void {
+  cachedOverrides = null;
+}
+
+/**
+ * Directly inject override values into the module-level cache.
+ *
+ * **Test-only** — bypasses file/gateway loading so unit tests can control
+ * flag state without writing to disk. Production code should never call this;
+ * use `clearFeatureFlagOverridesCache()` instead and let the resolver
+ * re-read from the appropriate source.
+ */
+export function _setOverridesForTesting(
+  overrides: Record<string, boolean>,
+): void {
+  cachedOverrides = { ...overrides };
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -113,19 +288,21 @@ function parseRegistryToDefaults(parsed: unknown): FeatureFlagDefaultsRegistry {
  * Resolve whether an assistant feature flag is enabled.
  *
  * Resolution order:
- *   1. `config.assistantFeatureFlagValues[key]`  (explicit override)
+ *   1. Override from `~/.vellum/protected/feature-flags.json` (local) or
+ *      gateway HTTP (Docker/containerized)
  *   2. defaults registry `defaultEnabled`         (for declared assistant-scope keys)
  *   3. `true`                                     (for undeclared keys with no override)
  */
 export function isAssistantFeatureFlagEnabled(
   key: string,
-  config: AssistantConfig,
+  _config: AssistantConfig,
 ): boolean {
   const defaults = loadDefaultsRegistry();
   const declared = defaults[key];
+  const overrides = loadOverrides();
 
-  // 1. Check config overrides
-  const explicit = config.assistantFeatureFlagValues?.[key];
+  // 1. Check overrides from protected feature-flags file / gateway
+  const explicit = overrides[key];
   if (typeof explicit === "boolean") return explicit;
 
   // 2. For declared keys, use the registry default


### PR DESCRIPTION
## Summary
- Changes daemon feature flag resolver to read overrides from `~/.vellum/protected/feature-flags.json` instead of `config.assistantFeatureFlagValues`
- Adds Docker mode support via gateway HTTP (following trust-client pattern)
- Adds module-level caching with `clearFeatureFlagOverridesCache()` export
- Keeps existing function signature for backward compatibility

Part of plan: expressive-brewing-scroll.md (PR 3 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
