### PR TITLE
fix: show blinking caret in composer when new conversation starts

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -126,13 +126,24 @@ struct ComposerView: View {
         .disabled(!hasAPIKey || !isInteractionEnabled)
         .animation(VAnimation.fast, value: isComposerFocused)
         .onAppear {
-            composerFocus = isInteractionEnabled
+            // Delay focus slightly so the NSTextView field editor is fully
+            // installed before we request first-responder status. Setting
+            // @FocusState synchronously during an animated layout pass
+            // (e.g. the empty-state fade-in) can give logical focus without
+            // rendering the blinking caret.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                composerFocus = isInteractionEnabled
+            }
             let identity = IdentityInfo.load()
             avatarSeed = identity?.name ?? "default"
         }
         .onChange(of: conversationId) {
             guard isInteractionEnabled, !hasPendingConfirmation else { return }
-            composerFocus = true
+            // Same delay: the conversation switch may trigger a view rebuild
+            // (new empty state) whose layout isn't settled yet.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                composerFocus = true
+            }
         }
         .onChange(of: currentMode) {
             composerLog.debug("Composer mode: \(String(describing: currentMode))")


### PR DESCRIPTION
## Summary
- Delays `composerFocus` assignment by 50ms in `.onAppear` and `.onChange(of: conversationId)` so the NSTextView field editor is fully installed before requesting first-responder status
- Fixes the issue where pressing Cmd+N to start a new conversation gave the text input logical focus (typing worked) but the blinking caret was not visually rendered
- Root cause: setting `@FocusState` synchronously during the empty-state fade-in animation causes macOS to skip caret rendering
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
