### PR TITLE
fix: suppress USER.md in buildCoreIdentityContext when userPersona is provided

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -416,6 +416,7 @@ export function buildCoreIdentityContext(
     // before onboarding completes.  Only skip IDENTITY.md and USER.md when
     // they are still unmodified templates (matching buildSystemPrompt).
     if (file !== "SOUL.md" && isTemplateContent(content, file)) continue;
+    if (file === "USER.md" && opts?.userPersona) continue;
     parts.push(content);
   }
   if (opts?.userPersona) parts.push(opts.userPersona);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for per-user-channel-persona.md.

**Gap:** buildCoreIdentityContext includes both USER.md and userPersona, duplicating identity content
**What was expected:** USER.md should be skipped when userPersona is set, matching buildSystemPrompt behavior
**What was found:** Both USER.md and userPersona were included in the identity context for subsystems
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
