### PR TITLE
feat: commit workspace state before and after Docker rollback

### DIFF
--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -1,4 +1,7 @@
+import { execFile } from "child_process";
 import { randomBytes } from "crypto";
+import { join } from "path";
+import { promisify } from "util";
 
 import {
   findAssistantByName,
@@ -120,6 +123,36 @@ function resolveTargetAssistant(nameArg: string | null): AssistantEntry {
   process.exit(1);
 }
 
+const execFileAsync = promisify(execFile);
+
+/**
+ * Best-effort commit of workspace state for rollback audit trail.
+ * Stages all changes and creates an --allow-empty commit so the history
+ * records every rollback attempt even when no files changed.
+ * Hooks are disabled (core.hooksPath=/dev/null, --no-verify) because
+ * workspace contents are model-writable and hooks are untrusted.
+ */
+async function commitWorkspaceChanges(
+  workspaceDir: string,
+  message: string,
+): Promise<void> {
+  const opts = { cwd: workspaceDir, timeout: 10_000 };
+  await execFileAsync("git", ["add", "-A"], opts);
+  await execFileAsync(
+    "git",
+    [
+      "-c",
+      "core.hooksPath=/dev/null",
+      "commit",
+      "--no-verify",
+      "--allow-empty",
+      "-m",
+      message,
+    ],
+    opts,
+  );
+}
+
 export async function rollback(): Promise<void> {
   const { name } = parseArgs();
   const entry = resolveTargetAssistant(name);
@@ -164,6 +197,26 @@ export async function rollback(): Promise<void> {
   const res = dockerResourceNames(instanceName);
 
   try {
+    const workspaceDir = entry.resources
+      ? join(entry.resources.instanceDir, ".vellum", "workspace")
+      : undefined;
+
+    // Record rollback start in workspace git history
+    if (workspaceDir) {
+      try {
+        await commitWorkspaceChanges(
+          workspaceDir,
+          `[rollback] Starting: ${entry.serviceGroupVersion ?? "unknown"} → ${entry.previousServiceGroupVersion ?? "unknown"}\n\n` +
+            `assistant: ${entry.assistantId}\n` +
+            `from: ${entry.serviceGroupVersion ?? "unknown"}\n` +
+            `to: ${entry.previousServiceGroupVersion ?? "unknown"}\n` +
+            `topology: docker`,
+        );
+      } catch {
+        // Best-effort — git failures must not block the rollback
+      }
+    }
+
     console.log(
       `🔄 Rolling back Docker assistant '${instanceName}' to ${entry.previousServiceGroupVersion}...\n`,
     );
@@ -294,6 +347,23 @@ export async function rollback(): Promise<void> {
         installedVersion: entry.previousServiceGroupVersion,
         success: true,
       });
+
+      // Record successful rollback in workspace git history
+      if (workspaceDir) {
+        try {
+          await commitWorkspaceChanges(
+            workspaceDir,
+            `[rollback] Complete: ${entry.serviceGroupVersion ?? "unknown"} → ${entry.previousServiceGroupVersion ?? "unknown"}\n\n` +
+              `assistant: ${entry.assistantId}\n` +
+              `from: ${entry.serviceGroupVersion ?? "unknown"}\n` +
+              `to: ${entry.previousServiceGroupVersion ?? "unknown"}\n` +
+              `result: success\n` +
+              `topology: docker`,
+          );
+        } catch {
+          // Best-effort — git failures must not block success reporting
+        }
+      }
 
       console.log(
         `\n✅ Docker assistant '${instanceName}' rolled back to ${entry.previousServiceGroupVersion}.`,


### PR DESCRIPTION
## Summary
- Add pre-rollback git commit with version transition metadata
- Add post-rollback git commit on success with result metadata
- Uses commitChanges() which creates commits even if workspace is clean

Part of plan: upgrade-git-commits.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
