### PR TITLE
fix: filter unknown checkpoint detection to actual migration keys only

### DIFF
--- a/assistant/src/memory/migrations/validate-migration-state.ts
+++ b/assistant/src/memory/migrations/validate-migration-state.ts
@@ -205,8 +205,20 @@ export function validateMigrationState(
 
   // Detect checkpoints that exist in the database but have no corresponding
   // registry entry — these are from a newer version of the daemon.
+  //
+  // The memory_checkpoints table is a general-purpose key-value store also
+  // used by non-migration subsystems (e.g., "identity:intro:text",
+  // "conversation_starters:item_count_at_last_gen"). Filter to only keys
+  // that follow migration naming conventions before comparing against the
+  // registry to avoid false-positive warnings.
   const registryKeys = new Set(MIGRATION_REGISTRY.map((e) => e.key));
-  const unknownCheckpoints = [...completed].filter((k) => !registryKeys.has(k));
+  const isMigrationKey = (k: string): boolean =>
+    k.startsWith("migration_") ||
+    k.startsWith("backfill_") ||
+    k.startsWith("drop_");
+  const unknownCheckpoints = [...completed].filter(
+    (k) => isMigrationKey(k) && !registryKeys.has(k),
+  );
 
   if (unknownCheckpoints.length > 0) {
     log.warn(


### PR DESCRIPTION
## Summary
Fixes false-positive unknown checkpoint warnings caused by non-migration keys in memory_checkpoints table.

**Gap:** memory_checkpoints stores non-migration data that was flagged as unknown migrations
**Fix:** Filter to keys matching migration naming patterns before comparison
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
