### PR TITLE
fix: update docstrings to reflect required down() on migration types

### DIFF
--- a/assistant/src/memory/migrations/validate-migration-state.ts
+++ b/assistant/src/memory/migrations/validate-migration-state.ts
@@ -222,10 +222,10 @@ export function validateMigrationState(
  * Roll back all completed memory (database) migrations with version > targetVersion.
  *
  * Iterates eligible migrations in reverse version order. For each:
- * 1. Verifies a `down` function exists (throws if missing).
- * 2. Marks the checkpoint as `"rolling_back"` for crash recovery.
- * 3. Calls `entry.down(database)` — each down() manages its own transactions.
- * 4. Deletes the checkpoint from `memory_checkpoints`.
+ * 1. Marks the checkpoint as `"rolling_back"` for crash recovery.
+ * 2. Calls `entry.down(database)` — each down() manages its own transactions.
+ *    (`down` is required on `MemoryMigrationEntry` at the type level.)
+ * 3. Deletes the checkpoint from `memory_checkpoints`.
  *
  * **Usage**: Pass the target version number you want to roll back *to*. All
  * migrations with a higher version number that have been applied will be

--- a/assistant/src/workspace/migrations/runner.ts
+++ b/assistant/src/workspace/migrations/runner.ts
@@ -141,11 +141,11 @@ export async function runWorkspaceMigrations(
  * `runWorkspaceMigrations` on the next startup (it re-runs interrupted
  * migrations).
  *
- * **Warning — data loss**: Some workspace migrations are irreversible (e.g.,
- * file deletions, format conversions that discard the original). These
- * migrations do not define a `down()` method and will throw an error if
- * rollback is attempted. Always verify that all target migrations have `down()`
- * support before calling this function.
+ * **Warning — data loss**: Every workspace migration must define a `down()`
+ * method (enforced at the type level), but some rollbacks are lossy (e.g.,
+ * file deletions or format conversions that discard the original cannot fully
+ * restore prior state). Review each migration's `down()` implementation
+ * before calling this function.
  *
  * **Important**: Stop the assistant before running rollbacks. Rolling back
  * workspace migrations while the assistant is running may cause file conflicts,


### PR DESCRIPTION
## Summary
Updates stale docstrings that still describe down() as optional.

**Gap:** Docs say down() is optional and throws if missing, but it's now required
**Fix:** Updated JSDoc to reflect compile-time guarantee
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
