### PR TITLE
fix: make gateway healthz migration fetch opt-in via ?include=migrations

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -207,9 +207,12 @@ async function upgradeDocker(
     lastWorkspaceMigrationId?: string;
   } = {};
   try {
-    const healthResp = await fetch(`${entry.runtimeUrl}/healthz`, {
-      signal: AbortSignal.timeout(5000),
-    });
+    const healthResp = await fetch(
+      `${entry.runtimeUrl}/healthz?include=migrations`,
+      {
+        signal: AbortSignal.timeout(5000),
+      },
+    );
     if (healthResp.ok) {
       const health = (await healthResp.json()) as {
         migrations?: { dbVersion?: number; lastWorkspaceMigrationId?: string };

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1013,7 +1013,12 @@ async function main() {
       // ── Pre-router: health/readiness probes ──
       // These bypass rate limiting and tracing for minimal overhead.
       if (url.pathname === "/healthz") {
-        // Also fetch the daemon's /healthz to surface migration state
+        const includeMigrations =
+          url.searchParams.get("include") === "migrations";
+        if (!includeMigrations) {
+          return Response.json({ status: "ok" });
+        }
+        // Fetch the daemon's /healthz to surface migration state
         // (dbVersion, lastWorkspaceMigrationId) so the CLI can capture
         // pre-upgrade migration state through the gateway.
         try {


### PR DESCRIPTION
## Summary
- Gateway /healthz returns instant { status: ok } by default (no upstream call)
- With ?include=migrations, fetches daemon healthz and includes migration state
- CLI upgrade uses the query parameter when capturing pre-migration state
- Addresses Devin review feedback on PR #20688
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
