### PR TITLE
fix: remove misleading progress message during downgrade schema alignment

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -455,15 +455,13 @@ async function upgradeDocker(
     };
     saveAssistantEntry(updatedEntry);
 
-    // After a downgrade, align the DB schema with the now-running old daemon
-    // by rolling back migrations above its own registry ceiling.
+    // After a downgrade, ask the now-running old daemon to roll back
+    // migrations above its own registry ceiling.  This may be a no-op when
+    // the old daemon's registry doesn't include the newer migrations, but
+    // it's harmless and correct for single-step rollbacks where the old
+    // daemon did add some of the newer migrations.  rollbackMigrations()
+    // logs the count internally when migrations are actually rolled back.
     if (isDowngrade) {
-      console.log("🔄 Aligning database schema with installed version...");
-      await broadcastUpgradeEvent(
-        entry.runtimeUrl,
-        entry.assistantId,
-        buildProgressEvent(UPGRADE_PROGRESS.ALIGNING_SCHEMA),
-      );
       await rollbackMigrations(
         entry.runtimeUrl,
         entry.assistantId,


### PR DESCRIPTION
## Summary
Removes the misleading 'Aligning database schema...' message and progress broadcast during downgrades.

**Gap:** The rollbackToRegistryCeiling call may be a no-op (old daemon can't roll back newer migrations it doesn't know about), but the UI suggests alignment is happening.
**Fix:** Silent call — rollbackMigrations() logs internally when migrations are actually rolled back.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
