### PR TITLE
feat: replace hardcoded Sentry DSNs with environment variable lookups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Root .env — sourced automatically by clients/macos/build.sh
+# Copy to .env and fill in values. This file is gitignored.
+# Existing environment variables take precedence over values here.
+
+# --- Sentry (crash reporting) ---
+# Omit or leave empty to disable Sentry in local builds.
+SENTRY_DSN_MACOS=
+SENTRY_DSN_ASSISTANT=

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -932,6 +932,8 @@ jobs:
           BUILD_VERSION="${{ steps.version.outputs.build_version }}" \
           COMMIT_SHA="${{ github.sha }}" \
           SU_PUBLIC_ED_KEY="${{ secrets.SPARKLE_ED_PUBLIC_KEY }}" \
+          SENTRY_DSN_MACOS="${{ secrets.SENTRY_DSN_MACOS }}" \
+          SENTRY_DSN_ASSISTANT="${{ secrets.SENTRY_DSN_ASSISTANT }}" \
           SIGN_IDENTITY="Developer ID Application" \
           RELEASE_ARCH_FLAGS="--arch arm64" \
           SKIP_BUN_REBUILD=1 \
@@ -1319,6 +1321,8 @@ jobs:
           BUILD_VERSION="${{ steps.version.outputs.build_version }}" \
           COMMIT_SHA="${{ github.sha }}" \
           SU_PUBLIC_ED_KEY="${{ secrets.SPARKLE_ED_PUBLIC_KEY }}" \
+          SENTRY_DSN_MACOS="${{ secrets.SENTRY_DSN_MACOS }}" \
+          SENTRY_DSN_ASSISTANT="${{ secrets.SENTRY_DSN_ASSISTANT }}" \
           SIGN_IDENTITY="Developer ID Application" \
           RELEASE_ARCH_FLAGS="--arch x86_64" \
           SKIP_BUN_REBUILD=1 \

--- a/assistant/.env.example
+++ b/assistant/.env.example
@@ -18,3 +18,7 @@ OLLAMA_BASE_URL=
 
 # Platform base URL (defaults to empty string)
 # PLATFORM_BASE_URL=
+
+# --- Sentry (crash reporting) ---
+# Omit to disable Sentry. Set to your Sentry project DSN to enable.
+# SENTRY_DSN_ASSISTANT=https://...@....ingest.us.sentry.io/...

--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -111,11 +111,8 @@ export function hasUngatedHttpAuthDisabled(): boolean {
 
 // ── Monitoring ───────────────────────────────────────────────────────────────
 
-const DEFAULT_SENTRY_DSN =
-  "https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992";
-
 export function getSentryDsn(): string {
-  return str("SENTRY_DSN") ?? DEFAULT_SENTRY_DSN;
+  return str("SENTRY_DSN_ASSISTANT") ?? "";
 }
 
 // ── Qdrant ───────────────────────────────────────────────────────────────────

--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -39,14 +39,17 @@ function redactObject(obj: unknown): unknown {
 }
 
 /**
- * Call after dotenv has loaded so SENTRY_DSN is available.
- * Always initializes Sentry to capture early startup crashes. If the user
- * later opts out via the sendDiagnostics config key (or VELLUM_DEV=1),
- * call closeSentry() after config is loaded to stop future event capturing.
+ * Call after dotenv has loaded so SENTRY_DSN_ASSISTANT is available.
+ * Initializes Sentry when the DSN is set; no-ops when empty/unset so
+ * local dev builds don't send crash reports. If the user later opts out
+ * via the sendDiagnostics config key (or VELLUM_DEV=1), call closeSentry()
+ * after config is loaded to stop future event capturing.
  */
 export function initSentry(): void {
+  const dsn = getSentryDsn();
+  if (!dsn) return;
   Sentry.init({
-    dsn: getSentryDsn(),
+    dsn,
     release: `vellum-assistant@${APP_VERSION}`,
     dist: COMMIT_SHA,
     environment: APP_VERSION === "0.0.0-dev" ? "development" : "production",

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -943,7 +943,7 @@ export async function startLocalDaemon(
         "QDRANT_HTTP_PORT",
         "QDRANT_URL",
         "RUNTIME_HTTP_PORT",
-        "SENTRY_DSN",
+        "SENTRY_DSN_ASSISTANT",
         "TMPDIR",
         "USER",
         "LANG",

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -24,6 +24,8 @@ set -euo pipefail
 #   SIGN_IDENTITY     Override code signing identity
 #   VELLUM_PLATFORM_URL  Override managed sign-in platform URL for app launches
 #   SKIP_BUN_REBUILD    Set to 1 to skip Bun binary staleness checks (use pre-built binaries as-is)
+#   SENTRY_DSN_MACOS     Sentry DSN for the macOS app project (omit to disable)
+#   SENTRY_DSN_ASSISTANT Sentry DSN for the assistant/daemon project (omit to disable)
 
 # ---------------------------------------------------------------------------
 # swift_with_retry — run a swift command with retries for transient SPM
@@ -99,6 +101,26 @@ cd "$SCRIPT_DIR"
 # the same .build directory via symlink) don't race on PCH files.
 # Uses a hash of the repo root's real path to produce a short, stable slug.
 _repo_root="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
+
+# Source .env from repo root for local dev convenience (CI sets env vars directly).
+# Existing environment variables take precedence over .env values.
+_dotenv="$_repo_root/.env"
+if [ -f "$_dotenv" ]; then
+    while IFS='=' read -r key value; do
+        # Skip comments and blank lines
+        [[ -z "$key" || "$key" == \#* ]] && continue
+        # Strip surrounding quotes from value
+        value="${value%\"}"
+        value="${value#\"}"
+        value="${value%\'}"
+        value="${value#\'}"
+        # Only set if not already in the environment
+        if [ -z "${!key+x}" ]; then
+            export "$key=$value"
+        fi
+    done < "$_dotenv"
+fi
+
 _cache_slug="$(printf '%s' "$_repo_root" | md5 -q 2>/dev/null || printf '%s' "$_repo_root" | md5sum | cut -d' ' -f1)"
 SPM_MODULE_CACHE="/tmp/spm-module-cache/${_cache_slug}"
 MODULE_CACHE_FLAGS="-Xswiftc -module-cache-path -Xswiftc $SPM_MODULE_CACHE"
@@ -737,14 +759,30 @@ EOF
 fi
 
 LSE_ENVIRONMENT_PLIST=""
+_LSE_ENTRIES=""
 if [ -n "${VELLUM_PLATFORM_URL:-}" ]; then
     PLATFORM_URL_OVERRIDE="${VELLUM_PLATFORM_URL%/}"
     echo "Embedding app platform URL override: $PLATFORM_URL_OVERRIDE"
+    _LSE_ENTRIES+="
+        <key>VELLUM_PLATFORM_URL</key>
+        <string>$PLATFORM_URL_OVERRIDE</string>"
+fi
+if [ -n "${SENTRY_DSN_MACOS:-}" ]; then
+    echo "Embedding SENTRY_DSN_MACOS"
+    _LSE_ENTRIES+="
+        <key>SENTRY_DSN_MACOS</key>
+        <string>$SENTRY_DSN_MACOS</string>"
+fi
+if [ -n "${SENTRY_DSN_ASSISTANT:-}" ]; then
+    echo "Embedding SENTRY_DSN_ASSISTANT"
+    _LSE_ENTRIES+="
+        <key>SENTRY_DSN_ASSISTANT</key>
+        <string>$SENTRY_DSN_ASSISTANT</string>"
+fi
+if [ -n "$_LSE_ENTRIES" ]; then
     LSE_ENVIRONMENT_PLIST=$(cat <<EOF
     <key>LSEnvironment</key>
-    <dict>
-        <key>VELLUM_PLATFORM_URL</key>
-        <string>$PLATFORM_URL_OVERRIDE</string>
+    <dict>$_LSE_ENTRIES
     </dict>
 EOF
 )

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -344,7 +344,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         let sendDiagnostics = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
             ?? UserDefaults.standard.object(forKey: "collectUsageData") as? Bool
             ?? true
-        if sendDiagnostics {
+        if sendDiagnostics && !MetricKitManager.macosDSN.isEmpty {
             let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
             let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
             let commitSHA = Bundle.main.infoDictionary?["VellumCommitSHA"] as? String

--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -112,7 +112,7 @@ final class VellumCli {
     nonisolated private static let forwardedEnvKeys: [String] = [
         "BASE_DATA_DIR",
         "VELLUM_PLATFORM_URL",
-        "SENTRY_DSN", "TMPDIR", "USER", "LANG",
+        "SENTRY_DSN_MACOS", "SENTRY_DSN_ASSISTANT", "TMPDIR", "USER", "LANG",
     ] + Array(providerEnvVars.values) + [
         // Cloud provider auth — needed by hatch and retire flows.
         "CLOUDSDK_CONFIG", "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -159,10 +159,10 @@ enum LogExporter {
             name: formData.name.isEmpty ? nil : formData.name
         )
 
-        // Route assistant behavior reports to the brain Sentry project
+        // Route assistant behavior reports to the assistant Sentry project
         // so they appear alongside daemon issues for triage.
         let dsn: String? = (formData.reason == .somethingBroken && errorCategoryString != nil)
-            ? MetricKitManager.brainDSN
+            ? MetricKitManager.assistantDSN
             : nil
 
         // Send lightweight Sentry event (no archive attachment) and capture the event ID

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -61,10 +61,14 @@ import os
     /// provides sufficient headroom.
     nonisolated static let sentryMaxAttachmentSize: UInt = 100 * 1024 * 1024
 
-    /// Default DSN for the macOS app Sentry project.
-    nonisolated static let macosDSN = "https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640"
-    /// DSN for the assistant/brain Sentry project.
-    nonisolated static let brainDSN = "https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992"
+    /// DSN for the macOS app Sentry project. Read from SENTRY_DSN_MACOS env var;
+    /// empty string disables Sentry.
+    nonisolated static let macosDSN: String =
+        ProcessInfo.processInfo.environment["SENTRY_DSN_MACOS"] ?? ""
+    /// DSN for the assistant Sentry project. Read from SENTRY_DSN_ASSISTANT env var;
+    /// empty string disables Sentry for this project.
+    nonisolated static let assistantDSN: String =
+        ProcessInfo.processInfo.environment["SENTRY_DSN_ASSISTANT"] ?? ""
 
     /// Sends a manual problem report unconditionally, even when the user has
     /// opted out of automatic crash reporting.  The SDK is temporarily started
@@ -83,6 +87,10 @@ import os
     ) {
         sentrySerialQueue.async {
             let targetDSN = dsn ?? macosDSN
+            guard !targetDSN.isEmpty else {
+                completion?(nil)
+                return
+            }
             let needsDSNSwitch = dsn != nil
             let wasEnabled = SentrySDK.isEnabled
 
@@ -215,6 +223,7 @@ import os
         let sendDiagnostics = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
             ?? true
         guard sendDiagnostics else { return }
+        guard !macosDSN.isEmpty else { return }
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
         let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
         let commitSHA = Bundle.main.infoDictionary?["VellumCommitSHA"] as? String


### PR DESCRIPTION
## Summary
- Remove hardcoded Sentry DSN strings from Swift macOS client and TypeScript daemon
- Replace with SENTRY_DSN_MACOS and SENTRY_DSN_ASSISTANT environment variable lookups (empty = disabled)
- Auto-source root .env file in build.sh for local dev convenience
- Update CI release workflow to pass DSN secrets to macOS build steps

Part of plan: sentry-dsn-env-vars.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
