### PR TITLE
fix: sort imports in ces-rpc-credential-backend.ts

### DIFF
--- a/assistant/src/security/ces-rpc-credential-backend.ts
+++ b/assistant/src/security/ces-rpc-credential-backend.ts
@@ -7,8 +7,9 @@
  * graceful fallback.
  */
 
-import type { CesClient } from "../credential-execution/client.js";
 import { CesRpcMethod } from "@vellumai/ces-contracts";
+
+import type { CesClient } from "../credential-execution/client.js";
 import { getLogger } from "../util/logger.js";
 import type {
   CredentialBackend,


### PR DESCRIPTION
## Summary
- Fix import sorting in `assistant/src/security/ces-rpc-credential-backend.ts` — the `@vellumai/ces-contracts` external import was mixed in with relative imports instead of being in its own group, causing `simple-import-sort/imports` lint failure.

## Original prompt
Fix import sorting lint error in assistant/src/security/ces-rpc-credential-backend.ts (same simple-import-sort/imports issue)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
