### PR TITLE
fix: increase CLI rollbackMigrations timeout to 120s

### DIFF
--- a/cli/src/lib/upgrade-lifecycle.ts
+++ b/cli/src/lib/upgrade-lifecycle.ts
@@ -212,7 +212,7 @@ export async function rollbackMigrations(
       method: "POST",
       headers,
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(30_000),
+      signal: AbortSignal.timeout(120_000),
     });
     if (!resp.ok) {
       const text = await resp.text();


### PR DESCRIPTION
## Summary
Changes CLI rollbackMigrations() timeout from 30s to 120s to match the gateway proxy timeout.

**Gap:** Client aborts before gateway on slow rollbacks
**Fix:** Match the 120s timeout used by the gateway proxy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
