### PR TITLE
refactor: update gateway feature flag routes to use new store

### DIFF
--- a/gateway/knip.json
+++ b/gateway/knip.json
@@ -1,8 +1,4 @@
 {
-  "entry": [
-    "src/**/*.test.ts",
-    "src/**/__tests__/**/*.ts",
-    "src/feature-flag-store.ts"
-  ],
+  "entry": ["src/**/*.test.ts", "src/**/__tests__/**/*.ts"],
   "project": ["src/**/*.ts"]
 }

--- a/gateway/src/http/routes/feature-flags.ts
+++ b/gateway/src/http/routes/feature-flags.ts
@@ -2,12 +2,11 @@ import {
   loadFeatureFlagDefaults,
   isFlagDeclared,
 } from "../../feature-flag-defaults.js";
-import { getLogger } from "../../logger.js";
 import {
-  enqueueConfigWrite,
-  readConfigFile,
-  writeConfigFileAtomic,
-} from "./config-file-utils.js";
+  readPersistedFeatureFlags,
+  writeFeatureFlag,
+} from "../../feature-flag-store.js";
+import { getLogger } from "../../logger.js";
 
 const log = getLogger("feature-flags");
 
@@ -17,29 +16,6 @@ const log = getLogger("feature-flags");
  * dots, hyphens, and underscores.
  */
 const ALLOWED_KEY_RE = /^feature_flags\.[a-z0-9][a-z0-9._-]*\.enabled$/;
-
-/**
- * Read persisted flag values from the canonical config section.
- * Returns a map of canonical key -> boolean value.
- */
-function readPersistedFlags(
-  config: Record<string, unknown>,
-): Map<string, boolean> {
-  const result = new Map<string, boolean>();
-
-  // Read `assistantFeatureFlagValues` section
-  const newRaw = config.assistantFeatureFlagValues;
-  if (newRaw && typeof newRaw === "object" && !Array.isArray(newRaw)) {
-    for (const [k, v] of Object.entries(newRaw as Record<string, unknown>)) {
-      if (typeof v !== "boolean") continue;
-      if (ALLOWED_KEY_RE.test(k)) {
-        result.set(k, v);
-      }
-    }
-  }
-
-  return result;
-}
 
 export type FeatureFlagEntry = {
   key: string;
@@ -53,15 +29,12 @@ export function createFeatureFlagsGetHandler() {
   return async (_req: Request): Promise<Response> => {
     try {
       const defaults = loadFeatureFlagDefaults();
-      const result = readConfigFile();
-      // For GET, a malformed config degrades gracefully to empty persisted values
-      const config = result.ok ? result.data : {};
-      const persisted = readPersistedFlags(config);
+      const persisted = readPersistedFeatureFlags();
 
       // Build entries for ALL declared flags, merging persisted values
       const entries: FeatureFlagEntry[] = [];
       for (const [key, def] of Object.entries(defaults)) {
-        const persistedValue = persisted.get(key);
+        const persistedValue = persisted[key];
         entries.push({
           key,
           label: def.label,
@@ -135,54 +108,13 @@ export function createFeatureFlagsPatchHandler() {
       );
     }
 
-    // Serialize config writes to prevent concurrent read-modify-write races
-    const writeResult = new Promise<Response>((resolve) => {
-      enqueueConfigWrite(() => {
-        try {
-          const result = readConfigFile();
-          if (!result.ok) {
-            log.error(
-              { reason: result.reason, detail: result.detail },
-              "Config file is malformed, refusing to overwrite",
-            );
-            resolve(
-              Response.json(
-                { error: "Config file is malformed, cannot safely write" },
-                { status: 500 },
-              ),
-            );
-            return;
-          }
-
-          const config = result.data;
-
-          // Write to the `assistantFeatureFlagValues` section
-          const existingNewFlags =
-            config.assistantFeatureFlagValues &&
-            typeof config.assistantFeatureFlagValues === "object" &&
-            !Array.isArray(config.assistantFeatureFlagValues)
-              ? (config.assistantFeatureFlagValues as Record<string, unknown>)
-              : {};
-
-          config.assistantFeatureFlagValues = {
-            ...existingNewFlags,
-            [flagKey]: enabled,
-          };
-
-          writeConfigFileAtomic(config);
-
-          log.info({ flagKey, enabled }, "Feature flag updated");
-
-          resolve(Response.json({ key: flagKey, enabled }));
-        } catch (err) {
-          log.error({ err, flagKey }, "Failed to update feature flag");
-          resolve(
-            Response.json({ error: "Internal server error" }, { status: 500 }),
-          );
-        }
-      });
-    });
-
-    return writeResult;
+    try {
+      writeFeatureFlag(flagKey, enabled);
+      log.info({ flagKey, enabled }, "Feature flag updated");
+      return Response.json({ key: flagKey, enabled });
+    } catch (err) {
+      log.error({ err, flagKey }, "Failed to update feature flag");
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    }
   };
 }


### PR DESCRIPTION
## Summary
- Updates GET handler to read from feature-flag-store instead of config.assistantFeatureFlagValues
- Updates PATCH handler to write via writeFeatureFlag() instead of config mutation
- Removes unused config-file-utils imports for flag operations

Part of plan: expressive-brewing-scroll.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
