### PR TITLE
refactor: remove KeychainBackend and keychain broker client from daemon

### DIFF
--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -23,52 +23,6 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-// ---------------------------------------------------------------------------
-// Broker client mock — set up before importing secure-keys so the
-// module-level `createBrokerClient()` call picks up our mock.
-// ---------------------------------------------------------------------------
-
-let mockBrokerAvailable = false;
-let mockBrokerStore: Map<string, string> = new Map();
-let mockBrokerGetError = false;
-let mockBrokerSetError = false;
-let mockBrokerDelError = false;
-let mockBrokerGetCalled = false;
-let mockBrokerSetCalled = false;
-
-mock.module("../security/keychain-broker-client.js", () => ({
-  createBrokerClient: () => ({
-    isAvailable: () => mockBrokerAvailable,
-    ping: async () => (mockBrokerAvailable ? { pong: true } : null),
-    get: async (account: string) => {
-      mockBrokerGetCalled = true;
-      // null = broker error (fall back to encrypted store)
-      if (mockBrokerGetError) return null;
-      const value = mockBrokerStore.get(account);
-      if (value !== undefined) return { found: true, value };
-      return { found: false };
-    },
-    set: async (account: string, value: string) => {
-      mockBrokerSetCalled = true;
-      if (mockBrokerSetError)
-        return {
-          status: "rejected" as const,
-          code: "KEYCHAIN_ERROR",
-          message: "mock error",
-        };
-      mockBrokerStore.set(account, value);
-      return { status: "ok" as const };
-    },
-    del: async (account: string) => {
-      if (mockBrokerDelError) return false;
-      const existed = mockBrokerStore.has(account);
-      mockBrokerStore.delete(account);
-      return existed;
-    },
-    list: async () => Array.from(mockBrokerStore.keys()),
-  }),
-}));
-
 import * as encryptedStore from "../security/encrypted-store.js";
 import { _setStorePath } from "../security/encrypted-store.js";
 import {
@@ -94,16 +48,7 @@ describe("secure-keys", () => {
   beforeEach(() => {
     _resetBackend();
 
-    // Reset broker mock state
-    mockBrokerAvailable = false;
-    mockBrokerStore = new Map();
-    mockBrokerGetError = false;
-    mockBrokerSetError = false;
-    mockBrokerDelError = false;
-    mockBrokerGetCalled = false;
-    mockBrokerSetCalled = false;
-
-    // Ensure VELLUM_DEV and VELLUM_DESKTOP_APP are NOT set so broker tests work by default
+    // Ensure VELLUM_DEV and VELLUM_DESKTOP_APP are NOT set
     delete process.env.VELLUM_DEV;
     delete process.env.VELLUM_DESKTOP_APP;
 
@@ -128,9 +73,9 @@ describe("secure-keys", () => {
   });
 
   // -----------------------------------------------------------------------
-  // CRUD operations (via encrypted store backend — broker unavailable)
+  // CRUD operations (encrypted store backend)
   // -----------------------------------------------------------------------
-  describe("CRUD with encrypted backend (broker unavailable)", () => {
+  describe("CRUD with encrypted backend", () => {
     test("set and get a key", async () => {
       await setSecureKeyAsync("openai", "sk-openai-789");
       expect(await getSecureKeyAsync("openai")).toBe("sk-openai-789");
@@ -152,197 +97,90 @@ describe("secure-keys", () => {
   });
 
   // -----------------------------------------------------------------------
-  // Single-writer: writes go to keychain only when broker available
+  // Desktop app uses encrypted store (same as dev/CLI)
   // -----------------------------------------------------------------------
-  describe("single-writer with broker available", () => {
-    test("setSecureKeyAsync writes to broker only (not encrypted store)", async () => {
+  describe("desktop app uses encrypted store", () => {
+    test("VELLUM_DESKTOP_APP=1 writes to encrypted store", async () => {
       process.env.VELLUM_DESKTOP_APP = "1";
-      mockBrokerAvailable = true;
       _resetBackend();
 
       const result = await setSecureKeyAsync("api-key", "new-value");
       expect(result).toBe(true);
-      // Value is in the broker store
-      expect(mockBrokerStore.get("api-key")).toBe("new-value");
-      // Value should NOT be in the encrypted store (single-writer)
-      expect(encryptedStore.getKey("api-key")).toBeUndefined();
+      expect(encryptedStore.getKey("api-key")).toBe("new-value");
     });
 
-    test("setSecureKeyAsync returns false on broker set error", async () => {
+    test("VELLUM_DESKTOP_APP=1 reads from encrypted store", async () => {
       process.env.VELLUM_DESKTOP_APP = "1";
-      mockBrokerAvailable = true;
-      mockBrokerSetError = true;
       _resetBackend();
 
-      const result = await setSecureKeyAsync("api-key", "new-value");
-      expect(result).toBe(false);
-      expect(mockBrokerStore.has("api-key")).toBe(false);
-    });
-  });
-
-  // -----------------------------------------------------------------------
-  // Reads: primary backend only, no fallback
-  // -----------------------------------------------------------------------
-  describe("reads with broker available", () => {
-    test("getSecureKeyAsync reads from broker (primary backend)", async () => {
-      process.env.VELLUM_DESKTOP_APP = "1";
-      mockBrokerAvailable = true;
-      _resetBackend();
-
-      mockBrokerStore.set("api-key", "broker-value");
-      const result = await getSecureKeyAsync("api-key");
-      expect(result).toBe("broker-value");
-      expect(mockBrokerGetCalled).toBe(true);
-    });
-
-    test("getSecureKeyAsync does not fall back to encrypted store", async () => {
-      process.env.VELLUM_DESKTOP_APP = "1";
-      mockBrokerAvailable = true;
-      _resetBackend();
-
-      // Pre-populate encrypted store directly (legacy key not in broker)
-      encryptedStore.setKey("legacy-key", "legacy-value");
-
-      const result = await getSecureKeyAsync("legacy-key");
-      expect(result).toBeUndefined();
-      // Broker was checked (returned nothing), no fallback to encrypted store
-      expect(mockBrokerGetCalled).toBe(true);
-    });
-
-    test("getSecureKeyAsync returns undefined when neither store has the key", async () => {
-      process.env.VELLUM_DESKTOP_APP = "1";
-      mockBrokerAvailable = true;
-      _resetBackend();
-
-      expect(await getSecureKeyAsync("missing-key")).toBeUndefined();
-    });
-
-    test("getSecureKeyAsync returns broker value even when encrypted store also has a value", async () => {
-      process.env.VELLUM_DESKTOP_APP = "1";
-      mockBrokerAvailable = true;
-      _resetBackend();
-
-      // Both stores have a value — broker (primary) should win
-      mockBrokerStore.set("api-key", "broker-value");
-      encryptedStore.setKey("api-key", "encrypted-value");
-
-      const result = await getSecureKeyAsync("api-key");
-      expect(result).toBe("broker-value");
-    });
-  });
-
-  // -----------------------------------------------------------------------
-  // Dev mode bypass — VELLUM_DEV=1 uses encrypted store only
-  // -----------------------------------------------------------------------
-  describe("dev mode bypass (VELLUM_DEV=1)", () => {
-    test("setSecureKeyAsync writes to encrypted store only, ignoring broker", async () => {
-      process.env.VELLUM_DEV = "1";
-      mockBrokerAvailable = true;
-      _resetBackend();
-
-      const result = await setSecureKeyAsync("api-key", "dev-value");
-      expect(result).toBe(true);
-      // Written to encrypted store
-      expect(encryptedStore.getKey("api-key")).toBe("dev-value");
-      // NOT written to broker
-      expect(mockBrokerStore.has("api-key")).toBe(false);
-      expect(mockBrokerSetCalled).toBe(false);
-    });
-
-    test("getSecureKeyAsync reads from encrypted store only, ignoring broker", async () => {
-      process.env.VELLUM_DEV = "1";
-      mockBrokerAvailable = true;
-      _resetBackend();
-
-      mockBrokerStore.set("api-key", "broker-value");
       encryptedStore.setKey("api-key", "encrypted-value");
 
       const result = await getSecureKeyAsync("api-key");
       expect(result).toBe("encrypted-value");
-      // Broker should not have been contacted
-      expect(mockBrokerGetCalled).toBe(false);
     });
 
-    test("getSecureKeyAsync returns undefined when encrypted store is empty (does not check broker)", async () => {
-      process.env.VELLUM_DEV = "1";
-      mockBrokerAvailable = true;
+    test("VELLUM_DESKTOP_APP=1 deletes from encrypted store", async () => {
+      process.env.VELLUM_DESKTOP_APP = "1";
       _resetBackend();
 
-      mockBrokerStore.set("api-key", "broker-value");
+      encryptedStore.setKey("api-key", "encrypted-value");
+
+      const result = await deleteSecureKeyAsync("api-key");
+      expect(result).toBe("deleted");
+      expect(encryptedStore.getKey("api-key")).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Dev mode — VELLUM_DEV=1 uses encrypted store
+  // -----------------------------------------------------------------------
+  describe("dev mode (VELLUM_DEV=1)", () => {
+    test("setSecureKeyAsync writes to encrypted store", async () => {
+      process.env.VELLUM_DEV = "1";
+      _resetBackend();
+
+      const result = await setSecureKeyAsync("api-key", "dev-value");
+      expect(result).toBe(true);
+      expect(encryptedStore.getKey("api-key")).toBe("dev-value");
+    });
+
+    test("getSecureKeyAsync reads from encrypted store", async () => {
+      process.env.VELLUM_DEV = "1";
+      _resetBackend();
+
+      encryptedStore.setKey("api-key", "encrypted-value");
+
+      const result = await getSecureKeyAsync("api-key");
+      expect(result).toBe("encrypted-value");
+    });
+
+    test("getSecureKeyAsync returns undefined when encrypted store is empty", async () => {
+      process.env.VELLUM_DEV = "1";
+      _resetBackend();
 
       const result = await getSecureKeyAsync("api-key");
       expect(result).toBeUndefined();
-      expect(mockBrokerGetCalled).toBe(false);
     });
   });
 
   // -----------------------------------------------------------------------
-  // VELLUM_DESKTOP_APP gating — keychain backend selection
+  // Non-desktop topology uses encrypted store
   // -----------------------------------------------------------------------
-  describe("VELLUM_DESKTOP_APP gating", () => {
-    test("uses keychain when VELLUM_DESKTOP_APP=1 and broker available", async () => {
-      process.env.VELLUM_DESKTOP_APP = "1";
-      mockBrokerAvailable = true;
+  describe("non-desktop topology", () => {
+    test("uses encrypted store", async () => {
       _resetBackend();
 
       const result = await setSecureKeyAsync("api-key", "new-value");
       expect(result).toBe(true);
-      // Value is in the broker store (keychain backend)
-      expect(mockBrokerStore.get("api-key")).toBe("new-value");
-      // Value should NOT be in the encrypted store
-      expect(encryptedStore.getKey("api-key")).toBeUndefined();
-    });
-
-    test(
-      "still resolves to keychain when VELLUM_DESKTOP_APP=1 and broker unavailable",
-      async () => {
-        process.env.VELLUM_DESKTOP_APP = "1";
-        mockBrokerAvailable = false;
-        mockBrokerGetError = true;
-        _resetBackend();
-
-        // Backend resolves to keychain even though broker is unavailable.
-        // Operations will report unreachable rather than falling back to encrypted store.
-        const result = await getSecureKeyResultAsync("api-key");
-        expect(result.value).toBeUndefined();
-        expect(result.unreachable).toBe(true);
-      },
-      { timeout: 10_000 },
-    );
-
-    test("non-desktop topology uses encrypted store even when broker is available", async () => {
-      // VELLUM_DESKTOP_APP is NOT set
-      mockBrokerAvailable = true;
-      _resetBackend();
-
-      const result = await setSecureKeyAsync("api-key", "new-value");
-      expect(result).toBe(true);
-      // Value is in the encrypted store (not broker)
       expect(encryptedStore.getKey("api-key")).toBe("new-value");
-      // Broker should NOT have been used
-      expect(mockBrokerSetCalled).toBe(false);
     });
   });
 
   // -----------------------------------------------------------------------
-  // Delete — single backend only
+  // Delete — single backend
   // -----------------------------------------------------------------------
-  describe("delete from single backend", () => {
-    test("deleteSecureKeyAsync removes from broker store only when broker available", async () => {
-      process.env.VELLUM_DESKTOP_APP = "1";
-      mockBrokerAvailable = true;
-      _resetBackend();
-
-      mockBrokerStore.set("api-key", "broker-value");
-      encryptedStore.setKey("api-key", "encrypted-value");
-
-      const result = await deleteSecureKeyAsync("api-key");
-      expect(result).toBe("deleted");
-      expect(mockBrokerStore.has("api-key")).toBe(false);
-    });
-
-    test("deleteSecureKeyAsync returns deleted when only encrypted store has key", async () => {
-      // Broker unavailable — only encrypted store
+  describe("delete from encrypted store", () => {
+    test("deleteSecureKeyAsync removes key from encrypted store", async () => {
       encryptedStore.setKey("api-key", "encrypted-value");
 
       const result = await deleteSecureKeyAsync("api-key");
@@ -350,91 +188,21 @@ describe("secure-keys", () => {
       expect(encryptedStore.getKey("api-key")).toBeUndefined();
     });
 
-    test("deleteSecureKeyAsync returns error when broker delete fails", async () => {
-      process.env.VELLUM_DESKTOP_APP = "1";
-      mockBrokerAvailable = true;
-      mockBrokerDelError = true;
-      _resetBackend();
-
-      mockBrokerStore.set("api-key", "broker-value");
-
-      const result = await deleteSecureKeyAsync("api-key");
-      expect(result).toBe("error");
-    });
-
-    test("deleteSecureKeyAsync in dev mode deletes from encrypted store only", async () => {
+    test("deleteSecureKeyAsync in dev mode deletes from encrypted store", async () => {
       process.env.VELLUM_DEV = "1";
       process.env.VELLUM_DESKTOP_APP = "1";
-      mockBrokerAvailable = true;
       _resetBackend();
 
-      mockBrokerStore.set("api-key", "broker-value");
       encryptedStore.setKey("api-key", "encrypted-value");
 
       const result = await deleteSecureKeyAsync("api-key");
       expect(result).toBe("deleted");
-      // Dev mode resolves to encrypted store — broker should NOT be touched
-      expect(mockBrokerStore.has("api-key")).toBe(true);
       expect(encryptedStore.getKey("api-key")).toBeUndefined();
     });
 
-    test("deleteSecureKeyAsync returns not-found when key missing from both stores", async () => {
-      // Broker unavailable, encrypted store empty
+    test("deleteSecureKeyAsync returns not-found when key missing", async () => {
       const result = await deleteSecureKeyAsync("missing-key");
       expect(result).toBe("not-found");
-    });
-  });
-
-  // -----------------------------------------------------------------------
-  // Legacy read fallback
-  // -----------------------------------------------------------------------
-  describe("legacy read fallback", () => {
-    test("does not fall back to encrypted store for legacy keys", async () => {
-      process.env.VELLUM_DESKTOP_APP = "1";
-      mockBrokerAvailable = true;
-      _resetBackend();
-
-      // Simulate a legacy key that was written to encrypted store before
-      // the single-writer migration — broker doesn't have it.
-      encryptedStore.setKey("legacy-account", "legacy-secret");
-
-      const result = await getSecureKeyAsync("legacy-account");
-      expect(result).toBeUndefined();
-    });
-
-    test("does not fall back to encrypted store when already using encrypted store backend", async () => {
-      // Broker unavailable — primary backend IS the encrypted store.
-      // No fallback needed.
-      encryptedStore.setKey("account", "value");
-      encryptedStore.setKey("other-account", "other-value");
-
-      // Should read directly from encrypted store (primary)
-      const result = await getSecureKeyAsync("account");
-      expect(result).toBe("value");
-      // Broker should not have been contacted
-      expect(mockBrokerGetCalled).toBe(false);
-    });
-  });
-
-  // -----------------------------------------------------------------------
-  // Stale-value prevention
-  // -----------------------------------------------------------------------
-  describe("stale-value prevention", () => {
-    test("setSecureKeyAsync failure does not corrupt broker store", async () => {
-      process.env.VELLUM_DESKTOP_APP = "1";
-      mockBrokerAvailable = true;
-      _resetBackend();
-
-      // Pre-seed broker with original value
-      mockBrokerStore.set("api-key", "original-value");
-
-      // Now fail the next set
-      mockBrokerSetError = true;
-      const ok = await setSecureKeyAsync("api-key", "new-value");
-      expect(ok).toBe(false);
-
-      // Broker should still have original value
-      expect(mockBrokerStore.get("api-key")).toBe("original-value");
     });
   });
 
@@ -442,29 +210,7 @@ describe("secure-keys", () => {
   // listSecureKeysAsync — single-backend key listing
   // -----------------------------------------------------------------------
   describe("listSecureKeysAsync", () => {
-    test("returns only broker keys when broker is primary (no encrypted store merge)", async () => {
-      process.env.VELLUM_DESKTOP_APP = "1";
-      mockBrokerAvailable = true;
-      _resetBackend();
-
-      // Broker has some keys
-      mockBrokerStore.set("broker-key-1", "val1");
-      mockBrokerStore.set("shared-key", "broker-val");
-
-      // Encrypted store has legacy keys — should NOT be included
-      encryptedStore.setKey("legacy-key-1", "val2");
-      encryptedStore.setKey("shared-key", "enc-val");
-
-      const keys = await listSecureKeysAsync();
-      expect(keys).toContain("broker-key-1");
-      expect(keys).toContain("shared-key");
-      expect(keys).not.toContain("legacy-key-1");
-      // Should be exactly 2 keys (broker only)
-      expect(keys.length).toBe(2);
-    });
-
-    test("returns only encrypted store keys when broker is unavailable", async () => {
-      // Broker unavailable (default state) — primary backend is encrypted store
+    test("returns encrypted store keys", async () => {
       encryptedStore.setKey("enc-key-1", "val1");
       encryptedStore.setKey("enc-key-2", "val2");
 
@@ -474,45 +220,33 @@ describe("secure-keys", () => {
       expect(keys.length).toBe(2);
     });
 
-    test("returns only encrypted store keys when VELLUM_DEV=1 (even if broker available)", async () => {
+    test("returns encrypted store keys with VELLUM_DEV=1", async () => {
       process.env.VELLUM_DEV = "1";
-      mockBrokerAvailable = true;
       _resetBackend();
 
-      // Broker has keys that should be ignored
-      mockBrokerStore.set("broker-only", "val1");
-
-      // Encrypted store has keys
       encryptedStore.setKey("dev-key-1", "val2");
       encryptedStore.setKey("dev-key-2", "val3");
 
       const keys = await listSecureKeysAsync();
       expect(keys).toContain("dev-key-1");
       expect(keys).toContain("dev-key-2");
-      // broker-only key should NOT appear since primary backend is encrypted store
-      expect(keys).not.toContain("broker-only");
       expect(keys.length).toBe(2);
     });
 
-    test("returns broker-only keys when encrypted store is empty", async () => {
+    test("returns encrypted store keys with VELLUM_DESKTOP_APP=1", async () => {
       process.env.VELLUM_DESKTOP_APP = "1";
-      mockBrokerAvailable = true;
       _resetBackend();
 
-      mockBrokerStore.set("broker-key-1", "val1");
-      mockBrokerStore.set("broker-key-2", "val2");
+      encryptedStore.setKey("desktop-key-1", "val1");
+      encryptedStore.setKey("desktop-key-2", "val2");
 
       const keys = await listSecureKeysAsync();
-      expect(keys).toContain("broker-key-1");
-      expect(keys).toContain("broker-key-2");
+      expect(keys).toContain("desktop-key-1");
+      expect(keys).toContain("desktop-key-2");
       expect(keys.length).toBe(2);
     });
 
-    test("returns empty array when both stores are empty", async () => {
-      process.env.VELLUM_DESKTOP_APP = "1";
-      mockBrokerAvailable = true;
-      _resetBackend();
-
+    test("returns empty array when store is empty", async () => {
       const keys = await listSecureKeysAsync();
       expect(keys).toEqual([]);
     });
@@ -522,53 +256,31 @@ describe("secure-keys", () => {
   // getSecureKeyResultAsync — richer result with unreachable flag
   // -----------------------------------------------------------------------
   describe("getSecureKeyResultAsync", () => {
-    test("returns unreachable true when broker errors", async () => {
-      process.env.VELLUM_DESKTOP_APP = "1";
-      mockBrokerAvailable = true;
-      mockBrokerGetError = true;
-      _resetBackend();
-
-      const result = await getSecureKeyResultAsync("api-key");
-      expect(result.value).toBeUndefined();
-      expect(result.unreachable).toBe(true);
-    });
-
     test("returns value and unreachable false on success", async () => {
-      process.env.VELLUM_DESKTOP_APP = "1";
-      mockBrokerAvailable = true;
-      _resetBackend();
+      encryptedStore.setKey("api-key", "stored-value");
 
-      mockBrokerStore.set("api-key", "broker-value");
       const result = await getSecureKeyResultAsync("api-key");
-      expect(result.value).toBe("broker-value");
+      expect(result.value).toBe("stored-value");
       expect(result.unreachable).toBe(false);
     });
 
-    test("returns unreachable when broker errors, does not fall back", async () => {
-      process.env.VELLUM_DESKTOP_APP = "1";
-      mockBrokerAvailable = true;
-      mockBrokerGetError = true;
-      _resetBackend();
-
-      encryptedStore.setKey("legacy-key", "legacy-value");
-      const result = await getSecureKeyResultAsync("legacy-key");
+    test("returns unreachable false when key missing (encrypted store always reachable)", async () => {
+      const result = await getSecureKeyResultAsync("missing-key");
       expect(result.value).toBeUndefined();
-      expect(result.unreachable).toBe(true);
+      expect(result.unreachable).toBe(false);
     });
 
-    test("propagates unreachable when broker errors and encrypted store also missing", async () => {
-      process.env.VELLUM_DESKTOP_APP = "1";
-      mockBrokerAvailable = true;
-      mockBrokerGetError = true;
+    test("returns unreachable false in dev mode", async () => {
+      process.env.VELLUM_DEV = "1";
       _resetBackend();
 
       const result = await getSecureKeyResultAsync("missing-key");
       expect(result.value).toBeUndefined();
-      expect(result.unreachable).toBe(true);
+      expect(result.unreachable).toBe(false);
     });
 
-    test("returns unreachable false in dev mode (encrypted store backend)", async () => {
-      process.env.VELLUM_DEV = "1";
+    test("returns unreachable false with VELLUM_DESKTOP_APP=1", async () => {
+      process.env.VELLUM_DESKTOP_APP = "1";
       _resetBackend();
 
       const result = await getSecureKeyResultAsync("missing-key");

--- a/assistant/src/security/credential-backend.ts
+++ b/assistant/src/security/credential-backend.ts
@@ -1,15 +1,10 @@
 /**
  * CredentialBackend interface and adapters — abstracts credential storage
  * behind a unified async API so callers don't need to know which backend
- * (macOS Keychain, encrypted file store, etc.) is in use.
+ * is in use.
  */
 
-import { getLogger } from "../util/logger.js";
 import * as encryptedStore from "./encrypted-store.js";
-import type { KeychainBrokerClient } from "./keychain-broker-client.js";
-import { createBrokerClient } from "./keychain-broker-client.js";
-
-const log = getLogger("credential-backend");
 
 // ---------------------------------------------------------------------------
 // Types
@@ -46,85 +41,6 @@ export interface CredentialBackend {
 
   /** List all account names. */
   list(): Promise<string[]>;
-}
-
-// ---------------------------------------------------------------------------
-// KeychainBackend
-// ---------------------------------------------------------------------------
-
-/** Suppress repeated "unreachable" warnings — log at most once per 5 minutes. */
-const UNREACHABLE_WARN_COOLDOWN_MS = 5 * 60 * 1000;
-let lastUnreachableWarnMs = 0;
-
-export class KeychainBackend implements CredentialBackend {
-  readonly name = "keychain";
-
-  constructor(private readonly client: KeychainBrokerClient) {}
-
-  isAvailable(): boolean {
-    return this.client.isAvailable();
-  }
-
-  async get(account: string): Promise<CredentialGetResult> {
-    try {
-      const result = await this.client.get(account);
-      if (result == null) {
-        const now = Date.now();
-        if (now - lastUnreachableWarnMs >= UNREACHABLE_WARN_COOLDOWN_MS) {
-          log.warn({ account }, "Keychain broker unreachable during get");
-          lastUnreachableWarnMs = now;
-        }
-        return { value: undefined, unreachable: true };
-      }
-      lastUnreachableWarnMs = 0; // Reset so next outage is logged immediately
-      if (!result.found) return { value: undefined, unreachable: false };
-      return { value: result.value, unreachable: false };
-    } catch (err) {
-      log.warn({ err, account }, "Keychain get threw unexpectedly");
-      return { value: undefined, unreachable: true };
-    }
-  }
-
-  async set(account: string, value: string): Promise<boolean> {
-    try {
-      const result = await this.client.set(account, value);
-      if (result.status === "ok") return true;
-      log.warn(
-        {
-          account,
-          status: result.status,
-          ...(result.status === "rejected"
-            ? { code: result.code, message: result.message }
-            : {}),
-        },
-        "Keychain broker set failed",
-      );
-      return false;
-    } catch (err) {
-      log.warn({ err, account }, "Keychain set threw unexpectedly");
-      return false;
-    }
-  }
-
-  async delete(account: string): Promise<DeleteResult> {
-    try {
-      const ok = await this.client.del(account);
-      // The keychain broker returns a boolean — it does not distinguish
-      // "not found" from a genuine error, so we map false → "error".
-      return ok ? "deleted" : "error";
-    } catch {
-      return "error";
-    }
-  }
-
-  async list(): Promise<string[]> {
-    try {
-      return await this.client.list();
-    } catch (err) {
-      log.warn({ err }, "Keychain list threw unexpectedly");
-      return [];
-    }
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -174,10 +90,6 @@ export class EncryptedStoreBackend implements CredentialBackend {
 // ---------------------------------------------------------------------------
 // Factory functions
 // ---------------------------------------------------------------------------
-
-export function createKeychainBackend(): KeychainBackend {
-  return new KeychainBackend(createBrokerClient());
-}
 
 export function createEncryptedStoreBackend(): EncryptedStoreBackend {
   return new EncryptedStoreBackend();

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -4,11 +4,7 @@
  *
  * Backend selection (`resolveBackendAsync`) is the single async decision point:
  *   - Containerized (IS_CONTAINERIZED + CES_CREDENTIAL_URL set): CES HTTP client.
- *   - Desktop app (VELLUM_DESKTOP_APP=1, non-dev): keychain backend always,
- *     with up to 5 s wait for the broker socket to appear. Even if the broker
- *     never becomes available, we commit to keychain so operations fail visibly
- *     rather than silently writing to a different store.
- *   - Dev mode or non-desktop topology: encrypted file store always.
+ *   - All other topologies (desktop app, dev, CLI): encrypted file store.
  *
  * All operations (reads, writes, lists, deletes) go to exactly one backend.
  * There are no cross-backend fallbacks or merges.
@@ -24,10 +20,7 @@ import { getIsContainerized } from "../config/env-registry.js";
 import { getLogger } from "../util/logger.js";
 import { createCesCredentialBackend } from "./ces-credential-client.js";
 import type { CredentialBackend, DeleteResult } from "./credential-backend.js";
-import {
-  createEncryptedStoreBackend,
-  createKeychainBackend,
-} from "./credential-backend.js";
+import { createEncryptedStoreBackend } from "./credential-backend.js";
 
 export type { DeleteResult } from "./credential-backend.js";
 
@@ -45,43 +38,22 @@ export interface SecureKeyResult {
 
 const log = getLogger("secure-keys");
 
-const BROKER_WAIT_INTERVAL_MS = 500;
-const BROKER_WAIT_MAX_ATTEMPTS = 10; // 5 seconds total
-
-let _keychain: CredentialBackend | undefined;
 let _encryptedStore: CredentialBackend | undefined;
 let _resolvedBackend: CredentialBackend | undefined;
 let _resolvePromise: Promise<CredentialBackend> | undefined;
-
-function getKeychainBackend(): CredentialBackend {
-  if (!_keychain) _keychain = createKeychainBackend();
-  return _keychain;
-}
 
 function getEncryptedStoreBackend(): CredentialBackend {
   if (!_encryptedStore) _encryptedStore = createEncryptedStoreBackend();
   return _encryptedStore;
 }
 
-async function waitForBrokerAvailability(): Promise<boolean> {
-  const keychain = getKeychainBackend();
-  for (let i = 0; i < BROKER_WAIT_MAX_ATTEMPTS; i++) {
-    if (keychain.isAvailable()) return true;
-    await new Promise((r) => setTimeout(r, BROKER_WAIT_INTERVAL_MS));
-  }
-  return false;
-}
-
 /**
  * Resolve the primary credential backend for this process (async).
  *
  * Priority:
- *   1. Containerized + CES_CREDENTIAL_URL → CES HTTP client (skip keychain
- *      and encrypted store entirely — the sidecar owns credential storage).
- *   2. Desktop app (VELLUM_DESKTOP_APP=1, non-dev) → keychain always, with
- *      up to 5 s wait for the broker socket. Even if the broker never becomes
- *      available, we commit to keychain so operations fail visibly.
- *   3. Dev mode or non-desktop topology → encrypted file store always.
+ *   1. Containerized + CES_CREDENTIAL_URL → CES HTTP client (the sidecar
+ *      owns credential storage).
+ *   2. All other topologies → encrypted file store.
  *
  * Once resolved, the backend does not change during the process lifetime.
  * Call `_resetBackend()` in tests to clear the cached resolution.
@@ -108,23 +80,7 @@ async function doResolveBackend(): Promise<CredentialBackend> {
     );
   }
 
-  // 2. Mac production: wait for keychain broker, commit to it even if
-  //    the wait times out (operations will fail with unreachable errors).
-  if (
-    process.env.VELLUM_DESKTOP_APP === "1" &&
-    process.env.VELLUM_DEV !== "1"
-  ) {
-    const available = await waitForBrokerAvailability();
-    if (!available) {
-      log.warn(
-        "Keychain broker not available after waiting — credential operations will fail until the Vellum app is restarted",
-      );
-    }
-    _resolvedBackend = getKeychainBackend();
-    return _resolvedBackend;
-  }
-
-  // 3. Dev mode or non-desktop topology
+  // 2. All other topologies (desktop app, dev, CLI)
   _resolvedBackend = getEncryptedStoreBackend();
   return _resolvedBackend;
 }
@@ -262,7 +218,6 @@ export async function getMaskedProviderKey(
 
 /** @internal Test-only: reset the cached backends so they're re-created. */
 export function _resetBackend(): void {
-  _keychain = undefined;
   _encryptedStore = undefined;
   _resolvedBackend = undefined;
   _resolvePromise = undefined;


### PR DESCRIPTION
## Summary
- Remove `KeychainBackend` class and `createKeychainBackend()` from credential-backend.ts
- Remove Keychain selection branch from `resolveBackendAsync()` in secure-keys.ts
- Desktop app now falls through to encrypted file store (same as dev/CLI mode)
- Keychain broker client retained for workspace migrations only

Part of plan: unify-creds-via-ces.md (PR 8 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
