### PR TITLE
fix: deduplicate backup.ts by importing shared helpers from backup-ops.ts

### DIFF
--- a/cli/src/commands/backup.ts
+++ b/cli/src/commands/backup.ts
@@ -1,21 +1,9 @@
 import { mkdirSync, writeFileSync } from "fs";
-import { homedir } from "os";
 import { dirname, join } from "path";
 
 import { findAssistantByName } from "../lib/assistant-config";
+import { getBackupsDir, formatSize } from "../lib/backup-ops.js";
 import { loadGuardianToken, leaseGuardianToken } from "../lib/guardian-token";
-
-function getBackupsDir(): string {
-  const dataHome =
-    process.env.XDG_DATA_HOME?.trim() || join(homedir(), ".local", "share");
-  return join(dataHome, "vellum", "backups");
-}
-
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
 
 export async function backup(): Promise<void> {
   const args = process.argv.slice(3);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for glimmering-yawning-toucan.md.

**Gap:** backup.ts not refactored to use shared helpers from backup-ops.ts
**What was expected:** backup.ts should use shared getBackupsDir and formatSize from backup-ops.ts
**What was found:** backup.ts still had its own private copies of both functions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
