### PR TITLE
Load per-user and per-channel persona files into the system prompt per-turn

### DIFF
--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -42,6 +42,7 @@ import { PermissionPrompter } from "../permissions/prompter.js";
 import { SecretPrompter } from "../permissions/secret-prompter.js";
 import { patternMatchesCandidate } from "../permissions/trust-store.js";
 import type { UserDecision } from "../permissions/types.js";
+import { resolvePersonaContext } from "../prompts/persona-resolver.js";
 import { buildSystemPrompt } from "../prompts/system-prompt.js";
 import type { Message } from "../providers/types.js";
 import type { Provider } from "../providers/types.js";
@@ -353,10 +354,18 @@ export class Conversation {
     const resolveSystemPromptCallback = (
       _history: import("../providers/types.js").Message[],
     ): ResolvedSystemPrompt => {
+      const persona = resolvePersonaContext(
+        this.trustContext,
+        this.channelCapabilities,
+      );
       const resolved = {
         systemPrompt: hasSystemPromptOverride
           ? systemPrompt
-          : buildSystemPrompt({ hasNoClient: this.hasNoClient }),
+          : buildSystemPrompt({
+              hasNoClient: this.hasNoClient,
+              userPersona: persona.userPersona,
+              channelPersona: persona.channelPersona,
+            }),
         maxTokens: configuredMaxTokens,
       };
       return resolved;


### PR DESCRIPTION
## Summary
- Wire `resolvePersonaContext()` into the system prompt callback in conversation.ts
- Each turn now dynamically loads the appropriate user persona file based on trust context
- Channel persona file is loaded based on channel capabilities (e.g. slack.md, vellum.md)
- Fallback behavior is unchanged when no persona files exist on disk

Part of plan: per-user-channel-persona.md (PR 6 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
