### PR TITLE
Remove unused launchEnvironment variable

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -55,7 +55,6 @@ extension AppDelegate {
     func configureDaemonTransport(for assistant: LockfileAssistant?) {
         isCurrentAssistantRemote = assistant?.isRemote ?? false
         isCurrentAssistantManaged = assistant?.isManaged ?? false
-        let launchEnvironment = ProcessInfo.processInfo.environment
 
         // Managed assistant: platform proxy with session token auth.
         if let assistant, assistant.isManaged {


### PR DESCRIPTION
## Summary
- Remove unused `launchEnvironment` variable in `AppDelegate+ConnectionSetup.swift` that was triggering a compiler warning

## Original prompt
Fix Swift compiler warning: `initialization of immutable value 'launchEnvironment' was never used`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
