### PR TITLE
fix: clear pendingUpdateVersion when update is skipped or not found

### DIFF
--- a/clients/macos/vellum-assistant/App/UpdateManager.swift
+++ b/clients/macos/vellum-assistant/App/UpdateManager.swift
@@ -282,6 +282,7 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
         Task { @MainActor in
             self.isUpdateAvailable = false
             self.availableUpdateVersion = nil
+            self.pendingUpdateVersion = nil
         }
     }
 
@@ -298,6 +299,7 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
                 log.info("User skipped update \(updateItem.displayVersionString, privacy: .public)")
                 self.isUpdateAvailable = false
                 self.availableUpdateVersion = nil
+                self.pendingUpdateVersion = nil
             }
         }
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for sparkle-backup-restore.md.

**Gap:** pendingUpdateVersion never cleared
**What was expected:** Cleared alongside isUpdateAvailable when skipped/not found
**What was found:** Only set, never cleared, leaving stale version info
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
