### PR TITLE
feat: add CesRpcCredentialBackend implementing CredentialBackend

### DIFF
--- a/assistant/src/security/ces-rpc-credential-backend.ts
+++ b/assistant/src/security/ces-rpc-credential-backend.ts
@@ -1,0 +1,84 @@
+/**
+ * CesRpcCredentialBackend — a CredentialBackend that delegates all credential
+ * operations to the Credential Execution Service (CES) via stdio RPC.
+ *
+ * Maps RPC responses to the existing CredentialGetResult and DeleteResult
+ * types. Errors are caught and mapped to unreachable/error states for
+ * graceful fallback.
+ */
+
+import type { CesClient } from "../credential-execution/client.js";
+import { CesRpcMethod } from "@vellumai/ces-contracts";
+import { getLogger } from "../util/logger.js";
+import type {
+  CredentialBackend,
+  CredentialGetResult,
+  DeleteResult,
+} from "./credential-backend.js";
+
+const log = getLogger("ces-rpc-credential-backend");
+
+export class CesRpcCredentialBackend implements CredentialBackend {
+  readonly name = "ces-rpc";
+
+  constructor(private readonly client: CesClient) {}
+
+  isAvailable(): boolean {
+    return this.client.isReady();
+  }
+
+  async get(account: string): Promise<CredentialGetResult> {
+    try {
+      const result = await this.client.call(
+        CesRpcMethod.GetCredential,
+        { account },
+      );
+      return {
+        value: result.found ? result.value : undefined,
+        unreachable: false,
+      };
+    } catch (err) {
+      log.warn({ err, account }, "CES RPC credential get failed");
+      return { value: undefined, unreachable: true };
+    }
+  }
+
+  async set(account: string, value: string): Promise<boolean> {
+    try {
+      const result = await this.client.call(
+        CesRpcMethod.SetCredential,
+        { account, value },
+      );
+      return result.ok;
+    } catch (err) {
+      log.warn({ err, account }, "CES RPC credential set failed");
+      return false;
+    }
+  }
+
+  async delete(account: string): Promise<DeleteResult> {
+    try {
+      const result = await this.client.call(
+        CesRpcMethod.DeleteCredential,
+        { account },
+      );
+      return result.result;
+    } catch (err) {
+      log.warn({ err, account }, "CES RPC credential delete failed");
+      return "error";
+    }
+  }
+
+  async list(): Promise<string[]> {
+    try {
+      const result = await this.client.call(
+        CesRpcMethod.ListCredentials,
+        {},
+      );
+      return result.accounts;
+    } catch (err) {
+      log.warn({ err }, "CES RPC credential list failed");
+      return [];
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- New `CesRpcCredentialBackend` class implementing the `CredentialBackend` interface
- Delegates all credential operations to CES via RPC (get_credential, set_credential, delete_credential, list_credentials)
- Error handling maps RPC failures to unreachable/error states

Part of plan: unify-creds-via-ces.md (PR 7 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
