### PR TITLE
Set VELLUM_DEV=1 in debug builds to prevent daemon crash-loop

### DIFF
--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -133,6 +133,13 @@ final class VellumCli {
             "PATH": fullEnv["PATH"] ?? "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
             "VELLUM_DESKTOP_APP": "1",
         ]
+        #if DEBUG
+        // Debug builds compile out KeychainBrokerServer (#if !DEBUG), so the
+        // keychain broker UDS never starts.  Tell the daemon this is a dev
+        // environment so it uses the encrypted file store instead of waiting
+        // for a broker that will never appear.
+        env["VELLUM_DEV"] = "1"
+        #endif
         for key in forwardedEnvKeys {
             if let val = fullEnv[key] {
                 env[key] = val


### PR DESCRIPTION
## Summary

- Debug builds compile out `KeychainBrokerServer` (`#if !DEBUG`), but the app always sets `VELLUM_DESKTOP_APP=1` when spawning the daemon. This mismatch causes the daemon to wait for a keychain broker UDS that will never start, then crash on workspace migration `015-migrate-credentials-to-keychain`, entering an infinite crash-loop.
- Set `VELLUM_DEV=1` in the daemon environment for debug builds so the daemon uses the encrypted file store backend instead of the keychain broker.

## Original prompt

Ship the VELLUM_DEV=1 fix for debug builds