### PR TITLE
feat: auto-backup, workspace commit, and progress events before Sparkle update

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -435,12 +435,77 @@ extension AppDelegate {
         guard !DevModeManager.shared.isDevMode else { return }
 
         updateManager.onWillInstallUpdate = { [weak self] in
+            guard let self else { return }
+            let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+            let targetVersion = self.updateManager.pendingUpdateVersion ?? "unknown"
+
+            // 1. Broadcast "starting" so the UI shows the progress spinner
+            _ = try? await GatewayHTTPClient.post(
+                path: "admin/upgrade-broadcast",
+                json: ["type": "starting", "targetVersion": targetVersion, "expectedDowntimeSeconds": 30],
+                timeout: 5
+            )
+
+            // 2. Workspace commit: record pre-update state
+            _ = try? await GatewayHTTPClient.post(
+                path: "admin/workspace-commit",
+                json: ["message": "[sparkle-update] Starting: \(currentVersion) → \(targetVersion)"],
+                timeout: 10
+            )
+
+            // 3. Progress: saving backup
+            _ = try? await GatewayHTTPClient.post(
+                path: "admin/upgrade-broadcast",
+                json: ["type": "progress", "statusMessage": "Saving a backup of your data…"],
+                timeout: 5
+            )
+
+            // 4. Create backup via gateway
+            if let response = try? await GatewayHTTPClient.post(path: "migrations/export", timeout: 120),
+               response.isSuccess {
+                let backupsDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+                    .appendingPathComponent("Vellum/backups", isDirectory: true)
+                try? FileManager.default.createDirectory(at: backupsDir, withIntermediateDirectories: true)
+                let formatter = DateFormatter()
+                formatter.dateFormat = "yyyy-MM-dd-HHmmss"
+                let filename = "pre-update-\(formatter.string(from: Date())).vbundle"
+                let fileURL = backupsDir.appendingPathComponent(filename)
+                try? response.data.write(to: fileURL)
+                UserDefaults.standard.set(fileURL.path, forKey: "preUpdateBackupPath")
+                Self.prunePreUpdateBackups(in: backupsDir, keep: 3)
+            }
+
+            // 5. Progress: installing update
+            _ = try? await GatewayHTTPClient.post(
+                path: "admin/upgrade-broadcast",
+                json: ["type": "progress", "statusMessage": "Installing the update…"],
+                timeout: 5
+            )
+
+            // 6. Cache current version for post-update detection
+            UserDefaults.standard.set(currentVersion, forKey: "preUpdateVersion")
+
+            // 7. Stop daemon — after this, no more broadcasts are possible
             #if !DEBUG
-            self?.keychainBroker?.stop()
+            self.keychainBroker?.stop()
             #endif
-            self?.vellumCli.stop()
+            self.vellumCli.stop()
         }
         updateManager.startAutomaticChecks()
+    }
+
+    /// Removes old pre-update backups, keeping only the most recent `keep` files.
+    static func prunePreUpdateBackups(in directory: URL, keep: Int) {
+        guard let contents = try? FileManager.default.contentsOfDirectory(
+            at: directory, includingPropertiesForKeys: nil
+        ) else { return }
+        let matching = contents
+            .filter { $0.lastPathComponent.hasPrefix("pre-update-") && $0.pathExtension == "vbundle" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        guard matching.count > keep else { return }
+        for file in matching.prefix(matching.count - keep) {
+            try? FileManager.default.removeItem(at: file)
+        }
     }
 
     // MARK: - CLI Symlink

--- a/clients/macos/vellum-assistant/App/UpdateManager.swift
+++ b/clients/macos/vellum-assistant/App/UpdateManager.swift
@@ -18,14 +18,20 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
     @Published public private(set) var isDeferredUpdateReady = false
     @Published public private(set) var availableUpdateVersion: String?
 
+    /// The version string of the update that Sparkle has found and is about to
+    /// install.  Set in `didFindValidUpdate` so the pre-update hook can include
+    /// the target version in progress broadcasts and workspace commits.
+    @Published public var pendingUpdateVersion: String?
+
     /// Whether a newer service group release is available for Docker/managed topologies.
     @Published public private(set) var isServiceGroupUpdateAvailable = false
     /// The version string of the available service group update, if any.
     @Published public private(set) var serviceGroupUpdateVersion: String?
 
     /// Called before the app is replaced — stop the daemon so the new version
-    /// can launch its own bundled daemon cleanly.
-    var onWillInstallUpdate: (() -> Void)?
+    /// can launch its own bundled daemon cleanly.  Async to allow best-effort
+    /// backup and progress broadcasts before shutdown.
+    var onWillInstallUpdate: (() async -> Void)?
 
     /// Timer for periodic service group update checks (Docker/managed topologies).
     private var serviceGroupCheckTimer: Timer?
@@ -118,8 +124,10 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
         guard let handler else { return }
         isDeferredUpdateReady = false
         log.info("Installing deferred update now")
-        onWillInstallUpdate?()
-        handler()
+        Task { @MainActor in
+            await onWillInstallUpdate?()
+            handler()
+        }
     }
 
     // MARK: - Service Group Update Check
@@ -231,7 +239,7 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
             // Skip the daemon stop if we have a deferred update — the daemon
             // will be stopped when the deferred handler is invoked at quit.
             guard !self.hasDeferredUpdate else { return }
-            self.onWillInstallUpdate?()
+            await self.onWillInstallUpdate?()
         }
     }
 
@@ -264,6 +272,7 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
             log.info("Found valid update: \(item.displayVersionString, privacy: .public)")
             self.isUpdateAvailable = true
             self.availableUpdateVersion = item.displayVersionString
+            self.pendingUpdateVersion = item.displayVersionString
         }
     }
 


### PR DESCRIPTION
## Summary
- Broadcasts `starting` and `progress` events so the UI shows backup/install stages
- Creates a .vbundle backup via gateway before daemon stops
- Creates a workspace git commit recording the update transition
- Caches version info in UserDefaults for post-update detection
- Makes `onWillInstallUpdate` async to avoid deadlocks

Part of plan: sparkle-backup-restore.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
