### PR TITLE
Add configurable keyboard shortcut for new chat (Cmd+N)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -60,6 +60,12 @@ extension UserDefaults {
         }
         return string(forKey: "sidebarToggleShortcut") ?? ""
     }
+    @objc dynamic var newChatShortcut: String {
+        if UserDefaults.standard.object(forKey: "newChatShortcut") == nil {
+            return "cmd+n"
+        }
+        return string(forKey: "newChatShortcut") ?? ""
+    }
 }
 
 // MARK: - Input Monitors
@@ -74,7 +80,7 @@ extension AppDelegate {
         registerQuickInputMonitor()
         registerFnVMonitor()
         registerCmdKMonitor()
-        registerCmdNMonitor()
+        registerNewChatMonitor()
 
         globalHotkeyObserver = Publishers.Merge4(
             UserDefaults.standard.publisher(for: \.globalHotkeyShortcut).map { _ in () },
@@ -82,11 +88,13 @@ extension AppDelegate {
             UserDefaults.standard.publisher(for: \.quickInputHotkeyKeyCode).map { _ in () },
             UserDefaults.standard.publisher(for: \.sidebarToggleShortcut).map { _ in () }
         )
+        .merge(with: UserDefaults.standard.publisher(for: \.newChatShortcut).map { _ in () })
         .debounce(for: .milliseconds(100), scheduler: RunLoop.main)
         .sink { [weak self] _ in
             self?.registerGlobalHotkeyMonitor()
             self?.registerQuickInputMonitor()
             self?.registerSidebarToggleMonitor()
+            self?.registerNewChatMonitor()
         }
     }
 
@@ -209,12 +217,24 @@ extension AppDelegate {
         fnVLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
     }
 
-    /// Registers Cmd+N as a local shortcut to create a new conversation.
-    func registerCmdNMonitor() {
+    /// Registers a local event monitor to create a new conversation when the
+    /// configured shortcut (default: Cmd+N) is pressed. The shortcut is read
+    /// dynamically from UserDefaults so it can be reconfigured without restarting.
+    func registerNewChatMonitor() {
+        if let existing = cmdNLocalMonitor {
+            NSEvent.removeMonitor(existing)
+            cmdNLocalMonitor = nil
+        }
+
+        let shortcut = UserDefaults.standard.string(forKey: "newChatShortcut") ?? "cmd+n"
+        guard !shortcut.isEmpty else { return }
+
+        let (targetModifiers, targetKey) = ShortcutHelper.parseShortcut(shortcut)
+
         let handler: (NSEvent) -> NSEvent? = { [weak self] event in
-            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            guard event.keyCode == 45, // kVK_ANSI_N
-                  mods == [.command] else {
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask).subtracting(.numericPad)
+            guard mods == targetModifiers,
+                  event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else {
                 return event
             }
             Task { @MainActor in

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -95,6 +95,7 @@ extension AppDelegate {
             self?.registerQuickInputMonitor()
             self?.registerSidebarToggleMonitor()
             self?.registerNewChatMonitor()
+            self?.updateNewChatMenuItemShortcut()
         }
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -240,7 +240,7 @@ extension AppDelegate {
             }
             Task { @MainActor in
                 guard self?.isBootstrapping != true else { return }
-                self?.createNewConversation()
+                self?.openNewChat()
             }
             return nil
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -369,7 +369,10 @@ extension AppDelegate {
 
         // Static actions
         window.actions = [
-            CommandPaletteAction(id: "new-conversation", icon: VIcon.squarePen.rawValue, label: "New Conversation", shortcutHint: "\u{2318}N") { [weak self] in
+            CommandPaletteAction(id: "new-conversation", icon: VIcon.squarePen.rawValue, label: "New Conversation", shortcutHint: {
+                let shortcut = UserDefaults.standard.string(forKey: "newChatShortcut") ?? "cmd+n"
+                return shortcut.isEmpty ? nil : ShortcutHelper.displayString(for: shortcut)
+            }()) { [weak self] in
                 self?.mainWindow?.conversationManager.createConversation()
                 SoundManager.shared.play(.newConversation)
                 if let id = self?.mainWindow?.conversationManager.activeConversationId {

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -110,6 +110,7 @@ extension AppDelegate {
         newChatItem.keyEquivalentModifierMask = .command
         newChatItem.target = self
         fileMenu.addItem(newChatItem)
+        self.newChatMenuItem = newChatItem
 
         let currentConversationItem = NSMenuItem(title: "Current Conversation", action: #selector(openCurrentConversation), keyEquivalent: "")
         currentConversationItem.target = self
@@ -152,6 +153,24 @@ extension AppDelegate {
             editMenuItem.submenu = editMenu
             mainMenu.insertItem(editMenuItem, at: 2)
         }
+
+        updateNewChatMenuItemShortcut()
+    }
+
+    /// Updates the File > New Chat menu item's key equivalent to match the
+    /// current `newChatShortcut` preference. Called once at setup and again
+    /// whenever the preference changes via the KVO observer.
+    func updateNewChatMenuItemShortcut() {
+        guard let item = newChatMenuItem else { return }
+        let shortcut = UserDefaults.standard.string(forKey: "newChatShortcut") ?? "cmd+n"
+        guard !shortcut.isEmpty else {
+            item.keyEquivalent = ""
+            item.keyEquivalentModifierMask = []
+            return
+        }
+        let (modifiers, key) = ShortcutHelper.parseShortcut(shortcut)
+        item.keyEquivalent = key
+        item.keyEquivalentModifierMask = modifiers
     }
 
     // MARK: - Menu Item Validation

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -307,7 +307,16 @@ extension AppDelegate {
         currentConversationItem.image = VIcon.messageSquare.nsImage(size: 16)
         menu.addItem(currentConversationItem)
 
-        let newChatItem = NSMenuItem(title: "New Chat", action: #selector(openNewChat), keyEquivalent: "n")
+        let newChatItem: NSMenuItem = {
+            let shortcut = UserDefaults.standard.string(forKey: "newChatShortcut") ?? "cmd+n"
+            guard !shortcut.isEmpty else {
+                return NSMenuItem(title: "New Chat", action: #selector(openNewChat), keyEquivalent: "")
+            }
+            let (modifiers, key) = ShortcutHelper.parseShortcut(shortcut)
+            let item = NSMenuItem(title: "New Chat", action: #selector(openNewChat), keyEquivalent: key)
+            item.keyEquivalentModifierMask = modifiers
+            return item
+        }()
         newChatItem.target = self
         newChatItem.image = VIcon.messageCirclePlus.nsImage(size: 16)
         menu.addItem(newChatItem)

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -51,6 +51,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var commandPaletteWindow: CommandPaletteWindow?
     var cmdKLocalMonitor: Any?
     var cmdNLocalMonitor: Any?
+    var newChatMenuItem: NSMenuItem?
     var navLocalMonitor: Any?
     var zoomLocalMonitor: Any?
     var sidebarToggleLocalMonitor: Any?

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationsHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationsHeader.swift
@@ -7,6 +7,15 @@ struct SidebarConversationsHeader: View {
     let onMarkAllSeen: () -> Void
     let onNewConversation: () -> Void
 
+    @AppStorage("newChatShortcut") private var newChatShortcut: String = "cmd+n"
+
+    private var newChatTooltip: String {
+        let label = "New conversation"
+        guard !newChatShortcut.isEmpty else { return label }
+        let display = ShortcutHelper.displayString(for: newChatShortcut)
+        return "\(label) (\(display))"
+    }
+
     var body: some View {
         HStack {
             Text("Conversations")
@@ -23,7 +32,7 @@ struct SidebarConversationsHeader: View {
                 )
                 .disabled(isLoading)
             }
-            VButton(label: "New conversation", iconOnly: VIcon.squarePen.rawValue, style: .ghost, action: onNewConversation)
+            VButton(label: "New conversation", iconOnly: VIcon.squarePen.rawValue, style: .ghost, tooltip: newChatTooltip, action: onNewConversation)
                 .disabled(isLoading)
                 .opacity(isLoading ? 0.4 : 1)
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -11,6 +11,7 @@ struct SettingsAppearanceTab: View {
     @State private var isRecordingGlobalHotkey = false
     @State private var isRecordingQuickInputHotkey = false
     @State private var isRecordingSidebarToggle = false
+    @State private var isRecordingNewChat = false
     @State private var isRecordingVoiceInput = false
     @State private var shortcutMonitor: Any?
     @State private var flagsMonitor: Any?
@@ -285,7 +286,36 @@ struct SettingsAppearanceTab: View {
 
                 SettingsDivider()
 
-                ShortcutRow(label: "New chat", shortcut: "⌘N")
+                // New chat (configurable)
+                HStack {
+                    Text("New chat")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentSecondary)
+                    Spacer()
+                    if isRecordingNewChat, let display = recordingDisplayString, !display.isEmpty {
+                        VShortcutTag(display)
+                    } else {
+                        VShortcutTag(ShortcutHelper.displayString(for: store.newChatShortcut))
+                    }
+
+                    if isRecordingNewChat {
+                        VButton(label: "Press shortcut...", style: .outlined) {
+                            stopRecording()
+                        }
+                    } else {
+                        HStack(spacing: VSpacing.sm) {
+                            VButton(label: "Record", style: .outlined) {
+                                startRecordingNewChat()
+                            }
+                            if !store.newChatShortcut.isEmpty {
+                                VButton(label: "Unbind", style: .outlined) {
+                                    store.newChatShortcut = ""
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical, VSpacing.md)
 
                 SettingsDivider()
 
@@ -524,6 +554,13 @@ struct SettingsAppearanceTab: View {
         isRecordingSidebarToggle = true
     }
 
+    private func startRecordingNewChat() {
+        startRecordingShortcut { shortcut, _ in
+            store.newChatShortcut = shortcut
+        }
+        isRecordingNewChat = true
+    }
+
     /// Shared recording logic. The callback receives the shortcut string and the raw NSEvent key code.
     private func startRecordingShortcut(onRecord: @escaping (String, UInt16) -> Void) {
         stopRecording()
@@ -568,6 +605,7 @@ struct SettingsAppearanceTab: View {
         isRecordingGlobalHotkey = false
         isRecordingQuickInputHotkey = false
         isRecordingSidebarToggle = false
+        isRecordingNewChat = false
         recordingDisplayString = nil
         if let monitor = shortcutMonitor {
             NSEvent.removeMonitor(monitor)
@@ -672,22 +710,5 @@ struct SettingsAppearanceTab: View {
         return true
     }
 
-}
-
-/// A read-only row displaying a keyboard shortcut and its description.
-private struct ShortcutRow: View {
-    let label: String
-    let shortcut: String
-
-    var body: some View {
-        HStack {
-            Text(label)
-                .font(VFont.body)
-                .foregroundColor(VColor.contentSecondary)
-            Spacer()
-            VShortcutTag(shortcut)
-        }
-        .padding(.vertical, VSpacing.md)
-    }
 }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -290,7 +290,7 @@ struct SettingsAppearanceTab: View {
                 HStack {
                     Text("New chat")
                         .font(VFont.body)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                     Spacer()
                     if isRecordingNewChat, let display = recordingDisplayString, !display.isEmpty {
                         VShortcutTag(display)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -80,6 +80,7 @@ public final class SettingsStore: ObservableObject {
     @Published var quickInputHotkeyShortcut: String
     @Published var quickInputHotkeyKeyCode: Int
     @Published var sidebarToggleShortcut: String
+    @Published var newChatShortcut: String
     @Published var cmdEnterToSend: Bool
 
     // MARK: - Media Embed Settings
@@ -419,6 +420,11 @@ public final class SettingsStore: ObservableObject {
         } else {
             self.sidebarToggleShortcut = UserDefaults.standard.string(forKey: "sidebarToggleShortcut") ?? ""
         }
+        if UserDefaults.standard.object(forKey: "newChatShortcut") == nil {
+            self.newChatShortcut = "cmd+n"
+        } else {
+            self.newChatShortcut = UserDefaults.standard.string(forKey: "newChatShortcut") ?? ""
+        }
 
         // Load media embed settings from workspace config
         let mediaSettings = Self.loadMediaEmbedSettings(from: configPath)
@@ -538,6 +544,11 @@ public final class SettingsStore: ObservableObject {
         $sidebarToggleShortcut
             .dropFirst()
             .sink { value in UserDefaults.standard.set(value, forKey: "sidebarToggleShortcut") }
+            .store(in: &cancellables)
+
+        $newChatShortcut
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "newChatShortcut") }
             .store(in: &cancellables)
 
         // Mirror GatewayConnectionManager's trust-rules-open flag so views can disable their buttons


### PR DESCRIPTION
## Summary
Makes the "New Chat" keyboard shortcut (default: Cmd+N) fully configurable, following the same pattern established by the sidebar toggle shortcut in PR #20515. Users can record a custom shortcut, unbind it, or keep the default — all through Settings > Keyboard Shortcuts.

## PRs merged into feature branch
- #20537: Add configurable `newChatShortcut` preference and dynamic event monitor
- #20542: Add configurable recording UI for new chat shortcut in Settings
- #20545: Update menu bar key equivalent and sidebar tooltip for configurable new chat shortcut
- #20550: fix: Use `.foregroundStyle()` instead of deprecated `.foregroundColor()`
- #20552: fix: Use configured shortcut hint in command palette New Conversation action
- #20553: fix: Use configured shortcut in status bar menu New Chat item

## Self-review result
PASS after 1 round of auto-remediation (3 gaps found and fixed).

## Fix PRs
- #20550: `.foregroundStyle()` migration
- #20552: Dynamic command palette shortcut hint
- #20553: Dynamic status bar menu key equivalent

Part of plan: new-chat-shortcut.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
