### PR TITLE
Add `user_file` column to contacts schema for per-user persona mapping

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -40,6 +40,7 @@ function parseContact(row: typeof contacts.$inferSelect): Contact {
     role: row.role as Contact["role"],
     contactType: (row.contactType as Contact["contactType"]) ?? "human",
     principalId: row.principalId,
+    userFile: row.userFile,
   };
 }
 

--- a/assistant/src/contacts/types.ts
+++ b/assistant/src/contacts/types.ts
@@ -44,6 +44,8 @@ export interface Contact {
    * identified by channel address instead.
    */
   principalId: string | null;
+  /** Workspace-relative path to a per-user persona file for this contact. */
+  userFile: string | null;
 }
 
 export type ChannelStatus =

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -36,6 +36,7 @@ import {
   createWatchersAndLogsTables,
   migrateAssistantContactMetadata,
   migrateBackfillAudioAttachmentMimeTypes,
+  migrateContactsUserFileColumn,
   migrateBackfillContactInteractionStats,
   migrateBackfillGuardianPrincipalId,
   migrateBackfillInlineAttachmentsToDisk,
@@ -499,6 +500,9 @@ export function initializeDb(): void {
 
   // 88. Backfill correct MIME types for audio attachments stored as application/octet-stream
   migrateBackfillAudioAttachmentMimeTypes(database);
+
+  // 89. Add user_file column to contacts for per-user persona file mapping
+  migrateContactsUserFileColumn(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/192-contacts-user-file-column.ts
+++ b/assistant/src/memory/migrations/192-contacts-user-file-column.ts
@@ -1,0 +1,15 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+export function migrateContactsUserFileColumn(database: DrizzleDb): void {
+  withCrashRecovery(database, "migration_contacts_user_file_column_v1", () => {
+    const raw = getSqliteFrom(database);
+
+    try {
+      raw.exec(/*sql*/ `ALTER TABLE contacts ADD COLUMN user_file TEXT`);
+    } catch {
+      /* already exists */
+    }
+  });
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -130,6 +130,7 @@ export { migrateScheduleQuietFlag } from "./188-schedule-quiet-flag.js";
 export { migrateDropSimplifiedMemory } from "./189-drop-simplified-memory.js";
 export { migrateCallSessionSkipDisclosure } from "./190-call-session-skip-disclosure.js";
 export { migrateBackfillAudioAttachmentMimeTypes } from "./191-backfill-audio-attachment-mime-types.js";
+export { migrateContactsUserFileColumn } from "./192-contacts-user-file-column.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/contacts.ts
+++ b/assistant/src/memory/schema/contacts.ts
@@ -10,6 +10,7 @@ export const contacts = sqliteTable("contacts", {
   updatedAt: integer("updated_at").notNull(),
   role: text("role").notNull().default("contact"), // 'guardian' | 'contact'
   principalId: text("principal_id"), // internal auth principal (nullable)
+  userFile: text("user_file"), // workspace-relative path to per-user persona file
   contactType: text("contact_type").notNull().default("human"), // 'human' | 'assistant'
 });
 


### PR DESCRIPTION
## Summary
- Add DB migration (step 192) to add `user_file` TEXT column to contacts table
- Update Drizzle schema and Contact TypeScript interface to include the new field
- Column maps each contact to a per-user persona file in the workspace

Part of plan: per-user-channel-persona.md (PR 1 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
