### PR TITLE
fix: disable upgrade button when pickerReleases is empty (prevent bypass of forward-only filter)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -316,7 +316,7 @@ struct AssistantUpgradeSection: View {
                     ) {
                         showingUpgradeConfirmation = true
                     }
-                    .disabled(!upgradeAvailable || isUpgrading)
+                    .disabled(!upgradeAvailable || isUpgrading || pickerReleases.isEmpty)
                 }
 
                 if topology != .local && topology != .remote {


### PR DESCRIPTION
## Summary
- Adds `pickerReleases.isEmpty` to the upgrade button's disabled condition
- Prevents a bug where users on a prerelease build newer than all stable releases could still trigger a downgrade via the button, even though the version picker was empty
- Addresses review feedback from Codex and Devin on PR #20662

## Original prompt
fix: disable upgrade button when pickerReleases is empty (prevent bypass of forward-only filter)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
