### PR TITLE
Remove lockfile read from identity endpoint, source data client-side

### DIFF
--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from "node:url";
 
 import { getBaseDataDir } from "../../config/env-registry.js";
 import { parseIdentityFields } from "../../daemon/handlers/identity.js";
-import { getWorkspacePromptPath, readLockfile } from "../../util/platform.js";
+import { getWorkspacePromptPath } from "../../util/platform.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 import { getCachedIntro } from "./identity-intro-cache.js";
@@ -163,31 +163,6 @@ export function handleGetIdentity(): Response {
     // ignore
   }
 
-  // Read lockfile for assistantId, cloud, and originSystem
-  let assistantId: string | undefined;
-  let cloud: string | undefined;
-  let originSystem: string | undefined;
-  try {
-    const lockData = readLockfile();
-    const assistants = lockData?.assistants as
-      | Array<Record<string, unknown>>
-      | undefined;
-    if (assistants && assistants.length > 0) {
-      // Use the most recently hatched assistant
-      const sorted = [...assistants].sort((a, b) => {
-        const dateA = new Date((a.hatchedAt as string) || 0).getTime();
-        const dateB = new Date((b.hatchedAt as string) || 0).getTime();
-        return dateB - dateA;
-      });
-      const latest = sorted[0];
-      assistantId = latest.assistantId as string | undefined;
-      cloud = latest.cloud as string | undefined;
-      originSystem = cloud === "local" ? "local" : cloud;
-    }
-  } catch {
-    // ignore -- lockfile may not exist
-  }
-
   return Response.json({
     name: fields.name ?? "",
     role: fields.role ?? "",
@@ -195,9 +170,7 @@ export function handleGetIdentity(): Response {
     emoji: fields.emoji ?? "",
     home: fields.home ?? "",
     version,
-    assistantId,
     createdAt,
-    originSystem,
   });
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -232,7 +232,6 @@ struct IdentityInfo {
 struct AssistantMetadata {
     let version: String
     let createdAt: Date?
-    let originSystem: String
 
     static func load() -> AssistantMetadata {
         let identityPath = NSHomeDirectory() + "/.vellum/workspace/IDENTITY.md"
@@ -250,10 +249,7 @@ struct AssistantMetadata {
             createdAt = nil
         }
 
-        // Origin system
-        let originSystem = Host.current().localizedName ?? "local"
-
-        return AssistantMetadata(version: version, createdAt: createdAt, originSystem: originSystem)
+        return AssistantMetadata(version: version, createdAt: createdAt)
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -269,7 +269,7 @@ struct IdentityPanel: View {
                 idRow(label: "Created at", value: formatDate(date))
             }
 
-            idRow(label: "Origin system", value: metadata?.originSystem ?? "local")
+            idRow(label: "Origin system", value: lockfileAssistant?.cloud ?? "local")
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -23,7 +23,6 @@ struct SettingsDeveloperTab: View {
     @ObservedObject var store: SettingsStore
     @ObservedObject private var devModeManager = DevModeManager.shared
     var connectionManager: GatewayConnectionManager?
-    var identityClient: IdentityClientProtocol = IdentityClient()
     var featureFlagClient: FeatureFlagClientProtocol = FeatureFlagClient()
     var authManager: AuthManager
     var onClose: () -> Void
@@ -34,7 +33,6 @@ struct SettingsDeveloperTab: View {
     @State private var lockfileAssistants: [LockfileAssistant] = []
     @State private var selectedAssistantId: String = ""
     @State private var identity: IdentityInfo?
-    @State private var remoteIdentity: RemoteIdentityInfo?
     @State private var devModeTapCount: Int = 0
     @State private var devModeMessage: String?
     @State private var showingHatchConfirmation: Bool = false
@@ -165,13 +163,6 @@ struct SettingsDeveloperTab: View {
             Task { await refreshAwakeStates() }
             refreshDisplayNames()
             identity = IdentityInfo.load()
-            if identity == nil,
-               let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }),
-               assistant.isRemote {
-                Task {
-                    remoteIdentity = await identityClient.fetchRemoteIdentity()
-                }
-            }
             resolvePlatformUuid()
             Task { await fetchHealthz() }
 

--- a/clients/shared/Network/IdentityClient.swift
+++ b/clients/shared/Network/IdentityClient.swift
@@ -10,25 +10,21 @@ public struct RemoteIdentityInfo: Decodable {
     public let personality: String
     public let emoji: String
     public let version: String?
-    public let assistantId: String?
     public let home: String?
     public let createdAt: String?
-    public let originSystem: String?
 
     public init(
         name: String, role: String, personality: String, emoji: String,
-        version: String? = nil, assistantId: String? = nil, home: String? = nil,
-        createdAt: String? = nil, originSystem: String? = nil
+        version: String? = nil, home: String? = nil,
+        createdAt: String? = nil
     ) {
         self.name = name
         self.role = role
         self.personality = personality
         self.emoji = emoji
         self.version = version
-        self.assistantId = assistantId
         self.home = home
         self.createdAt = createdAt
-        self.originSystem = originSystem
     }
 }
 


### PR DESCRIPTION
## Summary

The client already knows `assistantId` and `cloud` from the lockfile before it ever contacts the daemon. Having the daemon read the lockfile to echo these back was redundant coupling.

**Daemon side:**
- Remove the `readLockfile()` call from `handleGetIdentity()` in `identity-routes.ts`
- Drop `assistantId` and `originSystem` from the `/v1/identity` response

**Client side (macOS):**
- `IdentityPanel` now reads cloud from `lockfileAssistant.cloud` (already loaded on appear)
- Remove `originSystem` from `AssistantMetadata` struct (was using `Host.current().localizedName` which was wrong anyway)
- Remove dead `remoteIdentity` state and `identityClient` from `SettingsDeveloperTab`
- Remove `assistantId` and `originSystem` from `RemoteIdentityInfo`

## Test plan
- [x] Pre-push hook passes (Swift build + lint)
- [ ] Verify Identity panel still shows correct "Origin system" value from lockfile
- [ ] Verify remote assistant identity fetch still works (name, role, personality, version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)