### PR TITLE
feat: add backward-releases feature flag to gate version picker downgrades

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -55,9 +55,31 @@ struct AssistantUpgradeSection: View {
     @State private var isTakingLongerThanExpected = false
     @State private var escalationTask: Task<Void, Never>?
     @State private var dockerUpgradeTask: Task<Void, Never>?
+    @State private var backwardReleasesEnabled = false
+    private let featureFlagClient = FeatureFlagClient()
 
     private var latestRelease: AssistantRelease? {
         availableReleases.first
+    }
+
+    /// Releases that are newer than (or equal to) the current version.
+    /// Hides older versions to prevent unsafe downgrades (no down-migrations).
+    private var forwardReleases: [AssistantRelease] {
+        guard let current = currentVersion, !current.isEmpty,
+              let currentParsed = VersionCompat.parse(current) else {
+            return availableReleases
+        }
+        return availableReleases.filter { release in
+            guard let parsed = VersionCompat.parse(release.version) else { return true }
+            if parsed.major != currentParsed.major { return parsed.major > currentParsed.major }
+            if parsed.minor != currentParsed.minor { return parsed.minor > currentParsed.minor }
+            if parsed.patch != currentParsed.patch { return parsed.patch > currentParsed.patch }
+            return true // same version — keep it
+        }
+    }
+
+    private var pickerReleases: [AssistantRelease] {
+        backwardReleasesEnabled ? availableReleases : forwardReleases
     }
 
     private var effectiveSelectedVersion: String? {
@@ -218,9 +240,9 @@ struct AssistantUpgradeSection: View {
                     }
                 }
 
-                if !availableReleases.isEmpty && topology != .remote && topology != .local {
+                if !pickerReleases.isEmpty && topology != .remote && topology != .local {
                     HStack(spacing: VSpacing.sm) {
-                        Text(!upgradeAvailable ? "Selected:" : isRollback ? (topology == .managed ? "Downgrade to:" : "Roll back to:") : "Update to:")
+                        Text(!upgradeAvailable ? "Selected:" : (backwardReleasesEnabled && isRollback) ? (topology == .managed ? "Downgrade to:" : "Roll back to:") : "Update to:")
                             .font(VFont.caption)
                             .foregroundColor(VColor.contentTertiary)
                         Picker("", selection: Binding<String>(
@@ -229,7 +251,7 @@ struct AssistantUpgradeSection: View {
                                 selectedVersion = (newValue == latestRelease?.version) ? nil : newValue
                             }
                         )) {
-                            ForEach(availableReleases) { release in
+                            ForEach(pickerReleases) { release in
                                 Text(releaseLabel(for: release)).tag(release.version)
                             }
                         }
@@ -237,7 +259,7 @@ struct AssistantUpgradeSection: View {
                     }
                 }
 
-                if !upgradeAvailable && !isLoadingReleases && !availableReleases.isEmpty && topology != .local {
+                if !upgradeAvailable && !isLoadingReleases && !pickerReleases.isEmpty && topology != .local {
                     HStack(spacing: VSpacing.xs) {
                         VIconView(.circleCheck, size: 12)
                             .foregroundColor(VColor.systemPositiveStrong)
@@ -249,7 +271,7 @@ struct AssistantUpgradeSection: View {
                     }
                 }
 
-                if availableReleases.isEmpty && !isLoadingReleases && errorMessage == nil && topology != .local {
+                if pickerReleases.isEmpty && !isLoadingReleases && errorMessage == nil && topology != .local {
                     Text("No releases available.")
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)
@@ -349,6 +371,11 @@ struct AssistantUpgradeSection: View {
             }
         }
         .task { await loadReleases() }
+        .task {
+            if let flags = try? await featureFlagClient.getFeatureFlags() {
+                backwardReleasesEnabled = flags.first(where: { $0.key == "feature_flags.backward-releases.enabled" })?.enabled ?? false
+            }
+        }
         .onChange(of: currentVersion) { _, _ in
             Task { await loadReleasesQuietly() }
         }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -312,6 +312,14 @@
       "label": "Message Text-to-Speech",
       "description": "Show a speaker button on assistant messages to generate and play the message as audio via Fish Audio TTS",
       "defaultEnabled": false
+    },
+    {
+      "id": "backward-releases",
+      "scope": "assistant",
+      "key": "feature_flags.backward-releases.enabled",
+      "label": "Backward Releases",
+      "description": "Show older versions in the version picker, allowing rollback to previous releases (unsafe without down-migrations)",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Registers a new `backward-releases` assistant feature flag (disabled by default) in the feature flag registry
- When disabled (default), the Settings version picker only shows versions newer than or equal to the current version, preventing unsafe downgrades
- When enabled via Developer settings, all versions appear and the existing rollback/downgrade UI is preserved
- Minimal change — all rollback code paths remain intact, just gated behind the flag

## Original prompt
Add a backward-releases assistant feature flag to gate whether the version picker shows older versions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
