### PR TITLE
Fix Fish Audio REST: streaming finalization and read timeout

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -673,9 +673,10 @@ export class CallController {
     // encoding and is forwarded to Twilio as it arrives.
     if (useFishAudio && fishAudioTextBuffer.trim().length > 0) {
       if (!this.isCurrentRun(runVersion)) return fullResponseText;
+      let handle: ReturnType<typeof createStreamingEntry> | null = null;
       try {
         const format = config.fishAudio.format ?? "mp3";
-        const handle = createStreamingEntry(format as "mp3" | "wav" | "opus");
+        handle = createStreamingEntry(format as "mp3" | "wav" | "opus");
         const baseUrl = getPublicBaseUrl(config);
         const url = `${baseUrl}/v1/audio/${handle.audioId}`;
         this.relay.sendPlayUrl(url);
@@ -685,19 +686,19 @@ export class CallController {
           fishAudioTextBuffer.trim(),
           config.fishAudio,
           {
-            onChunk: (chunk) => handle.push(chunk),
+            onChunk: (chunk) => handle!.push(chunk),
             signal: abortController.signal,
           },
         );
-        handle.finalize();
-        this.activeFishAbort = null;
       } catch (err) {
-        this.activeFishAbort = null;
         if (err instanceof DOMException && err.name === "AbortError") {
           log.debug("Fish Audio synthesis aborted (barge-in)");
         } else {
           log.error({ err }, "Fish Audio synthesis failed — skipping");
         }
+      } finally {
+        this.activeFishAbort = null;
+        handle?.finalize();
       }
     }
 

--- a/assistant/src/calls/fish-audio-client.ts
+++ b/assistant/src/calls/fish-audio-client.ts
@@ -5,6 +5,12 @@ import { getLogger } from "../util/logger.js";
 
 const log = getLogger("fish-audio-client");
 
+/** Timeout waiting for the first chunk from Fish Audio (ms). */
+const FIRST_CHUNK_TIMEOUT_MS = 10_000;
+
+/** Timeout waiting between consecutive chunks (ms). */
+const IDLE_TIMEOUT_MS = 5_000;
+
 // ---------------------------------------------------------------------------
 // Fish Audio REST API (POST /v1/tts)
 // ---------------------------------------------------------------------------
@@ -79,11 +85,20 @@ export async function synthesizeWithFishAudio(
 
   const chunks: Uint8Array[] = [];
   const reader = response.body.getReader();
+  let isFirstChunk = true;
 
   while (true) {
-    const { done, value } = await reader.read();
+    const timeoutMs = isFirstChunk ? FIRST_CHUNK_TIMEOUT_MS : IDLE_TIMEOUT_MS;
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error(`Fish Audio read timed out after ${timeoutMs}ms`)),
+        timeoutMs,
+      ),
+    );
+    const { done, value } = await Promise.race([reader.read(), timeout]);
     if (done) break;
     if (value) {
+      isFirstChunk = false;
       chunks.push(value);
       options?.onChunk?.(value);
     }


### PR DESCRIPTION
## Summary
- Finalize streaming entry handle in `finally` block so Twilio streams are properly closed on abort/failure instead of hanging until TTL eviction.
- Add timeout to `reader.read()` loop (10s first chunk, 5s idle) to prevent indefinite hangs if Fish Audio stalls mid-response.
- `@msgpack/msgpack` was already removed — no further cleanup needed.

Addresses feedback from PR #20399.

## Test plan
- [ ] Verify barge-in (abort) during Fish Audio synthesis closes the audio stream promptly
- [ ] Verify Fish Audio API stall triggers timeout error instead of hanging
- [ ] Verify normal synthesis still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
