### PR TITLE
fix: normalize version prefix when matching releases for migration ceiling

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -260,7 +260,10 @@ async function upgradeDocker(
           db_migration_version?: number | null;
           last_workspace_migration_id?: string;
         }>;
-        const targetRelease = releases.find((r) => r.version === versionTag);
+        const normalizedTag = versionTag.replace(/^v/, "");
+        const targetRelease = releases.find(
+          (r) => r.version?.replace(/^v/, "") === normalizedTag,
+        );
         if (
           targetRelease?.db_migration_version != null ||
           targetRelease?.last_workspace_migration_id


### PR DESCRIPTION
## Summary
- Strips `v` prefix from both versionTag and release versions when matching
- Prevents silent fallback when CLI user passes `--version v1.2.3` but API stores `1.2.3`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
