### PR TITLE
feat: auto-backup before upgrade, auto-restore on rollback

### DIFF
--- a/cli/src/commands/backup.ts
+++ b/cli/src/commands/backup.ts
@@ -92,6 +92,33 @@ export async function backup(): Promise<void> {
       body: JSON.stringify({ description: "CLI backup" }),
       signal: AbortSignal.timeout(120_000),
     });
+
+    // Retry once with a fresh token on 401 — the cached token may be stale
+    // after a container restart that generated a new gateway signing key.
+    if (response.status === 401) {
+      let refreshedToken: string | null = null;
+      try {
+        const freshToken = await leaseGuardianToken(
+          entry.runtimeUrl,
+          entry.assistantId,
+        );
+        refreshedToken = freshToken.accessToken;
+      } catch {
+        // If token refresh fails, fall through to the !response.ok handler below
+      }
+      if (refreshedToken) {
+        accessToken = refreshedToken;
+        response = await fetch(`${entry.runtimeUrl}/v1/migrations/export`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ description: "CLI backup" }),
+          signal: AbortSignal.timeout(120_000),
+        });
+      }
+    }
   } catch (err) {
     if (err instanceof Error && err.name === "TimeoutError") {
       console.error("Error: Export request timed out after 2 minutes.");

--- a/cli/src/commands/backup.ts
+++ b/cli/src/commands/backup.ts
@@ -1,21 +1,9 @@
 import { mkdirSync, writeFileSync } from "fs";
-import { homedir } from "os";
 import { dirname, join } from "path";
 
 import { findAssistantByName } from "../lib/assistant-config";
+import { getBackupsDir, formatSize } from "../lib/backup-ops.js";
 import { loadGuardianToken, leaseGuardianToken } from "../lib/guardian-token";
-
-function getBackupsDir(): string {
-  const dataHome =
-    process.env.XDG_DATA_HOME?.trim() || join(homedir(), ".local", "share");
-  return join(dataHome, "vellum", "backups");
-}
-
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
 
 export async function backup(): Promise<void> {
   const args = process.argv.slice(3);

--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -23,6 +23,10 @@ import {
   loadBootstrapSecret,
   saveBootstrapSecret,
 } from "../lib/guardian-token";
+import {
+  findLatestPreUpgradeBackup,
+  restoreBackup,
+} from "../lib/backup-ops.js";
 import { emitCliError, categorizeUpgradeError } from "../lib/cli-error.js";
 import { commitWorkspaceState } from "../lib/workspace-git.js";
 import {
@@ -291,6 +295,29 @@ export async function rollback(): Promise<void> {
     const ready = await waitForReady(entry.runtimeUrl);
 
     if (ready) {
+      // Restore data from pre-upgrade backup if available
+      const latestBackup = findLatestPreUpgradeBackup(entry.assistantId);
+      if (latestBackup) {
+        console.log(`📦 Restoring data from pre-upgrade backup...`);
+        console.log(`   Source: ${latestBackup}`);
+        const restored = await restoreBackup(
+          entry.runtimeUrl,
+          entry.assistantId,
+          latestBackup,
+        );
+        if (restored) {
+          console.log("   ✅ Data restored successfully\n");
+        } else {
+          console.warn(
+            "   ⚠️  Data restore failed (rollback continues without data restoration)\n",
+          );
+        }
+      } else {
+        console.log(
+          "ℹ️  No pre-upgrade backup found, skipping data restoration\n",
+        );
+      }
+
       // Capture new digests from the rolled-back containers
       const newDigests = await captureImageRefs(res);
 

--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -28,12 +28,12 @@ import {
   restoreBackup,
 } from "../lib/backup-ops.js";
 import { emitCliError, categorizeUpgradeError } from "../lib/cli-error.js";
-import { commitWorkspaceState } from "../lib/workspace-git.js";
 import {
   broadcastUpgradeEvent,
   captureContainerEnv,
   waitForReady,
-} from "./upgrade";
+} from "../lib/upgrade-lifecycle.js";
+import { commitWorkspaceState } from "../lib/workspace-git.js";
 
 function parseArgs(): { name: string | null } {
   const args = process.argv.slice(3);

--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -23,10 +23,7 @@ import {
   loadBootstrapSecret,
   saveBootstrapSecret,
 } from "../lib/guardian-token";
-import {
-  findLatestPreUpgradeBackup,
-  restoreBackup,
-} from "../lib/backup-ops.js";
+import { restoreBackup } from "../lib/backup-ops.js";
 import { emitCliError, categorizeUpgradeError } from "../lib/cli-error.js";
 import {
   broadcastUpgradeEvent,
@@ -295,15 +292,19 @@ export async function rollback(): Promise<void> {
     const ready = await waitForReady(entry.runtimeUrl);
 
     if (ready) {
-      // Restore data from pre-upgrade backup if available
-      const latestBackup = findLatestPreUpgradeBackup(entry.assistantId);
-      if (latestBackup) {
+      // Restore data from the backup created for the specific upgrade being
+      // rolled back. We use the persisted preUpgradeBackupPath rather than
+      // scanning for the latest backup on disk — if the most recent upgrade's
+      // backup failed, a global scan would find a stale backup from a prior
+      // cycle and overwrite newer user data.
+      const backupPath = entry.preUpgradeBackupPath as string | undefined;
+      if (backupPath) {
         console.log(`📦 Restoring data from pre-upgrade backup...`);
-        console.log(`   Source: ${latestBackup}`);
+        console.log(`   Source: ${backupPath}`);
         const restored = await restoreBackup(
           entry.runtimeUrl,
           entry.assistantId,
-          latestBackup,
+          backupPath,
         );
         if (restored) {
           console.log("   ✅ Data restored successfully\n");
@@ -314,7 +315,7 @@ export async function rollback(): Promise<void> {
         }
       } else {
         console.log(
-          "ℹ️  No pre-upgrade backup found, skipping data restoration\n",
+          "ℹ️  No pre-upgrade backup was created for this upgrade, skipping data restoration\n",
         );
       }
 
@@ -336,6 +337,8 @@ export async function rollback(): Promise<void> {
         },
         previousServiceGroupVersion: entry.serviceGroupVersion,
         previousContainerInfo: entry.containerInfo,
+        // Clear the backup path — it belonged to the upgrade we just rolled back
+        preUpgradeBackupPath: undefined,
       };
       saveAssistantEntry(updatedEntry);
 

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -32,7 +32,12 @@ import {
   saveBootstrapSecret,
   loadGuardianToken,
 } from "../lib/guardian-token";
-import { createBackup, pruneOldBackups } from "../lib/backup-ops.js";
+import {
+  createBackup,
+  findLatestPreUpgradeBackup,
+  pruneOldBackups,
+  restoreBackup,
+} from "../lib/backup-ops.js";
 import { emitCliError, categorizeUpgradeError } from "../lib/cli-error.js";
 import { exec, execOutput } from "../lib/step-runner";
 import { commitWorkspaceState } from "../lib/workspace-git.js";
@@ -525,6 +530,29 @@ async function upgradeDocker(
 
         const rollbackReady = await waitForReady(entry.runtimeUrl);
         if (rollbackReady) {
+          // Restore data from pre-upgrade backup if available
+          const latestBackup = findLatestPreUpgradeBackup(entry.assistantId);
+          if (latestBackup) {
+            console.log(`📦 Restoring data from pre-upgrade backup...`);
+            console.log(`   Source: ${latestBackup}`);
+            const restored = await restoreBackup(
+              entry.runtimeUrl,
+              entry.assistantId,
+              latestBackup,
+            );
+            if (restored) {
+              console.log("   ✅ Data restored successfully\n");
+            } else {
+              console.warn(
+                "   ⚠️  Data restore failed (rollback continues without data restoration)\n",
+              );
+            }
+          } else {
+            console.log(
+              "ℹ️  No pre-upgrade backup found, skipping data restoration\n",
+            );
+          }
+
           // Capture fresh digests from the now-running rolled-back containers.
           const rollbackDigests = await captureImageRefs(res);
 

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -13,7 +13,6 @@ import type { AssistantEntry } from "../lib/assistant-config";
 import {
   captureImageRefs,
   clearSigningKeyBootstrapLock,
-  DOCKER_READY_TIMEOUT_MS,
   GATEWAY_INTERNAL_PORT,
   dockerResourceNames,
   migrateCesSecurityFiles,
@@ -30,16 +29,19 @@ import {
 import {
   loadBootstrapSecret,
   saveBootstrapSecret,
-  loadGuardianToken,
 } from "../lib/guardian-token";
 import {
   createBackup,
-  findLatestPreUpgradeBackup,
   pruneOldBackups,
   restoreBackup,
 } from "../lib/backup-ops.js";
 import { emitCliError, categorizeUpgradeError } from "../lib/cli-error.js";
-import { exec, execOutput } from "../lib/step-runner";
+import { exec } from "../lib/step-runner";
+import {
+  broadcastUpgradeEvent,
+  captureContainerEnv,
+  waitForReady,
+} from "../lib/upgrade-lifecycle.js";
 import { commitWorkspaceState } from "../lib/workspace-git.js";
 
 interface UpgradeArgs {
@@ -154,101 +156,6 @@ function resolveTargetAssistant(nameArg: string | null): AssistantEntry {
     emitCliError("ASSISTANT_NOT_FOUND", msg);
   }
   process.exit(1);
-}
-
-/**
- * Capture environment variables from a running Docker container so they
- * can be replayed onto the replacement container after upgrade.
- */
-export async function captureContainerEnv(
-  containerName: string,
-): Promise<Record<string, string>> {
-  const captured: Record<string, string> = {};
-  try {
-    const raw = await execOutput("docker", [
-      "inspect",
-      "--format",
-      "{{json .Config.Env}}",
-      containerName,
-    ]);
-    const entries = JSON.parse(raw) as string[];
-    for (const entry of entries) {
-      const eqIdx = entry.indexOf("=");
-      if (eqIdx > 0) {
-        captured[entry.slice(0, eqIdx)] = entry.slice(eqIdx + 1);
-      }
-    }
-  } catch {
-    // Container may not exist or not be inspectable
-  }
-  return captured;
-}
-
-/**
- * Poll the gateway `/readyz` endpoint until it returns 200 or the timeout
- * elapses. Returns whether the assistant became ready.
- */
-export async function waitForReady(runtimeUrl: string): Promise<boolean> {
-  const readyUrl = `${runtimeUrl}/readyz`;
-  const start = Date.now();
-
-  while (Date.now() - start < DOCKER_READY_TIMEOUT_MS) {
-    try {
-      const resp = await fetch(readyUrl, {
-        signal: AbortSignal.timeout(5000),
-      });
-      if (resp.ok) {
-        const elapsedSec = ((Date.now() - start) / 1000).toFixed(1);
-        console.log(`Assistant ready after ${elapsedSec}s`);
-        return true;
-      }
-      let detail = "";
-      try {
-        const body = await resp.text();
-        const json = JSON.parse(body);
-        const parts = [json.status];
-        if (json.upstream != null) parts.push(`upstream=${json.upstream}`);
-        detail = ` — ${parts.join(", ")}`;
-      } catch {
-        // ignore parse errors
-      }
-      console.log(`Readiness check: ${resp.status}${detail} (retrying...)`);
-    } catch {
-      // Connection refused / timeout — not up yet
-    }
-    await new Promise((r) => setTimeout(r, 1000));
-  }
-
-  return false;
-}
-
-/**
- * Best-effort broadcast of an upgrade lifecycle event to connected clients
- * via the gateway's upgrade-broadcast proxy. Uses guardian token auth.
- * Failures are logged but never block the upgrade flow.
- */
-export async function broadcastUpgradeEvent(
-  gatewayUrl: string,
-  assistantId: string,
-  event: Record<string, unknown>,
-): Promise<void> {
-  try {
-    const token = loadGuardianToken(assistantId);
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-    };
-    if (token?.accessToken) {
-      headers["Authorization"] = `Bearer ${token.accessToken}`;
-    }
-    await fetch(`${gatewayUrl}/v1/admin/upgrade-broadcast`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(event),
-      signal: AbortSignal.timeout(3000),
-    });
-  } catch {
-    // Best-effort — gateway/daemon may already be shutting down or not yet ready
-  }
 }
 
 async function upgradeDocker(
@@ -530,15 +437,17 @@ async function upgradeDocker(
 
         const rollbackReady = await waitForReady(entry.runtimeUrl);
         if (rollbackReady) {
-          // Restore data from pre-upgrade backup if available
-          const latestBackup = findLatestPreUpgradeBackup(entry.assistantId);
-          if (latestBackup) {
+          // Restore data from the backup created for THIS upgrade attempt.
+          // Only use the specific backupPath — never scan for the latest
+          // backup on disk, which could be from a previous upgrade cycle
+          // and contain stale data.
+          if (backupPath) {
             console.log(`📦 Restoring data from pre-upgrade backup...`);
-            console.log(`   Source: ${latestBackup}`);
+            console.log(`   Source: ${backupPath}`);
             const restored = await restoreBackup(
               entry.runtimeUrl,
               entry.assistantId,
-              latestBackup,
+              backupPath,
             );
             if (restored) {
               console.log("   ✅ Data restored successfully\n");
@@ -549,7 +458,7 @@ async function upgradeDocker(
             }
           } else {
             console.log(
-              "ℹ️  No pre-upgrade backup found, skipping data restoration\n",
+              "ℹ️  No pre-upgrade backup was created for this attempt, skipping data restoration\n",
             );
           }
 

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -36,7 +36,7 @@ import {
   restoreBackup,
 } from "../lib/backup-ops.js";
 import { emitCliError, categorizeUpgradeError } from "../lib/cli-error.js";
-import { exec } from "../lib/step-runner";
+import { exec } from "../lib/step-runner.js";
 import {
   broadcastUpgradeEvent,
   captureContainerEnv,
@@ -285,6 +285,19 @@ async function upgradeDocker(
     console.warn("⚠️  Pre-upgrade backup failed (continuing with upgrade)\n");
   }
 
+  // Persist the backup path so `vellum rollback` can restore the exact backup
+  // created for this upgrade attempt — never a stale backup from a prior cycle.
+  // Re-read the entry to pick up the rollback state saved earlier.
+  {
+    const current = findAssistantByName(entry.assistantId);
+    if (current) {
+      saveAssistantEntry({
+        ...current,
+        preUpgradeBackupPath: backupPath ?? undefined,
+      });
+    }
+  }
+
   // Notify connected clients that an upgrade is about to begin.
   console.log("📢 Notifying connected clients...");
   await broadcastUpgradeEvent(entry.runtimeUrl, entry.assistantId, {
@@ -371,6 +384,8 @@ async function upgradeDocker(
       },
       previousServiceGroupVersion: entry.serviceGroupVersion,
       previousContainerInfo: entry.containerInfo,
+      // Preserve the backup path so `vellum rollback` can restore it later
+      preUpgradeBackupPath: backupPath ?? undefined,
     };
     saveAssistantEntry(updatedEntry);
 
@@ -491,6 +506,8 @@ async function upgradeDocker(
             },
             previousServiceGroupVersion: undefined,
             previousContainerInfo: undefined,
+            // Clear the backup path — the upgrade that created it just failed
+            preUpgradeBackupPath: undefined,
           };
           saveAssistantEntry(rolledBackEntry);
 

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -32,6 +32,7 @@ import {
   saveBootstrapSecret,
   loadGuardianToken,
 } from "../lib/guardian-token";
+import { createBackup, pruneOldBackups } from "../lib/backup-ops.js";
 import { emitCliError, categorizeUpgradeError } from "../lib/cli-error.js";
 import { exec, execOutput } from "../lib/step-runner";
 import { commitWorkspaceState } from "../lib/workspace-git.js";
@@ -356,6 +357,20 @@ async function upgradeDocker(
   const bootstrapSecret = loadedSecret || randomBytes(32).toString("hex");
   if (!loadedSecret) {
     saveBootstrapSecret(instanceName, bootstrapSecret);
+  }
+
+  // Create pre-upgrade backup (best-effort, daemon must be running)
+  console.log("📦 Creating pre-upgrade backup...");
+  const backupPath = await createBackup(entry.runtimeUrl, entry.assistantId, {
+    prefix: `${entry.assistantId}-pre-upgrade`,
+    description: `Pre-upgrade snapshot before ${entry.serviceGroupVersion ?? "unknown"} → ${versionTag}`,
+  });
+  if (backupPath) {
+    console.log(`   Backup saved: ${backupPath}\n`);
+    // Clean up old pre-upgrade backups, keep last 3
+    pruneOldBackups(entry.assistantId, 3);
+  } else {
+    console.warn("⚠️  Pre-upgrade backup failed (continuing with upgrade)\n");
   }
 
   // Notify connected clients that an upgrade is about to begin.

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -90,6 +90,10 @@ export interface AssistantEntry {
   previousServiceGroupVersion?: string;
   /** Docker image metadata from before the last upgrade. Enables rollback to the prior version. */
   previousContainerInfo?: ContainerInfo;
+  /** Path to the .vbundle backup created for the most recent upgrade. Used by rollback to restore
+   *  only the backup from the specific upgrade being rolled back — never a stale backup from a
+   *  previous upgrade cycle. */
+  preUpgradeBackupPath?: string;
   [key: string]: unknown;
 }
 

--- a/cli/src/lib/backup-ops.ts
+++ b/cli/src/lib/backup-ops.ts
@@ -183,25 +183,6 @@ export async function restoreBackup(
 }
 
 /**
- * Find the most recent pre-upgrade backup for an assistant.
- * Looks for files matching `{assistantId}-pre-upgrade-*.vbundle` in the backups dir.
- */
-export function findLatestPreUpgradeBackup(assistantId: string): string | null {
-  const backupsDir = getBackupsDir();
-  if (!existsSync(backupsDir)) return null;
-
-  const prefix = `${assistantId}-pre-upgrade-`;
-  const entries = readdirSync(backupsDir)
-    .filter((f) => f.startsWith(prefix) && f.endsWith(".vbundle"))
-    .sort();
-
-  if (entries.length === 0) return null;
-
-  // Lexicographic sort puts ISO timestamps in chronological order; last = most recent
-  return join(backupsDir, entries[entries.length - 1]);
-}
-
-/**
  * Keep only the N most recent pre-upgrade backups for an assistant,
  * deleting older ones. Default: keep 3.
  */

--- a/cli/src/lib/backup-ops.ts
+++ b/cli/src/lib/backup-ops.ts
@@ -185,24 +185,29 @@ export async function restoreBackup(
 /**
  * Keep only the N most recent pre-upgrade backups for an assistant,
  * deleting older ones. Default: keep 3.
+ * Never throws — failures are silently ignored.
  */
 export function pruneOldBackups(assistantId: string, keep: number = 3): void {
-  const backupsDir = getBackupsDir();
-  if (!existsSync(backupsDir)) return;
+  try {
+    const backupsDir = getBackupsDir();
+    if (!existsSync(backupsDir)) return;
 
-  const prefix = `${assistantId}-pre-upgrade-`;
-  const entries = readdirSync(backupsDir)
-    .filter((f) => f.startsWith(prefix) && f.endsWith(".vbundle"))
-    .sort();
+    const prefix = `${assistantId}-pre-upgrade-`;
+    const entries = readdirSync(backupsDir)
+      .filter((f) => f.startsWith(prefix) && f.endsWith(".vbundle"))
+      .sort();
 
-  if (entries.length <= keep) return;
+    if (entries.length <= keep) return;
 
-  const toDelete = entries.slice(0, entries.length - keep);
-  for (const file of toDelete) {
-    try {
-      unlinkSync(join(backupsDir, file));
-    } catch {
-      // Best-effort cleanup — ignore errors
+    const toDelete = entries.slice(0, entries.length - keep);
+    for (const file of toDelete) {
+      try {
+        unlinkSync(join(backupsDir, file));
+      } catch {
+        // Best-effort cleanup — ignore individual file errors
+      }
     }
+  } catch {
+    // Best-effort cleanup — never block the upgrade
   }
 }

--- a/cli/src/lib/backup-ops.ts
+++ b/cli/src/lib/backup-ops.ts
@@ -29,10 +29,13 @@ export function formatSize(bytes: number): string {
 async function getGuardianAccessToken(
   runtimeUrl: string,
   assistantId: string,
+  forceRefresh?: boolean,
 ): Promise<string> {
-  const tokenData = loadGuardianToken(assistantId);
-  if (tokenData && new Date(tokenData.accessTokenExpiresAt) > new Date()) {
-    return tokenData.accessToken;
+  if (!forceRefresh) {
+    const tokenData = loadGuardianToken(assistantId);
+    if (tokenData && new Date(tokenData.accessTokenExpiresAt) > new Date()) {
+      return tokenData.accessToken;
+    }
   }
   const freshToken = await leaseGuardianToken(runtimeUrl, assistantId);
   return freshToken.accessToken;
@@ -49,9 +52,9 @@ export async function createBackup(
   options?: { prefix?: string; description?: string },
 ): Promise<string | null> {
   try {
-    const accessToken = await getGuardianAccessToken(runtimeUrl, assistantId);
+    let accessToken = await getGuardianAccessToken(runtimeUrl, assistantId);
 
-    const response = await fetch(`${runtimeUrl}/v1/migrations/export`, {
+    let response = await fetch(`${runtimeUrl}/v1/migrations/export`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -62,6 +65,23 @@ export async function createBackup(
       }),
       signal: AbortSignal.timeout(120_000),
     });
+
+    // Retry once with a fresh token on 401 — the cached token may be stale
+    // after a container restart that generated a new gateway signing key.
+    if (response.status === 401) {
+      accessToken = await getGuardianAccessToken(runtimeUrl, assistantId, true);
+      response = await fetch(`${runtimeUrl}/v1/migrations/export`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          description: options?.description ?? "CLI backup",
+        }),
+        signal: AbortSignal.timeout(120_000),
+      });
+    }
 
     if (!response.ok) {
       const body = await response.text();
@@ -109,9 +129,9 @@ export async function restoreBackup(
     }
 
     const bundleData = readFileSync(backupPath);
-    const accessToken = await getGuardianAccessToken(runtimeUrl, assistantId);
+    let accessToken = await getGuardianAccessToken(runtimeUrl, assistantId);
 
-    const response = await fetch(`${runtimeUrl}/v1/migrations/import`, {
+    let response = await fetch(`${runtimeUrl}/v1/migrations/import`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -120,6 +140,21 @@ export async function restoreBackup(
       body: bundleData,
       signal: AbortSignal.timeout(120_000),
     });
+
+    // Retry once with a fresh token on 401 — the cached token may be stale
+    // after a container restart that generated a new gateway signing key.
+    if (response.status === 401) {
+      accessToken = await getGuardianAccessToken(runtimeUrl, assistantId, true);
+      response = await fetch(`${runtimeUrl}/v1/migrations/import`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/octet-stream",
+        },
+        body: bundleData,
+        signal: AbortSignal.timeout(120_000),
+      });
+    }
 
     if (!response.ok) {
       const body = await response.text();

--- a/cli/src/lib/backup-ops.ts
+++ b/cli/src/lib/backup-ops.ts
@@ -1,0 +1,192 @@
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import { homedir } from "os";
+import { dirname, join } from "path";
+
+import { loadGuardianToken, leaseGuardianToken } from "./guardian-token.js";
+
+/** Default backup directory following XDG convention */
+export function getBackupsDir(): string {
+  const dataHome =
+    process.env.XDG_DATA_HOME?.trim() || join(homedir(), ".local", "share");
+  return join(dataHome, "vellum", "backups");
+}
+
+/** Human-readable file size */
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** Obtain a valid guardian access token (cached or fresh lease) */
+export async function getGuardianAccessToken(
+  runtimeUrl: string,
+  assistantId: string,
+): Promise<string> {
+  const tokenData = loadGuardianToken(assistantId);
+  if (tokenData && new Date(tokenData.accessTokenExpiresAt) > new Date()) {
+    return tokenData.accessToken;
+  }
+  const freshToken = await leaseGuardianToken(runtimeUrl, assistantId);
+  return freshToken.accessToken;
+}
+
+/**
+ * Create a .vbundle backup of a running assistant.
+ * Returns the path to the saved backup, or null if backup failed.
+ * Never throws — failures are logged as warnings.
+ */
+export async function createBackup(
+  runtimeUrl: string,
+  assistantId: string,
+  options?: { prefix?: string; description?: string },
+): Promise<string | null> {
+  try {
+    const accessToken = await getGuardianAccessToken(runtimeUrl, assistantId);
+
+    const response = await fetch(`${runtimeUrl}/v1/migrations/export`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        description: options?.description ?? "CLI backup",
+      }),
+      signal: AbortSignal.timeout(120_000),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      console.warn(
+        `Warning: backup export failed (${response.status}): ${body}`,
+      );
+      return null;
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    const data = new Uint8Array(arrayBuffer);
+
+    const isoTimestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const prefix = options?.prefix ?? assistantId;
+    const outputPath = join(
+      getBackupsDir(),
+      `${prefix}-${isoTimestamp}.vbundle`,
+    );
+
+    mkdirSync(dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, data);
+
+    return outputPath;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`Warning: backup failed: ${msg}`);
+    return null;
+  }
+}
+
+/**
+ * Restore a .vbundle backup into a running assistant.
+ * Returns true if restore succeeded, false otherwise.
+ * Never throws — failures are logged as warnings.
+ */
+export async function restoreBackup(
+  runtimeUrl: string,
+  assistantId: string,
+  backupPath: string,
+): Promise<boolean> {
+  try {
+    if (!existsSync(backupPath)) {
+      console.warn(`Warning: backup file not found: ${backupPath}`);
+      return false;
+    }
+
+    const bundleData = readFileSync(backupPath);
+    const accessToken = await getGuardianAccessToken(runtimeUrl, assistantId);
+
+    const response = await fetch(`${runtimeUrl}/v1/migrations/import`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/octet-stream",
+      },
+      body: bundleData,
+      signal: AbortSignal.timeout(120_000),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      console.warn(`Warning: restore failed (${response.status}): ${body}`);
+      return false;
+    }
+
+    const result = (await response.json()) as {
+      success: boolean;
+      message?: string;
+      reason?: string;
+    };
+    if (!result.success) {
+      console.warn(
+        `Warning: restore failed — ${result.message ?? result.reason ?? "unknown reason"}`,
+      );
+      return false;
+    }
+
+    return true;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`Warning: restore failed: ${msg}`);
+    return false;
+  }
+}
+
+/**
+ * Find the most recent pre-upgrade backup for an assistant.
+ * Looks for files matching `{assistantId}-pre-upgrade-*.vbundle` in the backups dir.
+ */
+export function findLatestPreUpgradeBackup(assistantId: string): string | null {
+  const backupsDir = getBackupsDir();
+  if (!existsSync(backupsDir)) return null;
+
+  const prefix = `${assistantId}-pre-upgrade-`;
+  const entries = readdirSync(backupsDir)
+    .filter((f) => f.startsWith(prefix) && f.endsWith(".vbundle"))
+    .sort();
+
+  if (entries.length === 0) return null;
+
+  // Lexicographic sort puts ISO timestamps in chronological order; last = most recent
+  return join(backupsDir, entries[entries.length - 1]);
+}
+
+/**
+ * Keep only the N most recent pre-upgrade backups for an assistant,
+ * deleting older ones. Default: keep 3.
+ */
+export function pruneOldBackups(assistantId: string, keep: number = 3): void {
+  const backupsDir = getBackupsDir();
+  if (!existsSync(backupsDir)) return;
+
+  const prefix = `${assistantId}-pre-upgrade-`;
+  const entries = readdirSync(backupsDir)
+    .filter((f) => f.startsWith(prefix) && f.endsWith(".vbundle"))
+    .sort();
+
+  if (entries.length <= keep) return;
+
+  const toDelete = entries.slice(0, entries.length - keep);
+  for (const file of toDelete) {
+    try {
+      unlinkSync(join(backupsDir, file));
+    } catch {
+      // Best-effort cleanup — ignore errors
+    }
+  }
+}

--- a/cli/src/lib/backup-ops.ts
+++ b/cli/src/lib/backup-ops.ts
@@ -26,7 +26,7 @@ export function formatSize(bytes: number): string {
 }
 
 /** Obtain a valid guardian access token (cached or fresh lease) */
-export async function getGuardianAccessToken(
+async function getGuardianAccessToken(
   runtimeUrl: string,
   assistantId: string,
 ): Promise<string> {

--- a/cli/src/lib/upgrade-lifecycle.ts
+++ b/cli/src/lib/upgrade-lifecycle.ts
@@ -1,0 +1,98 @@
+import { DOCKER_READY_TIMEOUT_MS } from "./docker.js";
+import { loadGuardianToken } from "./guardian-token.js";
+import { execOutput } from "./step-runner.js";
+
+/**
+ * Capture environment variables from a running Docker container so they
+ * can be replayed onto the replacement container after upgrade.
+ */
+export async function captureContainerEnv(
+  containerName: string,
+): Promise<Record<string, string>> {
+  const captured: Record<string, string> = {};
+  try {
+    const raw = await execOutput("docker", [
+      "inspect",
+      "--format",
+      "{{json .Config.Env}}",
+      containerName,
+    ]);
+    const entries = JSON.parse(raw) as string[];
+    for (const entry of entries) {
+      const eqIdx = entry.indexOf("=");
+      if (eqIdx > 0) {
+        captured[entry.slice(0, eqIdx)] = entry.slice(eqIdx + 1);
+      }
+    }
+  } catch {
+    // Container may not exist or not be inspectable
+  }
+  return captured;
+}
+
+/**
+ * Poll the gateway `/readyz` endpoint until it returns 200 or the timeout
+ * elapses. Returns whether the assistant became ready.
+ */
+export async function waitForReady(runtimeUrl: string): Promise<boolean> {
+  const readyUrl = `${runtimeUrl}/readyz`;
+  const start = Date.now();
+
+  while (Date.now() - start < DOCKER_READY_TIMEOUT_MS) {
+    try {
+      const resp = await fetch(readyUrl, {
+        signal: AbortSignal.timeout(5000),
+      });
+      if (resp.ok) {
+        const elapsedSec = ((Date.now() - start) / 1000).toFixed(1);
+        console.log(`Assistant ready after ${elapsedSec}s`);
+        return true;
+      }
+      let detail = "";
+      try {
+        const body = await resp.text();
+        const json = JSON.parse(body);
+        const parts = [json.status];
+        if (json.upstream != null) parts.push(`upstream=${json.upstream}`);
+        detail = ` — ${parts.join(", ")}`;
+      } catch {
+        // ignore parse errors
+      }
+      console.log(`Readiness check: ${resp.status}${detail} (retrying...)`);
+    } catch {
+      // Connection refused / timeout — not up yet
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+
+  return false;
+}
+
+/**
+ * Best-effort broadcast of an upgrade lifecycle event to connected clients
+ * via the gateway's upgrade-broadcast proxy. Uses guardian token auth.
+ * Failures are logged but never block the upgrade flow.
+ */
+export async function broadcastUpgradeEvent(
+  gatewayUrl: string,
+  assistantId: string,
+  event: Record<string, unknown>,
+): Promise<void> {
+  try {
+    const token = loadGuardianToken(assistantId);
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (token?.accessToken) {
+      headers["Authorization"] = `Bearer ${token.accessToken}`;
+    }
+    await fetch(`${gatewayUrl}/v1/admin/upgrade-broadcast`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(event),
+      signal: AbortSignal.timeout(3000),
+    });
+  } catch {
+    // Best-effort — gateway/daemon may already be shutting down or not yet ready
+  }
+}


### PR DESCRIPTION
## Summary
Adds automatic data protection during Docker upgrade and rollback operations:
- Creates a `.vbundle` backup before every Docker upgrade (while daemon is still running)
- Keeps the 3 most recent pre-upgrade backups per assistant, deletes older ones
- Automatically restores from the most recent pre-upgrade backup after rollback (both explicit `vellum rollback` and auto-rollback on upgrade failure)
- All operations are best-effort with warnings — failures never block the upgrade or rollback

## PRs merged into feature branch
- #20616: feat: extract shared backup/restore helpers into backup-ops.ts
- #20618: feat: add pre-upgrade backup to Docker upgrade flow
- #20619: feat: add auto-restore from pre-upgrade backup on Docker rollback
- #20620: fix: add data restoration to auto-rollback path in upgrade command
- #20621: fix: deduplicate backup.ts by importing shared helpers from backup-ops.ts
- #20622: fix: make getGuardianAccessToken module-private in backup-ops.ts
- #20623: fix: retry with fresh guardian token on 401 in backup/restore operations

## Self-review result
PASS after 4 review rounds. Key issues found and fixed:
1. Auto-rollback path in upgrade was missing data restore
2. backup.ts had duplicate helper functions
3. getGuardianAccessToken was unnecessarily exported
4. Stale guardian token after container restart caused silent 401 failures

Part of plan: glimmering-yawning-toucan.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
