### PR TITLE
feat: add gateway proxies for migration export and import endpoints

### DIFF
--- a/gateway/src/http/routes/migration-proxy.ts
+++ b/gateway/src/http/routes/migration-proxy.ts
@@ -1,0 +1,164 @@
+/**
+ * Gateway proxies for the daemon migration export/import endpoints.
+ *
+ * Follows the same forwarding pattern as upgrade-broadcast-proxy.ts:
+ * strips hop-by-hop headers, replaces the client's edge JWT with a
+ * minted service token, and proxies the request to the daemon.
+ */
+
+import { mintServiceToken } from "../../auth/token-exchange.js";
+import type { GatewayConfig } from "../../config.js";
+import { fetchImpl } from "../../fetch.js";
+import { getLogger } from "../../logger.js";
+import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
+
+const log = getLogger("migration-proxy");
+
+/** Timeout for migration requests (120 seconds) — exports/imports can be large. */
+const MIGRATION_TIMEOUT_MS = 120_000;
+
+export function createMigrationExportProxyHandler(config: GatewayConfig) {
+  return async function handleMigrationExport(req: Request): Promise<Response> {
+    const start = performance.now();
+    const bodyBuffer = await req.arrayBuffer();
+
+    const upstream = `${config.assistantRuntimeBaseUrl}/v1/migrations/export`;
+
+    const reqHeaders = stripHopByHop(new Headers(req.headers));
+    reqHeaders.delete("host");
+    reqHeaders.delete("authorization");
+
+    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
+    reqHeaders.set("content-length", String(bodyBuffer.byteLength));
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(
+        new DOMException(
+          "The operation was aborted due to timeout",
+          "TimeoutError",
+        ),
+      );
+    }, MIGRATION_TIMEOUT_MS);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(upstream, {
+        method: "POST",
+        headers: reqHeaders,
+        body: bodyBuffer,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+    } catch (err) {
+      clearTimeout(timeoutId);
+      const duration = Math.round(performance.now() - start);
+      if (err instanceof DOMException && err.name === "TimeoutError") {
+        log.error({ duration }, "Migration export proxy upstream timed out");
+        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
+      }
+      log.error(
+        { err, duration },
+        "Migration export proxy upstream connection failed",
+      );
+      return Response.json({ error: "Bad Gateway" }, { status: 502 });
+    }
+
+    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const duration = Math.round(performance.now() - start);
+
+    if (response.status >= 400) {
+      const body = await response.text();
+      log.warn(
+        { status: response.status, duration },
+        "Migration export proxy upstream error",
+      );
+      return new Response(body, {
+        status: response.status,
+        headers: resHeaders,
+      });
+    }
+
+    log.info(
+      { status: response.status, duration },
+      "Migration export proxy completed",
+    );
+    return new Response(response.body, {
+      status: response.status,
+      headers: resHeaders,
+    });
+  };
+}
+
+export function createMigrationImportProxyHandler(config: GatewayConfig) {
+  return async function handleMigrationImport(req: Request): Promise<Response> {
+    const start = performance.now();
+    const bodyBuffer = await req.arrayBuffer();
+
+    const upstream = `${config.assistantRuntimeBaseUrl}/v1/migrations/import`;
+
+    const reqHeaders = stripHopByHop(new Headers(req.headers));
+    reqHeaders.delete("host");
+    reqHeaders.delete("authorization");
+
+    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
+    reqHeaders.set("content-length", String(bodyBuffer.byteLength));
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(
+        new DOMException(
+          "The operation was aborted due to timeout",
+          "TimeoutError",
+        ),
+      );
+    }, MIGRATION_TIMEOUT_MS);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(upstream, {
+        method: "POST",
+        headers: reqHeaders,
+        body: bodyBuffer,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+    } catch (err) {
+      clearTimeout(timeoutId);
+      const duration = Math.round(performance.now() - start);
+      if (err instanceof DOMException && err.name === "TimeoutError") {
+        log.error({ duration }, "Migration import proxy upstream timed out");
+        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
+      }
+      log.error(
+        { err, duration },
+        "Migration import proxy upstream connection failed",
+      );
+      return Response.json({ error: "Bad Gateway" }, { status: 502 });
+    }
+
+    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const duration = Math.round(performance.now() - start);
+
+    if (response.status >= 400) {
+      const body = await response.text();
+      log.warn(
+        { status: response.status, duration },
+        "Migration import proxy upstream error",
+      );
+      return new Response(body, {
+        status: response.status,
+        headers: resHeaders,
+      });
+    }
+
+    log.info(
+      { status: response.status, duration },
+      "Migration import proxy completed",
+    );
+    return new Response(response.body, {
+      status: response.status,
+      headers: resHeaders,
+    });
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -57,6 +57,10 @@ import { createOAuthAppsProxyHandler } from "./http/routes/oauth-apps-proxy.js";
 import { createChannelReadinessProxyHandler } from "./http/routes/channel-readiness-proxy.js";
 import { createRuntimeHealthProxyHandler } from "./http/routes/runtime-health-proxy.js";
 import { createUpgradeBroadcastProxyHandler } from "./http/routes/upgrade-broadcast-proxy.js";
+import {
+  createMigrationExportProxyHandler,
+  createMigrationImportProxyHandler,
+} from "./http/routes/migration-proxy.js";
 import { createBrainGraphProxyHandler } from "./http/routes/brain-graph-proxy.js";
 import {
   createTrustRulesListHandler,
@@ -285,6 +289,8 @@ async function main() {
   const channelReadinessProxy = createChannelReadinessProxyHandler(config);
   const runtimeHealthProxy = createRuntimeHealthProxyHandler(config);
   const upgradeBroadcastProxy = createUpgradeBroadcastProxyHandler(config);
+  const migrationExportProxy = createMigrationExportProxyHandler(config);
+  const migrationImportProxy = createMigrationImportProxyHandler(config);
   const brainGraphProxy = createBrainGraphProxyHandler(config);
   const handleFeatureFlagsGet = createFeatureFlagsGetHandler();
   const handleFeatureFlagsPatch = createFeatureFlagsPatchHandler();
@@ -748,6 +754,20 @@ async function main() {
       method: "POST",
       auth: "edge",
       handler: (req) => upgradeBroadcastProxy(req),
+    },
+
+    // ── Migration export/import ──
+    {
+      path: "/v1/migrations/export",
+      method: "POST",
+      auth: "edge",
+      handler: (req) => migrationExportProxy(req),
+    },
+    {
+      path: "/v1/migrations/import",
+      method: "POST",
+      auth: "edge",
+      handler: (req) => migrationImportProxy(req),
     },
 
     // ── Channel readiness ──

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -2662,6 +2662,63 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/migrations/export": {
+        post: {
+          summary: "Export workspace backup",
+          description:
+            "Proxies a migration export request to the assistant daemon. Returns a binary .vbundle backup of the workspace. Authenticated with an edge JWT. Timeout is 120 seconds to accommodate large workspaces.",
+          operationId: "migrationExport",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: false,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "Binary .vbundle backup file",
+              content: {
+                "application/octet-stream": {
+                  schema: { type: "string", format: "binary" },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "502": { description: "Failed to reach assistant daemon" },
+            "504": { description: "Assistant daemon request timed out" },
+          },
+        },
+      },
+      "/v1/migrations/import": {
+        post: {
+          summary: "Import workspace backup",
+          description:
+            "Proxies a migration import request to the assistant daemon. Accepts a binary .vbundle backup body and restores the workspace from it. Authenticated with an edge JWT. Timeout is 120 seconds to accommodate large backups.",
+          operationId: "migrationImport",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/octet-stream": {
+                schema: { type: "string", format: "binary" },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Backup imported successfully" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "502": { description: "Failed to reach assistant daemon" },
+            "504": { description: "Assistant daemon request timed out" },
+          },
+        },
+      },
       "/{path}": {
         get: {
           summary: "Runtime proxy",


### PR DESCRIPTION
## Summary
- Adds gateway proxy for `POST /v1/migrations/export` (backup export)
- Adds gateway proxy for `POST /v1/migrations/import` (backup restore)
- Both use edge JWT auth, 120s timeout, and follow the upgrade-broadcast-proxy pattern

Part of plan: sparkle-backup-restore.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
