### PR TITLE
fix: make pre-update restore banner reactive with @AppStorage

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -20,6 +20,8 @@ struct AssistantBackupsSection: View {
     @State private var errorMessage: String?
     @State private var successMessage: String?
 
+    @AppStorage("preUpdateBackupPath") private var preUpdateBackupPath: String?
+
     // Managed assistant state
     @State private var managedBackups: [ManagedBackup] = []
     @State private var isLoadingBackups = false
@@ -33,7 +35,7 @@ struct AssistantBackupsSection: View {
                 .font(VFont.sectionTitle)
                 .foregroundColor(VColor.contentDefault)
 
-            if let backupPath = UserDefaults.standard.string(forKey: "preUpdateBackupPath"),
+            if let backupPath = preUpdateBackupPath,
                FileManager.default.fileExists(atPath: backupPath) {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("A backup was automatically created before the last update.")
@@ -43,11 +45,11 @@ struct AssistantBackupsSection: View {
                         VButton(label: "Restore Pre-Update Data", style: .outlined) {
                             Task {
                                 await performLocalRestore(URL(fileURLWithPath: backupPath))
-                                UserDefaults.standard.removeObject(forKey: "preUpdateBackupPath")
+                                preUpdateBackupPath = nil
                             }
                         }
                         VButton(label: "Dismiss", style: .text) {
-                            UserDefaults.standard.removeObject(forKey: "preUpdateBackupPath")
+                            preUpdateBackupPath = nil
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for sparkle-backup-restore.md.

**Gap:** Pre-update restore banner not reactive in SwiftUI
**What was expected:** Banner dismisses immediately when user taps Dismiss
**What was found:** Direct UserDefaults read in body doesn't trigger re-render

Replaced direct `UserDefaults.standard.string(forKey:)` read with `@AppStorage("preUpdateBackupPath")` property wrapper, making the banner reactive. Button actions now set the property to `nil` instead of calling `UserDefaults.standard.removeObject(forKey:)`, ensuring SwiftUI re-renders immediately when the banner is dismissed or after a restore.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
