### PR TITLE
feat: enable CES credential backend by default

### DIFF
--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -3,10 +3,12 @@
  * adapters.
  *
  * Backend selection (`resolveBackendAsync`) is the single async decision point:
- *   0. CES RPC client injected via `setCesClient()` (local mode with
- *      ces-credential-backend flag enabled): delegates to CES via stdio RPC.
- *   1. Containerized (IS_CONTAINERIZED + CES_CREDENTIAL_URL set): CES HTTP client.
- *   2. All other topologies (desktop app, dev, CLI): encrypted file store.
+ *   1. CES RPC (primary) — injected via `setCesClient()`: delegates credential
+ *      operations to the CES process over stdio RPC. This is the default path
+ *      for all local modes (desktop app, dev, CLI).
+ *   2. CES HTTP — containerized mode (IS_CONTAINERIZED + CES_CREDENTIAL_URL):
+ *      delegates to the CES sidecar over HTTP. Used in Docker/managed mode.
+ *   3. Encrypted file store (fallback) — used when CES is unavailable.
  *
  * All operations (reads, writes, lists, deletes) go to exactly one backend.
  * There are no cross-backend fallbacks or merges.
@@ -64,9 +66,9 @@ function getEncryptedStoreBackend(): CredentialBackend {
  * Resolve the primary credential backend for this process (async).
  *
  * Priority:
- *   1. Containerized + CES_CREDENTIAL_URL → CES HTTP client (the sidecar
- *      owns credential storage).
- *   2. All other topologies → encrypted file store.
+ *   1. CES RPC client → primary path for all local modes.
+ *   2. Containerized + CES_CREDENTIAL_URL → CES HTTP client (Docker/managed).
+ *   3. Encrypted file store → fallback when CES is unavailable.
  *
  * Once resolved, the backend does not change during the process lifetime.
  * Call `_resetBackend()` in tests to clear the cached resolution.
@@ -80,7 +82,7 @@ async function resolveBackendAsync(): Promise<CredentialBackend> {
 }
 
 async function doResolveBackend(): Promise<CredentialBackend> {
-  // 0. CES RPC client (local mode with ces-credential-backend enabled)
+  // 1. CES RPC — primary credential backend for all local modes
   if (_cesClient) {
     const cesRpc = new CesRpcCredentialBackend(_cesClient);
     if (cesRpc.isAvailable()) {
@@ -90,7 +92,7 @@ async function doResolveBackend(): Promise<CredentialBackend> {
     log.warn("CES RPC client is set but not ready — falling back to local credential store");
   }
 
-  // 1. Containerized + CES (unchanged)
+  // 2. CES HTTP — containerized / Docker / managed mode
   if (getIsContainerized() && process.env.CES_CREDENTIAL_URL) {
     const ces = createCesCredentialBackend();
     if (ces.isAvailable()) {
@@ -103,7 +105,7 @@ async function doResolveBackend(): Promise<CredentialBackend> {
     );
   }
 
-  // 2. All other topologies (desktop app, dev, CLI)
+  // 3. Encrypted file store — fallback when CES is unavailable
   _resolvedBackend = getEncryptedStoreBackend();
   return _resolvedBackend;
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -111,7 +111,7 @@
       "key": "feature_flags.ces-credential-backend.enabled",
       "label": "CES Credential Backend",
       "description": "Route credential reads and writes through the CES process instead of accessing the encrypted store directly",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "settings-billing",


### PR DESCRIPTION
## Summary
- Set `ces-credential-backend` flag `defaultEnabled` to `true`
- Clean up `doResolveBackend()` comments to reflect CES RPC as primary path
- Encrypted file store remains as fallback for CES unavailability

Part of plan: unify-creds-via-ces.md (PR 10 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
