### PR TITLE
feat: add migration down() rollback functions to both migration systems

### DIFF
--- a/assistant/src/__tests__/db-migration-rollback.test.ts
+++ b/assistant/src/__tests__/db-migration-rollback.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { Database } from "bun:sqlite";
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
@@ -21,7 +21,9 @@ import {
   migrateMemoryEntityRelationDedup,
   migrateMemoryItemsFingerprintScopeUnique,
   MIGRATION_REGISTRY,
+  type MigrationRegistryEntry,
   type MigrationValidationResult,
+  rollbackMemoryMigration,
   validateMigrationState,
 } from "../memory/migrations/index.js";
 import * as schema from "../memory/schema.js";
@@ -875,5 +877,351 @@ describe("schema-drift recovery: migration handles unexpected schema state", () 
       }
     ).c;
     expect(countAfter2).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. rollbackMemoryMigration
+// ---------------------------------------------------------------------------
+
+describe("rollbackMemoryMigration", () => {
+  // Track test entries pushed onto MIGRATION_REGISTRY so we can restore after
+  // each test. This avoids polluting the real registry across test runs.
+  let registrySnapshot: MigrationRegistryEntry[];
+
+  function saveRegistry() {
+    registrySnapshot = [...MIGRATION_REGISTRY];
+  }
+
+  function restoreRegistry() {
+    MIGRATION_REGISTRY.length = 0;
+    MIGRATION_REGISTRY.push(...registrySnapshot);
+  }
+
+  afterEach(() => {
+    restoreRegistry();
+  });
+
+  test("rolls back checkpoint-tracked migrations in reverse version order", () => {
+    saveRegistry();
+
+    const db = createTestDb();
+    const raw = getRaw(db);
+    bootstrapCheckpointsTable(raw);
+
+    // Track execution order of down() calls.
+    const downCalls: string[] = [];
+
+    const now = Date.now();
+
+    // Use very high version numbers to avoid colliding with real registry entries.
+    const testEntries: MigrationRegistryEntry[] = [
+      {
+        key: "test_rollback_v1000",
+        version: 1000,
+        description: "test migration v1000",
+        down: () => {
+          downCalls.push("test_rollback_v1000");
+        },
+      },
+      {
+        key: "test_rollback_v1001",
+        version: 1001,
+        description: "test migration v1001",
+        down: () => {
+          downCalls.push("test_rollback_v1001");
+        },
+      },
+      {
+        key: "test_rollback_v1002",
+        version: 1002,
+        description: "test migration v1002",
+        down: () => {
+          downCalls.push("test_rollback_v1002");
+        },
+      },
+    ];
+
+    MIGRATION_REGISTRY.push(...testEntries);
+
+    // Simulate all three migrations as completed.
+    for (const entry of testEntries) {
+      raw.exec(
+        `INSERT INTO memory_checkpoints (key, value, updated_at) VALUES ('${entry.key}', '1', ${now})`,
+      );
+    }
+
+    // Roll back to version 1000 — should roll back v1002 and v1001 (version > 1000).
+    const rolledBack = rollbackMemoryMigration(db, 1000);
+
+    // Verify returned keys.
+    expect(rolledBack).toEqual(["test_rollback_v1002", "test_rollback_v1001"]);
+
+    // Verify down() was called in reverse version order.
+    expect(downCalls).toEqual(["test_rollback_v1002", "test_rollback_v1001"]);
+
+    // Checkpoints for rolled-back migrations should be deleted.
+    const cp1001 = raw
+      .query(
+        `SELECT 1 FROM memory_checkpoints WHERE key = 'test_rollback_v1001'`,
+      )
+      .get();
+    expect(cp1001).toBeNull();
+
+    const cp1002 = raw
+      .query(
+        `SELECT 1 FROM memory_checkpoints WHERE key = 'test_rollback_v1002'`,
+      )
+      .get();
+    expect(cp1002).toBeNull();
+
+    // Checkpoint for the migration at target version should still exist.
+    const cp1000 = raw
+      .query(
+        `SELECT value FROM memory_checkpoints WHERE key = 'test_rollback_v1000'`,
+      )
+      .get() as { value: string } | null;
+    expect(cp1000).toBeTruthy();
+    expect(cp1000!.value).toBe("1");
+  });
+
+  test("throws when migration has no down function", () => {
+    saveRegistry();
+
+    const db = createTestDb();
+    const raw = getRaw(db);
+    bootstrapCheckpointsTable(raw);
+
+    const now = Date.now();
+
+    // Register an entry WITHOUT a down function.
+    MIGRATION_REGISTRY.push({
+      key: "test_no_down_v2000",
+      version: 2000,
+      description: "test migration without down()",
+      // no down() defined
+    });
+
+    // Mark it as completed.
+    raw.exec(
+      `INSERT INTO memory_checkpoints (key, value, updated_at) VALUES ('test_no_down_v2000', '1', ${now})`,
+    );
+
+    // Attempting to roll back should throw a descriptive error.
+    expect(() => rollbackMemoryMigration(db, 1999)).toThrow(
+      'Cannot roll back migration "test_no_down_v2000"',
+    );
+    expect(() => rollbackMemoryMigration(db, 1999)).toThrow(
+      "no down() function defined",
+    );
+  });
+
+  test("handles transaction failure in down() — rolls back and preserves checkpoint", () => {
+    saveRegistry();
+
+    const db = createTestDb();
+    const raw = getRaw(db);
+    bootstrapCheckpointsTable(raw);
+
+    const now = Date.now();
+
+    // Create a table that the down() function will try to modify.
+    raw.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS test_rollback_data (
+        id TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      )
+    `);
+    raw.exec(
+      `INSERT INTO test_rollback_data (id, value) VALUES ('row-1', 'original')`,
+    );
+
+    // Register a migration whose down() modifies test_rollback_data,
+    // but a trigger will force the modification to fail.
+    MIGRATION_REGISTRY.push({
+      key: "test_fail_down_v3000",
+      version: 3000,
+      description: "test migration with failing down()",
+      down: (database) => {
+        const sqlite = getSqliteFrom(database);
+        // This UPDATE will trigger our failure trigger.
+        sqlite.exec(
+          `UPDATE test_rollback_data SET value = 'rolled-back' WHERE id = 'row-1'`,
+        );
+      },
+    });
+
+    // Mark as completed.
+    raw.exec(
+      `INSERT INTO memory_checkpoints (key, value, updated_at) VALUES ('test_fail_down_v3000', '1', ${now})`,
+    );
+
+    // Install a trigger to force the down() function to fail.
+    raw.exec(/*sql*/ `
+      CREATE TRIGGER fail_on_update_test_rollback AFTER UPDATE ON test_rollback_data
+      BEGIN
+        SELECT RAISE(ABORT, 'simulated down() failure');
+      END
+    `);
+
+    // Rollback should throw because down() fails.
+    let threw = false;
+    try {
+      rollbackMemoryMigration(db, 2999);
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+
+    // Remove the trigger for inspection.
+    raw.exec(`DROP TRIGGER IF EXISTS fail_on_update_test_rollback`);
+
+    // The checkpoint should still exist (the transaction was rolled back,
+    // so the DELETE FROM memory_checkpoints inside the transaction was undone).
+    // However the checkpoint value was changed to 'rolling_back' BEFORE the
+    // transaction started (outside the BEGIN/COMMIT).
+    const cp = raw
+      .query(
+        `SELECT value FROM memory_checkpoints WHERE key = 'test_fail_down_v3000'`,
+      )
+      .get() as { value: string } | null;
+    expect(cp).toBeTruthy();
+    // The checkpoint is preserved (value = 'rolling_back' because the pre-txn
+    // update succeeded but the txn rolled back, leaving checkpoint intact).
+    expect(cp!.value).toBe("rolling_back");
+
+    // The data should be unchanged — the UPDATE inside down() was rolled back.
+    const row = raw
+      .query(`SELECT value FROM test_rollback_data WHERE id = 'row-1'`)
+      .get() as { value: string } | null;
+    expect(row).toBeTruthy();
+    expect(row!.value).toBe("original");
+  });
+
+  test("no-op when already at target version", () => {
+    saveRegistry();
+
+    const db = createTestDb();
+    const raw = getRaw(db);
+    bootstrapCheckpointsTable(raw);
+
+    const now = Date.now();
+
+    // Register entries with down functions — they should NOT be called.
+    const downCalls: string[] = [];
+
+    MIGRATION_REGISTRY.push(
+      {
+        key: "test_noop_v4000",
+        version: 4000,
+        description: "test noop v4000",
+        down: () => {
+          downCalls.push("test_noop_v4000");
+        },
+      },
+      {
+        key: "test_noop_v4001",
+        version: 4001,
+        description: "test noop v4001",
+        down: () => {
+          downCalls.push("test_noop_v4001");
+        },
+      },
+    );
+
+    // Mark both as completed.
+    raw.exec(
+      `INSERT INTO memory_checkpoints (key, value, updated_at) VALUES ('test_noop_v4000', '1', ${now})`,
+    );
+    raw.exec(
+      `INSERT INTO memory_checkpoints (key, value, updated_at) VALUES ('test_noop_v4001', '1', ${now})`,
+    );
+
+    // Roll back to version >= latest applied migration — should be a no-op.
+    const rolledBack = rollbackMemoryMigration(db, 4001);
+
+    expect(rolledBack).toEqual([]);
+    expect(downCalls).toEqual([]);
+
+    // Both checkpoints should remain.
+    const cp4000 = raw
+      .query(
+        `SELECT value FROM memory_checkpoints WHERE key = 'test_noop_v4000'`,
+      )
+      .get() as { value: string } | null;
+    const cp4001 = raw
+      .query(
+        `SELECT value FROM memory_checkpoints WHERE key = 'test_noop_v4001'`,
+      )
+      .get() as { value: string } | null;
+    expect(cp4000!.value).toBe("1");
+    expect(cp4001!.value).toBe("1");
+
+    // Also verify with a target version greater than the latest.
+    const rolledBack2 = rollbackMemoryMigration(db, 9999);
+    expect(rolledBack2).toEqual([]);
+    expect(downCalls).toEqual([]);
+  });
+
+  test("respects dependency ordering on rollback (children rolled back before parents)", () => {
+    saveRegistry();
+
+    const db = createTestDb();
+    const raw = getRaw(db);
+    bootstrapCheckpointsTable(raw);
+
+    const now = Date.now();
+    const downCalls: string[] = [];
+
+    // Parent migration at version 5000 — has a down().
+    // Child migration at version 5001 — depends on parent, has a down().
+    // Since the child has a higher version number, rolling back in reverse
+    // version order means the child (v5001) is rolled back BEFORE the parent
+    // (v5000), which is the correct dependency-safe ordering.
+    MIGRATION_REGISTRY.push(
+      {
+        key: "test_parent_v5000",
+        version: 5000,
+        description: "test parent migration",
+        down: () => {
+          downCalls.push("test_parent_v5000");
+        },
+      },
+      {
+        key: "test_child_v5001",
+        version: 5001,
+        dependsOn: ["test_parent_v5000"],
+        description: "test child migration depending on parent",
+        down: () => {
+          downCalls.push("test_child_v5001");
+        },
+      },
+    );
+
+    // Both are completed.
+    raw.exec(
+      `INSERT INTO memory_checkpoints (key, value, updated_at) VALUES ('test_parent_v5000', '1', ${now})`,
+    );
+    raw.exec(
+      `INSERT INTO memory_checkpoints (key, value, updated_at) VALUES ('test_child_v5001', '1', ${now})`,
+    );
+
+    // Roll back to version 4999 — both should be rolled back, child first.
+    const rolledBack = rollbackMemoryMigration(db, 4999);
+
+    expect(rolledBack).toEqual(["test_child_v5001", "test_parent_v5000"]);
+
+    // Verify down() execution order: child before parent.
+    expect(downCalls).toEqual(["test_child_v5001", "test_parent_v5000"]);
+
+    // Both checkpoints should be deleted.
+    const cpParent = raw
+      .query(`SELECT 1 FROM memory_checkpoints WHERE key = 'test_parent_v5000'`)
+      .get();
+    const cpChild = raw
+      .query(`SELECT 1 FROM memory_checkpoints WHERE key = 'test_child_v5001'`)
+      .get();
+    expect(cpParent).toBeNull();
+    expect(cpChild).toBeNull();
   });
 });

--- a/assistant/src/__tests__/db-migration-rollback.test.ts
+++ b/assistant/src/__tests__/db-migration-rollback.test.ts
@@ -10,16 +10,56 @@
  *     migration system detects and handles it gracefully.
  */
 
+import { createHash } from "node:crypto";
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, test } from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { getSqliteFrom } from "../memory/db-connection.js";
+import { downJobDeferrals } from "../memory/migrations/001-job-deferrals.js";
+import { downMemoryEntityRelationDedup } from "../memory/migrations/004-entity-relation-dedup.js";
+import { downMemoryItemsFingerprintScopeUnique } from "../memory/migrations/005-fingerprint-scope-unique.js";
+import { downMemoryItemsScopeSaltedFingerprints } from "../memory/migrations/006-scope-salted-fingerprints.js";
+import { downAssistantIdToSelf } from "../memory/migrations/007-assistant-id-to-self.js";
+import { downRemoveAssistantIdColumns } from "../memory/migrations/008-remove-assistant-id-columns.js";
+import { downLlmUsageEventsDropAssistantId } from "../memory/migrations/009-llm-usage-events-drop-assistant-id.js";
+import { downBackfillInboxThreadState } from "../memory/migrations/014-backfill-inbox-thread-state.js";
+import { downDropActiveSearchIndex } from "../memory/migrations/015-drop-active-search-index.js";
+import { downNotificationTablesSchema } from "../memory/migrations/019-notification-tables-schema-migration.js";
+import { downRenameChannelToVellum } from "../memory/migrations/020-rename-macos-ios-channel-to-vellum.js";
+import { downEmbeddingVectorBlob } from "../memory/migrations/024-embedding-vector-blob.js";
+import { downEmbeddingsNullableVectorJson } from "../memory/migrations/026a-embeddings-nullable-vector-json.js";
+import { downNormalizePhoneIdentities } from "../memory/migrations/036-normalize-phone-identities.js";
+import { downBackfillGuardianPrincipalId } from "../memory/migrations/126-backfill-guardian-principal-id.js";
+import { downGuardianPrincipalIdNotNull } from "../memory/migrations/127-guardian-principal-id-not-null.js";
+import { downContactsNotesColumn } from "../memory/migrations/134-contacts-notes-column.js";
+import { downBackfillContactInteractionStats } from "../memory/migrations/135-backfill-contact-interaction-stats.js";
+import { downDropAssistantIdColumns } from "../memory/migrations/136-drop-assistant-id-columns.js";
+import { downBackfillUsageCacheAccounting } from "../memory/migrations/140-backfill-usage-cache-accounting.js";
+import { downRenameVerificationTable } from "../memory/migrations/141-rename-verification-table.js";
+import { downRenameVerificationSessionIdColumn } from "../memory/migrations/142-rename-verification-session-id-column.js";
+import { downRenameGuardianVerificationValues } from "../memory/migrations/143-rename-guardian-verification-values.js";
+import { downRenameVoiceToPhone } from "../memory/migrations/144-rename-voice-to-phone.js";
+import { migrateDropAccountsTableDown } from "../memory/migrations/145-drop-accounts-table.js";
+import { migrateRemindersToSchedulesDown } from "../memory/migrations/147-migrate-reminders-to-schedules.js";
+import { migrateDropRemindersTableDown } from "../memory/migrations/148-drop-reminders-table.js";
+import { migrateOAuthAppsClientSecretPathDown } from "../memory/migrations/150-oauth-apps-client-secret-path.js";
+import {
+  migrateGuardianTimestampsEpochMsDown,
+  migrateGuardianTimestampsRebuildDown,
+} from "../memory/migrations/162-guardian-timestamps-epoch-ms.js";
+import { migrateRenameGmailProviderKeyToGoogleDown } from "../memory/migrations/169-rename-gmail-provider-key-to-google.js";
+import { migrateRenameThreadStartersTableDown } from "../memory/migrations/174-rename-thread-starters-table.js";
+import { migrateDropCapabilityCardStateDown } from "../memory/migrations/176-drop-capability-card-state.js";
+import { migrateBackfillInlineAttachmentsToDiskDown } from "../memory/migrations/180-backfill-inline-attachments-to-disk.js";
+import { migrateRenameThreadStartersCheckpointsDown } from "../memory/migrations/181-rename-thread-starters-checkpoints.js";
+import { migrateBackfillAudioAttachmentMimeTypesDown } from "../memory/migrations/191-backfill-audio-attachment-mime-types.js";
 import {
   migrateJobDeferrals,
   migrateMemoryEntityRelationDedup,
   migrateMemoryItemsFingerprintScopeUnique,
+  migrateMemoryItemsScopeSaltedFingerprints,
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,
   type MigrationValidationResult,
@@ -1223,5 +1263,1602 @@ describe("rollbackMemoryMigration", () => {
       .get();
     expect(cpParent).toBeNull();
     expect(cpChild).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Memory migration down() functions
+// ---------------------------------------------------------------------------
+
+describe("memory migration down() functions", () => {
+  // ── v1: downJobDeferrals ─────────────────────────────────────────────
+
+  describe("v1: downJobDeferrals", () => {
+    test("round-trip: forward + down restores original state", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      bootstrapCheckpointsTable(raw);
+      bootstrapMemoryJobsTable(raw);
+
+      const now = Date.now();
+      raw.exec(`
+        INSERT INTO memory_jobs (id, type, payload, status, attempts, deferrals, run_after, last_error, created_at, updated_at)
+        VALUES ('job-rt', 'embed_segment', '{}', 'pending', 3, 0, ${now}, NULL, ${now}, ${now})
+      `);
+
+      // Snapshot pre-migration state.
+      const before = raw
+        .query(
+          `SELECT attempts, deferrals FROM memory_jobs WHERE id = 'job-rt'`,
+        )
+        .get() as { attempts: number; deferrals: number };
+      expect(before.attempts).toBe(3);
+      expect(before.deferrals).toBe(0);
+
+      // Forward migration: moves attempts -> deferrals.
+      migrateJobDeferrals(db);
+
+      const afterForward = raw
+        .query(
+          `SELECT attempts, deferrals FROM memory_jobs WHERE id = 'job-rt'`,
+        )
+        .get() as { attempts: number; deferrals: number };
+      expect(afterForward.attempts).toBe(0);
+      expect(afterForward.deferrals).toBe(3);
+
+      // Down: moves deferrals -> attempts.
+      downJobDeferrals(db);
+
+      const afterDown = raw
+        .query(
+          `SELECT attempts, deferrals FROM memory_jobs WHERE id = 'job-rt'`,
+        )
+        .get() as { attempts: number; deferrals: number };
+      expect(afterDown.attempts).toBe(3);
+      expect(afterDown.deferrals).toBe(0);
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      bootstrapCheckpointsTable(raw);
+      bootstrapMemoryJobsTable(raw);
+
+      const now = Date.now();
+      raw.exec(`
+        INSERT INTO memory_jobs (id, type, payload, status, attempts, deferrals, run_after, last_error, created_at, updated_at)
+        VALUES ('job-idem2', 'embed_item', '{}', 'pending', 0, 5, ${now}, NULL, ${now}, ${now})
+      `);
+
+      downJobDeferrals(db);
+      const after1 = raw
+        .query(
+          `SELECT attempts, deferrals FROM memory_jobs WHERE id = 'job-idem2'`,
+        )
+        .get() as { attempts: number; deferrals: number };
+
+      // Second call — should be a no-op (deferrals already 0).
+      downJobDeferrals(db);
+      const after2 = raw
+        .query(
+          `SELECT attempts, deferrals FROM memory_jobs WHERE id = 'job-idem2'`,
+        )
+        .get() as { attempts: number; deferrals: number };
+
+      expect(after1.attempts).toBe(5);
+      expect(after1.deferrals).toBe(0);
+      expect(after2.attempts).toBe(after1.attempts);
+      expect(after2.deferrals).toBe(after1.deferrals);
+    });
+  });
+
+  // ── v2: downMemoryEntityRelationDedup (no-op) ────────────────────────
+
+  describe("v2: downMemoryEntityRelationDedup (no-op)", () => {
+    test("does not throw and does not modify data", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      bootstrapEntityRelationsTable(raw);
+
+      const now = Date.now();
+      raw.exec(
+        `INSERT INTO memory_entity_relations VALUES ('r1', 'e1', 'e2', 'knows', 'ev', ${now}, ${now})`,
+      );
+
+      const countBefore = (
+        raw
+          .query(`SELECT COUNT(*) AS c FROM memory_entity_relations`)
+          .get() as { c: number }
+      ).c;
+
+      downMemoryEntityRelationDedup(db);
+
+      const countAfter = (
+        raw
+          .query(`SELECT COUNT(*) AS c FROM memory_entity_relations`)
+          .get() as { c: number }
+      ).c;
+      expect(countAfter).toBe(countBefore);
+    });
+
+    test("idempotency: calling twice does not throw", () => {
+      const db = createTestDb();
+      downMemoryEntityRelationDedup(db);
+      downMemoryEntityRelationDedup(db);
+    });
+  });
+
+  // ── v3: downMemoryItemsFingerprintScopeUnique ────────────────────────
+
+  describe("v3: downMemoryItemsFingerprintScopeUnique", () => {
+    test("round-trip: forward + down restores column-level UNIQUE", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      bootstrapCheckpointsTable(raw);
+      bootstrapOldMemoryItemsTable(raw);
+
+      const now = Date.now();
+      raw.exec(`
+        INSERT INTO memory_items (id, kind, subject, statement, status, confidence, fingerprint,
+                                   first_seen_at, last_seen_at, scope_id)
+        VALUES ('item-rt', 'fact', 'User', 'likes coffee', 'active', 0.9, 'fp-rt1', ${now}, ${now}, 'default')
+      `);
+
+      // Old schema has UNIQUE on fingerprint.
+      const ddlBefore =
+        (
+          raw
+            .query(
+              `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'memory_items'`,
+            )
+            .get() as { sql: string }
+        )?.sql ?? "";
+      expect(ddlBefore).toMatch(/fingerprint\s+TEXT\s+NOT\s+NULL\s+UNIQUE/i);
+
+      // Forward migration: remove column-level UNIQUE.
+      migrateMemoryItemsFingerprintScopeUnique(db);
+
+      const ddlAfterForward =
+        (
+          raw
+            .query(
+              `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'memory_items'`,
+            )
+            .get() as { sql: string }
+        )?.sql ?? "";
+      expect(ddlAfterForward).not.toMatch(
+        /fingerprint\s+TEXT\s+NOT\s+NULL\s+UNIQUE/i,
+      );
+
+      // Down: restore column-level UNIQUE.
+      downMemoryItemsFingerprintScopeUnique(db);
+
+      const ddlAfterDown =
+        (
+          raw
+            .query(
+              `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'memory_items'`,
+            )
+            .get() as { sql: string }
+        )?.sql ?? "";
+      expect(ddlAfterDown).toMatch(/fingerprint\s+TEXT\s+NOT\s+NULL\s+UNIQUE/i);
+
+      // Data preserved.
+      const item = raw
+        .query(`SELECT id FROM memory_items WHERE id = 'item-rt'`)
+        .get();
+      expect(item).toBeTruthy();
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      bootstrapCheckpointsTable(raw);
+      bootstrapOldMemoryItemsTable(raw);
+
+      migrateMemoryItemsFingerprintScopeUnique(db);
+      downMemoryItemsFingerprintScopeUnique(db);
+      // Second call — column-level UNIQUE already restored.
+      downMemoryItemsFingerprintScopeUnique(db);
+
+      const ddl =
+        (
+          raw
+            .query(
+              `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'memory_items'`,
+            )
+            .get() as { sql: string }
+        )?.sql ?? "";
+      expect(ddl).toMatch(/fingerprint\s+TEXT\s+NOT\s+NULL\s+UNIQUE/i);
+    });
+  });
+
+  // ── v4: downMemoryItemsScopeSaltedFingerprints ───────────────────────
+
+  describe("v4: downMemoryItemsScopeSaltedFingerprints", () => {
+    test("round-trip: forward + down restores unsalted fingerprints", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      bootstrapCheckpointsTable(raw);
+
+      // Use modern schema (no column-level UNIQUE).
+      raw.exec(/*sql*/ `
+        CREATE TABLE IF NOT EXISTS memory_items (
+          id TEXT PRIMARY KEY,
+          kind TEXT NOT NULL,
+          subject TEXT NOT NULL,
+          statement TEXT NOT NULL,
+          status TEXT NOT NULL,
+          confidence REAL NOT NULL,
+          fingerprint TEXT NOT NULL,
+          first_seen_at INTEGER NOT NULL,
+          last_seen_at INTEGER NOT NULL,
+          last_used_at INTEGER,
+          scope_id TEXT NOT NULL DEFAULT 'default'
+        )
+      `);
+
+      // Compute the old (unsalted) fingerprint.
+      const kind = "fact";
+      const subject = "User";
+      const statement = "likes coffee";
+      const oldNormalized = `${kind}|${subject.toLowerCase()}|${statement.toLowerCase()}`;
+      const oldFingerprint = createHash("sha256")
+        .update(oldNormalized)
+        .digest("hex");
+
+      const now = Date.now();
+      raw.exec(`
+        INSERT INTO memory_items (id, kind, subject, statement, status, confidence, fingerprint,
+                                   first_seen_at, last_seen_at, scope_id)
+        VALUES ('item-salt', '${kind}', '${subject}', '${statement}', 'active', 0.9, '${oldFingerprint}', ${now}, ${now}, 'default')
+      `);
+
+      // Write fingerprint_scope_unique checkpoint so forward migration runs.
+      raw.exec(
+        `INSERT INTO memory_checkpoints (key, value, updated_at) VALUES ('migration_memory_items_fingerprint_scope_unique_v1', '1', ${now})`,
+      );
+
+      // Forward migration: recompute with scope_id prefix.
+      migrateMemoryItemsScopeSaltedFingerprints(db);
+
+      const afterForward = raw
+        .query(`SELECT fingerprint FROM memory_items WHERE id = 'item-salt'`)
+        .get() as { fingerprint: string };
+      expect(afterForward.fingerprint).not.toBe(oldFingerprint);
+
+      // Down: recompute WITHOUT scope_id prefix (old format).
+      downMemoryItemsScopeSaltedFingerprints(db);
+
+      const afterDown = raw
+        .query(`SELECT fingerprint FROM memory_items WHERE id = 'item-salt'`)
+        .get() as { fingerprint: string };
+      expect(afterDown.fingerprint).toBe(oldFingerprint);
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      raw.exec(/*sql*/ `
+        CREATE TABLE IF NOT EXISTS memory_items (
+          id TEXT PRIMARY KEY,
+          kind TEXT NOT NULL,
+          subject TEXT NOT NULL,
+          statement TEXT NOT NULL,
+          status TEXT NOT NULL,
+          confidence REAL NOT NULL,
+          fingerprint TEXT NOT NULL,
+          first_seen_at INTEGER NOT NULL,
+          last_seen_at INTEGER NOT NULL,
+          scope_id TEXT NOT NULL DEFAULT 'default'
+        )
+      `);
+
+      const now = Date.now();
+      raw.exec(`
+        INSERT INTO memory_items (id, kind, subject, statement, status, confidence, fingerprint,
+                                   first_seen_at, last_seen_at, scope_id)
+        VALUES ('item-idem', 'fact', 'User', 'likes tea', 'active', 0.8, 'some-fp', ${now}, ${now}, 'default')
+      `);
+
+      downMemoryItemsScopeSaltedFingerprints(db);
+      const fp1 = (
+        raw
+          .query(`SELECT fingerprint FROM memory_items WHERE id = 'item-idem'`)
+          .get() as { fingerprint: string }
+      ).fingerprint;
+
+      downMemoryItemsScopeSaltedFingerprints(db);
+      const fp2 = (
+        raw
+          .query(`SELECT fingerprint FROM memory_items WHERE id = 'item-idem'`)
+          .get() as { fingerprint: string }
+      ).fingerprint;
+
+      expect(fp1).toBe(fp2);
+    });
+  });
+
+  // ── No-op down functions (v5, v7/assistant-id-to-self, v8, v10, v14, v17, v18/contacts-notes, v20, v26, v33, v34, v36) ──
+
+  describe("no-op down() functions", () => {
+    const noOpFunctions = [
+      { name: "v5: downAssistantIdToSelf", fn: downAssistantIdToSelf },
+      {
+        name: "v8: downBackfillInboxThreadState",
+        fn: downBackfillInboxThreadState,
+      },
+      {
+        name: "v10: downNotificationTablesSchema",
+        fn: downNotificationTablesSchema,
+      },
+      {
+        name: "v14: downNormalizePhoneIdentities",
+        fn: downNormalizePhoneIdentities,
+      },
+      { name: "v17: downContactsNotesColumn", fn: downContactsNotesColumn },
+      {
+        name: "v20: downBackfillUsageCacheAccounting",
+        fn: downBackfillUsageCacheAccounting,
+      },
+      {
+        name: "v26: migrateRemindersToSchedulesDown",
+        fn: migrateRemindersToSchedulesDown,
+      },
+      {
+        name: "v33: migrateDropCapabilityCardStateDown",
+        fn: migrateDropCapabilityCardStateDown,
+      },
+      {
+        name: "v34: migrateBackfillInlineAttachmentsToDiskDown",
+        fn: migrateBackfillInlineAttachmentsToDiskDown,
+      },
+      {
+        name: "v36: migrateBackfillAudioAttachmentMimeTypesDown",
+        fn: migrateBackfillAudioAttachmentMimeTypesDown,
+      },
+    ];
+
+    for (const { name, fn } of noOpFunctions) {
+      test(`${name}: does not throw`, () => {
+        const db = createTestDb();
+        expect(() => fn(db)).not.toThrow();
+      });
+
+      test(`${name}: idempotency — calling twice does not throw`, () => {
+        const db = createTestDb();
+        fn(db);
+        fn(db);
+      });
+    }
+  });
+
+  // ── v6: downRemoveAssistantIdColumns (re-add via ALTER TABLE) ────────
+
+  describe("v6: downRemoveAssistantIdColumns", () => {
+    test("adds assistant_id column back to tables that lack it", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      // Create tables WITHOUT assistant_id (post-forward-migration state).
+      raw.exec(/*sql*/ `
+        CREATE TABLE conversations (id TEXT PRIMARY KEY, created_at INTEGER NOT NULL);
+        CREATE TABLE conversation_keys (id TEXT PRIMARY KEY, conversation_key TEXT NOT NULL UNIQUE, conversation_id TEXT NOT NULL, created_at INTEGER NOT NULL);
+        CREATE TABLE attachments (id TEXT PRIMARY KEY, original_filename TEXT NOT NULL, mime_type TEXT NOT NULL, size_bytes INTEGER NOT NULL, kind TEXT NOT NULL, data_base64 TEXT NOT NULL, content_hash TEXT, thumbnail_base64 TEXT, created_at INTEGER NOT NULL);
+        CREATE TABLE channel_inbound_events (id TEXT PRIMARY KEY, source_channel TEXT NOT NULL, external_chat_id TEXT NOT NULL, external_message_id TEXT NOT NULL, conversation_id TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+        CREATE TABLE messages (id TEXT PRIMARY KEY, created_at INTEGER NOT NULL);
+        CREATE TABLE message_runs (id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'running', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+      `);
+
+      downRemoveAssistantIdColumns(db);
+
+      // Verify assistant_id column was added to the 4 affected tables.
+      for (const table of [
+        "conversation_keys",
+        "attachments",
+        "channel_inbound_events",
+        "message_runs",
+      ]) {
+        const col = raw
+          .query(
+            `SELECT 1 FROM pragma_table_info('${table}') WHERE name = 'assistant_id'`,
+          )
+          .get();
+        expect(col).toBeTruthy();
+      }
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      raw.exec(/*sql*/ `
+        CREATE TABLE conversations (id TEXT PRIMARY KEY, created_at INTEGER NOT NULL);
+        CREATE TABLE conversation_keys (id TEXT PRIMARY KEY, conversation_key TEXT NOT NULL, conversation_id TEXT NOT NULL, created_at INTEGER NOT NULL);
+        CREATE TABLE attachments (id TEXT PRIMARY KEY, original_filename TEXT NOT NULL, mime_type TEXT NOT NULL, size_bytes INTEGER NOT NULL, kind TEXT NOT NULL, data_base64 TEXT NOT NULL, content_hash TEXT, created_at INTEGER NOT NULL);
+        CREATE TABLE channel_inbound_events (id TEXT PRIMARY KEY, source_channel TEXT NOT NULL, external_chat_id TEXT NOT NULL, external_message_id TEXT NOT NULL, conversation_id TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+        CREATE TABLE message_runs (id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL, status TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+      `);
+
+      downRemoveAssistantIdColumns(db);
+      downRemoveAssistantIdColumns(db);
+    });
+  });
+
+  // ── v7: downLlmUsageEventsDropAssistantId (re-add via ALTER TABLE) ──
+
+  describe("v7: downLlmUsageEventsDropAssistantId", () => {
+    test("adds assistant_id column back to llm_usage_events", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      raw.exec(/*sql*/ `
+        CREATE TABLE llm_usage_events (
+          id TEXT PRIMARY KEY,
+          created_at INTEGER NOT NULL,
+          actor TEXT NOT NULL,
+          provider TEXT NOT NULL,
+          model TEXT NOT NULL,
+          input_tokens INTEGER NOT NULL,
+          output_tokens INTEGER NOT NULL,
+          pricing_status TEXT NOT NULL
+        )
+      `);
+
+      downLlmUsageEventsDropAssistantId(db);
+
+      const col = raw
+        .query(
+          `SELECT 1 FROM pragma_table_info('llm_usage_events') WHERE name = 'assistant_id'`,
+        )
+        .get();
+      expect(col).toBeTruthy();
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      raw.exec(/*sql*/ `
+        CREATE TABLE llm_usage_events (
+          id TEXT PRIMARY KEY,
+          created_at INTEGER NOT NULL,
+          actor TEXT NOT NULL,
+          provider TEXT NOT NULL,
+          model TEXT NOT NULL,
+          input_tokens INTEGER NOT NULL,
+          output_tokens INTEGER NOT NULL,
+          pricing_status TEXT NOT NULL
+        )
+      `);
+
+      downLlmUsageEventsDropAssistantId(db);
+      downLlmUsageEventsDropAssistantId(db);
+    });
+  });
+
+  // ── v9: downDropActiveSearchIndex ────────────────────────────────────
+
+  describe("v9: downDropActiveSearchIndex", () => {
+    test("recreates the old index", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      bootstrapOldMemoryItemsTable(raw);
+
+      downDropActiveSearchIndex(db);
+
+      const idx = raw
+        .query(
+          `SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'idx_memory_items_active_search'`,
+        )
+        .get();
+      expect(idx).toBeTruthy();
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      bootstrapOldMemoryItemsTable(raw);
+
+      downDropActiveSearchIndex(db);
+      downDropActiveSearchIndex(db);
+    });
+  });
+
+  // ── v11: downRenameChannelToVellum (value rename) ───────────────────
+
+  describe("v11: downRenameChannelToVellum", () => {
+    test("renames 'vellum' values back to 'macos'", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      raw.exec(/*sql*/ `
+        CREATE TABLE guardian_action_deliveries (id TEXT PRIMARY KEY, destination_channel TEXT NOT NULL);
+        INSERT INTO guardian_action_deliveries VALUES ('d1', 'vellum');
+        INSERT INTO guardian_action_deliveries VALUES ('d2', 'sms');
+      `);
+
+      downRenameChannelToVellum(db);
+
+      const row = raw
+        .query(
+          `SELECT destination_channel FROM guardian_action_deliveries WHERE id = 'd1'`,
+        )
+        .get() as { destination_channel: string };
+      expect(row.destination_channel).toBe("macos");
+
+      // Non-vellum values are unchanged.
+      const row2 = raw
+        .query(
+          `SELECT destination_channel FROM guardian_action_deliveries WHERE id = 'd2'`,
+        )
+        .get() as { destination_channel: string };
+      expect(row2.destination_channel).toBe("sms");
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      raw.exec(
+        `CREATE TABLE guardian_action_deliveries (id TEXT PRIMARY KEY, destination_channel TEXT NOT NULL)`,
+      );
+      raw.exec(
+        `INSERT INTO guardian_action_deliveries VALUES ('d1', 'vellum')`,
+      );
+
+      downRenameChannelToVellum(db);
+      downRenameChannelToVellum(db);
+
+      const row = raw
+        .query(
+          `SELECT destination_channel FROM guardian_action_deliveries WHERE id = 'd1'`,
+        )
+        .get() as { destination_channel: string };
+      expect(row.destination_channel).toBe("macos");
+    });
+  });
+
+  // ── v19: downDropAssistantIdColumns (16-table column re-add) ────────
+
+  describe("v19: downDropAssistantIdColumns", () => {
+    test("adds assistant_id column to tables that lack it", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      // Create a subset of the 16 tables without assistant_id.
+      raw.exec(
+        `CREATE TABLE contacts (id TEXT PRIMARY KEY, name TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+      );
+      raw.exec(
+        `CREATE TABLE notification_events (id TEXT PRIMARY KEY, created_at INTEGER NOT NULL)`,
+      );
+
+      downDropAssistantIdColumns(db);
+
+      for (const table of ["contacts", "notification_events"]) {
+        const col = raw
+          .query(
+            `SELECT 1 FROM pragma_table_info('${table}') WHERE name = 'assistant_id'`,
+          )
+          .get();
+        expect(col).toBeTruthy();
+      }
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      raw.exec(
+        `CREATE TABLE contacts (id TEXT PRIMARY KEY, name TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+      );
+
+      downDropAssistantIdColumns(db);
+      downDropAssistantIdColumns(db);
+    });
+  });
+
+  // ── v21: downRenameVerificationTable (table rename) ─────────────────
+
+  describe("v21: downRenameVerificationTable", () => {
+    test("renames channel_verification_sessions back to channel_guardian_verification_challenges", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      // Setup: new table name (post-forward-migration).
+      raw.exec(/*sql*/ `
+        CREATE TABLE channel_verification_sessions (
+          id TEXT PRIMARY KEY,
+          channel TEXT NOT NULL,
+          challenge_hash TEXT,
+          status TEXT NOT NULL,
+          expected_external_user_id TEXT,
+          expected_chat_id TEXT,
+          destination_address TEXT,
+          bootstrap_token_hash TEXT,
+          created_at INTEGER NOT NULL
+        )
+      `);
+      raw.exec(
+        /*sql*/ `CREATE INDEX idx_verification_sessions_lookup ON channel_verification_sessions(channel, challenge_hash, status)`,
+      );
+
+      downRenameVerificationTable(db);
+
+      // Old table name should exist.
+      const oldTable = raw
+        .query(
+          `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'channel_guardian_verification_challenges'`,
+        )
+        .get();
+      expect(oldTable).toBeTruthy();
+
+      // New table name should no longer exist.
+      const newTable = raw
+        .query(
+          `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'channel_verification_sessions'`,
+        )
+        .get();
+      expect(newTable).toBeNull();
+
+      // Old-style indexes should exist.
+      const oldIdx = raw
+        .query(
+          `SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'idx_channel_guardian_challenges_lookup'`,
+        )
+        .get();
+      expect(oldIdx).toBeTruthy();
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      raw.exec(
+        `CREATE TABLE channel_verification_sessions (id TEXT PRIMARY KEY, channel TEXT NOT NULL, challenge_hash TEXT, status TEXT NOT NULL, expected_external_user_id TEXT, expected_chat_id TEXT, destination_address TEXT, bootstrap_token_hash TEXT, created_at INTEGER NOT NULL)`,
+      );
+
+      downRenameVerificationTable(db);
+      downRenameVerificationTable(db);
+    });
+  });
+
+  // ── v22: downRenameVerificationSessionIdColumn ──────────────────────
+
+  describe("v22: downRenameVerificationSessionIdColumn", () => {
+    test("renames verification_session_id back to guardian_verification_session_id", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      raw.exec(/*sql*/ `
+        CREATE TABLE call_sessions (
+          id TEXT PRIMARY KEY,
+          verification_session_id TEXT,
+          created_at INTEGER NOT NULL
+        )
+      `);
+
+      downRenameVerificationSessionIdColumn(db);
+
+      const columns = raw
+        .query(`PRAGMA table_info(call_sessions)`)
+        .all() as Array<{ name: string }>;
+      const hasOld = columns.some(
+        (c) => c.name === "guardian_verification_session_id",
+      );
+      const hasNew = columns.some((c) => c.name === "verification_session_id");
+      expect(hasOld).toBe(true);
+      expect(hasNew).toBe(false);
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      raw.exec(
+        `CREATE TABLE call_sessions (id TEXT PRIMARY KEY, verification_session_id TEXT, created_at INTEGER NOT NULL)`,
+      );
+
+      downRenameVerificationSessionIdColumn(db);
+      downRenameVerificationSessionIdColumn(db);
+    });
+  });
+
+  // ── v23: downRenameGuardianVerificationValues ───────────────────────
+
+  describe("v23: downRenameGuardianVerificationValues", () => {
+    test("restores guardian_ prefix on call_mode and event_type values", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      raw.exec(/*sql*/ `
+        CREATE TABLE call_sessions (id TEXT PRIMARY KEY, call_mode TEXT NOT NULL);
+        CREATE TABLE call_events (id TEXT PRIMARY KEY, event_type TEXT NOT NULL);
+        INSERT INTO call_sessions VALUES ('s1', 'verification');
+        INSERT INTO call_events VALUES ('e1', 'voice_verification_started');
+        INSERT INTO call_events VALUES ('e2', 'outbound_voice_verification_succeeded');
+      `);
+
+      downRenameGuardianVerificationValues(db);
+
+      const session = raw
+        .query(`SELECT call_mode FROM call_sessions WHERE id = 's1'`)
+        .get() as { call_mode: string };
+      expect(session.call_mode).toBe("guardian_verification");
+
+      const event1 = raw
+        .query(`SELECT event_type FROM call_events WHERE id = 'e1'`)
+        .get() as { event_type: string };
+      expect(event1.event_type).toBe("guardian_voice_verification_started");
+
+      const event2 = raw
+        .query(`SELECT event_type FROM call_events WHERE id = 'e2'`)
+        .get() as { event_type: string };
+      expect(event2.event_type).toBe(
+        "outbound_guardian_voice_verification_succeeded",
+      );
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      raw.exec(
+        `CREATE TABLE call_sessions (id TEXT PRIMARY KEY, call_mode TEXT NOT NULL)`,
+      );
+      raw.exec(
+        `CREATE TABLE call_events (id TEXT PRIMARY KEY, event_type TEXT NOT NULL)`,
+      );
+      raw.exec(`INSERT INTO call_sessions VALUES ('s1', 'verification')`);
+
+      downRenameGuardianVerificationValues(db);
+      downRenameGuardianVerificationValues(db);
+    });
+  });
+
+  // ── v24: downRenameVoiceToPhone (value rename) ──────────────────────
+
+  describe("v24: downRenameVoiceToPhone", () => {
+    test("renames 'phone' values back to 'voice'", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      raw.exec(/*sql*/ `
+        CREATE TABLE contact_channels (id TEXT PRIMARY KEY, type TEXT NOT NULL);
+        CREATE TABLE conversations (id TEXT PRIMARY KEY, origin_channel TEXT, origin_interface TEXT);
+        CREATE TABLE messages (id TEXT PRIMARY KEY, metadata TEXT);
+        CREATE TABLE assistant_ingress_invites (id TEXT PRIMARY KEY, source_channel TEXT NOT NULL);
+        CREATE TABLE assistant_inbox_thread_state (id TEXT PRIMARY KEY, source_channel TEXT NOT NULL);
+        CREATE TABLE guardian_action_requests (id TEXT PRIMARY KEY, source_channel TEXT, answered_by_channel TEXT);
+        CREATE TABLE channel_verification_sessions (id TEXT PRIMARY KEY, channel TEXT NOT NULL);
+        CREATE TABLE channel_guardian_approval_requests (id TEXT PRIMARY KEY, channel TEXT NOT NULL);
+        CREATE TABLE channel_guardian_rate_limits (id TEXT PRIMARY KEY, channel TEXT NOT NULL, actor_external_user_id TEXT, actor_chat_id TEXT);
+        CREATE TABLE notification_events (id TEXT PRIMARY KEY, source_channel TEXT);
+        CREATE TABLE notification_deliveries (id TEXT PRIMARY KEY, channel TEXT);
+        CREATE TABLE external_conversation_bindings (id TEXT PRIMARY KEY, source_channel TEXT NOT NULL);
+        CREATE TABLE channel_inbound_events (id TEXT PRIMARY KEY, source_channel TEXT NOT NULL);
+        CREATE TABLE conversation_attention_events (id TEXT PRIMARY KEY, source_channel TEXT);
+        CREATE TABLE conversation_assistant_attention_state (id TEXT PRIMARY KEY, last_seen_source_channel TEXT);
+        CREATE TABLE canonical_guardian_requests (id TEXT PRIMARY KEY, source_channel TEXT);
+        CREATE TABLE canonical_guardian_deliveries (id TEXT PRIMARY KEY, destination_channel TEXT NOT NULL);
+        CREATE TABLE guardian_action_deliveries (id TEXT PRIMARY KEY, destination_channel TEXT NOT NULL);
+        CREATE TABLE scoped_approval_grants (id TEXT PRIMARY KEY, request_channel TEXT NOT NULL, decision_channel TEXT NOT NULL, execution_channel TEXT);
+        CREATE TABLE sequences (id TEXT PRIMARY KEY, channel TEXT);
+        CREATE TABLE followups (id TEXT PRIMARY KEY, channel TEXT);
+      `);
+
+      raw.exec(`INSERT INTO contact_channels VALUES ('cc1', 'phone')`);
+      raw.exec(`INSERT INTO conversations VALUES ('c1', 'phone', 'phone')`);
+
+      downRenameVoiceToPhone(db);
+
+      const cc = raw
+        .query(`SELECT type FROM contact_channels WHERE id = 'cc1'`)
+        .get() as { type: string };
+      expect(cc.type).toBe("voice");
+
+      const conv = raw
+        .query(
+          `SELECT origin_channel, origin_interface FROM conversations WHERE id = 'c1'`,
+        )
+        .get() as { origin_channel: string; origin_interface: string };
+      expect(conv.origin_channel).toBe("voice");
+      expect(conv.origin_interface).toBe("voice");
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      raw.exec(
+        `CREATE TABLE contact_channels (id TEXT PRIMARY KEY, type TEXT NOT NULL)`,
+      );
+      raw.exec(
+        `CREATE TABLE conversations (id TEXT PRIMARY KEY, origin_channel TEXT, origin_interface TEXT)`,
+      );
+      raw.exec(`CREATE TABLE messages (id TEXT PRIMARY KEY, metadata TEXT)`);
+      raw.exec(
+        `CREATE TABLE assistant_ingress_invites (id TEXT PRIMARY KEY, source_channel TEXT NOT NULL)`,
+      );
+      raw.exec(
+        `CREATE TABLE assistant_inbox_thread_state (id TEXT PRIMARY KEY, source_channel TEXT NOT NULL)`,
+      );
+      raw.exec(
+        `CREATE TABLE guardian_action_requests (id TEXT PRIMARY KEY, source_channel TEXT, answered_by_channel TEXT)`,
+      );
+      raw.exec(
+        `CREATE TABLE channel_verification_sessions (id TEXT PRIMARY KEY, channel TEXT NOT NULL)`,
+      );
+      raw.exec(
+        `CREATE TABLE channel_guardian_approval_requests (id TEXT PRIMARY KEY, channel TEXT NOT NULL)`,
+      );
+      raw.exec(
+        `CREATE TABLE channel_guardian_rate_limits (id TEXT PRIMARY KEY, channel TEXT NOT NULL, actor_external_user_id TEXT, actor_chat_id TEXT)`,
+      );
+      raw.exec(
+        `CREATE TABLE notification_events (id TEXT PRIMARY KEY, source_channel TEXT)`,
+      );
+      raw.exec(
+        `CREATE TABLE notification_deliveries (id TEXT PRIMARY KEY, channel TEXT)`,
+      );
+      raw.exec(
+        `CREATE TABLE external_conversation_bindings (id TEXT PRIMARY KEY, source_channel TEXT NOT NULL)`,
+      );
+      raw.exec(
+        `CREATE TABLE channel_inbound_events (id TEXT PRIMARY KEY, source_channel TEXT NOT NULL)`,
+      );
+      raw.exec(
+        `CREATE TABLE conversation_attention_events (id TEXT PRIMARY KEY, source_channel TEXT)`,
+      );
+      raw.exec(
+        `CREATE TABLE conversation_assistant_attention_state (id TEXT PRIMARY KEY, last_seen_source_channel TEXT)`,
+      );
+      raw.exec(
+        `CREATE TABLE canonical_guardian_requests (id TEXT PRIMARY KEY, source_channel TEXT)`,
+      );
+      raw.exec(
+        `CREATE TABLE canonical_guardian_deliveries (id TEXT PRIMARY KEY, destination_channel TEXT NOT NULL)`,
+      );
+      raw.exec(
+        `CREATE TABLE guardian_action_deliveries (id TEXT PRIMARY KEY, destination_channel TEXT NOT NULL)`,
+      );
+      raw.exec(
+        `CREATE TABLE scoped_approval_grants (id TEXT PRIMARY KEY, request_channel TEXT NOT NULL, decision_channel TEXT NOT NULL, execution_channel TEXT)`,
+      );
+      raw.exec(`CREATE TABLE sequences (id TEXT PRIMARY KEY, channel TEXT)`);
+      raw.exec(`CREATE TABLE followups (id TEXT PRIMARY KEY, channel TEXT)`);
+
+      downRenameVoiceToPhone(db);
+      downRenameVoiceToPhone(db);
+    });
+  });
+
+  // ── v25: migrateDropAccountsTableDown (table recreation) ────────────
+
+  describe("v25: migrateDropAccountsTableDown", () => {
+    test("recreates the accounts table with correct schema", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      migrateDropAccountsTableDown(db);
+
+      const table = raw
+        .query(
+          `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'accounts'`,
+        )
+        .get();
+      expect(table).toBeTruthy();
+
+      // Check indexes.
+      const idxService = raw
+        .query(
+          `SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'idx_accounts_service'`,
+        )
+        .get();
+      expect(idxService).toBeTruthy();
+
+      const idxStatus = raw
+        .query(
+          `SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'idx_accounts_status'`,
+        )
+        .get();
+      expect(idxStatus).toBeTruthy();
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      migrateDropAccountsTableDown(db);
+      migrateDropAccountsTableDown(db);
+    });
+  });
+
+  // ── v27: migrateDropRemindersTableDown (table recreation) ───────────
+
+  describe("v27: migrateDropRemindersTableDown", () => {
+    test("recreates the reminders table with correct schema", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      migrateDropRemindersTableDown(db);
+
+      const table = raw
+        .query(
+          `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'reminders'`,
+        )
+        .get();
+      expect(table).toBeTruthy();
+
+      // Verify index.
+      const idx = raw
+        .query(
+          `SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'idx_reminders_status_fire_at'`,
+        )
+        .get();
+      expect(idx).toBeTruthy();
+
+      // Verify columns include routing_intent and routing_hints_json.
+      const cols = raw.query(`PRAGMA table_info(reminders)`).all() as Array<{
+        name: string;
+      }>;
+      const colNames = cols.map((c) => c.name);
+      expect(colNames).toContain("routing_intent");
+      expect(colNames).toContain("routing_hints_json");
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      migrateDropRemindersTableDown(db);
+      migrateDropRemindersTableDown(db);
+    });
+  });
+
+  // ── v28: migrateOAuthAppsClientSecretPathDown (column drop) ─────────
+
+  describe("v28: migrateOAuthAppsClientSecretPathDown", () => {
+    test("drops client_secret_credential_path column from oauth_apps", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      raw.exec(/*sql*/ `
+        CREATE TABLE oauth_providers (provider_key TEXT PRIMARY KEY, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+        CREATE TABLE oauth_apps (
+          id TEXT PRIMARY KEY,
+          provider_key TEXT NOT NULL REFERENCES oauth_providers(provider_key),
+          client_id TEXT NOT NULL,
+          client_secret_credential_path TEXT,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        );
+      `);
+
+      migrateOAuthAppsClientSecretPathDown(db);
+
+      const col = raw
+        .query(
+          `SELECT 1 FROM pragma_table_info('oauth_apps') WHERE name = 'client_secret_credential_path'`,
+        )
+        .get();
+      expect(col).toBeNull();
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      raw.exec(
+        `CREATE TABLE oauth_providers (provider_key TEXT PRIMARY KEY, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+      );
+      raw.exec(
+        `CREATE TABLE oauth_apps (id TEXT PRIMARY KEY, provider_key TEXT NOT NULL, client_id TEXT NOT NULL, client_secret_credential_path TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+      );
+
+      migrateOAuthAppsClientSecretPathDown(db);
+      migrateOAuthAppsClientSecretPathDown(db);
+    });
+  });
+
+  // ── v31: migrateRenameGmailProviderKeyToGoogleDown ──────────────────
+
+  describe("v31: migrateRenameGmailProviderKeyToGoogleDown", () => {
+    test("renames integration:google back to integration:gmail", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      raw.exec(/*sql*/ `
+        CREATE TABLE oauth_providers (provider_key TEXT PRIMARY KEY);
+        CREATE TABLE oauth_apps (id TEXT PRIMARY KEY, provider_key TEXT NOT NULL);
+        CREATE TABLE oauth_connections (id TEXT PRIMARY KEY, provider_key TEXT NOT NULL);
+        INSERT INTO oauth_providers VALUES ('integration:google');
+        INSERT INTO oauth_apps VALUES ('app1', 'integration:google');
+        INSERT INTO oauth_connections VALUES ('conn1', 'integration:google');
+      `);
+
+      migrateRenameGmailProviderKeyToGoogleDown(db);
+
+      const provider = raw
+        .query(
+          `SELECT provider_key FROM oauth_providers WHERE provider_key = 'integration:gmail'`,
+        )
+        .get();
+      expect(provider).toBeTruthy();
+
+      const app = raw
+        .query(`SELECT provider_key FROM oauth_apps WHERE id = 'app1'`)
+        .get() as { provider_key: string };
+      expect(app.provider_key).toBe("integration:gmail");
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      raw.exec(`CREATE TABLE oauth_providers (provider_key TEXT PRIMARY KEY)`);
+      raw.exec(
+        `CREATE TABLE oauth_apps (id TEXT PRIMARY KEY, provider_key TEXT NOT NULL)`,
+      );
+      raw.exec(
+        `CREATE TABLE oauth_connections (id TEXT PRIMARY KEY, provider_key TEXT NOT NULL)`,
+      );
+      raw.exec(`INSERT INTO oauth_providers VALUES ('integration:google')`);
+
+      migrateRenameGmailProviderKeyToGoogleDown(db);
+      migrateRenameGmailProviderKeyToGoogleDown(db);
+    });
+  });
+
+  // ── v32: migrateRenameThreadStartersTableDown ───────────────────────
+
+  describe("v32: migrateRenameThreadStartersTableDown", () => {
+    test("renames conversation_starters back to thread_starters", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      raw.exec(/*sql*/ `
+        CREATE TABLE conversation_starters (
+          id TEXT PRIMARY KEY,
+          generation_batch TEXT,
+          card_type TEXT,
+          scope_id TEXT,
+          created_at INTEGER NOT NULL
+        )
+      `);
+      raw.exec(
+        `CREATE INDEX idx_conversation_starters_batch ON conversation_starters(generation_batch, created_at)`,
+      );
+      raw.exec(
+        `CREATE INDEX idx_conversation_starters_card_type ON conversation_starters(card_type, scope_id)`,
+      );
+
+      migrateRenameThreadStartersTableDown(db);
+
+      const oldTable = raw
+        .query(
+          `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'thread_starters'`,
+        )
+        .get();
+      expect(oldTable).toBeTruthy();
+
+      const newTable = raw
+        .query(
+          `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'conversation_starters'`,
+        )
+        .get();
+      expect(newTable).toBeNull();
+
+      // Old-style indexes should exist.
+      const batchIdx = raw
+        .query(
+          `SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'idx_thread_starters_batch'`,
+        )
+        .get();
+      expect(batchIdx).toBeTruthy();
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      raw.exec(
+        `CREATE TABLE conversation_starters (id TEXT PRIMARY KEY, generation_batch TEXT, card_type TEXT, scope_id TEXT, created_at INTEGER NOT NULL)`,
+      );
+
+      migrateRenameThreadStartersTableDown(db);
+      migrateRenameThreadStartersTableDown(db);
+    });
+  });
+
+  // ── v35: migrateRenameThreadStartersCheckpointsDown ─────────────────
+
+  describe("v35: migrateRenameThreadStartersCheckpointsDown", () => {
+    test("renames conversation_starters: checkpoint keys back to thread_starters:", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      bootstrapCheckpointsTable(raw);
+
+      const now = Date.now();
+      raw.exec(
+        `INSERT INTO memory_checkpoints (key, value, updated_at) VALUES ('conversation_starters:gen_batch_1', '1', ${now})`,
+      );
+      raw.exec(
+        `INSERT INTO memory_checkpoints (key, value, updated_at) VALUES ('conversation_starters:gen_batch_2', '1', ${now})`,
+      );
+
+      migrateRenameThreadStartersCheckpointsDown(db);
+
+      const newPrefixCount = (
+        raw
+          .query(
+            `SELECT COUNT(*) AS c FROM memory_checkpoints WHERE key LIKE 'conversation_starters:%'`,
+          )
+          .get() as { c: number }
+      ).c;
+      expect(newPrefixCount).toBe(0);
+
+      const oldPrefixCount = (
+        raw
+          .query(
+            `SELECT COUNT(*) AS c FROM memory_checkpoints WHERE key LIKE 'thread_starters:%'`,
+          )
+          .get() as { c: number }
+      ).c;
+      expect(oldPrefixCount).toBe(2);
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      bootstrapCheckpointsTable(raw);
+
+      const now = Date.now();
+      raw.exec(
+        `INSERT INTO memory_checkpoints (key, value, updated_at) VALUES ('conversation_starters:gen_batch_1', '1', ${now})`,
+      );
+
+      migrateRenameThreadStartersCheckpointsDown(db);
+      migrateRenameThreadStartersCheckpointsDown(db);
+    });
+  });
+
+  // ── v18: downBackfillContactInteractionStats ────────────────────────
+
+  describe("v18: downBackfillContactInteractionStats", () => {
+    test("clears last_interaction column", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      raw.exec(/*sql*/ `
+        CREATE TABLE contacts (
+          id TEXT PRIMARY KEY,
+          last_interaction INTEGER,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        )
+      `);
+
+      const now = Date.now();
+      raw.exec(`INSERT INTO contacts VALUES ('c1', ${now}, ${now}, ${now})`);
+
+      downBackfillContactInteractionStats(db);
+
+      const contact = raw
+        .query(`SELECT last_interaction FROM contacts WHERE id = 'c1'`)
+        .get() as { last_interaction: number | null };
+      expect(contact.last_interaction).toBeNull();
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      raw.exec(
+        `CREATE TABLE contacts (id TEXT PRIMARY KEY, last_interaction INTEGER, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+      );
+      raw.exec(
+        `INSERT INTO contacts VALUES ('c1', ${Date.now()}, ${Date.now()}, ${Date.now()})`,
+      );
+
+      downBackfillContactInteractionStats(db);
+      downBackfillContactInteractionStats(db);
+    });
+  });
+
+  // ── v12: downEmbeddingVectorBlob (column drop) ──────────────────────
+
+  describe("v12: downEmbeddingVectorBlob", () => {
+    test("drops vector_blob column from memory_embeddings", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      raw.exec(/*sql*/ `
+        CREATE TABLE memory_embeddings (
+          id TEXT PRIMARY KEY,
+          target_type TEXT NOT NULL,
+          target_id TEXT NOT NULL,
+          provider TEXT NOT NULL,
+          model TEXT NOT NULL,
+          dimensions INTEGER NOT NULL,
+          vector_json TEXT,
+          vector_blob BLOB,
+          content_hash TEXT,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          UNIQUE (target_type, target_id, provider, model)
+        )
+      `);
+
+      downEmbeddingVectorBlob(db);
+
+      const col = raw
+        .query(
+          `SELECT 1 FROM pragma_table_info('memory_embeddings') WHERE name = 'vector_blob'`,
+        )
+        .get();
+      expect(col).toBeNull();
+
+      // Other columns should still exist.
+      const vectorJson = raw
+        .query(
+          `SELECT 1 FROM pragma_table_info('memory_embeddings') WHERE name = 'vector_json'`,
+        )
+        .get();
+      expect(vectorJson).toBeTruthy();
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      raw.exec(/*sql*/ `
+        CREATE TABLE memory_embeddings (
+          id TEXT PRIMARY KEY,
+          target_type TEXT NOT NULL,
+          target_id TEXT NOT NULL,
+          provider TEXT NOT NULL,
+          model TEXT NOT NULL,
+          dimensions INTEGER NOT NULL,
+          vector_json TEXT,
+          vector_blob BLOB,
+          content_hash TEXT,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        )
+      `);
+
+      downEmbeddingVectorBlob(db);
+      downEmbeddingVectorBlob(db);
+    });
+  });
+
+  // ── v13: downEmbeddingsNullableVectorJson ───────────────────────────
+
+  describe("v13: downEmbeddingsNullableVectorJson", () => {
+    test("restores NOT NULL on vector_json column", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      // Post-forward-migration schema: vector_json is nullable.
+      raw.exec(/*sql*/ `
+        CREATE TABLE memory_embeddings (
+          id TEXT PRIMARY KEY,
+          target_type TEXT NOT NULL,
+          target_id TEXT NOT NULL,
+          provider TEXT NOT NULL,
+          model TEXT NOT NULL,
+          dimensions INTEGER NOT NULL,
+          vector_json TEXT,
+          vector_blob BLOB,
+          content_hash TEXT,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          UNIQUE (target_type, target_id, provider, model)
+        )
+      `);
+
+      const now = Date.now();
+      raw.exec(
+        `INSERT INTO memory_embeddings VALUES ('e1', 'item', 'item-1', 'openai', 'text-embedding-3-small', 1536, '[0.1,0.2]', NULL, 'hash1', ${now}, ${now})`,
+      );
+
+      downEmbeddingsNullableVectorJson(db);
+
+      // Check that vector_json is now NOT NULL.
+      const ddl =
+        (
+          raw
+            .query(
+              `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'memory_embeddings'`,
+            )
+            .get() as { sql: string }
+        )?.sql ?? "";
+      expect(ddl).toMatch(/vector_json\s+TEXT\s+NOT\s+NULL/i);
+
+      // Data with non-null vector_json should be preserved.
+      const row = raw
+        .query(`SELECT id FROM memory_embeddings WHERE id = 'e1'`)
+        .get();
+      expect(row).toBeTruthy();
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      raw.exec(/*sql*/ `
+        CREATE TABLE memory_embeddings (
+          id TEXT PRIMARY KEY, target_type TEXT NOT NULL, target_id TEXT NOT NULL,
+          provider TEXT NOT NULL, model TEXT NOT NULL, dimensions INTEGER NOT NULL,
+          vector_json TEXT, vector_blob BLOB, content_hash TEXT,
+          created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
+          UNIQUE (target_type, target_id, provider, model)
+        )
+      `);
+
+      downEmbeddingsNullableVectorJson(db);
+      downEmbeddingsNullableVectorJson(db);
+    });
+  });
+
+  // ── v15: downBackfillGuardianPrincipalId ─────────────────────────────
+
+  describe("v15: downBackfillGuardianPrincipalId", () => {
+    test("nulls out guardian_principal_id on channel_guardian_bindings", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      raw.exec(/*sql*/ `
+        CREATE TABLE channel_guardian_bindings (
+          id TEXT PRIMARY KEY,
+          assistant_id TEXT NOT NULL,
+          channel TEXT NOT NULL,
+          guardian_external_user_id TEXT NOT NULL,
+          guardian_delivery_chat_id TEXT NOT NULL,
+          guardian_principal_id TEXT,
+          status TEXT NOT NULL DEFAULT 'active',
+          verified_at INTEGER NOT NULL,
+          verified_via TEXT NOT NULL DEFAULT 'challenge',
+          metadata_json TEXT,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        )
+      `);
+
+      const now = Date.now();
+      raw.exec(
+        `INSERT INTO channel_guardian_bindings VALUES ('b1', 'self', 'vellum', 'user1', 'chat1', 'principal1', 'active', ${now}, 'challenge', NULL, ${now}, ${now})`,
+      );
+
+      downBackfillGuardianPrincipalId(db);
+
+      const row = raw
+        .query(
+          `SELECT guardian_principal_id FROM channel_guardian_bindings WHERE id = 'b1'`,
+        )
+        .get() as { guardian_principal_id: string | null };
+      expect(row.guardian_principal_id).toBeNull();
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      raw.exec(
+        `CREATE TABLE channel_guardian_bindings (id TEXT PRIMARY KEY, guardian_principal_id TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+      );
+
+      downBackfillGuardianPrincipalId(db);
+      downBackfillGuardianPrincipalId(db);
+    });
+  });
+
+  // ── v16: downGuardianPrincipalIdNotNull ──────────────────────────────
+
+  describe("v16: downGuardianPrincipalIdNotNull", () => {
+    test("makes guardian_principal_id nullable again", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      raw.exec(/*sql*/ `
+        CREATE TABLE channel_guardian_bindings (
+          id TEXT PRIMARY KEY,
+          assistant_id TEXT NOT NULL,
+          channel TEXT NOT NULL,
+          guardian_external_user_id TEXT NOT NULL,
+          guardian_delivery_chat_id TEXT NOT NULL,
+          guardian_principal_id TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'active',
+          verified_at INTEGER NOT NULL,
+          verified_via TEXT NOT NULL DEFAULT 'challenge',
+          metadata_json TEXT,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        )
+      `);
+
+      // Confirm NOT NULL before down.
+      const colBefore = raw
+        .query(
+          `SELECT "notnull" FROM pragma_table_info('channel_guardian_bindings') WHERE name = 'guardian_principal_id'`,
+        )
+        .get() as { notnull: number };
+      expect(colBefore.notnull).toBe(1);
+
+      downGuardianPrincipalIdNotNull(db);
+
+      // After down, should be nullable.
+      const colAfter = raw
+        .query(
+          `SELECT "notnull" FROM pragma_table_info('channel_guardian_bindings') WHERE name = 'guardian_principal_id'`,
+        )
+        .get() as { notnull: number };
+      expect(colAfter.notnull).toBe(0);
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      raw.exec(/*sql*/ `
+        CREATE TABLE channel_guardian_bindings (
+          id TEXT PRIMARY KEY, assistant_id TEXT NOT NULL, channel TEXT NOT NULL,
+          guardian_external_user_id TEXT NOT NULL, guardian_delivery_chat_id TEXT NOT NULL,
+          guardian_principal_id TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'active',
+          verified_at INTEGER NOT NULL, verified_via TEXT NOT NULL DEFAULT 'challenge',
+          metadata_json TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+        )
+      `);
+
+      downGuardianPrincipalIdNotNull(db);
+      downGuardianPrincipalIdNotNull(db);
+    });
+  });
+
+  // ── v29: migrateGuardianTimestampsEpochMsDown ───────────────────────
+
+  describe("v29: migrateGuardianTimestampsEpochMsDown", () => {
+    test("converts epoch ms integers back to ISO 8601 strings", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      raw.exec(/*sql*/ `
+        CREATE TABLE canonical_guardian_requests (
+          id TEXT PRIMARY KEY, kind TEXT NOT NULL, source_type TEXT NOT NULL,
+          source_channel TEXT, status TEXT NOT NULL DEFAULT 'pending',
+          expires_at INTEGER, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+        );
+        CREATE TABLE canonical_guardian_deliveries (
+          id TEXT PRIMARY KEY, request_id TEXT NOT NULL, destination_channel TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'pending', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+        );
+        CREATE TABLE scoped_approval_grants (
+          id TEXT PRIMARY KEY, scope_mode TEXT NOT NULL, request_channel TEXT NOT NULL,
+          decision_channel TEXT NOT NULL, status TEXT NOT NULL,
+          expires_at INTEGER NOT NULL, consumed_at INTEGER, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+        );
+      `);
+
+      // Insert with epoch ms values (post-forward-migration state).
+      const epochMs = 1700000000000; // 2023-11-14T22:13:20.000Z
+      raw.exec(
+        `INSERT INTO canonical_guardian_requests VALUES ('r1', 'approval', 'desktop', 'vellum', 'pending', NULL, ${epochMs}, ${epochMs})`,
+      );
+      raw.exec(
+        `INSERT INTO canonical_guardian_deliveries VALUES ('d1', 'r1', 'vellum', 'pending', ${epochMs}, ${epochMs})`,
+      );
+      raw.exec(
+        `INSERT INTO scoped_approval_grants VALUES ('g1', 'once', 'vellum', 'vellum', 'active', ${epochMs}, NULL, ${epochMs}, ${epochMs})`,
+      );
+
+      migrateGuardianTimestampsEpochMsDown(db);
+
+      // Verify created_at is now a text ISO 8601 string.
+      const req = raw
+        .query(
+          `SELECT created_at, typeof(created_at) AS t FROM canonical_guardian_requests WHERE id = 'r1'`,
+        )
+        .get() as { created_at: string; t: string };
+      expect(req.t).toBe("text");
+      expect(req.created_at).toContain("2023-11-14");
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+      raw.exec(
+        `CREATE TABLE canonical_guardian_requests (id TEXT PRIMARY KEY, kind TEXT NOT NULL, source_type TEXT NOT NULL, source_channel TEXT, status TEXT NOT NULL, expires_at INTEGER, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+      );
+      raw.exec(
+        `CREATE TABLE canonical_guardian_deliveries (id TEXT PRIMARY KEY, request_id TEXT NOT NULL, destination_channel TEXT NOT NULL, status TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+      );
+      raw.exec(
+        `CREATE TABLE scoped_approval_grants (id TEXT PRIMARY KEY, scope_mode TEXT NOT NULL, request_channel TEXT NOT NULL, decision_channel TEXT NOT NULL, status TEXT NOT NULL, expires_at INTEGER NOT NULL, consumed_at INTEGER, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+      );
+
+      const epochMs = 1700000000000;
+      raw.exec(
+        `INSERT INTO canonical_guardian_requests VALUES ('r1', 'approval', 'desktop', 'vellum', 'pending', NULL, ${epochMs}, ${epochMs})`,
+      );
+
+      migrateGuardianTimestampsEpochMsDown(db);
+      // Second call — values are already text, typeof check skips them.
+      migrateGuardianTimestampsEpochMsDown(db);
+    });
+  });
+
+  // ── v30: migrateGuardianTimestampsRebuildDown ───────────────────────
+
+  describe("v30: migrateGuardianTimestampsRebuildDown", () => {
+    test("rebuilds tables with TEXT affinity on timestamp columns", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      // Post-forward-migration state: INTEGER affinity on timestamp columns.
+      raw.exec(/*sql*/ `
+        CREATE TABLE canonical_guardian_requests (
+          id TEXT PRIMARY KEY, kind TEXT NOT NULL, source_type TEXT NOT NULL,
+          source_channel TEXT, conversation_id TEXT, requester_external_user_id TEXT,
+          requester_chat_id TEXT, guardian_external_user_id TEXT, guardian_principal_id TEXT,
+          call_session_id TEXT, pending_question_id TEXT, question_text TEXT,
+          request_code TEXT, tool_name TEXT, input_digest TEXT,
+          status TEXT NOT NULL DEFAULT 'pending', answer_text TEXT,
+          decided_by_external_user_id TEXT, decided_by_principal_id TEXT,
+          followup_state TEXT, expires_at INTEGER,
+          created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+        );
+        CREATE TABLE canonical_guardian_deliveries (
+          id TEXT PRIMARY KEY, request_id TEXT NOT NULL REFERENCES canonical_guardian_requests(id) ON DELETE CASCADE,
+          destination_channel TEXT NOT NULL, destination_conversation_id TEXT,
+          destination_chat_id TEXT, destination_message_id TEXT,
+          status TEXT NOT NULL DEFAULT 'pending',
+          created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+        );
+        CREATE TABLE scoped_approval_grants (
+          id TEXT PRIMARY KEY, scope_mode TEXT NOT NULL, request_id TEXT,
+          tool_name TEXT, input_digest TEXT, request_channel TEXT NOT NULL,
+          decision_channel TEXT NOT NULL, execution_channel TEXT,
+          conversation_id TEXT, call_session_id TEXT,
+          requester_external_user_id TEXT, guardian_external_user_id TEXT,
+          status TEXT NOT NULL, expires_at INTEGER NOT NULL,
+          consumed_at INTEGER, consumed_by_request_id TEXT,
+          created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+        );
+      `);
+
+      migrateGuardianTimestampsRebuildDown(db);
+
+      // Verify TEXT affinity on created_at.
+      const colType = raw
+        .query(
+          `SELECT type FROM pragma_table_info('canonical_guardian_requests') WHERE name = 'created_at'`,
+        )
+        .get() as { type: string };
+      expect(colType.type.toUpperCase()).toBe("TEXT");
+    });
+
+    test("idempotency: calling down twice does not throw", () => {
+      const db = createTestDb();
+      const raw = getRaw(db);
+
+      raw.exec(/*sql*/ `
+        CREATE TABLE canonical_guardian_requests (
+          id TEXT PRIMARY KEY, kind TEXT NOT NULL, source_type TEXT NOT NULL,
+          source_channel TEXT, conversation_id TEXT, requester_external_user_id TEXT,
+          requester_chat_id TEXT, guardian_external_user_id TEXT, guardian_principal_id TEXT,
+          call_session_id TEXT, pending_question_id TEXT, question_text TEXT,
+          request_code TEXT, tool_name TEXT, input_digest TEXT,
+          status TEXT NOT NULL DEFAULT 'pending', answer_text TEXT,
+          decided_by_external_user_id TEXT, decided_by_principal_id TEXT,
+          followup_state TEXT, expires_at INTEGER,
+          created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+        );
+        CREATE TABLE canonical_guardian_deliveries (
+          id TEXT PRIMARY KEY, request_id TEXT NOT NULL REFERENCES canonical_guardian_requests(id) ON DELETE CASCADE,
+          destination_channel TEXT NOT NULL, destination_conversation_id TEXT,
+          destination_chat_id TEXT, destination_message_id TEXT,
+          status TEXT NOT NULL DEFAULT 'pending',
+          created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+        );
+        CREATE TABLE scoped_approval_grants (
+          id TEXT PRIMARY KEY, scope_mode TEXT NOT NULL, request_id TEXT,
+          tool_name TEXT, input_digest TEXT, request_channel TEXT NOT NULL,
+          decision_channel TEXT NOT NULL, execution_channel TEXT,
+          conversation_id TEXT, call_session_id TEXT,
+          requester_external_user_id TEXT, guardian_external_user_id TEXT,
+          status TEXT NOT NULL, expires_at INTEGER NOT NULL,
+          consumed_at INTEGER, consumed_by_request_id TEXT,
+          created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+        );
+      `);
+
+      migrateGuardianTimestampsRebuildDown(db);
+      migrateGuardianTimestampsRebuildDown(db);
+    });
   });
 });

--- a/assistant/src/__tests__/db-migration-rollback.test.ts
+++ b/assistant/src/__tests__/db-migration-rollback.test.ts
@@ -1116,26 +1116,86 @@ describe("rollbackMemoryMigration", () => {
     // Remove the trigger for inspection.
     raw.exec(`DROP TRIGGER IF EXISTS fail_on_update_test_rollback`);
 
-    // The checkpoint should still exist (the transaction was rolled back,
-    // so the DELETE FROM memory_checkpoints inside the transaction was undone).
-    // However the checkpoint value was changed to 'rolling_back' BEFORE the
-    // transaction started (outside the BEGIN/COMMIT).
+    // The checkpoint should still exist — down() threw before execution reached
+    // the DELETE FROM memory_checkpoints line. The 'rolling_back' marker was
+    // written before down() was called and is preserved.
     const cp = raw
       .query(
         `SELECT value FROM memory_checkpoints WHERE key = 'test_fail_down_v3000'`,
       )
       .get() as { value: string } | null;
     expect(cp).toBeTruthy();
-    // The checkpoint is preserved (value = 'rolling_back' because the pre-txn
-    // update succeeded but the txn rolled back, leaving checkpoint intact).
     expect(cp!.value).toBe("rolling_back");
 
-    // The data should be unchanged — the UPDATE inside down() was rolled back.
+    // The data should be unchanged — the RAISE(ABORT) trigger aborted the statement.
     const row = raw
       .query(`SELECT value FROM test_rollback_data WHERE id = 'row-1'`)
       .get() as { value: string } | null;
     expect(row).toBeTruthy();
     expect(row!.value).toBe("original");
+  });
+
+  test("down() with its own BEGIN/COMMIT succeeds without nested-transaction errors", () => {
+    saveRegistry();
+
+    const db = createTestDb();
+    const raw = getRaw(db);
+    bootstrapCheckpointsTable(raw);
+
+    const now = Date.now();
+
+    // Create a table for the down() function to operate on.
+    raw.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS test_self_txn_data (
+        id TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      )
+    `);
+    raw.exec(
+      `INSERT INTO test_self_txn_data (id, value) VALUES ('row-1', 'migrated')`,
+    );
+
+    // Register a migration whose down() manages its own transaction —
+    // this previously caused nested-transaction errors when rollbackMemoryMigration
+    // wrapped every down() call in BEGIN/COMMIT.
+    MIGRATION_REGISTRY.push({
+      key: "test_self_txn_down_v3500",
+      version: 3500,
+      description: "test migration with self-transactional down()",
+      down: (database) => {
+        const sqlite = getSqliteFrom(database);
+        sqlite.exec("BEGIN");
+        sqlite.exec(
+          `UPDATE test_self_txn_data SET value = 'original' WHERE id = 'row-1'`,
+        );
+        sqlite.exec("COMMIT");
+      },
+    });
+
+    // Mark as completed.
+    raw.exec(
+      `INSERT INTO memory_checkpoints (key, value, updated_at) VALUES ('test_self_txn_down_v3500', '1', ${now})`,
+    );
+
+    // This should succeed — no nested transaction error.
+    const rolledBack = rollbackMemoryMigration(db, 3499);
+
+    expect(rolledBack).toEqual(["test_self_txn_down_v3500"]);
+
+    // Verify the down() function's changes were applied.
+    const row = raw
+      .query(`SELECT value FROM test_self_txn_data WHERE id = 'row-1'`)
+      .get() as { value: string } | null;
+    expect(row).toBeTruthy();
+    expect(row!.value).toBe("original");
+
+    // Checkpoint should be deleted.
+    const cp = raw
+      .query(
+        `SELECT 1 FROM memory_checkpoints WHERE key = 'test_self_txn_down_v3500'`,
+      )
+      .get();
+    expect(cp).toBeNull();
   });
 
   test("no-op when already at target version", () => {

--- a/assistant/src/__tests__/workspace-migration-down-functions.test.ts
+++ b/assistant/src/__tests__/workspace-migration-down-functions.test.ts
@@ -1,0 +1,1009 @@
+/**
+ * Tests for workspace migration down() rollback functions.
+ *
+ * Each migration with a meaningful reverse operation is tested for:
+ *  1. Correctness: down() after run() restores pre-migration state
+ *  2. Idempotency: calling down() twice produces the same result
+ *  3. No-op safety: down() on a workspace where run() never executed
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must precede all migration imports
+// ---------------------------------------------------------------------------
+
+// Mock secure-keys (used by 006-services-config)
+mock.module("../security/secure-keys.js", () => ({
+  getProviderKeyAsync: async () => null,
+  getSecureKeyAsync: async () => null,
+}));
+
+mock.module("../security/credential-key.js", () => ({
+  credentialKey: (...args: string[]) => args.join(":"),
+}));
+
+// Mock getRootDir for 016-extract-feature-flags-to-protected
+let mockRootDir: string = "/tmp/mock-root";
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => mockRootDir,
+  getDataDir: () => join(mockRootDir, "workspace", "data"),
+  getWorkspaceDir: () => join(mockRootDir, "workspace"),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports — after mocking
+// ---------------------------------------------------------------------------
+
+import { avatarRenameMigration } from "../workspace/migrations/001-avatar-rename.js";
+import { extractCollectUsageDataMigration } from "../workspace/migrations/004-extract-collect-usage-data.js";
+import { servicesConfigMigration } from "../workspace/migrations/006-services-config.js";
+import { webSearchProviderRenameMigration } from "../workspace/migrations/007-web-search-provider-rename.js";
+import { appDirRenameMigration } from "../workspace/migrations/010-app-dir-rename.js";
+import { renameConversationDiskViewDirsMigration } from "../workspace/migrations/012-rename-conversation-disk-view-dirs.js";
+import { extractFeatureFlagsToProtectedMigration } from "../workspace/migrations/016-extract-feature-flags-to-protected.js";
+import { seedPersonaDirsMigration } from "../workspace/migrations/017-seed-persona-dirs.js";
+import { migrateToWorkspaceVolumeMigration } from "../workspace/migrations/migrate-to-workspace-volume.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let workspaceDir: string;
+
+function freshWorkspace(): string {
+  const dir = join(
+    tmpdir(),
+    `vellum-migration-down-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  workspaceDir = freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+  // Clean up any mock root dir created for feature-flags tests
+  if (existsSync(mockRootDir)) {
+    rmSync(mockRootDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 001-avatar-rename down()
+// ---------------------------------------------------------------------------
+
+describe("001-avatar-rename down()", () => {
+  test("renames files back to old names after run()", () => {
+    const avatarDir = join(workspaceDir, "data", "avatar");
+    mkdirSync(avatarDir, { recursive: true });
+
+    // Set up pre-migration state: old file names
+    writeFileSync(join(avatarDir, "custom-avatar.png"), "image-data");
+    writeFileSync(
+      join(avatarDir, "avatar-components.json"),
+      '{"traits": true}',
+    );
+
+    // Run forward migration
+    avatarRenameMigration.run(workspaceDir);
+
+    // Verify forward migration worked
+    expect(existsSync(join(avatarDir, "avatar-image.png"))).toBe(true);
+    expect(existsSync(join(avatarDir, "character-traits.json"))).toBe(true);
+    expect(existsSync(join(avatarDir, "custom-avatar.png"))).toBe(false);
+    expect(existsSync(join(avatarDir, "avatar-components.json"))).toBe(false);
+
+    // Run down() to reverse
+    avatarRenameMigration.down!(workspaceDir);
+
+    // Verify reversal
+    expect(existsSync(join(avatarDir, "custom-avatar.png"))).toBe(true);
+    expect(existsSync(join(avatarDir, "avatar-components.json"))).toBe(true);
+    expect(existsSync(join(avatarDir, "avatar-image.png"))).toBe(false);
+    expect(existsSync(join(avatarDir, "character-traits.json"))).toBe(false);
+
+    // Verify content preserved
+    expect(readFileSync(join(avatarDir, "custom-avatar.png"), "utf-8")).toBe(
+      "image-data",
+    );
+    expect(
+      readFileSync(join(avatarDir, "avatar-components.json"), "utf-8"),
+    ).toBe('{"traits": true}');
+  });
+
+  test("idempotent: calling down() twice produces same result", () => {
+    const avatarDir = join(workspaceDir, "data", "avatar");
+    mkdirSync(avatarDir, { recursive: true });
+
+    writeFileSync(join(avatarDir, "avatar-image.png"), "image-data");
+    writeFileSync(join(avatarDir, "character-traits.json"), '{"traits": true}');
+
+    avatarRenameMigration.down!(workspaceDir);
+    avatarRenameMigration.down!(workspaceDir);
+
+    expect(existsSync(join(avatarDir, "custom-avatar.png"))).toBe(true);
+    expect(existsSync(join(avatarDir, "avatar-components.json"))).toBe(true);
+    expect(existsSync(join(avatarDir, "avatar-image.png"))).toBe(false);
+    expect(existsSync(join(avatarDir, "character-traits.json"))).toBe(false);
+  });
+
+  test("no-op when forward migration never ran (no files)", () => {
+    const avatarDir = join(workspaceDir, "data", "avatar");
+    mkdirSync(avatarDir, { recursive: true });
+
+    // No files exist — down() should be a no-op
+    avatarRenameMigration.down!(workspaceDir);
+
+    expect(existsSync(join(avatarDir, "custom-avatar.png"))).toBe(false);
+    expect(existsSync(join(avatarDir, "avatar-image.png"))).toBe(false);
+  });
+
+  test("no-op when avatar directory does not exist", () => {
+    // No avatar dir at all — should not throw
+    avatarRenameMigration.down!(workspaceDir);
+  });
+
+  test("partial: only image exists in new name", () => {
+    const avatarDir = join(workspaceDir, "data", "avatar");
+    mkdirSync(avatarDir, { recursive: true });
+
+    writeFileSync(join(avatarDir, "avatar-image.png"), "image-data");
+
+    avatarRenameMigration.down!(workspaceDir);
+
+    expect(existsSync(join(avatarDir, "custom-avatar.png"))).toBe(true);
+    expect(existsSync(join(avatarDir, "avatar-image.png"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 004-extract-collect-usage-data down()
+// ---------------------------------------------------------------------------
+
+describe("004-extract-collect-usage-data down()", () => {
+  test("restores collectUsageData=false back to feature flag", () => {
+    writeConfig({
+      collectUsageData: false,
+      otherSetting: true,
+    });
+
+    extractCollectUsageDataMigration.down!(workspaceDir);
+
+    const config = readConfig();
+    expect(config.collectUsageData).toBeUndefined();
+    expect(config.otherSetting).toBe(true);
+    const flagValues = config.assistantFeatureFlagValues as Record<
+      string,
+      unknown
+    >;
+    expect(flagValues["feature_flags.collect-usage-data.enabled"]).toBe(false);
+  });
+
+  test("round-trip: run() then down() restores original state", () => {
+    const original = {
+      assistantFeatureFlagValues: {
+        "feature_flags.collect-usage-data.enabled": false,
+      },
+      otherSetting: "hello",
+    };
+    writeConfig(original);
+
+    extractCollectUsageDataMigration.run(workspaceDir);
+
+    // After run, collectUsageData should be extracted
+    const afterRun = readConfig();
+    expect(afterRun.collectUsageData).toBe(false);
+    expect(afterRun.assistantFeatureFlagValues).toBeUndefined();
+
+    extractCollectUsageDataMigration.down!(workspaceDir);
+
+    const afterDown = readConfig();
+    expect(afterDown.collectUsageData).toBeUndefined();
+    const flagValues = afterDown.assistantFeatureFlagValues as Record<
+      string,
+      unknown
+    >;
+    expect(flagValues["feature_flags.collect-usage-data.enabled"]).toBe(false);
+    expect(afterDown.otherSetting).toBe("hello");
+  });
+
+  test("idempotent: calling down() twice produces same result", () => {
+    writeConfig({ collectUsageData: false });
+
+    extractCollectUsageDataMigration.down!(workspaceDir);
+    const afterFirst = readConfig();
+
+    extractCollectUsageDataMigration.down!(workspaceDir);
+    const afterSecond = readConfig();
+
+    expect(afterSecond).toEqual(afterFirst);
+  });
+
+  test("no-op when collectUsageData not present", () => {
+    const original = { otherSetting: true };
+    writeConfig(original);
+
+    extractCollectUsageDataMigration.down!(workspaceDir);
+
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("no-op when config.json does not exist", () => {
+    extractCollectUsageDataMigration.down!(workspaceDir);
+    expect(existsSync(join(workspaceDir, "config.json"))).toBe(false);
+  });
+
+  test("merges into existing assistantFeatureFlagValues", () => {
+    writeConfig({
+      collectUsageData: false,
+      assistantFeatureFlagValues: {
+        "feature_flags.other-flag.enabled": true,
+      },
+    });
+
+    extractCollectUsageDataMigration.down!(workspaceDir);
+
+    const config = readConfig();
+    const flagValues = config.assistantFeatureFlagValues as Record<
+      string,
+      unknown
+    >;
+    expect(flagValues["feature_flags.collect-usage-data.enabled"]).toBe(false);
+    expect(flagValues["feature_flags.other-flag.enabled"]).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 006-services-config down()
+// ---------------------------------------------------------------------------
+
+describe("006-services-config down()", () => {
+  test("extracts services back to top-level fields", () => {
+    writeConfig({
+      services: {
+        inference: { mode: "your-own", provider: "openai", model: "gpt-4o" },
+        "image-generation": {
+          mode: "your-own",
+          provider: "openai",
+          model: "dall-e-3",
+        },
+        "web-search": { mode: "your-own", provider: "brave" },
+      },
+      otherSetting: true,
+    });
+
+    servicesConfigMigration.down!(workspaceDir);
+
+    const config = readConfig();
+    expect(config.provider).toBe("openai");
+    expect(config.model).toBe("gpt-4o");
+    expect(config.imageGenModel).toBe("dall-e-3");
+    expect(config.webSearchProvider).toBe("brave");
+    expect(config.services).toBeUndefined();
+    expect(config.otherSetting).toBe(true);
+  });
+
+  test("round-trip: run() then down() restores top-level fields", async () => {
+    writeConfig({
+      provider: "openai",
+      model: "gpt-4o",
+      imageGenModel: "dall-e-3",
+      webSearchProvider: "brave",
+      otherSetting: true,
+    });
+
+    await servicesConfigMigration.run(workspaceDir);
+
+    const afterRun = readConfig();
+    expect(afterRun.provider).toBeUndefined();
+    expect(afterRun.services).toBeDefined();
+
+    servicesConfigMigration.down!(workspaceDir);
+
+    const afterDown = readConfig();
+    expect(afterDown.provider).toBe("openai");
+    expect(afterDown.model).toBe("gpt-4o");
+    expect(afterDown.imageGenModel).toBe("dall-e-3");
+    expect(afterDown.webSearchProvider).toBe("brave");
+    expect(afterDown.services).toBeUndefined();
+    expect(afterDown.otherSetting).toBe(true);
+  });
+
+  test("idempotent: calling down() twice produces same result", () => {
+    writeConfig({
+      services: {
+        inference: {
+          mode: "your-own",
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        },
+        "image-generation": {
+          mode: "your-own",
+          provider: "gemini",
+          model: "gemini-2.5-flash-image",
+        },
+        "web-search": {
+          mode: "your-own",
+          provider: "inference-provider-native",
+        },
+      },
+    });
+
+    servicesConfigMigration.down!(workspaceDir);
+    const afterFirst = readConfig();
+
+    // Second call: services was already removed, so down() is a no-op
+    servicesConfigMigration.down!(workspaceDir);
+    const afterSecond = readConfig();
+
+    expect(afterSecond).toEqual(afterFirst);
+  });
+
+  test("no-op when no services object present", () => {
+    const original = { provider: "openai", model: "gpt-4o" };
+    writeConfig(original);
+
+    servicesConfigMigration.down!(workspaceDir);
+
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("no-op when config.json does not exist", () => {
+    servicesConfigMigration.down!(workspaceDir);
+    expect(existsSync(join(workspaceDir, "config.json"))).toBe(false);
+  });
+
+  test("gracefully handles invalid JSON", () => {
+    writeFileSync(join(workspaceDir, "config.json"), "not-valid-json");
+
+    servicesConfigMigration.down!(workspaceDir);
+
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      "not-valid-json",
+    );
+  });
+
+  test("handles partial services object (only inference present)", () => {
+    writeConfig({
+      services: {
+        inference: { mode: "your-own", provider: "openai", model: "gpt-4o" },
+      },
+    });
+
+    servicesConfigMigration.down!(workspaceDir);
+
+    const config = readConfig();
+    expect(config.provider).toBe("openai");
+    expect(config.model).toBe("gpt-4o");
+    expect(config.imageGenModel).toBeUndefined();
+    expect(config.webSearchProvider).toBeUndefined();
+    expect(config.services).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 007-web-search-provider-rename down()
+// ---------------------------------------------------------------------------
+
+describe("007-web-search-provider-rename down()", () => {
+  test("renames inference-provider-native back to anthropic-native", () => {
+    writeConfig({
+      services: {
+        inference: {
+          mode: "your-own",
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        },
+        "web-search": {
+          mode: "your-own",
+          provider: "inference-provider-native",
+        },
+      },
+    });
+
+    webSearchProviderRenameMigration.down!(workspaceDir);
+
+    const config = readConfig();
+    const services = config.services as Record<string, Record<string, unknown>>;
+    expect(services["web-search"].provider).toBe("anthropic-native");
+  });
+
+  test("round-trip: run() then down() restores original provider name", () => {
+    writeConfig({
+      services: {
+        "web-search": { mode: "your-own", provider: "anthropic-native" },
+      },
+    });
+
+    webSearchProviderRenameMigration.run(workspaceDir);
+
+    const afterRun = readConfig();
+    const svcAfterRun = afterRun.services as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(svcAfterRun["web-search"].provider).toBe(
+      "inference-provider-native",
+    );
+
+    webSearchProviderRenameMigration.down!(workspaceDir);
+
+    const afterDown = readConfig();
+    const svcAfterDown = afterDown.services as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(svcAfterDown["web-search"].provider).toBe("anthropic-native");
+  });
+
+  test("idempotent: calling down() twice produces same result", () => {
+    writeConfig({
+      services: {
+        "web-search": {
+          mode: "your-own",
+          provider: "inference-provider-native",
+        },
+      },
+    });
+
+    webSearchProviderRenameMigration.down!(workspaceDir);
+    const afterFirst = readConfig();
+
+    webSearchProviderRenameMigration.down!(workspaceDir);
+    const afterSecond = readConfig();
+
+    expect(afterSecond).toEqual(afterFirst);
+  });
+
+  test("no-op when provider is not inference-provider-native", () => {
+    const original = {
+      services: {
+        "web-search": { mode: "your-own", provider: "brave" },
+      },
+    };
+    writeConfig(original);
+
+    webSearchProviderRenameMigration.down!(workspaceDir);
+
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("no-op when config.json does not exist", () => {
+    webSearchProviderRenameMigration.down!(workspaceDir);
+    expect(existsSync(join(workspaceDir, "config.json"))).toBe(false);
+  });
+
+  test("no-op when services or web-search is missing", () => {
+    const original = { otherSetting: true };
+    writeConfig(original);
+
+    webSearchProviderRenameMigration.down!(workspaceDir);
+
+    expect(readConfig()).toEqual(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 010-app-dir-rename down()
+// ---------------------------------------------------------------------------
+
+describe("010-app-dir-rename down()", () => {
+  test("renames slugified app dirs back to UUID-based names", () => {
+    const appsDir = join(workspaceDir, "data", "apps");
+    mkdirSync(appsDir, { recursive: true });
+
+    const appId = "a1b2c3d4-5678-9abc-def0-123456789abc";
+    const dirName = "my-cool-app";
+
+    // Create migrated state: slugified dir, json with dirName
+    mkdirSync(join(appsDir, dirName), { recursive: true });
+    writeFileSync(join(appsDir, dirName, "index.html"), "<html>app</html>");
+    writeFileSync(
+      join(appsDir, `${dirName}.json`),
+      JSON.stringify({ id: appId, name: "My Cool App", dirName }),
+    );
+    writeFileSync(join(appsDir, `${dirName}.preview`), "preview-data");
+
+    appDirRenameMigration.down!(workspaceDir);
+
+    // UUID-based files should now exist
+    expect(existsSync(join(appsDir, appId))).toBe(true);
+    expect(existsSync(join(appsDir, `${appId}.json`))).toBe(true);
+    expect(existsSync(join(appsDir, `${appId}.preview`))).toBe(true);
+
+    // Slugified files should be gone
+    expect(existsSync(join(appsDir, dirName))).toBe(false);
+    expect(existsSync(join(appsDir, `${dirName}.json`))).toBe(false);
+    expect(existsSync(join(appsDir, `${dirName}.preview`))).toBe(false);
+
+    // JSON content should have dirName removed
+    const json = JSON.parse(
+      readFileSync(join(appsDir, `${appId}.json`), "utf-8"),
+    );
+    expect(json.id).toBe(appId);
+    expect(json.name).toBe("My Cool App");
+    expect(json.dirName).toBeUndefined();
+
+    // App files should be preserved
+    expect(readFileSync(join(appsDir, appId, "index.html"), "utf-8")).toBe(
+      "<html>app</html>",
+    );
+  });
+
+  test("idempotent: calling down() twice produces same result", () => {
+    const appsDir = join(workspaceDir, "data", "apps");
+    mkdirSync(appsDir, { recursive: true });
+
+    const appId = "b2c3d4e5-6789-abcd-ef01-234567890abc";
+    const dirName = "test-app";
+
+    mkdirSync(join(appsDir, dirName), { recursive: true });
+    writeFileSync(
+      join(appsDir, `${dirName}.json`),
+      JSON.stringify({ id: appId, name: "Test App", dirName }),
+    );
+
+    appDirRenameMigration.down!(workspaceDir);
+    appDirRenameMigration.down!(workspaceDir);
+
+    expect(existsSync(join(appsDir, appId))).toBe(true);
+    expect(existsSync(join(appsDir, `${appId}.json`))).toBe(true);
+    expect(existsSync(join(appsDir, dirName))).toBe(false);
+  });
+
+  test("no-op when apps directory does not exist", () => {
+    appDirRenameMigration.down!(workspaceDir);
+    // Should not throw
+  });
+
+  test("no-op when no JSON files exist", () => {
+    const appsDir = join(workspaceDir, "data", "apps");
+    mkdirSync(appsDir, { recursive: true });
+
+    appDirRenameMigration.down!(workspaceDir);
+    // Should not throw
+  });
+
+  test("handles multiple apps", () => {
+    const appsDir = join(workspaceDir, "data", "apps");
+    mkdirSync(appsDir, { recursive: true });
+
+    const apps = [
+      { id: "aaa-111", dirName: "first-app", name: "First App" },
+      { id: "bbb-222", dirName: "second-app", name: "Second App" },
+    ];
+
+    for (const app of apps) {
+      mkdirSync(join(appsDir, app.dirName), { recursive: true });
+      writeFileSync(
+        join(appsDir, `${app.dirName}.json`),
+        JSON.stringify({ id: app.id, name: app.name, dirName: app.dirName }),
+      );
+    }
+
+    appDirRenameMigration.down!(workspaceDir);
+
+    for (const app of apps) {
+      expect(existsSync(join(appsDir, app.id))).toBe(true);
+      expect(existsSync(join(appsDir, `${app.id}.json`))).toBe(true);
+      expect(existsSync(join(appsDir, app.dirName))).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 012-rename-conversation-disk-view-dirs down()
+// ---------------------------------------------------------------------------
+
+describe("012-rename-conversation-disk-view-dirs down()", () => {
+  test("renames timestamp-first dirs back to legacy id-first format", () => {
+    const conversationsDir = join(workspaceDir, "conversations");
+    mkdirSync(conversationsDir, { recursive: true });
+
+    // Create new-format dir: {timestamp}_{conversationId}
+    const timestamp = "2025-06-15T10-30-00.000Z";
+    const convId = "conv-abc-123";
+    const newName = `${timestamp}_${convId}`;
+    mkdirSync(join(conversationsDir, newName));
+    writeFileSync(join(conversationsDir, newName, "messages.json"), "[]");
+
+    renameConversationDiskViewDirsMigration.down!(workspaceDir);
+
+    const legacyName = `${convId}_${timestamp}`;
+    expect(existsSync(join(conversationsDir, legacyName))).toBe(true);
+    expect(existsSync(join(conversationsDir, newName))).toBe(false);
+
+    // Content preserved
+    expect(
+      readFileSync(
+        join(conversationsDir, legacyName, "messages.json"),
+        "utf-8",
+      ),
+    ).toBe("[]");
+  });
+
+  test("round-trip: run() then down() restores legacy format", () => {
+    const conversationsDir = join(workspaceDir, "conversations");
+    mkdirSync(conversationsDir, { recursive: true });
+
+    const timestamp = "2025-06-15T10-30-00.000Z";
+    const convId = "my-conversation";
+    const legacyName = `${convId}_${timestamp}`;
+    mkdirSync(join(conversationsDir, legacyName));
+
+    renameConversationDiskViewDirsMigration.run(workspaceDir);
+
+    const newName = `${timestamp}_${convId}`;
+    expect(existsSync(join(conversationsDir, newName))).toBe(true);
+    expect(existsSync(join(conversationsDir, legacyName))).toBe(false);
+
+    renameConversationDiskViewDirsMigration.down!(workspaceDir);
+
+    expect(existsSync(join(conversationsDir, legacyName))).toBe(true);
+    expect(existsSync(join(conversationsDir, newName))).toBe(false);
+  });
+
+  test("idempotent: calling down() twice produces same result", () => {
+    const conversationsDir = join(workspaceDir, "conversations");
+    mkdirSync(conversationsDir, { recursive: true });
+
+    const timestamp = "2025-01-01T00-00-00.000Z";
+    const convId = "test-conv";
+    mkdirSync(join(conversationsDir, `${timestamp}_${convId}`));
+
+    renameConversationDiskViewDirsMigration.down!(workspaceDir);
+    renameConversationDiskViewDirsMigration.down!(workspaceDir);
+
+    expect(existsSync(join(conversationsDir, `${convId}_${timestamp}`))).toBe(
+      true,
+    );
+    expect(existsSync(join(conversationsDir, `${timestamp}_${convId}`))).toBe(
+      false,
+    );
+  });
+
+  test("no-op when conversations directory does not exist", () => {
+    renameConversationDiskViewDirsMigration.down!(workspaceDir);
+    // Should not throw
+  });
+
+  test("no-op when no directories match new format", () => {
+    const conversationsDir = join(workspaceDir, "conversations");
+    mkdirSync(conversationsDir, { recursive: true });
+    mkdirSync(join(conversationsDir, "some-random-dir"));
+
+    renameConversationDiskViewDirsMigration.down!(workspaceDir);
+
+    expect(existsSync(join(conversationsDir, "some-random-dir"))).toBe(true);
+  });
+
+  test("handles multiple conversation directories", () => {
+    const conversationsDir = join(workspaceDir, "conversations");
+    mkdirSync(conversationsDir, { recursive: true });
+
+    const entries = [
+      { ts: "2025-01-01T00-00-00.000Z", id: "conv-a" },
+      { ts: "2025-02-15T12-30-00.000Z", id: "conv-b" },
+    ];
+
+    for (const { ts, id } of entries) {
+      mkdirSync(join(conversationsDir, `${ts}_${id}`));
+    }
+
+    renameConversationDiskViewDirsMigration.down!(workspaceDir);
+
+    for (const { ts, id } of entries) {
+      expect(existsSync(join(conversationsDir, `${id}_${ts}`))).toBe(true);
+      expect(existsSync(join(conversationsDir, `${ts}_${id}`))).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 014-migrate-to-workspace-volume down()
+// ---------------------------------------------------------------------------
+
+describe("014-migrate-to-workspace-volume down()", () => {
+  test("removes sentinel file", () => {
+    const sentinelPath = join(workspaceDir, ".workspace-volume-migrated");
+    writeFileSync(sentinelPath, new Date().toISOString());
+
+    expect(existsSync(sentinelPath)).toBe(true);
+
+    migrateToWorkspaceVolumeMigration.down!(workspaceDir);
+
+    expect(existsSync(sentinelPath)).toBe(false);
+  });
+
+  test("idempotent: calling down() twice does not error", () => {
+    const sentinelPath = join(workspaceDir, ".workspace-volume-migrated");
+    writeFileSync(sentinelPath, new Date().toISOString());
+
+    migrateToWorkspaceVolumeMigration.down!(workspaceDir);
+    migrateToWorkspaceVolumeMigration.down!(workspaceDir);
+
+    expect(existsSync(sentinelPath)).toBe(false);
+  });
+
+  test("no-op when sentinel file does not exist", () => {
+    migrateToWorkspaceVolumeMigration.down!(workspaceDir);
+    // Should not throw
+    expect(existsSync(join(workspaceDir, ".workspace-volume-migrated"))).toBe(
+      false,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 016-extract-feature-flags-to-protected down()
+// ---------------------------------------------------------------------------
+
+describe("016-extract-feature-flags-to-protected down()", () => {
+  beforeEach(() => {
+    // Set up mock root dir for getRootDir() to point to our temp dir
+    mockRootDir = freshWorkspace();
+  });
+
+  test("moves feature flags from protected dir back to config.json", () => {
+    const protectedDir = join(mockRootDir, "protected");
+    mkdirSync(protectedDir, { recursive: true });
+
+    // Write feature flags to protected dir (post-run() state)
+    writeFileSync(
+      join(protectedDir, "feature-flags.json"),
+      JSON.stringify(
+        {
+          version: 1,
+          values: {
+            "feature_flags.my-flag.enabled": true,
+            "feature_flags.other-flag.enabled": false,
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+
+    // Write config without feature flags
+    writeConfig({ otherSetting: true });
+
+    extractFeatureFlagsToProtectedMigration.down!(workspaceDir);
+
+    const config = readConfig();
+    const flagValues = config.assistantFeatureFlagValues as Record<
+      string,
+      boolean
+    >;
+    expect(flagValues["feature_flags.my-flag.enabled"]).toBe(true);
+    expect(flagValues["feature_flags.other-flag.enabled"]).toBe(false);
+    expect(config.otherSetting).toBe(true);
+
+    // Protected file should be cleaned up
+    expect(existsSync(join(protectedDir, "feature-flags.json"))).toBe(false);
+  });
+
+  test("round-trip: run() then down() restores config.json", () => {
+    const protectedDir = join(mockRootDir, "protected");
+
+    writeConfig({
+      assistantFeatureFlagValues: {
+        "feature_flags.test-flag.enabled": false,
+      },
+      otherSetting: "hello",
+    });
+
+    extractFeatureFlagsToProtectedMigration.run(workspaceDir);
+
+    // After run: feature flags should be in protected dir
+    expect(existsSync(join(protectedDir, "feature-flags.json"))).toBe(true);
+    const configAfterRun = readConfig();
+    expect(configAfterRun.assistantFeatureFlagValues).toBeUndefined();
+
+    extractFeatureFlagsToProtectedMigration.down!(workspaceDir);
+
+    const configAfterDown = readConfig();
+    const flagValues = configAfterDown.assistantFeatureFlagValues as Record<
+      string,
+      boolean
+    >;
+    expect(flagValues["feature_flags.test-flag.enabled"]).toBe(false);
+    expect(configAfterDown.otherSetting).toBe("hello");
+    expect(existsSync(join(protectedDir, "feature-flags.json"))).toBe(false);
+  });
+
+  test("idempotent: calling down() twice produces same result", () => {
+    const protectedDir = join(mockRootDir, "protected");
+    mkdirSync(protectedDir, { recursive: true });
+
+    writeFileSync(
+      join(protectedDir, "feature-flags.json"),
+      JSON.stringify({
+        version: 1,
+        values: { "feature_flags.flag.enabled": true },
+      }) + "\n",
+    );
+
+    writeConfig({});
+
+    extractFeatureFlagsToProtectedMigration.down!(workspaceDir);
+    const afterFirst = readConfig();
+
+    // Second call: feature-flags.json was already deleted, so this is a no-op
+    extractFeatureFlagsToProtectedMigration.down!(workspaceDir);
+    const afterSecond = readConfig();
+
+    expect(afterSecond).toEqual(afterFirst);
+  });
+
+  test("no-op when feature-flags.json does not exist in protected dir", () => {
+    const original = { otherSetting: true };
+    writeConfig(original);
+
+    extractFeatureFlagsToProtectedMigration.down!(workspaceDir);
+
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("no-op when feature-flags.json has no values", () => {
+    const protectedDir = join(mockRootDir, "protected");
+    mkdirSync(protectedDir, { recursive: true });
+
+    writeFileSync(
+      join(protectedDir, "feature-flags.json"),
+      JSON.stringify({ version: 1, values: {} }) + "\n",
+    );
+
+    const original = { otherSetting: true };
+    writeConfig(original);
+
+    extractFeatureFlagsToProtectedMigration.down!(workspaceDir);
+
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("merges into existing assistantFeatureFlagValues", () => {
+    const protectedDir = join(mockRootDir, "protected");
+    mkdirSync(protectedDir, { recursive: true });
+
+    writeFileSync(
+      join(protectedDir, "feature-flags.json"),
+      JSON.stringify({
+        version: 1,
+        values: { "feature_flags.new-flag.enabled": true },
+      }) + "\n",
+    );
+
+    writeConfig({
+      assistantFeatureFlagValues: {
+        "feature_flags.existing-flag.enabled": false,
+      },
+    });
+
+    extractFeatureFlagsToProtectedMigration.down!(workspaceDir);
+
+    const config = readConfig();
+    const flagValues = config.assistantFeatureFlagValues as Record<
+      string,
+      boolean
+    >;
+    expect(flagValues["feature_flags.existing-flag.enabled"]).toBe(false);
+    expect(flagValues["feature_flags.new-flag.enabled"]).toBe(true);
+  });
+
+  test("creates config.json if it does not exist", () => {
+    const protectedDir = join(mockRootDir, "protected");
+    mkdirSync(protectedDir, { recursive: true });
+
+    writeFileSync(
+      join(protectedDir, "feature-flags.json"),
+      JSON.stringify({
+        version: 1,
+        values: { "feature_flags.flag.enabled": true },
+      }) + "\n",
+    );
+
+    // No config.json exists
+
+    extractFeatureFlagsToProtectedMigration.down!(workspaceDir);
+
+    const config = readConfig();
+    const flagValues = config.assistantFeatureFlagValues as Record<
+      string,
+      boolean
+    >;
+    expect(flagValues["feature_flags.flag.enabled"]).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 017-seed-persona-dirs down()
+// ---------------------------------------------------------------------------
+
+describe("017-seed-persona-dirs down()", () => {
+  test("removes empty users/ and channels/ directories", () => {
+    const usersDir = join(workspaceDir, "users");
+    const channelsDir = join(workspaceDir, "channels");
+    mkdirSync(usersDir, { recursive: true });
+    mkdirSync(channelsDir, { recursive: true });
+
+    seedPersonaDirsMigration.down!(workspaceDir);
+
+    expect(existsSync(usersDir)).toBe(false);
+    expect(existsSync(channelsDir)).toBe(false);
+  });
+
+  test("leaves non-empty directories in place", () => {
+    const usersDir = join(workspaceDir, "users");
+    const channelsDir = join(workspaceDir, "channels");
+    mkdirSync(usersDir, { recursive: true });
+    mkdirSync(channelsDir, { recursive: true });
+
+    // Add content to users/ so it should not be removed
+    writeFileSync(join(usersDir, "guardian.md"), "# Guardian");
+
+    seedPersonaDirsMigration.down!(workspaceDir);
+
+    expect(existsSync(usersDir)).toBe(true);
+    expect(existsSync(channelsDir)).toBe(false);
+  });
+
+  test("idempotent: calling down() twice does not error", () => {
+    const usersDir = join(workspaceDir, "users");
+    const channelsDir = join(workspaceDir, "channels");
+    mkdirSync(usersDir, { recursive: true });
+    mkdirSync(channelsDir, { recursive: true });
+
+    seedPersonaDirsMigration.down!(workspaceDir);
+    seedPersonaDirsMigration.down!(workspaceDir);
+
+    expect(existsSync(usersDir)).toBe(false);
+    expect(existsSync(channelsDir)).toBe(false);
+  });
+
+  test("no-op when directories do not exist", () => {
+    seedPersonaDirsMigration.down!(workspaceDir);
+    // Should not throw
+    expect(existsSync(join(workspaceDir, "users"))).toBe(false);
+    expect(existsSync(join(workspaceDir, "channels"))).toBe(false);
+  });
+
+  test("handles case where only one directory exists", () => {
+    const usersDir = join(workspaceDir, "users");
+    mkdirSync(usersDir, { recursive: true });
+
+    seedPersonaDirsMigration.down!(workspaceDir);
+
+    expect(existsSync(usersDir)).toBe(false);
+    expect(existsSync(join(workspaceDir, "channels"))).toBe(false);
+  });
+});

--- a/assistant/src/__tests__/workspace-migrations-runner.test.ts
+++ b/assistant/src/__tests__/workspace-migrations-runner.test.ts
@@ -54,6 +54,7 @@ mock.module("node:fs", () => ({
 // Import after mocking
 import {
   loadCheckpoints,
+  rollbackWorkspaceMigrations,
   runWorkspaceMigrations,
 } from "../workspace/migrations/runner.js";
 
@@ -68,6 +69,15 @@ function makeMigration(id: string): WorkspaceMigration {
     id,
     description: `Migration ${id}`,
     run: mock(() => {}),
+  };
+}
+
+function makeMigrationWithDown(id: string): WorkspaceMigration {
+  return {
+    id,
+    description: `Migration ${id}`,
+    run: mock(() => {}),
+    down: mock(() => {}),
   };
 }
 
@@ -289,5 +299,135 @@ describe("runWorkspaceMigrations", () => {
     expect(logWarnFn).toHaveBeenCalledWith(
       expect.stringContaining("malformed"),
     );
+  });
+});
+
+describe("rollbackWorkspaceMigrations", () => {
+  beforeEach(() => {
+    mockCheckpointContents = null;
+    readTextFileSyncFn.mockClear();
+    ensureDirFn.mockClear();
+    writeFileSyncFn.mockClear();
+    renameSyncFn.mockClear();
+    logWarnFn.mockClear();
+    logInfoFn.mockClear();
+    logErrorFn.mockClear();
+  });
+
+  test("rolls back migrations in reverse order", async () => {
+    const m1 = makeMigrationWithDown("001");
+    const m2 = makeMigrationWithDown("002");
+    const m3 = makeMigrationWithDown("003");
+
+    // All three migrations are marked as completed in checkpoints
+    mockCheckpointContents = JSON.stringify({
+      applied: {
+        "001": { appliedAt: "2025-01-01T00:00:00.000Z", status: "completed" },
+        "002": { appliedAt: "2025-01-02T00:00:00.000Z", status: "completed" },
+        "003": { appliedAt: "2025-01-03T00:00:00.000Z", status: "completed" },
+      },
+    });
+
+    const callOrder: string[] = [];
+    (m2.down as ReturnType<typeof mock>).mockImplementation(() => {
+      callOrder.push("002");
+    });
+    (m3.down as ReturnType<typeof mock>).mockImplementation(() => {
+      callOrder.push("003");
+    });
+
+    // Roll back to m1 — should reverse m3 then m2, but not m1
+    await rollbackWorkspaceMigrations(WORKSPACE_DIR, [m1, m2, m3], "001");
+
+    expect(m3.down).toHaveBeenCalledTimes(1);
+    expect(m2.down).toHaveBeenCalledTimes(1);
+    expect(m1.down).not.toHaveBeenCalled();
+    expect(callOrder).toEqual(["003", "002"]);
+  });
+
+  test("throws when migration has no down function", async () => {
+    const m1 = makeMigrationWithDown("001");
+    // m2 has no down function
+    const m2 = makeMigration("002");
+
+    mockCheckpointContents = JSON.stringify({
+      applied: {
+        "001": { appliedAt: "2025-01-01T00:00:00.000Z", status: "completed" },
+        "002": { appliedAt: "2025-01-02T00:00:00.000Z", status: "completed" },
+      },
+    });
+
+    await expect(
+      rollbackWorkspaceMigrations(WORKSPACE_DIR, [m1, m2], "001"),
+    ).rejects.toThrow(
+      'Migration "002" does not support rollback (no down() method)',
+    );
+  });
+
+  test("handles crash during rollback (rolling_back status)", async () => {
+    const m1 = makeMigrationWithDown("001");
+
+    // Simulate a crash during a previous rollback — m1 is left in rolling_back state
+    mockCheckpointContents = JSON.stringify({
+      applied: {
+        "001": {
+          appliedAt: "2025-01-01T00:00:00.000Z",
+          status: "rolling_back",
+        },
+      },
+    });
+
+    // runWorkspaceMigrations should clear the rolling_back status and re-run forward
+    await runWorkspaceMigrations(WORKSPACE_DIR, [m1]);
+
+    // The runner treats "rolling_back" like "started" — it clears the entry and re-runs
+    expect(m1.run).toHaveBeenCalledTimes(1);
+  });
+
+  test("removes checkpoints for rolled-back migrations", async () => {
+    const m1 = makeMigrationWithDown("001");
+    const m2 = makeMigrationWithDown("002");
+    const m3 = makeMigrationWithDown("003");
+
+    mockCheckpointContents = JSON.stringify({
+      applied: {
+        "001": { appliedAt: "2025-01-01T00:00:00.000Z", status: "completed" },
+        "002": { appliedAt: "2025-01-02T00:00:00.000Z", status: "completed" },
+        "003": { appliedAt: "2025-01-03T00:00:00.000Z", status: "completed" },
+      },
+    });
+
+    await rollbackWorkspaceMigrations(WORKSPACE_DIR, [m1, m2, m3], "001");
+
+    // The last checkpoint write should only contain m1 (002 and 003 were rolled back)
+    const lastWriteCall = writeFileSyncFn.mock.calls.at(-1) as unknown[];
+    const finalCheckpoint = JSON.parse(lastWriteCall[1] as string);
+    expect(finalCheckpoint.applied["001"]).toBeDefined();
+    expect(finalCheckpoint.applied["002"]).toBeUndefined();
+    expect(finalCheckpoint.applied["003"]).toBeUndefined();
+  });
+
+  test("no-op when already at target", async () => {
+    const m1 = makeMigrationWithDown("001");
+    const m2 = makeMigrationWithDown("002");
+    const m3 = makeMigrationWithDown("003");
+
+    mockCheckpointContents = JSON.stringify({
+      applied: {
+        "001": { appliedAt: "2025-01-01T00:00:00.000Z", status: "completed" },
+        "002": { appliedAt: "2025-01-02T00:00:00.000Z", status: "completed" },
+        "003": { appliedAt: "2025-01-03T00:00:00.000Z", status: "completed" },
+      },
+    });
+
+    // Target is the last migration — nothing to roll back
+    await rollbackWorkspaceMigrations(WORKSPACE_DIR, [m1, m2, m3], "003");
+
+    expect(m1.down).not.toHaveBeenCalled();
+    expect(m2.down).not.toHaveBeenCalled();
+    expect(m3.down).not.toHaveBeenCalled();
+
+    // No checkpoint writes should have occurred (no rollback happened)
+    expect(writeFileSyncFn).not.toHaveBeenCalled();
   });
 });

--- a/assistant/src/memory/migrations/001-job-deferrals.ts
+++ b/assistant/src/memory/migrations/001-job-deferrals.ts
@@ -49,3 +49,22 @@ export function migrateJobDeferrals(database: DrizzleDb): void {
     throw e;
   }
 }
+
+/**
+ * Reverse the deferral reconciliation by moving `deferrals` back into `attempts`
+ * for pending embed jobs. Best-effort: jobs that accumulated real deferral counts
+ * after the forward migration ran cannot be distinguished from migrated ones.
+ */
+export function downJobDeferrals(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(/*sql*/ `
+    UPDATE memory_jobs
+    SET attempts = deferrals,
+        deferrals = 0,
+        updated_at = ${Date.now()}
+    WHERE status = 'pending'
+      AND deferrals > 0
+      AND attempts = 0
+      AND type IN ('embed_segment', 'embed_item', 'embed_summary')
+  `);
+}

--- a/assistant/src/memory/migrations/004-entity-relation-dedup.ts
+++ b/assistant/src/memory/migrations/004-entity-relation-dedup.ts
@@ -91,3 +91,13 @@ export function migrateMemoryEntityRelationDedup(database: DrizzleDb): void {
     throw e;
   }
 }
+
+/**
+ * No-op down: deduplication is a lossy operation — deleted duplicate rows
+ * cannot be restored. The forward migration merged rows by keeping the most
+ * recent evidence per (source, target, relation) triple; the discarded rows
+ * are permanently lost.
+ */
+export function downMemoryEntityRelationDedup(_database: DrizzleDb): void {
+  // Intentionally empty — irreversible lossy migration.
+}

--- a/assistant/src/memory/migrations/005-fingerprint-scope-unique.ts
+++ b/assistant/src/memory/migrations/005-fingerprint-scope-unique.ts
@@ -93,3 +93,79 @@ export function migrateMemoryItemsFingerprintScopeUnique(
     raw.exec("PRAGMA foreign_keys = ON");
   }
 }
+
+/**
+ * Reverse the compound (fingerprint, scope_id) unique index change by rebuilding
+ * memory_items with a column-level UNIQUE on fingerprint.
+ *
+ * WARNING: This is dangerous if data now relies on the compound constraint
+ * (i.e., the same fingerprint exists in multiple scopes). In that case, the
+ * rebuild will fail with a UNIQUE constraint violation. This is intentional —
+ * it prevents silent data loss on rollback.
+ */
+export function downMemoryItemsFingerprintScopeUnique(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  // Check if the column-level UNIQUE already exists — if so, nothing to do.
+  const tableDdl = raw
+    .query(
+      `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'memory_items'`,
+    )
+    .get() as { sql: string } | null;
+  if (
+    !tableDdl ||
+    tableDdl.sql.match(/fingerprint\s+TEXT\s+NOT\s+NULL\s+UNIQUE/i)
+  ) {
+    return;
+  }
+
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    raw.exec("BEGIN");
+
+    raw.exec(/*sql*/ `
+      CREATE TABLE memory_items_new (
+        id TEXT PRIMARY KEY,
+        kind TEXT NOT NULL,
+        subject TEXT NOT NULL,
+        statement TEXT NOT NULL,
+        status TEXT NOT NULL,
+        confidence REAL NOT NULL,
+        fingerprint TEXT NOT NULL UNIQUE,
+        first_seen_at INTEGER NOT NULL,
+        last_seen_at INTEGER NOT NULL,
+        last_used_at INTEGER,
+        importance REAL,
+        access_count INTEGER NOT NULL DEFAULT 0,
+        valid_from INTEGER,
+        invalid_at INTEGER,
+        verification_state TEXT NOT NULL DEFAULT 'assistant_inferred',
+        scope_id TEXT NOT NULL DEFAULT 'default'
+      )
+    `);
+
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_items_new
+      SELECT id, kind, subject, statement, status, confidence, fingerprint,
+             first_seen_at, last_seen_at, last_used_at, importance, access_count,
+             valid_from, invalid_at, verification_state, scope_id
+      FROM memory_items
+    `);
+
+    raw.exec(/*sql*/ `DROP TABLE memory_items`);
+    raw.exec(/*sql*/ `ALTER TABLE memory_items_new RENAME TO memory_items`);
+
+    raw.exec("COMMIT");
+  } catch (e) {
+    try {
+      raw.exec("ROLLBACK");
+    } catch {
+      /* no active transaction */
+    }
+    throw e;
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
+}

--- a/assistant/src/memory/migrations/006-scope-salted-fingerprints.ts
+++ b/assistant/src/memory/migrations/006-scope-salted-fingerprints.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
 import { computeMemoryFingerprint } from "../fingerprint.js";
 
@@ -64,6 +66,54 @@ export function migrateMemoryItemsScopeSaltedFingerprints(
         `INSERT OR IGNORE INTO memory_checkpoints (key, value, updated_at) VALUES (?, '1', ?)`,
       )
       .run(checkpointKey, Date.now());
+
+    raw.exec("COMMIT");
+  } catch (e) {
+    try {
+      raw.exec("ROLLBACK");
+    } catch {
+      /* no active transaction */
+    }
+    throw e;
+  }
+}
+
+/**
+ * Reverse the scope-salted fingerprint migration by recomputing fingerprints
+ * WITHOUT the scope_id prefix.
+ *
+ * Old format: sha256(`${kind}|${subject.toLowerCase()}|${statement.toLowerCase()}`)
+ */
+export function downMemoryItemsScopeSaltedFingerprints(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  interface ItemRow {
+    id: string;
+    kind: string;
+    subject: string;
+    statement: string;
+  }
+
+  const items = raw
+    .query(`SELECT id, kind, subject, statement FROM memory_items`)
+    .all() as ItemRow[];
+
+  if (items.length === 0) return;
+
+  try {
+    raw.exec("BEGIN");
+
+    const updateStmt = raw.prepare(
+      `UPDATE memory_items SET fingerprint = ? WHERE id = ?`,
+    );
+
+    for (const item of items) {
+      const normalized = `${item.kind}|${item.subject.toLowerCase()}|${item.statement.toLowerCase()}`;
+      const fingerprint = createHash("sha256").update(normalized).digest("hex");
+      updateStmt.run(fingerprint, item.id);
+    }
 
     raw.exec("COMMIT");
   } catch (e) {

--- a/assistant/src/memory/migrations/007-assistant-id-to-self.ts
+++ b/assistant/src/memory/migrations/007-assistant-id-to-self.ts
@@ -265,3 +265,13 @@ export function migrateAssistantIdToSelf(database: DrizzleDb): void {
     throw e;
   }
 }
+
+/**
+ * No-op down: the original assistant_id values are not recoverable. The forward
+ * migration normalized all assistant_id values to "self" and merged/deduplicated
+ * rows where the same logical entity existed under both the real assistantId and
+ * "self". The original per-assistant IDs are permanently lost.
+ */
+export function downAssistantIdToSelf(_database: DrizzleDb): void {
+  // Intentionally empty — original assistant_id values cannot be restored.
+}

--- a/assistant/src/memory/migrations/008-remove-assistant-id-columns.ts
+++ b/assistant/src/memory/migrations/008-remove-assistant-id-columns.ts
@@ -228,3 +228,37 @@ export function migrateRemoveAssistantIdColumns(database: DrizzleDb): void {
     raw.exec("PRAGMA foreign_keys = ON");
   }
 }
+
+/**
+ * Add the assistant_id column back to the 4 tables that had it removed.
+ *
+ * NOTE: The data previously stored in assistant_id is lost — all rows will
+ * have assistant_id = 'self' after this down migration. This only restores
+ * the column structure so that older code expecting the column can function.
+ */
+export function downRemoveAssistantIdColumns(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  const tables = [
+    "conversation_keys",
+    "attachments",
+    "channel_inbound_events",
+    "message_runs",
+  ];
+
+  for (const table of tables) {
+    // Check if the table exists and lacks assistant_id
+    const ddl = raw
+      .query(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?`)
+      .get(table) as { sql: string } | null;
+    if (!ddl || ddl.sql.includes("assistant_id")) continue;
+
+    try {
+      raw.exec(
+        /*sql*/ `ALTER TABLE ${table} ADD COLUMN assistant_id TEXT NOT NULL DEFAULT 'self'`,
+      );
+    } catch {
+      /* column already exists */
+    }
+  }
+}

--- a/assistant/src/memory/migrations/009-llm-usage-events-drop-assistant-id.ts
+++ b/assistant/src/memory/migrations/009-llm-usage-events-drop-assistant-id.ts
@@ -95,3 +95,29 @@ export function migrateLlmUsageEventsDropAssistantId(
     raw.exec("PRAGMA foreign_keys = ON");
   }
 }
+
+/**
+ * Add the assistant_id column back to llm_usage_events.
+ *
+ * NOTE: The data previously stored in assistant_id is lost — all rows will
+ * have assistant_id = NULL after this down migration. This only restores
+ * the column structure so that older code expecting the column can function.
+ */
+export function downLlmUsageEventsDropAssistantId(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  const ddl = raw
+    .query(
+      `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'llm_usage_events'`,
+    )
+    .get() as { sql: string } | null;
+  if (!ddl || ddl.sql.includes("assistant_id")) return;
+
+  try {
+    raw.exec(
+      /*sql*/ `ALTER TABLE llm_usage_events ADD COLUMN assistant_id TEXT`,
+    );
+  } catch {
+    /* column already exists */
+  }
+}

--- a/assistant/src/memory/migrations/014-backfill-inbox-thread-state.ts
+++ b/assistant/src/memory/migrations/014-backfill-inbox-thread-state.ts
@@ -88,3 +88,13 @@ export function migrateBackfillInboxThreadStateFromBindings(
     throw e;
   }
 }
+
+/**
+ * No-op down: the seeded inbox thread state rows are expected to remain.
+ * The forward migration used INSERT OR IGNORE, so existing rows were never
+ * modified. Removing the seeded rows could leave the inbox empty for
+ * pre-existing conversations, which is worse than keeping them.
+ */
+export function downBackfillInboxThreadState(_database: DrizzleDb): void {
+  // Intentionally empty — seeded data is expected to remain.
+}

--- a/assistant/src/memory/migrations/015-drop-active-search-index.ts
+++ b/assistant/src/memory/migrations/015-drop-active-search-index.ts
@@ -31,3 +31,20 @@ export function migrateDropActiveSearchIndex(database: DrizzleDb): void {
     throw e;
   }
 }
+
+/**
+ * Recreate the old idx_memory_items_active_search index with its original
+ * covering columns (before the migration added status and invalid_at as
+ * indexed columns).
+ */
+export function downDropActiveSearchIndex(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  // Drop the current index if it exists, then recreate with the old column set.
+  raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_memory_items_active_search`);
+  raw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_items_active_search
+    ON memory_items(last_seen_at DESC, subject, statement, id, kind, confidence, importance, first_seen_at, scope_id)
+    WHERE status = 'active' AND invalid_at IS NULL
+  `);
+}

--- a/assistant/src/memory/migrations/019-notification-tables-schema-migration.ts
+++ b/assistant/src/memory/migrations/019-notification-tables-schema-migration.ts
@@ -82,3 +82,15 @@ export function migrateNotificationTablesSchema(database: DrizzleDb): void {
     }
   }
 }
+
+/**
+ * No-op down: the old enum-based notification tables cannot be recreated
+ * without the original schema definitions (column names, types, constraints,
+ * and enum values). The forward migration dropped these tables entirely.
+ * Any data that was in them is permanently lost. The new signal-contract
+ * schema tables are structurally incompatible with the old enum-based ones.
+ */
+export function downNotificationTablesSchema(_database: DrizzleDb): void {
+  // Intentionally empty — old enum-based tables cannot be recreated without
+  // the original schema, and any data they contained is permanently lost.
+}

--- a/assistant/src/memory/migrations/020-rename-macos-ios-channel-to-vellum.ts
+++ b/assistant/src/memory/migrations/020-rename-macos-ios-channel-to-vellum.ts
@@ -130,3 +130,124 @@ export function migrateRenameChannelToVellum(database: DrizzleDb): void {
     throw e;
   }
 }
+
+/**
+ * Reverse the channel rename by changing "vellum" back to "macos" in all tables.
+ *
+ * NOTE: The forward migration renamed both "macos" and "ios" to "vellum", so we
+ * cannot distinguish which rows were originally "ios". This down migration
+ * conservatively maps all "vellum" values back to "macos" since that was the
+ * primary desktop channel identifier.
+ */
+export function downRenameChannelToVellum(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  try {
+    raw.exec("BEGIN");
+
+    // guardian_action_deliveries.destination_channel
+    const gadExists = raw
+      .query(
+        `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'guardian_action_deliveries'`,
+      )
+      .get();
+    if (gadExists) {
+      raw
+        .query(
+          `UPDATE guardian_action_deliveries SET destination_channel = 'macos' WHERE destination_channel = 'vellum'`,
+        )
+        .run();
+    }
+
+    // messages.user_message_channel / assistant_message_channel
+    const msgsExists = raw
+      .query(
+        `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'messages'`,
+      )
+      .get();
+    if (msgsExists) {
+      const hasUserMsgChannel = raw
+        .query(
+          `SELECT 1 FROM pragma_table_info('messages') WHERE name = 'user_message_channel'`,
+        )
+        .get();
+      if (hasUserMsgChannel) {
+        raw
+          .query(
+            `UPDATE messages SET user_message_channel = 'macos' WHERE user_message_channel = 'vellum'`,
+          )
+          .run();
+      }
+      const hasAssistantMsgChannel = raw
+        .query(
+          `SELECT 1 FROM pragma_table_info('messages') WHERE name = 'assistant_message_channel'`,
+        )
+        .get();
+      if (hasAssistantMsgChannel) {
+        raw
+          .query(
+            `UPDATE messages SET assistant_message_channel = 'macos' WHERE assistant_message_channel = 'vellum'`,
+          )
+          .run();
+      }
+    }
+
+    // external_conversation_bindings.source_channel
+    const ecbExists = raw
+      .query(
+        `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'external_conversation_bindings'`,
+      )
+      .get();
+    if (ecbExists) {
+      raw
+        .query(
+          `UPDATE external_conversation_bindings SET source_channel = 'macos' WHERE source_channel = 'vellum'`,
+        )
+        .run();
+    }
+
+    // assistant_inbox_thread_state.source_channel
+    const aitsExists = raw
+      .query(
+        `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'assistant_inbox_thread_state'`,
+      )
+      .get();
+    if (aitsExists) {
+      raw
+        .query(
+          `UPDATE assistant_inbox_thread_state SET source_channel = 'macos' WHERE source_channel = 'vellum'`,
+        )
+        .run();
+    }
+
+    // conversations.origin_channel
+    const convExists = raw
+      .query(
+        `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'conversations'`,
+      )
+      .get();
+    if (convExists) {
+      const hasOriginChannel = raw
+        .query(
+          `SELECT 1 FROM pragma_table_info('conversations') WHERE name = 'origin_channel'`,
+        )
+        .get();
+      if (hasOriginChannel) {
+        raw
+          .query(
+            `UPDATE conversations SET origin_channel = 'macos' WHERE origin_channel = 'vellum'`,
+          )
+          .run();
+      }
+    }
+
+    raw.exec("COMMIT");
+  } catch (e) {
+    try {
+      raw.exec("ROLLBACK");
+    } catch {
+      /* no active transaction */
+    }
+    throw e;
+  }
+}

--- a/assistant/src/memory/migrations/024-embedding-vector-blob.ts
+++ b/assistant/src/memory/migrations/024-embedding-vector-blob.ts
@@ -71,3 +71,77 @@ export function migrateEmbeddingVectorBlob(database: DrizzleDb): void {
       .run(checkpointKey, Date.now());
   }
 }
+
+/**
+ * Drop the vector_blob column from memory_embeddings.
+ *
+ * NOTE: Binary embedding data stored in vector_blob is lost on rollback.
+ * Rows that still have vector_json will continue to work; rows that only
+ * had vector_blob will lose their embedding vectors.
+ *
+ * SQLite does not support DROP COLUMN on all versions, so we rebuild the table.
+ */
+export function downEmbeddingVectorBlob(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  // Check if vector_blob column exists
+  const hasColumn = raw
+    .query(
+      `SELECT 1 FROM pragma_table_info('memory_embeddings') WHERE name = 'vector_blob'`,
+    )
+    .get();
+  if (!hasColumn) return;
+
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    raw.exec("BEGIN");
+
+    // Get the current columns minus vector_blob
+    const columns = raw
+      .query(`SELECT name FROM pragma_table_info('memory_embeddings')`)
+      .all() as Array<{ name: string }>;
+    const keepColumns = columns
+      .map((c) => c.name)
+      .filter((n) => n !== "vector_blob");
+
+    // Get the current DDL to understand the table structure
+    const ddl = raw
+      .query(
+        `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'memory_embeddings'`,
+      )
+      .get() as { sql: string } | null;
+    if (!ddl) {
+      raw.exec("ROLLBACK");
+      return;
+    }
+
+    // Remove the vector_blob column definition from the DDL
+    const newDdl = ddl.sql
+      .replace(/,\s*vector_blob\s+BLOB/i, "")
+      .replace("memory_embeddings", "memory_embeddings_new");
+
+    raw.exec(newDdl);
+
+    const colList = keepColumns.join(", ");
+    raw.exec(/*sql*/ `
+      INSERT INTO memory_embeddings_new (${colList})
+      SELECT ${colList} FROM memory_embeddings
+    `);
+
+    raw.exec(/*sql*/ `DROP TABLE memory_embeddings`);
+    raw.exec(
+      /*sql*/ `ALTER TABLE memory_embeddings_new RENAME TO memory_embeddings`,
+    );
+
+    raw.exec("COMMIT");
+  } catch (e) {
+    try {
+      raw.exec("ROLLBACK");
+    } catch {
+      /* no active transaction */
+    }
+    throw e;
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
+}

--- a/assistant/src/memory/migrations/026a-embeddings-nullable-vector-json.ts
+++ b/assistant/src/memory/migrations/026a-embeddings-nullable-vector-json.ts
@@ -105,6 +105,77 @@ export function migrateEmbeddingsNullableVectorJson(database: DrizzleDb): void {
   }
 }
 
+/**
+ * Reverse v13: rebuild memory_embeddings with NOT NULL on vector_json.
+ *
+ * WARNING: Any rows with NULL vector_json will be lost — they cannot satisfy
+ * the NOT NULL constraint. This is acceptable because the forward migration
+ * only relaxed the constraint; rows written after the forward migration may
+ * have NULL vector_json (relying on vector_blob instead).
+ */
+export function downEmbeddingsNullableVectorJson(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  const tableExists = raw
+    .query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'memory_embeddings'`,
+    )
+    .get();
+  if (!tableExists) return;
+
+  // Check if vector_json already has NOT NULL — already rolled back
+  const ddl = raw
+    .query(
+      `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'memory_embeddings'`,
+    )
+    .get() as { sql: string } | null;
+  if (ddl && isColumnNotNull(ddl.sql, "vector_json")) return;
+
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    raw.exec(/*sql*/ `
+      CREATE TABLE memory_embeddings_new (
+        id TEXT PRIMARY KEY,
+        target_type TEXT NOT NULL,
+        target_id TEXT NOT NULL,
+        provider TEXT NOT NULL,
+        model TEXT NOT NULL,
+        dimensions INTEGER NOT NULL,
+        vector_json TEXT NOT NULL,
+        vector_blob BLOB,
+        content_hash TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        UNIQUE (target_type, target_id, provider, model)
+      )
+    `);
+    // Only copy rows where vector_json is NOT NULL — rows with NULL cannot
+    // satisfy the restored constraint and are lost.
+    raw.exec(/*sql*/ `
+      INSERT OR IGNORE INTO memory_embeddings_new (
+        id, target_type, target_id, provider, model, dimensions,
+        vector_json, vector_blob, content_hash, created_at, updated_at
+      )
+      SELECT
+        id, target_type, target_id, provider, model, dimensions,
+        vector_json, vector_blob, content_hash, created_at, updated_at
+      FROM memory_embeddings
+      WHERE vector_json IS NOT NULL
+      ORDER BY updated_at DESC
+    `);
+    raw.exec(/*sql*/ `DROP TABLE memory_embeddings`);
+    raw.exec(
+      /*sql*/ `ALTER TABLE memory_embeddings_new RENAME TO memory_embeddings`,
+    );
+
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_content_hash ON memory_embeddings(content_hash, provider, model)`,
+    );
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
+}
+
 /** Check whether a column is declared NOT NULL in a CREATE TABLE DDL string. */
 function isColumnNotNull(ddl: string, column: string): boolean {
   const pattern = new RegExp(`${column}\\s+\\w+.*?NOT\\s+NULL`, "i");

--- a/assistant/src/memory/migrations/026a-embeddings-nullable-vector-json.ts
+++ b/assistant/src/memory/migrations/026a-embeddings-nullable-vector-json.ts
@@ -133,6 +133,8 @@ export function downEmbeddingsNullableVectorJson(database: DrizzleDb): void {
 
   raw.exec("PRAGMA foreign_keys = OFF");
   try {
+    raw.exec("BEGIN");
+
     raw.exec(/*sql*/ `
       CREATE TABLE memory_embeddings_new (
         id TEXT PRIMARY KEY,
@@ -171,6 +173,15 @@ export function downEmbeddingsNullableVectorJson(database: DrizzleDb): void {
     raw.exec(
       /*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_embeddings_content_hash ON memory_embeddings(content_hash, provider, model)`,
     );
+
+    raw.exec("COMMIT");
+  } catch (e) {
+    try {
+      raw.exec("ROLLBACK");
+    } catch {
+      /* no active transaction */
+    }
+    throw e;
   } finally {
     raw.exec("PRAGMA foreign_keys = ON");
   }

--- a/assistant/src/memory/migrations/036-normalize-phone-identities.ts
+++ b/assistant/src/memory/migrations/036-normalize-phone-identities.ts
@@ -336,3 +336,14 @@ export function migrateNormalizePhoneIdentities(database: DrizzleDb): void {
     throw e;
   }
 }
+
+/**
+ * Reverse v14: no-op — original non-E.164 phone formats are not recoverable.
+ *
+ * The forward migration normalised phone numbers to E.164. The original
+ * formatting (parentheses, dashes, spaces, country-code variants) was
+ * discarded during normalisation and cannot be reconstructed.
+ */
+export function downNormalizePhoneIdentities(_database: DrizzleDb): void {
+  // Lossy — original phone formats are not recoverable.
+}

--- a/assistant/src/memory/migrations/126-backfill-guardian-principal-id.ts
+++ b/assistant/src/memory/migrations/126-backfill-guardian-principal-id.ts
@@ -2,6 +2,58 @@ import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
 /**
+ * Reverse v15: set guardian_principal_id back to NULL on all rows in
+ * channel_guardian_bindings and canonical_guardian_requests.
+ *
+ * Also un-expires requests that the forward migration expired (sets them
+ * back to 'pending'). This is a best-effort reversal — the original status
+ * of expired requests cannot be perfectly reconstructed if they were already
+ * expired before the forward migration ran, but the forward migration only
+ * expired requests that had NULL guardian_principal_id and status = 'pending'.
+ */
+export function downBackfillGuardianPrincipalId(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  // Null out guardian_principal_id on channel_guardian_bindings
+  const bindingsExists = raw
+    .query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'channel_guardian_bindings'`,
+    )
+    .get();
+  if (bindingsExists) {
+    const colExists = raw
+      .query(
+        `SELECT 1 FROM pragma_table_info('channel_guardian_bindings') WHERE name = 'guardian_principal_id'`,
+      )
+      .get();
+    if (colExists) {
+      raw.exec(
+        /*sql*/ `UPDATE channel_guardian_bindings SET guardian_principal_id = NULL`,
+      );
+    }
+  }
+
+  // Null out guardian_principal_id on canonical_guardian_requests
+  const requestsExists = raw
+    .query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'canonical_guardian_requests'`,
+    )
+    .get();
+  if (requestsExists) {
+    const colExists = raw
+      .query(
+        `SELECT 1 FROM pragma_table_info('canonical_guardian_requests') WHERE name = 'guardian_principal_id'`,
+      )
+      .get();
+    if (colExists) {
+      raw.exec(
+        /*sql*/ `UPDATE canonical_guardian_requests SET guardian_principal_id = NULL`,
+      );
+    }
+  }
+}
+
+/**
  * Backfill guardianPrincipalId for existing channel_guardian_bindings and
  * canonical_guardian_requests rows.
  *

--- a/assistant/src/memory/migrations/127-guardian-principal-id-not-null.ts
+++ b/assistant/src/memory/migrations/127-guardian-principal-id-not-null.ts
@@ -2,6 +2,72 @@ import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
 /**
+ * Reverse v16: rebuild channel_guardian_bindings to make guardian_principal_id
+ * nullable again (removing the NOT NULL constraint added by the forward migration).
+ */
+export function downGuardianPrincipalIdNotNull(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  const tableExists = raw
+    .query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'channel_guardian_bindings'`,
+    )
+    .get();
+  if (!tableExists) return;
+
+  // Check if guardian_principal_id has NOT NULL — if not, already rolled back
+  const colInfo = raw
+    .query(
+      `SELECT "notnull" FROM pragma_table_info('channel_guardian_bindings') WHERE name = 'guardian_principal_id'`,
+    )
+    .get() as { notnull: number } | null;
+  if (!colInfo || colInfo.notnull === 0) return;
+
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    raw.exec(/*sql*/ `
+      CREATE TABLE channel_guardian_bindings_new (
+        id TEXT PRIMARY KEY,
+        assistant_id TEXT NOT NULL,
+        channel TEXT NOT NULL,
+        guardian_external_user_id TEXT NOT NULL,
+        guardian_delivery_chat_id TEXT NOT NULL,
+        guardian_principal_id TEXT,
+        status TEXT NOT NULL DEFAULT 'active',
+        verified_at INTEGER NOT NULL,
+        verified_via TEXT NOT NULL DEFAULT 'challenge',
+        metadata_json TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+
+    raw.exec(/*sql*/ `
+      INSERT INTO channel_guardian_bindings_new
+      SELECT id, assistant_id, channel, guardian_external_user_id,
+             guardian_delivery_chat_id, guardian_principal_id,
+             status, verified_at, verified_via, metadata_json,
+             created_at, updated_at
+      FROM channel_guardian_bindings
+    `);
+
+    raw.exec(/*sql*/ `DROP TABLE channel_guardian_bindings`);
+    raw.exec(
+      /*sql*/ `ALTER TABLE channel_guardian_bindings_new RENAME TO channel_guardian_bindings`,
+    );
+
+    // Recreate the unique index for active bindings
+    raw.exec(/*sql*/ `
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_channel_guardian_bindings_active
+      ON channel_guardian_bindings(assistant_id, channel)
+      WHERE status = 'active'
+    `);
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
+}
+
+/**
  * Enforce NOT NULL on channel_guardian_bindings.guardian_principal_id.
  *
  * Migration 125 added the column as nullable, and migration 126 backfilled

--- a/assistant/src/memory/migrations/127-guardian-principal-id-not-null.ts
+++ b/assistant/src/memory/migrations/127-guardian-principal-id-not-null.ts
@@ -25,6 +25,8 @@ export function downGuardianPrincipalIdNotNull(database: DrizzleDb): void {
 
   raw.exec("PRAGMA foreign_keys = OFF");
   try {
+    raw.exec("BEGIN");
+
     raw.exec(/*sql*/ `
       CREATE TABLE channel_guardian_bindings_new (
         id TEXT PRIMARY KEY,
@@ -62,6 +64,15 @@ export function downGuardianPrincipalIdNotNull(database: DrizzleDb): void {
       ON channel_guardian_bindings(assistant_id, channel)
       WHERE status = 'active'
     `);
+
+    raw.exec("COMMIT");
+  } catch (e) {
+    try {
+      raw.exec("ROLLBACK");
+    } catch {
+      /* no active transaction */
+    }
+    throw e;
   } finally {
     raw.exec("PRAGMA foreign_keys = ON");
   }

--- a/assistant/src/memory/migrations/134-contacts-notes-column.ts
+++ b/assistant/src/memory/migrations/134-contacts-notes-column.ts
@@ -2,6 +2,19 @@ import { getLogger } from "../../util/logger.js";
 import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
+/**
+ * Reverse v17: no-op — the original separate columns (relationship, importance,
+ * response_expectation, preferred_tone) cannot be reliably restored from the
+ * consolidated notes TEXT column.
+ *
+ * The forward migration concatenated multiple typed fields into a single
+ * free-text notes field and then dropped the original columns. Parsing the
+ * notes back into structured fields would be lossy and error-prone.
+ */
+export function downContactsNotesColumn(_database: DrizzleDb): void {
+  // Lossy — original structured columns cannot be restored from notes text.
+}
+
 const log = getLogger("migration-134");
 
 export function migrateContactsNotesColumn(database: DrizzleDb): void {

--- a/assistant/src/memory/migrations/135-backfill-contact-interaction-stats.ts
+++ b/assistant/src/memory/migrations/135-backfill-contact-interaction-stats.ts
@@ -2,6 +2,26 @@ import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
 /**
+ * Reverse v18: set contacts.last_interaction back to NULL.
+ *
+ * The forward migration backfilled last_interaction from channel data.
+ * Rolling back simply clears the column — the data can be re-derived by
+ * re-running the forward migration.
+ */
+export function downBackfillContactInteractionStats(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  const colExists = raw
+    .query(
+      `SELECT 1 FROM pragma_table_info('contacts') WHERE name = 'last_interaction'`,
+    )
+    .get();
+  if (!colExists) return;
+
+  raw.exec(/*sql*/ `UPDATE contacts SET last_interaction = NULL`);
+}
+
+/**
  * Backfill contacts.last_interaction from the max lastSeenAt across each
  * contact's channels. interactionCount cannot be reliably derived from
  * existing data, so it stays at 0 and accumulates going forward.

--- a/assistant/src/memory/migrations/136-drop-assistant-id-columns.ts
+++ b/assistant/src/memory/migrations/136-drop-assistant-id-columns.ts
@@ -2,6 +2,58 @@ import { getLogger } from "../../util/logger.js";
 import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
+/**
+ * Reverse v19: add assistant_id columns back to all 16 tables via
+ * ALTER TABLE ADD COLUMN, defaulting to 'self'.
+ *
+ * This restores the column that the forward migration dropped. All rows
+ * get assistant_id = 'self' since that was the only value before dropping.
+ */
+export function downDropAssistantIdColumns(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  const tables = [
+    "contacts",
+    "assistant_ingress_invites",
+    "assistant_inbox_thread_state",
+    "call_sessions",
+    "channel_guardian_verification_challenges",
+    "channel_guardian_approval_requests",
+    "channel_guardian_rate_limits",
+    "guardian_action_requests",
+    "scoped_approval_grants",
+    "notification_events",
+    "notification_preferences",
+    "notification_deliveries",
+    "conversation_attention_events",
+    "conversation_assistant_attention_state",
+    "actor_token_records",
+    "actor_refresh_token_records",
+  ];
+
+  for (const table of tables) {
+    // Skip if table doesn't exist
+    const tableExists = raw
+      .query(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?`)
+      .get(table);
+    if (!tableExists) continue;
+
+    // Skip if column already exists (idempotent)
+    const colExists = raw
+      .query(`SELECT 1 FROM pragma_table_info(?) WHERE name = 'assistant_id'`)
+      .get(table);
+    if (colExists) continue;
+
+    try {
+      raw.exec(
+        /*sql*/ `ALTER TABLE ${table} ADD COLUMN assistant_id TEXT NOT NULL DEFAULT 'self'`,
+      );
+    } catch {
+      /* column may already exist from partial run */
+    }
+  }
+}
+
 const log = getLogger("migration-136");
 
 /**

--- a/assistant/src/memory/migrations/140-backfill-usage-cache-accounting.ts
+++ b/assistant/src/memory/migrations/140-backfill-usage-cache-accounting.ts
@@ -8,6 +8,19 @@ import { resolvePricingForUsageWithOverrides } from "../../util/pricing.js";
 import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
+/**
+ * Reverse v20: no-op — cannot reliably identify which llm_usage_events rows
+ * were updated by the backfill vs already had correct cache accounting.
+ *
+ * The forward migration updated input_tokens, output_tokens, cache token
+ * columns, estimated_cost_usd, and pricing_status based on request logs.
+ * There is no marker distinguishing backfilled rows from naturally-written
+ * ones, so a reversal cannot be performed without risking data corruption.
+ */
+export function downBackfillUsageCacheAccounting(_database: DrizzleDb): void {
+  // Lossy — cannot identify which rows were backfilled.
+}
+
 const log = getLogger("memory-db");
 
 const CHECKPOINT_KEY = "migration_backfill_usage_cache_accounting_v1";

--- a/assistant/src/memory/migrations/141-rename-verification-table.ts
+++ b/assistant/src/memory/migrations/141-rename-verification-table.ts
@@ -2,6 +2,60 @@ import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
 /**
+ * Reverse v21: rename channel_verification_sessions back to
+ * channel_guardian_verification_challenges and recreate old indexes.
+ */
+export function downRenameVerificationTable(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  // Check the new table exists before attempting anything
+  const newTableExists = raw
+    .query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'channel_verification_sessions'`,
+    )
+    .get();
+  if (!newTableExists) return;
+
+  // If the old table already exists, skip (already rolled back)
+  const oldTableExists = raw
+    .query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'channel_guardian_verification_challenges'`,
+    )
+    .get();
+  if (oldTableExists) return;
+
+  // Rename back to old name
+  raw.exec(
+    /*sql*/ `ALTER TABLE channel_verification_sessions RENAME TO channel_guardian_verification_challenges`,
+  );
+
+  // Drop new-style indexes and recreate old-style ones
+  raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_verification_sessions_lookup`);
+  raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_verification_sessions_active`);
+  raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_verification_sessions_identity`);
+  raw.exec(
+    /*sql*/ `DROP INDEX IF EXISTS idx_verification_sessions_destination`,
+  );
+  raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_verification_sessions_bootstrap`);
+
+  raw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_channel_guardian_challenges_lookup ON channel_guardian_verification_challenges(channel, challenge_hash, status)`,
+  );
+  raw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_sessions_active ON channel_guardian_verification_challenges(channel, status)`,
+  );
+  raw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_sessions_identity ON channel_guardian_verification_challenges(channel, expected_external_user_id, expected_chat_id, status)`,
+  );
+  raw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_sessions_destination ON channel_guardian_verification_challenges(channel, destination_address)`,
+  );
+  raw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_sessions_bootstrap ON channel_guardian_verification_challenges(channel, bootstrap_token_hash, status)`,
+  );
+}
+
+/**
  * One-shot migration: rename channel_guardian_verification_challenges →
  * channel_verification_sessions, including all indexes that reference the
  * old table name.

--- a/assistant/src/memory/migrations/142-rename-verification-session-id-column.ts
+++ b/assistant/src/memory/migrations/142-rename-verification-session-id-column.ts
@@ -2,6 +2,31 @@ import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
 /**
+ * Reverse v22: rename verification_session_id back to
+ * guardian_verification_session_id in call_sessions.
+ */
+export function downRenameVerificationSessionIdColumn(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  const columns = raw.query(`PRAGMA table_info(call_sessions)`).all() as Array<{
+    name: string;
+  }>;
+  const hasNewColumn = columns.some(
+    (c) => c.name === "verification_session_id",
+  );
+  const hasOldColumn = columns.some(
+    (c) => c.name === "guardian_verification_session_id",
+  );
+  if (!hasNewColumn || hasOldColumn) return;
+
+  raw.exec(
+    /*sql*/ `ALTER TABLE call_sessions RENAME COLUMN verification_session_id TO guardian_verification_session_id`,
+  );
+}
+
+/**
  * One-shot migration: rename the guardian_verification_session_id column
  * in call_sessions to verification_session_id, dropping the "guardian_"
  * prefix to align with the broader verification vocabulary.

--- a/assistant/src/memory/migrations/143-rename-guardian-verification-values.ts
+++ b/assistant/src/memory/migrations/143-rename-guardian-verification-values.ts
@@ -2,6 +2,41 @@ import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
 /**
+ * Reverse v23: add the "guardian_" prefix back to verification-related
+ * call_mode and event_type values.
+ */
+export function downRenameGuardianVerificationValues(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  // Rename call_mode values back
+  raw.exec(
+    /*sql*/ `UPDATE call_sessions SET call_mode = 'guardian_verification' WHERE call_mode = 'verification'`,
+  );
+
+  // Rename event_type values back
+  raw.exec(
+    /*sql*/ `UPDATE call_events SET event_type = 'guardian_voice_verification_started' WHERE event_type = 'voice_verification_started'`,
+  );
+  raw.exec(
+    /*sql*/ `UPDATE call_events SET event_type = 'guardian_voice_verification_succeeded' WHERE event_type = 'voice_verification_succeeded'`,
+  );
+  raw.exec(
+    /*sql*/ `UPDATE call_events SET event_type = 'guardian_voice_verification_failed' WHERE event_type = 'voice_verification_failed'`,
+  );
+  raw.exec(
+    /*sql*/ `UPDATE call_events SET event_type = 'outbound_guardian_voice_verification_started' WHERE event_type = 'outbound_voice_verification_started'`,
+  );
+  raw.exec(
+    /*sql*/ `UPDATE call_events SET event_type = 'outbound_guardian_voice_verification_succeeded' WHERE event_type = 'outbound_voice_verification_succeeded'`,
+  );
+  raw.exec(
+    /*sql*/ `UPDATE call_events SET event_type = 'outbound_guardian_voice_verification_failed' WHERE event_type = 'outbound_voice_verification_failed'`,
+  );
+}
+
+/**
  * One-shot migration: rename persisted `guardian_verification` and
  * `guardian_voice_verification_*` / `outbound_guardian_voice_verification_*`
  * values in the call_sessions and call_events tables to drop the "guardian_"

--- a/assistant/src/memory/migrations/144-rename-voice-to-phone.ts
+++ b/assistant/src/memory/migrations/144-rename-voice-to-phone.ts
@@ -2,6 +2,142 @@ import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
 /**
+ * Reverse v24: rename "phone" channel values back to "voice" across all
+ * tables with channel text columns.
+ */
+export function downRenameVoiceToPhone(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  // contact_channels.type
+  raw.exec(
+    /*sql*/ `UPDATE contact_channels SET type = 'voice' WHERE type = 'phone'`,
+  );
+
+  // conversations.origin_channel
+  raw.exec(
+    /*sql*/ `UPDATE conversations SET origin_channel = 'voice' WHERE origin_channel = 'phone'`,
+  );
+
+  // conversations.origin_interface
+  raw.exec(
+    /*sql*/ `UPDATE conversations SET origin_interface = 'voice' WHERE origin_interface = 'phone'`,
+  );
+
+  // messages.metadata — reverse the JSON string replacement
+  raw.exec(
+    /*sql*/ `UPDATE messages SET metadata = REPLACE(metadata, '"phone"', '"voice"') WHERE metadata LIKE '%"phone"%'`,
+  );
+
+  // assistant_ingress_invites.source_channel
+  raw.exec(
+    /*sql*/ `UPDATE assistant_ingress_invites SET source_channel = 'voice' WHERE source_channel = 'phone'`,
+  );
+
+  // assistant_inbox_thread_state.source_channel
+  raw.exec(
+    /*sql*/ `UPDATE assistant_inbox_thread_state SET source_channel = 'voice' WHERE source_channel = 'phone'`,
+  );
+
+  // guardian_action_requests.source_channel
+  raw.exec(
+    /*sql*/ `UPDATE guardian_action_requests SET source_channel = 'voice' WHERE source_channel = 'phone'`,
+  );
+
+  // guardian_action_requests.answered_by_channel
+  raw.exec(
+    /*sql*/ `UPDATE guardian_action_requests SET answered_by_channel = 'voice' WHERE answered_by_channel = 'phone'`,
+  );
+
+  // channel_verification_sessions.channel (the forward migration ran after v21 rename)
+  raw.exec(
+    /*sql*/ `UPDATE channel_verification_sessions SET channel = 'voice' WHERE channel = 'phone'`,
+  );
+
+  // channel_guardian_approval_requests.channel
+  raw.exec(
+    /*sql*/ `UPDATE channel_guardian_approval_requests SET channel = 'voice' WHERE channel = 'phone'`,
+  );
+
+  // channel_guardian_rate_limits.channel
+  // Dedup: remove phone rows that would collide with existing voice rows
+  raw.exec(/*sql*/ `DELETE FROM channel_guardian_rate_limits WHERE channel = 'phone' AND EXISTS (
+      SELECT 1 FROM channel_guardian_rate_limits AS t2
+      WHERE t2.channel = 'voice'
+        AND t2.actor_external_user_id = channel_guardian_rate_limits.actor_external_user_id
+        AND t2.actor_chat_id = channel_guardian_rate_limits.actor_chat_id
+    )`);
+  raw.exec(
+    /*sql*/ `UPDATE channel_guardian_rate_limits SET channel = 'voice' WHERE channel = 'phone'`,
+  );
+
+  // notification_events.source_channel
+  raw.exec(
+    /*sql*/ `UPDATE notification_events SET source_channel = 'voice' WHERE source_channel = 'phone'`,
+  );
+
+  // notification_deliveries.channel
+  raw.exec(
+    /*sql*/ `UPDATE notification_deliveries SET channel = 'voice' WHERE channel = 'phone'`,
+  );
+
+  // external_conversation_bindings.source_channel
+  raw.exec(
+    /*sql*/ `UPDATE external_conversation_bindings SET source_channel = 'voice' WHERE source_channel = 'phone'`,
+  );
+
+  // channel_inbound_events.source_channel
+  raw.exec(
+    /*sql*/ `UPDATE channel_inbound_events SET source_channel = 'voice' WHERE source_channel = 'phone'`,
+  );
+
+  // conversation_attention_events.source_channel
+  raw.exec(
+    /*sql*/ `UPDATE conversation_attention_events SET source_channel = 'voice' WHERE source_channel = 'phone'`,
+  );
+
+  // conversation_assistant_attention_state.last_seen_source_channel
+  raw.exec(
+    /*sql*/ `UPDATE conversation_assistant_attention_state SET last_seen_source_channel = 'voice' WHERE last_seen_source_channel = 'phone'`,
+  );
+
+  // canonical_guardian_requests.source_channel
+  raw.exec(
+    /*sql*/ `UPDATE canonical_guardian_requests SET source_channel = 'voice' WHERE source_channel = 'phone'`,
+  );
+
+  // canonical_guardian_deliveries.destination_channel
+  raw.exec(
+    /*sql*/ `UPDATE canonical_guardian_deliveries SET destination_channel = 'voice' WHERE destination_channel = 'phone'`,
+  );
+
+  // guardian_action_deliveries.destination_channel
+  raw.exec(
+    /*sql*/ `UPDATE guardian_action_deliveries SET destination_channel = 'voice' WHERE destination_channel = 'phone'`,
+  );
+
+  // scoped_approval_grants: request_channel, decision_channel, execution_channel
+  raw.exec(
+    /*sql*/ `UPDATE scoped_approval_grants SET request_channel = 'voice' WHERE request_channel = 'phone'`,
+  );
+  raw.exec(
+    /*sql*/ `UPDATE scoped_approval_grants SET decision_channel = 'voice' WHERE decision_channel = 'phone'`,
+  );
+  raw.exec(
+    /*sql*/ `UPDATE scoped_approval_grants SET execution_channel = 'voice' WHERE execution_channel = 'phone'`,
+  );
+
+  // sequences.channel
+  raw.exec(
+    /*sql*/ `UPDATE sequences SET channel = 'voice' WHERE channel = 'phone'`,
+  );
+
+  // followups.channel
+  raw.exec(
+    /*sql*/ `UPDATE followups SET channel = 'voice' WHERE channel = 'phone'`,
+  );
+}
+
+/**
  * One-shot migration: rename stored "voice" channel values to "phone" across
  * all tables that persist channel identifiers as text.
  *

--- a/assistant/src/memory/migrations/145-drop-accounts-table.ts
+++ b/assistant/src/memory/migrations/145-drop-accounts-table.ts
@@ -17,3 +17,35 @@ export function migrateDropAccountsTable(database: DrizzleDb): void {
     raw.exec(/*sql*/ `DROP TABLE IF EXISTS accounts`);
   });
 }
+
+/**
+ * Reverse: recreate the accounts table with its original schema.
+ *
+ * Data is permanently lost — the table was dropped. This only restores the
+ * empty table structure so that earlier migrations referencing it can operate.
+ */
+export function migrateDropAccountsTableDown(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS accounts (
+      id TEXT PRIMARY KEY,
+      service TEXT NOT NULL,
+      username TEXT,
+      email TEXT,
+      display_name TEXT,
+      status TEXT NOT NULL DEFAULT 'active',
+      credential_ref TEXT,
+      metadata_json TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  raw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_accounts_service ON accounts(service)`,
+  );
+  raw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_accounts_status ON accounts(status)`,
+  );
+}

--- a/assistant/src/memory/migrations/147-migrate-reminders-to-schedules.ts
+++ b/assistant/src/memory/migrations/147-migrate-reminders-to-schedules.ts
@@ -1,4 +1,5 @@
-import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
 /**
@@ -122,4 +123,16 @@ export function migrateRemindersToSchedules(database: DrizzleDb): void {
       throw err;
     }
   });
+}
+
+/**
+ * Reverse: no-op.
+ *
+ * Cannot reliably identify which cron_jobs rows were migrated from reminders
+ * versus created natively as schedules. Rows share the same table and there
+ * is no origin marker. Deleting the wrong rows would destroy user-created
+ * schedules.
+ */
+export function migrateRemindersToSchedulesDown(_database: DrizzleDb): void {
+  // No-op — see comment above.
 }

--- a/assistant/src/memory/migrations/148-drop-reminders-table.ts
+++ b/assistant/src/memory/migrations/148-drop-reminders-table.ts
@@ -1,4 +1,5 @@
-import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
 /**
@@ -11,4 +12,37 @@ export function migrateDropRemindersTable(database: DrizzleDb): void {
     raw.run("DROP INDEX IF EXISTS idx_reminders_status_fire_at");
     raw.run("DROP TABLE IF EXISTS reminders");
   });
+}
+
+/**
+ * Reverse: recreate the reminders table with its original schema.
+ *
+ * Data is permanently lost — the table was dropped. This only restores the
+ * empty table structure so that earlier migrations referencing it can operate.
+ * Includes the routing_intent and routing_hints_json columns added by
+ * migration 118.
+ */
+export function migrateDropRemindersTableDown(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS reminders (
+      id TEXT PRIMARY KEY,
+      label TEXT NOT NULL,
+      message TEXT NOT NULL,
+      fire_at INTEGER NOT NULL,
+      mode TEXT NOT NULL,
+      status TEXT NOT NULL,
+      fired_at INTEGER,
+      conversation_id TEXT,
+      routing_intent TEXT NOT NULL DEFAULT 'all_channels',
+      routing_hints_json TEXT NOT NULL DEFAULT '{}',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  raw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_reminders_status_fire_at ON reminders(status, fire_at)`,
+  );
 }

--- a/assistant/src/memory/migrations/150-oauth-apps-client-secret-path.ts
+++ b/assistant/src/memory/migrations/150-oauth-apps-client-secret-path.ts
@@ -127,6 +127,8 @@ export function migrateOAuthAppsClientSecretPathDown(
 
   raw.exec("PRAGMA foreign_keys = OFF");
   try {
+    raw.exec("BEGIN");
+
     raw.exec(/*sql*/ `
       CREATE TABLE oauth_apps_rollback (
         id TEXT PRIMARY KEY,
@@ -149,6 +151,15 @@ export function migrateOAuthAppsClientSecretPathDown(
     raw.exec(
       /*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_oauth_apps_provider_client ON oauth_apps(provider_key, client_id)`,
     );
+
+    raw.exec("COMMIT");
+  } catch (e) {
+    try {
+      raw.exec("ROLLBACK");
+    } catch {
+      /* no active transaction */
+    }
+    throw e;
   } finally {
     raw.exec("PRAGMA foreign_keys = ON");
   }

--- a/assistant/src/memory/migrations/150-oauth-apps-client-secret-path.ts
+++ b/assistant/src/memory/migrations/150-oauth-apps-client-secret-path.ts
@@ -1,4 +1,5 @@
-import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
 /**
@@ -95,4 +96,60 @@ export function migrateOAuthAppsClientSecretPath(database: DrizzleDb): void {
       }
     },
   );
+}
+
+/**
+ * Reverse: drop the client_secret_credential_path column from oauth_apps.
+ *
+ * Rebuilds the table without the column (SQLite doesn't support DROP COLUMN
+ * on older versions). Idempotent — skips if the column doesn't exist.
+ */
+export function migrateOAuthAppsClientSecretPathDown(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  // Guard: table must exist
+  const tableExists = raw
+    .query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'oauth_apps'`,
+    )
+    .get();
+  if (!tableExists) return;
+
+  // Guard: if the column doesn't exist, nothing to do
+  const colInfo = raw
+    .query(
+      `SELECT 1 FROM pragma_table_info('oauth_apps') WHERE name = 'client_secret_credential_path'`,
+    )
+    .get();
+  if (!colInfo) return;
+
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    raw.exec(/*sql*/ `
+      CREATE TABLE oauth_apps_rollback (
+        id TEXT PRIMARY KEY,
+        provider_key TEXT NOT NULL REFERENCES oauth_providers(provider_key),
+        client_id TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+
+    raw.exec(/*sql*/ `
+      INSERT INTO oauth_apps_rollback
+      SELECT id, provider_key, client_id, created_at, updated_at
+      FROM oauth_apps
+    `);
+
+    raw.exec(/*sql*/ `DROP TABLE oauth_apps`);
+    raw.exec(/*sql*/ `ALTER TABLE oauth_apps_rollback RENAME TO oauth_apps`);
+
+    raw.exec(
+      /*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_oauth_apps_provider_client ON oauth_apps(provider_key, client_id)`,
+    );
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
 }

--- a/assistant/src/memory/migrations/162-guardian-timestamps-epoch-ms.ts
+++ b/assistant/src/memory/migrations/162-guardian-timestamps-epoch-ms.ts
@@ -364,10 +364,10 @@ function hasTextAffinity(raw: RawDb, table: string, column: string): boolean {
 function rebuildCanonicalGuardianRequestsToText(raw: RawDb): void {
   if (hasTextAffinity(raw, "canonical_guardian_requests", "created_at")) return;
 
-  // Caller (rollbackMemoryMigration) already manages the transaction.
-  // We only need to disable FK checks for the table rebuild.
   raw.exec("PRAGMA foreign_keys = OFF");
   try {
+    raw.exec("BEGIN");
+
     raw.exec(/*sql*/ `
       CREATE TABLE canonical_guardian_requests_rb (
         id TEXT PRIMARY KEY,
@@ -431,6 +431,15 @@ function rebuildCanonicalGuardianRequestsToText(raw: RawDb): void {
     raw.exec(
       /*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_request_code ON canonical_guardian_requests(request_code)`,
     );
+
+    raw.exec("COMMIT");
+  } catch (e) {
+    try {
+      raw.exec("ROLLBACK");
+    } catch {
+      /* no active transaction */
+    }
+    throw e;
   } finally {
     raw.exec("PRAGMA foreign_keys = ON");
   }
@@ -442,6 +451,8 @@ function rebuildCanonicalGuardianDeliveriesToText(raw: RawDb): void {
 
   raw.exec("PRAGMA foreign_keys = OFF");
   try {
+    raw.exec("BEGIN");
+
     raw.exec(/*sql*/ `
       CREATE TABLE canonical_guardian_deliveries_rb (
         id TEXT PRIMARY KEY,
@@ -478,6 +489,15 @@ function rebuildCanonicalGuardianDeliveriesToText(raw: RawDb): void {
     raw.exec(
       /*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_deliveries_destination ON canonical_guardian_deliveries(destination_channel, destination_chat_id)`,
     );
+
+    raw.exec("COMMIT");
+  } catch (e) {
+    try {
+      raw.exec("ROLLBACK");
+    } catch {
+      /* no active transaction */
+    }
+    throw e;
   } finally {
     raw.exec("PRAGMA foreign_keys = ON");
   }
@@ -488,6 +508,8 @@ function rebuildScopedApprovalGrantsToText(raw: RawDb): void {
 
   raw.exec("PRAGMA foreign_keys = OFF");
   try {
+    raw.exec("BEGIN");
+
     raw.exec(/*sql*/ `
       CREATE TABLE scoped_approval_grants_rb (
         id TEXT PRIMARY KEY,
@@ -536,6 +558,15 @@ function rebuildScopedApprovalGrantsToText(raw: RawDb): void {
     raw.exec(
       /*sql*/ `CREATE INDEX IF NOT EXISTS idx_scoped_grants_status_expires ON scoped_approval_grants(status, expires_at)`,
     );
+
+    raw.exec("COMMIT");
+  } catch (e) {
+    try {
+      raw.exec("ROLLBACK");
+    } catch {
+      /* no active transaction */
+    }
+    throw e;
   } finally {
     raw.exec("PRAGMA foreign_keys = ON");
   }

--- a/assistant/src/memory/migrations/162-guardian-timestamps-epoch-ms.ts
+++ b/assistant/src/memory/migrations/162-guardian-timestamps-epoch-ms.ts
@@ -281,3 +281,262 @@ function rebuildScopedApprovalGrants(raw: RawDb): void {
     raw.exec("PRAGMA foreign_keys = ON");
   }
 }
+
+// ---------------------------------------------------------------------------
+// Down functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Reverse v29: convert epoch ms timestamps back to ISO 8601 text in guardian
+ * tables.
+ *
+ * Uses SQLite's datetime() to reconstruct ISO 8601 strings from the integer
+ * values. The millisecond component is appended manually since datetime()
+ * only returns second precision.
+ */
+export function migrateGuardianTimestampsEpochMsDown(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  // Convert canonical_guardian_requests timestamp columns back to ISO 8601
+  raw.exec(/*sql*/ `
+    UPDATE canonical_guardian_requests
+    SET created_at = strftime('%Y-%m-%dT%H:%M:%S', created_at / 1000, 'unixepoch') || '.' || printf('%03d', created_at % 1000) || 'Z',
+        updated_at = strftime('%Y-%m-%dT%H:%M:%S', updated_at / 1000, 'unixepoch') || '.' || printf('%03d', updated_at % 1000) || 'Z',
+        expires_at = CASE
+          WHEN expires_at IS NOT NULL
+          THEN strftime('%Y-%m-%dT%H:%M:%S', expires_at / 1000, 'unixepoch') || '.' || printf('%03d', expires_at % 1000) || 'Z'
+          ELSE NULL
+        END
+    WHERE typeof(created_at) = 'integer'
+  `);
+
+  // Convert canonical_guardian_deliveries timestamp columns back to ISO 8601
+  raw.exec(/*sql*/ `
+    UPDATE canonical_guardian_deliveries
+    SET created_at = strftime('%Y-%m-%dT%H:%M:%S', created_at / 1000, 'unixepoch') || '.' || printf('%03d', created_at % 1000) || 'Z',
+        updated_at = strftime('%Y-%m-%dT%H:%M:%S', updated_at / 1000, 'unixepoch') || '.' || printf('%03d', updated_at % 1000) || 'Z'
+    WHERE typeof(created_at) = 'integer'
+  `);
+
+  // Convert scoped_approval_grants timestamp columns back to ISO 8601
+  raw.exec(/*sql*/ `
+    UPDATE scoped_approval_grants
+    SET expires_at = strftime('%Y-%m-%dT%H:%M:%S', expires_at / 1000, 'unixepoch') || '.' || printf('%03d', expires_at % 1000) || 'Z',
+        created_at = strftime('%Y-%m-%dT%H:%M:%S', created_at / 1000, 'unixepoch') || '.' || printf('%03d', created_at % 1000) || 'Z',
+        updated_at = strftime('%Y-%m-%dT%H:%M:%S', updated_at / 1000, 'unixepoch') || '.' || printf('%03d', updated_at % 1000) || 'Z',
+        consumed_at = CASE
+          WHEN consumed_at IS NOT NULL
+          THEN strftime('%Y-%m-%dT%H:%M:%S', consumed_at / 1000, 'unixepoch') || '.' || printf('%03d', consumed_at % 1000) || 'Z'
+          ELSE NULL
+        END
+    WHERE typeof(created_at) = 'integer'
+  `);
+}
+
+/**
+ * Reverse v30: rebuild guardian tables with TEXT affinity on timestamp columns.
+ *
+ * Restores the original TEXT column declarations so that timestamp columns
+ * have TEXT affinity (the state before the INTEGER rebuild).
+ */
+export function migrateGuardianTimestampsRebuildDown(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  rebuildCanonicalGuardianRequestsToText(raw);
+  rebuildCanonicalGuardianDeliveriesToText(raw);
+  rebuildScopedApprovalGrantsToText(raw);
+}
+
+function hasTextAffinity(raw: RawDb, table: string, column: string): boolean {
+  const row = raw
+    .query(
+      `SELECT type FROM pragma_table_info('${table}') WHERE name = '${column}'`,
+    )
+    .get() as { type: string } | null;
+  if (!row) return true; // column doesn't exist — nothing to fix
+  return row.type.toUpperCase() === "TEXT";
+}
+
+function rebuildCanonicalGuardianRequestsToText(raw: RawDb): void {
+  if (hasTextAffinity(raw, "canonical_guardian_requests", "created_at")) return;
+
+  // Caller (rollbackMemoryMigration) already manages the transaction.
+  // We only need to disable FK checks for the table rebuild.
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    raw.exec(/*sql*/ `
+      CREATE TABLE canonical_guardian_requests_rb (
+        id TEXT PRIMARY KEY,
+        kind TEXT NOT NULL,
+        source_type TEXT NOT NULL,
+        source_channel TEXT,
+        conversation_id TEXT,
+        requester_external_user_id TEXT,
+        requester_chat_id TEXT,
+        guardian_external_user_id TEXT,
+        guardian_principal_id TEXT,
+        call_session_id TEXT,
+        pending_question_id TEXT,
+        question_text TEXT,
+        request_code TEXT,
+        tool_name TEXT,
+        input_digest TEXT,
+        status TEXT NOT NULL DEFAULT 'pending',
+        answer_text TEXT,
+        decided_by_external_user_id TEXT,
+        decided_by_principal_id TEXT,
+        followup_state TEXT,
+        expires_at TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `);
+
+    raw.exec(/*sql*/ `
+      INSERT INTO canonical_guardian_requests_rb
+      SELECT id, kind, source_type, source_channel, conversation_id,
+             requester_external_user_id, requester_chat_id,
+             guardian_external_user_id, guardian_principal_id,
+             call_session_id, pending_question_id, question_text,
+             request_code, tool_name, input_digest, status, answer_text,
+             decided_by_external_user_id, decided_by_principal_id,
+             followup_state, expires_at, created_at, updated_at
+      FROM canonical_guardian_requests
+    `);
+
+    raw.exec(/*sql*/ `DROP TABLE canonical_guardian_requests`);
+    raw.exec(
+      /*sql*/ `ALTER TABLE canonical_guardian_requests_rb RENAME TO canonical_guardian_requests`,
+    );
+
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_status ON canonical_guardian_requests(status)`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_guardian ON canonical_guardian_requests(guardian_external_user_id, status)`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_conversation ON canonical_guardian_requests(conversation_id, status)`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_source ON canonical_guardian_requests(source_type, status)`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_kind ON canonical_guardian_requests(kind, status)`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_request_code ON canonical_guardian_requests(request_code)`,
+    );
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
+}
+
+function rebuildCanonicalGuardianDeliveriesToText(raw: RawDb): void {
+  if (hasTextAffinity(raw, "canonical_guardian_deliveries", "created_at"))
+    return;
+
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    raw.exec(/*sql*/ `
+      CREATE TABLE canonical_guardian_deliveries_rb (
+        id TEXT PRIMARY KEY,
+        request_id TEXT NOT NULL REFERENCES canonical_guardian_requests(id) ON DELETE CASCADE,
+        destination_channel TEXT NOT NULL,
+        destination_conversation_id TEXT,
+        destination_chat_id TEXT,
+        destination_message_id TEXT,
+        status TEXT NOT NULL DEFAULT 'pending',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `);
+
+    raw.exec(/*sql*/ `
+      INSERT INTO canonical_guardian_deliveries_rb
+      SELECT id, request_id, destination_channel, destination_conversation_id,
+             destination_chat_id, destination_message_id, status,
+             created_at, updated_at
+      FROM canonical_guardian_deliveries
+    `);
+
+    raw.exec(/*sql*/ `DROP TABLE canonical_guardian_deliveries`);
+    raw.exec(
+      /*sql*/ `ALTER TABLE canonical_guardian_deliveries_rb RENAME TO canonical_guardian_deliveries`,
+    );
+
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_deliveries_request_id ON canonical_guardian_deliveries(request_id)`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_deliveries_status ON canonical_guardian_deliveries(status)`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_canonical_guardian_deliveries_destination ON canonical_guardian_deliveries(destination_channel, destination_chat_id)`,
+    );
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
+}
+
+function rebuildScopedApprovalGrantsToText(raw: RawDb): void {
+  if (hasTextAffinity(raw, "scoped_approval_grants", "created_at")) return;
+
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    raw.exec(/*sql*/ `
+      CREATE TABLE scoped_approval_grants_rb (
+        id TEXT PRIMARY KEY,
+        scope_mode TEXT NOT NULL,
+        request_id TEXT,
+        tool_name TEXT,
+        input_digest TEXT,
+        request_channel TEXT NOT NULL,
+        decision_channel TEXT NOT NULL,
+        execution_channel TEXT,
+        conversation_id TEXT,
+        call_session_id TEXT,
+        requester_external_user_id TEXT,
+        guardian_external_user_id TEXT,
+        status TEXT NOT NULL,
+        expires_at TEXT NOT NULL,
+        consumed_at TEXT,
+        consumed_by_request_id TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `);
+
+    raw.exec(/*sql*/ `
+      INSERT INTO scoped_approval_grants_rb
+      SELECT id, scope_mode, request_id, tool_name, input_digest,
+             request_channel, decision_channel, execution_channel,
+             conversation_id, call_session_id,
+             requester_external_user_id, guardian_external_user_id,
+             status, expires_at, consumed_at, consumed_by_request_id,
+             created_at, updated_at
+      FROM scoped_approval_grants
+    `);
+
+    raw.exec(/*sql*/ `DROP TABLE scoped_approval_grants`);
+    raw.exec(
+      /*sql*/ `ALTER TABLE scoped_approval_grants_rb RENAME TO scoped_approval_grants`,
+    );
+
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_scoped_grants_request_id ON scoped_approval_grants(request_id) WHERE request_id IS NOT NULL`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_scoped_grants_tool_sig ON scoped_approval_grants(tool_name, input_digest) WHERE tool_name IS NOT NULL`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_scoped_grants_status_expires ON scoped_approval_grants(status, expires_at)`,
+    );
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
+}

--- a/assistant/src/memory/migrations/169-rename-gmail-provider-key-to-google.ts
+++ b/assistant/src/memory/migrations/169-rename-gmail-provider-key-to-google.ts
@@ -1,4 +1,5 @@
-import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
 /**
@@ -61,4 +62,53 @@ export function migrateRenameGmailProviderKeyToGoogle(
       }
     },
   );
+}
+
+/**
+ * Reverse: rename "integration:google" back to "integration:gmail" across
+ * OAuth tables.
+ *
+ * Mirrors the forward migration logic but in the opposite direction. If
+ * `integration:gmail` already exists (shouldn't normally happen on rollback),
+ * deletes the google rows to avoid duplicates.
+ */
+export function migrateRenameGmailProviderKeyToGoogleDown(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    const gmailExists = raw
+      .prepare(
+        /*sql*/ `SELECT 1 FROM oauth_providers WHERE provider_key = 'integration:gmail'`,
+      )
+      .get();
+
+    if (gmailExists) {
+      // Old gmail rows already exist — delete the google ones to avoid duplication.
+      raw.exec(
+        /*sql*/ `DELETE FROM oauth_connections WHERE provider_key = 'integration:google'`,
+      );
+      raw.exec(
+        /*sql*/ `DELETE FROM oauth_apps WHERE provider_key = 'integration:google'`,
+      );
+      raw.exec(
+        /*sql*/ `DELETE FROM oauth_providers WHERE provider_key = 'integration:google'`,
+      );
+    } else {
+      // Rename google back to gmail — children first, then parent.
+      raw.exec(
+        /*sql*/ `UPDATE oauth_connections SET provider_key = 'integration:gmail' WHERE provider_key = 'integration:google'`,
+      );
+      raw.exec(
+        /*sql*/ `UPDATE oauth_apps SET provider_key = 'integration:gmail' WHERE provider_key = 'integration:google'`,
+      );
+      raw.exec(
+        /*sql*/ `UPDATE oauth_providers SET provider_key = 'integration:gmail' WHERE provider_key = 'integration:google'`,
+      );
+    }
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
 }

--- a/assistant/src/memory/migrations/174-rename-thread-starters-table.ts
+++ b/assistant/src/memory/migrations/174-rename-thread-starters-table.ts
@@ -1,4 +1,5 @@
-import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
 /**
@@ -49,5 +50,50 @@ export function migrateRenameThreadStartersTable(database: DrizzleDb): void {
         /*sql*/ `CREATE INDEX IF NOT EXISTS idx_conversation_starters_card_type ON conversation_starters(card_type, scope_id)`,
       );
     },
+  );
+}
+
+/**
+ * Reverse: rename conversation_starters back to thread_starters and recreate
+ * old index names.
+ *
+ * Idempotent — skips if the old table already exists or the new table is
+ * absent.
+ */
+export function migrateRenameThreadStartersTableDown(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  // Guard: new table must exist
+  const newTableExists = raw
+    .query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'conversation_starters'`,
+    )
+    .get();
+  if (!newTableExists) return;
+
+  // Guard: old table must not already exist
+  const oldTableExists = raw
+    .query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'thread_starters'`,
+    )
+    .get();
+  if (oldTableExists) return;
+
+  // Rename the table back
+  raw.exec(
+    /*sql*/ `ALTER TABLE conversation_starters RENAME TO thread_starters`,
+  );
+
+  // Drop new indexes and recreate with old names
+  raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_conversation_starters_batch`);
+  raw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_thread_starters_batch ON thread_starters(generation_batch, created_at)`,
+  );
+
+  raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_conversation_starters_card_type`);
+  raw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_thread_starters_card_type ON thread_starters(card_type, scope_id)`,
   );
 }

--- a/assistant/src/memory/migrations/176-drop-capability-card-state.ts
+++ b/assistant/src/memory/migrations/176-drop-capability-card-state.ts
@@ -34,3 +34,16 @@ export function migrateDropCapabilityCardState(database: DrizzleDb): void {
     raw.exec(/*sql*/ `DROP TABLE IF EXISTS capability_card_categories`);
   });
 }
+
+/**
+ * Reverse: no-op.
+ *
+ * The forward migration deleted rows (card-type conversation starters,
+ * generate_capability_cards jobs, capability_cards checkpoints) and dropped
+ * the capability_card_categories table. The deleted data cannot be restored
+ * — it was discarded as dead state after the capability card feature was
+ * removed.
+ */
+export function migrateDropCapabilityCardStateDown(_database: DrizzleDb): void {
+  // No-op — see comment above.
+}

--- a/assistant/src/memory/migrations/180-backfill-inline-attachments-to-disk.ts
+++ b/assistant/src/memory/migrations/180-backfill-inline-attachments-to-disk.ts
@@ -64,3 +64,19 @@ export function migrateBackfillInlineAttachmentsToDisk(
     },
   );
 }
+
+/**
+ * Reverse: no-op.
+ *
+ * The forward migration moved attachment data from inline base64 in the
+ * database to on-disk files and cleared the dataBase64 column. The original
+ * base64 data has been deleted from the DB, and re-reading it from disk
+ * back into the database would be unreliable (file paths may have changed,
+ * disk files may have been cleaned up). The on-disk files remain intact
+ * and functional.
+ */
+export function migrateBackfillInlineAttachmentsToDiskDown(
+  _database: DrizzleDb,
+): void {
+  // No-op — see comment above.
+}

--- a/assistant/src/memory/migrations/181-rename-thread-starters-checkpoints.ts
+++ b/assistant/src/memory/migrations/181-rename-thread-starters-checkpoints.ts
@@ -1,4 +1,5 @@
-import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
 /**
@@ -42,5 +43,31 @@ export function migrateRenameThreadStartersCheckpoints(
         /*sql*/ `UPDATE memory_checkpoints SET key = replace(key, 'thread_starters:', 'conversation_starters:') WHERE key LIKE 'thread_starters:%'`,
       );
     },
+  );
+}
+
+/**
+ * Reverse: rename checkpoint keys from "conversation_starters:" back to
+ * "thread_starters:" prefix.
+ *
+ * Mirrors the forward migration but in reverse. Handles collisions the same
+ * way — if an old-prefix key already exists, the new-prefix key is dropped.
+ */
+export function migrateRenameThreadStartersCheckpointsDown(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  // 1. Delete conversation_starters: keys where a corresponding
+  //    thread_starters: key already exists.
+  raw.exec(/*sql*/ `DELETE FROM memory_checkpoints
+     WHERE key LIKE 'conversation_starters:%'
+       AND replace(key, 'conversation_starters:', 'thread_starters:') IN (
+         SELECT key FROM memory_checkpoints WHERE key LIKE 'thread_starters:%'
+       )`);
+
+  // 2. Rename remaining keys back to the old prefix.
+  raw.exec(
+    /*sql*/ `UPDATE memory_checkpoints SET key = replace(key, 'conversation_starters:', 'thread_starters:') WHERE key LIKE 'conversation_starters:%'`,
   );
 }

--- a/assistant/src/memory/migrations/191-backfill-audio-attachment-mime-types.ts
+++ b/assistant/src/memory/migrations/191-backfill-audio-attachment-mime-types.ts
@@ -49,3 +49,16 @@ export function migrateBackfillAudioAttachmentMimeTypes(
     },
   );
 }
+
+/**
+ * Reverse: no-op.
+ *
+ * The forward migration corrected incorrect MIME types (application/octet-stream)
+ * to their proper audio/* values. Restoring the wrong MIME types would break
+ * audio playback and file handling. The corrected values are the desired state.
+ */
+export function migrateBackfillAudioAttachmentMimeTypesDown(
+  _database: DrizzleDb,
+): void {
+  // No-op — see comment above.
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -138,6 +138,7 @@ export {
 } from "./registry.js";
 export {
   recoverCrashedMigrations,
+  rollbackMemoryMigration,
   validateMigrationState,
   withCrashRecovery,
 } from "./validate-migration-state.js";

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -1,3 +1,5 @@
+import type { DrizzleDb } from "../db-connection.js";
+
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
   key: string;
@@ -7,6 +9,8 @@ export interface MigrationRegistryEntry {
   dependsOn?: string[];
   /** Human-readable description for diagnostics and future authorship guidance. */
   description: string;
+  /** Reverse the migration. Must be idempotent — safe to re-run. */
+  down?: (database: DrizzleDb) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -1,4 +1,16 @@
 import type { DrizzleDb } from "../db-connection.js";
+import { downJobDeferrals } from "./001-job-deferrals.js";
+import { downMemoryEntityRelationDedup } from "./004-entity-relation-dedup.js";
+import { downMemoryItemsFingerprintScopeUnique } from "./005-fingerprint-scope-unique.js";
+import { downMemoryItemsScopeSaltedFingerprints } from "./006-scope-salted-fingerprints.js";
+import { downAssistantIdToSelf } from "./007-assistant-id-to-self.js";
+import { downRemoveAssistantIdColumns } from "./008-remove-assistant-id-columns.js";
+import { downLlmUsageEventsDropAssistantId } from "./009-llm-usage-events-drop-assistant-id.js";
+import { downBackfillInboxThreadState } from "./014-backfill-inbox-thread-state.js";
+import { downDropActiveSearchIndex } from "./015-drop-active-search-index.js";
+import { downNotificationTablesSchema } from "./019-notification-tables-schema-migration.js";
+import { downRenameChannelToVellum } from "./020-rename-macos-ios-channel-to-vellum.js";
+import { downEmbeddingVectorBlob } from "./024-embedding-vector-blob.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -30,18 +42,21 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     version: 1,
     description:
       "Reconcile legacy deferral history from attempts column into deferrals column",
+    down: downJobDeferrals,
   },
   {
     key: "migration_memory_entity_relations_dedup_v1",
     version: 2,
     description:
       "Deduplicate entity relation edges before enforcing the (source, target, relation) unique index",
+    down: downMemoryEntityRelationDedup,
   },
   {
     key: "migration_memory_items_fingerprint_scope_unique_v1",
     version: 3,
     description:
       "Replace column-level UNIQUE on fingerprint with compound (fingerprint, scope_id) unique index",
+    down: downMemoryItemsFingerprintScopeUnique,
   },
   {
     key: "migration_memory_items_scope_salted_fingerprints_v1",
@@ -49,12 +64,14 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     dependsOn: ["migration_memory_items_fingerprint_scope_unique_v1"],
     description:
       "Recompute memory item fingerprints to include scope_id prefix after schema change",
+    down: downMemoryItemsScopeSaltedFingerprints,
   },
   {
     key: "migration_normalize_assistant_id_to_self_v1",
     version: 5,
     description:
       'Normalize all assistant_id values in scoped tables to the implicit "self" single-tenant identity',
+    down: downAssistantIdToSelf,
   },
   {
     key: "migration_remove_assistant_id_columns_v1",
@@ -62,6 +79,7 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     dependsOn: ["migration_normalize_assistant_id_to_self_v1"],
     description:
       "Rebuild four tables to drop the assistant_id column after normalization",
+    down: downRemoveAssistantIdColumns,
   },
   {
     key: "migration_remove_assistant_id_lue_v1",
@@ -69,36 +87,42 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     dependsOn: ["migration_normalize_assistant_id_to_self_v1"],
     description:
       "Remove assistant_id column from llm_usage_events (separate checkpoint from the four-table migration)",
+    down: downLlmUsageEventsDropAssistantId,
   },
   {
     key: "backfill_inbox_thread_state_from_bindings",
     version: 8,
     description:
       "Seed assistant_inbox_thread_state from external_conversation_bindings",
+    down: downBackfillInboxThreadState,
   },
   {
     key: "drop_active_search_index_v1",
     version: 9,
     description:
       "Drop old idx_memory_items_active_search so it can be recreated with updated covering columns",
+    down: downDropActiveSearchIndex,
   },
   {
     key: "migration_notification_tables_schema_v1",
     version: 10,
     description:
       "Drop legacy enum-based notification tables so they can be recreated with the new signal-contract schema",
+    down: downNotificationTablesSchema,
   },
   {
     key: "migration_rename_macos_ios_channel_to_vellum_v1",
     version: 11,
     description:
       "Rename macos and ios channel identifiers to vellum across all tables",
+    down: downRenameChannelToVellum,
   },
   {
     key: "migration_embedding_vector_blob_v1",
     version: 12,
     description:
       "Add vector_blob BLOB column to memory_embeddings and backfill from vector_json for compact binary storage",
+    down: downEmbeddingVectorBlob,
   },
   {
     key: "migration_embeddings_nullable_vector_json_v1",

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -23,6 +23,20 @@ import { downRenameVerificationTable } from "./141-rename-verification-table.js"
 import { downRenameVerificationSessionIdColumn } from "./142-rename-verification-session-id-column.js";
 import { downRenameGuardianVerificationValues } from "./143-rename-guardian-verification-values.js";
 import { downRenameVoiceToPhone } from "./144-rename-voice-to-phone.js";
+import { migrateDropAccountsTableDown } from "./145-drop-accounts-table.js";
+import { migrateRemindersToSchedulesDown } from "./147-migrate-reminders-to-schedules.js";
+import { migrateDropRemindersTableDown } from "./148-drop-reminders-table.js";
+import { migrateOAuthAppsClientSecretPathDown } from "./150-oauth-apps-client-secret-path.js";
+import {
+  migrateGuardianTimestampsEpochMsDown,
+  migrateGuardianTimestampsRebuildDown,
+} from "./162-guardian-timestamps-epoch-ms.js";
+import { migrateRenameGmailProviderKeyToGoogleDown } from "./169-rename-gmail-provider-key-to-google.js";
+import { migrateRenameThreadStartersTableDown } from "./174-rename-thread-starters-table.js";
+import { migrateDropCapabilityCardStateDown } from "./176-drop-capability-card-state.js";
+import { migrateBackfillInlineAttachmentsToDiskDown } from "./180-backfill-inline-attachments-to-disk.js";
+import { migrateRenameThreadStartersCheckpointsDown } from "./181-rename-thread-starters-checkpoints.js";
+import { migrateBackfillAudioAttachmentMimeTypesDown } from "./191-backfill-audio-attachment-mime-types.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -228,12 +242,14 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     version: 25,
     description:
       "Drop the unused legacy accounts table and its leftover indexes after account_manage removal",
+    down: migrateDropAccountsTableDown,
   },
   {
     key: "migration_reminders_to_schedules_v1",
     version: 26,
     description:
       "Copy all existing reminders into cron_jobs as one-shot schedules with correct status and field mapping",
+    down: migrateRemindersToSchedulesDown,
   },
   {
     key: "migration_drop_reminders_table_v1",
@@ -241,18 +257,21 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     dependsOn: ["migration_reminders_to_schedules_v1"],
     description:
       "Drop the legacy reminders table and its index after data migration to cron_jobs",
+    down: migrateDropRemindersTableDown,
   },
   {
     key: "migration_oauth_apps_client_secret_path_v1",
     version: 28,
     description:
       "Add client_secret_credential_path column to oauth_apps and backfill existing rows with convention-based paths",
+    down: migrateOAuthAppsClientSecretPathDown,
   },
   {
     key: "migration_guardian_timestamps_epoch_ms_v1",
     version: 29,
     description:
       "Convert guardian table timestamps from ISO 8601 text to epoch ms integers for consistency with all other tables",
+    down: migrateGuardianTimestampsEpochMsDown,
   },
   {
     key: "migration_guardian_timestamps_rebuild_v1",
@@ -260,18 +279,21 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     dependsOn: ["migration_guardian_timestamps_epoch_ms_v1"],
     description:
       "Rebuild guardian tables so timestamp columns have INTEGER affinity instead of TEXT",
+    down: migrateGuardianTimestampsRebuildDown,
   },
   {
     key: "migration_rename_gmail_provider_key_to_google_v1",
     version: 31,
     description:
       "Rename integration:gmail provider key to integration:google across oauth_providers, oauth_apps, and oauth_connections",
+    down: migrateRenameGmailProviderKeyToGoogleDown,
   },
   {
     key: "migration_rename_thread_starters_table_v1",
     version: 32,
     description:
       "Rename thread_starters table to conversation_starters and recreate indexes with new names",
+    down: migrateRenameThreadStartersTableDown,
   },
   {
     key: "migration_drop_capability_card_state_v1",
@@ -279,12 +301,14 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     dependsOn: ["migration_rename_thread_starters_table_v1"],
     description:
       "Remove deleted capability-card rows, jobs, checkpoints, and category state",
+    down: migrateDropCapabilityCardStateDown,
   },
   {
     key: "migration_backfill_inline_attachments_v1",
     version: 34,
     description:
       "Backfill existing inline base64 attachments to on-disk storage and clear dataBase64",
+    down: migrateBackfillInlineAttachmentsToDiskDown,
   },
   {
     key: "migration_rename_thread_starters_checkpoints_v1",
@@ -292,12 +316,14 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     dependsOn: ["migration_rename_thread_starters_table_v1"],
     description:
       "Rename checkpoint keys from thread_starters: to conversation_starters: prefix so renamed code paths find existing generation state",
+    down: migrateRenameThreadStartersCheckpointsDown,
   },
   {
     key: "migration_backfill_audio_attachment_mime_types_v1",
     version: 36,
     description:
       "Backfill correct MIME types for audio attachments stored as application/octet-stream due to missing extension map entries",
+    down: migrateBackfillAudioAttachmentMimeTypesDown,
   },
 ];
 

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -11,6 +11,18 @@ import { downDropActiveSearchIndex } from "./015-drop-active-search-index.js";
 import { downNotificationTablesSchema } from "./019-notification-tables-schema-migration.js";
 import { downRenameChannelToVellum } from "./020-rename-macos-ios-channel-to-vellum.js";
 import { downEmbeddingVectorBlob } from "./024-embedding-vector-blob.js";
+import { downEmbeddingsNullableVectorJson } from "./026a-embeddings-nullable-vector-json.js";
+import { downNormalizePhoneIdentities } from "./036-normalize-phone-identities.js";
+import { downBackfillGuardianPrincipalId } from "./126-backfill-guardian-principal-id.js";
+import { downGuardianPrincipalIdNotNull } from "./127-guardian-principal-id-not-null.js";
+import { downContactsNotesColumn } from "./134-contacts-notes-column.js";
+import { downBackfillContactInteractionStats } from "./135-backfill-contact-interaction-stats.js";
+import { downDropAssistantIdColumns } from "./136-drop-assistant-id-columns.js";
+import { downBackfillUsageCacheAccounting } from "./140-backfill-usage-cache-accounting.js";
+import { downRenameVerificationTable } from "./141-rename-verification-table.js";
+import { downRenameVerificationSessionIdColumn } from "./142-rename-verification-session-id-column.js";
+import { downRenameGuardianVerificationValues } from "./143-rename-guardian-verification-values.js";
+import { downRenameVoiceToPhone } from "./144-rename-voice-to-phone.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -130,18 +142,21 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     dependsOn: ["migration_embedding_vector_blob_v1"],
     description:
       "Rebuild memory_embeddings to make vector_json nullable (pre-100 DBs had NOT NULL)",
+    down: downEmbeddingsNullableVectorJson,
   },
   {
     key: "migration_normalize_phone_identities_v1",
     version: 14,
     description:
       "Normalize phone-like identity fields to E.164 format across guardian bindings, verification challenges, canonical requests, ingress members, and rate limits",
+    down: downNormalizePhoneIdentities,
   },
   {
     key: "migration_backfill_guardian_principal_id_v3",
     version: 15,
     description:
       "Backfill guardianPrincipalId for existing channel_guardian_bindings and canonical_guardian_requests rows, expire unresolvable pending requests",
+    down: downBackfillGuardianPrincipalId,
   },
   {
     key: "migration_guardian_principal_id_not_null_v1",
@@ -149,18 +164,21 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     dependsOn: ["migration_backfill_guardian_principal_id_v3"],
     description:
       "Enforce NOT NULL on channel_guardian_bindings.guardian_principal_id after backfill",
+    down: downGuardianPrincipalIdNotNull,
   },
   {
     key: "migration_contacts_notes_column_v1",
     version: 17,
     description:
       "Consolidate relationship/importance/response_expectation/preferred_tone into a single notes TEXT column, then drop the legacy columns",
+    down: downContactsNotesColumn,
   },
   {
     key: "backfill_contact_interaction_stats",
     version: 18,
     description:
       "Backfill contacts.last_interaction from the max lastSeenAt across each contact's channels",
+    down: downBackfillContactInteractionStats,
   },
   {
     key: "migration_drop_assistant_id_columns_v1",
@@ -168,36 +186,42 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     dependsOn: ["migration_normalize_assistant_id_to_self_v1"],
     description:
       "Drop assistant_id columns from all 16 daemon tables after normalization to single-tenant identity",
+    down: downDropAssistantIdColumns,
   },
   {
     key: "migration_backfill_usage_cache_accounting_v1",
     version: 20,
     description:
       "Backfill historical Anthropic llm_usage_events rows from llm_request_logs with cache-aware pricing",
+    down: downBackfillUsageCacheAccounting,
   },
   {
     key: "migration_rename_verification_table_v1",
     version: 21,
     description:
       "Rename channel_guardian_verification_challenges table to channel_verification_sessions and update indexes",
+    down: downRenameVerificationTable,
   },
   {
     key: "migration_rename_verification_session_id_column_v1",
     version: 22,
     description:
       "Rename guardian_verification_session_id column in call_sessions to verification_session_id",
+    down: downRenameVerificationSessionIdColumn,
   },
   {
     key: "migration_rename_guardian_verification_values_v1",
     version: 23,
     description:
       "Rename persisted guardian_verification call_mode and guardian_voice_verification_* event_type values to drop the guardian_ prefix",
+    down: downRenameGuardianVerificationValues,
   },
   {
     key: "migration_rename_voice_to_phone_v1",
     version: 24,
     description:
       'Rename stored "voice" channel values to "phone" across all tables with channel text columns',
+    down: downRenameVoiceToPhone,
   },
   {
     key: "migration_drop_accounts_table_v1",

--- a/assistant/src/memory/migrations/validate-migration-state.ts
+++ b/assistant/src/memory/migrations/validate-migration-state.ts
@@ -33,7 +33,9 @@ export function recoverCrashedMigrations(database: DrizzleDb): string[] {
     return [];
   }
 
-  const crashed = rows.filter((r) => r.value === "started").map((r) => r.key);
+  const crashed = rows
+    .filter((r) => r.value === "started" || r.value === "rolling_back")
+    .map((r) => r.key);
   if (crashed.length === 0) return [];
 
   log.error(
@@ -192,4 +194,84 @@ export function validateMigrationState(
   }
 
   return { crashed, dependencyViolations };
+}
+
+/**
+ * Roll back all completed migrations with version > targetVersion.
+ *
+ * Iterates eligible migrations in reverse version order. For each:
+ * 1. Verifies a `down` function exists (throws if missing).
+ * 2. Marks the checkpoint as `"rolling_back"` for crash recovery.
+ * 3. Calls `entry.down(database)` inside a transaction.
+ * 4. Deletes the checkpoint from `memory_checkpoints`.
+ *
+ * @param database  The Drizzle database instance.
+ * @param targetVersion  Roll back to this version (exclusive — all migrations
+ *   with version > targetVersion are reversed).
+ * @returns The list of rolled-back migration keys.
+ */
+export function rollbackMemoryMigration(
+  database: DrizzleDb,
+  targetVersion: number,
+): string[] {
+  const raw = getSqliteFrom(database);
+
+  // Read completed checkpoints to determine which migrations have been applied.
+  let rows: Array<{ key: string; value: string }>;
+  try {
+    rows = raw
+      .query(`SELECT key, value FROM memory_checkpoints`)
+      .all() as Array<{ key: string; value: string }>;
+  } catch {
+    return [];
+  }
+
+  const completedKeys = new Set(
+    rows
+      .filter((r) => r.value !== "started" && r.value !== "rolling_back")
+      .map((r) => r.key),
+  );
+
+  // Find registry entries with version > targetVersion that have completed checkpoints.
+  const toRollback = MIGRATION_REGISTRY.filter(
+    (entry) => entry.version > targetVersion && completedKeys.has(entry.key),
+  ).sort((a, b) => b.version - a.version); // reverse version order
+
+  const rolledBack: string[] = [];
+
+  for (const entry of toRollback) {
+    if (!entry.down) {
+      throw new IntegrityError(
+        `Cannot roll back migration "${entry.key}" (version ${entry.version}): no down() function defined`,
+      );
+    }
+
+    // Mark as rolling_back for crash recovery — if the process crashes here,
+    // recoverCrashedMigrations will clear this checkpoint on next startup.
+    raw
+      .query(
+        `UPDATE memory_checkpoints SET value = 'rolling_back', updated_at = ? WHERE key = ?`,
+      )
+      .run(Date.now(), entry.key);
+
+    // Execute the down migration inside a transaction.
+    raw.exec("BEGIN");
+    try {
+      entry.down(database);
+      // Delete the checkpoint — the migration is no longer applied.
+      raw.query(`DELETE FROM memory_checkpoints WHERE key = ?`).run(entry.key);
+      raw.exec("COMMIT");
+    } catch (err) {
+      raw.exec("ROLLBACK");
+      throw err;
+    }
+
+    log.info(
+      { key: entry.key, version: entry.version },
+      `Rolled back migration "${entry.key}" (version ${entry.version})`,
+    );
+    rolledBack.push(entry.key);
+  }
+
+  return rolledBack;
 }

--- a/assistant/src/memory/migrations/validate-migration-state.ts
+++ b/assistant/src/memory/migrations/validate-migration-state.ts
@@ -131,9 +131,11 @@ export function validateMigrationState(
     return { crashed: [], dependencyViolations: [] };
   }
 
-  // Any remaining 'started' checkpoints after recovery + migration execution
-  // indicate a migration that was retried but failed again.
-  const crashed = rows.filter((r) => r.value === "started").map((r) => r.key);
+  // Any remaining 'started' or 'rolling_back' checkpoints after recovery +
+  // migration execution indicate a migration that was retried but failed again.
+  const crashed = rows
+    .filter((r) => r.value === "started" || r.value === "rolling_back")
+    .map((r) => r.key);
   if (crashed.length > 0) {
     log.error(
       { crashed },
@@ -151,11 +153,14 @@ export function validateMigrationState(
     );
   }
 
-  // Only rows whose value is NOT 'started' represent truly completed migrations.
-  // In-progress/crashed checkpoints (value = 'started') must not count as applied
-  // dependencies — the migration never finished, so its postconditions are unmet.
+  // Only rows whose value is NOT 'started' or 'rolling_back' represent truly
+  // completed migrations. In-progress/crashed checkpoints must not count as
+  // applied dependencies — the migration never finished, so its postconditions
+  // are unmet.
   const completed = new Set(
-    rows.filter((r) => r.value !== "started").map((r) => r.key),
+    rows
+      .filter((r) => r.value !== "started" && r.value !== "rolling_back")
+      .map((r) => r.key),
   );
 
   const dependencyViolations: Array<{
@@ -202,7 +207,7 @@ export function validateMigrationState(
  * Iterates eligible migrations in reverse version order. For each:
  * 1. Verifies a `down` function exists (throws if missing).
  * 2. Marks the checkpoint as `"rolling_back"` for crash recovery.
- * 3. Calls `entry.down(database)` inside a transaction.
+ * 3. Calls `entry.down(database)` — each down() manages its own transactions.
  * 4. Deletes the checkpoint from `memory_checkpoints`.
  *
  * **Usage**: Pass the target version number you want to roll back *to*. All
@@ -274,17 +279,14 @@ export function rollbackMemoryMigration(
       )
       .run(Date.now(), entry.key);
 
-    // Execute the down migration inside a transaction.
-    raw.exec("BEGIN");
-    try {
-      entry.down(database);
-      // Delete the checkpoint — the migration is no longer applied.
-      raw.query(`DELETE FROM memory_checkpoints WHERE key = ?`).run(entry.key);
-      raw.exec("COMMIT");
-    } catch (err) {
-      raw.exec("ROLLBACK");
-      throw err;
-    }
+    // Execute the down migration — let it manage its own transaction lifecycle.
+    // Many down() functions call BEGIN/COMMIT internally or use PRAGMA statements
+    // that are no-ops inside a transaction.
+    entry.down(database);
+
+    // Delete the checkpoint after down() succeeds — outside any transaction
+    // so it's not affected by down()'s internal transaction management.
+    raw.query(`DELETE FROM memory_checkpoints WHERE key = ?`).run(entry.key);
 
     log.info(
       { key: entry.key, version: entry.version },

--- a/assistant/src/memory/migrations/validate-migration-state.ts
+++ b/assistant/src/memory/migrations/validate-migration-state.ts
@@ -85,7 +85,12 @@ export function withCrashRecovery(
   const existing = raw
     .query(`SELECT value FROM memory_checkpoints WHERE key = ?`)
     .get(checkpointKey) as { value: string } | null;
-  if (existing && existing.value !== "started") return;
+  if (
+    existing &&
+    existing.value !== "started" &&
+    existing.value !== "rolling_back"
+  )
+    return;
 
   raw
     .query(

--- a/assistant/src/memory/migrations/validate-migration-state.ts
+++ b/assistant/src/memory/migrations/validate-migration-state.ts
@@ -197,13 +197,33 @@ export function validateMigrationState(
 }
 
 /**
- * Roll back all completed migrations with version > targetVersion.
+ * Roll back all completed memory (database) migrations with version > targetVersion.
  *
  * Iterates eligible migrations in reverse version order. For each:
  * 1. Verifies a `down` function exists (throws if missing).
  * 2. Marks the checkpoint as `"rolling_back"` for crash recovery.
  * 3. Calls `entry.down(database)` inside a transaction.
  * 4. Deletes the checkpoint from `memory_checkpoints`.
+ *
+ * **Usage**: Pass the target version number you want to roll back *to*. All
+ * migrations with a higher version number that have been applied will be
+ * reversed. For example, `rollbackMemoryMigration(db, 5)` rolls back all
+ * applied migrations with version > 5.
+ *
+ * **Checkpoint state**: Each rolled-back migration's checkpoint is deleted
+ * from `memory_checkpoints`. If the process crashes mid-rollback, the
+ * `"rolling_back"` marker is detected and cleared by
+ * `recoverCrashedMigrations` on the next startup.
+ *
+ * **Warning — data loss**: Some migrations are irreversible (e.g., DROP TABLE,
+ * data backfills that discard the original format). These migrations do not
+ * define a `down()` function and will throw an `IntegrityError` if rollback
+ * is attempted. Always check the migration registry for `down` support before
+ * calling this function programmatically.
+ *
+ * **Important**: Stop the assistant before running rollbacks. Rolling back
+ * migrations while the assistant is running may cause schema mismatches,
+ * query failures, or data corruption.
  *
  * @param database  The Drizzle database instance.
  * @param targetVersion  Roll back to this version (exclusive — all migrations

--- a/assistant/src/workspace/migrations/001-avatar-rename.ts
+++ b/assistant/src/workspace/migrations/001-avatar-rename.ts
@@ -22,4 +22,19 @@ export const avatarRenameMigration: WorkspaceMigration = {
       renameSync(oldTraits, newTraits);
     }
   },
+  down(workspaceDir: string): void {
+    const avatarDir = join(workspaceDir, "data", "avatar");
+
+    const newImage = join(avatarDir, "avatar-image.png");
+    const oldImage = join(avatarDir, "custom-avatar.png");
+    if (existsSync(newImage) && !existsSync(oldImage)) {
+      renameSync(newImage, oldImage);
+    }
+
+    const newTraits = join(avatarDir, "character-traits.json");
+    const oldTraits = join(avatarDir, "avatar-components.json");
+    if (existsSync(newTraits) && !existsSync(oldTraits)) {
+      renameSync(newTraits, oldTraits);
+    }
+  },
 };

--- a/assistant/src/workspace/migrations/003-seed-device-id.ts
+++ b/assistant/src/workspace/migrations/003-seed-device-id.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 
 import { getDeviceIdBaseDir } from "../../util/device-id.js";
@@ -95,6 +101,16 @@ export const seedDeviceIdMigration: WorkspaceMigration = {
       });
     } catch {
       // Best-effort — getDeviceId() will generate a new one if this fails.
+    }
+  },
+  down(_workspaceDir: string): void {
+    // The forward migration seeds deviceId in ~/.vellum/device.json from the
+    // lockfile. Reverse by removing device.json entirely — getDeviceId() will
+    // generate a fresh one on next startup if needed.
+    const base = getDeviceIdBaseDir();
+    const devicePath = join(base, ".vellum", "device.json");
+    if (existsSync(devicePath)) {
+      unlinkSync(devicePath);
     }
   },
 };

--- a/assistant/src/workspace/migrations/004-extract-collect-usage-data.ts
+++ b/assistant/src/workspace/migrations/004-extract-collect-usage-data.ts
@@ -47,4 +47,37 @@ export const extractCollectUsageDataMigration: WorkspaceMigration = {
 
     writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
   },
+  down(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    // Only reverse if collectUsageData was explicitly set to false
+    // (the forward migration only persisted false).
+    if (!("collectUsageData" in config)) return;
+    const value = config.collectUsageData;
+    if (typeof value !== "boolean") return;
+
+    // Restore the feature flag value
+    const FLAG_KEY = "feature_flags.collect-usage-data.enabled";
+    const flagValues = (config.assistantFeatureFlagValues ?? {}) as Record<
+      string,
+      unknown
+    >;
+    flagValues[FLAG_KEY] = value;
+    config.assistantFeatureFlagValues = flagValues;
+
+    // Remove the extracted top-level key
+    delete config.collectUsageData;
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
 };

--- a/assistant/src/workspace/migrations/005-add-send-diagnostics.ts
+++ b/assistant/src/workspace/migrations/005-add-send-diagnostics.ts
@@ -9,4 +9,7 @@ export const addSendDiagnosticsMigration: WorkspaceMigration = {
     // will sync the UserDefaults value on first startup. This migration exists
     // as a checkpoint marker for future reference.
   },
+  down(_workspaceDir: string): void {
+    // No-op — the forward migration is a checkpoint marker with no data changes.
+  },
 };

--- a/assistant/src/workspace/migrations/006-services-config.ts
+++ b/assistant/src/workspace/migrations/006-services-config.ts
@@ -134,4 +134,53 @@ export const servicesConfigMigration: WorkspaceMigration = {
 
     writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
   },
+  down(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const services = config.services;
+    if (!services || typeof services !== "object" || Array.isArray(services))
+      return;
+
+    const svc = services as Record<string, Record<string, unknown>>;
+
+    // Extract inference provider and model back to top-level fields.
+    // Note: inferenceMode is lost in this rollback — the original config did
+    // not store a mode field. This is an accepted lossy reversal.
+    if (svc.inference) {
+      if (typeof svc.inference.provider === "string") {
+        config.provider = svc.inference.provider;
+      }
+      if (typeof svc.inference.model === "string") {
+        config.model = svc.inference.model;
+      }
+    }
+
+    // Extract image generation model back to top-level
+    if (svc["image-generation"]) {
+      if (typeof svc["image-generation"].model === "string") {
+        config.imageGenModel = svc["image-generation"].model;
+      }
+    }
+
+    // Extract web search provider back to top-level
+    if (svc["web-search"]) {
+      if (typeof svc["web-search"].provider === "string") {
+        config.webSearchProvider = svc["web-search"].provider;
+      }
+    }
+
+    delete config.services;
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
 };

--- a/assistant/src/workspace/migrations/007-web-search-provider-rename.ts
+++ b/assistant/src/workspace/migrations/007-web-search-provider-rename.ts
@@ -34,4 +34,31 @@ export const webSearchProviderRenameMigration: WorkspaceMigration = {
     ws.provider = "inference-provider-native";
     writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
   },
+  down(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const services = config.services;
+    if (!services || typeof services !== "object" || Array.isArray(services))
+      return;
+
+    const webSearch = (services as Record<string, unknown>)["web-search"];
+    if (!webSearch || typeof webSearch !== "object" || Array.isArray(webSearch))
+      return;
+
+    const ws = webSearch as Record<string, unknown>;
+    if (ws.provider !== "inference-provider-native") return;
+
+    ws.provider = "anthropic-native";
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
 };

--- a/assistant/src/workspace/migrations/008-voice-timeout-and-max-steps.ts
+++ b/assistant/src/workspace/migrations/008-voice-timeout-and-max-steps.ts
@@ -9,4 +9,7 @@ export const voiceTimeoutAndMaxStepsMigration: WorkspaceMigration = {
     // Existing users: macOS client will sync UserDefaults values
     // to config on next startup via settings sync endpoints.
   },
+  down(_workspaceDir: string): void {
+    // No-op — the forward migration is a checkpoint marker with no data changes.
+  },
 };

--- a/assistant/src/workspace/migrations/009-backfill-conversation-disk-view.ts
+++ b/assistant/src/workspace/migrations/009-backfill-conversation-disk-view.ts
@@ -7,4 +7,8 @@ export const backfillConversationDiskViewMigration: WorkspaceMigration = {
   run(_workspaceDir: string): void {
     rebuildConversationDiskViewFromDb();
   },
+  // No-op: the disk view is a derived cache that can be regenerated from the
+  // database at any time. Removing it would only cause unnecessary I/O churn
+  // since the next forward migration (or startup rebuild) will recreate it.
+  down(_workspaceDir: string): void {},
 };

--- a/assistant/src/workspace/migrations/010-app-dir-rename.ts
+++ b/assistant/src/workspace/migrations/010-app-dir-rename.ts
@@ -76,6 +76,84 @@ export const appDirRenameMigration: WorkspaceMigration = {
   description:
     "Rename UUID-based app directories and files to human-readable slugified names",
 
+  down(workspaceDir: string): void {
+    const appsDir = join(workspaceDir, "data", "apps");
+    if (!existsSync(appsDir)) return;
+
+    const jsonFiles = readdirSync(appsDir)
+      .filter((f) => f.endsWith(".json"))
+      .sort();
+
+    if (jsonFiles.length === 0) return;
+
+    for (const jsonFile of jsonFiles) {
+      const jsonPath = join(appsDir, jsonFile);
+      let raw: string;
+      try {
+        raw = readFileSync(jsonPath, "utf-8");
+      } catch {
+        continue;
+      }
+
+      let parsed: {
+        id?: string;
+        name?: string;
+        dirName?: string;
+      };
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        continue;
+      }
+
+      const appId = parsed.id;
+      if (!appId || !parsed.dirName || !isValidDirName(parsed.dirName)) {
+        continue;
+      }
+
+      const dirName = parsed.dirName;
+
+      // 1. Rename the app directory: {dirName}/ -> {appId}/
+      const slugDir = join(appsDir, dirName);
+      const uuidDir = join(appsDir, appId);
+      if (existsSync(slugDir) && !existsSync(uuidDir) && slugDir !== uuidDir) {
+        renameSync(slugDir, uuidDir);
+      }
+
+      // 2. Rename the preview file: {dirName}.preview -> {appId}.preview
+      const slugPreview = join(appsDir, `${dirName}.preview`);
+      const uuidPreview = join(appsDir, `${appId}.preview`);
+      if (
+        existsSync(slugPreview) &&
+        !existsSync(uuidPreview) &&
+        slugPreview !== uuidPreview
+      ) {
+        renameSync(slugPreview, uuidPreview);
+      }
+
+      // 3. Remove dirName from JSON and rename file: {dirName}.json -> {appId}.json
+      const updatedParsed = { ...parsed };
+      delete updatedParsed.dirName;
+      const updatedJson = JSON.stringify(updatedParsed, null, 2);
+
+      const uuidJsonFile = `${appId}.json`;
+      const uuidJsonPath = join(appsDir, uuidJsonFile);
+
+      if (jsonFile !== uuidJsonFile) {
+        writeFileSync(uuidJsonPath, updatedJson, "utf-8");
+        if (existsSync(jsonPath) && jsonPath !== uuidJsonPath) {
+          try {
+            unlinkSync(jsonPath);
+          } catch {
+            // Old file cleanup is best-effort
+          }
+        }
+      } else {
+        writeFileSync(uuidJsonPath, updatedJson, "utf-8");
+      }
+    }
+  },
+
   run(workspaceDir: string): void {
     const appsDir = join(workspaceDir, "data", "apps");
     if (!existsSync(appsDir)) return;

--- a/assistant/src/workspace/migrations/011-backfill-installation-id.ts
+++ b/assistant/src/workspace/migrations/011-backfill-installation-id.ts
@@ -14,6 +14,17 @@ export const backfillInstallationIdMigration: WorkspaceMigration = {
   id: "011-backfill-installation-id",
   description:
     "Backfill installationId into lockfile from SQLite checkpoint and clean up stale row",
+
+  down(_workspaceDir: string): void {
+    // The forward migration moved an installationId from a SQLite checkpoint
+    // into the lockfile entry. Rolling back by removing installationId from
+    // the lockfile would break telemetry continuity and the field is harmless
+    // to leave in place. The SQLite checkpoint was already deleted and
+    // cannot be restored.
+    //
+    // No-op: leaving installationId in the lockfile is safe and non-disruptive.
+  },
+
   run(_workspaceDir: string): void {
     // a. Read existing installation ID from SQLite, or generate a new one.
     //    On fresh installs the memory_checkpoints table may not exist yet,

--- a/assistant/src/workspace/migrations/012-rename-conversation-disk-view-dirs.ts
+++ b/assistant/src/workspace/migrations/012-rename-conversation-disk-view-dirs.ts
@@ -17,6 +17,10 @@ import type { WorkspaceMigration } from "./types.js";
 const LEGACY_CONVERSATION_DIR_PATTERN =
   /^(.*)_(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z)$/;
 
+/** Matches the new timestamp-first format: {timestamp}_{conversationId} */
+const NEW_CONVERSATION_DIR_PATTERN =
+  /^(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z)_(.+)$/;
+
 function parseLegacyConversationDirName(
   dirName: string,
 ): { conversationId: string; timestamp: string } | null {
@@ -29,10 +33,50 @@ function parseLegacyConversationDirName(
   };
 }
 
+function parseNewConversationDirName(
+  dirName: string,
+): { timestamp: string; conversationId: string } | null {
+  const match = dirName.match(NEW_CONVERSATION_DIR_PATTERN);
+  if (!match) return null;
+
+  return {
+    timestamp: match[1],
+    conversationId: match[2],
+  };
+}
+
 export const renameConversationDiskViewDirsMigration: WorkspaceMigration = {
   id: "012-rename-conversation-disk-view-dirs",
   description:
     "Rename legacy conversation disk-view directories to timestamp-first names",
+
+  down(workspaceDir: string): void {
+    const conversationsDir = join(workspaceDir, "conversations");
+    if (!existsSync(conversationsDir)) return;
+
+    const entries = readdirSync(conversationsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+
+    for (const dirName of entries) {
+      const parsed = parseNewConversationDirName(dirName);
+      if (!parsed) continue;
+
+      const sourcePath = join(conversationsDir, dirName);
+      const targetName = `${parsed.conversationId}_${parsed.timestamp}`;
+      const targetPath = join(conversationsDir, targetName);
+
+      if (sourcePath === targetPath) continue;
+      if (existsSync(targetPath)) continue;
+
+      try {
+        renameSync(sourcePath, targetPath);
+      } catch {
+        // Best-effort: leave the directory in place if a single rename fails.
+      }
+    }
+  },
 
   run(workspaceDir: string): void {
     const conversationsDir = join(workspaceDir, "conversations");

--- a/assistant/src/workspace/migrations/013-repair-conversation-disk-view.ts
+++ b/assistant/src/workspace/migrations/013-repair-conversation-disk-view.ts
@@ -8,4 +8,9 @@ export const repairConversationDiskViewMigration: WorkspaceMigration = {
   run(_workspaceDir: string): void {
     rebuildConversationDiskViewFromDb();
   },
+  // No-op: this is a repair migration that rebuilds derived disk-view data
+  // from the database. There is no meaningful reverse operation — the data
+  // is a cache that can be regenerated, and removing it would just cause
+  // unnecessary churn on the next forward run.
+  down(_workspaceDir: string): void {},
 };

--- a/assistant/src/workspace/migrations/015-migrate-credentials-to-keychain.ts
+++ b/assistant/src/workspace/migrations/015-migrate-credentials-to-keychain.ts
@@ -11,6 +11,73 @@ export const migrateCredentialsToKeychainMigration: WorkspaceMigration = {
   description:
     "Copy encrypted store credentials to keychain for single-backend migration",
 
+  async down(_workspaceDir: string): Promise<void> {
+    // Reverse: copy credentials from keychain back to encrypted store.
+    // Mirrors the forward logic of 016-migrate-credentials-from-keychain.
+    if (
+      process.env.VELLUM_DESKTOP_APP !== "1" ||
+      process.env.VELLUM_DEV === "1"
+    ) {
+      return;
+    }
+
+    const { createBrokerClient } =
+      await import("../../security/keychain-broker-client.js");
+    const client = createBrokerClient();
+
+    let brokerAvailable = false;
+    for (let i = 0; i < BROKER_WAIT_MAX_ATTEMPTS; i++) {
+      if (client.isAvailable()) {
+        brokerAvailable = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, BROKER_WAIT_INTERVAL_MS));
+    }
+
+    if (!brokerAvailable) {
+      // If the broker is not available, credentials may already be in the
+      // encrypted store or we're in a non-desktop environment — skip silently.
+      return;
+    }
+
+    const { setKey } = await import("../../security/encrypted-store.js");
+
+    const accounts = await client.list();
+    if (accounts.length === 0) return;
+
+    let rolledBackCount = 0;
+    let failedCount = 0;
+
+    for (const account of accounts) {
+      const result = await client.get(account);
+      if (!result || !result.found || result.value === undefined) {
+        log.warn(
+          { account },
+          "Failed to read key from keychain during rollback — skipping",
+        );
+        failedCount++;
+        continue;
+      }
+
+      const written = setKey(account, result.value);
+      if (written) {
+        await client.del(account);
+        rolledBackCount++;
+      } else {
+        log.warn(
+          { account },
+          "Failed to write key to encrypted store during rollback — skipping",
+        );
+        failedCount++;
+      }
+    }
+
+    log.info(
+      { rolledBackCount, failedCount },
+      "Credential rollback from keychain to encrypted store complete",
+    );
+  },
+
   async run(_workspaceDir: string): Promise<void> {
     // Only run on mac production builds (desktop app, non-dev).
     if (

--- a/assistant/src/workspace/migrations/015-migrate-credentials-to-keychain.ts
+++ b/assistant/src/workspace/migrations/015-migrate-credentials-to-keychain.ts
@@ -35,9 +35,10 @@ export const migrateCredentialsToKeychainMigration: WorkspaceMigration = {
     }
 
     if (!brokerAvailable) {
-      // If the broker is not available, credentials may already be in the
-      // encrypted store or we're in a non-desktop environment — skip silently.
-      return;
+      throw new Error(
+        "Keychain broker not available after waiting — credential rollback " +
+          "will be retried on next startup",
+      );
     }
 
     const { setKey } = await import("../../security/encrypted-store.js");

--- a/assistant/src/workspace/migrations/016-extract-feature-flags-to-protected.ts
+++ b/assistant/src/workspace/migrations/016-extract-feature-flags-to-protected.ts
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   readFileSync,
   renameSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
@@ -15,6 +16,69 @@ export const extractFeatureFlagsToProtectedMigration: WorkspaceMigration = {
   id: "016-extract-feature-flags-to-protected",
   description:
     "Move assistantFeatureFlagValues from config.json to ~/.vellum/protected/feature-flags.json",
+
+  down(workspaceDir: string): void {
+    // Reverse: read feature flags from protected directory and write them
+    // back to config.json as assistantFeatureFlagValues.
+    const protectedDir = join(getRootDir(), "protected");
+    const featureFlagsPath = join(protectedDir, "feature-flags.json");
+
+    if (!existsSync(featureFlagsPath)) return;
+
+    let flagValues: Record<string, boolean>;
+    try {
+      const raw = JSON.parse(readFileSync(featureFlagsPath, "utf-8"));
+      if (
+        !raw ||
+        raw.version !== 1 ||
+        !raw.values ||
+        typeof raw.values !== "object"
+      ) {
+        return;
+      }
+      flagValues = raw.values;
+    } catch {
+      return; // Malformed file — skip
+    }
+
+    if (Object.keys(flagValues).length === 0) return;
+
+    // Read config.json and restore assistantFeatureFlagValues
+    const configPath = join(workspaceDir, "config.json");
+    let config: Record<string, unknown> = {};
+    if (existsSync(configPath)) {
+      try {
+        const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+        if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+          config = raw as Record<string, unknown>;
+        }
+      } catch {
+        // Malformed config — start with empty object
+      }
+    }
+
+    // Merge into existing assistantFeatureFlagValues if present
+    const existing = (config.assistantFeatureFlagValues ?? {}) as Record<
+      string,
+      boolean
+    >;
+    config.assistantFeatureFlagValues = { ...existing, ...flagValues };
+
+    const tmpConfigPath = configPath + ".tmp";
+    writeFileSync(
+      tmpConfigPath,
+      JSON.stringify(config, null, 2) + "\n",
+      "utf-8",
+    );
+    renameSync(tmpConfigPath, configPath);
+
+    // Remove the protected feature-flags file
+    try {
+      unlinkSync(featureFlagsPath);
+    } catch {
+      // Best-effort cleanup
+    }
+  },
 
   run(workspaceDir: string): void {
     const configPath = join(workspaceDir, "config.json");

--- a/assistant/src/workspace/migrations/016-migrate-credentials-from-keychain.ts
+++ b/assistant/src/workspace/migrations/016-migrate-credentials-from-keychain.ts
@@ -11,6 +11,75 @@ export const migrateCredentialsFromKeychainMigration: WorkspaceMigration = {
   description:
     "Copy keychain credentials back to encrypted store for CES unification",
 
+  async down(_workspaceDir: string): Promise<void> {
+    // Reverse: copy credentials from encrypted store back to keychain.
+    // Mirrors the forward logic of 015-migrate-credentials-to-keychain.
+    if (
+      process.env.VELLUM_DESKTOP_APP !== "1" ||
+      process.env.VELLUM_DEV === "1"
+    ) {
+      return;
+    }
+
+    const { createBrokerClient } =
+      await import("../../security/keychain-broker-client.js");
+    const client = createBrokerClient();
+
+    let brokerAvailable = false;
+    for (let i = 0; i < BROKER_WAIT_MAX_ATTEMPTS; i++) {
+      if (client.isAvailable()) {
+        brokerAvailable = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, BROKER_WAIT_INTERVAL_MS));
+    }
+
+    if (!brokerAvailable) {
+      throw new Error(
+        "Keychain broker not available after waiting — credential rollback " +
+          "will be retried on next startup",
+      );
+    }
+
+    const { listKeys, getKey, deleteKey } =
+      await import("../../security/encrypted-store.js");
+
+    const accounts = listKeys();
+    if (accounts.length === 0) return;
+
+    let rolledBackCount = 0;
+    let failedCount = 0;
+
+    for (const account of accounts) {
+      const value = getKey(account);
+      if (value === undefined) {
+        log.warn(
+          { account },
+          "Failed to read key from encrypted store during rollback — skipping",
+        );
+        failedCount++;
+        continue;
+      }
+
+      const result = await client.set(account, value);
+      if (result.status === "ok") {
+        deleteKey(account);
+        rolledBackCount++;
+      } else {
+        log.warn(
+          { account, status: result.status },
+          "Failed to write key to keychain during rollback — skipping",
+        );
+        failedCount++;
+      }
+    }
+
+    log.info(
+      { rolledBackCount, failedCount },
+      "Credential rollback from encrypted store to keychain complete",
+    );
+  },
+
   async run(_workspaceDir: string): Promise<void> {
     // Only run on mac production builds (desktop app, non-dev).
     if (
@@ -55,10 +124,7 @@ export const migrateCredentialsFromKeychainMigration: WorkspaceMigration = {
     for (const account of accounts) {
       const result = await client.get(account);
       if (!result || !result.found || result.value === undefined) {
-        log.warn(
-          { account },
-          "Failed to read key from keychain — skipping",
-        );
+        log.warn({ account }, "Failed to read key from keychain — skipping");
         failedCount++;
         continue;
       }

--- a/assistant/src/workspace/migrations/017-seed-persona-dirs.ts
+++ b/assistant/src/workspace/migrations/017-seed-persona-dirs.ts
@@ -1,4 +1,11 @@
-import { copyFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmdirSync,
+} from "node:fs";
 import { join } from "node:path";
 
 import { eq } from "drizzle-orm";
@@ -16,6 +23,27 @@ export const seedPersonaDirsMigration: WorkspaceMigration = {
   id: "017-seed-persona-dirs",
   description:
     "Create users/ and channels/ persona directories and migrate customized USER.md",
+
+  down(workspaceDir: string): void {
+    // Remove the seeded persona directories only if they are empty.
+    // We don't delete user-created content — only clean up the empty
+    // directories that the forward migration created.
+    const usersDir = join(workspaceDir, "users");
+    const channelsDir = join(workspaceDir, "channels");
+
+    for (const dir of [usersDir, channelsDir]) {
+      if (!existsSync(dir)) continue;
+      try {
+        const entries = readdirSync(dir);
+        if (entries.length === 0) {
+          rmdirSync(dir);
+        }
+      } catch {
+        // Best-effort: skip if we can't read or remove
+      }
+    }
+  },
+
   run(workspaceDir: string): void {
     // Create persona directories
     mkdirSync(join(workspaceDir, "users"), { recursive: true });

--- a/assistant/src/workspace/migrations/migrate-to-workspace-volume.ts
+++ b/assistant/src/workspace/migrations/migrate-to-workspace-volume.ts
@@ -14,7 +14,13 @@
  * - Skips if the old workspace directory doesn't exist or is empty.
  */
 
-import { cpSync, existsSync, readdirSync, writeFileSync } from "node:fs";
+import {
+  cpSync,
+  existsSync,
+  readdirSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 
 import {
@@ -29,6 +35,22 @@ export const migrateToWorkspaceVolumeMigration: WorkspaceMigration = {
   id: "014-migrate-to-workspace-volume",
   description:
     "Copy workspace data from old /data/.vellum/workspace to new WORKSPACE_DIR volume on first boot",
+
+  down(workspaceDir: string): void {
+    // This migration copies data between volumes. Actually reversing the copy
+    // (deleting data from the workspace volume) is dangerous and could cause
+    // data loss. Instead, we just remove the sentinel file so the migration
+    // will re-run and re-evaluate on next startup.
+    const sentinelPath = join(workspaceDir, SENTINEL_FILENAME);
+    if (existsSync(sentinelPath)) {
+      try {
+        unlinkSync(sentinelPath);
+      } catch {
+        // Best-effort — the migration runner's checkpoint removal will
+        // also ensure the migration re-runs.
+      }
+    }
+  },
 
   run(workspaceDir: string): void {
     const workspaceDirOverride = getWorkspaceDirOverride();

--- a/assistant/src/workspace/migrations/runner.ts
+++ b/assistant/src/workspace/migrations/runner.ts
@@ -173,8 +173,9 @@ export async function rollbackWorkspaceMigrations(
   const checkpoints = loadCheckpoints(workspaceDir);
 
   for (const migration of migrationsToRollback) {
-    // Only roll back migrations that have been applied
-    if (!checkpoints.applied[migration.id]) {
+    // Only roll back migrations that have been fully applied (completed)
+    const entry = checkpoints.applied[migration.id];
+    if (!entry || entry.status !== "completed") {
       continue;
     }
 

--- a/assistant/src/workspace/migrations/runner.ts
+++ b/assistant/src/workspace/migrations/runner.ts
@@ -173,9 +173,15 @@ export async function rollbackWorkspaceMigrations(
   const checkpoints = loadCheckpoints(workspaceDir);
 
   for (const migration of migrationsToRollback) {
-    // Only roll back migrations that have been fully applied (completed)
+    // Only roll back migrations that have been fully applied.
+    // Legacy checkpoints may not have a status field (just appliedAt) — treat
+    // missing/undefined status as completed, matching runWorkspaceMigrations behavior.
     const entry = checkpoints.applied[migration.id];
-    if (!entry || entry.status !== "completed") {
+    if (
+      !entry ||
+      entry.status === "started" ||
+      entry.status === "rolling_back"
+    ) {
       continue;
     }
 

--- a/assistant/src/workspace/migrations/runner.ts
+++ b/assistant/src/workspace/migrations/runner.ts
@@ -117,10 +117,38 @@ export async function runWorkspaceMigrations(
 }
 
 /**
- * Roll back workspace migrations in reverse order, stopping before the target migration.
+ * Roll back workspace (filesystem) migrations in reverse order, stopping before
+ * the target migration.
  *
- * Migrations after `targetMigrationId` in the array are reversed (the target itself is kept).
- * Each migration must have a `down()` method; if one is missing, an error is thrown.
+ * Migrations after `targetMigrationId` in the registry array are reversed in
+ * reverse order; the target migration itself is kept applied.
+ *
+ * **Usage**: Pass the full migrations array (typically `WORKSPACE_MIGRATIONS`
+ * from `registry.ts`) and the ID of the migration you want to roll back *to*.
+ * For example, `rollbackWorkspaceMigrations(dir, migrations, "010-app-dir-rename")`
+ * rolls back all applied migrations that appear after `010-app-dir-rename` in
+ * the registry.
+ *
+ * **Checkpoint state**: Each rolled-back migration's entry is deleted from the
+ * `.workspace-migrations.json` checkpoint file. If the process crashes
+ * mid-rollback, the `"rolling_back"` marker is detected and cleared by
+ * `runWorkspaceMigrations` on the next startup (it re-runs interrupted
+ * migrations).
+ *
+ * **Warning — data loss**: Some workspace migrations are irreversible (e.g.,
+ * file deletions, format conversions that discard the original). These
+ * migrations do not define a `down()` method and will throw an error if
+ * rollback is attempted. Always verify that all target migrations have `down()`
+ * support before calling this function.
+ *
+ * **Important**: Stop the assistant before running rollbacks. Rolling back
+ * workspace migrations while the assistant is running may cause file conflicts,
+ * stale caches, or data corruption.
+ *
+ * @param workspaceDir  The workspace directory path (e.g., `~/.vellum/workspace`).
+ * @param migrations  The full ordered array of workspace migrations (from `WORKSPACE_MIGRATIONS`).
+ * @param targetMigrationId  The migration ID to roll back to (exclusive — all
+ *   migrations after this one are reversed).
  */
 export async function rollbackWorkspaceMigrations(
   workspaceDir: string,

--- a/assistant/src/workspace/migrations/runner.ts
+++ b/assistant/src/workspace/migrations/runner.ts
@@ -10,7 +10,7 @@ const log = getLogger("workspace-migrations");
 export type CheckpointFile = {
   applied: Record<
     string,
-    { appliedAt: string; status?: "started" | "completed" }
+    { appliedAt: string; status?: "started" | "completed" | "rolling_back" }
   >;
 };
 
@@ -73,7 +73,7 @@ export async function runWorkspaceMigrations(
   const checkpoints = loadCheckpoints(workspaceDir);
 
   for (const [id, entry] of Object.entries(checkpoints.applied)) {
-    if (entry.status === "started") {
+    if (entry.status === "started" || entry.status === "rolling_back") {
       log.warn(
         `Workspace migration "${id}" was interrupted during a previous run; will re-run`,
       );
@@ -113,5 +113,74 @@ export async function runWorkspaceMigrations(
       status: "completed",
     };
     saveCheckpoints(workspaceDir, checkpoints);
+  }
+}
+
+/**
+ * Roll back workspace migrations in reverse order, stopping before the target migration.
+ *
+ * Migrations after `targetMigrationId` in the array are reversed (the target itself is kept).
+ * Each migration must have a `down()` method; if one is missing, an error is thrown.
+ */
+export async function rollbackWorkspaceMigrations(
+  workspaceDir: string,
+  migrations: WorkspaceMigration[],
+  targetMigrationId: string,
+): Promise<void> {
+  // Find the index of the target migration
+  const targetIndex = migrations.findIndex((m) => m.id === targetMigrationId);
+  if (targetIndex === -1) {
+    throw new Error(
+      `Target migration "${targetMigrationId}" not found in the migrations array`,
+    );
+  }
+
+  // Collect migrations that come after the target, in reverse order
+  const migrationsToRollback = migrations.slice(targetIndex + 1).reverse();
+  if (migrationsToRollback.length === 0) {
+    log.info("No migrations to roll back");
+    return;
+  }
+
+  const checkpoints = loadCheckpoints(workspaceDir);
+
+  for (const migration of migrationsToRollback) {
+    // Only roll back migrations that have been applied
+    if (!checkpoints.applied[migration.id]) {
+      continue;
+    }
+
+    if (!migration.down) {
+      throw new Error(
+        `Migration "${migration.id}" does not support rollback (no down() method)`,
+      );
+    }
+
+    log.info(
+      `Rolling back workspace migration: ${migration.id} — ${migration.description}`,
+    );
+
+    // Mark as rolling_back before execution (for crash recovery)
+    checkpoints.applied[migration.id] = {
+      appliedAt: checkpoints.applied[migration.id]!.appliedAt,
+      status: "rolling_back",
+    };
+    saveCheckpoints(workspaceDir, checkpoints);
+
+    try {
+      await migration.down(workspaceDir);
+    } catch (error) {
+      log.error(
+        { migrationId: migration.id, error },
+        `Workspace migration rollback failed: ${migration.id}`,
+      );
+      throw error;
+    }
+
+    // Remove the migration entry from checkpoints
+    delete checkpoints.applied[migration.id];
+    saveCheckpoints(workspaceDir, checkpoints);
+
+    log.info(`Rolled back workspace migration: ${migration.id}`);
   }
 }

--- a/assistant/src/workspace/migrations/types.ts
+++ b/assistant/src/workspace/migrations/types.ts
@@ -8,4 +8,8 @@ export interface WorkspaceMigration {
    *  Must be idempotent — safe to re-run if it was interrupted.
    *  Both synchronous and asynchronous migrations are supported. */
   run(workspaceDir: string): void | Promise<void>;
+  /** Reverse the migration. Receives the workspace directory path.
+   *  Must be idempotent — safe to re-run if it was interrupted.
+   *  Both synchronous and asynchronous rollbacks are supported. */
+  down?(workspaceDir: string): void | Promise<void>;
 }


### PR DESCRIPTION
## Summary
Add rollback (`down()`) support to both the memory (SQLite/Drizzle) migration system and the workspace file-system migration system. This enables safe version rollbacks by allowing each migration to cleanly undo its forward operation.

## PRs merged into feature branch
- #20663: feat: add down() support to workspace migration type and runner
- #20664: feat: add down() support to memory migration registry and runner
- #20665: test: add workspace migration runner rollback tests
- #20666: feat: add down() functions to workspace migrations 001-008
- #20667: test: add memory migration rollback tests
- #20668: feat: add down() functions to workspace migrations 009-017
- #20669: feat: add down() to memory migration registry entries versions 1-12
- #20670: feat: add down() to memory migration registry entries versions 13-24
- #20671: feat: add down() to memory migration registry entries versions 25-36
- #20672: feat: add migration rollback utility for memory and workspace migrations
- #20673: test: add tests for workspace migration down() functions
- #20674: test: add tests for memory migration down() functions

## What's included
- `WorkspaceMigration` interface extended with optional `down()` method
- `MigrationRegistryEntry` extended with optional `down` function
- `rollbackWorkspaceMigrations()` and `rollbackMemoryMigration()` functions
- Crash recovery for `rolling_back` checkpoint state
- `down()` implementations for all 17 workspace migrations and all 36 memory migration registry entries
- Comprehensive test suites (50+ workspace tests, 50+ memory tests, runner rollback tests)
- Lossy/irreversible migrations have documented no-op `down()` with explanatory comments

Part of plan: migration-down-functions.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
