### PR TITLE
fix: ensure deferred Sparkle install handler runs synchronously

### DIFF
--- a/clients/macos/vellum-assistant/App/UpdateManager.swift
+++ b/clients/macos/vellum-assistant/App/UpdateManager.swift
@@ -115,6 +115,12 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
 
     /// Install a previously deferred update immediately.
     /// Call this when the app is about to quit or when it becomes idle.
+    ///
+    /// `handler()` is called **synchronously** so that it executes before
+    /// `applicationWillTerminate` returns and the process exits.  The
+    /// pre-update async work (backup, progress broadcasts) is fired as
+    /// best-effort in a detached Task — if it finishes before the process
+    /// tears down, great; if not, the update still installs.
     func installDeferredUpdateIfAvailable() {
         let handler = deferredInstallLock.withLock { value -> (() -> Void)? in
             let h = value
@@ -124,10 +130,18 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
         guard let handler else { return }
         isDeferredUpdateReady = false
         log.info("Installing deferred update now")
-        Task { @MainActor in
-            await onWillInstallUpdate?()
-            handler()
+
+        // Fire pre-update work (backup, daemon stop, broadcasts) as
+        // best-effort.  This must not block the synchronous handler() call.
+        if let onWillInstall = onWillInstallUpdate {
+            Task { @MainActor in
+                await onWillInstall()
+            }
         }
+
+        // handler() must run synchronously so applicationWillTerminate
+        // cannot exit before Sparkle applies the update.
+        handler()
     }
 
     // MARK: - Service Group Update Check


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for sparkle-backup-restore.md.

**Gap:** installDeferredUpdateIfAvailable() regression
**What was expected:** handler() must run during applicationWillTerminate
**What was found:** handler() wrapped in fire-and-forget Task that may never execute

The fix moves handler() out of the Task so it runs synchronously. The pre-update async work (backup, progress broadcasts) remains in a fire-and-forget Task — if it completes before the process exits, great; if not, the update still installs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
