### PR TITLE
feat: run migration rollback during version-picker downgrades

### DIFF
--- a/assistant/src/runtime/routes/migration-rollback-routes.ts
+++ b/assistant/src/runtime/routes/migration-rollback-routes.ts
@@ -8,10 +8,12 @@
  */
 
 import { getDb } from "../../memory/db-connection.js";
+import { getMaxMigrationVersion } from "../../memory/migrations/registry.js";
 import { rollbackMemoryMigration } from "../../memory/migrations/validate-migration-state.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import { WORKSPACE_MIGRATIONS } from "../../workspace/migrations/registry.js";
 import {
+  getLastWorkspaceMigrationId,
   loadCheckpoints,
   rollbackWorkspaceMigrations,
 } from "../../workspace/migrations/runner.js";
@@ -39,15 +41,35 @@ export function migrationRollbackRouteDefinitions(): RouteDefinition[] {
           );
         }
 
-        const { targetDbVersion, targetWorkspaceMigrationId } = body as {
+        const {
+          targetDbVersion,
+          targetWorkspaceMigrationId,
+          rollbackToRegistryCeiling,
+        } = body as {
           targetDbVersion?: unknown;
           targetWorkspaceMigrationId?: unknown;
+          rollbackToRegistryCeiling?: unknown;
         };
+
+        // When rollbackToRegistryCeiling is true, auto-determine targets
+        // from this daemon's own migration registry ceilings.
+        let effectiveDbVersion = targetDbVersion as number | undefined;
+        let effectiveWorkspaceMigrationId = targetWorkspaceMigrationId as
+          | string
+          | undefined;
+
+        if (rollbackToRegistryCeiling === true) {
+          if (effectiveDbVersion === undefined)
+            effectiveDbVersion = getMaxMigrationVersion();
+          if (effectiveWorkspaceMigrationId === undefined)
+            effectiveWorkspaceMigrationId =
+              getLastWorkspaceMigrationId(WORKSPACE_MIGRATIONS) ?? undefined;
+        }
 
         // At least one rollback target must be specified.
         if (
-          targetDbVersion === undefined &&
-          targetWorkspaceMigrationId === undefined
+          effectiveDbVersion === undefined &&
+          effectiveWorkspaceMigrationId === undefined
         ) {
           return httpError(
             "BAD_REQUEST",
@@ -56,12 +78,12 @@ export function migrationRollbackRouteDefinitions(): RouteDefinition[] {
           );
         }
 
-        // Validate targetDbVersion when provided.
-        if (targetDbVersion !== undefined) {
+        // Validate effectiveDbVersion when provided.
+        if (effectiveDbVersion !== undefined) {
           if (
-            typeof targetDbVersion !== "number" ||
-            !Number.isInteger(targetDbVersion) ||
-            targetDbVersion < 0
+            typeof effectiveDbVersion !== "number" ||
+            !Number.isInteger(effectiveDbVersion) ||
+            effectiveDbVersion < 0
           ) {
             return httpError(
               "BAD_REQUEST",
@@ -71,11 +93,11 @@ export function migrationRollbackRouteDefinitions(): RouteDefinition[] {
           }
         }
 
-        // Validate targetWorkspaceMigrationId when provided.
-        if (targetWorkspaceMigrationId !== undefined) {
+        // Validate effectiveWorkspaceMigrationId when provided.
+        if (effectiveWorkspaceMigrationId !== undefined) {
           if (
-            typeof targetWorkspaceMigrationId !== "string" ||
-            targetWorkspaceMigrationId.length === 0
+            typeof effectiveWorkspaceMigrationId !== "string" ||
+            effectiveWorkspaceMigrationId.length === 0
           ) {
             return httpError(
               "BAD_REQUEST",
@@ -89,8 +111,8 @@ export function migrationRollbackRouteDefinitions(): RouteDefinition[] {
         // registry BEFORE executing any mutations. This prevents the DB
         // rollback from committing when the workspace target is invalid.
         let resolvedTargetIndex = -1;
-        if (targetWorkspaceMigrationId !== undefined) {
-          const targetId = targetWorkspaceMigrationId as string;
+        if (effectiveWorkspaceMigrationId !== undefined) {
+          const targetId = effectiveWorkspaceMigrationId as string;
           resolvedTargetIndex = WORKSPACE_MIGRATIONS.findIndex(
             (m) => m.id === targetId,
           );
@@ -109,11 +131,11 @@ export function migrationRollbackRouteDefinitions(): RouteDefinition[] {
         };
 
         // Roll back DB migrations if requested.
-        if (targetDbVersion !== undefined) {
+        if (effectiveDbVersion !== undefined) {
           try {
             rolledBack.db = rollbackMemoryMigration(
               getDb(),
-              targetDbVersion as number,
+              effectiveDbVersion,
             );
           } catch (err) {
             const detail = err instanceof Error ? err.message : "Unknown error";
@@ -126,12 +148,12 @@ export function migrationRollbackRouteDefinitions(): RouteDefinition[] {
         }
 
         // Roll back workspace migrations if requested.
-        if (targetWorkspaceMigrationId !== undefined) {
+        if (effectiveWorkspaceMigrationId !== undefined) {
           const workspaceDir = getWorkspaceDir();
 
           // Compute which migrations are candidates for rollback before
           // executing, since rollbackWorkspaceMigrations returns void.
-          const targetId = targetWorkspaceMigrationId as string;
+          const targetId = effectiveWorkspaceMigrationId;
 
           const checkpointsBefore = loadCheckpoints(workspaceDir);
           const candidateIds = WORKSPACE_MIGRATIONS.slice(

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -48,6 +48,7 @@ import {
   UPGRADE_PROGRESS,
   waitForReady,
 } from "../lib/upgrade-lifecycle.js";
+import { parseVersion } from "../lib/version-compat.js";
 import { commitWorkspaceState } from "../lib/workspace-git.js";
 
 interface UpgradeArgs {
@@ -218,6 +219,22 @@ async function upgradeDocker(
   } catch {
     // Best-effort — if we can't get migration state, rollback will skip migration reversal
   }
+
+  // Detect if this upgrade is actually a downgrade (user picked an older
+  // version via the version picker). Used after readiness succeeds to align
+  // the DB schema with the now-running old daemon.
+  const currentVersion = entry.serviceGroupVersion;
+  const isDowngrade =
+    currentVersion &&
+    versionTag &&
+    (() => {
+      const current = parseVersion(currentVersion);
+      const target = parseVersion(versionTag);
+      if (!current || !target) return false;
+      if (target.major !== current.major) return target.major < current.major;
+      if (target.minor !== current.minor) return target.minor < current.minor;
+      return target.patch < current.patch;
+    })();
 
   // Persist rollback state to lockfile BEFORE any destructive changes.
   // This enables the `vellum rollback` command to restore the previous version.
@@ -434,6 +451,24 @@ async function upgradeDocker(
       preUpgradeBackupPath: backupPath ?? undefined,
     };
     saveAssistantEntry(updatedEntry);
+
+    // After a downgrade, align the DB schema with the now-running old daemon
+    // by rolling back migrations above its own registry ceiling.
+    if (isDowngrade) {
+      console.log("🔄 Aligning database schema with installed version...");
+      await broadcastUpgradeEvent(
+        entry.runtimeUrl,
+        entry.assistantId,
+        buildProgressEvent(UPGRADE_PROGRESS.ALIGNING_SCHEMA),
+      );
+      await rollbackMigrations(
+        entry.runtimeUrl,
+        entry.assistantId,
+        undefined,
+        undefined,
+        true,
+      );
+    }
 
     // Notify clients on the new service group that the upgrade succeeded.
     await broadcastUpgradeEvent(

--- a/cli/src/lib/upgrade-lifecycle.ts
+++ b/cli/src/lib/upgrade-lifecycle.ts
@@ -15,6 +15,7 @@ export const UPGRADE_PROGRESS = {
   REVERTING_MIGRATIONS: "Reverting database changes…",
   RESTORING: "Restoring your data…",
   SWITCHING: "Switching to the previous version…",
+  ALIGNING_SCHEMA: "Aligning database with installed version…",
 } as const;
 
 export function buildStartingEvent(
@@ -184,8 +185,10 @@ export async function rollbackMigrations(
   assistantId: string,
   targetDbVersion?: number,
   targetWorkspaceMigrationId?: string,
+  rollbackToRegistryCeiling?: boolean,
 ): Promise<boolean> {
   if (
+    !rollbackToRegistryCeiling &&
     targetDbVersion === undefined &&
     targetWorkspaceMigrationId === undefined
   ) {
@@ -203,6 +206,7 @@ export async function rollbackMigrations(
     if (targetDbVersion !== undefined) body.targetDbVersion = targetDbVersion;
     if (targetWorkspaceMigrationId !== undefined)
       body.targetWorkspaceMigrationId = targetWorkspaceMigrationId;
+    if (rollbackToRegistryCeiling) body.rollbackToRegistryCeiling = true;
 
     const resp = await fetch(`${gatewayUrl}/v1/admin/rollback-migrations`, {
       method: "POST",


### PR DESCRIPTION
## Summary
- Adds `rollbackToRegistryCeiling` flag to migration rollback endpoint — daemon self-determines target from its own registry
- After successful downgrade via version picker, old daemon rolls back migrations above its ceiling
- Adds downgrade detection using semantic version comparison
- Shows progress message during schema alignment

Part of plan: safe-backward-releases.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20691" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
