### PR TITLE
Show save button for unplayable audio files

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineAudioAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineAudioAttachmentView.swift
@@ -97,7 +97,7 @@ struct InlineAudioAttachmentView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
 
             // Right: time display or save button
-            if isHovering && failure == nil {
+            if isHovering {
                 Button(action: saveAudio) {
                     if isSaving {
                         ProgressView()


### PR DESCRIPTION
Change save button visibility to show even when audio playback fails, so users can still download files that AVAudioPlayer cannot decode. Addresses feedback from PR #20406.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
