### PR TITLE
feat: include migration state in daemon healthz response

### DIFF
--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -327,6 +327,10 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
   },
 ];
 
+export function getMaxMigrationVersion(): number {
+  return Math.max(...MIGRATION_REGISTRY.map((e) => e.version));
+}
+
 export interface MigrationValidationResult {
   /** Keys of migrations whose checkpoint has value 'started' — started but never completed. */
   crashed: string[];

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -9,7 +9,10 @@ import { fileURLToPath } from "node:url";
 
 import { getBaseDataDir } from "../../config/env-registry.js";
 import { parseIdentityFields } from "../../daemon/handlers/identity.js";
+import { getMaxMigrationVersion } from "../../memory/migrations/registry.js";
 import { getWorkspacePromptPath } from "../../util/platform.js";
+import { WORKSPACE_MIGRATIONS } from "../../workspace/migrations/registry.js";
+import { getLastWorkspaceMigrationId } from "../../workspace/migrations/runner.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 import { getCachedIntro } from "./identity-intro-cache.js";
@@ -140,6 +143,11 @@ export function handleHealth(): Response {
     disk: getDiskSpaceInfo(),
     memory: getMemoryInfo(),
     cpu: getCpuInfo(),
+    migrations: {
+      dbVersion: getMaxMigrationVersion(),
+      lastWorkspaceMigrationId:
+        getLastWorkspaceMigrationId(WORKSPACE_MIGRATIONS),
+    },
   });
 }
 

--- a/assistant/src/workspace/migrations/runner.ts
+++ b/assistant/src/workspace/migrations/runner.ts
@@ -7,6 +7,12 @@ import type { WorkspaceMigration } from "./types.js";
 
 const log = getLogger("workspace-migrations");
 
+export function getLastWorkspaceMigrationId(
+  migrations: WorkspaceMigration[],
+): string | null {
+  return migrations.length > 0 ? migrations[migrations.length - 1].id : null;
+}
+
 export type CheckpointFile = {
   applied: Record<
     string,


### PR DESCRIPTION
## Summary
- Adds `getMaxMigrationVersion()` to DB migration registry
- Adds `getLastWorkspaceMigrationId()` to workspace migration runner
- Healthz now returns `migrations: { dbVersion, lastWorkspaceMigrationId }`

Part of plan: migration-rollback-wiring.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
