### PR TITLE
feat: enable backward-releases feature flag by default

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -318,8 +318,8 @@
       "scope": "assistant",
       "key": "feature_flags.backward-releases.enabled",
       "label": "Backward Releases",
-      "description": "Show older versions in the version picker, allowing rollback to previous releases (unsafe without down-migrations)",
-      "defaultEnabled": false
+      "description": "Show older versions in the version picker, allowing rollback to previous releases",
+      "defaultEnabled": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Enables the `backward-releases` feature flag by default
- Version picker now shows all versions including older ones
- Safe to enable now that migration rollback, unknown checkpoint detection, and schema compatibility checks are in place

Part of plan: safe-backward-releases.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
