### PR TITLE
fix: delay platform feedback upload to allow Sentry event indexing

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -190,6 +190,11 @@ enum LogExporter {
             // after the upload completes (or fails).
             let archiveURLCopy = archiveURL
             Task.detached {
+                // Give Sentry a few seconds to index the event before the
+                // platform tries to look it up for feedback URL enrichment.
+                if sentryEventId != nil {
+                    try? await Task.sleep(nanoseconds: 5_000_000_000)
+                }
                 await uploadFeedbackToPlatform(
                     archiveURL: archiveURLCopy,
                     formData: formData,


### PR DESCRIPTION
## Summary
- Add a 5-second delay in the macOS client's background feedback upload task before calling the platform API, giving Sentry time to index the event
- The delay only applies when a `sentryEventId` exists (no delay when there's no Sentry event)
- This is the client-side half of a two-part fix; the server-side retry logic is in a separate platform PR

## Original prompt
Fix timing race condition where `sentry_feedback_url` is always null because the platform tries to look up the Sentry issue before Sentry has indexed the event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
