### PR TITLE
feat: Sparkle update backup, restore, workspace commits, and progress events

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -516,3 +516,8 @@ registerPolicy("admin/upgrade-broadcast", {
   requiredScopes: ["internal.write"],
   allowedPrincipalTypes: ["svc_gateway"],
 });
+
+registerPolicy("admin/workspace-commit", {
+  requiredScopes: ["internal.write"],
+  allowedPrincipalTypes: ["svc_gateway"],
+});

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -180,6 +180,7 @@ import { upgradeBroadcastRouteDefinitions } from "./routes/upgrade-broadcast-rou
 import { usageRouteDefinitions } from "./routes/usage-routes.js";
 import { watchRouteDefinitions } from "./routes/watch-routes.js";
 import { workItemRouteDefinitions } from "./routes/work-items-routes.js";
+import { workspaceCommitRouteDefinitions } from "./routes/workspace-commit-routes.js";
 import { workspaceRouteDefinitions } from "./routes/workspace-routes.js";
 
 // Re-export for consumers
@@ -931,6 +932,7 @@ export class RuntimeHttpServer {
       }),
       ...identityRouteDefinitions(),
       ...upgradeBroadcastRouteDefinitions(),
+      ...workspaceCommitRouteDefinitions(),
       ...debugRouteDefinitions(),
       ...usageRouteDefinitions(),
       ...telemetryRouteDefinitions(),

--- a/assistant/src/runtime/routes/workspace-commit-routes.ts
+++ b/assistant/src/runtime/routes/workspace-commit-routes.ts
@@ -1,0 +1,62 @@
+/**
+ * Workspace commit endpoint — creates a git commit in the workspace
+ * directory with all pending changes.
+ *
+ * Protected by a route policy restricting access to gateway service
+ * principals only (`svc_gateway` with `internal.write` scope), following
+ * the same pattern as other gateway-forwarded control-plane endpoints.
+ */
+
+import { getWorkspaceDir } from "../../util/platform.js";
+import { getWorkspaceGitService } from "../../workspace/git-service.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+export function workspaceCommitRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "admin/workspace-commit",
+      method: "POST",
+      handler: async ({ req }) => {
+        let body: unknown;
+        try {
+          body = await req.json();
+        } catch {
+          return httpError("BAD_REQUEST", "Invalid JSON body", 400);
+        }
+
+        if (!body || typeof body !== "object") {
+          return httpError(
+            "BAD_REQUEST",
+            "Request body must be a JSON object",
+            400,
+          );
+        }
+
+        const { message } = body as { message?: unknown };
+
+        if (typeof message !== "string" || message.length === 0) {
+          return httpError(
+            "BAD_REQUEST",
+            "message is required and must be a non-empty string",
+            400,
+          );
+        }
+
+        try {
+          await getWorkspaceGitService(getWorkspaceDir()).commitChanges(
+            message,
+          );
+          return Response.json({ ok: true });
+        } catch (err) {
+          const detail = err instanceof Error ? err.message : "Unknown error";
+          return httpError(
+            "INTERNAL_ERROR",
+            `Workspace commit failed: ${detail}`,
+            500,
+          );
+        }
+      },
+    },
+  ];
+}

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -435,12 +435,77 @@ extension AppDelegate {
         guard !DevModeManager.shared.isDevMode else { return }
 
         updateManager.onWillInstallUpdate = { [weak self] in
+            guard let self else { return }
+            let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+            let targetVersion = self.updateManager.pendingUpdateVersion ?? "unknown"
+
+            // 1. Broadcast "starting" so the UI shows the progress spinner
+            _ = try? await GatewayHTTPClient.post(
+                path: "admin/upgrade-broadcast",
+                json: ["type": "starting", "targetVersion": targetVersion, "expectedDowntimeSeconds": 30],
+                timeout: 5
+            )
+
+            // 2. Workspace commit: record pre-update state
+            _ = try? await GatewayHTTPClient.post(
+                path: "admin/workspace-commit",
+                json: ["message": "[sparkle-update] Starting: \(currentVersion) → \(targetVersion)"],
+                timeout: 10
+            )
+
+            // 3. Progress: saving backup
+            _ = try? await GatewayHTTPClient.post(
+                path: "admin/upgrade-broadcast",
+                json: ["type": "progress", "statusMessage": "Saving a backup of your data…"],
+                timeout: 5
+            )
+
+            // 4. Create backup via gateway
+            if let response = try? await GatewayHTTPClient.post(path: "migrations/export", timeout: 120),
+               response.isSuccess {
+                let backupsDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+                    .appendingPathComponent("Vellum/backups", isDirectory: true)
+                try? FileManager.default.createDirectory(at: backupsDir, withIntermediateDirectories: true)
+                let formatter = DateFormatter()
+                formatter.dateFormat = "yyyy-MM-dd-HHmmss"
+                let filename = "pre-update-\(formatter.string(from: Date())).vbundle"
+                let fileURL = backupsDir.appendingPathComponent(filename)
+                try? response.data.write(to: fileURL)
+                UserDefaults.standard.set(fileURL.path, forKey: "preUpdateBackupPath")
+                Self.prunePreUpdateBackups(in: backupsDir, keep: 3)
+            }
+
+            // 5. Progress: installing update
+            _ = try? await GatewayHTTPClient.post(
+                path: "admin/upgrade-broadcast",
+                json: ["type": "progress", "statusMessage": "Installing the update…"],
+                timeout: 5
+            )
+
+            // 6. Cache current version for post-update detection
+            UserDefaults.standard.set(currentVersion, forKey: "preUpdateVersion")
+
+            // 7. Stop daemon — after this, no more broadcasts are possible
             #if !DEBUG
-            self?.keychainBroker?.stop()
+            self.keychainBroker?.stop()
             #endif
-            self?.vellumCli.stop()
+            self.vellumCli.stop()
         }
         updateManager.startAutomaticChecks()
+    }
+
+    /// Removes old pre-update backups, keeping only the most recent `keep` files.
+    static func prunePreUpdateBackups(in directory: URL, keep: Int) {
+        guard let contents = try? FileManager.default.contentsOfDirectory(
+            at: directory, includingPropertiesForKeys: nil
+        ) else { return }
+        let matching = contents
+            .filter { $0.lastPathComponent.hasPrefix("pre-update-") && $0.pathExtension == "vbundle" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        guard matching.count > keep else { return }
+        for file in matching.prefix(matching.count - keep) {
+            try? FileManager.default.removeItem(at: file)
+        }
     }
 
     // MARK: - CLI Symlink

--- a/clients/macos/vellum-assistant/App/UpdateManager.swift
+++ b/clients/macos/vellum-assistant/App/UpdateManager.swift
@@ -282,6 +282,7 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
         Task { @MainActor in
             self.isUpdateAvailable = false
             self.availableUpdateVersion = nil
+            self.pendingUpdateVersion = nil
         }
     }
 
@@ -298,6 +299,7 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
                 log.info("User skipped update \(updateItem.displayVersionString, privacy: .public)")
                 self.isUpdateAvailable = false
                 self.availableUpdateVersion = nil
+                self.pendingUpdateVersion = nil
             }
         }
     }

--- a/clients/macos/vellum-assistant/App/UpdateManager.swift
+++ b/clients/macos/vellum-assistant/App/UpdateManager.swift
@@ -18,14 +18,20 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
     @Published public private(set) var isDeferredUpdateReady = false
     @Published public private(set) var availableUpdateVersion: String?
 
+    /// The version string of the update that Sparkle has found and is about to
+    /// install.  Set in `didFindValidUpdate` so the pre-update hook can include
+    /// the target version in progress broadcasts and workspace commits.
+    @Published public var pendingUpdateVersion: String?
+
     /// Whether a newer service group release is available for Docker/managed topologies.
     @Published public private(set) var isServiceGroupUpdateAvailable = false
     /// The version string of the available service group update, if any.
     @Published public private(set) var serviceGroupUpdateVersion: String?
 
     /// Called before the app is replaced — stop the daemon so the new version
-    /// can launch its own bundled daemon cleanly.
-    var onWillInstallUpdate: (() -> Void)?
+    /// can launch its own bundled daemon cleanly.  Async to allow best-effort
+    /// backup and progress broadcasts before shutdown.
+    var onWillInstallUpdate: (() async -> Void)?
 
     /// Timer for periodic service group update checks (Docker/managed topologies).
     private var serviceGroupCheckTimer: Timer?
@@ -118,8 +124,10 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
         guard let handler else { return }
         isDeferredUpdateReady = false
         log.info("Installing deferred update now")
-        onWillInstallUpdate?()
-        handler()
+        Task { @MainActor in
+            await onWillInstallUpdate?()
+            handler()
+        }
     }
 
     // MARK: - Service Group Update Check
@@ -231,7 +239,7 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
             // Skip the daemon stop if we have a deferred update — the daemon
             // will be stopped when the deferred handler is invoked at quit.
             guard !self.hasDeferredUpdate else { return }
-            self.onWillInstallUpdate?()
+            await self.onWillInstallUpdate?()
         }
     }
 
@@ -264,6 +272,7 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
             log.info("Found valid update: \(item.displayVersionString, privacy: .public)")
             self.isUpdateAvailable = true
             self.availableUpdateVersion = item.displayVersionString
+            self.pendingUpdateVersion = item.displayVersionString
         }
     }
 

--- a/clients/macos/vellum-assistant/App/UpdateManager.swift
+++ b/clients/macos/vellum-assistant/App/UpdateManager.swift
@@ -115,6 +115,12 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
 
     /// Install a previously deferred update immediately.
     /// Call this when the app is about to quit or when it becomes idle.
+    ///
+    /// `handler()` is called **synchronously** so that it executes before
+    /// `applicationWillTerminate` returns and the process exits.  The
+    /// pre-update async work (backup, progress broadcasts) is fired as
+    /// best-effort in a detached Task — if it finishes before the process
+    /// tears down, great; if not, the update still installs.
     func installDeferredUpdateIfAvailable() {
         let handler = deferredInstallLock.withLock { value -> (() -> Void)? in
             let h = value
@@ -124,10 +130,18 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
         guard let handler else { return }
         isDeferredUpdateReady = false
         log.info("Installing deferred update now")
-        Task { @MainActor in
-            await onWillInstallUpdate?()
-            handler()
+
+        // Fire pre-update work (backup, daemon stop, broadcasts) as
+        // best-effort.  This must not block the synchronous handler() call.
+        if let onWillInstall = onWillInstallUpdate {
+            Task { @MainActor in
+                await onWillInstall()
+            }
         }
+
+        // handler() must run synchronously so applicationWillTerminate
+        // cannot exit before Sparkle applies the update.
+        handler()
     }
 
     // MARK: - Service Group Update Check

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -20,6 +20,8 @@ struct AssistantBackupsSection: View {
     @State private var errorMessage: String?
     @State private var successMessage: String?
 
+    @AppStorage("preUpdateBackupPath") private var preUpdateBackupPath: String?
+
     // Managed assistant state
     @State private var managedBackups: [ManagedBackup] = []
     @State private var isLoadingBackups = false
@@ -33,7 +35,7 @@ struct AssistantBackupsSection: View {
                 .font(VFont.sectionTitle)
                 .foregroundColor(VColor.contentDefault)
 
-            if let backupPath = UserDefaults.standard.string(forKey: "preUpdateBackupPath"),
+            if let backupPath = preUpdateBackupPath,
                FileManager.default.fileExists(atPath: backupPath) {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("A backup was automatically created before the last update.")
@@ -43,11 +45,11 @@ struct AssistantBackupsSection: View {
                         VButton(label: "Restore Pre-Update Data", style: .outlined) {
                             Task {
                                 await performLocalRestore(URL(fileURLWithPath: backupPath))
-                                UserDefaults.standard.removeObject(forKey: "preUpdateBackupPath")
+                                preUpdateBackupPath = nil
                             }
                         }
                         VButton(label: "Dismiss", style: .text) {
-                            UserDefaults.standard.removeObject(forKey: "preUpdateBackupPath")
+                            preUpdateBackupPath = nil
                         }
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -5,7 +5,7 @@ import VellumAssistantShared
 
 /// Backup and restore UI for the Settings Account tab.
 ///
-/// For local assistants, creates/restores `.vbundle` archives via the assistant's
+/// For local assistants, creates/restores `.vbundle` archives via the gateway's
 /// migration endpoints (`POST /v1/migrations/export` and `POST /v1/migrations/import`).
 ///
 /// For managed/remote assistants, uses the platform API endpoints
@@ -186,47 +186,19 @@ struct AssistantBackupsSection: View {
         isExporting = true
         defer { isExporting = false }
 
-        guard let baseURL = assistant.runtimeUrl else {
-            errorMessage = "No runtime URL configured for this assistant"
-            return
-        }
-        let token = ActorTokenManager.getToken()
-
-        guard let url = URL(string: "\(baseURL)/v1/migrations/export") else {
-            errorMessage = "Invalid assistant URL"
-            return
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.timeoutInterval = 30
-        if let token, !token.isEmpty {
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        }
-
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse else {
-                errorMessage = "Invalid response from assistant"
+            let response = try await GatewayHTTPClient.post(path: "migrations/export", timeout: 120)
+
+            guard response.isSuccess else {
+                errorMessage = "Export failed (HTTP \(response.statusCode))"
                 return
             }
 
-            guard httpResponse.statusCode == 200 else {
-                errorMessage = "Export failed (HTTP \(httpResponse.statusCode))"
-                return
-            }
-
-            // Extract filename from Content-Disposition header, or generate one
-            let filename: String
-            if let disposition = httpResponse.value(forHTTPHeaderField: "Content-Disposition"),
-               let nameMatch = disposition.range(of: "filename=\"", options: .caseInsensitive),
-               let endQuote = disposition[nameMatch.upperBound...].firstIndex(of: "\"") {
-                filename = String(disposition[nameMatch.upperBound..<endQuote])
-            } else {
-                let formatter = DateFormatter()
-                formatter.dateFormat = "yyyy-MM-dd-HHmmss"
-                filename = "export-\(formatter.string(from: Date())).vbundle"
-            }
+            // Generate a timestamped filename (Content-Disposition header is not
+            // available through GatewayHTTPClient.Response).
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd-HHmmss"
+            let filename = "export-\(formatter.string(from: Date())).vbundle"
 
             // Show save panel — don't set allowedContentTypes since the filename
             // already includes .vbundle; setting it causes NSSavePanel to append
@@ -238,8 +210,10 @@ struct AssistantBackupsSection: View {
             let panelResult = await panel.beginSheetModal(for: NSApp.keyWindow ?? NSApp.mainWindow ?? NSApp.windows.first!)
             guard panelResult == .OK, let saveURL = panel.url else { return }
 
-            try data.write(to: saveURL)
+            try response.data.write(to: saveURL)
             successMessage = "Backup saved to \(saveURL.lastPathComponent)"
+        } catch let error as GatewayHTTPClient.ClientError {
+            errorMessage = error.localizedDescription
         } catch {
             errorMessage = "Export failed: \(error.localizedDescription)"
         }
@@ -365,37 +339,12 @@ extension AssistantBackupsSection {
         isImporting = true
         defer { isImporting = false }
 
-        guard let baseURL = assistant.runtimeUrl else {
-            errorMessage = "No runtime URL configured for this assistant"
-            return
-        }
-        let token = ActorTokenManager.getToken()
-
-        guard let url = URL(string: "\(baseURL)/v1/migrations/import") else {
-            errorMessage = "Invalid assistant URL"
-            return
-        }
-
         do {
             let fileData = try Data(contentsOf: fileURL)
+            let response = try await GatewayHTTPClient.post(path: "migrations/import", body: fileData, timeout: 120)
 
-            var request = URLRequest(url: url)
-            request.httpMethod = "POST"
-            request.timeoutInterval = 60
-            request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
-            if let token, !token.isEmpty {
-                request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-            }
-            request.httpBody = fileData
-
-            let (data, response) = try await URLSession.shared.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse else {
-                errorMessage = "Invalid response from assistant"
-                return
-            }
-
-            if httpResponse.statusCode == 200 {
-                if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            if response.isSuccess {
+                if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
                    let success = json["success"] as? Bool, success {
                     successMessage = "Backup restored. Restarting assistant..."
 
@@ -416,11 +365,13 @@ extension AssistantBackupsSection {
                 } else {
                     errorMessage = "Import completed with warnings. Check assistant logs for details."
                 }
-            } else if httpResponse.statusCode == 413 {
+            } else if response.statusCode == 413 {
                 errorMessage = "Backup file is too large. Please upgrade the assistant to restore this backup."
             } else {
-                errorMessage = "Import failed (HTTP \(httpResponse.statusCode))"
+                errorMessage = "Import failed (HTTP \(response.statusCode))"
             }
+        } catch let error as GatewayHTTPClient.ClientError {
+            errorMessage = error.localizedDescription
         } catch {
             errorMessage = "Import failed: \(error.localizedDescription)"
         }

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -33,6 +33,26 @@ struct AssistantBackupsSection: View {
                 .font(VFont.sectionTitle)
                 .foregroundColor(VColor.contentDefault)
 
+            if let backupPath = UserDefaults.standard.string(forKey: "preUpdateBackupPath"),
+               FileManager.default.fileExists(atPath: backupPath) {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    Text("A backup was automatically created before the last update.")
+                        .font(VFont.caption)
+                        .foregroundStyle(VColor.contentSecondary)
+                    HStack {
+                        VButton(label: "Restore Pre-Update Data", style: .outlined) {
+                            Task {
+                                await performLocalRestore(URL(fileURLWithPath: backupPath))
+                                UserDefaults.standard.removeObject(forKey: "preUpdateBackupPath")
+                            }
+                        }
+                        VButton(label: "Dismiss", style: .text) {
+                            UserDefaults.standard.removeObject(forKey: "preUpdateBackupPath")
+                        }
+                    }
+                }
+            }
+
             if assistant.isManaged || (assistant.isRemote && !assistant.isDocker) {
                 managedBackupContent
             } else {

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -549,6 +549,46 @@ public final class GatewayConnectionManager: ObservableObject {
     }
     #endif
 
+    // MARK: - Post-Sparkle Update Detection
+
+    #if os(macOS)
+    /// Detects whether the app was relaunched after a Sparkle update by checking
+    /// the `preUpdateVersion` UserDefaults flag (set before the update started).
+    /// If the version has changed, broadcasts a `complete` event so the UI shows
+    /// a success toast and creates a workspace git commit recording the update.
+    /// The flag is cleared after processing so this only runs once per update.
+    private func handlePostSparkleUpdate() {
+        guard let preUpdateVersion = UserDefaults.standard.string(forKey: "preUpdateVersion") else { return }
+        let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        guard currentVersion != preUpdateVersion else { return }
+
+        // Clear the flag so this only runs once
+        UserDefaults.standard.removeObject(forKey: "preUpdateVersion")
+
+        log.info("Post-Sparkle-update detected: \(preUpdateVersion, privacy: .public) → \(currentVersion, privacy: .public)")
+
+        Task {
+            // 1. Broadcast "complete" so the UI clears the progress spinner and shows the outcome
+            _ = try? await GatewayHTTPClient.post(
+                path: "admin/upgrade-broadcast",
+                json: [
+                    "type": "complete",
+                    "installedVersion": currentVersion,
+                    "success": true
+                ] as [String: Any],
+                timeout: 5
+            )
+
+            // 2. Workspace commit: record successful update
+            _ = try? await GatewayHTTPClient.post(
+                path: "admin/workspace-commit",
+                json: ["message": "[sparkle-update] Complete: \(preUpdateVersion) → \(currentVersion)\n\nresult: success"],
+                timeout: 10
+            )
+        }
+    }
+    #endif
+
     // MARK: - Helpers
 
     private func setConnected(_ connected: Bool) {
@@ -557,6 +597,9 @@ public final class GatewayConnectionManager: ObservableObject {
         isConnecting = false
         if connected {
             NotificationCenter.default.post(name: .daemonDidReconnect, object: self)
+            #if os(macOS)
+            handlePostSparkleUpdate()
+            #endif
         }
         #if os(macOS)
         if !connected {

--- a/gateway/src/http/routes/migration-proxy.ts
+++ b/gateway/src/http/routes/migration-proxy.ts
@@ -1,0 +1,164 @@
+/**
+ * Gateway proxies for the daemon migration export/import endpoints.
+ *
+ * Follows the same forwarding pattern as upgrade-broadcast-proxy.ts:
+ * strips hop-by-hop headers, replaces the client's edge JWT with a
+ * minted service token, and proxies the request to the daemon.
+ */
+
+import { mintServiceToken } from "../../auth/token-exchange.js";
+import type { GatewayConfig } from "../../config.js";
+import { fetchImpl } from "../../fetch.js";
+import { getLogger } from "../../logger.js";
+import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
+
+const log = getLogger("migration-proxy");
+
+/** Timeout for migration requests (120 seconds) — exports/imports can be large. */
+const MIGRATION_TIMEOUT_MS = 120_000;
+
+export function createMigrationExportProxyHandler(config: GatewayConfig) {
+  return async function handleMigrationExport(req: Request): Promise<Response> {
+    const start = performance.now();
+    const bodyBuffer = await req.arrayBuffer();
+
+    const upstream = `${config.assistantRuntimeBaseUrl}/v1/migrations/export`;
+
+    const reqHeaders = stripHopByHop(new Headers(req.headers));
+    reqHeaders.delete("host");
+    reqHeaders.delete("authorization");
+
+    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
+    reqHeaders.set("content-length", String(bodyBuffer.byteLength));
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(
+        new DOMException(
+          "The operation was aborted due to timeout",
+          "TimeoutError",
+        ),
+      );
+    }, MIGRATION_TIMEOUT_MS);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(upstream, {
+        method: "POST",
+        headers: reqHeaders,
+        body: bodyBuffer,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+    } catch (err) {
+      clearTimeout(timeoutId);
+      const duration = Math.round(performance.now() - start);
+      if (err instanceof DOMException && err.name === "TimeoutError") {
+        log.error({ duration }, "Migration export proxy upstream timed out");
+        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
+      }
+      log.error(
+        { err, duration },
+        "Migration export proxy upstream connection failed",
+      );
+      return Response.json({ error: "Bad Gateway" }, { status: 502 });
+    }
+
+    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const duration = Math.round(performance.now() - start);
+
+    if (response.status >= 400) {
+      const body = await response.text();
+      log.warn(
+        { status: response.status, duration },
+        "Migration export proxy upstream error",
+      );
+      return new Response(body, {
+        status: response.status,
+        headers: resHeaders,
+      });
+    }
+
+    log.info(
+      { status: response.status, duration },
+      "Migration export proxy completed",
+    );
+    return new Response(response.body, {
+      status: response.status,
+      headers: resHeaders,
+    });
+  };
+}
+
+export function createMigrationImportProxyHandler(config: GatewayConfig) {
+  return async function handleMigrationImport(req: Request): Promise<Response> {
+    const start = performance.now();
+    const bodyBuffer = await req.arrayBuffer();
+
+    const upstream = `${config.assistantRuntimeBaseUrl}/v1/migrations/import`;
+
+    const reqHeaders = stripHopByHop(new Headers(req.headers));
+    reqHeaders.delete("host");
+    reqHeaders.delete("authorization");
+
+    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
+    reqHeaders.set("content-length", String(bodyBuffer.byteLength));
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(
+        new DOMException(
+          "The operation was aborted due to timeout",
+          "TimeoutError",
+        ),
+      );
+    }, MIGRATION_TIMEOUT_MS);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(upstream, {
+        method: "POST",
+        headers: reqHeaders,
+        body: bodyBuffer,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+    } catch (err) {
+      clearTimeout(timeoutId);
+      const duration = Math.round(performance.now() - start);
+      if (err instanceof DOMException && err.name === "TimeoutError") {
+        log.error({ duration }, "Migration import proxy upstream timed out");
+        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
+      }
+      log.error(
+        { err, duration },
+        "Migration import proxy upstream connection failed",
+      );
+      return Response.json({ error: "Bad Gateway" }, { status: 502 });
+    }
+
+    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const duration = Math.round(performance.now() - start);
+
+    if (response.status >= 400) {
+      const body = await response.text();
+      log.warn(
+        { status: response.status, duration },
+        "Migration import proxy upstream error",
+      );
+      return new Response(body, {
+        status: response.status,
+        headers: resHeaders,
+      });
+    }
+
+    log.info(
+      { status: response.status, duration },
+      "Migration import proxy completed",
+    );
+    return new Response(response.body, {
+      status: response.status,
+      headers: resHeaders,
+    });
+  };
+}

--- a/gateway/src/http/routes/workspace-commit-proxy.ts
+++ b/gateway/src/http/routes/workspace-commit-proxy.ts
@@ -1,0 +1,88 @@
+/**
+ * Gateway proxy for the daemon workspace-commit control-plane endpoint.
+ *
+ * Follows the same forwarding pattern as upgrade-broadcast-proxy.ts:
+ * strips hop-by-hop headers, replaces the client's edge JWT with a
+ * minted service token, and proxies the request to the daemon.
+ */
+
+import { mintServiceToken } from "../../auth/token-exchange.js";
+import type { GatewayConfig } from "../../config.js";
+import { fetchImpl } from "../../fetch.js";
+import { getLogger } from "../../logger.js";
+import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
+
+const log = getLogger("workspace-commit-proxy");
+
+export function createWorkspaceCommitProxyHandler(config: GatewayConfig) {
+  return async function handleWorkspaceCommit(req: Request): Promise<Response> {
+    const start = performance.now();
+    const bodyBuffer = await req.arrayBuffer();
+
+    const upstream = `${config.assistantRuntimeBaseUrl}/v1/admin/workspace-commit`;
+
+    const reqHeaders = stripHopByHop(new Headers(req.headers));
+    reqHeaders.delete("host");
+    reqHeaders.delete("authorization");
+
+    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
+    reqHeaders.set("content-length", String(bodyBuffer.byteLength));
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(
+        new DOMException(
+          "The operation was aborted due to timeout",
+          "TimeoutError",
+        ),
+      );
+    }, config.runtimeTimeoutMs);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(upstream, {
+        method: "POST",
+        headers: reqHeaders,
+        body: bodyBuffer,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+    } catch (err) {
+      clearTimeout(timeoutId);
+      const duration = Math.round(performance.now() - start);
+      if (err instanceof DOMException && err.name === "TimeoutError") {
+        log.error({ duration }, "Workspace commit proxy upstream timed out");
+        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
+      }
+      log.error(
+        { err, duration },
+        "Workspace commit proxy upstream connection failed",
+      );
+      return Response.json({ error: "Bad Gateway" }, { status: 502 });
+    }
+
+    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const duration = Math.round(performance.now() - start);
+
+    if (response.status >= 400) {
+      const body = await response.text();
+      log.warn(
+        { status: response.status, duration },
+        "Workspace commit proxy upstream error",
+      );
+      return new Response(body, {
+        status: response.status,
+        headers: resHeaders,
+      });
+    }
+
+    log.info(
+      { status: response.status, duration },
+      "Workspace commit proxy completed",
+    );
+    return new Response(response.body, {
+      status: response.status,
+      headers: resHeaders,
+    });
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -57,6 +57,10 @@ import { createOAuthAppsProxyHandler } from "./http/routes/oauth-apps-proxy.js";
 import { createChannelReadinessProxyHandler } from "./http/routes/channel-readiness-proxy.js";
 import { createRuntimeHealthProxyHandler } from "./http/routes/runtime-health-proxy.js";
 import { createUpgradeBroadcastProxyHandler } from "./http/routes/upgrade-broadcast-proxy.js";
+import {
+  createMigrationExportProxyHandler,
+  createMigrationImportProxyHandler,
+} from "./http/routes/migration-proxy.js";
 import { createBrainGraphProxyHandler } from "./http/routes/brain-graph-proxy.js";
 import {
   createTrustRulesListHandler,
@@ -285,6 +289,8 @@ async function main() {
   const channelReadinessProxy = createChannelReadinessProxyHandler(config);
   const runtimeHealthProxy = createRuntimeHealthProxyHandler(config);
   const upgradeBroadcastProxy = createUpgradeBroadcastProxyHandler(config);
+  const migrationExportProxy = createMigrationExportProxyHandler(config);
+  const migrationImportProxy = createMigrationImportProxyHandler(config);
   const brainGraphProxy = createBrainGraphProxyHandler(config);
   const handleFeatureFlagsGet = createFeatureFlagsGetHandler();
   const handleFeatureFlagsPatch = createFeatureFlagsPatchHandler();
@@ -748,6 +754,20 @@ async function main() {
       method: "POST",
       auth: "edge",
       handler: (req) => upgradeBroadcastProxy(req),
+    },
+
+    // ── Migration export/import ──
+    {
+      path: "/v1/migrations/export",
+      method: "POST",
+      auth: "edge",
+      handler: (req) => migrationExportProxy(req),
+    },
+    {
+      path: "/v1/migrations/import",
+      method: "POST",
+      auth: "edge",
+      handler: (req) => migrationImportProxy(req),
     },
 
     // ── Channel readiness ──

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -61,6 +61,7 @@ import {
   createMigrationExportProxyHandler,
   createMigrationImportProxyHandler,
 } from "./http/routes/migration-proxy.js";
+import { createWorkspaceCommitProxyHandler } from "./http/routes/workspace-commit-proxy.js";
 import { createBrainGraphProxyHandler } from "./http/routes/brain-graph-proxy.js";
 import {
   createTrustRulesListHandler,
@@ -291,6 +292,7 @@ async function main() {
   const upgradeBroadcastProxy = createUpgradeBroadcastProxyHandler(config);
   const migrationExportProxy = createMigrationExportProxyHandler(config);
   const migrationImportProxy = createMigrationImportProxyHandler(config);
+  const workspaceCommitProxy = createWorkspaceCommitProxyHandler(config);
   const brainGraphProxy = createBrainGraphProxyHandler(config);
   const handleFeatureFlagsGet = createFeatureFlagsGetHandler();
   const handleFeatureFlagsPatch = createFeatureFlagsPatchHandler();
@@ -768,6 +770,14 @@ async function main() {
       method: "POST",
       auth: "edge",
       handler: (req) => migrationImportProxy(req),
+    },
+
+    // ── Workspace commit ──
+    {
+      path: "/v1/admin/workspace-commit",
+      method: "POST",
+      auth: "edge",
+      handler: (req) => workspaceCommitProxy(req),
     },
 
     // ── Channel readiness ──

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -2719,6 +2719,31 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/admin/workspace-commit": {
+        post: {
+          summary: "Commit workspace changes",
+          description:
+            "Proxies a workspace-commit request to the assistant daemon. Creates a git commit of the current workspace state with the provided message. Authenticated with an edge JWT.",
+          operationId: "workspaceCommit",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: false,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Workspace commit created successfully" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "502": { description: "Failed to reach assistant daemon" },
+            "504": { description: "Assistant daemon request timed out" },
+          },
+        },
+      },
       "/{path}": {
         get: {
           summary: "Runtime proxy",

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -2662,6 +2662,63 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/migrations/export": {
+        post: {
+          summary: "Export workspace backup",
+          description:
+            "Proxies a migration export request to the assistant daemon. Returns a binary .vbundle backup of the workspace. Authenticated with an edge JWT. Timeout is 120 seconds to accommodate large workspaces.",
+          operationId: "migrationExport",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: false,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "Binary .vbundle backup file",
+              content: {
+                "application/octet-stream": {
+                  schema: { type: "string", format: "binary" },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "502": { description: "Failed to reach assistant daemon" },
+            "504": { description: "Assistant daemon request timed out" },
+          },
+        },
+      },
+      "/v1/migrations/import": {
+        post: {
+          summary: "Import workspace backup",
+          description:
+            "Proxies a migration import request to the assistant daemon. Accepts a binary .vbundle backup body and restores the workspace from it. Authenticated with an edge JWT. Timeout is 120 seconds to accommodate large backups.",
+          operationId: "migrationImport",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/octet-stream": {
+                schema: { type: "string", format: "binary" },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Backup imported successfully" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "502": { description: "Failed to reach assistant daemon" },
+            "504": { description: "Assistant daemon request timed out" },
+          },
+        },
+      },
       "/{path}": {
         get: {
           summary: "Runtime proxy",


### PR DESCRIPTION
## Summary
Adds automatic data protection to the Sparkle (local) update path — matching the safety net that Docker upgrades already have. Before every Sparkle update, the app creates a backup and workspace git commit while the daemon is still running. After the update, it detects the version change, records a completion commit, and shows a toast. If the new version has data issues, a "Restore Pre-Update Data" button appears in Settings.

Also adds gateway proxies for the migration export/import endpoints and migrates the existing manual backup UI from direct daemon calls to gateway calls.

## PRs merged into feature branch
- #20649: feat: add workspace-commit admin endpoint on daemon
- #20647: feat: add gateway proxies for migration export and import endpoints
- #20652: feat: add gateway proxy for workspace-commit endpoint
- #20651: refactor: migrate backup export/import in Settings to use gateway
- #20654: feat: auto-backup, workspace commit, and progress events before Sparkle update
- #20653: feat: detect Sparkle update on launch, broadcast completion, and enable restore

## Self-review result
PASS after 2 review rounds. Three integration issues found and fixed:
- installDeferredUpdateIfAvailable regression (handler must run synchronously)
- Pre-update restore banner not reactive (switched to @AppStorage)
- pendingUpdateVersion never cleared on skip/not-found

## Fix PRs
- #20658: fix: ensure deferred Sparkle install handler runs synchronously
- #20656: fix: make pre-update restore banner reactive with @AppStorage
- #20657: fix: clear pendingUpdateVersion when update is skipped or not found

Part of plan: sparkle-backup-restore.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
