### PR TITLE
feat: add down() functions to workspace migrations 009–017

### DIFF
--- a/assistant/src/workspace/migrations/009-backfill-conversation-disk-view.ts
+++ b/assistant/src/workspace/migrations/009-backfill-conversation-disk-view.ts
@@ -7,4 +7,8 @@ export const backfillConversationDiskViewMigration: WorkspaceMigration = {
   run(_workspaceDir: string): void {
     rebuildConversationDiskViewFromDb();
   },
+  // No-op: the disk view is a derived cache that can be regenerated from the
+  // database at any time. Removing it would only cause unnecessary I/O churn
+  // since the next forward migration (or startup rebuild) will recreate it.
+  down(_workspaceDir: string): void {},
 };

--- a/assistant/src/workspace/migrations/010-app-dir-rename.ts
+++ b/assistant/src/workspace/migrations/010-app-dir-rename.ts
@@ -76,6 +76,84 @@ export const appDirRenameMigration: WorkspaceMigration = {
   description:
     "Rename UUID-based app directories and files to human-readable slugified names",
 
+  down(workspaceDir: string): void {
+    const appsDir = join(workspaceDir, "data", "apps");
+    if (!existsSync(appsDir)) return;
+
+    const jsonFiles = readdirSync(appsDir)
+      .filter((f) => f.endsWith(".json"))
+      .sort();
+
+    if (jsonFiles.length === 0) return;
+
+    for (const jsonFile of jsonFiles) {
+      const jsonPath = join(appsDir, jsonFile);
+      let raw: string;
+      try {
+        raw = readFileSync(jsonPath, "utf-8");
+      } catch {
+        continue;
+      }
+
+      let parsed: {
+        id?: string;
+        name?: string;
+        dirName?: string;
+      };
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        continue;
+      }
+
+      const appId = parsed.id;
+      if (!appId || !parsed.dirName || !isValidDirName(parsed.dirName)) {
+        continue;
+      }
+
+      const dirName = parsed.dirName;
+
+      // 1. Rename the app directory: {dirName}/ -> {appId}/
+      const slugDir = join(appsDir, dirName);
+      const uuidDir = join(appsDir, appId);
+      if (existsSync(slugDir) && !existsSync(uuidDir) && slugDir !== uuidDir) {
+        renameSync(slugDir, uuidDir);
+      }
+
+      // 2. Rename the preview file: {dirName}.preview -> {appId}.preview
+      const slugPreview = join(appsDir, `${dirName}.preview`);
+      const uuidPreview = join(appsDir, `${appId}.preview`);
+      if (
+        existsSync(slugPreview) &&
+        !existsSync(uuidPreview) &&
+        slugPreview !== uuidPreview
+      ) {
+        renameSync(slugPreview, uuidPreview);
+      }
+
+      // 3. Remove dirName from JSON and rename file: {dirName}.json -> {appId}.json
+      const updatedParsed = { ...parsed };
+      delete updatedParsed.dirName;
+      const updatedJson = JSON.stringify(updatedParsed, null, 2);
+
+      const uuidJsonFile = `${appId}.json`;
+      const uuidJsonPath = join(appsDir, uuidJsonFile);
+
+      if (jsonFile !== uuidJsonFile) {
+        writeFileSync(uuidJsonPath, updatedJson, "utf-8");
+        if (existsSync(jsonPath) && jsonPath !== uuidJsonPath) {
+          try {
+            unlinkSync(jsonPath);
+          } catch {
+            // Old file cleanup is best-effort
+          }
+        }
+      } else {
+        writeFileSync(uuidJsonPath, updatedJson, "utf-8");
+      }
+    }
+  },
+
   run(workspaceDir: string): void {
     const appsDir = join(workspaceDir, "data", "apps");
     if (!existsSync(appsDir)) return;

--- a/assistant/src/workspace/migrations/011-backfill-installation-id.ts
+++ b/assistant/src/workspace/migrations/011-backfill-installation-id.ts
@@ -14,6 +14,17 @@ export const backfillInstallationIdMigration: WorkspaceMigration = {
   id: "011-backfill-installation-id",
   description:
     "Backfill installationId into lockfile from SQLite checkpoint and clean up stale row",
+
+  down(_workspaceDir: string): void {
+    // The forward migration moved an installationId from a SQLite checkpoint
+    // into the lockfile entry. Rolling back by removing installationId from
+    // the lockfile would break telemetry continuity and the field is harmless
+    // to leave in place. The SQLite checkpoint was already deleted and
+    // cannot be restored.
+    //
+    // No-op: leaving installationId in the lockfile is safe and non-disruptive.
+  },
+
   run(_workspaceDir: string): void {
     // a. Read existing installation ID from SQLite, or generate a new one.
     //    On fresh installs the memory_checkpoints table may not exist yet,

--- a/assistant/src/workspace/migrations/012-rename-conversation-disk-view-dirs.ts
+++ b/assistant/src/workspace/migrations/012-rename-conversation-disk-view-dirs.ts
@@ -17,6 +17,10 @@ import type { WorkspaceMigration } from "./types.js";
 const LEGACY_CONVERSATION_DIR_PATTERN =
   /^(.*)_(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z)$/;
 
+/** Matches the new timestamp-first format: {timestamp}_{conversationId} */
+const NEW_CONVERSATION_DIR_PATTERN =
+  /^(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z)_(.+)$/;
+
 function parseLegacyConversationDirName(
   dirName: string,
 ): { conversationId: string; timestamp: string } | null {
@@ -29,10 +33,50 @@ function parseLegacyConversationDirName(
   };
 }
 
+function parseNewConversationDirName(
+  dirName: string,
+): { timestamp: string; conversationId: string } | null {
+  const match = dirName.match(NEW_CONVERSATION_DIR_PATTERN);
+  if (!match) return null;
+
+  return {
+    timestamp: match[1],
+    conversationId: match[2],
+  };
+}
+
 export const renameConversationDiskViewDirsMigration: WorkspaceMigration = {
   id: "012-rename-conversation-disk-view-dirs",
   description:
     "Rename legacy conversation disk-view directories to timestamp-first names",
+
+  down(workspaceDir: string): void {
+    const conversationsDir = join(workspaceDir, "conversations");
+    if (!existsSync(conversationsDir)) return;
+
+    const entries = readdirSync(conversationsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+
+    for (const dirName of entries) {
+      const parsed = parseNewConversationDirName(dirName);
+      if (!parsed) continue;
+
+      const sourcePath = join(conversationsDir, dirName);
+      const targetName = `${parsed.conversationId}_${parsed.timestamp}`;
+      const targetPath = join(conversationsDir, targetName);
+
+      if (sourcePath === targetPath) continue;
+      if (existsSync(targetPath)) continue;
+
+      try {
+        renameSync(sourcePath, targetPath);
+      } catch {
+        // Best-effort: leave the directory in place if a single rename fails.
+      }
+    }
+  },
 
   run(workspaceDir: string): void {
     const conversationsDir = join(workspaceDir, "conversations");

--- a/assistant/src/workspace/migrations/013-repair-conversation-disk-view.ts
+++ b/assistant/src/workspace/migrations/013-repair-conversation-disk-view.ts
@@ -8,4 +8,9 @@ export const repairConversationDiskViewMigration: WorkspaceMigration = {
   run(_workspaceDir: string): void {
     rebuildConversationDiskViewFromDb();
   },
+  // No-op: this is a repair migration that rebuilds derived disk-view data
+  // from the database. There is no meaningful reverse operation — the data
+  // is a cache that can be regenerated, and removing it would just cause
+  // unnecessary churn on the next forward run.
+  down(_workspaceDir: string): void {},
 };

--- a/assistant/src/workspace/migrations/015-migrate-credentials-to-keychain.ts
+++ b/assistant/src/workspace/migrations/015-migrate-credentials-to-keychain.ts
@@ -11,6 +11,73 @@ export const migrateCredentialsToKeychainMigration: WorkspaceMigration = {
   description:
     "Copy encrypted store credentials to keychain for single-backend migration",
 
+  async down(_workspaceDir: string): Promise<void> {
+    // Reverse: copy credentials from keychain back to encrypted store.
+    // Mirrors the forward logic of 016-migrate-credentials-from-keychain.
+    if (
+      process.env.VELLUM_DESKTOP_APP !== "1" ||
+      process.env.VELLUM_DEV === "1"
+    ) {
+      return;
+    }
+
+    const { createBrokerClient } =
+      await import("../../security/keychain-broker-client.js");
+    const client = createBrokerClient();
+
+    let brokerAvailable = false;
+    for (let i = 0; i < BROKER_WAIT_MAX_ATTEMPTS; i++) {
+      if (client.isAvailable()) {
+        brokerAvailable = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, BROKER_WAIT_INTERVAL_MS));
+    }
+
+    if (!brokerAvailable) {
+      // If the broker is not available, credentials may already be in the
+      // encrypted store or we're in a non-desktop environment — skip silently.
+      return;
+    }
+
+    const { setKey } = await import("../../security/encrypted-store.js");
+
+    const accounts = await client.list();
+    if (accounts.length === 0) return;
+
+    let rolledBackCount = 0;
+    let failedCount = 0;
+
+    for (const account of accounts) {
+      const result = await client.get(account);
+      if (!result || !result.found || result.value === undefined) {
+        log.warn(
+          { account },
+          "Failed to read key from keychain during rollback — skipping",
+        );
+        failedCount++;
+        continue;
+      }
+
+      const written = setKey(account, result.value);
+      if (written) {
+        await client.del(account);
+        rolledBackCount++;
+      } else {
+        log.warn(
+          { account },
+          "Failed to write key to encrypted store during rollback — skipping",
+        );
+        failedCount++;
+      }
+    }
+
+    log.info(
+      { rolledBackCount, failedCount },
+      "Credential rollback from keychain to encrypted store complete",
+    );
+  },
+
   async run(_workspaceDir: string): Promise<void> {
     // Only run on mac production builds (desktop app, non-dev).
     if (

--- a/assistant/src/workspace/migrations/016-extract-feature-flags-to-protected.ts
+++ b/assistant/src/workspace/migrations/016-extract-feature-flags-to-protected.ts
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   readFileSync,
   renameSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
@@ -15,6 +16,69 @@ export const extractFeatureFlagsToProtectedMigration: WorkspaceMigration = {
   id: "016-extract-feature-flags-to-protected",
   description:
     "Move assistantFeatureFlagValues from config.json to ~/.vellum/protected/feature-flags.json",
+
+  down(workspaceDir: string): void {
+    // Reverse: read feature flags from protected directory and write them
+    // back to config.json as assistantFeatureFlagValues.
+    const protectedDir = join(getRootDir(), "protected");
+    const featureFlagsPath = join(protectedDir, "feature-flags.json");
+
+    if (!existsSync(featureFlagsPath)) return;
+
+    let flagValues: Record<string, boolean>;
+    try {
+      const raw = JSON.parse(readFileSync(featureFlagsPath, "utf-8"));
+      if (
+        !raw ||
+        raw.version !== 1 ||
+        !raw.values ||
+        typeof raw.values !== "object"
+      ) {
+        return;
+      }
+      flagValues = raw.values;
+    } catch {
+      return; // Malformed file — skip
+    }
+
+    if (Object.keys(flagValues).length === 0) return;
+
+    // Read config.json and restore assistantFeatureFlagValues
+    const configPath = join(workspaceDir, "config.json");
+    let config: Record<string, unknown> = {};
+    if (existsSync(configPath)) {
+      try {
+        const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+        if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+          config = raw as Record<string, unknown>;
+        }
+      } catch {
+        // Malformed config — start with empty object
+      }
+    }
+
+    // Merge into existing assistantFeatureFlagValues if present
+    const existing = (config.assistantFeatureFlagValues ?? {}) as Record<
+      string,
+      boolean
+    >;
+    config.assistantFeatureFlagValues = { ...existing, ...flagValues };
+
+    const tmpConfigPath = configPath + ".tmp";
+    writeFileSync(
+      tmpConfigPath,
+      JSON.stringify(config, null, 2) + "\n",
+      "utf-8",
+    );
+    renameSync(tmpConfigPath, configPath);
+
+    // Remove the protected feature-flags file
+    try {
+      unlinkSync(featureFlagsPath);
+    } catch {
+      // Best-effort cleanup
+    }
+  },
 
   run(workspaceDir: string): void {
     const configPath = join(workspaceDir, "config.json");

--- a/assistant/src/workspace/migrations/016-migrate-credentials-from-keychain.ts
+++ b/assistant/src/workspace/migrations/016-migrate-credentials-from-keychain.ts
@@ -11,6 +11,75 @@ export const migrateCredentialsFromKeychainMigration: WorkspaceMigration = {
   description:
     "Copy keychain credentials back to encrypted store for CES unification",
 
+  async down(_workspaceDir: string): Promise<void> {
+    // Reverse: copy credentials from encrypted store back to keychain.
+    // Mirrors the forward logic of 015-migrate-credentials-to-keychain.
+    if (
+      process.env.VELLUM_DESKTOP_APP !== "1" ||
+      process.env.VELLUM_DEV === "1"
+    ) {
+      return;
+    }
+
+    const { createBrokerClient } =
+      await import("../../security/keychain-broker-client.js");
+    const client = createBrokerClient();
+
+    let brokerAvailable = false;
+    for (let i = 0; i < BROKER_WAIT_MAX_ATTEMPTS; i++) {
+      if (client.isAvailable()) {
+        brokerAvailable = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, BROKER_WAIT_INTERVAL_MS));
+    }
+
+    if (!brokerAvailable) {
+      throw new Error(
+        "Keychain broker not available after waiting — credential rollback " +
+          "will be retried on next startup",
+      );
+    }
+
+    const { listKeys, getKey, deleteKey } =
+      await import("../../security/encrypted-store.js");
+
+    const accounts = listKeys();
+    if (accounts.length === 0) return;
+
+    let rolledBackCount = 0;
+    let failedCount = 0;
+
+    for (const account of accounts) {
+      const value = getKey(account);
+      if (value === undefined) {
+        log.warn(
+          { account },
+          "Failed to read key from encrypted store during rollback — skipping",
+        );
+        failedCount++;
+        continue;
+      }
+
+      const result = await client.set(account, value);
+      if (result.status === "ok") {
+        deleteKey(account);
+        rolledBackCount++;
+      } else {
+        log.warn(
+          { account, status: result.status },
+          "Failed to write key to keychain during rollback — skipping",
+        );
+        failedCount++;
+      }
+    }
+
+    log.info(
+      { rolledBackCount, failedCount },
+      "Credential rollback from encrypted store to keychain complete",
+    );
+  },
+
   async run(_workspaceDir: string): Promise<void> {
     // Only run on mac production builds (desktop app, non-dev).
     if (
@@ -55,10 +124,7 @@ export const migrateCredentialsFromKeychainMigration: WorkspaceMigration = {
     for (const account of accounts) {
       const result = await client.get(account);
       if (!result || !result.found || result.value === undefined) {
-        log.warn(
-          { account },
-          "Failed to read key from keychain — skipping",
-        );
+        log.warn({ account }, "Failed to read key from keychain — skipping");
         failedCount++;
         continue;
       }

--- a/assistant/src/workspace/migrations/017-seed-persona-dirs.ts
+++ b/assistant/src/workspace/migrations/017-seed-persona-dirs.ts
@@ -1,4 +1,11 @@
-import { copyFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmdirSync,
+} from "node:fs";
 import { join } from "node:path";
 
 import { eq } from "drizzle-orm";
@@ -16,6 +23,27 @@ export const seedPersonaDirsMigration: WorkspaceMigration = {
   id: "017-seed-persona-dirs",
   description:
     "Create users/ and channels/ persona directories and migrate customized USER.md",
+
+  down(workspaceDir: string): void {
+    // Remove the seeded persona directories only if they are empty.
+    // We don't delete user-created content — only clean up the empty
+    // directories that the forward migration created.
+    const usersDir = join(workspaceDir, "users");
+    const channelsDir = join(workspaceDir, "channels");
+
+    for (const dir of [usersDir, channelsDir]) {
+      if (!existsSync(dir)) continue;
+      try {
+        const entries = readdirSync(dir);
+        if (entries.length === 0) {
+          rmdirSync(dir);
+        }
+      } catch {
+        // Best-effort: skip if we can't read or remove
+      }
+    }
+  },
+
   run(workspaceDir: string): void {
     // Create persona directories
     mkdirSync(join(workspaceDir, "users"), { recursive: true });

--- a/assistant/src/workspace/migrations/migrate-to-workspace-volume.ts
+++ b/assistant/src/workspace/migrations/migrate-to-workspace-volume.ts
@@ -14,7 +14,13 @@
  * - Skips if the old workspace directory doesn't exist or is empty.
  */
 
-import { cpSync, existsSync, readdirSync, writeFileSync } from "node:fs";
+import {
+  cpSync,
+  existsSync,
+  readdirSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 
 import {
@@ -29,6 +35,22 @@ export const migrateToWorkspaceVolumeMigration: WorkspaceMigration = {
   id: "014-migrate-to-workspace-volume",
   description:
     "Copy workspace data from old /data/.vellum/workspace to new WORKSPACE_DIR volume on first boot",
+
+  down(workspaceDir: string): void {
+    // This migration copies data between volumes. Actually reversing the copy
+    // (deleting data from the workspace volume) is dangerous and could cause
+    // data loss. Instead, we just remove the sentinel file so the migration
+    // will re-run and re-evaluate on next startup.
+    const sentinelPath = join(workspaceDir, SENTINEL_FILENAME);
+    if (existsSync(sentinelPath)) {
+      try {
+        unlinkSync(sentinelPath);
+      } catch {
+        // Best-effort — the migration runner's checkpoint removal will
+        // also ensure the migration re-runs.
+      }
+    }
+  },
 
   run(workspaceDir: string): void {
     const workspaceDirOverride = getWorkspaceDirOverride();


### PR DESCRIPTION
## Summary
- Add idempotent down() rollback functions to workspace migrations 009 through 017 and migrate-to-workspace-volume
- Irreversible migrations (repair, volume copy) have documented no-op down() functions

Part of plan: migration-down-functions.md (PR 6 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
