### PR TITLE
fix: improve update button UX — remove arrow icon, route service group updates to Settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -433,7 +433,6 @@ struct MainWindowView: View {
                     label: updateManager.isDeferredUpdateReady
                         ? "Restart to update"
                         : (connectionManager.versionMismatch ? "Compatibility update" : "Update"),
-                    leftIcon: VIcon.arrowUp.rawValue,
                     style: updateManager.isDeferredUpdateReady ? .primary : (connectionManager.versionMismatch ? .outlined : .primary),
                     size: .pill,
                     tooltip: updateManager.isDeferredUpdateReady
@@ -444,6 +443,10 @@ struct MainWindowView: View {
                 ) {
                     if updateManager.isDeferredUpdateReady {
                         NSApp.terminate(nil)
+                    } else if updateManager.isServiceGroupUpdateAvailable && !updateManager.isUpdateAvailable {
+                        // Service group update only — navigate to Settings where the upgrade controls live
+                        settingsStore.pendingSettingsTab = .general
+                        windowState.selection = .panel(.settings)
                     } else {
                         AppDelegate.shared?.checkForUpdates()
                     }

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -48,7 +48,7 @@ struct AssistantBackupsSection: View {
                                 preUpdateBackupPath = nil
                             }
                         }
-                        VButton(label: "Dismiss", style: .text) {
+                        VButton(label: "Dismiss", style: .ghost) {
                             preUpdateBackupPath = nil
                         }
                     }


### PR DESCRIPTION
## Summary
- Removes the arrow-up icon from the top-bar Update pill button for a cleaner look
- Fixes click action for service group updates: navigates to Settings > General (where the version picker and upgrade controls live) instead of opening the Sparkle dialog which is only relevant for app updates
- Changes pre-update restore banner Dismiss button from `.text` to `.ghost` style for better visibility
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
