### PR TITLE
refactor: rename "New Chat" to "New Conversation" across macOS UI

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -48,7 +48,7 @@ final class AppMenuPatchDelegate: NSObject, NSMenuDelegate {
 }
 
 /// Delegate installed on the SwiftUI-managed File submenu to inject
-/// "New Chat" and "Current Conversation" items every time the menu opens.
+/// "New Conversation" and "Current Conversation" items every time the menu opens.
 /// SwiftUI rebuilds the File menu on each scene body evaluation (leaving
 /// only "Close"), so AppKit-level insertions get wiped.  This delegate
 /// re-applies them right before macOS renders the menu.
@@ -67,10 +67,10 @@ final class FileMenuPatchDelegate: NSObject, NSMenuDelegate {
         let shortcut = UserDefaults.standard.string(forKey: "newChatShortcut") ?? "cmd+n"
         let newChatItem: NSMenuItem
         if shortcut.isEmpty {
-            newChatItem = NSMenuItem(title: "New Chat", action: #selector(AppDelegate.openNewChat), keyEquivalent: "")
+            newChatItem = NSMenuItem(title: "New Conversation", action: #selector(AppDelegate.openNewChat), keyEquivalent: "")
         } else {
             let (modifiers, key) = ShortcutHelper.parseShortcut(shortcut)
-            newChatItem = NSMenuItem(title: "New Chat", action: #selector(AppDelegate.openNewChat), keyEquivalent: key)
+            newChatItem = NSMenuItem(title: "New Conversation", action: #selector(AppDelegate.openNewChat), keyEquivalent: key)
             newChatItem.keyEquivalentModifierMask = modifiers
         }
         newChatItem.target = appDelegate
@@ -178,8 +178,8 @@ extension AppDelegate {
         updateNewChatMenuItemShortcut()
     }
 
-    /// Updates the File > New Chat menu item's key equivalent to match the
-    /// current `newChatShortcut` preference. Called once at setup and again
+    /// Updates the File > New Conversation menu item's key equivalent to match
+    /// the current `newChatShortcut` preference. Called once at setup and again
     /// whenever the preference changes via the KVO observer.
     func updateNewChatMenuItemShortcut() {
         guard let item = newChatMenuItem else { return }
@@ -331,10 +331,10 @@ extension AppDelegate {
         let newChatItem: NSMenuItem = {
             let shortcut = UserDefaults.standard.string(forKey: "newChatShortcut") ?? "cmd+n"
             guard !shortcut.isEmpty else {
-                return NSMenuItem(title: "New Chat", action: #selector(openNewChat), keyEquivalent: "")
+                return NSMenuItem(title: "New Conversation", action: #selector(openNewChat), keyEquivalent: "")
             }
             let (modifiers, key) = ShortcutHelper.parseShortcut(shortcut)
-            let item = NSMenuItem(title: "New Chat", action: #selector(openNewChat), keyEquivalent: key)
+            let item = NSMenuItem(title: "New Conversation", action: #selector(openNewChat), keyEquivalent: key)
             item.keyEquivalentModifierMask = modifiers
             return item
         }()
@@ -410,7 +410,7 @@ extension AppDelegate {
     public func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {
         let menu = NSMenu()
 
-        let newChatItem = NSMenuItem(title: "New Chat", action: #selector(openNewChat), keyEquivalent: "")
+        let newChatItem = NSMenuItem(title: "New Conversation", action: #selector(openNewChat), keyEquivalent: "")
         newChatItem.target = self
         menu.addItem(newChatItem)
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -474,7 +474,7 @@ extension MainWindowView {
             }
             sidebarSectionDivider()
 
-            SidebarNavRow(icon: VIcon.squarePen.rawValue, label: "New Chat", isActive: false, isExpanded: false) {
+            SidebarNavRow(icon: VIcon.squarePen.rawValue, label: "New Conversation", isActive: false, isExpanded: false) {
                 startNewConversation()
             }
 

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputView.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputView.swift
@@ -112,9 +112,9 @@ struct QuickInputView: View {
 
                 Spacer(minLength: 0)
 
-                // "New Chat" / conversation selector dropdown
+                // "New Conversation" / conversation selector dropdown
                 Menu {
-                    Button("New Chat") {
+                    Button("New Conversation") {
                         textModel.selectedConversationId = nil
                         textModel.selectedConversationTitle = nil
                     }
@@ -130,7 +130,7 @@ struct QuickInputView: View {
                     }
                 } label: {
                     HStack(spacing: VSpacing.xxs) {
-                        Text(textModel.selectedConversationTitle ?? "New Chat")
+                        Text(textModel.selectedConversationTitle ?? "New Conversation")
                             .font(.system(size: 13, weight: .medium))
                             .foregroundColor(VColor.contentSecondary)
                             .lineLimit(1)


### PR DESCRIPTION
## Summary
- Renamed all user-facing "New Chat" strings to "New Conversation" for consistency with the existing "Current Conversation" action
- Updated menu items (File menu, status bar menu, dock menu), quick input dropdown, and collapsed sidebar label

## Original prompt
Rename the "New Chat" action to "New Conversation" across the entire macOS codebase to be consistent with the "Current Conversation" action. This includes:
- Menu item titles
- Action names/identifiers
- Any UI strings, tooltips, or accessibility labels
- Comments that reference "New Chat"

Search for all occurrences of "New Chat" (case-sensitive and case-insensitive) and rename them to "New Conversation". Do NOT change any identifiers like function names, variable names, or enum cases that use "newChat" in camelCase - only change user-facing strings and comments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
