### PR TITLE
fix: remove redundant conditional cast in ToolPermissionTesterModel

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
@@ -110,15 +110,13 @@ final class ToolPermissionTesterModel: ObservableObject {
             .store(in: &cancellables)
 
         // Re-fetch tool names whenever the daemon (re)connects.
-        if let dc = connectionManager as? GatewayConnectionManager {
-            dc.$isConnected
-                .removeDuplicates()
-                .filter { $0 }
-                .sink { [weak self] _ in
-                    self?.fetchToolNames()
-                }
-                .store(in: &cancellables)
-        }
+        connectionManager.$isConnected
+            .removeDuplicates()
+            .filter { $0 }
+            .sink { [weak self] _ in
+                self?.fetchToolNames()
+            }
+            .store(in: &cancellables)
     }
 
     // MARK: - Tool Names Fetching


### PR DESCRIPTION
## Summary
- Remove unnecessary `as? GatewayConnectionManager` conditional cast in `ToolPermissionTesterModel` — `connectionManager` is already typed as `GatewayConnectionManager`, so the cast always succeeds and produces a compiler warning.

## Test plan
- [ ] Verify the project builds without the conditional cast warning
- [ ] Confirm tool permission tester still re-fetches tool names on reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
