### PR TITLE
feat: improve Assistant Version panel UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -241,22 +241,21 @@ struct AssistantUpgradeSection: View {
                 }
 
                 if !pickerReleases.isEmpty && topology != .remote && topology != .local {
-                    HStack(spacing: VSpacing.sm) {
-                        Text(!upgradeAvailable ? "Selected:" : (backwardReleasesEnabled && isRollback) ? (topology == .managed ? "Downgrade to:" : "Roll back to:") : "Update to:")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.contentTertiary)
-                        Picker("", selection: Binding<String>(
+                    VDropdown(
+                        !upgradeAvailable ? "Selected:" : (backwardReleasesEnabled && isRollback) ? (topology == .managed ? "Downgrade to:" : "Roll back to:") : "Update to:",
+                        placeholder: "Select version",
+                        selection: Binding<String>(
                             get: { selectedVersion ?? latestRelease?.version ?? "" },
                             set: { newValue in
                                 selectedVersion = (newValue == latestRelease?.version) ? nil : newValue
                             }
-                        )) {
-                            ForEach(pickerReleases) { release in
-                                Text(releaseLabel(for: release)).tag(release.version)
-                            }
-                        }
-                        .pickerStyle(.menu)
-                    }
+                        ),
+                        options: pickerReleases.map { release in
+                            (label: releaseLabel(for: release), value: release.version)
+                        },
+                        size: .small,
+                        maxWidth: 240
+                    )
                 }
 
                 if !upgradeAvailable && !isLoadingReleases && !pickerReleases.isEmpty && topology != .local {
@@ -307,7 +306,14 @@ struct AssistantUpgradeSection: View {
                         }
                     }
                 } else if topology != .remote {
-                    // Docker and managed get the upgrade button
+                    VButton(
+                        label: isLoadingReleases ? "Checking..." : "Check for Updates",
+                        style: .outlined
+                    ) {
+                        Task { await loadReleases() }
+                    }
+                    .disabled(isLoadingReleases || isUpgrading)
+
                     VButton(
                         label: isUpgrading
                             ? (isRollback ? (topology == .managed ? "Downgrading..." : "Rolling back...") : "Updating...")
@@ -317,16 +323,6 @@ struct AssistantUpgradeSection: View {
                         showingUpgradeConfirmation = true
                     }
                     .disabled(!upgradeAvailable || isUpgrading || pickerReleases.isEmpty)
-                }
-
-                if topology != .local && topology != .remote {
-                    VButton(
-                        label: isLoadingReleases ? "Checking..." : "Check for Updates",
-                        style: .outlined
-                    ) {
-                        Task { await loadReleases() }
-                    }
-                    .disabled(isLoadingReleases || isUpgrading)
                 }
             }
 


### PR DESCRIPTION
## Summary
- Swapped button order: "Check for Updates" now appears before "Update Now" for Docker/managed topologies
- Replaced native SwiftUI `Picker` with the design system's `VDropdown` component for consistent styling with the rest of the app
- Constrained the version selector dropdown width to 240pt (was full-width)

## Original prompt
Use the /frontend-design skill to improve the Assistant Version UI panel. Requirements:
1. Swap the order of the "Check for Updates" and "Update" button (Check for Updates should come first, Update Now second)
2. Use our library component for the dropdown and reduce its width
3. Apply any other design improvements the frontend-design skill suggests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20708" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
