### PR TITLE
refactor: remove assistantFeatureFlagValues from config schema

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -303,15 +303,6 @@ export const AssistantConfigSchema = z
       NotificationsConfigSchema.parse({}),
     ),
     ui: UiConfigSchema.default(UiConfigSchema.parse({})),
-    assistantFeatureFlagValues: z
-      .record(
-        z.string(),
-        z.boolean({
-          error: "assistantFeatureFlagValues values must be booleans",
-        }),
-      )
-      .optional()
-      .describe("Feature flag overrides — map of flag names to boolean values"),
     collectUsageData: z
       .boolean()
       .default(true)


### PR DESCRIPTION
## Summary
- Removes `assistantFeatureFlagValues` field from AssistantConfigSchema
- Config loader will no longer backfill this field into config.json
- Safe to remove: daemon and gateway no longer read from this config field (PRs 2 and 3)

Part of plan: expressive-brewing-scroll.md (PR 5 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
