### PR TITLE
fix: correct type name in rollbackMemoryMigration docstring

### DIFF
--- a/assistant/src/memory/migrations/validate-migration-state.ts
+++ b/assistant/src/memory/migrations/validate-migration-state.ts
@@ -236,7 +236,7 @@ export function validateMigrationState(
  * Iterates eligible migrations in reverse version order. For each:
  * 1. Marks the checkpoint as `"rolling_back"` for crash recovery.
  * 2. Calls `entry.down(database)` — each down() manages its own transactions.
- *    (`down` is required on `MemoryMigrationEntry` at the type level.)
+ *    (`down` is required on `MigrationRegistryEntry` at the type level.)
  * 3. Deletes the checkpoint from `memory_checkpoints`.
  *
  * **Usage**: Pass the target version number you want to roll back *to*. All


### PR DESCRIPTION
## Summary
- Fixes typo: `MemoryMigrationEntry` → `MigrationRegistryEntry` in the rollbackMemoryMigration docstring
- The type was renamed when down() was made required but the docstring referenced a non-existent type
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
