### PR TITLE
feat: add auto-restore from pre-upgrade backup on Docker rollback

### DIFF
--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -23,6 +23,10 @@ import {
   loadBootstrapSecret,
   saveBootstrapSecret,
 } from "../lib/guardian-token";
+import {
+  findLatestPreUpgradeBackup,
+  restoreBackup,
+} from "../lib/backup-ops.js";
 import { emitCliError, categorizeUpgradeError } from "../lib/cli-error.js";
 import { commitWorkspaceState } from "../lib/workspace-git.js";
 import {
@@ -291,6 +295,29 @@ export async function rollback(): Promise<void> {
     const ready = await waitForReady(entry.runtimeUrl);
 
     if (ready) {
+      // Restore data from pre-upgrade backup if available
+      const latestBackup = findLatestPreUpgradeBackup(entry.assistantId);
+      if (latestBackup) {
+        console.log(`📦 Restoring data from pre-upgrade backup...`);
+        console.log(`   Source: ${latestBackup}`);
+        const restored = await restoreBackup(
+          entry.runtimeUrl,
+          entry.assistantId,
+          latestBackup,
+        );
+        if (restored) {
+          console.log("   ✅ Data restored successfully\n");
+        } else {
+          console.warn(
+            "   ⚠️  Data restore failed (rollback continues without data restoration)\n",
+          );
+        }
+      } else {
+        console.log(
+          "ℹ️  No pre-upgrade backup found, skipping data restoration\n",
+        );
+      }
+
       // Capture new digests from the rolled-back containers
       const newDigests = await captureImageRefs(res);
 


### PR DESCRIPTION
## Summary
- Adds automatic data restoration from pre-upgrade backup after Docker rollback completes
- Restores from the most recent pre-upgrade backup after waitForReady() confirms old daemon is up
- Uses best-effort restoreBackup() from backup-ops — failures warn but don't block rollback

Part of plan: glimmering-yawning-toucan.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
