### PR TITLE
fix: make getGuardianAccessToken module-private in backup-ops.ts

### DIFF
--- a/cli/src/lib/backup-ops.ts
+++ b/cli/src/lib/backup-ops.ts
@@ -26,7 +26,7 @@ export function formatSize(bytes: number): string {
 }
 
 /** Obtain a valid guardian access token (cached or fresh lease) */
-export async function getGuardianAccessToken(
+async function getGuardianAccessToken(
   runtimeUrl: string,
   assistantId: string,
 ): Promise<string> {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for glimmering-yawning-toucan.md.

**Gap:** getGuardianAccessToken is exported but has no external consumers
**What was expected:** Only externally-used functions should be exported
**What was found:** getGuardianAccessToken is only used internally within backup-ops.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20622" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
