### PR TITLE
feat: route credential reads through CES when `ces-credential-backend` flag is enabled

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -19,7 +19,10 @@ import { loadConfig, mergeDefaultWorkspaceConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/schema.js";
 import type { CesClient } from "../credential-execution/client.js";
 import { createCesClient } from "../credential-execution/client.js";
-import { isCesToolsEnabled } from "../credential-execution/feature-gates.js";
+import {
+  isCesCredentialBackendEnabled,
+  isCesToolsEnabled,
+} from "../credential-execution/feature-gates.js";
 import {
   type CesProcessManager,
   CesUnavailableError,
@@ -70,6 +73,7 @@ import {
 import { ensureVellumGuardianBinding } from "../runtime/guardian-vellum-migration.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import { startScheduler } from "../schedule/scheduler.js";
+import { setCesClient } from "../security/secure-keys.js";
 import { seedCatalogSkillMemories } from "../skills/skill-memory.js";
 import { UsageTelemetryReporter } from "../telemetry/usage-telemetry-reporter.js";
 import { getDeviceId } from "../util/device-id.js";
@@ -157,7 +161,8 @@ export interface CesStartupResult {
 export async function startCesProcess(
   config: AssistantConfig,
 ): Promise<CesStartupResult> {
-  if (!isCesToolsEnabled(config)) {
+  const shouldStartCes = isCesToolsEnabled(config) || isCesCredentialBackendEnabled(config);
+  if (!shouldStartCes) {
     return {
       client: undefined,
       processManager: undefined,
@@ -444,10 +449,30 @@ export async function runDaemon(): Promise<void> {
       log.info("Usage telemetry reporter started");
     }
 
-    // CES lifecycle — fire-and-forget. Kick off early so CES handshake runs
-    // concurrently with provider/tool initialization. The CES sidecar accepts
-    // exactly one bootstrap connection, so startup must happen at the process level.
-    const cesResult = startCesProcess(config);
+    // CES lifecycle — kick off early so CES handshake runs concurrently with
+    // provider/tool initialization. The CES sidecar accepts exactly one
+    // bootstrap connection, so startup must happen at the process level.
+    const cesStartupPromise = startCesProcess(config);
+
+    // When the credential backend flag is enabled, CES startup must complete
+    // BEFORE provider initialization so credential reads can go through CES.
+    // Block with a 3-second timeout — fall back to direct credential store
+    // on timeout.
+    if (isCesCredentialBackendEnabled(config)) {
+      const cesResult = await Promise.race([
+        cesStartupPromise,
+        new Promise<CesStartupResult>((resolve) =>
+          setTimeout(() => {
+            log.warn("CES startup timed out after 3s — falling back to direct credential store");
+            resolve({ client: undefined, processManager: undefined, clientPromise: undefined, abortController: undefined });
+          }, 3000),
+        ),
+      ]);
+      // Inject CES client into secure-keys for credential routing
+      if (cesResult.client) {
+        setCesClient(cesResult.client);
+      }
+    }
 
     await initializeProvidersAndTools(config);
 
@@ -455,7 +480,7 @@ export async function runDaemon(): Promise<void> {
     // routes can begin accepting requests while Qdrant initializes.
     log.info("Daemon startup: starting DaemonServer");
     const server = new DaemonServer();
-    server.setCes(await cesResult);
+    server.setCes(await cesStartupPromise);
     await server.start();
     log.info("Daemon startup: DaemonServer started");
 

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -3,8 +3,10 @@
  * adapters.
  *
  * Backend selection (`resolveBackendAsync`) is the single async decision point:
- *   - Containerized (IS_CONTAINERIZED + CES_CREDENTIAL_URL set): CES HTTP client.
- *   - All other topologies (desktop app, dev, CLI): encrypted file store.
+ *   0. CES RPC client injected via `setCesClient()` (local mode with
+ *      ces-credential-backend flag enabled): delegates to CES via stdio RPC.
+ *   1. Containerized (IS_CONTAINERIZED + CES_CREDENTIAL_URL set): CES HTTP client.
+ *   2. All other topologies (desktop app, dev, CLI): encrypted file store.
  *
  * All operations (reads, writes, lists, deletes) go to exactly one backend.
  * There are no cross-backend fallbacks or merges.
@@ -17,8 +19,10 @@ import type {
 
 import providerEnvVarsRegistry from "../../../meta/provider-env-vars.json" with { type: "json" };
 import { getIsContainerized } from "../config/env-registry.js";
+import type { CesClient } from "../credential-execution/client.js";
 import { getLogger } from "../util/logger.js";
 import { createCesCredentialBackend } from "./ces-credential-client.js";
+import { CesRpcCredentialBackend } from "./ces-rpc-credential-backend.js";
 import type { CredentialBackend, DeleteResult } from "./credential-backend.js";
 import { createEncryptedStoreBackend } from "./credential-backend.js";
 
@@ -38,9 +42,18 @@ export interface SecureKeyResult {
 
 const log = getLogger("secure-keys");
 
+let _cesClient: CesClient | undefined;
 let _encryptedStore: CredentialBackend | undefined;
 let _resolvedBackend: CredentialBackend | undefined;
 let _resolvePromise: Promise<CredentialBackend> | undefined;
+
+/** Inject a CES RPC client for credential routing. Resets the resolved backend. */
+export function setCesClient(client: CesClient | undefined): void {
+  _cesClient = client;
+  // Reset resolved backend so next call picks up CES
+  _resolvedBackend = undefined;
+  _resolvePromise = undefined;
+}
 
 function getEncryptedStoreBackend(): CredentialBackend {
   if (!_encryptedStore) _encryptedStore = createEncryptedStoreBackend();
@@ -67,6 +80,16 @@ async function resolveBackendAsync(): Promise<CredentialBackend> {
 }
 
 async function doResolveBackend(): Promise<CredentialBackend> {
+  // 0. CES RPC client (local mode with ces-credential-backend enabled)
+  if (_cesClient) {
+    const cesRpc = new CesRpcCredentialBackend(_cesClient);
+    if (cesRpc.isAvailable()) {
+      _resolvedBackend = cesRpc;
+      return cesRpc;
+    }
+    log.warn("CES RPC client is set but not ready — falling back to local credential store");
+  }
+
   // 1. Containerized + CES (unchanged)
   if (getIsContainerized() && process.env.CES_CREDENTIAL_URL) {
     const ces = createCesCredentialBackend();
@@ -218,6 +241,7 @@ export async function getMaskedProviderKey(
 
 /** @internal Test-only: reset the cached backends so they're re-created. */
 export function _resetBackend(): void {
+  _cesClient = undefined;
   _encryptedStore = undefined;
   _resolvedBackend = undefined;
   _resolvePromise = undefined;


### PR DESCRIPTION
## Summary
- Start CES when `ces-credential-backend` flag is enabled (not just `ces-tools`)
- Block startup for up to 3s to await CES handshake when credential routing is enabled
- Inject CES client into `secure-keys.ts` via `setCesClient()` for credential routing
- `CesRpcCredentialBackend` becomes the primary credential backend when CES is available
- Graceful fallback to encrypted file store on timeout or CES unavailability

Part of plan: unify-creds-via-ces.md (PR 9 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
