### PR TITLE
feat: add down() support to workspace migration type and runner

### DIFF
--- a/assistant/src/workspace/migrations/runner.ts
+++ b/assistant/src/workspace/migrations/runner.ts
@@ -10,7 +10,7 @@ const log = getLogger("workspace-migrations");
 export type CheckpointFile = {
   applied: Record<
     string,
-    { appliedAt: string; status?: "started" | "completed" }
+    { appliedAt: string; status?: "started" | "completed" | "rolling_back" }
   >;
 };
 
@@ -73,7 +73,7 @@ export async function runWorkspaceMigrations(
   const checkpoints = loadCheckpoints(workspaceDir);
 
   for (const [id, entry] of Object.entries(checkpoints.applied)) {
-    if (entry.status === "started") {
+    if (entry.status === "started" || entry.status === "rolling_back") {
       log.warn(
         `Workspace migration "${id}" was interrupted during a previous run; will re-run`,
       );
@@ -113,5 +113,74 @@ export async function runWorkspaceMigrations(
       status: "completed",
     };
     saveCheckpoints(workspaceDir, checkpoints);
+  }
+}
+
+/**
+ * Roll back workspace migrations in reverse order, stopping before the target migration.
+ *
+ * Migrations after `targetMigrationId` in the array are reversed (the target itself is kept).
+ * Each migration must have a `down()` method; if one is missing, an error is thrown.
+ */
+export async function rollbackWorkspaceMigrations(
+  workspaceDir: string,
+  migrations: WorkspaceMigration[],
+  targetMigrationId: string,
+): Promise<void> {
+  // Find the index of the target migration
+  const targetIndex = migrations.findIndex((m) => m.id === targetMigrationId);
+  if (targetIndex === -1) {
+    throw new Error(
+      `Target migration "${targetMigrationId}" not found in the migrations array`,
+    );
+  }
+
+  // Collect migrations that come after the target, in reverse order
+  const migrationsToRollback = migrations.slice(targetIndex + 1).reverse();
+  if (migrationsToRollback.length === 0) {
+    log.info("No migrations to roll back");
+    return;
+  }
+
+  const checkpoints = loadCheckpoints(workspaceDir);
+
+  for (const migration of migrationsToRollback) {
+    // Only roll back migrations that have been applied
+    if (!checkpoints.applied[migration.id]) {
+      continue;
+    }
+
+    if (!migration.down) {
+      throw new Error(
+        `Migration "${migration.id}" does not support rollback (no down() method)`,
+      );
+    }
+
+    log.info(
+      `Rolling back workspace migration: ${migration.id} — ${migration.description}`,
+    );
+
+    // Mark as rolling_back before execution (for crash recovery)
+    checkpoints.applied[migration.id] = {
+      appliedAt: checkpoints.applied[migration.id]!.appliedAt,
+      status: "rolling_back",
+    };
+    saveCheckpoints(workspaceDir, checkpoints);
+
+    try {
+      await migration.down(workspaceDir);
+    } catch (error) {
+      log.error(
+        { migrationId: migration.id, error },
+        `Workspace migration rollback failed: ${migration.id}`,
+      );
+      throw error;
+    }
+
+    // Remove the migration entry from checkpoints
+    delete checkpoints.applied[migration.id];
+    saveCheckpoints(workspaceDir, checkpoints);
+
+    log.info(`Rolled back workspace migration: ${migration.id}`);
   }
 }

--- a/assistant/src/workspace/migrations/types.ts
+++ b/assistant/src/workspace/migrations/types.ts
@@ -8,4 +8,8 @@ export interface WorkspaceMigration {
    *  Must be idempotent — safe to re-run if it was interrupted.
    *  Both synchronous and asynchronous migrations are supported. */
   run(workspaceDir: string): void | Promise<void>;
+  /** Reverse the migration. Receives the workspace directory path.
+   *  Must be idempotent — safe to re-run if it was interrupted.
+   *  Both synchronous and asynchronous rollbacks are supported. */
+  down?(workspaceDir: string): void | Promise<void>;
 }


### PR DESCRIPTION
## Summary
- Add optional `down()` method to `WorkspaceMigration` interface for rollback support
- Add `rollbackWorkspaceMigrations` function that reverses migrations in order with crash recovery
- Extend checkpoint status to include `rolling_back` state with proper recovery handling

Part of plan: migration-down-functions.md (PR 1 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
