### PR TITLE
fix: increase migration rollback proxy timeout to 120s

### DIFF
--- a/gateway/src/http/routes/migration-rollback-proxy.ts
+++ b/gateway/src/http/routes/migration-rollback-proxy.ts
@@ -14,6 +14,9 @@ import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
 
 const log = getLogger("migration-rollback-proxy");
 
+/** Timeout for migration rollback requests (120 seconds) — rollbacks can be slow when many migrations have complex down() functions. */
+const MIGRATION_ROLLBACK_TIMEOUT_MS = 120_000;
+
 export function createMigrationRollbackProxyHandler(config: GatewayConfig) {
   return async function handleMigrationRollback(
     req: Request,
@@ -38,7 +41,7 @@ export function createMigrationRollbackProxyHandler(config: GatewayConfig) {
           "TimeoutError",
         ),
       );
-    }, config.runtimeTimeoutMs);
+    }, MIGRATION_ROLLBACK_TIMEOUT_MS);
 
     let response: Response;
     try {


### PR DESCRIPTION
## Summary
- Changes migration rollback gateway proxy timeout from ~30s to 120s
- Matches the timeout used by migration export/import proxies
- Prevents timeouts when rolling back many migrations with complex down() functions
- Addresses Devin review feedback on PR #20688
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
