### PR TITLE
refactor: gateway fetches migration state from daemon `/v1/health` instead of `/healthz`

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1018,12 +1018,12 @@ async function main() {
         if (!includeMigrations) {
           return Response.json({ status: "ok" });
         }
-        // Fetch the daemon's /healthz to surface migration state
+        // Fetch the daemon's /v1/health to surface migration state
         // (dbVersion, lastWorkspaceMigrationId) so the CLI can capture
         // pre-upgrade migration state through the gateway.
         try {
           const upstream = await fetch(
-            `${config.assistantRuntimeBaseUrl}/healthz`,
+            `${config.assistantRuntimeBaseUrl}/v1/health`,
             { signal: AbortSignal.timeout(3000) },
           );
           if (upstream.ok) {


### PR DESCRIPTION
## Summary
- Switch gateway `/healthz?include=migrations` to fetch from daemon `/v1/health` instead of `/healthz`
- Update comment to reflect new upstream source
- Decouples migration-info need from the daemon's liveness probe

Part of plan: health-probe-cleanup.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
