### PR TITLE
feat: add ServiceGroupUpdateProgress event type and gateway validation

### DIFF
--- a/assistant/src/daemon/message-types/upgrades.ts
+++ b/assistant/src/daemon/message-types/upgrades.ts
@@ -7,6 +7,13 @@ export interface ServiceGroupUpdateStarting {
   expectedDowntimeSeconds: number;
 }
 
+/** Broadcast to connected clients with a progress update during an upgrade or rollback. */
+export interface ServiceGroupUpdateProgress {
+  type: "service_group_update_progress";
+  /** A short, user-friendly status message describing what's happening right now. */
+  statusMessage: string;
+}
+
 /** Broadcast to connected clients when a service group update has completed. */
 export interface ServiceGroupUpdateComplete {
   type: "service_group_update_complete";
@@ -20,4 +27,5 @@ export interface ServiceGroupUpdateComplete {
 
 export type _UpgradesServerMessages =
   | ServiceGroupUpdateStarting
+  | ServiceGroupUpdateProgress
   | ServiceGroupUpdateComplete;

--- a/assistant/src/runtime/routes/upgrade-broadcast-routes.ts
+++ b/assistant/src/runtime/routes/upgrade-broadcast-routes.ts
@@ -1,6 +1,6 @@
 /**
  * Upgrade broadcast endpoint — publishes service group update lifecycle
- * events (starting / complete) to all connected SSE clients.
+ * events (starting / progress / complete) to all connected SSE clients.
  *
  * Protected by a route policy restricting access to gateway service
  * principals only (`svc_gateway` with `internal.write` scope), following
@@ -11,6 +11,7 @@
 
 import type {
   ServiceGroupUpdateComplete,
+  ServiceGroupUpdateProgress,
   ServiceGroupUpdateStarting,
 } from "../../daemon/message-types/upgrades.js";
 import { buildAssistantEvent } from "../assistant-event.js";
@@ -86,6 +87,29 @@ export function upgradeBroadcastRouteDefinitions(): RouteDefinition[] {
           return Response.json({ ok: true });
         }
 
+        if (type === "progress") {
+          const { statusMessage } = body as { statusMessage?: unknown };
+
+          if (typeof statusMessage !== "string" || statusMessage.length === 0) {
+            return httpError(
+              "BAD_REQUEST",
+              "statusMessage is required and must be a non-empty string",
+              400,
+            );
+          }
+
+          const message: ServiceGroupUpdateProgress = {
+            type: "service_group_update_progress",
+            statusMessage,
+          };
+
+          await assistantEventHub.publish(
+            buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, message),
+          );
+
+          return Response.json({ ok: true });
+        }
+
         if (type === "complete") {
           const { installedVersion, success, rolledBackToVersion } = body as {
             installedVersion?: unknown;
@@ -142,7 +166,7 @@ export function upgradeBroadcastRouteDefinitions(): RouteDefinition[] {
 
         return httpError(
           "BAD_REQUEST",
-          'type must be "starting" or "complete"',
+          'type must be "starting", "progress", or "complete"',
           400,
         );
       },


### PR DESCRIPTION
## Summary
- Adds `ServiceGroupUpdateProgress` interface to `upgrades.ts` with `type` and `statusMessage` fields
- Adds gateway route validation for `{ type: "progress", statusMessage: "..." }` events
- Publishes progress events to SSE via assistantEventHub

Part of plan: upgrade-progress-events.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
