### PR TITLE
feat: detect Sparkle update on launch, broadcast completion, and enable restore

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -33,6 +33,26 @@ struct AssistantBackupsSection: View {
                 .font(VFont.sectionTitle)
                 .foregroundColor(VColor.contentDefault)
 
+            if let backupPath = UserDefaults.standard.string(forKey: "preUpdateBackupPath"),
+               FileManager.default.fileExists(atPath: backupPath) {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    Text("A backup was automatically created before the last update.")
+                        .font(VFont.caption)
+                        .foregroundStyle(VColor.contentSecondary)
+                    HStack {
+                        VButton(label: "Restore Pre-Update Data", style: .outlined) {
+                            Task {
+                                await performLocalRestore(URL(fileURLWithPath: backupPath))
+                                UserDefaults.standard.removeObject(forKey: "preUpdateBackupPath")
+                            }
+                        }
+                        VButton(label: "Dismiss", style: .text) {
+                            UserDefaults.standard.removeObject(forKey: "preUpdateBackupPath")
+                        }
+                    }
+                }
+            }
+
             if assistant.isManaged || (assistant.isRemote && !assistant.isDocker) {
                 managedBackupContent
             } else {

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -549,6 +549,46 @@ public final class GatewayConnectionManager: ObservableObject {
     }
     #endif
 
+    // MARK: - Post-Sparkle Update Detection
+
+    #if os(macOS)
+    /// Detects whether the app was relaunched after a Sparkle update by checking
+    /// the `preUpdateVersion` UserDefaults flag (set before the update started).
+    /// If the version has changed, broadcasts a `complete` event so the UI shows
+    /// a success toast and creates a workspace git commit recording the update.
+    /// The flag is cleared after processing so this only runs once per update.
+    private func handlePostSparkleUpdate() {
+        guard let preUpdateVersion = UserDefaults.standard.string(forKey: "preUpdateVersion") else { return }
+        let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        guard currentVersion != preUpdateVersion else { return }
+
+        // Clear the flag so this only runs once
+        UserDefaults.standard.removeObject(forKey: "preUpdateVersion")
+
+        log.info("Post-Sparkle-update detected: \(preUpdateVersion, privacy: .public) → \(currentVersion, privacy: .public)")
+
+        Task {
+            // 1. Broadcast "complete" so the UI clears the progress spinner and shows the outcome
+            _ = try? await GatewayHTTPClient.post(
+                path: "admin/upgrade-broadcast",
+                json: [
+                    "type": "complete",
+                    "installedVersion": currentVersion,
+                    "success": true
+                ] as [String: Any],
+                timeout: 5
+            )
+
+            // 2. Workspace commit: record successful update
+            _ = try? await GatewayHTTPClient.post(
+                path: "admin/workspace-commit",
+                json: ["message": "[sparkle-update] Complete: \(preUpdateVersion) → \(currentVersion)\n\nresult: success"],
+                timeout: 10
+            )
+        }
+    }
+    #endif
+
     // MARK: - Helpers
 
     private func setConnected(_ connected: Bool) {
@@ -557,6 +597,9 @@ public final class GatewayConnectionManager: ObservableObject {
         isConnecting = false
         if connected {
             NotificationCenter.default.post(name: .daemonDidReconnect, object: self)
+            #if os(macOS)
+            handlePostSparkleUpdate()
+            #endif
         }
         #if os(macOS)
         if !connected {


### PR DESCRIPTION
## Summary
- Detects post-Sparkle-update on first connection and broadcasts `complete` event
- Creates workspace git commit recording the successful update
- Adds "Restore Pre-Update Data" button in Settings backups section when a pre-update backup exists

Part of plan: sparkle-backup-restore.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
