### PR TITLE
Fix save toast showing on failed writes in audio/video views

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineAudioAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineAudioAttachmentView.swift
@@ -470,10 +470,15 @@ struct InlineAudioAttachmentView: View {
                         await MainActor.run { self.isSaving = false }
                         return
                     }
-                    try? data.write(to: destURL)
-                    await MainActor.run {
-                        self.isSaving = false
-                        Self.showSaveSuccessToast(destURL)
+                    do {
+                        try data.write(to: destURL)
+                        await MainActor.run {
+                            self.isSaving = false
+                            Self.showSaveSuccessToast(destURL)
+                        }
+                    } catch {
+                        log.error("Failed to save audio: \(error)")
+                        await MainActor.run { self.isSaving = false }
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -506,10 +506,15 @@ struct InlineVideoAttachmentView: View {
                         await MainActor.run { self.isSaving = false }
                         return
                     }
-                    try? data.write(to: destURL)
-                    await MainActor.run {
-                        self.isSaving = false
-                        Self.showSaveSuccessToast(destURL)
+                    do {
+                        try data.write(to: destURL)
+                        await MainActor.run {
+                            self.isSaving = false
+                            Self.showSaveSuccessToast(destURL)
+                        }
+                    } catch {
+                        log.error("Failed to save video: \(error)")
+                        await MainActor.run { self.isSaving = false }
                     }
                 }
             }


### PR DESCRIPTION
Replace try? with do/catch in base64 save paths so success toast only shows when write succeeds. Fixes InlineAudioAttachmentView and InlineVideoAttachmentView. Addresses feedback from PR #20547.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
