### PR TITLE
Fix tooltip text truncation

### DIFF
--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -221,6 +221,7 @@ private struct VTooltipContent: View {
 
     var body: some View {
         Text(text)
+            .fixedSize()
             .font(VFont.caption)
             .foregroundColor(VColor.contentDefault)
             .padding(.horizontal, VSpacing.sm)


### PR DESCRIPTION
## Summary
- Add `.fixedSize()` to `VTooltipContent`'s `Text` so tooltip labels like "Copy" and "Inspect LLM context" render fully instead of truncating to "C..." / "Inspe..."

## Original prompt
these tooltips shouldn't get truncated
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
