### PR TITLE
feat: add admin endpoint for rolling back DB and workspace migrations

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -521,3 +521,8 @@ registerPolicy("admin/workspace-commit", {
   requiredScopes: ["internal.write"],
   allowedPrincipalTypes: ["svc_gateway"],
 });
+
+registerPolicy("admin/rollback-migrations", {
+  requiredScopes: ["internal.write"],
+  allowedPrincipalTypes: ["svc_gateway"],
+});

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -155,6 +155,7 @@ import { vercelRouteDefinitions } from "./routes/integrations/vercel.js";
 import { inviteRouteDefinitions } from "./routes/invite-routes.js";
 import { logExportRouteDefinitions } from "./routes/log-export-routes.js";
 import { memoryItemRouteDefinitions } from "./routes/memory-item-routes.js";
+import { migrationRollbackRouteDefinitions } from "./routes/migration-rollback-routes.js";
 import { migrationRouteDefinitions } from "./routes/migration-routes.js";
 import { notificationRouteDefinitions } from "./routes/notification-routes.js";
 import { oauthAppsRouteDefinitions } from "./routes/oauth-apps.js";
@@ -933,6 +934,7 @@ export class RuntimeHttpServer {
       ...identityRouteDefinitions(),
       ...upgradeBroadcastRouteDefinitions(),
       ...workspaceCommitRouteDefinitions(),
+      ...migrationRollbackRouteDefinitions(),
       ...debugRouteDefinitions(),
       ...usageRouteDefinitions(),
       ...telemetryRouteDefinitions(),

--- a/assistant/src/runtime/routes/migration-rollback-routes.ts
+++ b/assistant/src/runtime/routes/migration-rollback-routes.ts
@@ -1,0 +1,162 @@
+/**
+ * Migration rollback endpoint — rolls back DB and/or workspace migrations
+ * to a specified target version/migration ID.
+ *
+ * Protected by a route policy restricting access to gateway service
+ * principals only (`svc_gateway` with `internal.write` scope), following
+ * the same pattern as other gateway-forwarded control-plane endpoints.
+ */
+
+import { getDb } from "../../memory/db-connection.js";
+import { rollbackMemoryMigration } from "../../memory/migrations/validate-migration-state.js";
+import { getWorkspaceDir } from "../../util/platform.js";
+import { WORKSPACE_MIGRATIONS } from "../../workspace/migrations/registry.js";
+import {
+  loadCheckpoints,
+  rollbackWorkspaceMigrations,
+} from "../../workspace/migrations/runner.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+export function migrationRollbackRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "admin/rollback-migrations",
+      method: "POST",
+      handler: async ({ req }) => {
+        let body: unknown;
+        try {
+          body = await req.json();
+        } catch {
+          return httpError("BAD_REQUEST", "Invalid JSON body", 400);
+        }
+
+        if (!body || typeof body !== "object") {
+          return httpError(
+            "BAD_REQUEST",
+            "Request body must be a JSON object",
+            400,
+          );
+        }
+
+        const { targetDbVersion, targetWorkspaceMigrationId } = body as {
+          targetDbVersion?: unknown;
+          targetWorkspaceMigrationId?: unknown;
+        };
+
+        // At least one rollback target must be specified.
+        if (
+          targetDbVersion === undefined &&
+          targetWorkspaceMigrationId === undefined
+        ) {
+          return httpError(
+            "BAD_REQUEST",
+            "At least one of targetDbVersion or targetWorkspaceMigrationId must be provided",
+            400,
+          );
+        }
+
+        // Validate targetDbVersion when provided.
+        if (targetDbVersion !== undefined) {
+          if (
+            typeof targetDbVersion !== "number" ||
+            !Number.isInteger(targetDbVersion) ||
+            targetDbVersion < 0
+          ) {
+            return httpError(
+              "BAD_REQUEST",
+              "targetDbVersion must be a non-negative integer",
+              400,
+            );
+          }
+        }
+
+        // Validate targetWorkspaceMigrationId when provided.
+        if (targetWorkspaceMigrationId !== undefined) {
+          if (
+            typeof targetWorkspaceMigrationId !== "string" ||
+            targetWorkspaceMigrationId.length === 0
+          ) {
+            return httpError(
+              "BAD_REQUEST",
+              "targetWorkspaceMigrationId must be a non-empty string",
+              400,
+            );
+          }
+        }
+
+        const rolledBack: { db: string[]; workspace: string[] } = {
+          db: [],
+          workspace: [],
+        };
+
+        // Roll back DB migrations if requested.
+        if (targetDbVersion !== undefined) {
+          try {
+            rolledBack.db = rollbackMemoryMigration(
+              getDb(),
+              targetDbVersion as number,
+            );
+          } catch (err) {
+            const detail = err instanceof Error ? err.message : "Unknown error";
+            return httpError(
+              "INTERNAL_ERROR",
+              `DB migration rollback failed: ${detail}`,
+              500,
+            );
+          }
+        }
+
+        // Roll back workspace migrations if requested.
+        if (targetWorkspaceMigrationId !== undefined) {
+          try {
+            const workspaceDir = getWorkspaceDir();
+
+            // Compute which migrations will be rolled back before executing,
+            // since rollbackWorkspaceMigrations returns void.
+            const targetId = targetWorkspaceMigrationId as string;
+            const targetIndex = WORKSPACE_MIGRATIONS.findIndex(
+              (m) => m.id === targetId,
+            );
+            if (targetIndex === -1) {
+              return httpError(
+                "BAD_REQUEST",
+                `Target workspace migration "${targetId}" not found in the registry`,
+                400,
+              );
+            }
+
+            const checkpoints = loadCheckpoints(workspaceDir);
+            const candidateIds = WORKSPACE_MIGRATIONS.slice(targetIndex + 1)
+              .filter((m) => {
+                const entry = checkpoints.applied[m.id];
+                return (
+                  entry &&
+                  entry.status !== "started" &&
+                  entry.status !== "rolling_back"
+                );
+              })
+              .map((m) => m.id);
+
+            await rollbackWorkspaceMigrations(
+              workspaceDir,
+              WORKSPACE_MIGRATIONS,
+              targetId,
+            );
+
+            rolledBack.workspace = candidateIds;
+          } catch (err) {
+            const detail = err instanceof Error ? err.message : "Unknown error";
+            return httpError(
+              "INTERNAL_ERROR",
+              `Workspace migration rollback failed: ${detail}`,
+              500,
+            );
+          }
+        }
+
+        return Response.json({ ok: true, rolledBack });
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Adds `POST /v1/admin/rollback-migrations` endpoint for reversing DB and workspace migrations
- Accepts `targetDbVersion` and/or `targetWorkspaceMigrationId` to scope the rollback
- Protected by svc_gateway + internal.write scope

Part of plan: migration-rollback-wiring.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
