### PR TITLE
fix: retry with fresh guardian token on 401 in backup/restore operations

### DIFF
--- a/cli/src/lib/backup-ops.ts
+++ b/cli/src/lib/backup-ops.ts
@@ -29,10 +29,13 @@ export function formatSize(bytes: number): string {
 async function getGuardianAccessToken(
   runtimeUrl: string,
   assistantId: string,
+  forceRefresh?: boolean,
 ): Promise<string> {
-  const tokenData = loadGuardianToken(assistantId);
-  if (tokenData && new Date(tokenData.accessTokenExpiresAt) > new Date()) {
-    return tokenData.accessToken;
+  if (!forceRefresh) {
+    const tokenData = loadGuardianToken(assistantId);
+    if (tokenData && new Date(tokenData.accessTokenExpiresAt) > new Date()) {
+      return tokenData.accessToken;
+    }
   }
   const freshToken = await leaseGuardianToken(runtimeUrl, assistantId);
   return freshToken.accessToken;
@@ -49,9 +52,9 @@ export async function createBackup(
   options?: { prefix?: string; description?: string },
 ): Promise<string | null> {
   try {
-    const accessToken = await getGuardianAccessToken(runtimeUrl, assistantId);
+    let accessToken = await getGuardianAccessToken(runtimeUrl, assistantId);
 
-    const response = await fetch(`${runtimeUrl}/v1/migrations/export`, {
+    let response = await fetch(`${runtimeUrl}/v1/migrations/export`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -62,6 +65,23 @@ export async function createBackup(
       }),
       signal: AbortSignal.timeout(120_000),
     });
+
+    // Retry once with a fresh token on 401 — the cached token may be stale
+    // after a container restart that generated a new gateway signing key.
+    if (response.status === 401) {
+      accessToken = await getGuardianAccessToken(runtimeUrl, assistantId, true);
+      response = await fetch(`${runtimeUrl}/v1/migrations/export`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          description: options?.description ?? "CLI backup",
+        }),
+        signal: AbortSignal.timeout(120_000),
+      });
+    }
 
     if (!response.ok) {
       const body = await response.text();
@@ -109,9 +129,9 @@ export async function restoreBackup(
     }
 
     const bundleData = readFileSync(backupPath);
-    const accessToken = await getGuardianAccessToken(runtimeUrl, assistantId);
+    let accessToken = await getGuardianAccessToken(runtimeUrl, assistantId);
 
-    const response = await fetch(`${runtimeUrl}/v1/migrations/import`, {
+    let response = await fetch(`${runtimeUrl}/v1/migrations/import`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -120,6 +140,21 @@ export async function restoreBackup(
       body: bundleData,
       signal: AbortSignal.timeout(120_000),
     });
+
+    // Retry once with a fresh token on 401 — the cached token may be stale
+    // after a container restart that generated a new gateway signing key.
+    if (response.status === 401) {
+      accessToken = await getGuardianAccessToken(runtimeUrl, assistantId, true);
+      response = await fetch(`${runtimeUrl}/v1/migrations/import`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/octet-stream",
+        },
+        body: bundleData,
+        signal: AbortSignal.timeout(120_000),
+      });
+    }
 
     if (!response.ok) {
       const body = await response.text();


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for glimmering-yawning-toucan.md.

**Gap:** Stale guardian token causes restoreBackup to always fail after container restart
**What was expected:** Backup/restore should work after container restart (which invalidates cached tokens)
**What was found:** getGuardianAccessToken returns cached token even when gateway has a new signing key, causing 401s

Adds forceRefresh parameter to getGuardianAccessToken and retry-on-401 logic in both createBackup and restoreBackup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20623" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
