### PR TITLE
fix: add boolean filtering in daemon resolver and 0o600 perms in Swift writer

### DIFF
--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -162,7 +162,11 @@ function loadOverridesFromFile(): Record<string, boolean> {
       typeof data.values === "object" &&
       !Array.isArray(data.values)
     ) {
-      return { ...data.values };
+      const filtered: Record<string, boolean> = {};
+      for (const [k, v] of Object.entries(data.values)) {
+        if (typeof v === "boolean") filtered[k] = v;
+      }
+      return filtered;
     }
     return {};
   } catch {

--- a/clients/macos/vellum-assistant/Services/AssistantFeatureFlagResolver.swift
+++ b/clients/macos/vellum-assistant/Services/AssistantFeatureFlagResolver.swift
@@ -125,5 +125,11 @@ enum AssistantFeatureFlagResolver {
         )
 
         try data.write(to: fileURL, options: .atomic)
+
+        // Restrict to owner-only (0o600), matching the gateway and migration.
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: filePath
+        )
     }
 }


### PR DESCRIPTION
## Summary
Fixes defensive consistency gaps identified during plan review round 2.

**Gaps fixed:**
- Daemon loadOverridesFromFile now filters non-boolean values (matching gateway pattern)
- Swift mergePersistedFlag now sets 0o600 file permissions (matching gateway and migration)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
