### PR TITLE
feat: add feature-flags.json to daemon config watcher

### DIFF
--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -12,6 +12,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
+import { clearFeatureFlagOverridesCache } from "../config/assistant-feature-flags.js";
 import { getConfig, invalidateConfigCache } from "../config/loader.js";
 import { clearEmbeddingBackendCache } from "../memory/embedding-backend.js";
 import { clearCache as clearTrustCache } from "../permissions/trust-store.js";
@@ -152,6 +153,9 @@ export class ConfigWatcher {
     const protectedHandlers: Record<string, () => void> = {
       "trust.json": () => {
         clearTrustCache();
+      },
+      "feature-flags.json": () => {
+        clearFeatureFlagOverridesCache();
       },
       "secret-allowlist.json": () => {
         resetAllowlist();


### PR DESCRIPTION
## Summary
- Adds `feature-flags.json` handler to the protected directory watcher in config-watcher.ts
- Calls `clearFeatureFlagOverridesCache()` when the file changes on disk
- Piggybacks on existing protected directory watcher — no new watcher created

Part of plan: expressive-brewing-scroll.md (PR 4 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
