### PR TITLE
fix: broadcast completion event on all upgrade/rollback failure paths

### DIFF
--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -378,6 +378,11 @@ export async function rollback(): Promise<void> {
       console.log(
         `   Check logs with: docker logs -f ${res.assistantContainer}`,
       );
+      await broadcastUpgradeEvent(entry.runtimeUrl, entry.assistantId, {
+        type: "complete",
+        installedVersion: entry.previousServiceGroupVersion ?? "unknown",
+        success: false,
+      });
       emitCliError(
         "READINESS_TIMEOUT",
         "Rolled-back containers failed to become ready within the timeout.",
@@ -387,6 +392,11 @@ export async function rollback(): Promise<void> {
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
     console.error(`\n❌ Rollback failed: ${detail}`);
+    await broadcastUpgradeEvent(entry.runtimeUrl, entry.assistantId, {
+      type: "complete",
+      installedVersion: entry.serviceGroupVersion ?? "unknown",
+      success: false,
+    });
     emitCliError(categorizeUpgradeError(err), "Rollback failed", detail);
     process.exit(1);
   }

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -533,6 +533,11 @@ async function upgradeDocker(
           console.log(
             `   Check logs with: docker logs -f ${res.assistantContainer}`,
           );
+          await broadcastUpgradeEvent(entry.runtimeUrl, entry.assistantId, {
+            type: "complete",
+            installedVersion: entry.serviceGroupVersion ?? "unknown",
+            success: false,
+          });
           emitCliError(
             "ROLLBACK_FAILED",
             "Rollback also failed after readiness timeout. Manual intervention required.",
@@ -548,6 +553,11 @@ async function upgradeDocker(
         console.log(
           `   Check logs with: docker logs -f ${res.assistantContainer}`,
         );
+        await broadcastUpgradeEvent(entry.runtimeUrl, entry.assistantId, {
+          type: "complete",
+          installedVersion: entry.serviceGroupVersion ?? "unknown",
+          success: false,
+        });
         emitCliError(
           "ROLLBACK_FAILED",
           "Auto-rollback failed after readiness timeout. Manual intervention required.",
@@ -559,6 +569,11 @@ async function upgradeDocker(
       console.log(
         `   Check logs with: docker logs -f ${res.assistantContainer}`,
       );
+      await broadcastUpgradeEvent(entry.runtimeUrl, entry.assistantId, {
+        type: "complete",
+        installedVersion: entry.serviceGroupVersion ?? "unknown",
+        success: false,
+      });
       emitCliError(
         "ROLLBACK_NO_STATE",
         "Containers failed to become ready and no previous images available for rollback.",


### PR DESCRIPTION
## Summary
- Adds missing `complete` broadcast events on 5 failure paths across upgrade.ts and rollback.ts
- Ensures the UI always receives a completion signal instead of timing out after 90 seconds
- All broadcasts are best-effort (never block the error flow)

Part of plan: upgrade-progress-events.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
