### PR TITLE
feat: capture pre-upgrade migration state in lockfile for rollback targeting

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -198,6 +198,26 @@ async function upgradeDocker(
     );
   }
 
+  // Capture current migration state for rollback targeting.
+  // Must happen while daemon is still running (before containers are stopped).
+  let preMigrationState: {
+    dbVersion?: number;
+    lastWorkspaceMigrationId?: string;
+  } = {};
+  try {
+    const healthResp = await fetch(`${entry.runtimeUrl}/healthz`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (healthResp.ok) {
+      const health = (await healthResp.json()) as {
+        migrations?: { dbVersion?: number; lastWorkspaceMigrationId?: string };
+      };
+      preMigrationState = health.migrations ?? {};
+    }
+  } catch {
+    // Best-effort — if we can't get migration state, rollback will skip migration reversal
+  }
+
   // Persist rollback state to lockfile BEFORE any destructive changes.
   // This enables the `vellum rollback` command to restore the previous version.
   if (entry.serviceGroupVersion && entry.containerInfo) {
@@ -205,6 +225,8 @@ async function upgradeDocker(
       ...entry,
       previousServiceGroupVersion: entry.serviceGroupVersion,
       previousContainerInfo: { ...entry.containerInfo },
+      previousDbMigrationVersion: preMigrationState.dbVersion,
+      previousWorkspaceMigrationId: preMigrationState.lastWorkspaceMigrationId,
     };
     saveAssistantEntry(rollbackEntry);
     console.log(`   Saved rollback state: ${entry.serviceGroupVersion}\n`);
@@ -405,6 +427,8 @@ async function upgradeDocker(
       },
       previousServiceGroupVersion: entry.serviceGroupVersion,
       previousContainerInfo: entry.containerInfo,
+      previousDbMigrationVersion: preMigrationState.dbVersion,
+      previousWorkspaceMigrationId: preMigrationState.lastWorkspaceMigrationId,
       // Preserve the backup path so `vellum rollback` can restore it later
       preUpgradeBackupPath: backupPath ?? undefined,
     };
@@ -533,6 +557,8 @@ async function upgradeDocker(
             },
             previousServiceGroupVersion: undefined,
             previousContainerInfo: undefined,
+            previousDbMigrationVersion: undefined,
+            previousWorkspaceMigrationId: undefined,
             // Clear the backup path — the upgrade that created it just failed
             preUpgradeBackupPath: undefined,
           };

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -94,6 +94,10 @@ export interface AssistantEntry {
    *  only the backup from the specific upgrade being rolled back — never a stale backup from a
    *  previous upgrade cycle. */
   preUpgradeBackupPath?: string;
+  /** Pre-upgrade DB migration version — used by rollback to know how far back to revert. */
+  previousDbMigrationVersion?: number;
+  /** Pre-upgrade workspace migration ID — used by rollback to know how far back to revert. */
+  previousWorkspaceMigrationId?: string;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
- Adds `previousDbMigrationVersion` and `previousWorkspaceMigrationId` to AssistantEntry
- Queries daemon healthz before Docker upgrade to capture current migration state
- Saves state in lockfile alongside `previousServiceGroupVersion` for rollback use

Part of plan: migration-rollback-wiring.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
