### PR TITLE
feat: add workspace migration to copy Keychain credentials back to encrypted store

### DIFF
--- a/assistant/src/workspace/migrations/016-migrate-credentials-from-keychain.ts
+++ b/assistant/src/workspace/migrations/016-migrate-credentials-from-keychain.ts
@@ -1,0 +1,84 @@
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("workspace-migrations");
+
+const BROKER_WAIT_INTERVAL_MS = 500;
+const BROKER_WAIT_MAX_ATTEMPTS = 10; // 5 seconds total
+
+export const migrateCredentialsFromKeychainMigration: WorkspaceMigration = {
+  id: "016-migrate-credentials-from-keychain",
+  description:
+    "Copy keychain credentials back to encrypted store for CES unification",
+
+  async run(_workspaceDir: string): Promise<void> {
+    // Only run on mac production builds (desktop app, non-dev).
+    if (
+      process.env.VELLUM_DESKTOP_APP !== "1" ||
+      process.env.VELLUM_DEV === "1"
+    ) {
+      return;
+    }
+
+    const { createBrokerClient } =
+      await import("../../security/keychain-broker-client.js");
+    const client = createBrokerClient();
+
+    // Wait for the broker to become available (up to 5 seconds), matching
+    // the retry strategy in secure-keys.ts waitForBrokerAvailability().
+    let brokerAvailable = false;
+    for (let i = 0; i < BROKER_WAIT_MAX_ATTEMPTS; i++) {
+      if (client.isAvailable()) {
+        brokerAvailable = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, BROKER_WAIT_INTERVAL_MS));
+    }
+
+    if (!brokerAvailable) {
+      // Unlike migration 015, we return silently here. If the broker is not
+      // available, credentials may already be in the encrypted store from
+      // before migration 015 ran, or from a non-desktop environment.
+      return;
+    }
+
+    const { setKey } = await import("../../security/encrypted-store.js");
+
+    const accounts = await client.list();
+    if (accounts.length === 0) {
+      return;
+    }
+
+    let migratedCount = 0;
+    let failedCount = 0;
+
+    for (const account of accounts) {
+      const result = await client.get(account);
+      if (!result || !result.found || result.value === undefined) {
+        log.warn(
+          { account },
+          "Failed to read key from keychain — skipping",
+        );
+        failedCount++;
+        continue;
+      }
+
+      const written = setKey(account, result.value);
+      if (written) {
+        await client.del(account);
+        migratedCount++;
+      } else {
+        log.warn(
+          { account },
+          "Failed to write key to encrypted store — skipping",
+        );
+        failedCount++;
+      }
+    }
+
+    log.info(
+      { migratedCount, failedCount },
+      "Credential migration from keychain complete",
+    );
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -11,6 +11,7 @@ import { backfillInstallationIdMigration } from "./011-backfill-installation-id.
 import { renameConversationDiskViewDirsMigration } from "./012-rename-conversation-disk-view-dirs.js";
 import { repairConversationDiskViewMigration } from "./013-repair-conversation-disk-view.js";
 import { migrateCredentialsToKeychainMigration } from "./015-migrate-credentials-to-keychain.js";
+import { migrateCredentialsFromKeychainMigration } from "./016-migrate-credentials-from-keychain.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -33,4 +34,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   repairConversationDiskViewMigration,
   migrateToWorkspaceVolumeMigration,
   migrateCredentialsToKeychainMigration,
+  migrateCredentialsFromKeychainMigration,
 ];


### PR DESCRIPTION
## Summary
- Add migration 016-migrate-credentials-from-keychain (reverse of 015)
- Only runs on macOS desktop production builds
- Copies credentials from Keychain to encrypted store, then deletes from Keychain
- Register in WORKSPACE_MIGRATIONS

Part of plan: unify-creds-via-ces.md (PR 4 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
