### PR TITLE
Remove auto-scrolling from chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBottomPinCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBottomPinCoordinator.swift
@@ -3,175 +3,119 @@ import os
 
 private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "ChatBottomPinCoordinator")
 
-// MARK: - Request Reasons & User Actions
-
-/// Reasons the system may request a scroll-to-bottom pin.
-enum BottomPinRequestReason: String, Sendable {
-    /// Initial conversation load / restore from disk.
-    case initialRestore
-    /// A new message was appended to the conversation.
-    case messageCount
-    /// An inline element (progress card, tool output) expanded its height.
-    case expansion
-    /// The chat container was resized (sidebar toggle, window drag).
-    case resize
-}
-
-/// User-initiated actions that affect the follow/detach state machine.
-enum BottomPinUserAction: Sendable {
-    /// Physical scroll-wheel / trackpad upward movement.
-    case scrollUp
-    /// User explicitly scrolled to the bottom (wheel hit bottom, or clicked "Scroll to latest").
-    case scrollToBottom
-    /// User clicked "Jump to latest" or equivalent explicit re-tether action.
-    case jumpToLatest
-}
-
-// MARK: - Pin Session
-
-/// Represents a single bounded scroll-to-bottom retry session.
-/// Sessions coalesce duplicate requests and cap total retry attempts.
-struct BottomPinSession: Sendable {
-    /// Stable identifier for tracing this session across log entries.
-    let sessionId: UUID
-    /// The conversation this session targets.
-    let conversationId: UUID
-    /// The reason that initiated this session.
-    let reason: BottomPinRequestReason
-    /// Number of retry attempts executed so far.
-    private(set) var attemptCount: Int = 0
-    /// Wall-clock time the session was created.
-    let startTime: CFAbsoluteTime
-
-    /// Maximum retries before the session self-terminates.
-    /// Prevents an unbounded series of pin attempts from a single trigger.
-    static let maxRetries: Int = 5
-
-    /// Whether the session has exhausted its retry budget.
-    var isExhausted: Bool { attemptCount >= Self.maxRetries }
-
-    /// Records a retry attempt. Returns false if the budget is exhausted.
-    @discardableResult
-    mutating func recordAttempt() -> Bool {
-        guard !isExhausted else { return false }
-        attemptCount += 1
-        return true
-    }
-
-    /// Elapsed milliseconds since the session was created.
-    var elapsedMs: Int {
-        Int((CFAbsoluteTimeGetCurrent() - startTime) * 1000)
-    }
-
-    /// Whether this session can coalesce a new request with the given reason
-    /// and conversation. Coalescing merges duplicates into the existing session
-    /// instead of creating a new retry loop.
-    func canCoalesce(reason: BottomPinRequestReason, conversationId: UUID) -> Bool {
-        guard self.conversationId == conversationId else { return false }
-        guard !isExhausted else { return false }
-        // Requests coalesce freely when they share the same reason within the same conversation.
-        // Different reasons (e.g. resize vs expansion) start a fresh session.
-        switch (self.reason, reason) {
-        case (.initialRestore, .initialRestore),
-             (.expansion, .expansion),
-             (.messageCount, .messageCount),
-             (.resize, .resize):
-            return true
-        default:
-            return false
-        }
-    }
-}
-
-// MARK: - Cancellation Triggers
-
-/// Events that cancel the active pin session.
-enum BottomPinCancellationTrigger: String, Sendable {
-    /// User scrolled up away from the bottom.
-    case userScrollUp
-    /// A deep-link anchor was set, handing off scroll control.
-    case deepLinkAnchorHandoff
-    /// Pagination scroll-position restore is in progress.
-    case paginationRestore
-    /// The active conversation changed.
-    case conversationSwitch
-}
-
 // MARK: - Coordinator
 
-/// Centralizes the transcript follow-vs-detached state and coordinates bounded
-/// scroll-to-bottom retry sessions.
+/// Centralizes the transcript follow-vs-detached state and provides a single
+/// `scrollToBottom()` entry point for initial load positioning and the
+/// "Scroll to latest" button.
 ///
 /// The coordinator is decision-complete: while the user is detached from the
-/// bottom, background requests from streaming, message growth, and progress
-/// expansion are suppressed. Once the user explicitly returns to the bottom,
-/// requests may schedule a bounded retry sequence again.
-///
-/// Only one pin session is active at a time. Duplicate requests for the same
-/// conversation inside the active window merge into the existing session
-/// instead of creating a fresh loop.
+/// bottom, `scrollToBottom()` calls are suppressed. Once the user explicitly
+/// returns to the bottom via `handleUserAction(.scrollToBottom)` or
+/// `.jumpToLatest`, the follow state is re-armed.
 @MainActor
 final class ChatBottomPinCoordinator {
 
     // MARK: - State
 
     /// Whether the viewport is logically following the bottom of the transcript.
-    /// When false (detached), background pin requests are suppressed.
+    /// When false (detached), `scrollToBottom()` calls are suppressed.
     private(set) var isFollowingBottom: Bool = true
-
-    /// The currently active pin session, if any.
-    private(set) var activeSession: BottomPinSession?
-
-    /// The in-flight async task driving the active session's retry loop.
-    private var sessionTask: Task<Void, Never>?
-
-    /// Monotonically increasing generation counter. Incremented each time a new
-    /// session task is started so that stale tasks don't clobber newer sessions.
-    private var sessionGeneration: Int = 0
-
-    /// Timestamp of the last conversation switch (set by `reset()`).
-    /// During the grace period after a switch, all pin reasons coalesce
-    /// to prevent competing sessions from initialRestore + messageCount + expansion.
-    private var lastResetTime: CFAbsoluteTime?
-
-    /// Duration after a conversation switch during which all pin reasons
-    /// coalesce into the active session regardless of reason type.
-    static let initialLoadGracePeriod: TimeInterval = 0.5
 
     /// Callback invoked when the coordinator decides a scroll-to-bottom should
     /// be executed. The caller (typically MessageListView) performs the actual
     /// `proxy.scrollTo` call. The Bool return indicates whether the pin was
     /// successful (anchor is within viewport).
-    var onPinRequested: ((_ reason: BottomPinRequestReason, _ animated: Bool) -> Bool)?
+    var onPinRequested: (() -> Bool)?
 
     /// Callback invoked when the follow/detach state changes, allowing the
     /// view to update `isNearBottom` and related reactive state.
     var onFollowStateChanged: ((_ isFollowing: Bool) -> Void)?
 
-    // MARK: - Configuration
+    // MARK: - User Actions
 
-    /// Delay between retry attempts in a pin session.
-    static let retryInterval: UInt64 = 50_000_000 // 50ms
+    /// User-initiated actions that affect the follow/detach state machine.
+    enum UserAction: Sendable {
+        /// Physical scroll-wheel / trackpad upward movement.
+        case scrollUp
+        /// User explicitly scrolled to the bottom (wheel hit bottom, or clicked "Scroll to latest").
+        case scrollToBottom
+        /// User clicked "Jump to latest" or equivalent explicit re-tether action.
+        case jumpToLatest
+    }
 
-    /// Maximum elapsed time for a single pin session before it self-terminates,
-    /// even if retries remain. Prevents stale sessions from lingering.
-    static let sessionTimeout: TimeInterval = 0.5
+    /// Processes a user-initiated action that affects follow/detach state.
+    func handleUserAction(_ action: UserAction) {
+        switch action {
+        case .scrollUp:
+            detach()
+
+        case .scrollToBottom, .jumpToLatest:
+            reattach()
+        }
+    }
+
+    // MARK: - Scroll to Bottom
+
+    /// Active initial-load retry task, cancelled on detach or conversation switch.
+    private var initialLoadTask: Task<Void, Never>?
+
+    /// Requests a single synchronous scroll-to-bottom. Used by the
+    /// "Scroll to latest" button.
+    ///
+    /// When the user is detached, the request is silently suppressed.
+    @discardableResult
+    func scrollToBottom() -> Bool {
+        guard isFollowingBottom else {
+            log.debug("[BottomPin] suppressed scrollToBottom isFollowingBottom=false")
+            return false
+        }
+
+        log.debug("[BottomPin] scrollToBottom isFollowingBottom=\(self.isFollowingBottom)")
+        let pinned = onPinRequested?() ?? false
+        log.debug("[BottomPin] scrollToBottom result=\(pinned)")
+        return pinned
+    }
+
+    /// Scroll to bottom with bounded retries for initial load positioning.
+    /// Layout may not be ready on the first attempt after a conversation switch,
+    /// so retries up to 3 times with 50ms intervals (150ms total window).
+    func scrollToBottomWithRetry() {
+        initialLoadTask?.cancel()
+
+        // Try immediately first
+        if scrollToBottom() { return }
+
+        // Retry asynchronously if the first attempt failed
+        initialLoadTask = Task { [weak self] in
+            for attempt in 1...3 {
+                try? await Task.sleep(nanoseconds: 50_000_000) // 50ms
+                guard !Task.isCancelled else { return }
+                guard let self, self.isFollowingBottom else { return }
+                if self.scrollToBottom() {
+                    log.debug("[BottomPin] initialLoad succeeded on retry \(attempt)")
+                    return
+                }
+            }
+        }
+    }
 
     // MARK: - Follow/Detach State Machine
 
-    /// Transitions to the detached state, suppressing all background pin requests.
-    func detach(trigger: BottomPinCancellationTrigger) {
+    /// Transitions to the detached state, suppressing all scroll-to-bottom requests.
+    func detach() {
         let wasFollowing = isFollowingBottom
         isFollowingBottom = false
-        cancelActiveSession(reason: trigger)
+        initialLoadTask?.cancel()
+        initialLoadTask = nil
 
         if wasFollowing {
-            log.debug("[BottomPin] detach trigger=\(trigger.rawValue) isFollowingBottom=false")
+            log.debug("[BottomPin] detach isFollowingBottom=false")
             onFollowStateChanged?(false)
         }
     }
 
-    /// Transitions to the following state, allowing pin requests to proceed.
+    /// Transitions to the following state, allowing scroll-to-bottom requests to proceed.
     func reattach() {
         let wasDetached = !isFollowingBottom
         isFollowingBottom = true
@@ -182,180 +126,11 @@ final class ChatBottomPinCoordinator {
         }
     }
 
-    // MARK: - User Actions
-
-    /// Processes a user-initiated action that affects follow/detach state.
-    func handleUserAction(_ action: BottomPinUserAction) {
-        switch action {
-        case .scrollUp:
-            detach(trigger: .userScrollUp)
-
-        case .scrollToBottom, .jumpToLatest:
-            reattach()
-        }
-    }
-
-    // MARK: - Pin Requests
-
-    /// Requests a scroll-to-bottom pin for the given reason.
-    ///
-    /// When the user is detached, the request is silently suppressed (decision-
-    /// complete suppression). When following, the request either coalesces into
-    /// the active session or starts a new bounded session.
-    ///
-    /// - Parameters:
-    ///   - reason: Why the pin is being requested.
-    ///   - conversationId: The conversation the request targets.
-    ///   - animated: Whether the scroll should be animated.
-    func requestPin(
-        reason: BottomPinRequestReason,
-        conversationId: UUID,
-        animated: Bool = false
-    ) {
-        // Decision-complete suppression: detached users are not yanked to bottom.
-        guard isFollowingBottom else {
-            log.debug("[BottomPin] suppressed reason=\(reason.rawValue) isFollowingBottom=false")
-            return
-        }
-
-        // Coalesce into active session if possible.
-        // During the initial-load grace period after a conversation switch,
-        // all pin reasons coalesce (regardless of reason type) to prevent
-        // competing sessions from initialRestore + messageCount + expansion.
-        let inGracePeriod = lastResetTime.map { CFAbsoluteTimeGetCurrent() - $0 < Self.initialLoadGracePeriod } ?? false
-        let canCoalesce = if let session = activeSession {
-            inGracePeriod
-                ? (session.conversationId == conversationId && !session.isExhausted)
-                : session.canCoalesce(reason: reason, conversationId: conversationId)
-        } else {
-            false
-        }
-        if canCoalesce {
-            let session = activeSession!
-            log.debug("[BottomPin] coalesce sid=\(session.sessionId) reason=\(reason.rawValue) attempt=\(session.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(session.elapsedMs) gracePeriod=\(inGracePeriod) isFollowingBottom=\(self.isFollowingBottom)")
-            // The existing session task continues; no new task needed.
-            // Just record that a new request arrived (the retry loop will
-            // pick it up on its next iteration).
-            return
-        }
-
-        // Cancel any stale session before starting a new one.
-        cancelActiveSession(reason: .conversationSwitch)
-
-        // Start a new bounded session.
-        let session = BottomPinSession(
-            sessionId: UUID(),
-            conversationId: conversationId,
-            reason: reason,
-            startTime: CFAbsoluteTimeGetCurrent()
-        )
-        activeSession = session
-        log.debug("[BottomPin] start sid=\(session.sessionId) reason=\(reason.rawValue) animated=\(animated) isFollowingBottom=\(self.isFollowingBottom)")
-        startSessionTask(animated: animated)
-    }
-
-    /// Cancels the active pin session and its associated task.
-    func cancelActiveSession(reason: BottomPinCancellationTrigger) {
-        guard let session = activeSession else { return }
-        log.debug("[BottomPin] cancel sid=\(session.sessionId) trigger=\(reason.rawValue) attempt=\(session.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(session.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
-        sessionTask?.cancel()
-        sessionTask = nil
-        activeSession = nil
-    }
-
     /// Resets all state, typically called on conversation switch.
-    func reset(newConversationId: UUID? = nil) {
-        cancelActiveSession(reason: .conversationSwitch)
+    func reset() {
+        initialLoadTask?.cancel()
+        initialLoadTask = nil
         isFollowingBottom = true
-        lastResetTime = CFAbsoluteTimeGetCurrent()
         onFollowStateChanged?(true)
-    }
-
-    // MARK: - Session Task
-
-    private func startSessionTask(animated: Bool) {
-        sessionTask?.cancel()
-        sessionGeneration += 1
-        let generation = sessionGeneration
-
-        // Immediate first attempt — synchronous so callers see the result
-        // before yielding (important for tests and single-frame UI updates).
-        guard var session = activeSession else { return }
-        session.recordAttempt()
-        activeSession = session
-        log.debug("[BottomPin] immediateAttempt sid=\(session.sessionId) reason=\(session.reason.rawValue) animated=\(animated) attempt=\(session.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(session.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
-        let pinned = onPinRequested?(session.reason, animated) ?? false
-
-        if pinned {
-            log.debug("[BottomPin] success sid=\(session.sessionId) attempt=\(session.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(session.elapsedMs)")
-            completeSession(generation: generation)
-            return
-        }
-
-        // Async bounded retry loop for subsequent attempts.
-        sessionTask = Task { @MainActor [weak self] in
-            while !Task.isCancelled {
-                guard let self else { break }
-                guard self.sessionGeneration == generation else {
-                    if let s = self.activeSession {
-                        log.debug("[BottomPin] generationMismatch sid=\(s.sessionId) staleGen=\(generation) currentGen=\(self.sessionGeneration)")
-                    }
-                    break
-                }
-                guard var currentSession = self.activeSession else { break }
-                guard !currentSession.isExhausted else {
-                    log.debug("[BottomPin] exhausted sid=\(currentSession.sessionId) attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(currentSession.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
-                    break
-                }
-
-                // Check session timeout.
-                let elapsed = CFAbsoluteTimeGetCurrent() - currentSession.startTime
-                if elapsed > Self.sessionTimeout {
-                    let elapsedMs = Int(elapsed * 1000)
-                    log.debug("[BottomPin] timeout sid=\(currentSession.sessionId) attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
-                    break
-                }
-
-                do {
-                    try await Task.sleep(nanoseconds: Self.retryInterval)
-                } catch {
-                    break
-                }
-                guard !Task.isCancelled else { break }
-
-                // Re-check follow state after sleep — user may have scrolled up.
-                guard self.isFollowingBottom else {
-                    log.debug("[BottomPin] retryAborted sid=\(currentSession.sessionId) reason=detachedDuringSleep attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(currentSession.elapsedMs) isFollowingBottom=false")
-                    break
-                }
-
-                currentSession.recordAttempt()
-                self.activeSession = currentSession
-                log.debug("[BottomPin] retryAttempt sid=\(currentSession.sessionId) reason=\(currentSession.reason.rawValue) animated=\(animated) attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(currentSession.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
-                let succeeded = self.onPinRequested?(currentSession.reason, animated) ?? false
-
-                if succeeded {
-                    log.debug("[BottomPin] success sid=\(currentSession.sessionId) attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(currentSession.elapsedMs)")
-                    self.completeSession(generation: generation)
-                    return
-                }
-            }
-
-            // Clean up if we fell through without completing.
-            if let self, let s = self.activeSession, self.sessionGeneration == generation {
-                log.debug("[BottomPin] sessionEnd sid=\(s.sessionId) attempt=\(s.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(s.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
-            }
-            self?.completeSession(generation: generation)
-        }
-    }
-
-    private func completeSession(generation: Int) {
-        guard sessionGeneration == generation else { return }
-        sessionTask = nil
-        activeSession = nil
-    }
-
-    deinit {
-        sessionTask?.cancel()
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -162,13 +162,9 @@ struct MessageListView: View {
     /// between Task launch and the first `await` (before isLoadingMoreMessages is set).
     @State private var isPaginationInFlight: Bool = false
     @State private var paginationTask: Task<Void, Never>?
-    /// Suppresses bottom auto-scroll for the ~32ms layout window after pagination
-    /// restores scroll position, preventing a jump back to the bottom.
-    @State private var isSuppressingBottomScroll: Bool = false
     @State private var isAppActive: Bool = NSApp.isActive
     @State private var conversationSwitchSuppressionTask: Task<Void, Never>?
     @State private var suppressScrollbarDuringConversationSwitch: Bool = false
-    @State private var expandSuppressionTask: Task<Void, Never>?
     /// Tracks the last pending confirmation request ID that triggered an
     /// auto-focus handoff. Used to detect nil→non-nil transitions so we
     /// resign first responder exactly once per new confirmation appearance.
@@ -180,8 +176,7 @@ struct MessageListView: View {
     /// trigger re-renders.
     @StateObject private var anchorTracker = AnchorVisibilityTracker()
     /// Whether a physical scroll event (wheel/trackpad) has been received since
-    /// the current conversation loaded. Used by `restoreScrollToBottom` to skip
-    /// retries once the user has interacted, and by the scroll-bottom-anchor's
+    /// the current conversation loaded. Used by the scroll-bottom-anchor's
     /// `onAppear` to avoid premature re-tethering during LazyVStack prefetch.
     @State private var hasReceivedScrollEvent: Bool = false
     /// The scroll view's viewport height, captured via preference key. Used by
@@ -197,13 +192,8 @@ struct MessageListView: View {
     /// Last container width that triggered a resize scroll handler, used to
     /// detect meaningful width changes (>2pt) and avoid sub-pixel jitter.
     @State private var lastHandledContainerWidth: CGFloat = 0
-    /// In-flight resize scroll stabilization task; cancelled on each new resize.
-    @State private var resizeScrollTask: Task<Void, Never>?
     /// Task that clears the highlight flash after the animation duration.
     @State private var highlightDismissTask: Task<Void, Never>?
-    /// In-flight staged scroll-to-bottom task used after conversation switches and
-    /// app restarts to reliably anchor the viewport once layout settles.
-    @State private var scrollRestoreTask: Task<Void, Never>?
     /// Whether the AnchorMinYKey preference has fired since the last scroll
     /// restore began. Ensures anchorTracker.isVisible reflects real geometry
     /// rather than the manual reset applied on conversation switch.
@@ -560,19 +550,16 @@ struct MessageListView: View {
         }
     }
 
-    /// Staged scroll-to-bottom that retries after increasing delays to handle
-    /// cases where SwiftUI hasn't committed the new content's layout yet (e.g.
-    /// after a conversation switch or app restart). Cancelled by user scroll-up,
-    /// user scroll-to-bottom, anchor message set, or view disappearance.
-    private func restoreScrollToBottom(proxy: ScrollViewProxy) {
-        scrollRestoreTask?.cancel()
+    /// Resets avatar follower state and issues a one-shot scroll-to-bottom
+    /// for initial load / conversation switch positioning. No staged retries.
+    private func resetAvatarAndScrollToBottom(proxy: ScrollViewProxy) {
         hasFreshAnchorMeasurement = false
 
         // Reset avatar follower state so the avatar starts hidden and only
         // appears once the conversation tail anchor reports a fresh position
         // after the scroll settles. Without this, the avatar can flash at a
         // stale Y from a previous layout pass (e.g. app re-launch where
-        // onAppear calls restoreScrollToBottom without resetting avatar state).
+        // onAppear calls this without resetting avatar state).
         avatarSmoothingTask?.cancel()
         avatarSmoothingTask = nil
         scrollTracking.avatarTargetY = .infinity
@@ -582,55 +569,19 @@ struct MessageListView: View {
         scrollTracking.avatarLastAppliedAt = nil
         scrollTracking.lastTailAnchorY = .infinity
 
-        // Route the initial restore through the coordinator for bounded retries.
+        // One-shot scroll to bottom for initial load positioning.
         if anchorMessageId == nil {
-            requestBottomPin(reason: .initialRestore, proxy: proxy)
-        }
-
-        scrollRestoreTask = Task { @MainActor in
-            guard !Task.isCancelled else { return }
-            // Stage 0: immediate — the coordinator fires its first attempt above.
-            os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=0")
-            log.debug("Scroll restore: stage 0 (immediate, coordinator-driven)")
-
-            // Stage 1: ~3 frames — handles most conversation switches.
-            try? await Task.sleep(nanoseconds: 50_000_000)
-            guard !Task.isCancelled else { return }
-            os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=1")
-            if anchorMessageId == nil {
-                requestBottomPin(reason: .initialRestore, proxy: proxy)
-            }
-            log.debug("Scroll restore: stage 1 (50ms)")
-
-            // Stage 2: ~9 frames — catches slower layout/materialization.
-            try? await Task.sleep(nanoseconds: 150_000_000)
-            guard !Task.isCancelled else { return }
-            // Only retry when the anchor genuinely drifted off-screen.
-            // `geometryUnavailable` means layout hasn't measured yet —
-            // the coordinator will pick up the next finite preference update
-            // instead of spinning retries on missing geometry.
-            let restoreOutcome = MessageListBottomAnchorPolicy.verify(
-                anchorMinY: anchorTracker.lastMinY,
-                viewportHeight: scrollViewportHeight
+            let convId = conversationId ?? Self.bootstrapConversationId
+            bottomPinCoordinator.requestPin(
+                reason: .initialRestore,
+                conversationId: convId,
+                animated: false
             )
-            if anchorMessageId == nil
-                && !hasReceivedScrollEvent
-                && restoreOutcome == .needsRepin
-            {
-                os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=2 action=retry")
-                requestBottomPin(reason: .initialRestore, proxy: proxy)
-                log.debug("Scroll restore: stage 2 (200ms) — retrying via coordinator")
-            } else {
-                os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=2 action=skipped")
-                log.debug("Scroll restore: stage 2 skipped (anchor=\(String(describing: anchorMessageId)) scrollEvent=\(hasReceivedScrollEvent))")
-            }
-
-            if !Task.isCancelled { scrollRestoreTask = nil }
         }
     }
 
     /// Fires a single pagination load, restores the scroll anchor, and
-    /// manages the `isPaginationInFlight` / `isSuppressingBottomScroll` guards.
+    /// manages the `isPaginationInFlight` guard.
     private func triggerPagination(proxy: ScrollViewProxy) {
         guard !isPaginationInFlight else { return }
         isPaginationInFlight = true
@@ -652,24 +603,15 @@ struct MessageListView: View {
             let hadMore = await loadPreviousMessagePage?() ?? false
             log.debug("[pagination] loadPreviousMessagePage returned hadMore=\(hadMore)")
             if hadMore, let id = anchorId {
-                // Suppress bottom auto-scroll for the brief layout window so the
-                // restored anchor position is not immediately overridden.
-                isSuppressingBottomScroll = true
-                os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=pagination")
                 // Wait ~6 frames for SwiftUI to complete layout before restoring position.
                 // 100ms gives video embed cards (which animate height over 0.25s) enough
                 // time to settle so the scroll restoration lands at the right position.
                 try? await Task.sleep(nanoseconds: 100_000_000)
-                guard !Task.isCancelled else {
-                    isSuppressingBottomScroll = false
-                    return
-                }
+                guard !Task.isCancelled else { return }
                 os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=paginationAnchor")
                 recordScrollLoopEvent(.scrollToRequested)
                 proxy.scrollTo(id, anchor: .top)
                 log.debug("[pagination] scroll restored to anchor \(id)")
-                isSuppressingBottomScroll = false
-                os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "off reason=paginationDone")
             }
         }
     }
@@ -771,7 +713,7 @@ struct MessageListView: View {
             isNearBottom: isNearBottom,
             hasReceivedScrollEvent: hasReceivedScrollEvent,
             isPaginationInFlight: isPaginationInFlight,
-            suppressionReason: isSuppressingBottomScroll ? "bottomScrollSuppressed" : nil,
+            suppressionReason: nil,
             anchorMessageId: anchorMessageId?.uuidString,
             highlightedMessageId: highlightedMessageId?.uuidString,
             anchorMinY: safeAnchorMinY,
@@ -818,7 +760,6 @@ struct MessageListView: View {
     /// the scroll view proxy and follow-state changes back to `isNearBottom`.
     private func configureBottomPinCoordinator(proxy: ScrollViewProxy) {
         bottomPinCoordinator.onPinRequested = { [self] reason, animated in
-            guard !isSuppressingBottomScroll else { return false }
             // Circuit breaker: suppress scroll-to when a scroll loop was detected.
             // The guard re-arms after a quiet cooldown window elapses.
             let convIdString = conversationId?.uuidString ?? "unknown"
@@ -1078,38 +1019,10 @@ struct MessageListView: View {
             .plainTextCopy()
             .coordinateSpace(name: "chatScrollView")
             .scrollDisabled(messages.isEmpty && !isSending)
-            .environment(\.suppressAutoScroll, { [self] in
-                expandSuppressionTask?.cancel()
-                if isNearBottom {
-                    // Clear any stale suppression left by a canceled off-bottom expansion,
-                    // but only when the resize guard isn't actively suppressing scroll.
-                    let resizeActive = resizeScrollTask != nil && !resizeScrollTask!.isCancelled
-                    if !resizeActive {
-                        isSuppressingBottomScroll = false
-                    }
-                    // Route expansion bottom-follow through the coordinator for
-                    // bounded staged retries instead of per-frame repinning.
-                    os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=expansionPinning")
-                    recordScrollLoopEvent(.suppressionFlip)
-                    requestBottomPin(reason: .expansion, proxy: proxy, animated: false)
-                } else {
-                    // When scrolled away from bottom, suppress auto-scroll so the
-                    // expansion doesn't yank the viewport to the bottom.
-                    isSuppressingBottomScroll = true
-                    os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=offBottomExpansion")
-                    recordScrollLoopEvent(.suppressionFlip)
-                    expandSuppressionTask = Task { @MainActor in
-                        try? await Task.sleep(nanoseconds: 200_000_000)
-                        guard !Task.isCancelled else { return }
-                        // Only clear if no other mechanism (resize, pagination) still needs suppression.
-                        let resizeActive = resizeScrollTask != nil && !resizeScrollTask!.isCancelled
-                        let paginationActive = isPaginationInFlight
-                        if !resizeActive && !paginationActive {
-                            isSuppressingBottomScroll = false
-                            os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "off reason=expansionExpired")
-                        }
-                    }
-                }
+            .environment(\.suppressAutoScroll, {
+                // No-op: auto-scroll during content expansion has been removed.
+                // This environment callback is kept so child views calling
+                // suppressAutoScroll don't crash on a nil closure.
             })
             .background {
                 GeometryReader { geo in
@@ -1117,21 +1030,12 @@ struct MessageListView: View {
                 }
                 ScrollWheelDetector(
                     onScrollUp: {
-
-                        scrollRestoreTask?.cancel()
-                        scrollRestoreTask = nil
-                        expandSuppressionTask?.cancel()
-                        expandSuppressionTask = nil
-                        isSuppressingBottomScroll = false
                         // Signal the coordinator to detach — this sets isNearBottom
                         // to false and cancels any active pin session.
                         bottomPinCoordinator.handleUserAction(.scrollUp)
                         hasReceivedScrollEvent = true
                     },
                     onScrollToBottom: {
-                        scrollRestoreTask?.cancel()
-                        scrollRestoreTask = nil
-                        isSuppressingBottomScroll = false
                         // Signal the coordinator to reattach — this sets isNearBottom
                         // to true and allows future pin requests.
                         bottomPinCoordinator.handleUserAction(.scrollToBottom)
@@ -1326,7 +1230,7 @@ struct MessageListView: View {
                         }
                     }
                 } else {
-                    restoreScrollToBottom(proxy: proxy)
+                    resetAvatarAndScrollToBottom(proxy: proxy)
                 }
                 // When anchorMessageId is set but the target message isn't loaded
                 // yet, skip scrolling entirely — onChange(of: messages.count) will
@@ -1338,12 +1242,6 @@ struct MessageListView: View {
                 suppressScrollbarDuringConversationSwitch = false
                 anchorTimeoutTask?.cancel()
                 anchorTimeoutTask = nil
-                resizeScrollTask?.cancel()
-                resizeScrollTask = nil
-                expandSuppressionTask?.cancel()
-                expandSuppressionTask = nil
-                scrollRestoreTask?.cancel()
-                scrollRestoreTask = nil
                 paginationTask?.cancel()
                 paginationTask = nil
                 isPaginationInFlight = false
@@ -1362,24 +1260,6 @@ struct MessageListView: View {
             .onChange(of: isSending) {
                 if isSending {
                     hasReceivedScrollEvent = true
-                    // Reattach and pin to bottom for user-initiated actions (send,
-                    // regenerate, retry). Skip reattach only when the daemon resumes
-                    // from a tool confirmation (not a user action during confirmation).
-                    //
-                    // Detection: when the daemon resumes, it sets both isSending=true
-                    // AND assistantActivityPhase="thinking" in the same mutation. When
-                    // the user sends/regenerates during confirmation, only isSending
-                    // changes — assistantActivityPhase stays "awaiting_confirmation"
-                    // until the daemon processes the new request.
-                    let isDaemonConfirmationResume =
-                        phaseWhenSendingStopped == "awaiting_confirmation"
-                        && assistantActivityPhase != "awaiting_confirmation"
-                    if isDaemonConfirmationResume && !bottomPinCoordinator.isFollowingBottom {
-                        // Daemon resumed from confirmation while user was scrolled up.
-                    } else {
-                        bottomPinCoordinator.reattach()
-                        requestBottomPin(reason: .messageCount, proxy: proxy, animated: true)
-                    }
                 } else {
                     // Capture the activity phase at the moment sending stops.
                     // "awaiting_confirmation" marks a mid-turn pause; any other value
@@ -1456,65 +1336,16 @@ struct MessageListView: View {
                         return
                     }
                 }
-                if isNearBottom && !isSuppressingBottomScroll && anchorMessageId == nil {
-                    requestBottomPin(reason: .messageCount, proxy: proxy, animated: true)
-                } else if isSuppressingBottomScroll {
-                    log.debug("Auto-scroll suppressed (bottom-scroll suppression active)")
-                }
             }
             .onChange(of: containerWidth) {
                 // Ignore sub-pixel jitter and initial zero value.
-                // Use a tight 2pt threshold so scroll suppression activates on
-                // any meaningful width change during divider drag — the previous
-                // 20pt dead-zone let intermediate reflows through without suppression,
-                // causing scroll position desync and disappearing messages.
                 guard containerWidth > 0, abs(containerWidth - lastHandledContainerWidth) > 2 else { return }
                 lastHandledContainerWidth = containerWidth
-
-                // Cancel competing scroll tasks to prevent jitter during resize
-                resizeScrollTask?.cancel()
-
-                resizeScrollTask = Task { @MainActor in
-                    // Temporarily suppress bottom auto-scroll so streaming/message-count
-                    // handlers don't fight with the resize stabilization.
-                    isSuppressingBottomScroll = true
-                    os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=resize")
-                    defer {
-                        if !Task.isCancelled {
-                            isSuppressingBottomScroll = false
-                            os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "off reason=resizeDone")
-                            resizeScrollTask = nil
-                        }
-                    }
-                    // Wait for layout to settle (~100ms ≈ 6 frames)
-                    try? await Task.sleep(nanoseconds: 100_000_000)
-                    guard !Task.isCancelled else { return }
-
-                    if isNearBottom && anchorMessageId == nil {
-                        // Pin to bottom without animation to avoid visual bounce.
-                        // Skip when an anchor is pending (deep-link / notification)
-                        // to avoid yanking the viewport away from the target message.
-                        // Only repin for genuinely off-screen anchors — transient
-                        // missing geometry waits for the next finite preference update.
-                        let resizeOutcome = MessageListBottomAnchorPolicy.verify(
-                            anchorMinY: anchorTracker.lastMinY,
-                            viewportHeight: scrollViewportHeight
-                        )
-                        if resizeOutcome == .needsRepin {
-                            requestBottomPin(reason: .resize, proxy: proxy)
-                        }
-                    }
-                    // If not near bottom or anchor is set, preserve viewport.
-                }
             }
             .onChange(of: conversationId) { oldConversationId, _ in
                 // Keep the underlying NSScrollView instance stable across conversation
                 // switches (prevents default-scroller flash), and reset view-local
                 // scroll state explicitly instead of remounting the whole view.
-                resizeScrollTask?.cancel()
-                resizeScrollTask = nil
-                expandSuppressionTask?.cancel()
-                expandSuppressionTask = nil
                 avatarSmoothingTask?.cancel()
                 avatarSmoothingTask = nil
                 scrollTracking.snapshotDebounceTask?.cancel()
@@ -1523,7 +1354,6 @@ struct MessageListView: View {
                 paginationTask = nil
                 isPaginationInFlight = false
                 wasPaginationTriggerInRange = false
-                isSuppressingBottomScroll = false
                 // Reset the coordinator for the new conversation — cancels any
                 // active pin session and resets to following state.
                 bottomPinCoordinator.reset(newConversationId: conversationId)
@@ -1566,17 +1396,12 @@ struct MessageListView: View {
                 }
                 hasPlayedTailEntryAnimation = false
                 // Avatar state (scrollTracking.avatarTargetY, avatarDisplayY, scrollTracking)
-                // is reset inside
-                // restoreScrollToBottom so the reset is shared with onAppear.
-                restoreScrollToBottom(proxy: proxy)
+                // is reset inside resetAvatarAndScrollToBottom so the reset is
+                // shared with onAppear.
+                resetAvatarAndScrollToBottom(proxy: proxy)
             }
             .onChange(of: anchorMessageId) {
-                // Only cancel scroll restore when a new anchor is set (non-nil).
-                // The nil transition fires during conversation switches (stale anchor
-                // cleanup) and must not cancel the restore just started.
                 if anchorMessageId != nil {
-                    scrollRestoreTask?.cancel()
-                    scrollRestoreTask = nil
                     // Anchor jumps are higher priority — cancel any active pin session.
                     bottomPinCoordinator.cancelActiveSession(reason: .deepLinkAnchorHandoff)
                 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -569,14 +569,10 @@ struct MessageListView: View {
         scrollTracking.avatarLastAppliedAt = nil
         scrollTracking.lastTailAnchorY = .infinity
 
-        // One-shot scroll to bottom for initial load positioning.
+        // Scroll to bottom for initial load positioning with bounded retries.
+        // Layout may not be ready on the first attempt after a conversation switch.
         if anchorMessageId == nil {
-            let convId = conversationId ?? Self.bootstrapConversationId
-            bottomPinCoordinator.requestPin(
-                reason: .initialRestore,
-                conversationId: convId,
-                animated: false
-            )
+            bottomPinCoordinator.scrollToBottomWithRetry()
         }
     }
 
@@ -585,9 +581,9 @@ struct MessageListView: View {
     private func triggerPagination(proxy: ScrollViewProxy) {
         guard !isPaginationInFlight else { return }
         isPaginationInFlight = true
-        // Pagination scroll-position restore is higher priority — cancel any
-        // active pin session so the coordinator doesn't fight the restore.
-        bottomPinCoordinator.cancelActiveSession(reason: .paginationRestore)
+        // Pagination scroll-position restore is higher priority — detach
+        // the coordinator so it doesn't fight the restore.
+        bottomPinCoordinator.detach()
         let anchorId = visibleMessages.first?.id
         os_signpost(.event, log: PerfSignposts.log, name: "paginationSentinelFired")
         log.debug("[pagination] fired — anchorId: \(String(describing: anchorId))")
@@ -735,31 +731,10 @@ struct MessageListView: View {
     }
 
     /// Routes an automatic bottom-follow request through the coordinator.
-    /// The coordinator decides whether to suppress (user is detached), coalesce
-    /// (duplicate request within an active session), or start a new bounded
-    /// retry session. Anchor-message jumps and pagination restoration bypass
-    /// this helper entirely — they are higher-priority flows.
-    /// Sentinel UUID used for pin requests before the daemon assigns a real
-    /// conversation ID. Lets bootstrap-window requests coalesce normally.
-    private static let bootstrapConversationId = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
-
-    private func requestBottomPin(
-        reason: BottomPinRequestReason,
-        proxy: ScrollViewProxy,
-        animated: Bool = false
-    ) {
-        let convId = conversationId ?? Self.bootstrapConversationId
-        bottomPinCoordinator.requestPin(
-            reason: reason,
-            conversationId: convId,
-            animated: animated
-        )
-    }
-
     /// Configures the coordinator's callbacks to wire pin requests back to
     /// the scroll view proxy and follow-state changes back to `isNearBottom`.
     private func configureBottomPinCoordinator(proxy: ScrollViewProxy) {
-        bottomPinCoordinator.onPinRequested = { [self] reason, animated in
+        bottomPinCoordinator.onPinRequested = { [self] in
             // Circuit breaker: suppress scroll-to when a scroll loop was detected.
             // The guard re-arms after a quiet cooldown window elapses.
             let convIdString = conversationId?.uuidString ?? "unknown"
@@ -769,19 +744,10 @@ struct MessageListView: View {
                 return false
             }
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested",
-                        "target=bottomAnchor reason=coordinator-%{public}s", reason.rawValue)
+                        "target=bottomAnchor reason=coordinator-scrollToBottom")
             recordScrollLoopEvent(.scrollToRequested)
-            if animated {
-                withAnimation(VAnimation.fast) {
-                    proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
-                }
-            } else {
-                proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
-            }
+            proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
             // Check if the pin succeeded (anchor within viewport).
-            // Use `verify()` so that `geometryUnavailable` returns false
-            // (wait for the next finite preference update) instead of being
-            // treated as an immediate failed pin that triggers retry churn.
             let outcome = MessageListBottomAnchorPolicy.verify(
                 anchorMinY: anchorTracker.lastMinY,
                 viewportHeight: scrollViewportHeight
@@ -1163,7 +1129,7 @@ struct MessageListView: View {
                         hasReceivedScrollEvent = true
                         // Signal the coordinator to reattach and scroll to bottom.
                         bottomPinCoordinator.handleUserAction(.jumpToLatest)
-                        requestBottomPin(reason: .initialRestore, proxy: proxy, animated: true)
+                        bottomPinCoordinator.scrollToBottom()
                     }) {
                         HStack(spacing: VSpacing.xs) {
                             VIconView(.arrowDown, size: 10)
@@ -1226,7 +1192,7 @@ struct MessageListView: View {
                             anchorSetTime = nil
                             anchorTimeoutTask = nil
                             bottomPinCoordinator.reattach()
-                            requestBottomPin(reason: .initialRestore, proxy: proxy, animated: true)
+                            bottomPinCoordinator.scrollToBottom()
                         }
                     }
                 } else {
@@ -1252,9 +1218,8 @@ struct MessageListView: View {
                 scrollTracking.snapshotDebounceTask?.cancel()
                 scrollTracking.snapshotDebounceTask = nil
                 highlightedMessageId = nil
-                // Cancel any active pin session to prevent the coordinator's
-                // sessionTask from calling scrollTo on a stale ScrollViewProxy.
-                bottomPinCoordinator.cancelActiveSession(reason: .conversationSwitch)
+                // Clear the coordinator's callback to prevent it from calling
+                // scrollTo on a stale ScrollViewProxy.
                 bottomPinCoordinator.onPinRequested = nil
             }
             .onChange(of: isSending) {
@@ -1303,7 +1268,7 @@ struct MessageListView: View {
                     os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundInMessages")
                     recordScrollLoopEvent(.scrollToRequested)
                     // Anchor jumps bypass the coordinator — they are higher priority.
-                    bottomPinCoordinator.cancelActiveSession(reason: .deepLinkAnchorHandoff)
+                    bottomPinCoordinator.detach()
                     withAnimation {
                         proxy.scrollTo(id, anchor: .center)
                     }
@@ -1332,7 +1297,7 @@ struct MessageListView: View {
                         anchorTimeoutTask?.cancel()
                         anchorTimeoutTask = nil
                         bottomPinCoordinator.reattach()
-                        requestBottomPin(reason: .messageCount, proxy: proxy, animated: true)
+                        bottomPinCoordinator.scrollToBottom()
                         return
                     }
                 }
@@ -1354,9 +1319,8 @@ struct MessageListView: View {
                 paginationTask = nil
                 isPaginationInFlight = false
                 wasPaginationTriggerInRange = false
-                // Reset the coordinator for the new conversation — cancels any
-                // active pin session and resets to following state.
-                bottomPinCoordinator.reset(newConversationId: conversationId)
+                // Reset the coordinator for the new conversation.
+                bottomPinCoordinator.reset()
                 isNearBottom = true
                 highlightedMessageId = nil
                 highlightDismissTask?.cancel()
@@ -1402,8 +1366,8 @@ struct MessageListView: View {
             }
             .onChange(of: anchorMessageId) {
                 if anchorMessageId != nil {
-                    // Anchor jumps are higher priority — cancel any active pin session.
-                    bottomPinCoordinator.cancelActiveSession(reason: .deepLinkAnchorHandoff)
+                    // Anchor jumps are higher priority — detach the coordinator.
+                    bottomPinCoordinator.detach()
                 }
                 // Record the timestamp when a new anchor is set so the
                 // pagination-exhaustion guard can measure elapsed time.
@@ -1443,7 +1407,7 @@ struct MessageListView: View {
                         anchorSetTime = nil
                         anchorTimeoutTask = nil
                         bottomPinCoordinator.reattach()
-                        requestBottomPin(reason: .initialRestore, proxy: proxy, animated: true)
+                        bottomPinCoordinator.scrollToBottom()
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -189,6 +189,11 @@ struct MessageListView: View {
     /// regardless of whether messages.count changes. This covers the edge
     /// case where pagination stalls without adding/removing messages.
     @State private var anchorTimeoutTask: Task<Void, Never>?
+    /// Whether the initial scroll-to-bottom has completed for this conversation.
+    /// Set true after the first successful scroll; reset on conversation switch.
+    /// Used in onChange(of: messages.count) to scroll to bottom when messages
+    /// first materialize (async load), without auto-scrolling during streaming.
+    @State private var hasCompletedInitialScroll: Bool = false
     /// Last container width that triggered a resize scroll handler, used to
     /// detect meaningful width changes (>2pt) and avoid sub-pixel jitter.
     @State private var lastHandledContainerWidth: CGFloat = 0
@@ -1301,6 +1306,15 @@ struct MessageListView: View {
                         return
                     }
                 }
+
+                // One-time initial scroll: when messages first materialize after
+                // async load, scroll to bottom. This only fires once per conversation
+                // (hasCompletedInitialScroll is reset on conversation switch).
+                // Not triggered during streaming — the flag is already true by then.
+                if !hasCompletedInitialScroll && anchorMessageId == nil && !messages.isEmpty {
+                    hasCompletedInitialScroll = true
+                    bottomPinCoordinator.scrollToBottomWithRetry()
+                }
             }
             .onChange(of: containerWidth) {
                 // Ignore sub-pixel jitter and initial zero value.
@@ -1333,6 +1347,7 @@ struct MessageListView: View {
                 // hasFreshAnchorMeasurement from becoming true.
                 anchorTracker.lastMinY = .infinity
                 hasReceivedScrollEvent = false
+                hasCompletedInitialScroll = false
                 // Capture the new conversation's activity phase so a conversation
                 // already paused in awaiting_confirmation is correctly tracked.
                 phaseWhenSendingStopped = isSending ? "" : assistantActivityPhase

--- a/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
@@ -5,8 +5,6 @@ import XCTest
 final class ChatBottomPinCoordinatorTests: XCTestCase {
     private var coordinator: ChatBottomPinCoordinator!
     private var pinRequestCount: Int = 0
-    private var lastPinReason: BottomPinRequestReason?
-    private var lastPinAnimated: Bool?
     private var pinShouldSucceed: Bool = true
     private var followStateChanges: [Bool] = []
 
@@ -14,15 +12,11 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
         super.setUp()
         coordinator = ChatBottomPinCoordinator()
         pinRequestCount = 0
-        lastPinReason = nil
-        lastPinAnimated = nil
         pinShouldSucceed = true
         followStateChanges = []
 
-        coordinator.onPinRequested = { [weak self] reason, animated in
+        coordinator.onPinRequested = { [weak self] in
             self?.pinRequestCount += 1
-            self?.lastPinReason = reason
-            self?.lastPinAnimated = animated
             return self?.pinShouldSucceed ?? false
         }
         coordinator.onFollowStateChanged = { [weak self] isFollowing in
@@ -39,7 +33,6 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
 
     func testInitialStateIsFollowingBottom() {
         XCTAssertTrue(coordinator.isFollowingBottom)
-        XCTAssertNil(coordinator.activeSession)
     }
 
     // MARK: - Detach on Upward Scroll
@@ -49,18 +42,6 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
 
         XCTAssertFalse(coordinator.isFollowingBottom)
         XCTAssertEqual(followStateChanges, [false])
-    }
-
-    func testScrollUpCancelsActiveSession() {
-        let convId = UUID()
-        pinShouldSucceed = false
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-        XCTAssertNotNil(coordinator.activeSession)
-
-        coordinator.handleUserAction(.scrollUp)
-
-        XCTAssertFalse(coordinator.isFollowingBottom)
-        XCTAssertNil(coordinator.activeSession)
     }
 
     func testRepeatedScrollUpDoesNotDuplicateStateChange() {
@@ -101,570 +82,135 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
 
     // MARK: - Suppression While Detached
 
-    func testPinRequestSuppressedWhileDetached() {
-        let convId = UUID()
+    func testScrollToBottomSuppressedWhileDetached() {
         coordinator.handleUserAction(.scrollUp)
 
-        coordinator.requestPin(reason: .resize, conversationId: convId)
+        let result = coordinator.scrollToBottom()
 
-        XCTAssertEqual(pinRequestCount, 0)
-        XCTAssertNil(coordinator.activeSession)
-    }
-
-    func testPinRequestSuppressedForMessageCountWhileDetached() {
-        let convId = UUID()
-        coordinator.handleUserAction(.scrollUp)
-
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-
+        XCTAssertFalse(result)
         XCTAssertEqual(pinRequestCount, 0)
     }
 
-    func testPinRequestSuppressedForExpansionWhileDetached() {
-        let convId = UUID()
+    func testScrollToBottomAllowedAfterReattach() {
         coordinator.handleUserAction(.scrollUp)
-
-        coordinator.requestPin(reason: .expansion, conversationId: convId)
-
-        XCTAssertEqual(pinRequestCount, 0)
-    }
-
-    func testPinRequestAllowedAfterReattach() {
-        let convId = UUID()
-        coordinator.handleUserAction(.scrollUp)
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
+        let suppressedResult = coordinator.scrollToBottom()
+        XCTAssertFalse(suppressedResult)
         XCTAssertEqual(pinRequestCount, 0)
 
         coordinator.handleUserAction(.scrollToBottom)
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
+        let result = coordinator.scrollToBottom()
 
+        XCTAssertTrue(result)
         XCTAssertEqual(pinRequestCount, 1)
     }
 
-    // MARK: - Coalescing Duplicate Requests
+    // MARK: - scrollToBottom
 
-    func testDuplicateExpansionRequestsCoalesce() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.requestPin(reason: .expansion, conversationId: convId)
-        let firstSessionStartTime = coordinator.activeSession?.startTime
-
-        // Second expansion request should coalesce.
-        coordinator.requestPin(reason: .expansion, conversationId: convId)
-
-        // Should still be the same session (same start time).
-        XCTAssertEqual(coordinator.activeSession?.startTime, firstSessionStartTime)
-        // Only one pin call from the initial session start.
-        XCTAssertEqual(pinRequestCount, 1)
-    }
-
-    func testDuplicateMessageCountRequestsCoalesce() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-        let firstStartTime = coordinator.activeSession?.startTime
-
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-
-        XCTAssertEqual(coordinator.activeSession?.startTime, firstStartTime)
-        XCTAssertEqual(pinRequestCount, 1)
-    }
-
-    func testDifferentReasonsDoNotCoalesce() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.requestPin(reason: .expansion, conversationId: convId)
-        let firstStartTime = coordinator.activeSession?.startTime
-
-        coordinator.requestPin(reason: .resize, conversationId: convId)
-
-        // Should be a new session with a new start time.
-        XCTAssertNotEqual(coordinator.activeSession?.startTime, firstStartTime)
-    }
-
-    func testDifferentConversationsDoNotCoalesce() {
-        let conv1 = UUID()
-        let conv2 = UUID()
-        pinShouldSucceed = false
-
-        coordinator.requestPin(reason: .expansion, conversationId: conv1)
-        let firstConvSession = coordinator.activeSession
-
-        coordinator.requestPin(reason: .expansion, conversationId: conv2)
-
-        // New session for the different conversation.
-        XCTAssertNotEqual(coordinator.activeSession?.conversationId, firstConvSession?.conversationId)
-        XCTAssertEqual(coordinator.activeSession?.conversationId, conv2)
-    }
-
-    // MARK: - Bounded Retry Sessions
-
-    func testSessionCapsRetries() {
-        var session = BottomPinSession(
-            sessionId: UUID(),
-            conversationId: UUID(),
-            reason: .expansion,
-            startTime: CFAbsoluteTimeGetCurrent()
-        )
-
-        for _ in 0..<BottomPinSession.maxRetries {
-            XCTAssertFalse(session.isExhausted)
-            let recorded = session.recordAttempt()
-            XCTAssertTrue(recorded)
-        }
-
-        XCTAssertTrue(session.isExhausted)
-        let overBudget = session.recordAttempt()
-        XCTAssertFalse(overBudget)
-        XCTAssertEqual(session.attemptCount, BottomPinSession.maxRetries)
-    }
-
-    func testExhaustedSessionDoesNotCoalesce() {
-        var session = BottomPinSession(
-            sessionId: UUID(),
-            conversationId: UUID(),
-            reason: .expansion,
-            startTime: CFAbsoluteTimeGetCurrent()
-        )
-
-        for _ in 0..<BottomPinSession.maxRetries {
-            session.recordAttempt()
-        }
-
-        XCTAssertFalse(session.canCoalesce(reason: .expansion, conversationId: session.conversationId))
-    }
-
-    func testSuccessfulPinCompletesSession() {
-        let convId = UUID()
+    func testScrollToBottomCallsOnPinRequested() {
         pinShouldSucceed = true
 
-        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
+        let result = coordinator.scrollToBottom()
 
-        // Successful pin on first attempt should clear the session.
+        XCTAssertTrue(result)
         XCTAssertEqual(pinRequestCount, 1)
-        XCTAssertNil(coordinator.activeSession)
     }
 
-    // MARK: - Cancellation Triggers
-
-    func testDeepLinkAnchorCancelsSession() {
-        let convId = UUID()
+    func testScrollToBottomReturnsFalseWhenPinFails() {
         pinShouldSucceed = false
 
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-        XCTAssertNotNil(coordinator.activeSession)
+        let result = coordinator.scrollToBottom()
 
-        coordinator.cancelActiveSession(reason: .deepLinkAnchorHandoff)
-
-        XCTAssertNil(coordinator.activeSession)
+        XCTAssertFalse(result)
+        XCTAssertEqual(pinRequestCount, 1)
     }
 
-    func testPaginationRestoreCancelsSession() {
-        let convId = UUID()
-        pinShouldSucceed = false
+    func testScrollToBottomReturnsFalseWhenNoCallback() {
+        coordinator.onPinRequested = nil
 
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-        XCTAssertNotNil(coordinator.activeSession)
+        let result = coordinator.scrollToBottom()
 
-        coordinator.cancelActiveSession(reason: .paginationRestore)
-
-        XCTAssertNil(coordinator.activeSession)
+        XCTAssertFalse(result)
     }
 
-    func testConversationSwitchCancelsSession() {
-        let convId = UUID()
-        pinShouldSucceed = false
+    // MARK: - Detach / Reattach
 
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-        XCTAssertNotNil(coordinator.activeSession)
+    func testDetachSuppressesFutureScrollToBottom() {
+        coordinator.detach()
 
-        coordinator.cancelActiveSession(reason: .conversationSwitch)
+        XCTAssertFalse(coordinator.isFollowingBottom)
 
-        XCTAssertNil(coordinator.activeSession)
+        let result = coordinator.scrollToBottom()
+        XCTAssertFalse(result)
+        XCTAssertEqual(pinRequestCount, 0)
+    }
+
+    func testDetachFiresFollowStateChanged() {
+        coordinator.detach()
+
+        XCTAssertEqual(followStateChanges, [false])
+    }
+
+    func testDetachWhenAlreadyDetachedDoesNotFireCallback() {
+        coordinator.detach()
+        coordinator.detach()
+
+        // Only one state change callback should fire.
+        XCTAssertEqual(followStateChanges, [false])
+    }
+
+    func testReattachAllowsScrollToBottom() {
+        coordinator.detach()
+        coordinator.reattach()
+
+        let result = coordinator.scrollToBottom()
+        XCTAssertTrue(result)
+        XCTAssertEqual(pinRequestCount, 1)
+    }
+
+    func testReattachFiresFollowStateChanged() {
+        coordinator.detach()
+        coordinator.reattach()
+
+        XCTAssertEqual(followStateChanges, [false, true])
+    }
+
+    func testReattachWhenAlreadyFollowingDoesNotFireCallback() {
+        coordinator.reattach()
+
+        XCTAssertEqual(followStateChanges, [])
     }
 
     // MARK: - Reset
 
-    func testResetClearsAllStateAndReattaches() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
+    func testResetResetsFollowState() {
         coordinator.handleUserAction(.scrollUp)
-        coordinator.requestPin(reason: .expansion, conversationId: convId)
         XCTAssertFalse(coordinator.isFollowingBottom)
 
-        let newConvId = UUID()
-        coordinator.reset(newConversationId: newConvId)
+        coordinator.reset()
 
         XCTAssertTrue(coordinator.isFollowingBottom)
-        XCTAssertNil(coordinator.activeSession)
     }
 
-    // MARK: - Pin Session Struct
-
-    func testSessionCoalesceRequiresSameConversation() {
-        let convA = UUID()
-        let convB = UUID()
-        let session = BottomPinSession(
-            sessionId: UUID(),
-            conversationId: convA,
-            reason: .expansion,
-            startTime: CFAbsoluteTimeGetCurrent()
-        )
-
-        XCTAssertTrue(session.canCoalesce(reason: .expansion, conversationId: convA))
-        XCTAssertFalse(session.canCoalesce(reason: .expansion, conversationId: convB))
-    }
-
-    func testSessionCoalesceRequiresSameReason() {
-        let convId = UUID()
-        let session = BottomPinSession(
-            sessionId: UUID(),
-            conversationId: convId,
-            reason: .messageCount,
-            startTime: CFAbsoluteTimeGetCurrent()
-        )
-
-        XCTAssertTrue(session.canCoalesce(reason: .messageCount, conversationId: convId))
-        XCTAssertFalse(session.canCoalesce(reason: .expansion, conversationId: convId))
-        XCTAssertFalse(session.canCoalesce(reason: .resize, conversationId: convId))
-        XCTAssertFalse(session.canCoalesce(reason: .initialRestore, conversationId: convId))
-    }
-
-    // MARK: - Async Retry Behavior
-
-    func testRetryLoopStopsOnSuccess() async throws {
-        let convId = UUID()
-        var callCount = 0
-        pinShouldSucceed = false
-
-        coordinator.onPinRequested = { [weak self] reason, animated in
-            callCount += 1
-            self?.pinRequestCount = callCount
-            // Succeed on the third attempt.
-            if callCount >= 3 {
-                return true
-            }
-            return false
-        }
-
-        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
-
-        // Poll until the session completes (robust against slow CI scheduling).
-        let deadline = CFAbsoluteTimeGetCurrent() + 1.0
-        while coordinator.activeSession != nil, CFAbsoluteTimeGetCurrent() < deadline {
-            try await Task.sleep(nanoseconds: 10_000_000) // 10ms
-        }
-
-        // Should have stopped after success (3 attempts), not continued to maxRetries.
-        XCTAssertGreaterThanOrEqual(callCount, 3)
-        XCTAssertLessThanOrEqual(callCount, BottomPinSession.maxRetries)
-        XCTAssertNil(coordinator.activeSession)
-    }
-
-    func testRetryLoopAbortsOnDetach() async throws {
-        let convId = UUID()
-        var callCount = 0
-        pinShouldSucceed = false
-
-        coordinator.onPinRequested = { reason, animated in
-            callCount += 1
-            return false
-        }
-
-        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
-
-        // Let one retry fire.
-        try await Task.sleep(nanoseconds: 80_000_000)
-
-        // User scrolls up mid-session.
+    func testResetFiresFollowStateChanged() {
         coordinator.handleUserAction(.scrollUp)
+        followStateChanges = []
 
-        let countAfterDetach = callCount
-        try await Task.sleep(nanoseconds: 200_000_000)
+        coordinator.reset()
 
-        // No more attempts after detach.
-        XCTAssertEqual(callCount, countAfterDetach)
-        XCTAssertNil(coordinator.activeSession)
+        XCTAssertEqual(followStateChanges, [true])
     }
 
-    // MARK: - Session ID Stability
+    func testResetWithoutPriorDetachStillFiresCallback() {
+        coordinator.reset()
 
-    func testSessionHasStableSessionId() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-
-        let sessionId = coordinator.activeSession?.sessionId
-        XCTAssertNotNil(sessionId, "Active session should have a stable sessionId")
+        // reset() always fires onFollowStateChanged(true).
+        XCTAssertEqual(followStateChanges, [true])
     }
 
-    func testCoalescingPreservesSessionId() {
-        let convId = UUID()
-        pinShouldSucceed = false
+    func testResetDoesNotTriggerPinRequest() {
+        coordinator.reset()
 
-        coordinator.requestPin(reason: .expansion, conversationId: convId)
-        let originalSessionId = coordinator.activeSession?.sessionId
-
-        // Second request with same reason coalesces.
-        coordinator.requestPin(reason: .expansion, conversationId: convId)
-
-        XCTAssertEqual(coordinator.activeSession?.sessionId, originalSessionId,
-                       "Coalesced request should preserve the original sessionId")
-    }
-
-    func testNewSessionGetsDistinctSessionId() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.requestPin(reason: .expansion, conversationId: convId)
-        let firstSessionId = coordinator.activeSession?.sessionId
-
-        // Different reason triggers a new session.
-        coordinator.requestPin(reason: .resize, conversationId: convId)
-        let secondSessionId = coordinator.activeSession?.sessionId
-
-        XCTAssertNotNil(firstSessionId)
-        XCTAssertNotNil(secondSessionId)
-        XCTAssertNotEqual(firstSessionId, secondSessionId,
-                          "A new session should get a distinct sessionId")
-    }
-
-    // MARK: - Timeout
-
-    func testSessionTimesOutAfterDeadline() async throws {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
-        XCTAssertNotNil(coordinator.activeSession)
-
-        // Wait longer than sessionTimeout (0.5s) + retry interval headroom.
-        try await Task.sleep(nanoseconds: 700_000_000)
-
-        // Session should have self-terminated via timeout.
-        XCTAssertNil(coordinator.activeSession,
-                     "Session should be nil after timeout expires")
-    }
-
-    // MARK: - Cancel on Detach
-
-    func testDetachCancelsActiveSessionAndSuppressesFutureRequests() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-        XCTAssertNotNil(coordinator.activeSession)
-
-        coordinator.detach(trigger: .userScrollUp)
-
-        XCTAssertNil(coordinator.activeSession,
-                     "Detach should cancel the active session")
-        XCTAssertFalse(coordinator.isFollowingBottom)
-
-        // Subsequent requests should be suppressed.
-        let countBefore = pinRequestCount
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-        XCTAssertEqual(pinRequestCount, countBefore,
-                       "Pin requests should be suppressed while detached")
-    }
-
-    func testCancelOnDetachDuringRetryLoop() async throws {
-        let convId = UUID()
-        var callCount = 0
-        pinShouldSucceed = false
-
-        coordinator.onPinRequested = { reason, animated in
-            callCount += 1
-            return false
-        }
-
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-        XCTAssertNotNil(coordinator.activeSession)
-
-        // Let a retry or two fire.
-        try await Task.sleep(nanoseconds: 120_000_000)
-        let countBeforeDetach = callCount
-
-        // Detach mid-retry loop.
-        coordinator.detach(trigger: .userScrollUp)
-
-        // Wait for the task to observe cancellation.
-        try await Task.sleep(nanoseconds: 200_000_000)
-
-        XCTAssertNil(coordinator.activeSession)
-        // No additional pin attempts should have been made after detach.
-        XCTAssertEqual(callCount, countBeforeDetach,
-                       "No retries should fire after detach")
-    }
-
-    // MARK: - Stale Task Cleanup (Generation Mismatch)
-
-    func testStaleTaskDoesNotClobberNewerSession() async throws {
-        let conv1 = UUID()
-        let conv2 = UUID()
-        pinShouldSucceed = false
-
-        // Start a session that will enter the retry loop.
-        coordinator.requestPin(reason: .messageCount, conversationId: conv1)
-        let firstSessionId = coordinator.activeSession?.sessionId
-        XCTAssertNotNil(firstSessionId)
-
-        // Immediately start a new session for a different conversation,
-        // which bumps the generation counter and invalidates the first task.
-        coordinator.requestPin(reason: .expansion, conversationId: conv2)
-        let secondSessionId = coordinator.activeSession?.sessionId
-        XCTAssertNotNil(secondSessionId)
-        XCTAssertNotEqual(firstSessionId, secondSessionId)
-
-        // Let async tasks run to completion.
-        try await Task.sleep(nanoseconds: 300_000_000)
-
-        // The stale first task should not have cleared the second session.
-        // The second session either completed normally or timed out on its own.
-        // Either way, no leftover state from the first session should remain.
-        if let remaining = coordinator.activeSession {
-            XCTAssertEqual(remaining.sessionId, secondSessionId,
-                           "If a session remains, it must be the newer one")
-        }
-    }
-
-    func testRapidRequestsOnlyKeepLatestSession() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        // Fire multiple requests with different reasons in rapid succession.
-        coordinator.requestPin(reason: .expansion, conversationId: convId)
-        coordinator.requestPin(reason: .resize, conversationId: convId)
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-
-        // Only the last session should be active.
-        XCTAssertEqual(coordinator.activeSession?.reason, .messageCount,
-                       "Only the most recent session should remain active")
-    }
-
-    // MARK: - Completion Path
-
-    func testSuccessfulRetryCompletesSession() async throws {
-        let convId = UUID()
-        var callCount = 0
-
-        coordinator.onPinRequested = { reason, animated in
-            callCount += 1
-            // Succeed on the second attempt (first retry).
-            return callCount >= 2
-        }
-
-        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
-
-        // First attempt fails synchronously; retry loop should succeed.
-        try await Task.sleep(nanoseconds: 200_000_000)
-
-        XCTAssertGreaterThanOrEqual(callCount, 2)
-        XCTAssertNil(coordinator.activeSession,
-                     "Session should be cleared after successful retry")
-        XCTAssertTrue(coordinator.isFollowingBottom,
-                      "Coordinator should still be following bottom after success")
-    }
-
-    func testSessionElapsedMsIsNonNegative() {
-        let session = BottomPinSession(
-            sessionId: UUID(),
-            conversationId: UUID(),
-            reason: .messageCount,
-            startTime: CFAbsoluteTimeGetCurrent()
-        )
-
-        XCTAssertGreaterThanOrEqual(session.elapsedMs, 0,
-                                    "elapsedMs should be non-negative for a freshly created session")
-    }
-
-    // MARK: - Geometry Unavailable Regression
-
-    /// Regression: transient missing geometry must not trigger endless retry churn.
-    ///
-    /// Before the fix, `geometryUnavailable` was collapsed into `needsRepin = true`,
-    /// so the coordinator's `onPinRequested` callback would always return `false`
-    /// when geometry was missing, causing the session to exhaust its retry budget
-    /// and then potentially trigger new sessions from other call sites that also
-    /// treated missing geometry as "needs repin". With the fix, call sites only
-    /// request new pins for `.needsRepin` (genuine drift), and the coordinator
-    /// callback returns `outcome == .anchored` (only true for finite, in-bounds
-    /// geometry). This test verifies the session terminates within its retry budget
-    /// when geometry is persistently unavailable, and that follow state is preserved.
-    func testTransientMissingGeometryDoesNotCauseEndlessRetries() async throws {
-        let convId = UUID()
-        var callCount = 0
-
-        // Simulate geometry unavailable: onPinRequested always returns false
-        // (the verify() call would return .geometryUnavailable, so
-        // outcome == .anchored is false).
-        coordinator.onPinRequested = { reason, animated in
-            callCount += 1
-            return false // geometry unavailable — not anchored
-        }
-
-        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
-
-        // Wait long enough for the session to exhaust or timeout.
-        try await Task.sleep(nanoseconds: 700_000_000)
-
-        // The session must have terminated on its own (bounded retries or timeout).
-        XCTAssertNil(coordinator.activeSession,
-                     "Session should terminate after bounded retries, not run indefinitely")
-
-        // Total attempts must not exceed the session budget.
-        XCTAssertLessThanOrEqual(callCount, BottomPinSession.maxRetries,
-                                  "Retry count should be bounded by maxRetries")
-
-        // The coordinator should still be logically following bottom —
-        // transient geometry issues must not detach the follow state.
-        XCTAssertTrue(coordinator.isFollowingBottom,
-                      "Transient geometry unavailability should not detach follow state")
-
-        // Issuing the same pin reason again must NOT coalesce with the
-        // now-terminated session — it starts a fresh one, proving the old
-        // session was fully cleaned up.
-        let countBefore = callCount
-        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
-        XCTAssertGreaterThan(callCount, countBefore,
-                             "A new pin request after session cleanup should fire immediately")
-    }
-
-    /// Regression: when geometry transitions from unavailable to available
-    /// mid-session, the session should complete successfully without churning
-    /// through all retries.
-    func testGeometryBecomingAvailableMidSessionCompletesPin() async throws {
-        let convId = UUID()
-        var callCount = 0
-
-        // First few attempts simulate geometry unavailable (returns false),
-        // then geometry becomes available (returns true).
-        coordinator.onPinRequested = { reason, animated in
-            callCount += 1
-            return callCount >= 3 // anchored after attempt 3
-        }
-
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-
-        // Wait for retries to process. Use a generous timeout because
-        // @MainActor Task scheduling on CI runners can be much slower than
-        // the 50ms retry interval would suggest.
-        try await Task.sleep(nanoseconds: 1_000_000_000)
-
-        // Session should have completed successfully once geometry appeared.
-        XCTAssertNil(coordinator.activeSession,
-                     "Session should complete once geometry becomes available")
-        XCTAssertGreaterThanOrEqual(callCount, 3,
-                                    "Should have retried until geometry was available")
-        XCTAssertLessThanOrEqual(callCount, BottomPinSession.maxRetries,
-                                  "Should not have retried beyond the success point")
-        XCTAssertTrue(coordinator.isFollowingBottom,
-                      "Should still be following bottom after successful pin")
+        XCTAssertEqual(pinRequestCount, 0)
     }
 
     // MARK: - VerificationOutcome Policy
@@ -707,138 +253,6 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
             anchorMinY: .nan, viewportHeight: 600
         )
         XCTAssertEqual(nanAnchor, .geometryUnavailable)
-    }
-
-    // MARK: - Initial-Load Grace Period
-
-    /// Within 500ms of `reset()`, `.initialRestore` and `.messageCount` coalesce
-    /// into one session even though they have different reasons.
-    func testGracePeriodCoalescesInitialRestoreAndMessageCount() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.reset(newConversationId: convId)
-        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
-        let firstSessionId = coordinator.activeSession?.sessionId
-        let firstStartTime = coordinator.activeSession?.startTime
-        XCTAssertNotNil(firstSessionId)
-
-        // During grace period, a different reason should coalesce.
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-
-        XCTAssertEqual(coordinator.activeSession?.sessionId, firstSessionId,
-                       "messageCount should coalesce with initialRestore during grace period")
-        XCTAssertEqual(coordinator.activeSession?.startTime, firstStartTime,
-                       "Coalesced request should preserve the original session start time")
-        // Only one pin call from the initial session start.
-        XCTAssertEqual(pinRequestCount, 1)
-    }
-
-    /// Within 500ms of `reset()`, `.expansion` also coalesces with the active session.
-    func testGracePeriodCoalescesExpansionWithActiveSession() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.reset(newConversationId: convId)
-        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
-        let firstSessionId = coordinator.activeSession?.sessionId
-        XCTAssertNotNil(firstSessionId)
-
-        // Expansion should also coalesce during grace period.
-        coordinator.requestPin(reason: .expansion, conversationId: convId)
-
-        XCTAssertEqual(coordinator.activeSession?.sessionId, firstSessionId,
-                       "expansion should coalesce with initialRestore during grace period")
-        XCTAssertEqual(pinRequestCount, 1)
-    }
-
-    /// After the grace period expires, normal reason-based coalescing rules apply
-    /// (different reasons do NOT coalesce).
-    func testAfterGracePeriodNormalCoalescingRulesApply() async throws {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.reset(newConversationId: convId)
-        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
-        let firstSessionId = coordinator.activeSession?.sessionId
-        XCTAssertNotNil(firstSessionId)
-
-        // Wait for grace period to expire.
-        try await Task.sleep(nanoseconds: 600_000_000) // 600ms > 500ms grace period
-
-        // After grace period, a different reason should NOT coalesce.
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-
-        XCTAssertNotEqual(coordinator.activeSession?.sessionId, firstSessionId,
-                          "After grace period, different reasons should start a new session")
-    }
-
-    /// `reset()` without subsequent pin requests should have no side effects
-    /// beyond resetting follow state.
-    func testResetWithoutSubsequentRequestsHasNoSideEffects() {
-        coordinator.handleUserAction(.scrollUp)
-        XCTAssertFalse(coordinator.isFollowingBottom)
-
-        coordinator.reset()
-
-        XCTAssertTrue(coordinator.isFollowingBottom)
-        XCTAssertNil(coordinator.activeSession)
-        // No pin calls should have been triggered.
-        XCTAssertEqual(pinRequestCount, 0)
-    }
-
-    /// Grace period coalescing still requires the same conversation ID.
-    func testGracePeriodDoesNotCoalesceDifferentConversations() {
-        let conv1 = UUID()
-        let conv2 = UUID()
-        pinShouldSucceed = false
-
-        coordinator.reset(newConversationId: conv1)
-        coordinator.requestPin(reason: .initialRestore, conversationId: conv1)
-        let firstSessionId = coordinator.activeSession?.sessionId
-
-        // Different conversation should NOT coalesce even during grace period.
-        coordinator.requestPin(reason: .messageCount, conversationId: conv2)
-
-        XCTAssertNotEqual(coordinator.activeSession?.sessionId, firstSessionId,
-                          "Grace period should not coalesce requests for different conversations")
-        XCTAssertEqual(coordinator.activeSession?.conversationId, conv2)
-    }
-
-    /// Grace period coalescing does not apply to exhausted sessions.
-    func testGracePeriodDoesNotCoalesceExhaustedSession() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.reset(newConversationId: convId)
-        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
-
-        // Exhaust the session by recording max attempts.
-        // We need to manipulate the session directly since it's a struct.
-        if var session = coordinator.activeSession {
-            for _ in 0..<BottomPinSession.maxRetries {
-                session.recordAttempt()
-            }
-            // The coordinator won't see our local mutations since BottomPinSession is a struct.
-            // Instead, start a fresh session and exhaust it through rapid requests.
-        }
-
-        // Exhaust the session by sending maxRetries worth of different-conversation requests
-        // that force new sessions. Instead, let's test through the coordinator by
-        // verifying that canCoalesce returns false for exhausted sessions.
-        var session = BottomPinSession(
-            sessionId: UUID(),
-            conversationId: convId,
-            reason: .initialRestore,
-            startTime: CFAbsoluteTimeGetCurrent()
-        )
-        for _ in 0..<BottomPinSession.maxRetries {
-            session.recordAttempt()
-        }
-        XCTAssertTrue(session.isExhausted)
-        // An exhausted session should not coalesce, even during grace period.
-        // This is enforced by the `!session.isExhausted` guard in the grace-period path.
-        XCTAssertFalse(session.canCoalesce(reason: .messageCount, conversationId: convId))
     }
 
     /// Verifies that the legacy `needsRepin` helper still collapses


### PR DESCRIPTION
## Summary
Removes all programmatic auto-scrolling during message generation, tool calls, content expansion, and resize. The chat now relies on the "Scroll to latest" button and standard trackpad/mouse scrolling. Initial conversation load positioning is preserved with bounded retries.

This eliminates scroll lock (auto-scroll fighting user input) and jitter (competing @State mutations from multiple onChange handlers).

## Changes
- Removed all `requestBottomPin` calls from onChange handlers (isSending, messages.count, expansion, resize)
- Removed `isSuppressingBottomScroll` state and all suppression logic
- Removed `restoreScrollToBottom()` staged retry function
- Simplified ChatBottomPinCoordinator from 361 → 120 lines: removed PinSession, retry loops, PinReason, coalescing, session tracking
- Added `scrollToBottomWithRetry()` for initial load positioning (3 retries at 50ms)
- Kept "Scroll to latest" button, ScrollWheelDetector, isNearBottom tracking, avatar follower

## Milestone PRs (merged into feature branch)
- #20593: M1: Remove auto-scroll triggers from onChange handlers
- #20597: M2: Simplify ChatBottomPinCoordinator

## Project issue
Closes #20590

## Test plan
- [ ] Open a conversation — should start at the bottom (latest messages)
- [ ] Switch between conversations — should land at bottom each time
- [ ] Send a message — response streams but chat does NOT auto-scroll
- [ ] "Scroll to latest" button appears when scrolled up — clicking it scrolls to bottom
- [ ] Scroll up during generation — no scroll lock, stays where you scrolled
- [ ] No jitter during streaming or tool call expansion
- [ ] Pagination (scroll to top) still works
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
