### PR TITLE
Add configurable newChatShortcut preference and dynamic event monitor

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -60,6 +60,12 @@ extension UserDefaults {
         }
         return string(forKey: "sidebarToggleShortcut") ?? ""
     }
+    @objc dynamic var newChatShortcut: String {
+        if UserDefaults.standard.object(forKey: "newChatShortcut") == nil {
+            return "cmd+n"
+        }
+        return string(forKey: "newChatShortcut") ?? ""
+    }
 }
 
 // MARK: - Input Monitors
@@ -74,7 +80,7 @@ extension AppDelegate {
         registerQuickInputMonitor()
         registerFnVMonitor()
         registerCmdKMonitor()
-        registerCmdNMonitor()
+        registerNewChatMonitor()
 
         globalHotkeyObserver = Publishers.Merge4(
             UserDefaults.standard.publisher(for: \.globalHotkeyShortcut).map { _ in () },
@@ -82,11 +88,13 @@ extension AppDelegate {
             UserDefaults.standard.publisher(for: \.quickInputHotkeyKeyCode).map { _ in () },
             UserDefaults.standard.publisher(for: \.sidebarToggleShortcut).map { _ in () }
         )
+        .merge(with: UserDefaults.standard.publisher(for: \.newChatShortcut).map { _ in () })
         .debounce(for: .milliseconds(100), scheduler: RunLoop.main)
         .sink { [weak self] _ in
             self?.registerGlobalHotkeyMonitor()
             self?.registerQuickInputMonitor()
             self?.registerSidebarToggleMonitor()
+            self?.registerNewChatMonitor()
         }
     }
 
@@ -209,12 +217,24 @@ extension AppDelegate {
         fnVLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
     }
 
-    /// Registers Cmd+N as a local shortcut to create a new conversation.
-    func registerCmdNMonitor() {
+    /// Registers a local event monitor to create a new conversation when the
+    /// configured shortcut (default: Cmd+N) is pressed. The shortcut is read
+    /// dynamically from UserDefaults so it can be reconfigured without restarting.
+    func registerNewChatMonitor() {
+        if let existing = cmdNLocalMonitor {
+            NSEvent.removeMonitor(existing)
+            cmdNLocalMonitor = nil
+        }
+
+        let shortcut = UserDefaults.standard.string(forKey: "newChatShortcut") ?? "cmd+n"
+        guard !shortcut.isEmpty else { return }
+
+        let (targetModifiers, targetKey) = ShortcutHelper.parseShortcut(shortcut)
+
         let handler: (NSEvent) -> NSEvent? = { [weak self] event in
-            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            guard event.keyCode == 45, // kVK_ANSI_N
-                  mods == [.command] else {
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask).subtracting(.numericPad)
+            guard mods == targetModifiers,
+                  event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else {
                 return event
             }
             Task { @MainActor in

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -80,6 +80,7 @@ public final class SettingsStore: ObservableObject {
     @Published var quickInputHotkeyShortcut: String
     @Published var quickInputHotkeyKeyCode: Int
     @Published var sidebarToggleShortcut: String
+    @Published var newChatShortcut: String
     @Published var cmdEnterToSend: Bool
 
     // MARK: - Media Embed Settings
@@ -419,6 +420,11 @@ public final class SettingsStore: ObservableObject {
         } else {
             self.sidebarToggleShortcut = UserDefaults.standard.string(forKey: "sidebarToggleShortcut") ?? ""
         }
+        if UserDefaults.standard.object(forKey: "newChatShortcut") == nil {
+            self.newChatShortcut = "cmd+n"
+        } else {
+            self.newChatShortcut = UserDefaults.standard.string(forKey: "newChatShortcut") ?? ""
+        }
 
         // Load media embed settings from workspace config
         let mediaSettings = Self.loadMediaEmbedSettings(from: configPath)
@@ -538,6 +544,11 @@ public final class SettingsStore: ObservableObject {
         $sidebarToggleShortcut
             .dropFirst()
             .sink { value in UserDefaults.standard.set(value, forKey: "sidebarToggleShortcut") }
+            .store(in: &cancellables)
+
+        $newChatShortcut
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "newChatShortcut") }
             .store(in: &cancellables)
 
         // Mirror GatewayConnectionManager's trust-rules-open flag so views can disable their buttons


### PR DESCRIPTION
## Summary
- Add @Published newChatShortcut property to SettingsStore with UserDefaults persistence (default: cmd+n)
- Add KVO-observable UserDefaults property and dynamic re-registration via observer
- Convert hardcoded registerCmdNMonitor() to dynamic registerNewChatMonitor() using ShortcutHelper.parseShortcut()

Part of plan: new-chat-shortcut.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
