### PR TITLE
feat: broadcast progress events during Docker rollback

### DIFF
--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -252,6 +252,12 @@ export async function rollback(): Promise<void> {
     // Brief pause to allow SSE delivery before containers stop.
     await new Promise((r) => setTimeout(r, 500));
 
+    // Progress: switching version (must be sent BEFORE stopContainers)
+    await broadcastUpgradeEvent(entry.runtimeUrl, entry.assistantId, {
+      type: "progress",
+      statusMessage: "Switching to the previous version…",
+    });
+
     console.log("🛑 Stopping existing containers...");
     await stopContainers(res);
     console.log("✅ Containers stopped\n");
@@ -299,6 +305,12 @@ export async function rollback(): Promise<void> {
       // cycle and overwrite newer user data.
       const backupPath = entry.preUpgradeBackupPath as string | undefined;
       if (backupPath) {
+        // Progress: restoring data (gateway is back up at this point)
+        await broadcastUpgradeEvent(entry.runtimeUrl, entry.assistantId, {
+          type: "progress",
+          statusMessage: "Restoring your data…",
+        });
+
         console.log(`📦 Restoring data from pre-upgrade backup...`);
         console.log(`   Source: ${backupPath}`);
         const restored = await restoreBackup(


### PR DESCRIPTION
## Summary
- Adds 2 progress broadcast events during Docker rollback: switching version and restoring data
- Messages are non-technical and user-friendly
- All broadcasts are best-effort and never block the rollback flow

Part of plan: upgrade-progress-events.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
