### PR TITLE
Run platform feedback upload in background so success alert shows immediately

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -184,18 +184,23 @@ enum LogExporter {
                 }
             }
 
-            // --- Phase 2: Upload archive to platform API ---
+            // --- Phase 2: Upload archive to platform API (background) ---
+            // Fire-and-forget so the user sees "Feedback Sent" immediately
+            // after the Sentry event is captured. The archive is cleaned up
+            // after the upload completes (or fails).
+            let archiveURLCopy = archiveURL
+            Task.detached {
+                await uploadFeedbackToPlatform(
+                    archiveURL: archiveURLCopy,
+                    formData: formData,
+                    sentryEventId: sentryEventId,
+                    connectedAssistantId: connectedAssistantId,
+                    connectedAssistant: connectedAssistantForTags
+                )
 
-            await uploadFeedbackToPlatform(
-                archiveURL: archiveURL,
-                formData: formData,
-                sentryEventId: sentryEventId,
-                connectedAssistantId: connectedAssistantId,
-                connectedAssistant: connectedAssistantForTags
-            )
-
-            // Clean up the archive temp file after platform upload completes (or fails).
-            try? fileManager.removeItem(at: archiveURL)
+                // Clean up the archive temp file after platform upload completes (or fails).
+                try? FileManager.default.removeItem(at: archiveURLCopy)
+            }
 
             // Re-activate before showing the alert in case the app reverted
             // to .accessory policy after the log report window was dismissed.


### PR DESCRIPTION
## Summary
- Wrap the platform API upload (Phase 2) in a detached `Task` so it runs in the background
- The "Feedback Sent" alert now shows immediately after the Sentry event is captured (Phase 1), without waiting for the platform upload to complete or fail
- Archive cleanup still happens after the upload finishes, just in the background task

## Original prompt
Fire the platform upload concurrently so it doesn't block the user-facing alert
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
