### PR TITLE
fix: remove fragile upload delay and fix conversation_id tag overwrite

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -122,8 +122,6 @@ enum LogExporter {
                     }
                 }
                 if let conversationId = vm.conversationId {
-                    // Prefer the view model's conversationId (most up-to-date)
-                    tags["conversation_id"] = conversationId
                     // For conversation-scoped exports, conversation_id reflects the
                     // reported conversation, not the active one — skip the overwrite.
                     if case .global = formData.scope {
@@ -190,11 +188,6 @@ enum LogExporter {
             // after the upload completes (or fails).
             let archiveURLCopy = archiveURL
             Task.detached {
-                // Give Sentry a few seconds to index the event before the
-                // platform tries to look it up for feedback URL enrichment.
-                if sentryEventId != nil {
-                    try? await Task.sleep(nanoseconds: 5_000_000_000)
-                }
                 await uploadFeedbackToPlatform(
                     archiveURL: archiveURLCopy,
                     formData: formData,


### PR DESCRIPTION
## Summary
- Remove the 5-second `Task.sleep` before platform feedback upload (added in #20615) — it risked dropping the upload if the user quit the app during the sleep window. Server-side retry in the platform handles the Sentry indexing delay instead.
- Fix pre-existing bug where `conversation_id` tag was unconditionally overwritten with the active conversation's ID, defeating the scope guard meant to preserve the reported conversation's ID for conversation-scoped exports.

## Original prompt
Two fixes in `clients/macos/vellum-assistant/Logging/LogExporter.swift`:

**Fix 1**: Remove client-side 5-second delay before platform upload (reverts #20615 delay). Server-side retry handles the Sentry indexing delay.

**Fix 2**: Fix conversation_id tag overwrite bug — remove unconditional assignment at line 126 that defeated the scope guard at lines 129-131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
