### PR TITLE
fix: mock resolveGuardianPersona in notification decision tests to fix flakiness

### DIFF
--- a/assistant/src/__tests__/notification-decision-fallback.test.ts
+++ b/assistant/src/__tests__/notification-decision-fallback.test.ts
@@ -34,6 +34,10 @@ mock.module("../notifications/conversation-candidates.js", () => ({
   serializeCandidatesForPrompt: () => undefined,
 }));
 
+mock.module("../prompts/persona-resolver.js", () => ({
+  resolveGuardianPersona: () => null,
+}));
+
 let configuredProvider: { sendMessage: () => Promise<unknown> } | null = null;
 let extractedToolUse: unknown = null;
 

--- a/assistant/src/__tests__/notification-decision-identity.test.ts
+++ b/assistant/src/__tests__/notification-decision-identity.test.ts
@@ -36,6 +36,10 @@ mock.module("../notifications/conversation-candidates.js", () => ({
   serializeCandidatesForPrompt: () => undefined,
 }));
 
+mock.module("../prompts/persona-resolver.js", () => ({
+  resolveGuardianPersona: () => null,
+}));
+
 // ── Identity context mock ─────────────────────────────────────────────
 
 let mockIdentityContext: string | null = null;


### PR DESCRIPTION
## Summary
- Notification decision tests (`notification-decision-fallback` and `notification-decision-identity`) were flaky in CI because `resolveGuardianPersona()` queries the `contacts` SQLite table, which doesn't exist in the test environment
- The unmocked DB access caused `classifyWithLLM` to throw and silently fall back to the deterministic path, making all tests expecting the LLM path (`fallbackUsed === false`) fail
- Added `mock.module("../prompts/persona-resolver.js")` in both test files to return `null` for `resolveGuardianPersona`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
