### PR TITLE
feat: add down() to memory migration registry entries versions 25–36

### DIFF
--- a/assistant/src/memory/migrations/145-drop-accounts-table.ts
+++ b/assistant/src/memory/migrations/145-drop-accounts-table.ts
@@ -17,3 +17,35 @@ export function migrateDropAccountsTable(database: DrizzleDb): void {
     raw.exec(/*sql*/ `DROP TABLE IF EXISTS accounts`);
   });
 }
+
+/**
+ * Reverse: recreate the accounts table with its original schema.
+ *
+ * Data is permanently lost — the table was dropped. This only restores the
+ * empty table structure so that earlier migrations referencing it can operate.
+ */
+export function migrateDropAccountsTableDown(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS accounts (
+      id TEXT PRIMARY KEY,
+      service TEXT NOT NULL,
+      username TEXT,
+      email TEXT,
+      display_name TEXT,
+      status TEXT NOT NULL DEFAULT 'active',
+      credential_ref TEXT,
+      metadata_json TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  raw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_accounts_service ON accounts(service)`,
+  );
+  raw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_accounts_status ON accounts(status)`,
+  );
+}

--- a/assistant/src/memory/migrations/147-migrate-reminders-to-schedules.ts
+++ b/assistant/src/memory/migrations/147-migrate-reminders-to-schedules.ts
@@ -1,4 +1,5 @@
-import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
 /**
@@ -122,4 +123,16 @@ export function migrateRemindersToSchedules(database: DrizzleDb): void {
       throw err;
     }
   });
+}
+
+/**
+ * Reverse: no-op.
+ *
+ * Cannot reliably identify which cron_jobs rows were migrated from reminders
+ * versus created natively as schedules. Rows share the same table and there
+ * is no origin marker. Deleting the wrong rows would destroy user-created
+ * schedules.
+ */
+export function migrateRemindersToSchedulesDown(_database: DrizzleDb): void {
+  // No-op — see comment above.
 }

--- a/assistant/src/memory/migrations/148-drop-reminders-table.ts
+++ b/assistant/src/memory/migrations/148-drop-reminders-table.ts
@@ -1,4 +1,5 @@
-import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
 /**
@@ -11,4 +12,37 @@ export function migrateDropRemindersTable(database: DrizzleDb): void {
     raw.run("DROP INDEX IF EXISTS idx_reminders_status_fire_at");
     raw.run("DROP TABLE IF EXISTS reminders");
   });
+}
+
+/**
+ * Reverse: recreate the reminders table with its original schema.
+ *
+ * Data is permanently lost — the table was dropped. This only restores the
+ * empty table structure so that earlier migrations referencing it can operate.
+ * Includes the routing_intent and routing_hints_json columns added by
+ * migration 118.
+ */
+export function migrateDropRemindersTableDown(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS reminders (
+      id TEXT PRIMARY KEY,
+      label TEXT NOT NULL,
+      message TEXT NOT NULL,
+      fire_at INTEGER NOT NULL,
+      mode TEXT NOT NULL,
+      status TEXT NOT NULL,
+      fired_at INTEGER,
+      conversation_id TEXT,
+      routing_intent TEXT NOT NULL DEFAULT 'all_channels',
+      routing_hints_json TEXT NOT NULL DEFAULT '{}',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  raw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_reminders_status_fire_at ON reminders(status, fire_at)`,
+  );
 }

--- a/assistant/src/memory/migrations/150-oauth-apps-client-secret-path.ts
+++ b/assistant/src/memory/migrations/150-oauth-apps-client-secret-path.ts
@@ -1,4 +1,5 @@
-import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
 /**
@@ -95,4 +96,60 @@ export function migrateOAuthAppsClientSecretPath(database: DrizzleDb): void {
       }
     },
   );
+}
+
+/**
+ * Reverse: drop the client_secret_credential_path column from oauth_apps.
+ *
+ * Rebuilds the table without the column (SQLite doesn't support DROP COLUMN
+ * on older versions). Idempotent — skips if the column doesn't exist.
+ */
+export function migrateOAuthAppsClientSecretPathDown(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  // Guard: table must exist
+  const tableExists = raw
+    .query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'oauth_apps'`,
+    )
+    .get();
+  if (!tableExists) return;
+
+  // Guard: if the column doesn't exist, nothing to do
+  const colInfo = raw
+    .query(
+      `SELECT 1 FROM pragma_table_info('oauth_apps') WHERE name = 'client_secret_credential_path'`,
+    )
+    .get();
+  if (!colInfo) return;
+
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    raw.exec(/*sql*/ `
+      CREATE TABLE oauth_apps_rollback (
+        id TEXT PRIMARY KEY,
+        provider_key TEXT NOT NULL REFERENCES oauth_providers(provider_key),
+        client_id TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+
+    raw.exec(/*sql*/ `
+      INSERT INTO oauth_apps_rollback
+      SELECT id, provider_key, client_id, created_at, updated_at
+      FROM oauth_apps
+    `);
+
+    raw.exec(/*sql*/ `DROP TABLE oauth_apps`);
+    raw.exec(/*sql*/ `ALTER TABLE oauth_apps_rollback RENAME TO oauth_apps`);
+
+    raw.exec(
+      /*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_oauth_apps_provider_client ON oauth_apps(provider_key, client_id)`,
+    );
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
 }

--- a/assistant/src/memory/migrations/162-guardian-timestamps-epoch-ms.ts
+++ b/assistant/src/memory/migrations/162-guardian-timestamps-epoch-ms.ts
@@ -281,3 +281,262 @@ function rebuildScopedApprovalGrants(raw: RawDb): void {
     raw.exec("PRAGMA foreign_keys = ON");
   }
 }
+
+// ---------------------------------------------------------------------------
+// Down functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Reverse v29: convert epoch ms timestamps back to ISO 8601 text in guardian
+ * tables.
+ *
+ * Uses SQLite's datetime() to reconstruct ISO 8601 strings from the integer
+ * values. The millisecond component is appended manually since datetime()
+ * only returns second precision.
+ */
+export function migrateGuardianTimestampsEpochMsDown(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  // Convert canonical_guardian_requests timestamp columns back to ISO 8601
+  raw.exec(/*sql*/ `
+    UPDATE canonical_guardian_requests
+    SET created_at = strftime('%Y-%m-%dT%H:%M:%S', created_at / 1000, 'unixepoch') || '.' || printf('%03d', created_at % 1000) || 'Z',
+        updated_at = strftime('%Y-%m-%dT%H:%M:%S', updated_at / 1000, 'unixepoch') || '.' || printf('%03d', updated_at % 1000) || 'Z',
+        expires_at = CASE
+          WHEN expires_at IS NOT NULL
+          THEN strftime('%Y-%m-%dT%H:%M:%S', expires_at / 1000, 'unixepoch') || '.' || printf('%03d', expires_at % 1000) || 'Z'
+          ELSE NULL
+        END
+    WHERE typeof(created_at) = 'integer'
+  `);
+
+  // Convert canonical_guardian_deliveries timestamp columns back to ISO 8601
+  raw.exec(/*sql*/ `
+    UPDATE canonical_guardian_deliveries
+    SET created_at = strftime('%Y-%m-%dT%H:%M:%S', created_at / 1000, 'unixepoch') || '.' || printf('%03d', created_at % 1000) || 'Z',
+        updated_at = strftime('%Y-%m-%dT%H:%M:%S', updated_at / 1000, 'unixepoch') || '.' || printf('%03d', updated_at % 1000) || 'Z'
+    WHERE typeof(created_at) = 'integer'
+  `);
+
+  // Convert scoped_approval_grants timestamp columns back to ISO 8601
+  raw.exec(/*sql*/ `
+    UPDATE scoped_approval_grants
+    SET expires_at = strftime('%Y-%m-%dT%H:%M:%S', expires_at / 1000, 'unixepoch') || '.' || printf('%03d', expires_at % 1000) || 'Z',
+        created_at = strftime('%Y-%m-%dT%H:%M:%S', created_at / 1000, 'unixepoch') || '.' || printf('%03d', created_at % 1000) || 'Z',
+        updated_at = strftime('%Y-%m-%dT%H:%M:%S', updated_at / 1000, 'unixepoch') || '.' || printf('%03d', updated_at % 1000) || 'Z',
+        consumed_at = CASE
+          WHEN consumed_at IS NOT NULL
+          THEN strftime('%Y-%m-%dT%H:%M:%S', consumed_at / 1000, 'unixepoch') || '.' || printf('%03d', consumed_at % 1000) || 'Z'
+          ELSE NULL
+        END
+    WHERE typeof(created_at) = 'integer'
+  `);
+}
+
+/**
+ * Reverse v30: rebuild guardian tables with TEXT affinity on timestamp columns.
+ *
+ * Restores the original TEXT column declarations so that timestamp columns
+ * have TEXT affinity (the state before the INTEGER rebuild).
+ */
+export function migrateGuardianTimestampsRebuildDown(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  rebuildCanonicalGuardianRequestsToText(raw);
+  rebuildCanonicalGuardianDeliveriesToText(raw);
+  rebuildScopedApprovalGrantsToText(raw);
+}
+
+function hasTextAffinity(raw: RawDb, table: string, column: string): boolean {
+  const row = raw
+    .query(
+      `SELECT type FROM pragma_table_info('${table}') WHERE name = '${column}'`,
+    )
+    .get() as { type: string } | null;
+  if (!row) return true; // column doesn't exist — nothing to fix
+  return row.type.toUpperCase() === "TEXT";
+}
+
+function rebuildCanonicalGuardianRequestsToText(raw: RawDb): void {
+  if (hasTextAffinity(raw, "canonical_guardian_requests", "created_at")) return;
+
+  // Caller (rollbackMemoryMigration) already manages the transaction.
+  // We only need to disable FK checks for the table rebuild.
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    raw.exec(/*sql*/ `
+      CREATE TABLE canonical_guardian_requests_rb (
+        id TEXT PRIMARY KEY,
+        kind TEXT NOT NULL,
+        source_type TEXT NOT NULL,
+        source_channel TEXT,
+        conversation_id TEXT,
+        requester_external_user_id TEXT,
+        requester_chat_id TEXT,
+        guardian_external_user_id TEXT,
+        guardian_principal_id TEXT,
+        call_session_id TEXT,
+        pending_question_id TEXT,
+        question_text TEXT,
+        request_code TEXT,
+        tool_name TEXT,
+        input_digest TEXT,
+        status TEXT NOT NULL DEFAULT 'pending',
+        answer_text TEXT,
+        decided_by_external_user_id TEXT,
+        decided_by_principal_id TEXT,
+        followup_state TEXT,
+        expires_at TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `);
+
+    raw.exec(/*sql*/ `
+      INSERT INTO canonical_guardian_requests_rb
+      SELECT id, kind, source_type, source_channel, conversation_id,
+             requester_external_user_id, requester_chat_id,
+             guardian_external_user_id, guardian_principal_id,
+             call_session_id, pending_question_id, question_text,
+             request_code, tool_name, input_digest, status, answer_text,
+             decided_by_external_user_id, decided_by_principal_id,
+             followup_state, expires_at, created_at, updated_at
+      FROM canonical_guardian_requests
+    `);
+
+    raw.exec(/*sql*/ `DROP TABLE canonical_guardian_requests`);
+    raw.exec(
+      /*sql*/ `ALTER TABLE canonical_guardian_requests_rb RENAME TO canonical_guardian_requests`,
+    );
+
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_status ON canonical_guardian_requests(status)`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_guardian ON canonical_guardian_requests(guardian_external_user_id, status)`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_conversation ON canonical_guardian_requests(conversation_id, status)`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_source ON canonical_guardian_requests(source_type, status)`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_kind ON canonical_guardian_requests(kind, status)`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_request_code ON canonical_guardian_requests(request_code)`,
+    );
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
+}
+
+function rebuildCanonicalGuardianDeliveriesToText(raw: RawDb): void {
+  if (hasTextAffinity(raw, "canonical_guardian_deliveries", "created_at"))
+    return;
+
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    raw.exec(/*sql*/ `
+      CREATE TABLE canonical_guardian_deliveries_rb (
+        id TEXT PRIMARY KEY,
+        request_id TEXT NOT NULL REFERENCES canonical_guardian_requests(id) ON DELETE CASCADE,
+        destination_channel TEXT NOT NULL,
+        destination_conversation_id TEXT,
+        destination_chat_id TEXT,
+        destination_message_id TEXT,
+        status TEXT NOT NULL DEFAULT 'pending',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `);
+
+    raw.exec(/*sql*/ `
+      INSERT INTO canonical_guardian_deliveries_rb
+      SELECT id, request_id, destination_channel, destination_conversation_id,
+             destination_chat_id, destination_message_id, status,
+             created_at, updated_at
+      FROM canonical_guardian_deliveries
+    `);
+
+    raw.exec(/*sql*/ `DROP TABLE canonical_guardian_deliveries`);
+    raw.exec(
+      /*sql*/ `ALTER TABLE canonical_guardian_deliveries_rb RENAME TO canonical_guardian_deliveries`,
+    );
+
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_deliveries_request_id ON canonical_guardian_deliveries(request_id)`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_deliveries_status ON canonical_guardian_deliveries(status)`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_deliveries_destination ON canonical_guardian_deliveries(destination_channel, destination_chat_id)`,
+    );
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
+}
+
+function rebuildScopedApprovalGrantsToText(raw: RawDb): void {
+  if (hasTextAffinity(raw, "scoped_approval_grants", "created_at")) return;
+
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    raw.exec(/*sql*/ `
+      CREATE TABLE scoped_approval_grants_rb (
+        id TEXT PRIMARY KEY,
+        scope_mode TEXT NOT NULL,
+        request_id TEXT,
+        tool_name TEXT,
+        input_digest TEXT,
+        request_channel TEXT NOT NULL,
+        decision_channel TEXT NOT NULL,
+        execution_channel TEXT,
+        conversation_id TEXT,
+        call_session_id TEXT,
+        requester_external_user_id TEXT,
+        guardian_external_user_id TEXT,
+        status TEXT NOT NULL,
+        expires_at TEXT NOT NULL,
+        consumed_at TEXT,
+        consumed_by_request_id TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `);
+
+    raw.exec(/*sql*/ `
+      INSERT INTO scoped_approval_grants_rb
+      SELECT id, scope_mode, request_id, tool_name, input_digest,
+             request_channel, decision_channel, execution_channel,
+             conversation_id, call_session_id,
+             requester_external_user_id, guardian_external_user_id,
+             status, expires_at, consumed_at, consumed_by_request_id,
+             created_at, updated_at
+      FROM scoped_approval_grants
+    `);
+
+    raw.exec(/*sql*/ `DROP TABLE scoped_approval_grants`);
+    raw.exec(
+      /*sql*/ `ALTER TABLE scoped_approval_grants_rb RENAME TO scoped_approval_grants`,
+    );
+
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_scoped_grants_request_id ON scoped_approval_grants(request_id) WHERE request_id IS NOT NULL`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_scoped_grants_tool_sig ON scoped_approval_grants(tool_name, input_digest) WHERE tool_name IS NOT NULL`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_scoped_grants_status_expires ON scoped_approval_grants(status, expires_at)`,
+    );
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
+}

--- a/assistant/src/memory/migrations/169-rename-gmail-provider-key-to-google.ts
+++ b/assistant/src/memory/migrations/169-rename-gmail-provider-key-to-google.ts
@@ -1,4 +1,5 @@
-import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
 /**
@@ -61,4 +62,53 @@ export function migrateRenameGmailProviderKeyToGoogle(
       }
     },
   );
+}
+
+/**
+ * Reverse: rename "integration:google" back to "integration:gmail" across
+ * OAuth tables.
+ *
+ * Mirrors the forward migration logic but in the opposite direction. If
+ * `integration:gmail` already exists (shouldn't normally happen on rollback),
+ * deletes the google rows to avoid duplicates.
+ */
+export function migrateRenameGmailProviderKeyToGoogleDown(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    const gmailExists = raw
+      .prepare(
+        /*sql*/ `SELECT 1 FROM oauth_providers WHERE provider_key = 'integration:gmail'`,
+      )
+      .get();
+
+    if (gmailExists) {
+      // Old gmail rows already exist — delete the google ones to avoid duplication.
+      raw.exec(
+        /*sql*/ `DELETE FROM oauth_connections WHERE provider_key = 'integration:google'`,
+      );
+      raw.exec(
+        /*sql*/ `DELETE FROM oauth_apps WHERE provider_key = 'integration:google'`,
+      );
+      raw.exec(
+        /*sql*/ `DELETE FROM oauth_providers WHERE provider_key = 'integration:google'`,
+      );
+    } else {
+      // Rename google back to gmail — children first, then parent.
+      raw.exec(
+        /*sql*/ `UPDATE oauth_connections SET provider_key = 'integration:gmail' WHERE provider_key = 'integration:google'`,
+      );
+      raw.exec(
+        /*sql*/ `UPDATE oauth_apps SET provider_key = 'integration:gmail' WHERE provider_key = 'integration:google'`,
+      );
+      raw.exec(
+        /*sql*/ `UPDATE oauth_providers SET provider_key = 'integration:gmail' WHERE provider_key = 'integration:google'`,
+      );
+    }
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
 }

--- a/assistant/src/memory/migrations/174-rename-thread-starters-table.ts
+++ b/assistant/src/memory/migrations/174-rename-thread-starters-table.ts
@@ -1,4 +1,5 @@
-import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
 /**
@@ -49,5 +50,50 @@ export function migrateRenameThreadStartersTable(database: DrizzleDb): void {
         /*sql*/ `CREATE INDEX IF NOT EXISTS idx_conversation_starters_card_type ON conversation_starters(card_type, scope_id)`,
       );
     },
+  );
+}
+
+/**
+ * Reverse: rename conversation_starters back to thread_starters and recreate
+ * old index names.
+ *
+ * Idempotent — skips if the old table already exists or the new table is
+ * absent.
+ */
+export function migrateRenameThreadStartersTableDown(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  // Guard: new table must exist
+  const newTableExists = raw
+    .query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'conversation_starters'`,
+    )
+    .get();
+  if (!newTableExists) return;
+
+  // Guard: old table must not already exist
+  const oldTableExists = raw
+    .query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'thread_starters'`,
+    )
+    .get();
+  if (oldTableExists) return;
+
+  // Rename the table back
+  raw.exec(
+    /*sql*/ `ALTER TABLE conversation_starters RENAME TO thread_starters`,
+  );
+
+  // Drop new indexes and recreate with old names
+  raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_conversation_starters_batch`);
+  raw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_thread_starters_batch ON thread_starters(generation_batch, created_at)`,
+  );
+
+  raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_conversation_starters_card_type`);
+  raw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_thread_starters_card_type ON thread_starters(card_type, scope_id)`,
   );
 }

--- a/assistant/src/memory/migrations/176-drop-capability-card-state.ts
+++ b/assistant/src/memory/migrations/176-drop-capability-card-state.ts
@@ -34,3 +34,16 @@ export function migrateDropCapabilityCardState(database: DrizzleDb): void {
     raw.exec(/*sql*/ `DROP TABLE IF EXISTS capability_card_categories`);
   });
 }
+
+/**
+ * Reverse: no-op.
+ *
+ * The forward migration deleted rows (card-type conversation starters,
+ * generate_capability_cards jobs, capability_cards checkpoints) and dropped
+ * the capability_card_categories table. The deleted data cannot be restored
+ * — it was discarded as dead state after the capability card feature was
+ * removed.
+ */
+export function migrateDropCapabilityCardStateDown(_database: DrizzleDb): void {
+  // No-op — see comment above.
+}

--- a/assistant/src/memory/migrations/180-backfill-inline-attachments-to-disk.ts
+++ b/assistant/src/memory/migrations/180-backfill-inline-attachments-to-disk.ts
@@ -64,3 +64,19 @@ export function migrateBackfillInlineAttachmentsToDisk(
     },
   );
 }
+
+/**
+ * Reverse: no-op.
+ *
+ * The forward migration moved attachment data from inline base64 in the
+ * database to on-disk files and cleared the dataBase64 column. The original
+ * base64 data has been deleted from the DB, and re-reading it from disk
+ * back into the database would be unreliable (file paths may have changed,
+ * disk files may have been cleaned up). The on-disk files remain intact
+ * and functional.
+ */
+export function migrateBackfillInlineAttachmentsToDiskDown(
+  _database: DrizzleDb,
+): void {
+  // No-op — see comment above.
+}

--- a/assistant/src/memory/migrations/181-rename-thread-starters-checkpoints.ts
+++ b/assistant/src/memory/migrations/181-rename-thread-starters-checkpoints.ts
@@ -1,4 +1,5 @@
-import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
 /**
@@ -42,5 +43,31 @@ export function migrateRenameThreadStartersCheckpoints(
         /*sql*/ `UPDATE memory_checkpoints SET key = replace(key, 'thread_starters:', 'conversation_starters:') WHERE key LIKE 'thread_starters:%'`,
       );
     },
+  );
+}
+
+/**
+ * Reverse: rename checkpoint keys from "conversation_starters:" back to
+ * "thread_starters:" prefix.
+ *
+ * Mirrors the forward migration but in reverse. Handles collisions the same
+ * way — if an old-prefix key already exists, the new-prefix key is dropped.
+ */
+export function migrateRenameThreadStartersCheckpointsDown(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  // 1. Delete conversation_starters: keys where a corresponding
+  //    thread_starters: key already exists.
+  raw.exec(/*sql*/ `DELETE FROM memory_checkpoints
+     WHERE key LIKE 'conversation_starters:%'
+       AND replace(key, 'conversation_starters:', 'thread_starters:') IN (
+         SELECT key FROM memory_checkpoints WHERE key LIKE 'thread_starters:%'
+       )`);
+
+  // 2. Rename remaining keys back to the old prefix.
+  raw.exec(
+    /*sql*/ `UPDATE memory_checkpoints SET key = replace(key, 'conversation_starters:', 'thread_starters:') WHERE key LIKE 'conversation_starters:%'`,
   );
 }

--- a/assistant/src/memory/migrations/191-backfill-audio-attachment-mime-types.ts
+++ b/assistant/src/memory/migrations/191-backfill-audio-attachment-mime-types.ts
@@ -49,3 +49,16 @@ export function migrateBackfillAudioAttachmentMimeTypes(
     },
   );
 }
+
+/**
+ * Reverse: no-op.
+ *
+ * The forward migration corrected incorrect MIME types (application/octet-stream)
+ * to their proper audio/* values. Restoring the wrong MIME types would break
+ * audio playback and file handling. The corrected values are the desired state.
+ */
+export function migrateBackfillAudioAttachmentMimeTypesDown(
+  _database: DrizzleDb,
+): void {
+  // No-op — see comment above.
+}

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -1,4 +1,18 @@
 import type { DrizzleDb } from "../db-connection.js";
+import { migrateDropAccountsTableDown } from "./145-drop-accounts-table.js";
+import { migrateRemindersToSchedulesDown } from "./147-migrate-reminders-to-schedules.js";
+import { migrateDropRemindersTableDown } from "./148-drop-reminders-table.js";
+import { migrateOAuthAppsClientSecretPathDown } from "./150-oauth-apps-client-secret-path.js";
+import {
+  migrateGuardianTimestampsEpochMsDown,
+  migrateGuardianTimestampsRebuildDown,
+} from "./162-guardian-timestamps-epoch-ms.js";
+import { migrateRenameGmailProviderKeyToGoogleDown } from "./169-rename-gmail-provider-key-to-google.js";
+import { migrateRenameThreadStartersTableDown } from "./174-rename-thread-starters-table.js";
+import { migrateDropCapabilityCardStateDown } from "./176-drop-capability-card-state.js";
+import { migrateBackfillInlineAttachmentsToDiskDown } from "./180-backfill-inline-attachments-to-disk.js";
+import { migrateRenameThreadStartersCheckpointsDown } from "./181-rename-thread-starters-checkpoints.js";
+import { migrateBackfillAudioAttachmentMimeTypesDown } from "./191-backfill-audio-attachment-mime-types.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -180,12 +194,14 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     version: 25,
     description:
       "Drop the unused legacy accounts table and its leftover indexes after account_manage removal",
+    down: migrateDropAccountsTableDown,
   },
   {
     key: "migration_reminders_to_schedules_v1",
     version: 26,
     description:
       "Copy all existing reminders into cron_jobs as one-shot schedules with correct status and field mapping",
+    down: migrateRemindersToSchedulesDown,
   },
   {
     key: "migration_drop_reminders_table_v1",
@@ -193,18 +209,21 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     dependsOn: ["migration_reminders_to_schedules_v1"],
     description:
       "Drop the legacy reminders table and its index after data migration to cron_jobs",
+    down: migrateDropRemindersTableDown,
   },
   {
     key: "migration_oauth_apps_client_secret_path_v1",
     version: 28,
     description:
       "Add client_secret_credential_path column to oauth_apps and backfill existing rows with convention-based paths",
+    down: migrateOAuthAppsClientSecretPathDown,
   },
   {
     key: "migration_guardian_timestamps_epoch_ms_v1",
     version: 29,
     description:
       "Convert guardian table timestamps from ISO 8601 text to epoch ms integers for consistency with all other tables",
+    down: migrateGuardianTimestampsEpochMsDown,
   },
   {
     key: "migration_guardian_timestamps_rebuild_v1",
@@ -212,18 +231,21 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     dependsOn: ["migration_guardian_timestamps_epoch_ms_v1"],
     description:
       "Rebuild guardian tables so timestamp columns have INTEGER affinity instead of TEXT",
+    down: migrateGuardianTimestampsRebuildDown,
   },
   {
     key: "migration_rename_gmail_provider_key_to_google_v1",
     version: 31,
     description:
       "Rename integration:gmail provider key to integration:google across oauth_providers, oauth_apps, and oauth_connections",
+    down: migrateRenameGmailProviderKeyToGoogleDown,
   },
   {
     key: "migration_rename_thread_starters_table_v1",
     version: 32,
     description:
       "Rename thread_starters table to conversation_starters and recreate indexes with new names",
+    down: migrateRenameThreadStartersTableDown,
   },
   {
     key: "migration_drop_capability_card_state_v1",
@@ -231,12 +253,14 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     dependsOn: ["migration_rename_thread_starters_table_v1"],
     description:
       "Remove deleted capability-card rows, jobs, checkpoints, and category state",
+    down: migrateDropCapabilityCardStateDown,
   },
   {
     key: "migration_backfill_inline_attachments_v1",
     version: 34,
     description:
       "Backfill existing inline base64 attachments to on-disk storage and clear dataBase64",
+    down: migrateBackfillInlineAttachmentsToDiskDown,
   },
   {
     key: "migration_rename_thread_starters_checkpoints_v1",
@@ -244,12 +268,14 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     dependsOn: ["migration_rename_thread_starters_table_v1"],
     description:
       "Rename checkpoint keys from thread_starters: to conversation_starters: prefix so renamed code paths find existing generation state",
+    down: migrateRenameThreadStartersCheckpointsDown,
   },
   {
     key: "migration_backfill_audio_attachment_mime_types_v1",
     version: 36,
     description:
       "Backfill correct MIME types for audio attachments stored as application/octet-stream due to missing extension map entries",
+    down: migrateBackfillAudioAttachmentMimeTypesDown,
   },
 ];
 


### PR DESCRIPTION
## Summary
- Add down() rollback functions to memory migration registry entries versions 25 through 36
- Lossy operations (table drops, data backfills) have documented no-op down() functions

Part of plan: migration-down-functions.md (PR 10 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
