### PR TITLE
feat: add gateway proxy for migration rollback endpoint

### DIFF
--- a/gateway/src/http/routes/migration-rollback-proxy.ts
+++ b/gateway/src/http/routes/migration-rollback-proxy.ts
@@ -1,0 +1,90 @@
+/**
+ * Gateway proxy for the daemon rollback-migrations control-plane endpoint.
+ *
+ * Follows the same forwarding pattern as workspace-commit-proxy.ts:
+ * strips hop-by-hop headers, replaces the client's edge JWT with a
+ * minted service token, and proxies the request to the daemon.
+ */
+
+import { mintServiceToken } from "../../auth/token-exchange.js";
+import type { GatewayConfig } from "../../config.js";
+import { fetchImpl } from "../../fetch.js";
+import { getLogger } from "../../logger.js";
+import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
+
+const log = getLogger("migration-rollback-proxy");
+
+export function createMigrationRollbackProxyHandler(config: GatewayConfig) {
+  return async function handleMigrationRollback(
+    req: Request,
+  ): Promise<Response> {
+    const start = performance.now();
+    const bodyBuffer = await req.arrayBuffer();
+
+    const upstream = `${config.assistantRuntimeBaseUrl}/v1/admin/rollback-migrations`;
+
+    const reqHeaders = stripHopByHop(new Headers(req.headers));
+    reqHeaders.delete("host");
+    reqHeaders.delete("authorization");
+
+    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
+    reqHeaders.set("content-length", String(bodyBuffer.byteLength));
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(
+        new DOMException(
+          "The operation was aborted due to timeout",
+          "TimeoutError",
+        ),
+      );
+    }, config.runtimeTimeoutMs);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(upstream, {
+        method: "POST",
+        headers: reqHeaders,
+        body: bodyBuffer,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+    } catch (err) {
+      clearTimeout(timeoutId);
+      const duration = Math.round(performance.now() - start);
+      if (err instanceof DOMException && err.name === "TimeoutError") {
+        log.error({ duration }, "Migration rollback proxy upstream timed out");
+        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
+      }
+      log.error(
+        { err, duration },
+        "Migration rollback proxy upstream connection failed",
+      );
+      return Response.json({ error: "Bad Gateway" }, { status: 502 });
+    }
+
+    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const duration = Math.round(performance.now() - start);
+
+    if (response.status >= 400) {
+      const body = await response.text();
+      log.warn(
+        { status: response.status, duration },
+        "Migration rollback proxy upstream error",
+      );
+      return new Response(body, {
+        status: response.status,
+        headers: resHeaders,
+      });
+    }
+
+    log.info(
+      { status: response.status, duration },
+      "Migration rollback proxy completed",
+    );
+    return new Response(response.body, {
+      status: response.status,
+      headers: resHeaders,
+    });
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -61,6 +61,7 @@ import {
   createMigrationExportProxyHandler,
   createMigrationImportProxyHandler,
 } from "./http/routes/migration-proxy.js";
+import { createMigrationRollbackProxyHandler } from "./http/routes/migration-rollback-proxy.js";
 import { createWorkspaceCommitProxyHandler } from "./http/routes/workspace-commit-proxy.js";
 import { createBrainGraphProxyHandler } from "./http/routes/brain-graph-proxy.js";
 import {
@@ -292,6 +293,7 @@ async function main() {
   const upgradeBroadcastProxy = createUpgradeBroadcastProxyHandler(config);
   const migrationExportProxy = createMigrationExportProxyHandler(config);
   const migrationImportProxy = createMigrationImportProxyHandler(config);
+  const migrationRollbackProxy = createMigrationRollbackProxyHandler(config);
   const workspaceCommitProxy = createWorkspaceCommitProxyHandler(config);
   const brainGraphProxy = createBrainGraphProxyHandler(config);
   const handleFeatureFlagsGet = createFeatureFlagsGetHandler();
@@ -778,6 +780,14 @@ async function main() {
       method: "POST",
       auth: "edge",
       handler: (req) => workspaceCommitProxy(req),
+    },
+
+    // ── Migration rollback ──
+    {
+      path: "/v1/admin/rollback-migrations",
+      method: "POST",
+      auth: "edge",
+      handler: (req) => migrationRollbackProxy(req),
     },
 
     // ── Channel readiness ──

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -2744,6 +2744,31 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/admin/rollback-migrations": {
+        post: {
+          summary: "Rollback database and workspace migrations",
+          description:
+            "Proxies a rollback-migrations request to the assistant daemon. Rolls back database and workspace migrations to a specified target version. Authenticated with an edge JWT.",
+          operationId: "rollbackMigrations",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: false,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Migrations rolled back successfully" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "502": { description: "Failed to reach assistant daemon" },
+            "504": { description: "Assistant daemon request timed out" },
+          },
+        },
+      },
       "/{path}": {
         get: {
           summary: "Runtime proxy",


### PR DESCRIPTION
## Summary
- Adds gateway proxy for `POST /v1/admin/rollback-migrations`
- Forwards to daemon with service token auth
- Includes OpenAPI schema entry

Part of plan: migration-rollback-wiring.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
