### PR TITLE
fix: move starting broadcast before backup so progress events are visible

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -229,6 +229,18 @@ async function upgradeDocker(
     `   Captured ${Object.keys(capturedEnv).length} env var(s) from ${res.assistantContainer}\n`,
   );
 
+  // Notify connected clients that an upgrade is about to begin.
+  // This must fire BEFORE any progress broadcasts so the UI sets
+  // isUpdateInProgress = true and starts displaying status messages.
+  console.log("📢 Notifying connected clients...");
+  await broadcastUpgradeEvent(entry.runtimeUrl, entry.assistantId, {
+    type: "starting",
+    targetVersion: versionTag,
+    expectedDowntimeSeconds: 60,
+  });
+  // Brief pause to allow SSE delivery before progress events.
+  await new Promise((r) => setTimeout(r, 500));
+
   await broadcastUpgradeEvent(entry.runtimeUrl, entry.assistantId, {
     type: "progress",
     statusMessage: "Downloading the update…",
@@ -305,16 +317,6 @@ async function upgradeDocker(
       });
     }
   }
-
-  // Notify connected clients that an upgrade is about to begin.
-  console.log("📢 Notifying connected clients...");
-  await broadcastUpgradeEvent(entry.runtimeUrl, entry.assistantId, {
-    type: "starting",
-    targetVersion: versionTag,
-    expectedDowntimeSeconds: 60,
-  });
-  // Brief pause to allow SSE delivery before containers stop.
-  await new Promise((r) => setTimeout(r, 500));
 
   await broadcastUpgradeEvent(entry.runtimeUrl, entry.assistantId, {
     type: "progress",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for upgrade-progress-events.md.

**Gap:** Progress events before starting are invisible to the user
**What was expected:** Progress events should be visible in the UI
**What was found:** Starting broadcast came after backup/download progress events, so the UI wasn't active yet
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
