### PR TITLE
feat: handle service group progress events in macOS client

### DIFF
--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -36,6 +36,7 @@ public final class GatewayConnectionManager: ObservableObject {
     @Published public internal(set) var versionMismatch: Bool = false
     @Published public internal(set) var isUpdateInProgress: Bool = false
     @Published public internal(set) var updateTargetVersion: String?
+    @Published public var updateStatusMessage: String?
     var updateExpiresAt: Date?
     private var outcomeEmittedForCurrentCycle = false
     @Published public internal(set) var lastUpdateOutcome: UpdateOutcome?
@@ -319,6 +320,7 @@ public final class GatewayConnectionManager: ObservableObject {
                     self.isUpdateInProgress = false
                     self.updateTargetVersion = nil
                     self.updateExpiresAt = nil
+                    self.updateStatusMessage = nil
                     self.eventStreamClient.resetSSEReconnectDelay()
                 }
             }
@@ -356,6 +358,7 @@ public final class GatewayConnectionManager: ObservableObject {
             // Preserve updateTargetVersion — only the authoritative
             // .serviceGroupUpdateComplete SSE event or timeout clears it.
             updateExpiresAt = nil
+            updateStatusMessage = nil
             eventStreamClient.resetSSEReconnectDelay()
         }
     }
@@ -395,6 +398,7 @@ public final class GatewayConnectionManager: ObservableObject {
                     // Preserve updateTargetVersion — only the authoritative
                     // .serviceGroupUpdateComplete SSE event or timeout clears it.
                     self.updateExpiresAt = nil
+                    self.updateStatusMessage = nil
                     self.eventStreamClient.resetSSEReconnectDelay()
                 }
             }
@@ -414,8 +418,11 @@ public final class GatewayConnectionManager: ObservableObject {
         case .serviceGroupUpdateStarting(let msg):
             self.updateTargetVersion = msg.targetVersion
             self.updateExpiresAt = Date().addingTimeInterval(msg.expectedDowntimeSeconds * 2)
+            self.updateStatusMessage = "Preparing to update…"
             setUpdateInProgress(true)
             log.info("Service group update starting — target: \(msg.targetVersion, privacy: .public), expected downtime: \(msg.expectedDowntimeSeconds)s")
+        case .serviceGroupUpdateProgress(let msg):
+            self.updateStatusMessage = msg.statusMessage
         case .serviceGroupUpdateComplete(let msg):
             outcomeEmittedForCurrentCycle = true
             if msg.success {
@@ -428,6 +435,7 @@ public final class GatewayConnectionManager: ObservableObject {
             self.isUpdateInProgress = false
             self.updateTargetVersion = nil
             self.updateExpiresAt = nil
+            self.updateStatusMessage = nil
             self.eventStreamClient.resetSSEReconnectDelay()
         case .modelInfo(let msg):
             currentModel = msg.model

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1294,6 +1294,11 @@ public typealias ServiceGroupUpdateStartingMessage = ServiceGroupUpdateStarting
 /// Backed by generated `ServiceGroupUpdateComplete`.
 public typealias ServiceGroupUpdateCompleteMessage = ServiceGroupUpdateComplete
 
+/// Broadcast when a service group update has progress to report.
+public struct ServiceGroupUpdateProgressMessage: Codable, Equatable {
+    public let statusMessage: String
+}
+
 /// Watch session started notification from daemon.
 /// Backed by generated `WatchStarted`.
 public typealias WatchStartedMessage = WatchStarted
@@ -2147,6 +2152,7 @@ public enum ServerMessage: Decodable, Sendable {
     case hostCuRequest(HostCuRequest)
     case usageUpdate(UsageUpdate)
     case serviceGroupUpdateStarting(ServiceGroupUpdateStartingMessage)
+    case serviceGroupUpdateProgress(ServiceGroupUpdateProgressMessage)
     case serviceGroupUpdateComplete(ServiceGroupUpdateCompleteMessage)
     case conversationIdResolved(localId: String, serverId: String)
     case pong
@@ -2579,6 +2585,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "service_group_update_starting":
             let message = try ServiceGroupUpdateStartingMessage(from: decoder)
             self = .serviceGroupUpdateStarting(message)
+        case "service_group_update_progress":
+            let message = try ServiceGroupUpdateProgressMessage(from: decoder)
+            self = .serviceGroupUpdateProgress(message)
         case "service_group_update_complete":
             let message = try ServiceGroupUpdateCompleteMessage(from: decoder)
             self = .serviceGroupUpdateComplete(message)


### PR DESCRIPTION
## Summary
- Adds `ServiceGroupUpdateProgressMessage` struct and `ServerMessage.serviceGroupUpdateProgress` case
- Adds `updateStatusMessage` published property to `GatewayConnectionManager`
- Progress events update the status message; it's cleared on completion/timeout

Part of plan: upgrade-progress-events.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20630" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
