### PR TITLE
fix: report actual workspace rollback progress on partial failure

### DIFF
--- a/assistant/src/runtime/routes/migration-rollback-routes.ts
+++ b/assistant/src/runtime/routes/migration-rollback-routes.ts
@@ -127,27 +127,27 @@ export function migrationRollbackRouteDefinitions(): RouteDefinition[] {
 
         // Roll back workspace migrations if requested.
         if (targetWorkspaceMigrationId !== undefined) {
+          const workspaceDir = getWorkspaceDir();
+
+          // Compute which migrations are candidates for rollback before
+          // executing, since rollbackWorkspaceMigrations returns void.
+          const targetId = targetWorkspaceMigrationId as string;
+
+          const checkpointsBefore = loadCheckpoints(workspaceDir);
+          const candidateIds = WORKSPACE_MIGRATIONS.slice(
+            resolvedTargetIndex + 1,
+          )
+            .filter((m) => {
+              const entry = checkpointsBefore.applied[m.id];
+              return (
+                entry &&
+                entry.status !== "started" &&
+                entry.status !== "rolling_back"
+              );
+            })
+            .map((m) => m.id);
+
           try {
-            const workspaceDir = getWorkspaceDir();
-
-            // Compute which migrations will be rolled back before executing,
-            // since rollbackWorkspaceMigrations returns void.
-            const targetId = targetWorkspaceMigrationId as string;
-
-            const checkpoints = loadCheckpoints(workspaceDir);
-            const candidateIds = WORKSPACE_MIGRATIONS.slice(
-              resolvedTargetIndex + 1,
-            )
-              .filter((m) => {
-                const entry = checkpoints.applied[m.id];
-                return (
-                  entry &&
-                  entry.status !== "started" &&
-                  entry.status !== "rolling_back"
-                );
-              })
-              .map((m) => m.id);
-
             await rollbackWorkspaceMigrations(
               workspaceDir,
               WORKSPACE_MIGRATIONS,
@@ -156,12 +156,26 @@ export function migrationRollbackRouteDefinitions(): RouteDefinition[] {
 
             rolledBack.workspace = candidateIds;
           } catch (err) {
+            // Re-read checkpoints to determine which migrations were actually
+            // rolled back before the error occurred. A candidate whose entry
+            // is no longer present in the checkpoint file was successfully
+            // reverted.
+            const checkpointsAfter = loadCheckpoints(workspaceDir);
+            const actuallyRolledBack = candidateIds.filter(
+              (id) => !checkpointsAfter.applied[id],
+            );
+
             const detail = err instanceof Error ? err.message : "Unknown error";
             return httpError(
               "INTERNAL_ERROR",
               `Workspace migration rollback failed: ${detail}`,
               500,
-              { partialRolledBack: { db: rolledBack.db, workspace: [] } },
+              {
+                partialRolledBack: {
+                  db: rolledBack.db,
+                  workspace: actuallyRolledBack,
+                },
+              },
             );
           }
         }


### PR DESCRIPTION
Addresses review feedback on PR #20685 — re-reads checkpoints after a workspace rollback error to report which migrations were actually reverted, instead of always reporting workspace: [].
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
