### PR TITLE
fix: log warning for empty assistantDSN and update stale brain comments

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -96,7 +96,7 @@ enum LogExporter {
             if let conversationId = activeConversation.conversationId {
                 // Setting conversation_id enables cross-project search: find
                 // the daemon error that corresponds to a macOS log report by
-                // querying conversation_id in the vellum-assistant-brain
+                // querying conversation_id in the assistant
                 // Sentry project.
                 // For conversation-scoped exports, conversation_id was already set
                 // to the reported conversation's ID above — don't overwrite it with
@@ -125,7 +125,7 @@ enum LogExporter {
                 }
             }
         }
-        // When routing to the brain project, tag the event so it's clear
+        // When routing to the assistant project, tag the event so it's clear
         // it originated from the macOS client (not the daemon itself).
         if formData.reason == .somethingBroken && errorCategoryString != nil {
             tags["client"] = "macos"
@@ -161,9 +161,17 @@ enum LogExporter {
 
         // Route assistant behavior reports to the assistant Sentry project
         // so they appear alongside daemon issues for triage.
-        let dsn: String? = (formData.reason == .somethingBroken && errorCategoryString != nil)
-            ? MetricKitManager.assistantDSN
-            : nil
+        let dsn: String?
+        if formData.reason == .somethingBroken && errorCategoryString != nil {
+            if MetricKitManager.assistantDSN.isEmpty {
+                log.warning("SENTRY_DSN_ASSISTANT not configured; assistant behavior report will use default Sentry project")
+                dsn = nil
+            } else {
+                dsn = MetricKitManager.assistantDSN
+            }
+        } else {
+            dsn = nil
+        }
 
         // Send lightweight Sentry event (no archive attachment) and capture the event ID
         // for linking to the platform API upload.

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -94,7 +94,7 @@ import os
             let needsDSNSwitch = dsn != nil
             let wasEnabled = SentrySDK.isEnabled
 
-            // When targeting a different DSN (e.g. brain project), close the
+            // When targeting a different DSN (e.g. assistant project), close the
             // current SDK first so we can restart with the alternate DSN.
             if needsDSNSwitch && wasEnabled {
                 SentrySDK.flush(timeout: 5)


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for sentry-dsn-env-vars.md.

**Gap 1:** When SENTRY_DSN_ASSISTANT is empty, the LogExporter was passing an empty string as a non-nil dsn override to sendManualReport, which caused the empty-DSN guard to silently drop the report. Now logs a warning and passes nil so the report uses the default Sentry project.

**Gap 2:** Updated stale brain references in comments to assistant terminology.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
