### PR TITLE
Make error log string interpolations public

### DIFF
--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -279,14 +279,14 @@ public final class GatewayConnectionManager: ObservableObject {
             log.info("Health check passed")
             setConnected(true)
         } catch let error as GatewayHTTPClient.ClientError {
-            log.error("Health check client error: \(error.localizedDescription)")
+            log.error("Health check client error: \(error.localizedDescription, privacy: .public)")
             setConnected(false)
             throw ConnectionError.healthCheckFailed
         } catch let error as ConnectionError {
             setConnected(false)
             throw error
         } catch {
-            log.error("Health check failed: \(error.localizedDescription)")
+            log.error("Health check failed: \(error.localizedDescription, privacy: .public)")
             setConnected(false)
             throw ConnectionError.healthCheckFailed
         }
@@ -309,7 +309,7 @@ public final class GatewayConnectionManager: ObservableObject {
                 do {
                     try await self.performHealthCheck()
                 } catch {
-                    log.warning("Periodic health check failed: \(error.localizedDescription)")
+                    log.warning("Periodic health check failed: \(error.localizedDescription, privacy: .public)")
                 }
 
                 // Check for update timeout

--- a/clients/shared/Network/SettingsClient.swift
+++ b/clients/shared/Network/SettingsClient.swift
@@ -61,7 +61,7 @@ public struct SettingsClient: SettingsClientProtocol {
             let patched = injectType("vercel_api_config_response", into: response.data)
             return try JSONDecoder().decode(VercelApiConfigResponseMessage.self, from: patched)
         } catch {
-            log.error("fetchVercelConfig error: \(error.localizedDescription)")
+            log.error("fetchVercelConfig error: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }
@@ -79,7 +79,7 @@ public struct SettingsClient: SettingsClientProtocol {
             let patched = injectType("vercel_api_config_response", into: response.data)
             return try JSONDecoder().decode(VercelApiConfigResponseMessage.self, from: patched)
         } catch {
-            log.error("saveVercelConfig error: \(error.localizedDescription)")
+            log.error("saveVercelConfig error: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }
@@ -97,7 +97,7 @@ public struct SettingsClient: SettingsClientProtocol {
             let patched = injectType("vercel_api_config_response", into: response.data)
             return try JSONDecoder().decode(VercelApiConfigResponseMessage.self, from: patched)
         } catch {
-            log.error("deleteVercelConfig error: \(error.localizedDescription)")
+            log.error("deleteVercelConfig error: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }
@@ -114,7 +114,7 @@ public struct SettingsClient: SettingsClientProtocol {
             let patched = injectType("model_info", into: response.data)
             return try JSONDecoder().decode(ModelInfoMessage.self, from: patched)
         } catch {
-            log.error("fetchModelInfo error: \(error.localizedDescription)")
+            log.error("fetchModelInfo error: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }
@@ -133,7 +133,7 @@ public struct SettingsClient: SettingsClientProtocol {
             let patched = injectType("model_info", into: response.data)
             return try JSONDecoder().decode(ModelInfoMessage.self, from: patched)
         } catch {
-            log.error("setModel error: \(error.localizedDescription)")
+            log.error("setModel error: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }
@@ -150,7 +150,7 @@ public struct SettingsClient: SettingsClientProtocol {
             let patched = injectType("model_info", into: response.data)
             return try JSONDecoder().decode(ModelInfoMessage.self, from: patched)
         } catch {
-            log.error("setImageGenModel error: \(error.localizedDescription)")
+            log.error("setImageGenModel error: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }
@@ -166,7 +166,7 @@ public struct SettingsClient: SettingsClientProtocol {
             }
             return try JSONDecoder().decode(EmbeddingConfigMessage.self, from: response.data)
         } catch {
-            log.error("fetchEmbeddingConfig error: \(error.localizedDescription)")
+            log.error("fetchEmbeddingConfig error: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }
@@ -184,7 +184,7 @@ public struct SettingsClient: SettingsClientProtocol {
             }
             return try JSONDecoder().decode(EmbeddingConfigMessage.self, from: response.data)
         } catch {
-            log.error("setEmbeddingConfig error: \(error.localizedDescription)")
+            log.error("setEmbeddingConfig error: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }
@@ -201,7 +201,7 @@ public struct SettingsClient: SettingsClientProtocol {
             let patched = injectType("telegram_config_response", into: response.data)
             return try JSONDecoder().decode(TelegramConfigResponseMessage.self, from: patched)
         } catch {
-            log.error("fetchTelegramConfig error: \(error.localizedDescription)")
+            log.error("fetchTelegramConfig error: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }
@@ -235,7 +235,7 @@ public struct SettingsClient: SettingsClientProtocol {
             let patched = injectType("telegram_config_response", into: response.data)
             return try JSONDecoder().decode(TelegramConfigResponseMessage.self, from: patched)
         } catch {
-            log.error("setTelegramConfig error: \(error.localizedDescription)")
+            log.error("setTelegramConfig error: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }
@@ -255,7 +255,7 @@ public struct SettingsClient: SettingsClientProtocol {
             }
             return enabled
         } catch {
-            log.error("fetchDangerouslySkipPermissions error: \(error.localizedDescription)")
+            log.error("fetchDangerouslySkipPermissions error: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }
@@ -272,7 +272,7 @@ public struct SettingsClient: SettingsClientProtocol {
             }
             return true
         } catch {
-            log.error("setDangerouslySkipPermissions error: \(error.localizedDescription)")
+            log.error("setDangerouslySkipPermissions error: \(error.localizedDescription, privacy: .public)")
             return false
         }
     }
@@ -291,7 +291,7 @@ public struct SettingsClient: SettingsClientProtocol {
             }
             return true
         } catch {
-            log.error("setSlackWebhookConfig error: \(error.localizedDescription)")
+            log.error("setSlackWebhookConfig error: \(error.localizedDescription, privacy: .public)")
             return false
         }
     }
@@ -304,13 +304,13 @@ public struct SettingsClient: SettingsClientProtocol {
                 timeout: 10
             )
             guard response.isSuccess else {
-                log.error("fetchChannelVerificationStatus(\(channel)) failed (HTTP \(response.statusCode))")
+                log.error("fetchChannelVerificationStatus(\(channel, privacy: .public)) failed (HTTP \(response.statusCode))")
                 return nil
             }
             let patched = injectType("channel_verification_session_response", into: response.data)
             return try JSONDecoder().decode(ChannelVerificationSessionResponseMessage.self, from: patched)
         } catch {
-            log.error("fetchChannelVerificationStatus(\(channel)) error: \(error.localizedDescription)")
+            log.error("fetchChannelVerificationStatus(\(channel, privacy: .public)) error: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }
@@ -356,13 +356,13 @@ public struct SettingsClient: SettingsClientProtocol {
             }
 
             guard response.isSuccess else {
-                log.error("sendChannelVerificationSession(\(action), \(channel ?? "nil")) failed (HTTP \(response.statusCode))")
+                log.error("sendChannelVerificationSession(\(action, privacy: .public), \(channel ?? "nil", privacy: .public)) failed (HTTP \(response.statusCode))")
                 return decodeErrorResponse(from: response.data, channel: channel)
             }
             let patched = injectType("channel_verification_session_response", into: response.data)
             return try JSONDecoder().decode(ChannelVerificationSessionResponseMessage.self, from: patched)
         } catch {
-            log.error("sendChannelVerificationSession(\(action)) error: \(error.localizedDescription)")
+            log.error("sendChannelVerificationSession(\(action, privacy: .public)) error: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }
@@ -405,7 +405,7 @@ public struct SettingsClient: SettingsClientProtocol {
             }
             return true
         } catch {
-            log.error("updateVoiceConfig error: \(error.localizedDescription)")
+            log.error("updateVoiceConfig error: \(error.localizedDescription, privacy: .public)")
             return false
         }
     }
@@ -424,7 +424,7 @@ public struct SettingsClient: SettingsClientProtocol {
             }
             return true
         } catch {
-            log.error("startOAuthConnect error: \(error.localizedDescription)")
+            log.error("startOAuthConnect error: \(error.localizedDescription, privacy: .public)")
             return false
         }
     }
@@ -447,7 +447,7 @@ public struct SettingsClient: SettingsClientProtocol {
             }
             return true
         } catch {
-            log.error("registerDeviceToken error: \(error.localizedDescription)")
+            log.error("registerDeviceToken error: \(error.localizedDescription, privacy: .public)")
             return false
         }
     }
@@ -465,7 +465,7 @@ public struct SettingsClient: SettingsClientProtocol {
             let patched = injectType("ingress_config_response", into: response.data)
             return try JSONDecoder().decode(IngressConfigResponseMessage.self, from: patched)
         } catch {
-            log.error("fetchIngressConfig error: \(error.localizedDescription)")
+            log.error("fetchIngressConfig error: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }
@@ -487,7 +487,7 @@ public struct SettingsClient: SettingsClientProtocol {
             let patched = injectType("ingress_config_response", into: response.data)
             return try JSONDecoder().decode(IngressConfigResponseMessage.self, from: patched)
         } catch {
-            log.error("updateIngressConfig error: \(error.localizedDescription)")
+            log.error("updateIngressConfig error: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }
@@ -509,7 +509,7 @@ public struct SettingsClient: SettingsClientProtocol {
             let enriched = try JSONSerialization.data(withJSONObject: json)
             return try JSONDecoder().decode(SuggestionResponseMessage.self, from: enriched)
         } catch {
-            log.error("fetchSuggestion error: \(error.localizedDescription)")
+            log.error("fetchSuggestion error: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }
@@ -528,7 +528,7 @@ public struct SettingsClient: SettingsClientProtocol {
             let patched = injectType("platform_config_response", into: response.data)
             return try JSONDecoder().decode(PlatformConfigResponseMessage.self, from: patched)
         } catch {
-            log.error("fetchPlatformConfig error: \(error.localizedDescription)")
+            log.error("fetchPlatformConfig error: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }
@@ -546,7 +546,7 @@ public struct SettingsClient: SettingsClientProtocol {
             let patched = injectType("platform_config_response", into: response.data)
             return try JSONDecoder().decode(PlatformConfigResponseMessage.self, from: patched)
         } catch {
-            log.error("setPlatformConfig error: \(error.localizedDescription)")
+            log.error("setPlatformConfig error: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }


### PR DESCRIPTION
## Summary
- Adds `privacy: .public` to all string interpolations in `log.error()` calls in `SettingsClient` and `GatewayConnectionManager`
- Swift's `os_log` redacts dynamic strings as `<private>` by default in release builds, making error logs unreadable in `log stream` output
- No functional changes — only affects log visibility

## Test plan
- [ ] Build and run the app
- [ ] Run `log stream --predicate 'subsystem == "com.vellum.vellum-assistant"' --level error` and trigger an error condition (e.g. stop the gateway)
- [ ] Verify error details appear instead of `<private>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
