### PR TITLE
feat: embed migration ceiling in release metadata for precise downgrade rollback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -661,6 +661,39 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Compute migration ceilings
+        id: migration-ceilings
+        run: |
+          # Extract max DB migration version from the registry
+          DB_VERSION=$(node -e "
+            const fs = require('fs');
+            const content = fs.readFileSync('assistant/src/memory/migrations/registry.ts', 'utf-8');
+            const versions = [...content.matchAll(/version:\s*(\d+)/g)].map(m => parseInt(m[1]));
+            console.log(Math.max(...versions));
+          ")
+          echo "db_version=$DB_VERSION" >> "$GITHUB_OUTPUT"
+
+          # Extract last workspace migration ID from the registry
+          WS_ID=$(node -e "
+            const fs = require('fs');
+            const path = require('path');
+            const registry = fs.readFileSync('assistant/src/workspace/migrations/registry.ts', 'utf-8');
+            const importMap = {};
+            for (const m of registry.matchAll(/import\s+\{\s*(\w+)\s*\}\s+from\s+['\x22]\.\/([^'\x22]+)['\x22];/g)) {
+              importMap[m[1]] = m[2];
+            }
+            const arrayMatch = registry.match(/WORKSPACE_MIGRATIONS[^=]*=\s*\[([\s\S]*?)\]/);
+            const entries = arrayMatch[1].match(/\w+/g);
+            const lastVar = entries[entries.length - 1];
+            const relPath = importMap[lastVar];
+            const filePath = path.join('assistant/src/workspace/migrations', relPath.replace(/\.js$/, '.ts'));
+            const src = fs.readFileSync(filePath, 'utf-8');
+            const idMatch = src.match(/id:\s*['\x22]([^'\x22]+)['\x22]/);
+            console.log(idMatch[1]);
+          ")
+          echo "ws_id=$WS_ID" >> "$GITHUB_OUTPUT"
+          echo "Migration ceilings: db=$DB_VERSION, workspace=$WS_ID"
+
       - name: Get release SHA
         id: release-sha
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
@@ -715,6 +748,8 @@ jobs:
           PAYLOAD=$(jq -n \
             --arg version "$VERSION" \
             --arg released_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --argjson db_migration_version "${{ steps.migration-ceilings.outputs.db_version }}" \
+            --arg last_workspace_migration_id "${{ steps.migration-ceilings.outputs.ws_id }}" \
             --arg assistant_repo "$ASSISTANT_REPO" \
             --arg assistant_tag "v${VERSION}" \
             --arg assistant_sha "$SHA" \
@@ -731,6 +766,8 @@ jobs:
               version: $version,
               released_at: $released_at,
               is_stable: true,
+              db_migration_version: $db_migration_version,
+              last_workspace_migration_id: $last_workspace_migration_id,
               assistant_image: {
                 repository: $assistant_repo,
                 tag: $assistant_tag,

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -260,7 +260,10 @@ async function upgradeDocker(
           db_migration_version?: number | null;
           last_workspace_migration_id?: string;
         }>;
-        const targetRelease = releases.find((r) => r.version === versionTag);
+        const normalizedTag = versionTag.replace(/^v/, "");
+        const targetRelease = releases.find(
+          (r) => r.version?.replace(/^v/, "") === normalizedTag,
+        );
         if (
           targetRelease?.db_migration_version != null ||
           targetRelease?.last_workspace_migration_id

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -239,6 +239,44 @@ async function upgradeDocker(
       return target.patch < current.patch;
     })();
 
+  // For downgrades, fetch the target version's migration ceiling from the
+  // releases API. This tells us exactly which DB migration version and
+  // workspace migration the target version expects, enabling a precise
+  // rollback on the CURRENT (newer) daemon before swapping containers.
+  let targetMigrationCeiling: {
+    dbVersion?: number;
+    workspaceMigrationId?: string;
+  } = {};
+  if (isDowngrade) {
+    try {
+      const platformUrl = getPlatformUrl();
+      const releasesResp = await fetch(
+        `${platformUrl}/v1/releases/?stable=true`,
+        { signal: AbortSignal.timeout(10000) },
+      );
+      if (releasesResp.ok) {
+        const releases = (await releasesResp.json()) as Array<{
+          version: string;
+          db_migration_version?: number | null;
+          last_workspace_migration_id?: string;
+        }>;
+        const targetRelease = releases.find((r) => r.version === versionTag);
+        if (
+          targetRelease?.db_migration_version != null ||
+          targetRelease?.last_workspace_migration_id
+        ) {
+          targetMigrationCeiling = {
+            dbVersion: targetRelease.db_migration_version ?? undefined,
+            workspaceMigrationId:
+              targetRelease.last_workspace_migration_id || undefined,
+          };
+        }
+      }
+    } catch {
+      // Best-effort — fall back to rollbackToRegistryCeiling post-swap
+    }
+  }
+
   // Persist rollback state to lockfile BEFORE any destructive changes.
   // This enables the `vellum rollback` command to restore the previous version.
   if (entry.serviceGroupVersion && entry.containerInfo) {
@@ -386,6 +424,32 @@ async function upgradeDocker(
     entry.assistantId,
     buildProgressEvent(UPGRADE_PROGRESS.INSTALLING),
   );
+
+  // If we have the target version's migration ceiling, run a PRECISE
+  // rollback on the CURRENT (newer) daemon before stopping it. The current
+  // daemon has the `down()` code for all migrations it applied, so it can
+  // cleanly revert to the target version's ceiling. This is critical for
+  // multi-version downgrades where the old daemon wouldn't know about
+  // migrations introduced after its release.
+  if (
+    isDowngrade &&
+    (targetMigrationCeiling.dbVersion !== undefined ||
+      targetMigrationCeiling.workspaceMigrationId !== undefined)
+  ) {
+    console.log("🔄 Reverting database changes for downgrade...");
+    await broadcastUpgradeEvent(
+      entry.runtimeUrl,
+      entry.assistantId,
+      buildProgressEvent(UPGRADE_PROGRESS.REVERTING_MIGRATIONS),
+    );
+    await rollbackMigrations(
+      entry.runtimeUrl,
+      entry.assistantId,
+      targetMigrationCeiling.dbVersion,
+      targetMigrationCeiling.workspaceMigrationId,
+    );
+  }
+
   console.log("🛑 Stopping existing containers...");
   await stopContainers(res);
   console.log("✅ Containers stopped\n");
@@ -455,13 +519,16 @@ async function upgradeDocker(
     };
     saveAssistantEntry(updatedEntry);
 
-    // After a downgrade, ask the now-running old daemon to roll back
-    // migrations above its own registry ceiling.  This may be a no-op when
-    // the old daemon's registry doesn't include the newer migrations, but
-    // it's harmless and correct for single-step rollbacks where the old
-    // daemon did add some of the newer migrations.  rollbackMigrations()
-    // logs the count internally when migrations are actually rolled back.
-    if (isDowngrade) {
+    // After a downgrade, if the precise pre-swap rollback wasn't available
+    // (no release metadata), fall back to asking the now-running old daemon
+    // to roll back migrations above its own registry ceiling. This is a
+    // no-op for multi-version jumps where the old daemon doesn't know about
+    // the newer migrations, but correct for single-step rollbacks.
+    if (
+      isDowngrade &&
+      targetMigrationCeiling.dbVersion === undefined &&
+      targetMigrationCeiling.workspaceMigrationId === undefined
+    ) {
       await rollbackMigrations(
         entry.runtimeUrl,
         entry.assistantId,

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -434,6 +434,7 @@ async function upgradeDocker(
   // cleanly revert to the target version's ceiling. This is critical for
   // multi-version downgrades where the old daemon wouldn't know about
   // migrations introduced after its release.
+  let preSwapRollbackOk = true;
   if (
     isDowngrade &&
     (targetMigrationCeiling.dbVersion !== undefined ||
@@ -445,7 +446,7 @@ async function upgradeDocker(
       entry.assistantId,
       buildProgressEvent(UPGRADE_PROGRESS.REVERTING_MIGRATIONS),
     );
-    await rollbackMigrations(
+    preSwapRollbackOk = await rollbackMigrations(
       entry.runtimeUrl,
       entry.assistantId,
       targetMigrationCeiling.dbVersion,
@@ -522,15 +523,17 @@ async function upgradeDocker(
     };
     saveAssistantEntry(updatedEntry);
 
-    // After a downgrade, if the precise pre-swap rollback wasn't available
-    // (no release metadata), fall back to asking the now-running old daemon
-    // to roll back migrations above its own registry ceiling. This is a
-    // no-op for multi-version jumps where the old daemon doesn't know about
-    // the newer migrations, but correct for single-step rollbacks.
+    // After a downgrade, fall back to asking the now-running old daemon
+    // to roll back migrations above its own registry ceiling when either:
+    // (a) no release metadata was available for a precise pre-swap rollback, or
+    // (b) the precise pre-swap rollback failed (timeout, daemon crash, etc.).
+    // This is a no-op for multi-version jumps where the old daemon doesn't
+    // know about the newer migrations, but correct for single-step rollbacks.
     if (
       isDowngrade &&
-      targetMigrationCeiling.dbVersion === undefined &&
-      targetMigrationCeiling.workspaceMigrationId === undefined
+      (!preSwapRollbackOk ||
+        (targetMigrationCeiling.dbVersion === undefined &&
+          targetMigrationCeiling.workspaceMigrationId === undefined))
     ) {
       await rollbackMigrations(
         entry.runtimeUrl,

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -620,6 +620,8 @@ struct AssistantRelease: Decodable, Identifiable {
     let assistantImageRef: String?
     let gatewayImageRef: String?
     let credentialExecutorImageRef: String?
+    let dbMigrationVersion: Int?
+    let lastWorkspaceMigrationId: String?
 
     var id: String { version }
 }


### PR DESCRIPTION
## Summary
Embeds DB migration version and workspace migration ID in release metadata so the CLI can run precise migration rollback during multi-version downgrades. The newer daemon (which has all the down() code) now rolls back to the target version's exact migration ceiling BEFORE containers are swapped — solving the architectural gap where the old daemon couldn't roll back migrations it didn't know about.

## Cross-repo changes
### vellum-assistant-platform
- #2865: Add db_migration_version and last_workspace_migration_id to AssistantRelease model
- #2866: Expose migration ceiling in release list and registration APIs

### vellum-assistant (this PR)
- #20702: Compute and register migration ceiling during CI release
- #20701: Parse migration ceiling in macOS AssistantRelease struct
- #20703: Use release migration ceiling for precise rollback during downgrades

## Self-review result
PASS after 1 fix round. Two issues found and fixed:
- Pre-swap rollback failure silently prevented fallback
- Version v-prefix mismatch in release lookup

## Fix PRs
- #20705: fix: run fallback rollback when pre-swap rollback fails
- #20704: fix: normalize version prefix when matching releases

Part of plan: release-migration-ceiling.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
