### PR TITLE
Update menu bar key equivalent and sidebar tooltip for configurable new chat shortcut

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -95,6 +95,7 @@ extension AppDelegate {
             self?.registerQuickInputMonitor()
             self?.registerSidebarToggleMonitor()
             self?.registerNewChatMonitor()
+            self?.updateNewChatMenuItemShortcut()
         }
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -110,6 +110,7 @@ extension AppDelegate {
         newChatItem.keyEquivalentModifierMask = .command
         newChatItem.target = self
         fileMenu.addItem(newChatItem)
+        self.newChatMenuItem = newChatItem
 
         let currentConversationItem = NSMenuItem(title: "Current Conversation", action: #selector(openCurrentConversation), keyEquivalent: "")
         currentConversationItem.target = self
@@ -152,6 +153,24 @@ extension AppDelegate {
             editMenuItem.submenu = editMenu
             mainMenu.insertItem(editMenuItem, at: 2)
         }
+
+        updateNewChatMenuItemShortcut()
+    }
+
+    /// Updates the File > New Chat menu item's key equivalent to match the
+    /// current `newChatShortcut` preference. Called once at setup and again
+    /// whenever the preference changes via the KVO observer.
+    func updateNewChatMenuItemShortcut() {
+        guard let item = newChatMenuItem else { return }
+        let shortcut = UserDefaults.standard.string(forKey: "newChatShortcut") ?? "cmd+n"
+        guard !shortcut.isEmpty else {
+            item.keyEquivalent = ""
+            item.keyEquivalentModifierMask = []
+            return
+        }
+        let (modifiers, key) = ShortcutHelper.parseShortcut(shortcut)
+        item.keyEquivalent = key
+        item.keyEquivalentModifierMask = modifiers
     }
 
     // MARK: - Menu Item Validation

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -51,6 +51,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var commandPaletteWindow: CommandPaletteWindow?
     var cmdKLocalMonitor: Any?
     var cmdNLocalMonitor: Any?
+    var newChatMenuItem: NSMenuItem?
     var navLocalMonitor: Any?
     var zoomLocalMonitor: Any?
     var sidebarToggleLocalMonitor: Any?

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationsHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationsHeader.swift
@@ -7,6 +7,15 @@ struct SidebarConversationsHeader: View {
     let onMarkAllSeen: () -> Void
     let onNewConversation: () -> Void
 
+    @AppStorage("newChatShortcut") private var newChatShortcut: String = "cmd+n"
+
+    private var newChatTooltip: String {
+        let label = "New conversation"
+        guard !newChatShortcut.isEmpty else { return label }
+        let display = ShortcutHelper.displayString(for: newChatShortcut)
+        return "\(label) (\(display))"
+    }
+
     var body: some View {
         HStack {
             Text("Conversations")
@@ -23,7 +32,7 @@ struct SidebarConversationsHeader: View {
                 )
                 .disabled(isLoading)
             }
-            VButton(label: "New conversation", iconOnly: VIcon.squarePen.rawValue, style: .ghost, action: onNewConversation)
+            VButton(label: "New conversation", iconOnly: VIcon.squarePen.rawValue, style: .ghost, tooltip: newChatTooltip, action: onNewConversation)
                 .disabled(isLoading)
                 .opacity(isLoading ? 0.4 : 1)
         }


### PR DESCRIPTION
## Summary
- Store New Chat NSMenuItem as property and update its key equivalent dynamically when preference changes
- Add tooltip to sidebar New Conversation button showing configured shortcut
- Wire up menu item update to KVO observer for automatic sync

Part of plan: new-chat-shortcut.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
