### PR TITLE
fix: reset updateStatusMessage in reconfigure() and fix access control

### DIFF
--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -36,7 +36,7 @@ public final class GatewayConnectionManager: ObservableObject {
     @Published public internal(set) var versionMismatch: Bool = false
     @Published public internal(set) var isUpdateInProgress: Bool = false
     @Published public internal(set) var updateTargetVersion: String?
-    @Published public var updateStatusMessage: String?
+    @Published public internal(set) var updateStatusMessage: String?
     var updateExpiresAt: Date?
     private var outcomeEmittedForCurrentCycle = false
     @Published public internal(set) var lastUpdateOutcome: UpdateOutcome?
@@ -231,6 +231,7 @@ public final class GatewayConnectionManager: ObservableObject {
         versionMismatch = false
         isUpdateInProgress = false
         updateTargetVersion = nil
+        updateStatusMessage = nil
         updateExpiresAt = nil
         lastUpdateOutcome = nil
         keyFingerprint = nil


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for upgrade-progress-events.md.

**Gap 1:** reconfigure() missing updateStatusMessage reset
**Gap 2:** updateStatusMessage should use public internal(set) var
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
