### PR TITLE
fix: log warnings when workspace git commits fail during upgrade/rollback

### DIFF
--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -212,8 +212,10 @@ export async function rollback(): Promise<void> {
             `to: ${entry.previousServiceGroupVersion ?? "unknown"}\n` +
             `topology: docker`,
         );
-      } catch {
-        // Best-effort — git failures must not block the rollback
+      } catch (err) {
+        console.warn(
+          `⚠️  Failed to create pre-rollback workspace commit: ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
     }
 
@@ -360,8 +362,10 @@ export async function rollback(): Promise<void> {
               `result: success\n` +
               `topology: docker`,
           );
-        } catch {
-          // Best-effort — git failures must not block success reporting
+        } catch (err) {
+          console.warn(
+            `⚠️  Failed to create post-rollback workspace commit: ${err instanceof Error ? err.message : String(err)}`,
+          );
         }
       }
 

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -333,8 +333,10 @@ async function upgradeDocker(
           `to: ${versionTag}\n` +
           `topology: docker`,
       );
-    } catch {
-      // Best-effort — git failures must not block the upgrade
+    } catch (err) {
+      console.warn(
+        `⚠️  Failed to create pre-upgrade workspace commit: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 
@@ -494,8 +496,10 @@ async function upgradeDocker(
             `result: success\n` +
             `topology: docker`,
         );
-      } catch {
-        // Best-effort — git failures must not block success reporting
+      } catch (err) {
+        console.warn(
+          `⚠️  Failed to create post-upgrade workspace commit: ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
     }
 
@@ -650,8 +654,10 @@ async function upgradePlatform(
           `to: ${version ?? "latest"}\n` +
           `topology: managed`,
       );
-    } catch {
-      // Best-effort — git failures must not block the upgrade
+    } catch (err) {
+      console.warn(
+        `⚠️  Failed to create pre-upgrade workspace commit: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 
@@ -736,8 +742,10 @@ async function upgradePlatform(
           `result: success\n` +
           `topology: managed`,
       );
-    } catch {
-      // Best-effort — git failures must not block the upgrade
+    } catch (err) {
+      console.warn(
+        `⚠️  Failed to create post-upgrade workspace commit: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- Replace silent empty catch blocks with console.warn logging in all 6 git commit try/catch blocks
- Warnings include the error message for debuggability
- Still best-effort: git failures never block the upgrade/rollback flow

## Original prompt
fix: log warnings when workspace git commits fail during upgrade/rollback
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
