### PR TITLE
Remove syncConfigToLockfile from assistant daemon

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -101,7 +101,6 @@ mock.module("../config/loader.js", () => ({
   invalidateConfigCache: () => {},
   getNestedValue: () => undefined,
   setNestedValue: () => {},
-  syncConfigToLockfile: () => {},
 }));
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/assistant/src/__tests__/config-schema-cmd.test.ts
+++ b/assistant/src/__tests__/config-schema-cmd.test.ts
@@ -88,7 +88,6 @@ mock.module("../config/loader.js", () => ({
   invalidateConfigCache: () => {},
   getNestedValue: () => undefined,
   setNestedValue: () => {},
-  syncConfigToLockfile: () => {},
 }));
 
 import { Command } from "commander";

--- a/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
+++ b/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
@@ -77,7 +77,6 @@ mock.module("../config/loader.js", () => ({
   invalidateConfigCache: () => {},
   getNestedValue: () => undefined,
   setNestedValue: () => {},
-  syncConfigToLockfile: () => {},
 }));
 
 const { buildSystemPrompt } = await import("../prompts/system-prompt.js");

--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -76,7 +76,6 @@ mock.module("../config/loader.js", () => ({
   invalidateConfigCache: () => {},
   getNestedValue: () => undefined,
   setNestedValue: () => {},
-  syncConfigToLockfile: () => {},
 }));
 
 // ── Import after mocks ───────────────────────────────────────────────

--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -75,7 +75,6 @@ mock.module("../config/loader.js", () => ({
   invalidateConfigCache: () => {},
   getNestedValue: () => undefined,
   setNestedValue: () => {},
-  syncConfigToLockfile: () => {},
 }));
 
 await import("../tools/skills/load.js");

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -86,7 +86,6 @@ mock.module("../config/loader.js", () => ({
   invalidateConfigCache: () => {},
   getNestedValue: () => undefined,
   setNestedValue: () => {},
-  syncConfigToLockfile: () => {},
 }));
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/assistant/src/cli/commands/config.ts
+++ b/assistant/src/cli/commands/config.ts
@@ -6,7 +6,6 @@ import {
   loadRawConfig,
   saveRawConfig,
   setNestedValue,
-  syncConfigToLockfile,
 } from "../../config/loader.js";
 import { AssistantConfigSchema } from "../../config/schema.js";
 import { getSchemaAtPath } from "../../config/schema-utils.js";
@@ -73,8 +72,7 @@ Arguments:
           true, "42" becomes number 42). Falls back to plain string if JSON
           parsing fails.
 
-After writing the value to config.json, the lockfile is automatically synced
-to reflect the updated configuration.
+After writing the value to config.json, the change takes effect immediately.
 
 To manage API keys, use "assistant keys set <provider> <key>" instead.
 
@@ -93,7 +91,6 @@ Examples:
       }
       setNestedValue(raw, key, parsed);
       saveRawConfig(raw);
-      syncConfigToLockfile();
       log.info(`Set ${key} = ${JSON.stringify(parsed)}`);
     });
 

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -9,12 +9,7 @@ import { dirname } from "node:path";
 
 import { ConfigError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
-import {
-  ensureDataDir,
-  getWorkspaceConfigPath,
-  readLockfile,
-  writeLockfile,
-} from "../util/platform.js";
+import { ensureDataDir, getWorkspaceConfigPath } from "../util/platform.js";
 import { AssistantConfigSchema } from "./schema.js";
 import type { AssistantConfig } from "./types.js";
 
@@ -373,30 +368,6 @@ export function saveRawConfig(config: Record<string, unknown>): void {
   writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
 
   cached = null; // invalidate cache
-}
-
-/**
- * Sync client-relevant config values (e.g. platform.baseUrl) to the lockfile
- * so external tools (e.g. vel) can discover them without importing the full
- * config schema.  Mirrors the behaviour of `syncConfigToLockfile` in the
- * lightweight CLI (`cli/src/lib/assistant-config.ts`).
- */
-export function syncConfigToLockfile(): void {
-  const configPath = getWorkspaceConfigPath();
-  if (!existsSync(configPath)) return;
-
-  try {
-    const raw = JSON.parse(readFileSync(configPath, "utf-8")) as Record<
-      string,
-      unknown
-    >;
-    const platform = raw.platform as Record<string, unknown> | undefined;
-    const data = readLockfile() ?? {};
-    data.platformBaseUrl = (platform?.baseUrl as string) || undefined;
-    writeLockfile(data);
-  } catch {
-    // Config file unreadable — skip sync
-  }
 }
 
 export function getNestedValue(


### PR DESCRIPTION
## Summary
- Removes `syncConfigToLockfile()` from `assistant/src/config/loader.ts` — the daemon should not write to the lockfile
- Removes the call site in `assistant/src/cli/commands/config.ts`
- Removes stale `syncConfigToLockfile` mock entries from 6 test files
- The CLI already has its own `syncConfigToLockfile` in `cli/src/lib/assistant-config.ts` for syncing `platformBaseUrl` to the lockfile — the assistant-side copy was redundant
- Part of decoupling the daemon from host filesystem state for Docker deployments

## Test plan
- [x] Pre-commit hooks pass (lint, typecheck, format)
- [ ] Verify `assistant config set` still works without lockfile sync
- [ ] Verify CLI-side `syncConfigToLockfile` continues to handle lockfile writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
