### PR TITLE
feat: add configurable keyboard shortcut for Current Conversation (⇧⌘N)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -66,6 +66,12 @@ extension UserDefaults {
         }
         return string(forKey: "newChatShortcut") ?? ""
     }
+    @objc dynamic var currentConversationShortcut: String {
+        if UserDefaults.standard.object(forKey: "currentConversationShortcut") == nil {
+            return "cmd+shift+n"
+        }
+        return string(forKey: "currentConversationShortcut") ?? ""
+    }
 }
 
 // MARK: - Input Monitors
@@ -81,6 +87,7 @@ extension AppDelegate {
         registerFnVMonitor()
         registerCmdKMonitor()
         registerNewChatMonitor()
+        registerCurrentConversationMonitor()
 
         globalHotkeyObserver = Publishers.Merge4(
             UserDefaults.standard.publisher(for: \.globalHotkeyShortcut).map { _ in () },
@@ -89,13 +96,16 @@ extension AppDelegate {
             UserDefaults.standard.publisher(for: \.sidebarToggleShortcut).map { _ in () }
         )
         .merge(with: UserDefaults.standard.publisher(for: \.newChatShortcut).map { _ in () })
+        .merge(with: UserDefaults.standard.publisher(for: \.currentConversationShortcut).map { _ in () })
         .debounce(for: .milliseconds(100), scheduler: RunLoop.main)
         .sink { [weak self] _ in
             self?.registerGlobalHotkeyMonitor()
             self?.registerQuickInputMonitor()
             self?.registerSidebarToggleMonitor()
             self?.registerNewChatMonitor()
+            self?.registerCurrentConversationMonitor()
             self?.updateNewChatMenuItemShortcut()
+            self?.updateCurrentConversationMenuItemShortcut()
         }
     }
 
@@ -181,6 +191,10 @@ extension AppDelegate {
             NSEvent.removeMonitor(monitor)
             cmdNLocalMonitor = nil
         }
+        if let monitor = currentConversationLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            currentConversationLocalMonitor = nil
+        }
         if let monitor = navLocalMonitor {
             NSEvent.removeMonitor(monitor)
             navLocalMonitor = nil
@@ -245,6 +259,35 @@ extension AppDelegate {
             return nil
         }
         cmdNLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+    }
+
+    /// Registers a local event monitor to open the current conversation when the
+    /// configured shortcut (default: Cmd+Shift+N) is pressed. The shortcut is read
+    /// dynamically from UserDefaults so it can be reconfigured without restarting.
+    func registerCurrentConversationMonitor() {
+        if let existing = currentConversationLocalMonitor {
+            NSEvent.removeMonitor(existing)
+            currentConversationLocalMonitor = nil
+        }
+
+        let shortcut = UserDefaults.standard.string(forKey: "currentConversationShortcut") ?? "cmd+shift+n"
+        guard !shortcut.isEmpty else { return }
+
+        let (targetModifiers, targetKey) = ShortcutHelper.parseShortcut(shortcut)
+
+        let handler: (NSEvent) -> NSEvent? = { [weak self] event in
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask).subtracting(.numericPad)
+            guard mods == targetModifiers,
+                  event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else {
+                return event
+            }
+            Task { @MainActor in
+                guard self?.isBootstrapping != true else { return }
+                self?.openCurrentConversation()
+            }
+            return nil
+        }
+        currentConversationLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
     }
 
     /// Registers Cmd+K as a local shortcut to open the command palette.
@@ -378,6 +421,12 @@ extension AppDelegate {
                 if let id = self?.mainWindow?.conversationManager.activeConversationId {
                     self?.mainWindow?.windowState.selection = .conversation(id)
                 }
+            },
+            CommandPaletteAction(id: "current-conversation", icon: VIcon.messageSquare.rawValue, label: "Current Conversation", shortcutHint: {
+                let shortcut = UserDefaults.standard.string(forKey: "currentConversationShortcut") ?? "cmd+shift+n"
+                return shortcut.isEmpty ? nil : ShortcutHelper.displayString(for: shortcut)
+            }()) { [weak self] in
+                self?.openCurrentConversation()
             },
             CommandPaletteAction(id: "settings", icon: VIcon.settings.rawValue, label: "Settings", shortcutHint: "\u{2318},") { [weak self] in
                 self?.mainWindow?.windowState.showPanel(.settings)

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -77,7 +77,15 @@ final class FileMenuPatchDelegate: NSObject, NSMenuDelegate {
         newChatItem.tag = Self.injectedTag
         menu.insertItem(newChatItem, at: 0)
 
-        let currentItem = NSMenuItem(title: "Current Conversation", action: #selector(AppDelegate.openCurrentConversation), keyEquivalent: "")
+        let currentConversationShortcut = UserDefaults.standard.string(forKey: "currentConversationShortcut") ?? "cmd+shift+n"
+        let currentItem: NSMenuItem
+        if currentConversationShortcut.isEmpty {
+            currentItem = NSMenuItem(title: "Current Conversation", action: #selector(AppDelegate.openCurrentConversation), keyEquivalent: "")
+        } else {
+            let (ccModifiers, ccKey) = ShortcutHelper.parseShortcut(currentConversationShortcut)
+            currentItem = NSMenuItem(title: "Current Conversation", action: #selector(AppDelegate.openCurrentConversation), keyEquivalent: ccKey)
+            currentItem.keyEquivalentModifierMask = ccModifiers
+        }
         currentItem.target = appDelegate
         currentItem.tag = Self.injectedTag
         menu.insertItem(currentItem, at: 1)
@@ -176,6 +184,7 @@ extension AppDelegate {
         }
 
         updateNewChatMenuItemShortcut()
+        updateCurrentConversationMenuItemShortcut()
     }
 
     /// Updates the File > New Conversation menu item's key equivalent to match
@@ -184,6 +193,22 @@ extension AppDelegate {
     func updateNewChatMenuItemShortcut() {
         guard let item = newChatMenuItem else { return }
         let shortcut = UserDefaults.standard.string(forKey: "newChatShortcut") ?? "cmd+n"
+        guard !shortcut.isEmpty else {
+            item.keyEquivalent = ""
+            item.keyEquivalentModifierMask = []
+            return
+        }
+        let (modifiers, key) = ShortcutHelper.parseShortcut(shortcut)
+        item.keyEquivalent = key
+        item.keyEquivalentModifierMask = modifiers
+    }
+
+    /// Updates the File > Current Conversation menu item's key equivalent to
+    /// match the current `currentConversationShortcut` preference. Called once
+    /// at setup and again whenever the preference changes via the KVO observer.
+    func updateCurrentConversationMenuItemShortcut() {
+        guard let item = currentConversationMenuItem else { return }
+        let shortcut = UserDefaults.standard.string(forKey: "currentConversationShortcut") ?? "cmd+shift+n"
         guard !shortcut.isEmpty else {
             item.keyEquivalent = ""
             item.keyEquivalentModifierMask = []
@@ -323,7 +348,16 @@ extension AppDelegate {
 
         menu.addItem(NSMenuItem.separator())
 
-        let currentConversationItem = NSMenuItem(title: "Current Conversation", action: #selector(openCurrentConversation), keyEquivalent: "")
+        let currentConversationItem: NSMenuItem = {
+            let shortcut = UserDefaults.standard.string(forKey: "currentConversationShortcut") ?? "cmd+shift+n"
+            guard !shortcut.isEmpty else {
+                return NSMenuItem(title: "Current Conversation", action: #selector(openCurrentConversation), keyEquivalent: "")
+            }
+            let (modifiers, key) = ShortcutHelper.parseShortcut(shortcut)
+            let item = NSMenuItem(title: "Current Conversation", action: #selector(openCurrentConversation), keyEquivalent: key)
+            item.keyEquivalentModifierMask = modifiers
+            return item
+        }()
         currentConversationItem.target = self
         currentConversationItem.image = VIcon.messageSquare.nsImage(size: 16)
         menu.addItem(currentConversationItem)

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -51,7 +51,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var commandPaletteWindow: CommandPaletteWindow?
     var cmdKLocalMonitor: Any?
     var cmdNLocalMonitor: Any?
+    var currentConversationLocalMonitor: Any?
     var newChatMenuItem: NSMenuItem?
+    var currentConversationMenuItem: NSMenuItem?
     var fileMenuPatchDelegate: FileMenuPatchDelegate?
     var navLocalMonitor: Any?
     var zoomLocalMonitor: Any?

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -12,6 +12,7 @@ struct SettingsAppearanceTab: View {
     @State private var isRecordingQuickInputHotkey = false
     @State private var isRecordingSidebarToggle = false
     @State private var isRecordingNewChat = false
+    @State private var isRecordingCurrentConversation = false
     @State private var isRecordingVoiceInput = false
     @State private var shortcutMonitor: Any?
     @State private var flagsMonitor: Any?
@@ -319,6 +320,39 @@ struct SettingsAppearanceTab: View {
 
                 SettingsDivider()
 
+                // Current conversation (configurable)
+                HStack {
+                    Text("Current conversation")
+                        .font(VFont.body)
+                        .foregroundStyle(VColor.contentSecondary)
+                    Spacer()
+                    if isRecordingCurrentConversation, let display = recordingDisplayString, !display.isEmpty {
+                        VShortcutTag(display)
+                    } else {
+                        VShortcutTag(ShortcutHelper.displayString(for: store.currentConversationShortcut))
+                    }
+
+                    if isRecordingCurrentConversation {
+                        VButton(label: "Press shortcut...", style: .outlined) {
+                            stopRecording()
+                        }
+                    } else {
+                        HStack(spacing: VSpacing.sm) {
+                            VButton(label: "Record", style: .outlined) {
+                                startRecordingCurrentConversation()
+                            }
+                            if !store.currentConversationShortcut.isEmpty {
+                                VButton(label: "Unbind", style: .outlined) {
+                                    store.currentConversationShortcut = ""
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical, VSpacing.md)
+
+                SettingsDivider()
+
                 // Toggle sidebar (configurable)
                 HStack {
                     Text("Toggle sidebar")
@@ -561,6 +595,13 @@ struct SettingsAppearanceTab: View {
         isRecordingNewChat = true
     }
 
+    private func startRecordingCurrentConversation() {
+        startRecordingShortcut { shortcut, _ in
+            store.currentConversationShortcut = shortcut
+        }
+        isRecordingCurrentConversation = true
+    }
+
     /// Shared recording logic. The callback receives the shortcut string and the raw NSEvent key code.
     private func startRecordingShortcut(onRecord: @escaping (String, UInt16) -> Void) {
         stopRecording()
@@ -606,6 +647,7 @@ struct SettingsAppearanceTab: View {
         isRecordingQuickInputHotkey = false
         isRecordingSidebarToggle = false
         isRecordingNewChat = false
+        isRecordingCurrentConversation = false
         recordingDisplayString = nil
         if let monitor = shortcutMonitor {
             NSEvent.removeMonitor(monitor)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -81,6 +81,7 @@ public final class SettingsStore: ObservableObject {
     @Published var quickInputHotkeyKeyCode: Int
     @Published var sidebarToggleShortcut: String
     @Published var newChatShortcut: String
+    @Published var currentConversationShortcut: String
     @Published var cmdEnterToSend: Bool
 
     // MARK: - Media Embed Settings
@@ -425,6 +426,11 @@ public final class SettingsStore: ObservableObject {
         } else {
             self.newChatShortcut = UserDefaults.standard.string(forKey: "newChatShortcut") ?? ""
         }
+        if UserDefaults.standard.object(forKey: "currentConversationShortcut") == nil {
+            self.currentConversationShortcut = "cmd+shift+n"
+        } else {
+            self.currentConversationShortcut = UserDefaults.standard.string(forKey: "currentConversationShortcut") ?? ""
+        }
 
         // Use defaults for config-dependent properties; the daemon will
         // provide authoritative values once reachable via loadConfigFromDaemon().
@@ -508,6 +514,11 @@ public final class SettingsStore: ObservableObject {
         $newChatShortcut
             .dropFirst()
             .sink { value in UserDefaults.standard.set(value, forKey: "newChatShortcut") }
+            .store(in: &cancellables)
+
+        $currentConversationShortcut
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "currentConversationShortcut") }
             .store(in: &cancellables)
 
         // Mirror GatewayConnectionManager's trust-rules-open flag so views can disable their buttons


### PR DESCRIPTION
## Summary
- Adds a configurable keyboard shortcut for "Current Conversation" (default: Cmd+Shift+N), following the same pattern as the existing configurable "New Conversation" shortcut from PR #20554
- Wires the shortcut through all the same surfaces: File menu, status bar menu, dock menu, command palette, local event monitor, and Settings > Keyboard Shortcuts (with Record/Unbind)
- UserDefaults key: `currentConversationShortcut`, default: `cmd+shift+n`

## Original prompt
Add a configurable keyboard shortcut for "Current Conversation" (default: cmd+shift+n), following the exact same pattern established by the "New Chat" shortcut in PR #20554.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
