### PR TITLE
fix: use omittingEmptySubsequences: false in version compat parsing

### DIFF
--- a/clients/shared/Utilities/VersionCompat.swift
+++ b/clients/shared/Utilities/VersionCompat.swift
@@ -22,7 +22,7 @@ public enum VersionCompat {
         // Strip pre-release (-beta.1) and build metadata (+build.123) before splitting on dots
         let withoutPreRelease = cleaned.split(separator: "-", maxSplits: 1).first.map(String.init) ?? cleaned
         let withoutBuild = withoutPreRelease.split(separator: "+", maxSplits: 1).first.map(String.init) ?? withoutPreRelease
-        let segments = withoutBuild.split(separator: ".").map(String.init)
+        let segments = withoutBuild.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
         let components = segments.compactMap { Int($0) }
         // Fail-fast if any segment was non-numeric (compactMap silently drops them)
         guard components.count == segments.count,


### PR DESCRIPTION
Addresses review feedback on PR #19952 — Swift split(separator:) silently drops empty subsequences, accepting malformed versions like '1..2' as valid.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
