### PR TITLE
fix: await CES handshake before credential routing injection

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -459,18 +459,23 @@ export async function runDaemon(): Promise<void> {
     // Block with a 3-second timeout — fall back to direct credential store
     // on timeout.
     if (isCesCredentialBackendEnabled(config)) {
-      const cesResult = await Promise.race([
-        cesStartupPromise,
-        new Promise<CesStartupResult>((resolve) =>
-          setTimeout(() => {
-            log.warn("CES startup timed out after 3s — falling back to direct credential store");
-            resolve({ client: undefined, processManager: undefined, clientPromise: undefined, abortController: undefined });
-          }, 3000),
-        ),
-      ]);
-      // Inject CES client into secure-keys for credential routing
-      if (cesResult.client) {
-        setCesClient(cesResult.client);
+      const cesResult = await cesStartupPromise;
+      // startCesProcess() returns immediately — the actual handshake runs
+      // inside clientPromise. Await it (with a 3s timeout) so the CES client
+      // is available before provider initialization.
+      if (cesResult.clientPromise) {
+        const client = await Promise.race([
+          cesResult.clientPromise,
+          new Promise<undefined>((resolve) =>
+            setTimeout(() => {
+              log.warn("CES handshake timed out after 3s — falling back to direct credential store");
+              resolve(undefined);
+            }, 3000),
+          ),
+        ]);
+        if (client) {
+          setCesClient(client);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for unify-creds-via-ces.md.

**Gap:** CES credential routing race condition
**What was expected:** setCesClient() called with a defined CES client before provider init
**What was found:** startCesProcess() returns before handshake completes, client always undefined
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
