### PR TITLE
fix: correct misleading comment about required image refs

### DIFF
--- a/cli/src/lib/platform-releases.ts
+++ b/cli/src/lib/platform-releases.ts
@@ -85,7 +85,7 @@ async function fetchPlatformImageRefs(
     const gatewayImage = release.gateway_image_ref;
     let credentialExecutorImage = release.credential_executor_image_ref;
 
-    // All three images must be present for a valid resolution
+    // Assistant and gateway images are required; credential-executor falls back to DockerHub
     if (!assistantImage || !gatewayImage) {
       log?.("Platform release missing required image refs");
       return null;


### PR DESCRIPTION
Addresses review feedback on PR #20144 — comment incorrectly claimed all three images are required when only two are checked.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
