### PR TITLE
feat: add down() to memory migration registry entries versions 1–12

### DIFF
--- a/assistant/src/memory/migrations/001-job-deferrals.ts
+++ b/assistant/src/memory/migrations/001-job-deferrals.ts
@@ -49,3 +49,22 @@ export function migrateJobDeferrals(database: DrizzleDb): void {
     throw e;
   }
 }
+
+/**
+ * Reverse the deferral reconciliation by moving `deferrals` back into `attempts`
+ * for pending embed jobs. Best-effort: jobs that accumulated real deferral counts
+ * after the forward migration ran cannot be distinguished from migrated ones.
+ */
+export function downJobDeferrals(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(/*sql*/ `
+    UPDATE memory_jobs
+    SET attempts = deferrals,
+        deferrals = 0,
+        updated_at = ${Date.now()}
+    WHERE status = 'pending'
+      AND deferrals > 0
+      AND attempts = 0
+      AND type IN ('embed_segment', 'embed_item', 'embed_summary')
+  `);
+}

--- a/assistant/src/memory/migrations/004-entity-relation-dedup.ts
+++ b/assistant/src/memory/migrations/004-entity-relation-dedup.ts
@@ -91,3 +91,13 @@ export function migrateMemoryEntityRelationDedup(database: DrizzleDb): void {
     throw e;
   }
 }
+
+/**
+ * No-op down: deduplication is a lossy operation — deleted duplicate rows
+ * cannot be restored. The forward migration merged rows by keeping the most
+ * recent evidence per (source, target, relation) triple; the discarded rows
+ * are permanently lost.
+ */
+export function downMemoryEntityRelationDedup(_database: DrizzleDb): void {
+  // Intentionally empty — irreversible lossy migration.
+}

--- a/assistant/src/memory/migrations/005-fingerprint-scope-unique.ts
+++ b/assistant/src/memory/migrations/005-fingerprint-scope-unique.ts
@@ -93,3 +93,79 @@ export function migrateMemoryItemsFingerprintScopeUnique(
     raw.exec("PRAGMA foreign_keys = ON");
   }
 }
+
+/**
+ * Reverse the compound (fingerprint, scope_id) unique index change by rebuilding
+ * memory_items with a column-level UNIQUE on fingerprint.
+ *
+ * WARNING: This is dangerous if data now relies on the compound constraint
+ * (i.e., the same fingerprint exists in multiple scopes). In that case, the
+ * rebuild will fail with a UNIQUE constraint violation. This is intentional —
+ * it prevents silent data loss on rollback.
+ */
+export function downMemoryItemsFingerprintScopeUnique(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  // Check if the column-level UNIQUE already exists — if so, nothing to do.
+  const tableDdl = raw
+    .query(
+      `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'memory_items'`,
+    )
+    .get() as { sql: string } | null;
+  if (
+    !tableDdl ||
+    tableDdl.sql.match(/fingerprint\s+TEXT\s+NOT\s+NULL\s+UNIQUE/i)
+  ) {
+    return;
+  }
+
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    raw.exec("BEGIN");
+
+    raw.exec(/*sql*/ `
+      CREATE TABLE memory_items_new (
+        id TEXT PRIMARY KEY,
+        kind TEXT NOT NULL,
+        subject TEXT NOT NULL,
+        statement TEXT NOT NULL,
+        status TEXT NOT NULL,
+        confidence REAL NOT NULL,
+        fingerprint TEXT NOT NULL UNIQUE,
+        first_seen_at INTEGER NOT NULL,
+        last_seen_at INTEGER NOT NULL,
+        last_used_at INTEGER,
+        importance REAL,
+        access_count INTEGER NOT NULL DEFAULT 0,
+        valid_from INTEGER,
+        invalid_at INTEGER,
+        verification_state TEXT NOT NULL DEFAULT 'assistant_inferred',
+        scope_id TEXT NOT NULL DEFAULT 'default'
+      )
+    `);
+
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_items_new
+      SELECT id, kind, subject, statement, status, confidence, fingerprint,
+             first_seen_at, last_seen_at, last_used_at, importance, access_count,
+             valid_from, invalid_at, verification_state, scope_id
+      FROM memory_items
+    `);
+
+    raw.exec(/*sql*/ `DROP TABLE memory_items`);
+    raw.exec(/*sql*/ `ALTER TABLE memory_items_new RENAME TO memory_items`);
+
+    raw.exec("COMMIT");
+  } catch (e) {
+    try {
+      raw.exec("ROLLBACK");
+    } catch {
+      /* no active transaction */
+    }
+    throw e;
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
+}

--- a/assistant/src/memory/migrations/006-scope-salted-fingerprints.ts
+++ b/assistant/src/memory/migrations/006-scope-salted-fingerprints.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
 import { computeMemoryFingerprint } from "../fingerprint.js";
 
@@ -64,6 +66,54 @@ export function migrateMemoryItemsScopeSaltedFingerprints(
         `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,
       )
       .run(checkpointKey, Date.now());
+
+    raw.exec("COMMIT");
+  } catch (e) {
+    try {
+      raw.exec("ROLLBACK");
+    } catch {
+      /* no active transaction */
+    }
+    throw e;
+  }
+}
+
+/**
+ * Reverse the scope-salted fingerprint migration by recomputing fingerprints
+ * WITHOUT the scope_id prefix.
+ *
+ * Old format: sha256(`${kind}|${subject.toLowerCase()}|${statement.toLowerCase()}`)
+ */
+export function downMemoryItemsScopeSaltedFingerprints(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  interface ItemRow {
+    id: string;
+    kind: string;
+    subject: string;
+    statement: string;
+  }
+
+  const items = raw
+    .query(`SELECT id, kind, subject, statement FROM memory_items`)
+    .all() as ItemRow[];
+
+  if (items.length === 0) return;
+
+  try {
+    raw.exec("BEGIN");
+
+    const updateStmt = raw.prepare(
+      `UPDATE memory_items SET fingerprint = ? WHERE id = ?`,
+    );
+
+    for (const item of items) {
+      const normalized = `${item.kind}|${item.subject.toLowerCase()}|${item.statement.toLowerCase()}`;
+      const fingerprint = createHash("sha256").update(normalized).digest("hex");
+      updateStmt.run(fingerprint, item.id);
+    }
 
     raw.exec("COMMIT");
   } catch (e) {

--- a/assistant/src/memory/migrations/007-assistant-id-to-self.ts
+++ b/assistant/src/memory/migrations/007-assistant-id-to-self.ts
@@ -265,3 +265,13 @@ export function migrateAssistantIdToSelf(database: DrizzleDb): void {
     throw e;
   }
 }
+
+/**
+ * No-op down: the original assistant_id values are not recoverable. The forward
+ * migration normalized all assistant_id values to "self" and merged/deduplicated
+ * rows where the same logical entity existed under both the real assistantId and
+ * "self". The original per-assistant IDs are permanently lost.
+ */
+export function downAssistantIdToSelf(_database: DrizzleDb): void {
+  // Intentionally empty — original assistant_id values cannot be restored.
+}

--- a/assistant/src/memory/migrations/008-remove-assistant-id-columns.ts
+++ b/assistant/src/memory/migrations/008-remove-assistant-id-columns.ts
@@ -228,3 +228,37 @@ export function migrateRemoveAssistantIdColumns(database: DrizzleDb): void {
     raw.exec("PRAGMA foreign_keys = ON");
   }
 }
+
+/**
+ * Add the assistant_id column back to the 4 tables that had it removed.
+ *
+ * NOTE: The data previously stored in assistant_id is lost — all rows will
+ * have assistant_id = 'self' after this down migration. This only restores
+ * the column structure so that older code expecting the column can function.
+ */
+export function downRemoveAssistantIdColumns(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  const tables = [
+    "conversation_keys",
+    "attachments",
+    "channel_inbound_events",
+    "message_runs",
+  ];
+
+  for (const table of tables) {
+    // Check if the table exists and lacks assistant_id
+    const ddl = raw
+      .query(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?`)
+      .get(table) as { sql: string } | null;
+    if (!ddl || ddl.sql.includes("assistant_id")) continue;
+
+    try {
+      raw.exec(
+        /*sql*/ `ALTER TABLE ${table} ADD COLUMN assistant_id TEXT NOT NULL DEFAULT 'self'`,
+      );
+    } catch {
+      /* column already exists */
+    }
+  }
+}

--- a/assistant/src/memory/migrations/009-llm-usage-events-drop-assistant-id.ts
+++ b/assistant/src/memory/migrations/009-llm-usage-events-drop-assistant-id.ts
@@ -95,3 +95,29 @@ export function migrateLlmUsageEventsDropAssistantId(
     raw.exec("PRAGMA foreign_keys = ON");
   }
 }
+
+/**
+ * Add the assistant_id column back to llm_usage_events.
+ *
+ * NOTE: The data previously stored in assistant_id is lost — all rows will
+ * have assistant_id = NULL after this down migration. This only restores
+ * the column structure so that older code expecting the column can function.
+ */
+export function downLlmUsageEventsDropAssistantId(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  const ddl = raw
+    .query(
+      `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'llm_usage_events'`,
+    )
+    .get() as { sql: string } | null;
+  if (!ddl || ddl.sql.includes("assistant_id")) return;
+
+  try {
+    raw.exec(
+      /*sql*/ `ALTER TABLE llm_usage_events ADD COLUMN assistant_id TEXT`,
+    );
+  } catch {
+    /* column already exists */
+  }
+}

--- a/assistant/src/memory/migrations/014-backfill-inbox-thread-state.ts
+++ b/assistant/src/memory/migrations/014-backfill-inbox-thread-state.ts
@@ -88,3 +88,13 @@ export function migrateBackfillInboxThreadStateFromBindings(
     throw e;
   }
 }
+
+/**
+ * No-op down: the seeded inbox thread state rows are expected to remain.
+ * The forward migration used INSERT OR IGNORE, so existing rows were never
+ * modified. Removing the seeded rows could leave the inbox empty for
+ * pre-existing conversations, which is worse than keeping them.
+ */
+export function downBackfillInboxThreadState(_database: DrizzleDb): void {
+  // Intentionally empty — seeded data is expected to remain.
+}

--- a/assistant/src/memory/migrations/015-drop-active-search-index.ts
+++ b/assistant/src/memory/migrations/015-drop-active-search-index.ts
@@ -31,3 +31,20 @@ export function migrateDropActiveSearchIndex(database: DrizzleDb): void {
     throw e;
   }
 }
+
+/**
+ * Recreate the old idx_memory_items_active_search index with its original
+ * covering columns (before the migration added status and invalid_at as
+ * indexed columns).
+ */
+export function downDropActiveSearchIndex(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  // Drop the current index if it exists, then recreate with the old column set.
+  raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_memory_items_active_search`);
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_items_active_search
+    ON memory_items(last_seen_at DESC, subject, statement, id, kind, confidence, importance, first_seen_at, scope_id)
+    WHERE status = 'active' AND invalid_at IS NULL
+  `);
+}

--- a/assistant/src/memory/migrations/019-notification-tables-schema-migration.ts
+++ b/assistant/src/memory/migrations/019-notification-tables-schema-migration.ts
@@ -82,3 +82,15 @@ export function migrateNotificationTablesSchema(database: DrizzleDb): void {
     }
   }
 }
+
+/**
+ * No-op down: the old enum-based notification tables cannot be recreated
+ * without the original schema definitions (column names, types, constraints,
+ * and enum values). The forward migration dropped these tables entirely.
+ * Any data that was in them is permanently lost. The new signal-contract
+ * schema tables are structurally incompatible with the old enum-based ones.
+ */
+export function downNotificationTablesSchema(_database: DrizzleDb): void {
+  // Intentionally empty — old enum-based tables cannot be recreated without
+  // the original schema, and any data they contained is permanently lost.
+}

--- a/assistant/src/memory/migrations/020-rename-macos-ios-channel-to-vellum.ts
+++ b/assistant/src/memory/migrations/020-rename-macos-ios-channel-to-vellum.ts
@@ -130,3 +130,124 @@ export function migrateRenameChannelToVellum(database: DrizzleDb): void {
     throw e;
   }
 }
+
+/**
+ * Reverse the channel rename by changing "vellum" back to "macos" in all tables.
+ *
+ * NOTE: The forward migration renamed both "macos" and "ios" to "vellum", so we
+ * cannot distinguish which rows were originally "ios". This down migration
+ * conservatively maps all "vellum" values back to "macos" since that was the
+ * primary desktop channel identifier.
+ */
+export function downRenameChannelToVellum(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  try {
+    raw.exec("BEGIN");
+
+    // guardian_action_deliveries.destination_channel
+    const gadExists = raw
+      .query(
+        `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'guardian_action_deliveries'`,
+      )
+      .get();
+    if (gadExists) {
+      raw
+        .query(
+          `UPDATE guardian_action_deliveries SET destination_channel = 'macos' WHERE destination_channel = 'vellum'`,
+        )
+        .run();
+    }
+
+    // messages.user_message_channel / assistant_message_channel
+    const msgsExists = raw
+      .query(
+        `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'messages'`,
+      )
+      .get();
+    if (msgsExists) {
+      const hasUserMsgChannel = raw
+        .query(
+          `SELECT 1 FROM pragma_table_info('messages') WHERE name = 'user_message_channel'`,
+        )
+        .get();
+      if (hasUserMsgChannel) {
+        raw
+          .query(
+            `UPDATE messages SET user_message_channel = 'macos' WHERE user_message_channel = 'vellum'`,
+          )
+          .run();
+      }
+      const hasAssistantMsgChannel = raw
+        .query(
+          `SELECT 1 FROM pragma_table_info('messages') WHERE name = 'assistant_message_channel'`,
+        )
+        .get();
+      if (hasAssistantMsgChannel) {
+        raw
+          .query(
+            `UPDATE messages SET assistant_message_channel = 'macos' WHERE assistant_message_channel = 'vellum'`,
+          )
+          .run();
+      }
+    }
+
+    // external_conversation_bindings.source_channel
+    const ecbExists = raw
+      .query(
+        `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'external_conversation_bindings'`,
+      )
+      .get();
+    if (ecbExists) {
+      raw
+        .query(
+          `UPDATE external_conversation_bindings SET source_channel = 'macos' WHERE source_channel = 'vellum'`,
+        )
+        .run();
+    }
+
+    // assistant_inbox_thread_state.source_channel
+    const aitsExists = raw
+      .query(
+        `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'assistant_inbox_thread_state'`,
+      )
+      .get();
+    if (aitsExists) {
+      raw
+        .query(
+          `UPDATE assistant_inbox_thread_state SET source_channel = 'macos' WHERE source_channel = 'vellum'`,
+        )
+        .run();
+    }
+
+    // conversations.origin_channel
+    const convExists = raw
+      .query(
+        `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'conversations'`,
+      )
+      .get();
+    if (convExists) {
+      const hasOriginChannel = raw
+        .query(
+          `SELECT 1 FROM pragma_table_info('conversations') WHERE name = 'origin_channel'`,
+        )
+        .get();
+      if (hasOriginChannel) {
+        raw
+          .query(
+            `UPDATE conversations SET origin_channel = 'macos' WHERE origin_channel = 'vellum'`,
+          )
+          .run();
+      }
+    }
+
+    raw.exec("COMMIT");
+  } catch (e) {
+    try {
+      raw.exec("ROLLBACK");
+    } catch {
+      /* no active transaction */
+    }
+    throw e;
+  }
+}

--- a/assistant/src/memory/migrations/024-embedding-vector-blob.ts
+++ b/assistant/src/memory/migrations/024-embedding-vector-blob.ts
@@ -71,3 +71,77 @@ export function migrateEmbeddingVectorBlob(database: DrizzleDb): void {
       .run(checkpointKey, Date.now());
   }
 }
+
+/**
+ * Drop the vector_blob column from memory_embeddings.
+ *
+ * NOTE: Binary embedding data stored in vector_blob is lost on rollback.
+ * Rows that still have vector_json will continue to work; rows that only
+ * had vector_blob will lose their embedding vectors.
+ *
+ * SQLite does not support DROP COLUMN on all versions, so we rebuild the table.
+ */
+export function downEmbeddingVectorBlob(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  // Check if vector_blob column exists
+  const hasColumn = raw
+    .query(
+      `SELECT 1 FROM pragma_table_info('memory_embeddings') WHERE name = 'vector_blob'`,
+    )
+    .get();
+  if (!hasColumn) return;
+
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    raw.exec("BEGIN");
+
+    // Get the current columns minus vector_blob
+    const columns = raw
+      .query(`SELECT name FROM pragma_table_info('memory_embeddings')`)
+      .all() as Array<{ name: string }>;
+    const keepColumns = columns
+      .map((c) => c.name)
+      .filter((n) => n !== "vector_blob");
+
+    // Get the current DDL to understand the table structure
+    const ddl = raw
+      .query(
+        `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'memory_embeddings'`,
+      )
+      .get() as { sql: string } | null;
+    if (!ddl) {
+      raw.exec("ROLLBACK");
+      return;
+    }
+
+    // Remove the vector_blob column definition from the DDL
+    const newDdl = ddl.sql
+      .replace(/,\s*vector_blob\s+BLOB/i, "")
+      .replace("memory_embeddings", "memory_embeddings_new");
+
+    raw.exec(newDdl);
+
+    const colList = keepColumns.join(", ");
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_embeddings_new (${colList})
+      SELECT ${colList} FROM memory_embeddings
+    `);
+
+    raw.exec(/*sql*/ `DROP TABLE memory_embeddings`);
+    raw.exec(
+      /*sql*/ `ALTER TABLE memory_embeddings_new RENAME TO memory_embeddings`,
+    );
+
+    raw.exec("COMMIT");
+  } catch (e) {
+    try {
+      raw.exec("ROLLBACK");
+    } catch {
+      /* no active transaction */
+    }
+    throw e;
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
+}

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -1,4 +1,16 @@
 import type { DrizzleDb } from "../db-connection.js";
+import { downJobDeferrals } from "./001-job-deferrals.js";
+import { downMemoryEntityRelationDedup } from "./004-entity-relation-dedup.js";
+import { downMemoryItemsFingerprintScopeUnique } from "./005-fingerprint-scope-unique.js";
+import { downMemoryItemsScopeSaltedFingerprints } from "./006-scope-salted-fingerprints.js";
+import { downAssistantIdToSelf } from "./007-assistant-id-to-self.js";
+import { downRemoveAssistantIdColumns } from "./008-remove-assistant-id-columns.js";
+import { downLlmUsageEventsDropAssistantId } from "./009-llm-usage-events-drop-assistant-id.js";
+import { downBackfillInboxThreadState } from "./014-backfill-inbox-thread-state.js";
+import { downDropActiveSearchIndex } from "./015-drop-active-search-index.js";
+import { downNotificationTablesSchema } from "./019-notification-tables-schema-migration.js";
+import { downRenameChannelToVellum } from "./020-rename-macos-ios-channel-to-vellum.js";
+import { downEmbeddingVectorBlob } from "./024-embedding-vector-blob.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -30,18 +42,21 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     version: 1,
     description:
       "Reconcile legacy deferral history from attempts column into deferrals column",
+    down: downJobDeferrals,
   },
   {
     key: "migration_memory_entity_relations_dedup_v1",
     version: 2,
     description:
       "Deduplicate entity relation edges before enforcing the (source, target, relation) unique index",
+    down: downMemoryEntityRelationDedup,
   },
   {
     key: "migration_memory_items_fingerprint_scope_unique_v1",
     version: 3,
     description:
       "Replace column-level UNIQUE on fingerprint with compound (fingerprint, scope_id) unique index",
+    down: downMemoryItemsFingerprintScopeUnique,
   },
   {
     key: "migration_memory_items_scope_salted_fingerprints_v1",
@@ -49,12 +64,14 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     dependsOn: ["migration_memory_items_fingerprint_scope_unique_v1"],
     description:
       "Recompute memory item fingerprints to include scope_id prefix after schema change",
+    down: downMemoryItemsScopeSaltedFingerprints,
   },
   {
     key: "migration_normalize_assistant_id_to_self_v1",
     version: 5,
     description:
       'Normalize all assistant_id values in scoped tables to the implicit "self" single-tenant identity',
+    down: downAssistantIdToSelf,
   },
   {
     key: "migration_remove_assistant_id_columns_v1",
@@ -62,6 +79,7 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     dependsOn: ["migration_normalize_assistant_id_to_self_v1"],
     description:
       "Rebuild four tables to drop the assistant_id column after normalization",
+    down: downRemoveAssistantIdColumns,
   },
   {
     key: "migration_remove_assistant_id_lue_v1",
@@ -69,36 +87,42 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     dependsOn: ["migration_normalize_assistant_id_to_self_v1"],
     description:
       "Remove assistant_id column from llm_usage_events (separate checkpoint from the four-table migration)",
+    down: downLlmUsageEventsDropAssistantId,
   },
   {
     key: "backfill_inbox_thread_state_from_bindings",
     version: 8,
     description:
       "Seed assistant_inbox_thread_state from external_conversation_bindings",
+    down: downBackfillInboxThreadState,
   },
   {
     key: "drop_active_search_index_v1",
     version: 9,
     description:
       "Drop old idx_memory_items_active_search so it can be recreated with updated covering columns",
+    down: downDropActiveSearchIndex,
   },
   {
     key: "migration_notification_tables_schema_v1",
     version: 10,
     description:
       "Drop legacy enum-based notification tables so they can be recreated with the new signal-contract schema",
+    down: downNotificationTablesSchema,
   },
   {
     key: "migration_rename_macos_ios_channel_to_vellum_v1",
     version: 11,
     description:
       "Rename macos and ios channel identifiers to vellum across all tables",
+    down: downRenameChannelToVellum,
   },
   {
     key: "migration_embedding_vector_blob_v1",
     version: 12,
     description:
       "Add vector_blob BLOB column to memory_embeddings and backfill from vector_json for compact binary storage",
+    down: downEmbeddingVectorBlob,
   },
   {
     key: "migration_embeddings_nullable_vector_json_v1",


### PR DESCRIPTION
## Summary
- Add down() rollback functions to memory migration registry entries versions 1 through 12
- Lossy operations (dedup, normalization) have documented no-op down() functions
- Functions exported from individual migration files and wired into MIGRATION_REGISTRY

Part of plan: migration-down-functions.md (PR 8 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
