### PR TITLE
Add `userPersona` and `channelPersona` options to system prompt builder

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -93,6 +93,8 @@ export function ensurePromptFiles(): void {
 export interface BuildSystemPromptOptions {
   hasNoClient?: boolean;
   excludeBootstrap?: boolean;
+  userPersona?: string | null;
+  channelPersona?: string | null;
 }
 
 /**
@@ -159,7 +161,9 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
     dynamicParts.push(identity);
   }
   if (soul) dynamicParts.push(soul);
-  if (user && !userIsTemplate) dynamicParts.push(user);
+  if (options?.userPersona) dynamicParts.push(options.userPersona);
+  if (options?.channelPersona) dynamicParts.push(options.channelPersona);
+  if (user && !userIsTemplate && !options?.userPersona) dynamicParts.push(user);
   if (includeBootstrap) {
     dynamicParts.push(
       "# First-Run Ritual\n\n" +


### PR DESCRIPTION
## Summary
- Extend BuildSystemPromptOptions with optional userPersona and channelPersona fields
- Inject per-user and per-channel persona content into the dynamic block after SOUL.md
- Skip USER.md when a per-user file is loaded to avoid duplication

Part of plan: per-user-channel-persona.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
