### PR TITLE
feat: detect and warn about unknown migration checkpoints from newer versions

### DIFF
--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -336,4 +336,6 @@ export interface MigrationValidationResult {
   crashed: string[];
   /** Pairs where a completed migration's declared prerequisite is missing from checkpoints. */
   dependencyViolations: Array<{ migration: string; missingDependency: string }>;
+  /** Checkpoint keys present in the database but absent from the migration registry — likely from a newer version. */
+  unknownCheckpoints: string[];
 }

--- a/assistant/src/memory/migrations/validate-migration-state.ts
+++ b/assistant/src/memory/migrations/validate-migration-state.ts
@@ -133,7 +133,7 @@ export function validateMigrationState(
       .all() as Array<{ key: string; value: string }>;
   } catch {
     // memory_checkpoints may not exist on a very old database; skip.
-    return { crashed: [], dependencyViolations: [] };
+    return { crashed: [], dependencyViolations: [], unknownCheckpoints: [] };
   }
 
   // Any remaining 'started' or 'rolling_back' checkpoints after recovery +
@@ -203,7 +203,19 @@ export function validateMigrationState(
     );
   }
 
-  return { crashed, dependencyViolations };
+  // Detect checkpoints that exist in the database but have no corresponding
+  // registry entry — these are from a newer version of the daemon.
+  const registryKeys = new Set(MIGRATION_REGISTRY.map((e) => e.key));
+  const unknownCheckpoints = [...completed].filter((k) => !registryKeys.has(k));
+
+  if (unknownCheckpoints.length > 0) {
+    log.warn(
+      { unknownCheckpoints },
+      `Database contains ${unknownCheckpoints.length} migration checkpoint(s) from a newer version. Data may be incompatible.`,
+    );
+  }
+
+  return { crashed, dependencyViolations, unknownCheckpoints };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `unknownCheckpoints` field to `MigrationValidationResult`
- Detects migration checkpoints in DB that don't exist in current registry
- Logs a warning on startup (non-blocking) so users know their data may be from a newer version

Part of plan: safe-backward-releases.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
