### PR TITLE
fix: Use configured shortcut hint in command palette New Conversation action

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -369,7 +369,10 @@ extension AppDelegate {
 
         // Static actions
         window.actions = [
-            CommandPaletteAction(id: "new-conversation", icon: VIcon.squarePen.rawValue, label: "New Conversation", shortcutHint: "\u{2318}N") { [weak self] in
+            CommandPaletteAction(id: "new-conversation", icon: VIcon.squarePen.rawValue, label: "New Conversation", shortcutHint: {
+                let shortcut = UserDefaults.standard.string(forKey: "newChatShortcut") ?? "cmd+n"
+                return shortcut.isEmpty ? nil : ShortcutHelper.displayString(for: shortcut)
+            }()) { [weak self] in
                 self?.mainWindow?.conversationManager.createConversation()
                 SoundManager.shared.play(.newConversation)
                 if let id = self?.mainWindow?.conversationManager.activeConversationId {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for new-chat-shortcut.md.

**Gap:** Command palette has hardcoded shortcut hint for New Conversation
**What was expected:** The command palette should display the user's configured shortcut
**What was found:** Hardcoded shortcutHint: "\u{2318}N" in toggleCommandPalette()
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
