### PR TITLE
Add persona resolver for per-user and per-channel file loading

### DIFF
--- a/assistant/src/prompts/persona-resolver.ts
+++ b/assistant/src/prompts/persona-resolver.ts
@@ -1,0 +1,138 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  findContactByChannelExternalId,
+  listGuardianChannels,
+} from "../contacts/contact-store.js";
+import type {
+  ChannelCapabilities,
+  TrustContext,
+} from "../daemon/conversation-runtime-assembly.js";
+import { getLogger } from "../util/logger.js";
+import { getWorkspaceDir } from "../util/platform.js";
+import { stripCommentLines } from "./system-prompt.js";
+
+const log = getLogger("persona-resolver");
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export interface PersonaContext {
+  userPersona: string | null;
+  channelPersona: string | null;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+/**
+ * Read a persona file from disk, apply comment stripping, and return
+ * the content. Returns null if the file does not exist or is empty
+ * after stripping.
+ */
+function readPersonaFile(filePath: string): string | null {
+  if (!existsSync(filePath)) return null;
+  const raw = readFileSync(filePath, "utf-8");
+  const content = stripCommentLines(raw).trim();
+  return content.length > 0 ? content : null;
+}
+
+// ── User persona ───────────────────────────────────────────────────
+
+/**
+ * Resolve the per-user persona file for the current actor.
+ *
+ * - If `trustContext` is undefined (desktop/native), looks up the guardian
+ *   contact and reads their user file.
+ * - If `trustContext` is defined and carries a `requesterExternalUserId`,
+ *   looks up the contact by channel + external user ID.
+ * - Falls back to `users/default.md` when no contact is found or the
+ *   contact has no `userFile` set.
+ * - Logs a debug warning when a contact's `userFile` is set but the
+ *   corresponding file is missing on disk.
+ */
+export function resolveUserPersona(
+  trustContext: TrustContext | undefined,
+): string | null {
+  const usersDir = join(getWorkspaceDir(), "users");
+  const defaultPath = join(usersDir, "default.md");
+
+  let filename: string | null = null;
+
+  if (trustContext === undefined) {
+    // Desktop / native — resolve via guardian contact
+    const guardian = listGuardianChannels();
+    if (guardian) {
+      filename = guardian.contact.userFile ?? null;
+    }
+  } else if (trustContext.requesterExternalUserId) {
+    // Channel-routed request — look up contact by channel identity
+    const contactWithChannels = findContactByChannelExternalId(
+      trustContext.sourceChannel,
+      trustContext.requesterExternalUserId,
+    );
+    if (contactWithChannels) {
+      filename = contactWithChannels.userFile ?? null;
+    }
+  }
+
+  // Resolve file path
+  if (filename) {
+    const filePath = join(usersDir, filename);
+    if (existsSync(filePath)) {
+      return readPersonaFile(filePath);
+    }
+    // userFile is set but the file doesn't exist on disk
+    log.debug(
+      { userFile: filename },
+      "Contact has userFile set but file is missing on disk; falling back to default.md",
+    );
+  }
+
+  // Fall back to default.md
+  return readPersonaFile(defaultPath);
+}
+
+// ── Channel persona ────────────────────────────────────────────────
+
+/**
+ * Resolve the per-channel persona file based on channel capabilities.
+ *
+ * Reads from `channels/<channel>.md` in the workspace directory.
+ * Defaults to `"vellum"` when no channel capabilities are provided.
+ * Returns null if the channel file does not exist.
+ */
+export function resolveChannelPersona(
+  channelCapabilities: ChannelCapabilities | undefined,
+): string | null {
+  const channel = channelCapabilities?.channel ?? "vellum";
+  const filePath = join(getWorkspaceDir(), "channels", channel + ".md");
+  return readPersonaFile(filePath);
+}
+
+// ── Combined resolver ──────────────────────────────────────────────
+
+/**
+ * Resolve both user and channel persona context in a single call.
+ */
+export function resolvePersonaContext(
+  trustContext: TrustContext | undefined,
+  channelCapabilities: ChannelCapabilities | undefined,
+): PersonaContext {
+  return {
+    userPersona: resolveUserPersona(trustContext),
+    channelPersona: resolveChannelPersona(channelCapabilities),
+  };
+}
+
+// ── Guardian convenience ───────────────────────────────────────────
+
+/**
+ * Resolve the guardian's user persona.
+ *
+ * This is a convenience wrapper for background subsystems that need
+ * the guardian's persona without a full trust context. Passing
+ * `undefined` triggers the guardian lookup path in `resolveUserPersona`.
+ */
+export function resolveGuardianPersona(): string | null {
+  return resolveUserPersona(undefined);
+}


### PR DESCRIPTION
## Summary
- New `persona-resolver.ts` module that maps trust context to per-user persona files
- Resolves user identity via contact DB lookup, loads corresponding `users/<name>.md` file
- Resolves channel persona from `channels/<channel>.md` based on channel capabilities
- Falls back to `users/default.md` for unknown users or missing files
- Exports `resolveGuardianPersona()` convenience function for background subsystems

Part of plan: per-user-channel-persona.md (PR 4 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
