### PR TITLE
feat: use release migration ceiling for precise rollback during downgrades

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -239,6 +239,44 @@ async function upgradeDocker(
       return target.patch < current.patch;
     })();
 
+  // For downgrades, fetch the target version's migration ceiling from the
+  // releases API. This tells us exactly which DB migration version and
+  // workspace migration the target version expects, enabling a precise
+  // rollback on the CURRENT (newer) daemon before swapping containers.
+  let targetMigrationCeiling: {
+    dbVersion?: number;
+    workspaceMigrationId?: string;
+  } = {};
+  if (isDowngrade) {
+    try {
+      const platformUrl = getPlatformUrl();
+      const releasesResp = await fetch(
+        `${platformUrl}/v1/releases/?stable=true`,
+        { signal: AbortSignal.timeout(10000) },
+      );
+      if (releasesResp.ok) {
+        const releases = (await releasesResp.json()) as Array<{
+          version: string;
+          db_migration_version?: number | null;
+          last_workspace_migration_id?: string;
+        }>;
+        const targetRelease = releases.find((r) => r.version === versionTag);
+        if (
+          targetRelease?.db_migration_version != null ||
+          targetRelease?.last_workspace_migration_id
+        ) {
+          targetMigrationCeiling = {
+            dbVersion: targetRelease.db_migration_version ?? undefined,
+            workspaceMigrationId:
+              targetRelease.last_workspace_migration_id || undefined,
+          };
+        }
+      }
+    } catch {
+      // Best-effort — fall back to rollbackToRegistryCeiling post-swap
+    }
+  }
+
   // Persist rollback state to lockfile BEFORE any destructive changes.
   // This enables the `vellum rollback` command to restore the previous version.
   if (entry.serviceGroupVersion && entry.containerInfo) {
@@ -386,6 +424,32 @@ async function upgradeDocker(
     entry.assistantId,
     buildProgressEvent(UPGRADE_PROGRESS.INSTALLING),
   );
+
+  // If we have the target version's migration ceiling, run a PRECISE
+  // rollback on the CURRENT (newer) daemon before stopping it. The current
+  // daemon has the `down()` code for all migrations it applied, so it can
+  // cleanly revert to the target version's ceiling. This is critical for
+  // multi-version downgrades where the old daemon wouldn't know about
+  // migrations introduced after its release.
+  if (
+    isDowngrade &&
+    (targetMigrationCeiling.dbVersion !== undefined ||
+      targetMigrationCeiling.workspaceMigrationId !== undefined)
+  ) {
+    console.log("🔄 Reverting database changes for downgrade...");
+    await broadcastUpgradeEvent(
+      entry.runtimeUrl,
+      entry.assistantId,
+      buildProgressEvent(UPGRADE_PROGRESS.REVERTING_MIGRATIONS),
+    );
+    await rollbackMigrations(
+      entry.runtimeUrl,
+      entry.assistantId,
+      targetMigrationCeiling.dbVersion,
+      targetMigrationCeiling.workspaceMigrationId,
+    );
+  }
+
   console.log("🛑 Stopping existing containers...");
   await stopContainers(res);
   console.log("✅ Containers stopped\n");
@@ -455,13 +519,16 @@ async function upgradeDocker(
     };
     saveAssistantEntry(updatedEntry);
 
-    // After a downgrade, ask the now-running old daemon to roll back
-    // migrations above its own registry ceiling.  This may be a no-op when
-    // the old daemon's registry doesn't include the newer migrations, but
-    // it's harmless and correct for single-step rollbacks where the old
-    // daemon did add some of the newer migrations.  rollbackMigrations()
-    // logs the count internally when migrations are actually rolled back.
-    if (isDowngrade) {
+    // After a downgrade, if the precise pre-swap rollback wasn't available
+    // (no release metadata), fall back to asking the now-running old daemon
+    // to roll back migrations above its own registry ceiling. This is a
+    // no-op for multi-version jumps where the old daemon doesn't know about
+    // the newer migrations, but correct for single-step rollbacks.
+    if (
+      isDowngrade &&
+      targetMigrationCeiling.dbVersion === undefined &&
+      targetMigrationCeiling.workspaceMigrationId === undefined
+    ) {
       await rollbackMigrations(
         entry.runtimeUrl,
         entry.assistantId,


### PR DESCRIPTION
## Summary
- Fetches target version's migration ceiling from the releases API during downgrades
- Runs precise migration rollback on the CURRENT (newer) daemon BEFORE container swap
- Falls back to rollbackToRegistryCeiling when release metadata isn't available
- Solves the multi-version downgrade gap: newer daemon now rolls back its own migrations to the target version's ceiling

Part of plan: release-migration-ceiling.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
