### PR TITLE
Make conversation starters and notification engine user-aware

### DIFF
--- a/assistant/src/memory/job-handlers/conversation-starters.ts
+++ b/assistant/src/memory/job-handlers/conversation-starters.ts
@@ -9,6 +9,7 @@ import { and, desc, eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { loadSkillCatalog } from "../../config/skills.js";
+import { resolveGuardianPersona } from "../../prompts/persona-resolver.js";
 import { buildCoreIdentityContext } from "../../prompts/system-prompt.js";
 import {
   createTimeout,
@@ -171,7 +172,9 @@ async function generateStarters(scopeId: string): Promise<GeneratedStarter[]> {
 
   // Truncate identity context to prevent oversized prompts when SOUL.md /
   // IDENTITY.md / USER.md are large.
-  const rawIdentityContext = buildCoreIdentityContext();
+  const rawIdentityContext = buildCoreIdentityContext({
+    userPersona: resolveGuardianPersona(),
+  });
   const identityContext = rawIdentityContext
     ? truncate(rawIdentityContext, 2000, "\n…[truncated]")
     : null;

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -13,6 +13,7 @@ import { v4 as uuid } from "uuid";
 
 import { getDeliverableChannels } from "../channels/config.js";
 import { getConfig } from "../config/loader.js";
+import { resolveGuardianPersona } from "../prompts/persona-resolver.js";
 import { buildCoreIdentityContext } from "../prompts/system-prompt.js";
 import {
   createTimeout,
@@ -800,7 +801,9 @@ async function classifyWithLLM(
   const candidateContext = candidateSet
     ? (serializeCandidatesForPrompt(candidateSet) ?? undefined)
     : undefined;
-  const rawIdentityContext = buildCoreIdentityContext();
+  const rawIdentityContext = buildCoreIdentityContext({
+    userPersona: resolveGuardianPersona(),
+  });
   const identityContext = rawIdentityContext
     ? truncate(rawIdentityContext, MAX_IDENTITY_CONTEXT_CHARS, "\n…[truncated]")
     : undefined;

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -405,7 +405,9 @@ function readPromptFile(path: string): string | null {
  * This is useful for injecting identity context into subsystems (e.g. memory
  * extraction) that run outside the main system prompt pipeline.
  */
-export function buildCoreIdentityContext(): string | null {
+export function buildCoreIdentityContext(
+  opts?: { userPersona?: string | null },
+): string | null {
   const parts: string[] = [];
   for (const file of PROMPT_FILES) {
     const content = readPromptFile(getWorkspacePromptPath(file));
@@ -416,6 +418,7 @@ export function buildCoreIdentityContext(): string | null {
     if (file !== "SOUL.md" && isTemplateContent(content, file)) continue;
     parts.push(content);
   }
+  if (opts?.userPersona) parts.push(opts.userPersona);
   return parts.length > 0 ? parts.join("\n\n") : null;
 }
 


### PR DESCRIPTION
## Summary
- Extend `buildCoreIdentityContext()` to accept optional `userPersona` content
- Thread guardian persona into conversation starters for personalized suggestions
- Thread guardian persona into notification decision engine for tone-appropriate decisions

Part of plan: per-user-channel-persona.md (PR 7 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
