### PR TITLE
fix: add guards for empty platform URL and forward new env vars

### DIFF
--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -103,7 +103,11 @@ function buildHeaders(): Record<string, string> {
 // ─── Catalog operations ──────────────────────────────────────────────────────
 
 export async function fetchCatalog(): Promise<CatalogSkill[]> {
-  const url = `${getPlatformUrl()}/v1/skills/`;
+  const platformUrl = getPlatformUrl();
+  if (!platformUrl) {
+    return [];
+  }
+  const url = `${platformUrl}/v1/skills/`;
   const response = await fetch(url, {
     headers: buildHeaders(),
     signal: AbortSignal.timeout(10000),
@@ -210,7 +214,13 @@ export async function fetchAndExtractSkill(
   skillId: string,
   destDir: string,
 ): Promise<void> {
-  const url = `${getPlatformUrl()}/v1/skills/${encodeURIComponent(skillId)}/`;
+  const platformUrl = getPlatformUrl();
+  if (!platformUrl) {
+    throw new Error(
+      `Cannot fetch skill "${skillId}": VELLUM_PLATFORM_URL is not configured.`,
+    );
+  }
+  const url = `${platformUrl}/v1/skills/${encodeURIComponent(skillId)}/`;
   const response = await fetch(url, {
     headers: buildHeaders(),
     signal: AbortSignal.timeout(15000),

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -140,7 +140,7 @@ export class UsageTelemetryReporter {
 
       // Resolve auth context — skip flush when neither auth mode is viable
       const client = await VellumPlatformClient.create();
-      if (!client && !getTelemetryAppToken()) {
+      if (!client && (!getTelemetryAppToken() || !getTelemetryPlatformUrl())) {
         return;
       }
 

--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -88,7 +88,7 @@ const ALLOWED_HOST_PATTERNS: readonly string[] = (() => {
 function isAllowedHost(hostname: string): boolean {
   for (const pattern of ALLOWED_HOST_PATTERNS) {
     if (pattern.startsWith("*.")) {
-      const suffix = pattern.slice(1); // e.g. ".vellum.ai"
+      const suffix = pattern.slice(1); // e.g. ".example.com"
       if (hostname.endsWith(suffix) || hostname === pattern.slice(2)) {
         return true;
       }

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -23,6 +23,20 @@ export function getPlatformUrl(): string {
   return process.env.VELLUM_PLATFORM_URL ?? DEFAULT_PLATFORM_URL;
 }
 
+/**
+ * Returns the platform URL, throwing a clear error if it is not configured.
+ * Use this in functions that need a valid URL to make HTTP requests.
+ */
+function requirePlatformUrl(): string {
+  const url = getPlatformUrl();
+  if (!url) {
+    throw new Error(
+      "VELLUM_PLATFORM_URL is not configured. Set it in your environment or .env file.",
+    );
+  }
+  return url;
+}
+
 export function readPlatformToken(): string | null {
   try {
     return readFileSync(getPlatformTokenPath(), "utf-8").trim();
@@ -60,7 +74,7 @@ interface OrganizationListResponse {
 }
 
 export async function fetchOrganizationId(token: string): Promise<string> {
-  const platformUrl = getPlatformUrl();
+  const platformUrl = requirePlatformUrl();
   const url = `${platformUrl}/v1/organizations/`;
   const response = await fetch(url, {
     headers: { "X-Session-Token": token },
@@ -92,7 +106,7 @@ interface AllauthSessionResponse {
 }
 
 export async function fetchCurrentUser(token: string): Promise<PlatformUser> {
-  const url = `${getPlatformUrl()}/_allauth/app/v1/auth/session`;
+  const url = `${requirePlatformUrl()}/_allauth/app/v1/auth/session`;
   const response = await fetch(url, {
     headers: { "X-Session-Token": token },
   });

--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -112,6 +112,10 @@ final class VellumCli {
     nonisolated private static let forwardedEnvKeys: [String] = [
         "BASE_DATA_DIR",
         "VELLUM_PLATFORM_URL",
+        "TELEMETRY_PLATFORM_URL", "TELEMETRY_APP_TOKEN",
+        "ASSISTANT_GIT_USER_NAME", "ASSISTANT_GIT_USER_EMAIL",
+        "CLI_GIT_USER_NAME", "CLI_GIT_USER_EMAIL",
+        "PROXY_ALLOWED_HOSTS", "HTTP_USER_AGENT", "DOCTOR_SERVICE_URL",
         "SENTRY_DSN_MACOS", "SENTRY_DSN_ASSISTANT", "TMPDIR", "USER", "LANG",
     ] + Array(providerEnvVars.values) + [
         // Cloud provider auth — needed by hatch and retire flows.


### PR DESCRIPTION
## Summary
Fixes integration gaps identified during plan review for hardcoded-values-env-vars.md.

- Add requirePlatformUrl() guard in CLI platform-client to throw clear error when VELLUM_PLATFORM_URL is not set
- Guard fetchCatalog/fetchAndExtractSkill on empty platform URL in catalog-install
- Optimize telemetry flush early-exit to also check platform URL
- Fix stale comment in session-manager
- Forward all new env vars from macOS client to CLI child processes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
