### PR TITLE
Fix NSSavePanel save failure on macOS Tahoe

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineAudioAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineAudioAttachmentView.swift
@@ -415,50 +415,52 @@ struct InlineAudioAttachmentView: View {
         let panel = NSSavePanel()
         panel.nameFieldStringValue = (attachment.filename as NSString).lastPathComponent
         panel.canCreateDirectories = true
-        guard panel.runModal() == .OK, let destURL = panel.url else { return }
-
-        isSaving = true
-        if let sourceURL = localFileURL ?? cachedFileURL {
-            Task.detached {
-                do {
-                    let tempURL = FileManager.default.temporaryDirectory
-                        .appendingPathComponent(UUID().uuidString)
-                        .appendingPathExtension(destURL.pathExtension)
-                    try FileManager.default.copyItem(at: sourceURL, to: tempURL)
-                    if FileManager.default.fileExists(atPath: destURL.path) {
-                        _ = try FileManager.default.replaceItemAt(destURL, withItemAt: tempURL)
-                    } else {
-                        try FileManager.default.moveItem(at: tempURL, to: destURL)
+        // Use begin() instead of runModal() — runModal() fails on macOS Tahoe
+        // with "failed to connect to the open and save panel service".
+        let sourceURL = localFileURL ?? cachedFileURL
+        let isLazy = attachment.isLazyLoad
+        let attachmentId = attachment.id.isEmpty ? nil : attachment.id
+        let gatewayBaseUrl = isLazy ? resolveAudioGatewayBaseUrl() : ""
+        let base64 = attachment.data
+        panel.begin { response in
+            guard response == .OK, let destURL = panel.url else { return }
+            self.isSaving = true
+            if let sourceURL {
+                Task.detached {
+                    do {
+                        let tempURL = FileManager.default.temporaryDirectory
+                            .appendingPathComponent(UUID().uuidString)
+                            .appendingPathExtension(destURL.pathExtension)
+                        try FileManager.default.copyItem(at: sourceURL, to: tempURL)
+                        if FileManager.default.fileExists(atPath: destURL.path) {
+                            _ = try FileManager.default.replaceItemAt(destURL, withItemAt: tempURL)
+                        } else {
+                            try FileManager.default.moveItem(at: tempURL, to: destURL)
+                        }
+                    } catch {
+                        log.error("Failed to save audio: \(error)")
                     }
-                } catch {
-                    log.error("Failed to save audio: \(error)")
+                    await MainActor.run { self.isSaving = false }
                 }
-                await MainActor.run { isSaving = false }
-            }
-        } else if attachment.isLazyLoad {
-            guard let attachmentId = attachment.id.isEmpty ? nil : attachment.id else {
-                isSaving = false
-                return
-            }
-            let gatewayBaseUrl = resolveAudioGatewayBaseUrl()
-            Task {
-                do {
-                    let data = try await fetchAudioAttachmentContent(gatewayBaseUrl: gatewayBaseUrl, attachmentId: attachmentId)
-                    try data.write(to: destURL)
-                    await MainActor.run { isSaving = false }
-                } catch {
-                    await MainActor.run { isSaving = false }
+            } else if isLazy, let attachmentId {
+                Task {
+                    do {
+                        let data = try await fetchAudioAttachmentContent(gatewayBaseUrl: gatewayBaseUrl, attachmentId: attachmentId)
+                        try data.write(to: destURL)
+                        await MainActor.run { self.isSaving = false }
+                    } catch {
+                        await MainActor.run { self.isSaving = false }
+                    }
                 }
-            }
-        } else {
-            let base64 = attachment.data
-            Task.detached {
-                guard let data = Data(base64Encoded: base64) else {
-                    await MainActor.run { isSaving = false }
-                    return
+            } else {
+                Task.detached {
+                    guard let data = Data(base64Encoded: base64) else {
+                        await MainActor.run { self.isSaving = false }
+                        return
+                    }
+                    try? data.write(to: destURL)
+                    await MainActor.run { self.isSaving = false }
                 }
-                try? data.write(to: destURL)
-                await MainActor.run { isSaving = false }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -450,52 +450,52 @@ struct InlineVideoAttachmentView: View {
         let panel = NSSavePanel()
         panel.nameFieldStringValue = (attachment.filename as NSString).lastPathComponent
         panel.canCreateDirectories = true
-        guard panel.runModal() == .OK, let destURL = panel.url else { return }
-
-        isSaving = true
-        if let sourceURL = localFileURL ?? cachedFileURL {
-            Task.detached {
-                do {
-                    // Copy to a temp location first, then atomically replace the destination so the
-                    // original file is never removed before we have a working replacement in hand.
-                    let tempURL = FileManager.default.temporaryDirectory
-                        .appendingPathComponent(UUID().uuidString)
-                        .appendingPathExtension(destURL.pathExtension)
-                    try FileManager.default.copyItem(at: sourceURL, to: tempURL)
-                    if FileManager.default.fileExists(atPath: destURL.path) {
-                        _ = try FileManager.default.replaceItemAt(destURL, withItemAt: tempURL)
-                    } else {
-                        try FileManager.default.moveItem(at: tempURL, to: destURL)
+        // Use begin() instead of runModal() — runModal() fails on macOS Tahoe
+        // with "failed to connect to the open and save panel service".
+        let sourceURL = localFileURL ?? cachedFileURL
+        let isLazy = attachment.isLazyLoad
+        let attachmentId = attachment.id.isEmpty ? nil : attachment.id
+        let gatewayBaseUrl = isLazy ? resolveGatewayBaseUrl() : ""
+        let base64 = attachment.data
+        panel.begin { response in
+            guard response == .OK, let destURL = panel.url else { return }
+            self.isSaving = true
+            if let sourceURL {
+                Task.detached {
+                    do {
+                        let tempURL = FileManager.default.temporaryDirectory
+                            .appendingPathComponent(UUID().uuidString)
+                            .appendingPathExtension(destURL.pathExtension)
+                        try FileManager.default.copyItem(at: sourceURL, to: tempURL)
+                        if FileManager.default.fileExists(atPath: destURL.path) {
+                            _ = try FileManager.default.replaceItemAt(destURL, withItemAt: tempURL)
+                        } else {
+                            try FileManager.default.moveItem(at: tempURL, to: destURL)
+                        }
+                    } catch {
+                        log.error("Failed to save video: \(error)")
                     }
-                } catch {
-                    log.error("Failed to save video: \(error)")
+                    await MainActor.run { self.isSaving = false }
                 }
-                await MainActor.run { isSaving = false }
-            }
-        } else if attachment.isLazyLoad {
-            guard let attachmentId = attachment.id.isEmpty ? nil : attachment.id else {
-                isSaving = false
-                return
-            }
-            let gatewayBaseUrl = resolveGatewayBaseUrl()
-            Task {
-                do {
-                    let data = try await fetchAttachmentContent(gatewayBaseUrl: gatewayBaseUrl, attachmentId: attachmentId)
-                    try data.write(to: destURL)
-                    await MainActor.run { isSaving = false }
-                } catch {
-                    await MainActor.run { isSaving = false }
+            } else if isLazy, let attachmentId {
+                Task {
+                    do {
+                        let data = try await fetchAttachmentContent(gatewayBaseUrl: gatewayBaseUrl, attachmentId: attachmentId)
+                        try data.write(to: destURL)
+                        await MainActor.run { self.isSaving = false }
+                    } catch {
+                        await MainActor.run { self.isSaving = false }
+                    }
                 }
-            }
-        } else {
-            let base64 = attachment.data
-            Task.detached {
-                guard let data = Data(base64Encoded: base64) else {
-                    await MainActor.run { isSaving = false }
-                    return
+            } else {
+                Task.detached {
+                    guard let data = Data(base64Encoded: base64) else {
+                        await MainActor.run { self.isSaving = false }
+                        return
+                    }
+                    try? data.write(to: destURL)
+                    await MainActor.run { self.isSaving = false }
                 }
-                try? data.write(to: destURL)
-                await MainActor.run { isSaving = false }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Switch `NSSavePanel.runModal()` to `panel.begin()` (async callback) in audio and video save operations
- `runModal()` consistently fails on macOS Tahoe with "failed to connect to the open and save panel service"
- Document export and image save already use `begin()` and work fine — this aligns the remaining save operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
