### PR TITLE
feat: add New Chat and Current Conversation to macOS File menu

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -47,6 +47,47 @@ final class AppMenuPatchDelegate: NSObject, NSMenuDelegate {
     }
 }
 
+/// Delegate installed on the SwiftUI-managed File submenu to inject
+/// "New Chat" and "Current Conversation" items every time the menu opens.
+/// SwiftUI rebuilds the File menu on each scene body evaluation (leaving
+/// only "Close"), so AppKit-level insertions get wiped.  This delegate
+/// re-applies them right before macOS renders the menu.
+final class FileMenuPatchDelegate: NSObject, NSMenuDelegate {
+    weak var appDelegate: AppDelegate?
+
+    /// Tag used to identify items we injected so we can avoid duplicates.
+    private static let injectedTag = 9001
+
+    func menuWillOpen(_ menu: NSMenu) {
+        guard let appDelegate else { return }
+
+        // Already patched for this open cycle — skip.
+        if menu.items.first(where: { $0.tag == Self.injectedTag }) != nil { return }
+
+        let shortcut = UserDefaults.standard.string(forKey: "newChatShortcut") ?? "cmd+n"
+        let newChatItem: NSMenuItem
+        if shortcut.isEmpty {
+            newChatItem = NSMenuItem(title: "New Chat", action: #selector(AppDelegate.openNewChat), keyEquivalent: "")
+        } else {
+            let (modifiers, key) = ShortcutHelper.parseShortcut(shortcut)
+            newChatItem = NSMenuItem(title: "New Chat", action: #selector(AppDelegate.openNewChat), keyEquivalent: key)
+            newChatItem.keyEquivalentModifierMask = modifiers
+        }
+        newChatItem.target = appDelegate
+        newChatItem.tag = Self.injectedTag
+        menu.insertItem(newChatItem, at: 0)
+
+        let currentItem = NSMenuItem(title: "Current Conversation", action: #selector(AppDelegate.openCurrentConversation), keyEquivalent: "")
+        currentItem.target = appDelegate
+        currentItem.tag = Self.injectedTag
+        menu.insertItem(currentItem, at: 1)
+
+        let separator = NSMenuItem.separator()
+        separator.tag = Self.injectedTag
+        menu.insertItem(separator, at: 2)
+    }
+}
+
 extension AppDelegate {
 
     // MARK: - Menu Bar
@@ -101,30 +142,10 @@ extension AppDelegate {
     func setupFileMenu() {
         guard let mainMenu = NSApp.mainMenu else { return }
 
-        // Avoid duplicate File menus on logout/re-login cycles
-        if mainMenu.indexOfItem(withTitle: "File") >= 0 { return }
-
-        let fileMenu = NSMenu(title: "File")
-
-        let newChatItem = NSMenuItem(title: "New Chat", action: #selector(openNewChat), keyEquivalent: "n")
-        newChatItem.keyEquivalentModifierMask = .command
-        newChatItem.target = self
-        fileMenu.addItem(newChatItem)
-        self.newChatMenuItem = newChatItem
-
-        let currentConversationItem = NSMenuItem(title: "Current Conversation", action: #selector(openCurrentConversation), keyEquivalent: "")
-        currentConversationItem.target = self
-        fileMenu.addItem(currentConversationItem)
-
-        fileMenu.addItem(NSMenuItem.separator())
-
-        let closeItem = NSMenuItem(title: "Close Window", action: #selector(NSWindow.performClose(_:)), keyEquivalent: "w")
-        closeItem.keyEquivalentModifierMask = .command
-        fileMenu.addItem(closeItem)
-
-        let fileMenuItem = NSMenuItem(title: "File", action: nil, keyEquivalent: "")
-        fileMenuItem.submenu = fileMenu
-        mainMenu.insertItem(fileMenuItem, at: 1)
+        // Ensure the File menu delegate is installed (may already be from
+        // applicationDidFinishLaunching, but re-check in case SwiftUI
+        // replaced the menu object).
+        installFileMenuDelegate()
 
         // Edit menu — provides Cmd+F "Find" so the shortcut works regardless of focus state.
         if mainMenu.indexOfItem(withTitle: "Edit") < 0 {
@@ -404,19 +425,23 @@ extension AppDelegate {
         return menu
     }
 
-    @objc func openCurrentConversation() {
+    @objc public func openCurrentConversation() {
         guard !isBootstrapping else { return }
         showMainWindow()
         mainWindow?.windowState.dismissOverlay()
     }
 
-    @objc func openNewChat() {
+    @objc public func openNewChat() {
         guard !isBootstrapping else { return }
         showMainWindow()
         mainWindow?.conversationManager.createConversation()
         SoundManager.shared.play(.newConversation)
         if let id = mainWindow?.conversationManager.activeConversationId {
             mainWindow?.windowState.selection = .conversation(id)
+        } else {
+            // Draft mode — no activeConversationId yet, but still dismiss
+            // any visible panel so the user sees the new empty chat.
+            mainWindow?.windowState.selection = nil
         }
         UserDefaults.standard.set(false, forKey: "sidebarExpanded")
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -52,6 +52,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var cmdKLocalMonitor: Any?
     var cmdNLocalMonitor: Any?
     var newChatMenuItem: NSMenuItem?
+    var fileMenuPatchDelegate: FileMenuPatchDelegate?
     var navLocalMonitor: Any?
     var zoomLocalMonitor: Any?
     var sidebarToggleLocalMonitor: Any?
@@ -261,6 +262,29 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         }
     }
 
+    /// Install the `FileMenuPatchDelegate` on the SwiftUI-managed File menu.
+    /// SwiftUI may not have created the menu yet at launch time, so we retry
+    /// with delays (same pattern as Help menu and app-name patching).
+    func installFileMenuDelegate() {
+        installFileMenuDelegateOnce()
+        for delay in [0.1, 0.5, 1.0] {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                self?.installFileMenuDelegateOnce()
+            }
+        }
+    }
+
+    private func installFileMenuDelegateOnce() {
+        guard let mainMenu = NSApp.mainMenu,
+              let fileItem = mainMenu.items.first(where: { $0.title == "File" }),
+              let fileMenu = fileItem.submenu,
+              !(fileMenu.delegate is FileMenuPatchDelegate) else { return }
+        let delegate = FileMenuPatchDelegate()
+        delegate.appDelegate = self
+        self.fileMenuPatchDelegate = delegate
+        fileMenu.delegate = delegate
+    }
+
     public func applicationDidFinishLaunching(_ notification: Notification) {
         // ── Single-instance guard ──────────────────────────────────────
         // If another copy of this app is already running (e.g. Sparkle
@@ -404,6 +428,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         setupMenuBar()
         patchAppMenuTitles()
         stripHelpMenuSearchField()
+        installFileMenuDelegate()
         setupHotKey()
 
         // Install CLI symlinks early so they are available before the daemon


### PR DESCRIPTION
## Summary
- Add **New Chat** (with custom shortcut support) and **Current Conversation** items to the macOS File menu using a `FileMenuPatchDelegate` that survives SwiftUI scene rebuilds
- Fix File menu items never appearing because the old `setupFileMenu()` bailed when SwiftUI's auto-created File menu already existed
- Handle draft-mode fallback in `openNewChat` when no `activeConversationId` is available yet
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
