### PR TITLE
feat: remove hardcoded Vellum-specific values for open-source readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,34 +4,19 @@
 
 # --- Sentry (crash reporting) ---
 # Omit or leave empty to disable Sentry in local builds.
-SENTRY_DSN_MACOS=
-SENTRY_DSN_ASSISTANT=
+SENTRY_DSN_MACOS=https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640
+SENTRY_DSN_ASSISTANT=https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992
 
 # --- Telemetry ---
 # Omit or leave empty to disable telemetry.
-TELEMETRY_PLATFORM_URL=
-TELEMETRY_APP_TOKEN=
-
-# --- Sparkle auto-update ---
-# Omit to use default (Vellum GitHub releases).
-# SU_FEED_URL=
+TELEMETRY_PLATFORM_URL=https://platform.vellum.ai
+TELEMETRY_APP_TOKEN=e01cf85768cc3617e986f0a7f1966b72e25316526c5db54c8b94a9c3c5c9eaed
 
 # --- Doctor service ---
 # Omit to disable the doctor command.
-# DOCTOR_SERVICE_URL=
-
-# --- Git commit identity ---
-# Defaults shown. Override to customize commits made by the assistant/CLI.
-# ASSISTANT_GIT_USER_NAME=Vellum Assistant
-# ASSISTANT_GIT_USER_EMAIL=assistant@vellum.ai
-# CLI_GIT_USER_NAME=vellum-cli
-# CLI_GIT_USER_EMAIL=cli@vellum.ai
+DOCTOR_SERVICE_URL=https://doctor.vellum.ai
 
 # --- Network proxy ---
-# Comma-separated host patterns allowed through the proxy (e.g. "*.example.com,api.foo.bar").
+# Comma-separated host patterns allowed through the proxy.
 # localhost is always allowed.
-# PROXY_ALLOWED_HOSTS=
-
-# --- HTTP ---
-# Override the User-Agent header for outbound web fetches.
-# HTTP_USER_AGENT=VellumAssistant/1.0 (+https://vellum.ai)
+PROXY_ALLOWED_HOSTS=*.vellum.ai

--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,32 @@
 # Omit or leave empty to disable Sentry in local builds.
 SENTRY_DSN_MACOS=
 SENTRY_DSN_ASSISTANT=
+
+# --- Telemetry ---
+# Omit or leave empty to disable telemetry.
+TELEMETRY_PLATFORM_URL=
+TELEMETRY_APP_TOKEN=
+
+# --- Sparkle auto-update ---
+# Omit to use default (Vellum GitHub releases).
+# SU_FEED_URL=
+
+# --- Doctor service ---
+# Omit to disable the doctor command.
+# DOCTOR_SERVICE_URL=
+
+# --- Git commit identity ---
+# Defaults shown. Override to customize commits made by the assistant/CLI.
+# ASSISTANT_GIT_USER_NAME=Vellum Assistant
+# ASSISTANT_GIT_USER_EMAIL=assistant@vellum.ai
+# CLI_GIT_USER_NAME=vellum-cli
+# CLI_GIT_USER_EMAIL=cli@vellum.ai
+
+# --- Network proxy ---
+# Comma-separated host patterns allowed through the proxy (e.g. "*.example.com,api.foo.bar").
+# localhost is always allowed.
+# PROXY_ALLOWED_HOSTS=
+
+# --- HTTP ---
+# Override the User-Agent header for outbound web fetches.
+# HTTP_USER_AGENT=VellumAssistant/1.0 (+https://vellum.ai)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -951,10 +951,13 @@ jobs:
         continue-on-error: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG || 'vellum' }}
+          SENTRY_PROJECT_MACOS: ${{ vars.SENTRY_PROJECT_MACOS || 'vellum-assistant-macos' }}
+          SENTRY_PROJECT_ASSISTANT: ${{ vars.SENTRY_PROJECT_ASSISTANT || 'vellum-assistant-brain' }}
         run: |
           npm install -g @sentry/cli@2.42.2
-          sentry-cli debug-files upload --org vellum --project vellum-assistant-macos dist/*.dSYM
-          sentry-cli debug-files upload --org vellum --project vellum-assistant-brain dist/*.dSYM
+          sentry-cli debug-files upload --org "$SENTRY_ORG" --project "$SENTRY_PROJECT_MACOS" dist/*.dSYM
+          sentry-cli debug-files upload --org "$SENTRY_ORG" --project "$SENTRY_PROJECT_ASSISTANT" dist/*.dSYM
 
       - name: Free disk space
         run: |
@@ -1343,10 +1346,13 @@ jobs:
         continue-on-error: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG || 'vellum' }}
+          SENTRY_PROJECT_MACOS: ${{ vars.SENTRY_PROJECT_MACOS || 'vellum-assistant-macos' }}
+          SENTRY_PROJECT_ASSISTANT: ${{ vars.SENTRY_PROJECT_ASSISTANT || 'vellum-assistant-brain' }}
         run: |
           npm install -g @sentry/cli@2.42.2
-          sentry-cli debug-files upload --org vellum --project vellum-assistant-macos dist/*.dSYM
-          sentry-cli debug-files upload --org vellum --project vellum-assistant-brain dist/*.dSYM
+          sentry-cli debug-files upload --org "$SENTRY_ORG" --project "$SENTRY_PROJECT_MACOS" dist/*.dSYM
+          sentry-cli debug-files upload --org "$SENTRY_ORG" --project "$SENTRY_PROJECT_ASSISTANT" dist/*.dSYM
 
       - name: Free disk space
         run: |

--- a/assistant/.env.example
+++ b/assistant/.env.example
@@ -22,3 +22,22 @@ OLLAMA_BASE_URL=
 # --- Sentry (crash reporting) ---
 # Omit to disable Sentry. Set to your Sentry project DSN to enable.
 # SENTRY_DSN_ASSISTANT=https://...@....ingest.us.sentry.io/...
+
+# --- Telemetry ---
+# Omit to disable telemetry reporting.
+# TELEMETRY_PLATFORM_URL=https://...
+# TELEMETRY_APP_TOKEN=...
+
+# --- Git commit identity ---
+# Defaults shown. Override to customize commits made by the assistant.
+# ASSISTANT_GIT_USER_NAME=Vellum Assistant
+# ASSISTANT_GIT_USER_EMAIL=assistant@vellum.ai
+
+# --- Network proxy ---
+# Comma-separated host patterns allowed through the proxy (e.g. "*.example.com,api.foo.bar").
+# localhost is always allowed.
+# PROXY_ALLOWED_HOSTS=
+
+# --- HTTP ---
+# Override the User-Agent header for outbound web fetches.
+# HTTP_USER_AGENT=VellumAssistant/1.0 (+https://vellum.ai)

--- a/assistant/.env.example
+++ b/assistant/.env.example
@@ -20,24 +20,15 @@ OLLAMA_BASE_URL=
 # PLATFORM_BASE_URL=
 
 # --- Sentry (crash reporting) ---
-# Omit to disable Sentry. Set to your Sentry project DSN to enable.
-# SENTRY_DSN_ASSISTANT=https://...@....ingest.us.sentry.io/...
+# Omit to disable Sentry.
+SENTRY_DSN_ASSISTANT=https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992
 
 # --- Telemetry ---
 # Omit to disable telemetry reporting.
-# TELEMETRY_PLATFORM_URL=https://...
-# TELEMETRY_APP_TOKEN=...
-
-# --- Git commit identity ---
-# Defaults shown. Override to customize commits made by the assistant.
-# ASSISTANT_GIT_USER_NAME=Vellum Assistant
-# ASSISTANT_GIT_USER_EMAIL=assistant@vellum.ai
+TELEMETRY_PLATFORM_URL=https://platform.vellum.ai
+TELEMETRY_APP_TOKEN=e01cf85768cc3617e986f0a7f1966b72e25316526c5db54c8b94a9c3c5c9eaed
 
 # --- Network proxy ---
-# Comma-separated host patterns allowed through the proxy (e.g. "*.example.com,api.foo.bar").
+# Comma-separated host patterns allowed through the proxy.
 # localhost is always allowed.
-# PROXY_ALLOWED_HOSTS=
-
-# --- HTTP ---
-# Override the User-Agent header for outbound web fetches.
-# HTTP_USER_AGENT=VellumAssistant/1.0 (+https://vellum.ai)
+PROXY_ALLOWED_HOSTS=*.vellum.ai

--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -202,14 +202,11 @@ export function getPlatformInternalApiKey(): string {
 // ── Telemetry ──────────────────────────────────────────────────────────────────
 
 export function getTelemetryPlatformUrl(): string {
-  return str("TELEMETRY_PLATFORM_URL") ?? "https://platform.vellum.ai";
+  return str("TELEMETRY_PLATFORM_URL") ?? "";
 }
 
 export function getTelemetryAppToken(): string {
-  return (
-    str("TELEMETRY_APP_TOKEN") ??
-    "e01cf85768cc3617e986f0a7f1966b72e25316526c5db54c8b94a9c3c5c9eaed"
-  );
+  return str("TELEMETRY_APP_TOKEN") ?? "";
 }
 
 // ── Startup validation ──────────────────────────────────────────────────────

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -88,11 +88,7 @@ function getConfigPlatformUrl(): string | undefined {
 }
 
 function getPlatformUrl(): string {
-  return (
-    process.env.VELLUM_PLATFORM_URL ??
-    getConfigPlatformUrl() ??
-    "https://platform.vellum.ai"
-  );
+  return process.env.VELLUM_PLATFORM_URL ?? getConfigPlatformUrl() ?? "";
 }
 
 function buildHeaders(): Record<string, string> {

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -103,7 +103,11 @@ function buildHeaders(): Record<string, string> {
 // ─── Catalog operations ──────────────────────────────────────────────────────
 
 export async function fetchCatalog(): Promise<CatalogSkill[]> {
-  const url = `${getPlatformUrl()}/v1/skills/`;
+  const platformUrl = getPlatformUrl();
+  if (!platformUrl) {
+    return [];
+  }
+  const url = `${platformUrl}/v1/skills/`;
   const response = await fetch(url, {
     headers: buildHeaders(),
     signal: AbortSignal.timeout(10000),
@@ -210,7 +214,13 @@ export async function fetchAndExtractSkill(
   skillId: string,
   destDir: string,
 ): Promise<void> {
-  const url = `${getPlatformUrl()}/v1/skills/${encodeURIComponent(skillId)}/`;
+  const platformUrl = getPlatformUrl();
+  if (!platformUrl) {
+    throw new Error(
+      `Cannot fetch skill "${skillId}": VELLUM_PLATFORM_URL is not configured.`,
+    );
+  }
+  const url = `${platformUrl}/v1/skills/${encodeURIComponent(skillId)}/`;
   const response = await fetch(url, {
     headers: buildHeaders(),
     signal: AbortSignal.timeout(15000),

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -203,7 +203,9 @@ export class UsageTelemetryReporter {
       if (client) {
         resp = await client.fetch(TELEMETRY_PATH, fetchInit);
       } else {
-        const url = `${getTelemetryPlatformUrl()}${TELEMETRY_PATH}`;
+        const platformUrl = getTelemetryPlatformUrl();
+        if (!platformUrl) return;
+        const url = `${platformUrl}${TELEMETRY_PATH}`;
         resp = await fetch(url, {
           ...fetchInit,
           headers: {

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -140,7 +140,7 @@ export class UsageTelemetryReporter {
 
       // Resolve auth context — skip flush when neither auth mode is viable
       const client = await VellumPlatformClient.create();
-      if (!client && !getTelemetryAppToken()) {
+      if (!client && (!getTelemetryAppToken() || !getTelemetryPlatformUrl())) {
         return;
       }
 

--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -61,10 +61,25 @@ const store = new SessionStore();
 /**
  * Host patterns that are allowed by default through the proxy policy engine,
  * regardless of session configuration. Supports exact matches (e.g.
- * `"localhost"`) and wildcard subdomain patterns (e.g. `"*.vellum.ai"`
- * matches `platform.vellum.ai`, `dev-platform.vellum.ai`, etc.).
+ * `"localhost"`) and wildcard subdomain patterns (e.g. `"*.example.com"`
+ * matches `api.example.com`, `dev.example.com`, etc.).
+ *
+ * Additional patterns can be added via the `PROXY_ALLOWED_HOSTS` env var
+ * (comma-separated, e.g. `"*.example.com,api.foo.bar"`).
  */
-const ALLOWED_HOST_PATTERNS: readonly string[] = ["*.vellum.ai", "localhost"];
+const ALLOWED_HOST_PATTERNS: readonly string[] = (() => {
+  const extra = process.env.PROXY_ALLOWED_HOSTS?.trim();
+  const defaults = ["localhost"];
+  if (extra) {
+    defaults.push(
+      ...extra
+        .split(",")
+        .map((h) => h.trim())
+        .filter(Boolean),
+    );
+  }
+  return defaults;
+})();
 
 /**
  * Returns `true` when `hostname` matches any entry in

--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -88,7 +88,7 @@ const ALLOWED_HOST_PATTERNS: readonly string[] = (() => {
 function isAllowedHost(hostname: string): boolean {
   for (const pattern of ALLOWED_HOST_PATTERNS) {
     if (pattern.startsWith("*.")) {
-      const suffix = pattern.slice(1); // e.g. ".vellum.ai"
+      const suffix = pattern.slice(1); // e.g. ".example.com"
       if (hostname.endsWith(suffix) || hostname === pattern.slice(2)) {
         return true;
       }

--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -573,7 +573,9 @@ export async function executeWebFetch(
       Accept:
         "text/markdown, text/html;q=0.9, application/xhtml+xml;q=0.9, text/plain;q=0.8, application/json;q=0.7, */*;q=0.6",
       "Accept-Encoding": "identity",
-      "User-Agent": "VellumAssistant/1.0 (+https://vellum.ai)",
+      "User-Agent":
+        process.env.HTTP_USER_AGENT ||
+        "VellumAssistant/1.0 (+https://vellum.ai)",
     };
 
     let currentUrl = new URL(requestedUrl);

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -753,8 +753,11 @@ export class WorkspaceGitService {
    * Must be called with the mutex lock held.
    */
   private async ensureCommitIdentityLocked(): Promise<void> {
-    await this.execGit(["config", "user.name", "Vellum Assistant"]);
-    await this.execGit(["config", "user.email", "assistant@vellum.ai"]);
+    const gitName = process.env.ASSISTANT_GIT_USER_NAME || "Vellum Assistant";
+    const gitEmail =
+      process.env.ASSISTANT_GIT_USER_EMAIL || "assistant@vellum.ai";
+    await this.execGit(["config", "user.name", gitName]);
+    await this.execGit(["config", "user.email", gitEmail]);
   }
 
   /**

--- a/cli/src/lib/doctor-client.ts
+++ b/cli/src/lib/doctor-client.ts
@@ -1,4 +1,4 @@
-const DOCTOR_URL = "https://doctor.vellum.ai";
+const DOCTOR_URL = process.env.DOCTOR_SERVICE_URL?.trim() || "";
 
 export type ProgressPhase =
   | "invoking_prompt"
@@ -107,6 +107,16 @@ async function callDoctorDaemon(
   chatContext?: ChatLogEntry[],
   onLog?: DoctorLogCallback,
 ): Promise<DoctorResult> {
+  if (!DOCTOR_URL) {
+    onLog?.("Doctor service not configured (DOCTOR_SERVICE_URL is not set)");
+    return {
+      assistantId,
+      diagnostics: null,
+      recommendation: null,
+      error: "Doctor service not configured",
+    };
+  }
+
   const MAX_RETRIES = 2;
   let lastError: unknown;
 

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -23,6 +23,20 @@ export function getPlatformUrl(): string {
   return process.env.VELLUM_PLATFORM_URL ?? DEFAULT_PLATFORM_URL;
 }
 
+/**
+ * Returns the platform URL, throwing a clear error if it is not configured.
+ * Use this in functions that need a valid URL to make HTTP requests.
+ */
+function requirePlatformUrl(): string {
+  const url = getPlatformUrl();
+  if (!url) {
+    throw new Error(
+      "VELLUM_PLATFORM_URL is not configured. Set it in your environment or .env file.",
+    );
+  }
+  return url;
+}
+
 export function readPlatformToken(): string | null {
   try {
     return readFileSync(getPlatformTokenPath(), "utf-8").trim();
@@ -60,7 +74,7 @@ interface OrganizationListResponse {
 }
 
 export async function fetchOrganizationId(token: string): Promise<string> {
-  const platformUrl = getPlatformUrl();
+  const platformUrl = requirePlatformUrl();
   const url = `${platformUrl}/v1/organizations/`;
   const response = await fetch(url, {
     headers: { "X-Session-Token": token },
@@ -92,7 +106,7 @@ interface AllauthSessionResponse {
 }
 
 export async function fetchCurrentUser(token: string): Promise<PlatformUser> {
-  const url = `${getPlatformUrl()}/_allauth/app/v1/auth/session`;
+  const url = `${requirePlatformUrl()}/_allauth/app/v1/auth/session`;
   const response = await fetch(url, {
     headers: { "X-Session-Token": token },
   });

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -9,7 +9,7 @@ import {
 import { homedir } from "os";
 import { join, dirname } from "path";
 
-const DEFAULT_PLATFORM_URL = "https://platform.vellum.ai";
+const DEFAULT_PLATFORM_URL = "";
 
 function getXdgConfigHome(): string {
   return process.env.XDG_CONFIG_HOME?.trim() || join(homedir(), ".config");

--- a/cli/src/lib/workspace-git.ts
+++ b/cli/src/lib/workspace-git.ts
@@ -23,9 +23,9 @@ export async function commitWorkspaceState(
     "git",
     [
       "-c",
-      "user.name=vellum-cli",
+      `user.name=${process.env.CLI_GIT_USER_NAME || "vellum-cli"}`,
       "-c",
-      "user.email=cli@vellum.ai",
+      `user.email=${process.env.CLI_GIT_USER_EMAIL || "cli@vellum.ai"}`,
       "-c",
       "core.hooksPath=/dev/null",
       "commit",

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -26,6 +26,7 @@ set -euo pipefail
 #   SKIP_BUN_REBUILD    Set to 1 to skip Bun binary staleness checks (use pre-built binaries as-is)
 #   SENTRY_DSN_MACOS     Sentry DSN for the macOS app project (omit to disable)
 #   SENTRY_DSN_ASSISTANT Sentry DSN for the assistant/daemon project (omit to disable)
+#   SU_FEED_URL          Sparkle appcast URL for auto-updates (default: Vellum GitHub releases)
 
 # ---------------------------------------------------------------------------
 # swift_with_retry — run a swift command with retries for transient SPM
@@ -824,7 +825,7 @@ cat > "$CONTENTS/Info.plist" <<PLIST
     <key>NSSpeechRecognitionUsageDescription</key>
     <string>Vellum uses speech recognition to convert voice commands into tasks.</string>
     <key>SUFeedURL</key>
-    <string>https://github.com/vellum-ai/velly/releases/latest/download/appcast.xml</string>
+    <string>${SU_FEED_URL:-https://github.com/vellum-ai/velly/releases/latest/download/appcast.xml}</string>
     <key>SUPublicEDKey</key>
     <string>${SU_PUBLIC_ED_KEY:-}</string>
     <key>SUEnableAutomaticChecks</key>

--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -112,6 +112,10 @@ final class VellumCli {
     nonisolated private static let forwardedEnvKeys: [String] = [
         "BASE_DATA_DIR",
         "VELLUM_PLATFORM_URL",
+        "TELEMETRY_PLATFORM_URL", "TELEMETRY_APP_TOKEN",
+        "ASSISTANT_GIT_USER_NAME", "ASSISTANT_GIT_USER_EMAIL",
+        "CLI_GIT_USER_NAME", "CLI_GIT_USER_EMAIL",
+        "PROXY_ALLOWED_HOSTS", "HTTP_USER_AGENT", "DOCTOR_SERVICE_URL",
         "SENTRY_DSN_MACOS", "SENTRY_DSN_ASSISTANT", "TMPDIR", "USER", "LANG",
     ] + Array(providerEnvVars.values) + [
         // Cloud provider auth — needed by hatch and retire flows.

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -126,13 +126,24 @@ struct ComposerView: View {
         .disabled(!hasAPIKey || !isInteractionEnabled)
         .animation(VAnimation.fast, value: isComposerFocused)
         .onAppear {
-            composerFocus = isInteractionEnabled
+            // Delay focus slightly so the NSTextView field editor is fully
+            // installed before we request first-responder status. Setting
+            // @FocusState synchronously during an animated layout pass
+            // (e.g. the empty-state fade-in) can give logical focus without
+            // rendering the blinking caret.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                composerFocus = isInteractionEnabled
+            }
             let identity = IdentityInfo.load()
             avatarSeed = identity?.name ?? "default"
         }
         .onChange(of: conversationId) {
             guard isInteractionEnabled, !hasPendingConfirmation else { return }
-            composerFocus = true
+            // Same delay: the conversation switch may trigger a view rebuild
+            // (new empty state) whose layout isn't settled yet.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                composerFocus = true
+            }
         }
         .onChange(of: currentMode) {
             composerLog.debug("Composer mode: \(String(describing: currentMode))")


### PR DESCRIPTION
## Summary
- Replace all hardcoded Vellum-specific service URLs, tokens, and config with environment variable lookups
- Service endpoints (telemetry, doctor, platform URL) default to empty (disabled) — forks won't send data to Vellum infrastructure
- Identity strings (git name/email, User-Agent) and build config (Sparkle URL, Sentry CLI) keep sensible defaults with env var overrides
- `.env.example` files populated with actual Vellum values so internal devs just `cp .env.example .env`
- Guards added for all empty-URL paths to produce clear error messages instead of crashes

## PRs merged into feature branch
- #20645: feat: replace remaining hardcoded Vellum values with env var lookups
- #20646: fix: add guards for empty platform URL and forward new env vars
- #20648: chore: populate .env.example files with default Vellum values

## Post-merge action
- Add GitHub Secrets: `SENTRY_DSN_MACOS`, `SENTRY_DSN_ASSISTANT`
- Add GitHub Variables (optional): `SENTRY_ORG`, `SENTRY_PROJECT_MACOS`, `SENTRY_PROJECT_ASSISTANT`
- All developers: `cp .env.example .env` at repo root

Part of plan: hardcoded-values-env-vars.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
