### PR TITLE
feat: run down() migrations during upgrade auto-rollback

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -44,6 +44,7 @@ import {
   buildUpgradeCommitMessage,
   captureContainerEnv,
   CONTAINER_ENV_EXCLUDE_KEYS,
+  rollbackMigrations,
   UPGRADE_PROGRESS,
   waitForReady,
 } from "../lib/upgrade-lifecycle.js";
@@ -477,6 +478,26 @@ async function upgradeDocker(
       );
       console.log(`\n🔄 Rolling back to previous images...`);
       try {
+        // Attempt to roll back migrations before swapping containers.
+        // The new daemon may be partially up — try best-effort.
+        if (
+          preMigrationState.dbVersion !== undefined ||
+          preMigrationState.lastWorkspaceMigrationId !== undefined
+        ) {
+          console.log("🔄 Reverting database changes...");
+          await broadcastUpgradeEvent(
+            entry.runtimeUrl,
+            entry.assistantId,
+            buildProgressEvent(UPGRADE_PROGRESS.REVERTING_MIGRATIONS),
+          );
+          await rollbackMigrations(
+            entry.runtimeUrl,
+            entry.assistantId,
+            preMigrationState.dbVersion,
+            preMigrationState.lastWorkspaceMigrationId,
+          );
+        }
+
         await stopContainers(res);
 
         await migrateGatewaySecurityFiles(res, (msg) => console.log(msg));

--- a/cli/src/lib/upgrade-lifecycle.ts
+++ b/cli/src/lib/upgrade-lifecycle.ts
@@ -12,9 +12,9 @@ export const UPGRADE_PROGRESS = {
   BACKING_UP: "Saving a backup of your data…",
   INSTALLING: "Installing the update…",
   REVERTING: "The update didn't work. Reverting to the previous version…",
+  REVERTING_MIGRATIONS: "Reverting database changes…",
   RESTORING: "Restoring your data…",
   SWITCHING: "Switching to the previous version…",
-  REVERTING_MIGRATIONS: "Reverting database changes…",
 } as const;
 
 export function buildStartingEvent(


### PR DESCRIPTION
## Summary
- Adds migration rollback to the upgrade auto-rollback path (readiness failure)
- Attempts to reverse DB and workspace migrations before container swap
- Best-effort — if daemon is unreachable, backup restore is the fallback
- Clears saved migration state in the rollback lockfile entry

Part of plan: migration-rollback-wiring.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
