### PR TITLE
fix: add daemon/lifecycle.ts to secure-keys authorized importers

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -218,6 +218,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "daemon/conversation-process.ts", // masked provider key display
       "daemon/handlers/config-model.ts", // masked provider key display
       "providers/speech-to-text/resolve.ts", // STT provider API key lookup
+      "daemon/lifecycle.ts", // CES client injection into secure-keys at startup
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Summary
- Add `daemon/lifecycle.ts` to the `ALLOWED_IMPORTERS` set in `credential-security-invariants.test.ts`. It imports `setCesClient()` from `secure-keys` to inject the CES client at startup — infrastructure wiring, not secret access.

## Original prompt
Fix credential-security-invariants.test.ts failure: daemon/lifecycle.ts imports secure-keys but isn't in the authorized importers list.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
