### PR TITLE
fix: Use configured shortcut in status bar menu New Chat item

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -307,7 +307,16 @@ extension AppDelegate {
         currentConversationItem.image = VIcon.messageSquare.nsImage(size: 16)
         menu.addItem(currentConversationItem)
 
-        let newChatItem = NSMenuItem(title: "New Chat", action: #selector(openNewChat), keyEquivalent: "n")
+        let newChatItem: NSMenuItem = {
+            let shortcut = UserDefaults.standard.string(forKey: "newChatShortcut") ?? "cmd+n"
+            guard !shortcut.isEmpty else {
+                return NSMenuItem(title: "New Chat", action: #selector(openNewChat), keyEquivalent: "")
+            }
+            let (modifiers, key) = ShortcutHelper.parseShortcut(shortcut)
+            let item = NSMenuItem(title: "New Chat", action: #selector(openNewChat), keyEquivalent: key)
+            item.keyEquivalentModifierMask = modifiers
+            return item
+        }()
         newChatItem.target = self
         newChatItem.image = VIcon.messageCirclePlus.nsImage(size: 16)
         menu.addItem(newChatItem)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for new-chat-shortcut.md.

**Gap:** Status bar popup menu has hardcoded key equivalent for New Chat
**What was expected:** The status bar menu should display the user's configured shortcut
**What was found:** Hardcoded keyEquivalent: "n" in showStatusMenu()
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
