### PR TITLE
Fix tooltip sticking on scroll

### DIFF
--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -98,6 +98,7 @@ private final class VTooltipTrackerView: NSView {
     var showDelay: TimeInterval = 0.2
     private var showTimer: Timer?
     private var panel: NSPanel?
+    private var scrollObserver: NSObjectProtocol?
 
     override func hitTest(_ point: NSPoint) -> NSView? { nil }
 
@@ -105,8 +106,8 @@ private final class VTooltipTrackerView: NSView {
         super.updateTrackingAreas()
         trackingAreas.forEach { removeTrackingArea($0) }
         addTrackingArea(NSTrackingArea(
-            rect: bounds,
-            options: [.mouseEnteredAndExited, .activeInActiveApp],
+            rect: .zero,
+            options: [.mouseEnteredAndExited, .activeInActiveApp, .inVisibleRect],
             owner: self
         ))
     }
@@ -126,6 +127,7 @@ private final class VTooltipTrackerView: NSView {
 
     override func removeFromSuperview() {
         showTimer?.invalidate()
+        stopObservingScroll()
         hideTooltip()
         super.removeFromSuperview()
     }
@@ -134,7 +136,28 @@ private final class VTooltipTrackerView: NSView {
         super.viewDidMoveToWindow()
         if window == nil {
             showTimer?.invalidate()
+            stopObservingScroll()
             hideTooltip()
+        }
+    }
+
+    private func startObservingScroll() {
+        guard scrollObserver == nil else { return }
+        scrollObserver = NotificationCenter.default.addObserver(
+            forName: NSScrollView.willStartLiveScrollNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.showTimer?.invalidate()
+            self?.showTimer = nil
+            self?.hideTooltip()
+        }
+    }
+
+    private func stopObservingScroll() {
+        if let observer = scrollObserver {
+            NotificationCenter.default.removeObserver(observer)
+            scrollObserver = nil
         }
     }
 
@@ -177,11 +200,13 @@ private final class VTooltipTrackerView: NSView {
             p.animator().alphaValue = 1
         }
         panel = p
+        startObservingScroll()
     }
 
     private func hideTooltip() {
         guard let p = panel else { return }
         panel = nil
+        stopObservingScroll()
         NSAnimationContext.runAnimationGroup({ ctx in
             ctx.duration = 0.08
             p.animator().alphaValue = 0


### PR DESCRIPTION
## Summary
- Dismiss `vTooltip` panels when the user scrolls by observing `NSScrollView.willStartLiveScrollNotification`
- Add `.inVisibleRect` to the tracking area so the system auto-recalculates when the view's visible rect changes
- Observer is only active while a tooltip is visible, so zero overhead otherwise
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
