### PR TITLE
fix: Use .foregroundStyle() instead of deprecated .foregroundColor() in new chat shortcut UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -290,7 +290,7 @@ struct SettingsAppearanceTab: View {
                 HStack {
                     Text("New chat")
                         .font(VFont.body)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                     Spacer()
                     if isRecordingNewChat, let display = recordingDisplayString, !display.isEmpty {
                         VShortcutTag(display)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for new-chat-shortcut.md.

**Gap:** New code uses deprecated .foregroundColor() API
**What was expected:** .foregroundStyle() per AGENTS.md guidance
**What was found:** .foregroundColor(VColor.contentSecondary) on new chat label
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
