### PR TITLE
Fix lazy-load attachment save writing 0-byte files

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineAudioAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineAudioAttachmentView.swift
@@ -460,6 +460,10 @@ struct InlineAudioAttachmentView: View {
                         await MainActor.run { self.isSaving = false }
                     }
                 }
+            } else if isLazy {
+                // Lazy-load attachment with no valid ID — cannot save
+                self.isSaving = false
+                return
             } else {
                 Task.detached {
                     guard let data = Data(base64Encoded: base64) else {

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -496,6 +496,10 @@ struct InlineVideoAttachmentView: View {
                         await MainActor.run { self.isSaving = false }
                     }
                 }
+            } else if isLazy {
+                // Lazy-load attachment with no valid ID — cannot save
+                self.isSaving = false
+                return
             } else {
                 Task.detached {
                     guard let data = Data(base64Encoded: base64) else {


### PR DESCRIPTION
Add guard for lazy-load attachments with nil/empty IDs to prevent falling through to the base64 branch which writes a 0-byte file. Fixes both audio and video save views. Addresses feedback from PR #20543.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
