### PR TITLE
fix: include daemon migration state in gateway healthz response

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1013,6 +1013,29 @@ async function main() {
       // ── Pre-router: health/readiness probes ──
       // These bypass rate limiting and tracing for minimal overhead.
       if (url.pathname === "/healthz") {
+        // Also fetch the daemon's /healthz to surface migration state
+        // (dbVersion, lastWorkspaceMigrationId) so the CLI can capture
+        // pre-upgrade migration state through the gateway.
+        try {
+          const upstream = await fetch(
+            `${config.assistantRuntimeBaseUrl}/healthz`,
+            { signal: AbortSignal.timeout(3000) },
+          );
+          if (upstream.ok) {
+            const body = (await upstream.json()) as {
+              migrations?: {
+                dbVersion?: number;
+                lastWorkspaceMigrationId?: string;
+              };
+            };
+            return Response.json({
+              status: "ok",
+              ...(body.migrations ? { migrations: body.migrations } : {}),
+            });
+          }
+        } catch {
+          // Daemon unreachable — graceful degradation, still return ok
+        }
         return Response.json({ status: "ok" });
       }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for migration-rollback-wiring.md.

**Gap:** Gateway /healthz returns no migration data
**What was expected:** CLI captures daemon's migration state via gateway
**What was found:** Gateway returned bare { status: ok } without querying daemon
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
