### PR TITLE
feat: display progress messages during upgrade in macOS settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -34,6 +34,9 @@ struct AssistantUpgradeSection: View {
     /// Whether a service group update is in progress (managed topology).
     var isServiceGroupUpdateInProgress: Bool = false
 
+    /// Progress message from service group update events (e.g. "Downloading the update…").
+    var updateStatusMessage: String?
+
     /// Whether the healthz fetch has completed (regardless of success/failure).
     var healthzLoaded: Bool = false
 
@@ -339,7 +342,7 @@ struct AssistantUpgradeSection: View {
                         .controlSize(.small)
                     Text(isTakingLongerThanExpected
                         ? "Taking longer than expected. The assistant may still be updating..."
-                        : "Assistant is updating...")
+                        : (updateStatusMessage ?? "Assistant is updating..."))
                         .font(VFont.caption)
                         .foregroundStyle(isTakingLongerThanExpected ? VColor.systemMidStrong : VColor.contentTertiary)
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -21,6 +21,7 @@ struct SettingsGeneralTab: View {
     @State private var sparkleUpdateAvailable: Bool = false
     @State private var sparkleUpdateVersion: String?
     @State private var isServiceGroupUpdateInProgress = false
+    @State private var updateStatusMessage: String?
     @State private var lockfileAssistants: [LockfileAssistant] = []
     @State private var selectedAssistantId: String = ""
     @State private var dockerOperationTimedOut = false
@@ -34,6 +35,15 @@ struct SettingsGeneralTab: View {
             return cm.$isUpdateInProgress.eraseToAnyPublisher()
         }
         return Just(false).eraseToAnyPublisher()
+    }
+
+    /// Publisher for reactive observation of connectionManager's updateStatusMessage.
+    /// Falls back to a single `nil` emission when connectionManager is nil.
+    private var updateStatusMessagePublisher: AnyPublisher<String?, Never> {
+        if let cm = connectionManager {
+            return cm.$updateStatusMessage.eraseToAnyPublisher()
+        }
+        return Just(nil).eraseToAnyPublisher()
     }
 
     /// Derive the topology for the currently selected assistant.
@@ -59,6 +69,7 @@ struct SettingsGeneralTab: View {
                     sparkleUpdateAvailable: sparkleUpdateAvailable,
                     sparkleUpdateVersion: sparkleUpdateVersion,
                     isServiceGroupUpdateInProgress: isServiceGroupUpdateInProgress,
+                    updateStatusMessage: updateStatusMessage,
                     healthzLoaded: healthzLoaded
                 )
             }
@@ -79,6 +90,9 @@ struct SettingsGeneralTab: View {
         }
         .onReceive(updateInProgressPublisher) { inProgress in
             isServiceGroupUpdateInProgress = inProgress
+        }
+        .onReceive(updateStatusMessagePublisher) { message in
+            updateStatusMessage = message
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             sparkleUpdateAvailable = AppDelegate.shared?.updateManager.isUpdateAvailable ?? false


### PR DESCRIPTION
## Summary
- Updates the upgrade progress indicator to show specific status messages from progress events
- Falls back to "Assistant is updating..." when no progress events are available
- "Taking longer than expected" escalation still takes priority after 90 seconds

Part of plan: upgrade-progress-events.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
