### PR TITLE
feat: add workspace-commit admin endpoint on daemon

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -516,3 +516,8 @@ registerPolicy("admin/upgrade-broadcast", {
   requiredScopes: ["internal.write"],
   allowedPrincipalTypes: ["svc_gateway"],
 });
+
+registerPolicy("admin/workspace-commit", {
+  requiredScopes: ["internal.write"],
+  allowedPrincipalTypes: ["svc_gateway"],
+});

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -180,6 +180,7 @@ import { upgradeBroadcastRouteDefinitions } from "./routes/upgrade-broadcast-rou
 import { usageRouteDefinitions } from "./routes/usage-routes.js";
 import { watchRouteDefinitions } from "./routes/watch-routes.js";
 import { workItemRouteDefinitions } from "./routes/work-items-routes.js";
+import { workspaceCommitRouteDefinitions } from "./routes/workspace-commit-routes.js";
 import { workspaceRouteDefinitions } from "./routes/workspace-routes.js";
 
 // Re-export for consumers
@@ -931,6 +932,7 @@ export class RuntimeHttpServer {
       }),
       ...identityRouteDefinitions(),
       ...upgradeBroadcastRouteDefinitions(),
+      ...workspaceCommitRouteDefinitions(),
       ...debugRouteDefinitions(),
       ...usageRouteDefinitions(),
       ...telemetryRouteDefinitions(),

--- a/assistant/src/runtime/routes/workspace-commit-routes.ts
+++ b/assistant/src/runtime/routes/workspace-commit-routes.ts
@@ -1,0 +1,62 @@
+/**
+ * Workspace commit endpoint — creates a git commit in the workspace
+ * directory with all pending changes.
+ *
+ * Protected by a route policy restricting access to gateway service
+ * principals only (`svc_gateway` with `internal.write` scope), following
+ * the same pattern as other gateway-forwarded control-plane endpoints.
+ */
+
+import { getWorkspaceDir } from "../../util/platform.js";
+import { getWorkspaceGitService } from "../../workspace/git-service.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+export function workspaceCommitRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "admin/workspace-commit",
+      method: "POST",
+      handler: async ({ req }) => {
+        let body: unknown;
+        try {
+          body = await req.json();
+        } catch {
+          return httpError("BAD_REQUEST", "Invalid JSON body", 400);
+        }
+
+        if (!body || typeof body !== "object") {
+          return httpError(
+            "BAD_REQUEST",
+            "Request body must be a JSON object",
+            400,
+          );
+        }
+
+        const { message } = body as { message?: unknown };
+
+        if (typeof message !== "string" || message.length === 0) {
+          return httpError(
+            "BAD_REQUEST",
+            "message is required and must be a non-empty string",
+            400,
+          );
+        }
+
+        try {
+          await getWorkspaceGitService(getWorkspaceDir()).commitChanges(
+            message,
+          );
+          return Response.json({ ok: true });
+        } catch (err) {
+          const detail = err instanceof Error ? err.message : "Unknown error";
+          return httpError(
+            "INTERNAL_ERROR",
+            `Workspace commit failed: ${detail}`,
+            500,
+          );
+        }
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Adds `POST /v1/admin/workspace-commit` route that creates a git commit in the workspace
- Validates `message` is a non-empty string, returns 400 on invalid input
- Protected by `svc_gateway` + `internal.write` scope policy

Part of plan: sparkle-backup-restore.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
