### PR TITLE
Fix speechModel default to be provider-aware

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -637,7 +637,6 @@ describe("AssistantConfigSchema", () => {
       voice: {
         language: "en-US",
         transcriptionProvider: "Deepgram",
-        speechModel: "nova-3",
         ttsProvider: "elevenlabs",
       },
       callerIdentity: {

--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -62,7 +62,9 @@ export function resolveVoiceQualityProfile(
   return {
     language: voice.language,
     transcriptionProvider: voice.transcriptionProvider,
-    speechModel: voice.speechModel,
+    speechModel:
+      voice.speechModel ??
+      (voice.transcriptionProvider === "Google" ? undefined : "nova-3"),
     ttsProvider: fishAudio ? "Google" : "ElevenLabs",
     voice: fishAudio ? "" : buildElevenLabsVoiceSpec(cfg.elevenlabs),
   };

--- a/assistant/src/config/schemas/calls.ts
+++ b/assistant/src/config/schemas/calls.ts
@@ -60,7 +60,7 @@ export const CallsVoiceConfigSchema = z
       .describe("Speech-to-text provider used for call transcription"),
     speechModel: z
       .string({ error: "calls.voice.speechModel must be a string" })
-      .default("nova-3")
+      .optional()
       .describe(
         "ASR model to use for speech recognition (e.g. nova-3, nova-2-phonecall for Deepgram; telephony, long for Google)",
       ),


### PR DESCRIPTION
Only default speechModel to nova-3 when transcriptionProvider is Deepgram or unset. Prevents emitting an invalid model name for Google STT configs. Addresses feedback from PR #20386.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
