### PR TITLE
feat: run down() migrations during Docker rollback before container swap

### DIFF
--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -32,6 +32,7 @@ import {
   buildUpgradeCommitMessage,
   captureContainerEnv,
   CONTAINER_ENV_EXCLUDE_KEYS,
+  rollbackMigrations,
   UPGRADE_PROGRESS,
   waitForReady,
 } from "../lib/upgrade-lifecycle.js";
@@ -259,6 +260,25 @@ export async function rollback(): Promise<void> {
     // Brief pause to allow SSE delivery before containers stop.
     await new Promise((r) => setTimeout(r, 500));
 
+    // Roll back migrations to pre-upgrade state (must happen before containers stop)
+    if (
+      entry.previousDbMigrationVersion !== undefined ||
+      entry.previousWorkspaceMigrationId !== undefined
+    ) {
+      console.log("🔄 Reverting database changes...");
+      await broadcastUpgradeEvent(
+        entry.runtimeUrl,
+        entry.assistantId,
+        buildProgressEvent(UPGRADE_PROGRESS.REVERTING_MIGRATIONS),
+      );
+      await rollbackMigrations(
+        entry.runtimeUrl,
+        entry.assistantId,
+        entry.previousDbMigrationVersion,
+        entry.previousWorkspaceMigrationId,
+      );
+    }
+
     // Progress: switching version (must be sent BEFORE stopContainers)
     await broadcastUpgradeEvent(
       entry.runtimeUrl,
@@ -351,6 +371,8 @@ export async function rollback(): Promise<void> {
         previousContainerInfo: entry.containerInfo,
         // Clear the backup path — it belonged to the upgrade we just rolled back
         preUpgradeBackupPath: undefined,
+        previousDbMigrationVersion: undefined,
+        previousWorkspaceMigrationId: undefined,
       };
       saveAssistantEntry(updatedEntry);
 

--- a/cli/src/lib/upgrade-lifecycle.ts
+++ b/cli/src/lib/upgrade-lifecycle.ts
@@ -14,6 +14,7 @@ export const UPGRADE_PROGRESS = {
   REVERTING: "The update didn't work. Reverting to the previous version…",
   RESTORING: "Restoring your data…",
   SWITCHING: "Switching to the previous version…",
+  REVERTING_MIGRATIONS: "Reverting database changes…",
 } as const;
 
 export function buildStartingEvent(
@@ -171,5 +172,63 @@ export async function broadcastUpgradeEvent(
     });
   } catch {
     // Best-effort — gateway/daemon may already be shutting down or not yet ready
+  }
+}
+
+/**
+ * Roll back DB and workspace migrations to a target state via the gateway.
+ * Best-effort — failures are logged but never block the rollback flow.
+ */
+export async function rollbackMigrations(
+  gatewayUrl: string,
+  assistantId: string,
+  targetDbVersion?: number,
+  targetWorkspaceMigrationId?: string,
+): Promise<boolean> {
+  if (
+    targetDbVersion === undefined &&
+    targetWorkspaceMigrationId === undefined
+  ) {
+    return false;
+  }
+  try {
+    const token = loadGuardianToken(assistantId);
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (token?.accessToken) {
+      headers["Authorization"] = `Bearer ${token.accessToken}`;
+    }
+    const body: Record<string, unknown> = {};
+    if (targetDbVersion !== undefined) body.targetDbVersion = targetDbVersion;
+    if (targetWorkspaceMigrationId !== undefined)
+      body.targetWorkspaceMigrationId = targetWorkspaceMigrationId;
+
+    const resp = await fetch(`${gatewayUrl}/v1/admin/rollback-migrations`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!resp.ok) {
+      const text = await resp.text();
+      console.warn(`⚠️  Migration rollback failed (${resp.status}): ${text}`);
+      return false;
+    }
+    const result = (await resp.json()) as {
+      rolledBack?: { db?: string[]; workspace?: string[] };
+    };
+    const dbCount = result.rolledBack?.db?.length ?? 0;
+    const wsCount = result.rolledBack?.workspace?.length ?? 0;
+    if (dbCount > 0 || wsCount > 0) {
+      console.log(
+        `   Rolled back ${dbCount} DB migration(s) and ${wsCount} workspace migration(s)`,
+      );
+    }
+    return true;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`⚠️  Migration rollback failed: ${msg}`);
+    return false;
   }
 }


### PR DESCRIPTION
## Summary
- Adds `rollbackMigrations()` helper to upgrade-lifecycle.ts
- Adds `REVERTING_MIGRATIONS` progress constant
- CLI rollback now reverses DB and workspace migrations before stopping containers
- Migration rollback is best-effort — failures don't block the rollback

Part of plan: migration-rollback-wiring.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20683" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
