### PR TITLE
refactor: extract commitWorkspaceState into shared cli/src/lib/workspace-git.ts

### DIFF
--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -1,7 +1,5 @@
-import { execFile } from "child_process";
 import { randomBytes } from "crypto";
 import { join } from "path";
-import { promisify } from "util";
 
 import {
   findAssistantByName,
@@ -26,6 +24,7 @@ import {
   saveBootstrapSecret,
 } from "../lib/guardian-token";
 import { emitCliError, categorizeUpgradeError } from "../lib/cli-error.js";
+import { commitWorkspaceState } from "../lib/workspace-git.js";
 import {
   broadcastUpgradeEvent,
   captureContainerEnv,
@@ -123,36 +122,6 @@ function resolveTargetAssistant(nameArg: string | null): AssistantEntry {
   process.exit(1);
 }
 
-const execFileAsync = promisify(execFile);
-
-/**
- * Best-effort commit of workspace state for rollback audit trail.
- * Stages all changes and creates an --allow-empty commit so the history
- * records every rollback attempt even when no files changed.
- * Hooks are disabled (core.hooksPath=/dev/null, --no-verify) because
- * workspace contents are model-writable and hooks are untrusted.
- */
-async function commitWorkspaceChanges(
-  workspaceDir: string,
-  message: string,
-): Promise<void> {
-  const opts = { cwd: workspaceDir, timeout: 10_000 };
-  await execFileAsync("git", ["add", "-A"], opts);
-  await execFileAsync(
-    "git",
-    [
-      "-c",
-      "core.hooksPath=/dev/null",
-      "commit",
-      "--no-verify",
-      "--allow-empty",
-      "-m",
-      message,
-    ],
-    opts,
-  );
-}
-
 export async function rollback(): Promise<void> {
   const { name } = parseArgs();
   const entry = resolveTargetAssistant(name);
@@ -204,7 +173,7 @@ export async function rollback(): Promise<void> {
     // Record rollback start in workspace git history
     if (workspaceDir) {
       try {
-        await commitWorkspaceChanges(
+        await commitWorkspaceState(
           workspaceDir,
           `[rollback] Starting: ${entry.serviceGroupVersion ?? "unknown"} → ${entry.previousServiceGroupVersion ?? "unknown"}\n\n` +
             `assistant: ${entry.assistantId}\n` +
@@ -353,7 +322,7 @@ export async function rollback(): Promise<void> {
       // Record successful rollback in workspace git history
       if (workspaceDir) {
         try {
-          await commitWorkspaceChanges(
+          await commitWorkspaceState(
             workspaceDir,
             `[rollback] Complete: ${entry.serviceGroupVersion ?? "unknown"} → ${entry.previousServiceGroupVersion ?? "unknown"}\n\n` +
               `assistant: ${entry.assistantId}\n` +

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -34,6 +34,7 @@ import {
 } from "../lib/guardian-token";
 import { emitCliError, categorizeUpgradeError } from "../lib/cli-error.js";
 import { exec, execOutput } from "../lib/step-runner";
+import { commitWorkspaceState } from "../lib/workspace-git.js";
 
 interface UpgradeArgs {
   name: string | null;
@@ -242,37 +243,6 @@ export async function broadcastUpgradeEvent(
   } catch {
     // Best-effort — gateway/daemon may already be shutting down or not yet ready
   }
-}
-
-/**
- * Best-effort git commit in the workspace directory.
- * Stages all changes and creates an --allow-empty commit.
- * Mirrors the safety measures from WorkspaceGitService: disables hooks
- * and sets a deterministic committer identity.
- */
-async function commitWorkspaceState(
-  workspaceDir: string,
-  message: string,
-): Promise<void> {
-  const opts = { cwd: workspaceDir };
-  await exec("git", ["add", "-A"], opts);
-  await exec(
-    "git",
-    [
-      "-c",
-      "user.name=vellum-cli",
-      "-c",
-      "user.email=cli@vellum.ai",
-      "-c",
-      "core.hooksPath=/dev/null",
-      "commit",
-      "--no-verify",
-      "--allow-empty",
-      "-m",
-      message,
-    ],
-    opts,
-  );
 }
 
 async function upgradeDocker(

--- a/cli/src/lib/workspace-git.ts
+++ b/cli/src/lib/workspace-git.ts
@@ -1,0 +1,39 @@
+import { exec } from "./step-runner";
+
+/**
+ * Best-effort git commit in a workspace directory.
+ *
+ * Stages all changes and creates an `--allow-empty` commit so the
+ * history records every upgrade/rollback even when no files changed.
+ *
+ * Safety measures (mirroring WorkspaceGitService in the assistant package):
+ * - Deterministic committer identity (`vellum-cli`)
+ * - Hooks disabled (`core.hooksPath=/dev/null`, `--no-verify`)
+ *
+ * Callers should wrap this in try/catch — failures must never block
+ * the upgrade or rollback flow.
+ */
+export async function commitWorkspaceState(
+  workspaceDir: string,
+  message: string,
+): Promise<void> {
+  const opts = { cwd: workspaceDir };
+  await exec("git", ["add", "-A"], opts);
+  await exec(
+    "git",
+    [
+      "-c",
+      "user.name=vellum-cli",
+      "-c",
+      "user.email=cli@vellum.ai",
+      "-c",
+      "core.hooksPath=/dev/null",
+      "commit",
+      "--no-verify",
+      "--allow-empty",
+      "-m",
+      message,
+    ],
+    opts,
+  );
+}


### PR DESCRIPTION
## Summary
- Extract duplicated commitWorkspaceState helper into cli/src/lib/workspace-git.ts
- Remove local copies from upgrade.ts and rollback.ts, import from shared module
- Unifies the implementation (rollback was using execFile/promisify, upgrade was using exec from step-runner; now both use the step-runner pattern with deterministic committer identity)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
