### PR TITLE
feat: add `ces-credential-backend` feature flag

### DIFF
--- a/assistant/src/credential-execution/feature-gates.ts
+++ b/assistant/src/credential-execution/feature-gates.ts
@@ -35,6 +35,10 @@ export const CES_GRANT_AUDIT_FLAG_KEY =
 export const CES_MANAGED_SIDECAR_FLAG_KEY =
   "feature_flags.ces-managed-sidecar.enabled" as const;
 
+/** Gate for routing credential reads/writes through the CES process. */
+export const CES_CREDENTIAL_BACKEND_FLAG_KEY =
+  "feature_flags.ces-credential-backend.enabled" as const;
+
 // ---------------------------------------------------------------------------
 // Public API — predicate functions
 // ---------------------------------------------------------------------------
@@ -72,4 +76,16 @@ export function isCesGrantAuditEnabled(config: AssistantConfig): boolean {
  */
 export function isCesManagedSidecarEnabled(config: AssistantConfig): boolean {
   return isAssistantFeatureFlagEnabled(CES_MANAGED_SIDECAR_FLAG_KEY, config);
+}
+
+/**
+ * Whether credential reads and writes should be routed through the CES process.
+ */
+export function isCesCredentialBackendEnabled(
+  config: AssistantConfig,
+): boolean {
+  return isAssistantFeatureFlagEnabled(
+    CES_CREDENTIAL_BACKEND_FLAG_KEY,
+    config,
+  );
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -106,6 +106,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "ces-credential-backend",
+      "scope": "assistant",
+      "key": "feature_flags.ces-credential-backend.enabled",
+      "label": "CES Credential Backend",
+      "description": "Route credential reads and writes through the CES process instead of accessing the encrypted store directly",
+      "defaultEnabled": false
+    },
+    {
       "id": "settings-billing",
       "scope": "macos",
       "key": "settings_billing_enabled",


### PR DESCRIPTION
## Summary
- Add `ces-credential-backend` feature flag to the registry (default off)
- Add `isCesCredentialBackendEnabled()` predicate to feature-gates.ts

Part of plan: unify-creds-via-ces.md (PR 1 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
