### PR TITLE
feat: parse migration ceiling from release API in macOS client

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -620,6 +620,8 @@ struct AssistantRelease: Decodable, Identifiable {
     let assistantImageRef: String?
     let gatewayImageRef: String?
     let credentialExecutorImageRef: String?
+    let dbMigrationVersion: Int?
+    let lastWorkspaceMigrationId: String?
 
     var id: String { version }
 }


### PR DESCRIPTION
## Summary
- Adds `dbMigrationVersion: Int?` and `lastWorkspaceMigrationId: String?` to `AssistantRelease` struct
- Decoded automatically via `convertFromSnakeCase` strategy
- Optional fields — older releases without the data decode as nil

Part of plan: release-migration-ceiling.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
