### PR TITLE
fix: add data restoration to auto-rollback path in upgrade command

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -32,7 +32,12 @@ import {
   saveBootstrapSecret,
   loadGuardianToken,
 } from "../lib/guardian-token";
-import { createBackup, pruneOldBackups } from "../lib/backup-ops.js";
+import {
+  createBackup,
+  findLatestPreUpgradeBackup,
+  pruneOldBackups,
+  restoreBackup,
+} from "../lib/backup-ops.js";
 import { emitCliError, categorizeUpgradeError } from "../lib/cli-error.js";
 import { exec, execOutput } from "../lib/step-runner";
 import { commitWorkspaceState } from "../lib/workspace-git.js";
@@ -525,6 +530,29 @@ async function upgradeDocker(
 
         const rollbackReady = await waitForReady(entry.runtimeUrl);
         if (rollbackReady) {
+          // Restore data from pre-upgrade backup if available
+          const latestBackup = findLatestPreUpgradeBackup(entry.assistantId);
+          if (latestBackup) {
+            console.log(`📦 Restoring data from pre-upgrade backup...`);
+            console.log(`   Source: ${latestBackup}`);
+            const restored = await restoreBackup(
+              entry.runtimeUrl,
+              entry.assistantId,
+              latestBackup,
+            );
+            if (restored) {
+              console.log("   ✅ Data restored successfully\n");
+            } else {
+              console.warn(
+                "   ⚠️  Data restore failed (rollback continues without data restoration)\n",
+              );
+            }
+          } else {
+            console.log(
+              "ℹ️  No pre-upgrade backup found, skipping data restoration\n",
+            );
+          }
+
           // Capture fresh digests from the now-running rolled-back containers.
           const rollbackDigests = await captureImageRefs(res);
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for glimmering-yawning-toucan.md.

**Gap:** Auto-rollback in upgrade.ts does not restore data from pre-upgrade backup
**What was expected:** Both rollback paths should restore data from pre-upgrade backup
**What was found:** Only explicit rollback command restores data; auto-rollback in upgrade skips it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
