### PR TITLE
fix: add defensive validation for feature flag file reads

### DIFF
--- a/clients/macos/vellum-assistant/Services/AssistantFeatureFlagResolver.swift
+++ b/clients/macos/vellum-assistant/Services/AssistantFeatureFlagResolver.swift
@@ -47,6 +47,7 @@ enum AssistantFeatureFlagResolver {
 
         guard let json = try? JSONSerialization.jsonObject(with: data, options: []),
               let dict = json as? [String: Any],
+              dict["version"] as? Int == 1,
               let values = dict["values"] as? [String: Bool] else {
             return [:]
         }

--- a/gateway/src/__tests__/feature-flags-route.test.ts
+++ b/gateway/src/__tests__/feature-flags-route.test.ts
@@ -244,19 +244,15 @@ describe("GET /v1/feature-flags handler", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
 
-    // readPersistedFeatureFlags returns whatever is in the values object,
-    // but the route handler only uses boolean values from the defaults merge.
-    // The non-boolean "no" will be used as-is since readPersistedFeatureFlags
-    // doesn't filter types. The route just checks `persistedValue !== undefined`.
-    // So browser flag enabled will be set to "no" (truthy). This is expected
-    // behavior — the store enforces type safety at write time, not read time.
+    // readPersistedFeatureFlags filters out non-boolean values, so the
+    // invalid "no" string is dropped and the flag falls back to its
+    // registry default (true).
     const browserFlag = body.flags.find(
       (f: { key: string }) => f.key === "feature_flags.browser.enabled",
     );
     expect(browserFlag).toBeDefined();
-    // The persisted value is "no" which is truthy and !== undefined, so
-    // it will be used as the enabled value
-    expect(browserFlag.enabled).toBe("no");
+    expect(browserFlag.enabled).toBe(true);
+    expect(browserFlag.defaultEnabled).toBe(true);
   });
 });
 

--- a/gateway/src/feature-flag-store.ts
+++ b/gateway/src/feature-flag-store.ts
@@ -72,12 +72,19 @@ export function readPersistedFeatureFlags(): Record<string, boolean> {
       return cachedValues;
     }
 
-    cachedValues =
+    if (
       data.values &&
       typeof data.values === "object" &&
       !Array.isArray(data.values)
-        ? { ...data.values }
-        : {};
+    ) {
+      const filtered: Record<string, boolean> = {};
+      for (const [k, v] of Object.entries(data.values)) {
+        if (typeof v === "boolean") filtered[k] = v;
+      }
+      cachedValues = filtered;
+    } else {
+      cachedValues = {};
+    }
     return cachedValues;
   } catch (err) {
     log.error({ err }, "Failed to load feature flag store");


### PR DESCRIPTION
## Summary
Fixes defensive validation gaps identified during plan review for expressive-brewing-scroll.md.

**Gaps fixed:**
- Gateway readPersistedFeatureFlags now filters non-boolean values (matching old behavior)
- macOS client readPersistedFlags now validates version field (matching daemon and gateway)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
