### PR TITLE
chore: populate .env.example files with default Vellum values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,34 +4,19 @@
 
 # --- Sentry (crash reporting) ---
 # Omit or leave empty to disable Sentry in local builds.
-SENTRY_DSN_MACOS=
-SENTRY_DSN_ASSISTANT=
+SENTRY_DSN_MACOS=https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640
+SENTRY_DSN_ASSISTANT=https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992
 
 # --- Telemetry ---
 # Omit or leave empty to disable telemetry.
-TELEMETRY_PLATFORM_URL=
-TELEMETRY_APP_TOKEN=
-
-# --- Sparkle auto-update ---
-# Omit to use default (Vellum GitHub releases).
-# SU_FEED_URL=
+TELEMETRY_PLATFORM_URL=https://platform.vellum.ai
+TELEMETRY_APP_TOKEN=e01cf85768cc3617e986f0a7f1966b72e25316526c5db54c8b94a9c3c5c9eaed
 
 # --- Doctor service ---
 # Omit to disable the doctor command.
-# DOCTOR_SERVICE_URL=
-
-# --- Git commit identity ---
-# Defaults shown. Override to customize commits made by the assistant/CLI.
-# ASSISTANT_GIT_USER_NAME=Vellum Assistant
-# ASSISTANT_GIT_USER_EMAIL=assistant@vellum.ai
-# CLI_GIT_USER_NAME=vellum-cli
-# CLI_GIT_USER_EMAIL=cli@vellum.ai
+DOCTOR_SERVICE_URL=https://doctor.vellum.ai
 
 # --- Network proxy ---
-# Comma-separated host patterns allowed through the proxy (e.g. "*.example.com,api.foo.bar").
+# Comma-separated host patterns allowed through the proxy.
 # localhost is always allowed.
-# PROXY_ALLOWED_HOSTS=
-
-# --- HTTP ---
-# Override the User-Agent header for outbound web fetches.
-# HTTP_USER_AGENT=VellumAssistant/1.0 (+https://vellum.ai)
+PROXY_ALLOWED_HOSTS=*.vellum.ai

--- a/assistant/.env.example
+++ b/assistant/.env.example
@@ -20,24 +20,15 @@ OLLAMA_BASE_URL=
 # PLATFORM_BASE_URL=
 
 # --- Sentry (crash reporting) ---
-# Omit to disable Sentry. Set to your Sentry project DSN to enable.
-# SENTRY_DSN_ASSISTANT=https://...@....ingest.us.sentry.io/...
+# Omit to disable Sentry.
+SENTRY_DSN_ASSISTANT=https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992
 
 # --- Telemetry ---
 # Omit to disable telemetry reporting.
-# TELEMETRY_PLATFORM_URL=https://...
-# TELEMETRY_APP_TOKEN=...
-
-# --- Git commit identity ---
-# Defaults shown. Override to customize commits made by the assistant.
-# ASSISTANT_GIT_USER_NAME=Vellum Assistant
-# ASSISTANT_GIT_USER_EMAIL=assistant@vellum.ai
+TELEMETRY_PLATFORM_URL=https://platform.vellum.ai
+TELEMETRY_APP_TOKEN=e01cf85768cc3617e986f0a7f1966b72e25316526c5db54c8b94a9c3c5c9eaed
 
 # --- Network proxy ---
-# Comma-separated host patterns allowed through the proxy (e.g. "*.example.com,api.foo.bar").
+# Comma-separated host patterns allowed through the proxy.
 # localhost is always allowed.
-# PROXY_ALLOWED_HOSTS=
-
-# --- HTTP ---
-# Override the User-Agent header for outbound web fetches.
-# HTTP_USER_AGENT=VellumAssistant/1.0 (+https://vellum.ai)
+PROXY_ALLOWED_HOSTS=*.vellum.ai


### PR DESCRIPTION
## Summary
- Fill in actual Vellum service values in .env.example files so developers can just `cp .env.example .env`
- Includes Sentry DSNs, telemetry URL/token, doctor service URL, and proxy allowlist
- Removed unnecessary commented-out entries (git identity, user-agent, sparkle URL) that already have sensible defaults in code
- None of these values are secrets — they are public client-side configuration

Part of plan: hardcoded-values-env-vars.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
