### PR TITLE
feat: make down() function required on DB and workspace migration types

### DIFF
--- a/assistant/src/__tests__/db-migration-rollback.test.ts
+++ b/assistant/src/__tests__/db-migration-rollback.test.ts
@@ -1025,37 +1025,6 @@ describe("rollbackMemoryMigration", () => {
     expect(cp1000!.value).toBe("1");
   });
 
-  test("throws when migration has no down function", () => {
-    saveRegistry();
-
-    const db = createTestDb();
-    const raw = getRaw(db);
-    bootstrapCheckpointsTable(raw);
-
-    const now = Date.now();
-
-    // Register an entry WITHOUT a down function.
-    MIGRATION_REGISTRY.push({
-      key: "test_no_down_v2000",
-      version: 2000,
-      description: "test migration without down()",
-      // no down() defined
-    });
-
-    // Mark it as completed.
-    raw.exec(
-      `INSERT INTO memory_checkpoints (key, value, updated_at) VALUES ('test_no_down_v2000', '1', ${now})`,
-    );
-
-    // Attempting to roll back should throw a descriptive error.
-    expect(() => rollbackMemoryMigration(db, 1999)).toThrow(
-      'Cannot roll back migration "test_no_down_v2000"',
-    );
-    expect(() => rollbackMemoryMigration(db, 1999)).toThrow(
-      "no down() function defined",
-    );
-  });
-
   test("handles transaction failure in down() — rolls back and preserves checkpoint", () => {
     saveRegistry();
 

--- a/assistant/src/__tests__/workspace-migrations-runner.test.ts
+++ b/assistant/src/__tests__/workspace-migrations-runner.test.ts
@@ -69,14 +69,6 @@ function makeMigration(id: string): WorkspaceMigration {
     id,
     description: `Migration ${id}`,
     run: mock(() => {}),
-  };
-}
-
-function makeMigrationWithDown(id: string): WorkspaceMigration {
-  return {
-    id,
-    description: `Migration ${id}`,
-    run: mock(() => {}),
     down: mock(() => {}),
   };
 }
@@ -254,6 +246,7 @@ describe("runWorkspaceMigrations", () => {
         // Simulate async work
         await Promise.resolve();
       }),
+      down: mock(() => {}),
     };
 
     await runWorkspaceMigrations(WORKSPACE_DIR, [asyncMigration]);
@@ -315,9 +308,9 @@ describe("rollbackWorkspaceMigrations", () => {
   });
 
   test("rolls back migrations in reverse order", async () => {
-    const m1 = makeMigrationWithDown("001");
-    const m2 = makeMigrationWithDown("002");
-    const m3 = makeMigrationWithDown("003");
+    const m1 = makeMigration("001");
+    const m2 = makeMigration("002");
+    const m3 = makeMigration("003");
 
     // All three migrations are marked as completed in checkpoints
     mockCheckpointContents = JSON.stringify({
@@ -345,27 +338,8 @@ describe("rollbackWorkspaceMigrations", () => {
     expect(callOrder).toEqual(["003", "002"]);
   });
 
-  test("throws when migration has no down function", async () => {
-    const m1 = makeMigrationWithDown("001");
-    // m2 has no down function
-    const m2 = makeMigration("002");
-
-    mockCheckpointContents = JSON.stringify({
-      applied: {
-        "001": { appliedAt: "2025-01-01T00:00:00.000Z", status: "completed" },
-        "002": { appliedAt: "2025-01-02T00:00:00.000Z", status: "completed" },
-      },
-    });
-
-    await expect(
-      rollbackWorkspaceMigrations(WORKSPACE_DIR, [m1, m2], "001"),
-    ).rejects.toThrow(
-      'Migration "002" does not support rollback (no down() method)',
-    );
-  });
-
   test("handles crash during rollback (rolling_back status)", async () => {
-    const m1 = makeMigrationWithDown("001");
+    const m1 = makeMigration("001");
 
     // Simulate a crash during a previous rollback — m1 is left in rolling_back state
     mockCheckpointContents = JSON.stringify({
@@ -385,9 +359,9 @@ describe("rollbackWorkspaceMigrations", () => {
   });
 
   test("removes checkpoints for rolled-back migrations", async () => {
-    const m1 = makeMigrationWithDown("001");
-    const m2 = makeMigrationWithDown("002");
-    const m3 = makeMigrationWithDown("003");
+    const m1 = makeMigration("001");
+    const m2 = makeMigration("002");
+    const m3 = makeMigration("003");
 
     mockCheckpointContents = JSON.stringify({
       applied: {
@@ -408,9 +382,9 @@ describe("rollbackWorkspaceMigrations", () => {
   });
 
   test("no-op when already at target", async () => {
-    const m1 = makeMigrationWithDown("001");
-    const m2 = makeMigrationWithDown("002");
-    const m3 = makeMigrationWithDown("003");
+    const m1 = makeMigration("001");
+    const m2 = makeMigration("002");
+    const m3 = makeMigration("003");
 
     mockCheckpointContents = JSON.stringify({
       applied: {

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -48,7 +48,7 @@ export interface MigrationRegistryEntry {
   /** Human-readable description for diagnostics and future authorship guidance. */
   description: string;
   /** Reverse the migration. Must be idempotent — safe to re-run. */
-  down?: (database: DrizzleDb) => void;
+  down: (database: DrizzleDb) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/memory/migrations/validate-migration-state.ts
+++ b/assistant/src/memory/migrations/validate-migration-state.ts
@@ -225,11 +225,10 @@ export function validateMigrationState(
  * `"rolling_back"` marker is detected and cleared by
  * `recoverCrashedMigrations` on the next startup.
  *
- * **Warning — data loss**: Some migrations are irreversible (e.g., DROP TABLE,
- * data backfills that discard the original format). These migrations do not
- * define a `down()` function and will throw an `IntegrityError` if rollback
- * is attempted. Always check the migration registry for `down` support before
- * calling this function programmatically.
+ * **Warning — data loss**: Some down() migrations may not fully restore the
+ * original state (e.g., DROP TABLE migrations recreate the table but cannot
+ * recover the original data). Review each migration's down() implementation
+ * before calling this function programmatically.
  *
  * **Important**: Stop the assistant before running rollbacks. Rolling back
  * migrations while the assistant is running may cause schema mismatches,
@@ -270,12 +269,6 @@ export function rollbackMemoryMigration(
   const rolledBack: string[] = [];
 
   for (const entry of toRollback) {
-    if (!entry.down) {
-      throw new IntegrityError(
-        `Cannot roll back migration "${entry.key}" (version ${entry.version}): no down() function defined`,
-      );
-    }
-
     // Mark as rolling_back for crash recovery — if the process crashes here,
     // recoverCrashedMigrations will clear this checkpoint on next startup.
     raw

--- a/assistant/src/workspace/migrations/runner.ts
+++ b/assistant/src/workspace/migrations/runner.ts
@@ -191,12 +191,6 @@ export async function rollbackWorkspaceMigrations(
       continue;
     }
 
-    if (!migration.down) {
-      throw new Error(
-        `Migration "${migration.id}" does not support rollback (no down() method)`,
-      );
-    }
-
     log.info(
       `Rolling back workspace migration: ${migration.id} — ${migration.description}`,
     );

--- a/assistant/src/workspace/migrations/types.ts
+++ b/assistant/src/workspace/migrations/types.ts
@@ -11,5 +11,5 @@ export interface WorkspaceMigration {
   /** Reverse the migration. Receives the workspace directory path.
    *  Must be idempotent — safe to re-run if it was interrupted.
    *  Both synchronous and asynchronous rollbacks are supported. */
-  down?(workspaceDir: string): void | Promise<void>;
+  down(workspaceDir: string): void | Promise<void>;
 }


### PR DESCRIPTION
## Summary
- Makes `down` required on `MigrationRegistryEntry` and `WorkspaceMigration` interfaces
- Removes runtime `!entry.down` checks since TypeScript enforces presence at compile time
- Removes now-redundant "throws when migration has no down function" tests
- Future migrations that omit `down()` will fail type-checking

Part of plan: safe-backward-releases.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20690" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
