### PR TITLE
feat: warn on .vbundle import when migration checkpoints don't match registry

### DIFF
--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -15,7 +15,8 @@ import { join } from "node:path";
 import { Database } from "bun:sqlite";
 
 import { invalidateConfigCache } from "../../config/loader.js";
-import { resetDb } from "../../memory/db-connection.js";
+import { getDb, resetDb } from "../../memory/db-connection.js";
+import { validateMigrationState } from "../../memory/migrations/validate-migration-state.js";
 import { clearCache as clearTrustCache } from "../../permissions/trust-store.js";
 import { getLogger } from "../../util/logger.js";
 import {
@@ -437,6 +438,21 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
     // Invalidate in-process caches so imported settings.json and trust.json take effect
     invalidateConfigCache();
     clearTrustCache();
+
+    // Check whether the imported database contains migration checkpoints from
+    // a newer version. This is non-blocking — the import has already
+    // succeeded — but we surface a warning so the caller knows some data may
+    // not be fully compatible with this daemon's schema.
+    try {
+      const migrationValidation = validateMigrationState(getDb());
+      if (migrationValidation.unknownCheckpoints.length > 0) {
+        result.report.warnings.push(
+          `Imported data contains ${migrationValidation.unknownCheckpoints.length} migration(s) from a newer version. Some data may not be fully compatible.`,
+        );
+      }
+    } catch {
+      // Don't fail the import if validation itself errors
+    }
 
     return Response.json(result.report);
   } catch (err) {


### PR DESCRIPTION
## Summary
- After .vbundle import, validates migration checkpoints against current registry
- Adds warnings to import response when unknown checkpoints from a newer version are detected
- Non-blocking — import always succeeds, warnings are informational

Part of plan: safe-backward-releases.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
