### PR TITLE
Fix Skill memory kind: backend validation and UI exclusion

### DIFF
--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -45,6 +45,7 @@ const VALID_KINDS = [
   "decision",
   "constraint",
   "event",
+  "capability",
 ] as const;
 
 type MemoryItemKind = (typeof VALID_KINDS)[number];

--- a/clients/ios/Views/Intelligence/MemoryItemCreateView.swift
+++ b/clients/ios/Views/Intelligence/MemoryItemCreateView.swift
@@ -17,7 +17,7 @@ struct MemoryItemCreateView: View {
         Form {
             Section("Kind") {
                 Picker("Kind", selection: $kind) {
-                    ForEach(MemoryKind.allCases) { memoryKind in
+                    ForEach(MemoryKind.userCreatableKinds) { memoryKind in
                         Text(memoryKind.label).tag(memoryKind.rawValue)
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemCreateSheet.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemCreateSheet.swift
@@ -23,7 +23,7 @@ struct MemoryItemCreateSheet: View {
                     VDropdown(
                         placeholder: "Kind",
                         selection: $kind,
-                        options: MemoryKind.allCases.map { ($0.label, $0.rawValue) }
+                        options: MemoryKind.userCreatableKinds.map { ($0.label, $0.rawValue) }
                     )
                 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Content.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Content.swift
@@ -131,7 +131,7 @@ extension MemoryItemDetailSheet {
                 VDropdown(
                     placeholder: "Kind",
                     selection: $editKind,
-                    options: MemoryKind.allCases.map { ($0.label, $0.rawValue) }
+                    options: MemoryKind.userCreatableKinds.map { ($0.label, $0.rawValue) }
                 )
             }
 

--- a/clients/shared/Features/Memory/MemoryKindStyle.swift
+++ b/clients/shared/Features/Memory/MemoryKindStyle.swift
@@ -12,6 +12,12 @@ public enum MemoryKind: String, CaseIterable, Identifiable, Sendable {
 
     public var id: String { rawValue }
 
+    /// Kinds that users may select when creating or editing memory items.
+    /// Excludes system-managed kinds like `.capability` (Skill).
+    public static var userCreatableKinds: [MemoryKind] {
+        allCases.filter { $0 != .capability }
+    }
+
     /// Capitalised display label for the kind.
     public var label: String {
         switch self {


### PR DESCRIPTION
Add capability to VALID_KINDS in memory-item-routes.ts so filtering/creating/editing capability items works at the API level. Exclude capability from user-facing create/edit kind pickers since these items are system-managed. Addresses feedback from PR #20408.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
