### PR TITLE
fix: resolve SendableClosureCaptures warning in InlineAudioAttachmentView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineAudioAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineAudioAttachmentView.swift
@@ -442,9 +442,10 @@ struct InlineAudioAttachmentView: View {
                     } catch {
                         log.error("Failed to save audio: \(error)")
                     }
+                    let didSucceed = succeeded
                     await MainActor.run {
                         self.isSaving = false
-                        if succeeded { Self.showSaveSuccessToast(destURL) }
+                        if didSucceed { Self.showSaveSuccessToast(destURL) }
                     }
                 }
             } else if isLazy, let attachmentId {


### PR DESCRIPTION
## Summary
- Capture `succeeded` into a `let` binding before passing it into the `MainActor.run` closure to avoid referencing a mutable `var` in concurrently-executing code
- Eliminates Swift 6 `#SendableClosureCaptures` warning in the audio save-to-disk flow

## Original prompt
Fix: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
Building (debug)...
[1/1] Planning build
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineAudioAttachmentView.swift:447:28: warning: reference to captured var 'succeeded' in concurrently-executing code; this is an error in the Swift 6 language mode [#SendableClosureCaptures]
445 |                     await MainActor.run {
446 |                         self.isSaving = false
447 |                         if succeeded { Self.showSaveSuccessToast(destURL) }
    |                            `- warning: reference to captured var 'succeeded' in concurrently-executing code; this is an error in the Swift 6 language mode [#SendableClosureCaptures]
448 |                     }
449 |                 }
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
