### PR TITLE
feat: add down() functions to workspace migrations 001–008

### DIFF
--- a/assistant/src/workspace/migrations/001-avatar-rename.ts
+++ b/assistant/src/workspace/migrations/001-avatar-rename.ts
@@ -22,4 +22,19 @@ export const avatarRenameMigration: WorkspaceMigration = {
       renameSync(oldTraits, newTraits);
     }
   },
+  down(workspaceDir: string): void {
+    const avatarDir = join(workspaceDir, "data", "avatar");
+
+    const newImage = join(avatarDir, "avatar-image.png");
+    const oldImage = join(avatarDir, "custom-avatar.png");
+    if (existsSync(newImage) && !existsSync(oldImage)) {
+      renameSync(newImage, oldImage);
+    }
+
+    const newTraits = join(avatarDir, "character-traits.json");
+    const oldTraits = join(avatarDir, "avatar-components.json");
+    if (existsSync(newTraits) && !existsSync(oldTraits)) {
+      renameSync(newTraits, oldTraits);
+    }
+  },
 };

--- a/assistant/src/workspace/migrations/003-seed-device-id.ts
+++ b/assistant/src/workspace/migrations/003-seed-device-id.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 
 import { getDeviceIdBaseDir } from "../../util/device-id.js";
@@ -95,6 +101,16 @@ export const seedDeviceIdMigration: WorkspaceMigration = {
       });
     } catch {
       // Best-effort — getDeviceId() will generate a new one if this fails.
+    }
+  },
+  down(_workspaceDir: string): void {
+    // The forward migration seeds deviceId in ~/.vellum/device.json from the
+    // lockfile. Reverse by removing device.json entirely — getDeviceId() will
+    // generate a fresh one on next startup if needed.
+    const base = getDeviceIdBaseDir();
+    const devicePath = join(base, ".vellum", "device.json");
+    if (existsSync(devicePath)) {
+      unlinkSync(devicePath);
     }
   },
 };

--- a/assistant/src/workspace/migrations/004-extract-collect-usage-data.ts
+++ b/assistant/src/workspace/migrations/004-extract-collect-usage-data.ts
@@ -47,4 +47,37 @@ export const extractCollectUsageDataMigration: WorkspaceMigration = {
 
     writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
   },
+  down(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    // Only reverse if collectUsageData was explicitly set to false
+    // (the forward migration only persisted false).
+    if (!("collectUsageData" in config)) return;
+    const value = config.collectUsageData;
+    if (typeof value !== "boolean") return;
+
+    // Restore the feature flag value
+    const FLAG_KEY = "feature_flags.collect-usage-data.enabled";
+    const flagValues = (config.assistantFeatureFlagValues ?? {}) as Record<
+      string,
+      unknown
+    >;
+    flagValues[FLAG_KEY] = value;
+    config.assistantFeatureFlagValues = flagValues;
+
+    // Remove the extracted top-level key
+    delete config.collectUsageData;
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
 };

--- a/assistant/src/workspace/migrations/005-add-send-diagnostics.ts
+++ b/assistant/src/workspace/migrations/005-add-send-diagnostics.ts
@@ -9,4 +9,7 @@ export const addSendDiagnosticsMigration: WorkspaceMigration = {
     // will sync the UserDefaults value on first startup. This migration exists
     // as a checkpoint marker for future reference.
   },
+  down(_workspaceDir: string): void {
+    // No-op — the forward migration is a checkpoint marker with no data changes.
+  },
 };

--- a/assistant/src/workspace/migrations/006-services-config.ts
+++ b/assistant/src/workspace/migrations/006-services-config.ts
@@ -134,4 +134,53 @@ export const servicesConfigMigration: WorkspaceMigration = {
 
     writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
   },
+  down(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const services = config.services;
+    if (!services || typeof services !== "object" || Array.isArray(services))
+      return;
+
+    const svc = services as Record<string, Record<string, unknown>>;
+
+    // Extract inference provider and model back to top-level fields.
+    // Note: inferenceMode is lost in this rollback — the original config did
+    // not store a mode field. This is an accepted lossy reversal.
+    if (svc.inference) {
+      if (typeof svc.inference.provider === "string") {
+        config.provider = svc.inference.provider;
+      }
+      if (typeof svc.inference.model === "string") {
+        config.model = svc.inference.model;
+      }
+    }
+
+    // Extract image generation model back to top-level
+    if (svc["image-generation"]) {
+      if (typeof svc["image-generation"].model === "string") {
+        config.imageGenModel = svc["image-generation"].model;
+      }
+    }
+
+    // Extract web search provider back to top-level
+    if (svc["web-search"]) {
+      if (typeof svc["web-search"].provider === "string") {
+        config.webSearchProvider = svc["web-search"].provider;
+      }
+    }
+
+    delete config.services;
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
 };

--- a/assistant/src/workspace/migrations/007-web-search-provider-rename.ts
+++ b/assistant/src/workspace/migrations/007-web-search-provider-rename.ts
@@ -34,4 +34,31 @@ export const webSearchProviderRenameMigration: WorkspaceMigration = {
     ws.provider = "inference-provider-native";
     writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
   },
+  down(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const services = config.services;
+    if (!services || typeof services !== "object" || Array.isArray(services))
+      return;
+
+    const webSearch = (services as Record<string, unknown>)["web-search"];
+    if (!webSearch || typeof webSearch !== "object" || Array.isArray(webSearch))
+      return;
+
+    const ws = webSearch as Record<string, unknown>;
+    if (ws.provider !== "inference-provider-native") return;
+
+    ws.provider = "anthropic-native";
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
 };

--- a/assistant/src/workspace/migrations/008-voice-timeout-and-max-steps.ts
+++ b/assistant/src/workspace/migrations/008-voice-timeout-and-max-steps.ts
@@ -9,4 +9,7 @@ export const voiceTimeoutAndMaxStepsMigration: WorkspaceMigration = {
     // Existing users: macOS client will sync UserDefaults values
     // to config on next startup via settings sync endpoints.
   },
+  down(_workspaceDir: string): void {
+    // No-op — the forward migration is a checkpoint marker with no data changes.
+  },
 };


### PR DESCRIPTION
## Summary
- Add idempotent down() rollback functions to workspace migrations 001 through 008
- Each down() reverses its corresponding forward migration with proper guards

Part of plan: migration-down-functions.md (PR 5 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
