### PR TITLE
feat: support running CES from TypeScript source in local mode

### DIFF
--- a/assistant/src/credential-execution/executable-discovery.ts
+++ b/assistant/src/credential-execution/executable-discovery.ts
@@ -79,6 +79,11 @@ export interface LocalDiscoverySuccess {
   executablePath: string;
 }
 
+export interface LocalSourceDiscoverySuccess {
+  mode: "local-source";
+  sourcePath: string;
+}
+
 export interface ManagedDiscoverySuccess {
   mode: "managed";
   socketPath: string;
@@ -91,6 +96,7 @@ export interface DiscoveryFailure {
 
 export type DiscoveryResult =
   | LocalDiscoverySuccess
+  | LocalSourceDiscoverySuccess
   | ManagedDiscoverySuccess
   | DiscoveryFailure;
 
@@ -101,11 +107,16 @@ export type DiscoveryResult =
 /**
  * Discover the local CES executable.
  *
- * Searches well-known paths for the `credential-executor` binary. Returns
- * a structured result — never throws. If the binary is not found, returns
+ * Searches well-known paths for the `credential-executor` binary. If the
+ * compiled binary is not found, falls back to the TypeScript source entry
+ * point in the monorepo. Returns a structured result — never throws. If
+ * neither the binary nor the source entry point is found, returns
  * `{ mode: "unavailable" }` so the caller can fail closed.
  */
-export function discoverLocalCes(): LocalDiscoverySuccess | DiscoveryFailure {
+export function discoverLocalCes():
+  | LocalDiscoverySuccess
+  | LocalSourceDiscoverySuccess
+  | DiscoveryFailure {
   const searchPaths = getLocalBinarySearchPaths();
 
   for (const candidate of searchPaths) {
@@ -115,7 +126,20 @@ export function discoverLocalCes(): LocalDiscoverySuccess | DiscoveryFailure {
     }
   }
 
-  const reason = `CES executable not found. Searched: ${searchPaths.join(", ")}`;
+  // Fallback: check for source entry point in the monorepo
+  const monorepoRoot = join(import.meta.dir, "..", "..", "..", "..");
+  const sourceEntry = join(
+    monorepoRoot,
+    "credential-executor",
+    "src",
+    "main.ts",
+  );
+  if (existsSync(sourceEntry)) {
+    log.info({ path: sourceEntry }, "Found local CES source entry point");
+    return { mode: "local-source", sourcePath: sourceEntry };
+  }
+
+  const reason = `CES executable not found. Searched: ${searchPaths.join(", ")}; also checked source at ${sourceEntry}`;
   log.warn(reason);
   return { mode: "unavailable", reason };
 }

--- a/assistant/src/credential-execution/process-manager.ts
+++ b/assistant/src/credential-execution/process-manager.ts
@@ -38,6 +38,7 @@ import {
   discoverLocalCes,
   type DiscoveryResult,
   type LocalDiscoverySuccess,
+  type LocalSourceDiscoverySuccess,
   type ManagedDiscoverySuccess,
 } from "./executable-discovery.js";
 import { isCesManagedSidecarEnabled } from "./feature-gates.js";
@@ -156,6 +157,12 @@ export function createCesProcessManager(
         return transport;
       }
 
+      if (discoveryResult.mode === "local-source") {
+        const transport = await startLocalSourceProcess(discoveryResult);
+        running = true;
+        return transport;
+      }
+
       // managed mode
       const transport = await connectManagedSocket(discoveryResult);
       running = true;
@@ -231,6 +238,37 @@ export function createCesProcessManager(
     childProcess = proc;
 
     log.info({ pid: proc.pid }, "CES child process started");
+
+    return createStdioTransport(proc);
+  }
+
+  // -------------------------------------------------------------------------
+  // Local source mode — child process over stdio (bun run)
+  // -------------------------------------------------------------------------
+
+  async function startLocalSourceProcess(
+    discovery: LocalSourceDiscoverySuccess,
+  ): Promise<CesTransport> {
+    log.info(
+      { sourcePath: discovery.sourcePath },
+      "Spawning CES child process from source",
+    );
+
+    const proc = Bun.spawn({
+      cmd: ["bun", "run", discovery.sourcePath],
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "ignore",
+      env: {
+        ...process.env,
+        // Signal to CES that it was launched by the assistant
+        CES_LAUNCHED_BY: "assistant",
+      },
+    });
+
+    childProcess = proc;
+
+    log.info({ pid: proc.pid }, "CES child process started (from source)");
 
     return createStdioTransport(proc);
   }


### PR DESCRIPTION
## Summary
- Add `LocalSourceDiscoverySuccess` result type to CES discovery
- Fall back to `credential-executor/src/main.ts` when compiled binary not found
- Spawn CES via `bun run` for source-based discovery

Part of plan: unify-creds-via-ces.md (PR 3 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
