### PR TITLE
Fix Swift 6 sendable closure capture warning in InlineVideoAttachmentView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -477,9 +477,10 @@ struct InlineVideoAttachmentView: View {
                     } catch {
                         log.error("Failed to save video: \(error)")
                     }
+                    let didSucceed = succeeded
                     await MainActor.run {
                         self.isSaving = false
-                        if succeeded { Self.showSaveSuccessToast(destURL) }
+                        if didSucceed { Self.showSaveSuccessToast(destURL) }
                     }
                 }
             } else if isLazy, let attachmentId {


### PR DESCRIPTION
## Summary
- Copy mutable `succeeded` var to a `let` binding before capturing it in the `MainActor.run` closure, fixing the Swift 6 `SendableClosureCaptures` warning

## Original prompt
Fix Swift 6 warning: reference to captured var `succeeded` in concurrently-executing code in `InlineVideoAttachmentView.swift:482`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
