### PR TITLE
fix: improve Docker image pull error messages with service names and dev build guidance

### DIFF
--- a/assistant/docs/credential-execution-service.md
+++ b/assistant/docs/credential-execution-service.md
@@ -251,11 +251,11 @@ To dark-launch CES in managed deployments without user impact:
 
 1. **Deploy the CES container image** via the `credential_executor_image` field in `POST /v1/internal/assistant-image-releases/`. The warm-pool manager picks it up and includes it in pod templates. The CES container starts, binds its bootstrap socket and health port (8090), but does nothing until an assistant connects.
 
-2. **Verify sidecar health** using kubelet probes: `/healthz` (liveness) and `/readyz` (readiness, always returns 200; includes `rpcConnected` field for observability). CES reports its protocol version in both probe responses.
+2. **Verify sidecar health** using kubelet probes: `/healthz` (liveness, returns `{"status": "ok"}`) and `/readyz` (readiness, always returns 200; includes `rpcConnected` field for observability).
 
 3. **Enable `ces-tools`** first on a test cohort. The assistant spawns a local CES child process and registers tools. Verify tool registration, grant creation, and audit logging work end-to-end without affecting existing workflows.
 
-4. **Enable `ces-managed-sidecar`** on the same cohort. The assistant switches from child-process transport to the bootstrap Unix socket. CES `/readyz` always returns 200; check the `rpcConnected` field in the response body to verify the assistant has connected.
+4. **Enable `ces-managed-sidecar`** on the same cohort. The assistant switches from child-process transport to the bootstrap Unix socket. CES `/readyz` always returns 200 with `{"status": "ok", "rpcConnected": <boolean>}`; check the `rpcConnected` field to verify the assistant has connected.
 
 5. **Progressive rollout**: Widen the cohort by enabling flags on more assistants. Monitor for grant failures, materializer errors, and egress proxy issues.
 

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -145,7 +145,7 @@ import { handleGuardianRefresh } from "./routes/guardian-refresh-routes.js";
 import { hostBashRouteDefinitions } from "./routes/host-bash-routes.js";
 import { hostCuRouteDefinitions } from "./routes/host-cu-routes.js";
 import { hostFileRouteDefinitions } from "./routes/host-file-routes.js";
-import { handleHealth } from "./routes/identity-routes.js";
+import { handleHealth, handleReadyz } from "./routes/identity-routes.js";
 import { identityRouteDefinitions } from "./routes/identity-routes.js";
 import { slackChannelRouteDefinitions } from "./routes/integrations/slack/channel.js";
 import { slackShareRouteDefinitions } from "./routes/integrations/slack/share.js";
@@ -470,7 +470,10 @@ export class RuntimeHttpServer {
     server.timeout(req, 1800);
     // Skip request logging for health-check probes to reduce log noise.
     const url = new URL(req.url);
-    if (url.pathname === "/healthz" && req.method === "GET") {
+    if (
+      (url.pathname === "/healthz" || url.pathname === "/readyz") &&
+      req.method === "GET"
+    ) {
       return this.routeRequest(req, server);
     }
     return withRequestLogging(req, () => this.routeRequest(req, server));
@@ -485,6 +488,10 @@ export class RuntimeHttpServer {
 
     if (path === "/healthz" && req.method === "GET") {
       return handleHealth();
+    }
+
+    if (path === "/readyz" && req.method === "GET") {
+      return handleReadyz();
     }
 
     // WebSocket upgrade for the Chrome extension browser relay.

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -151,6 +151,10 @@ export function handleHealth(): Response {
   });
 }
 
+export function handleReadyz(): Response {
+  return Response.json({ status: "ok" });
+}
+
 export function handleGetIdentity(): Response {
   const identityPath = getWorkspacePromptPath("IDENTITY.md");
   if (!existsSync(identityPath)) {

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -584,7 +584,11 @@ struct AssistantUpgradeSection: View {
         case "DOCKER_NOT_RUNNING":
             return "Docker doesn't appear to be running. Start Docker Desktop and try again."
         case "IMAGE_PULL_FAILED":
-            return "Failed to download the update. Check your internet connection and try again."
+            let base = "Failed to download the update. Check that Docker is running and you have internet access."
+            if DevModeManager.shared.isDevMode {
+                return base + " Development builds cannot download released versions."
+            }
+            return base
         case "READINESS_TIMEOUT":
             return "The assistant didn't start up in time. Check Docker Desktop for container status, or try rolling back."
         case "ROLLBACK_FAILED":

--- a/credential-executor/src/__tests__/managed-integration.test.ts
+++ b/credential-executor/src/__tests__/managed-integration.test.ts
@@ -351,13 +351,13 @@ describe("managed CES integration (real Unix socket)", () => {
         const url = new URL(req.url);
         if (url.pathname === "/healthz") {
           return new Response(
-            JSON.stringify({ status: "ok", version: CES_PROTOCOL_VERSION }),
+            JSON.stringify({ status: "ok" }),
             { headers: { "Content-Type": "application/json" } },
           );
         }
         if (url.pathname === "/readyz") {
           return new Response(
-            JSON.stringify({ ready: true, version: CES_PROTOCOL_VERSION }),
+            JSON.stringify({ status: "ok", rpcConnected: false }),
             { status: 200, headers: { "Content-Type": "application/json" } },
           );
         }
@@ -466,13 +466,11 @@ describe("managed CES integration (real Unix socket)", () => {
     expect(healthzResp.status).toBe(200);
     const healthzBody = await healthzResp.json();
     expect(healthzBody.status).toBe("ok");
-    expect(healthzBody.version).toBe(CES_PROTOCOL_VERSION);
 
     const readyzResp = await fetch(`http://localhost:${healthPort}/readyz`);
     expect(readyzResp.status).toBe(200);
     const readyzBody = await readyzResp.json();
-    expect(readyzBody.ready).toBe(true);
-    expect(readyzBody.version).toBe(CES_PROTOCOL_VERSION);
+    expect(readyzBody.status).toBe("ok");
 
     // -- Step 5: Unknown method returns METHOD_NOT_FOUND -----------------------
     const unknownRpcId = "rpc-3";

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -342,7 +342,7 @@ function startHealthServer(
       const url = new URL(req.url);
       if (url.pathname === "/healthz") {
         return new Response(
-          JSON.stringify({ status: "ok", version: CES_PROTOCOL_VERSION }),
+          JSON.stringify({ status: "ok" }),
           { headers: { "Content-Type": "application/json" } },
         );
       }
@@ -354,7 +354,7 @@ function startHealthServer(
         // without a connection anyway, so readiness is purely about the
         // process being up and able to accept a future connection.
         return new Response(
-          JSON.stringify({ ready: true, rpcConnected, version: CES_PROTOCOL_VERSION }),
+          JSON.stringify({ status: "ok", rpcConnected }),
           {
             status: 200,
             headers: { "Content-Type": "application/json" },

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1018,12 +1018,12 @@ async function main() {
         if (!includeMigrations) {
           return Response.json({ status: "ok" });
         }
-        // Fetch the daemon's /healthz to surface migration state
+        // Fetch the daemon's /v1/health to surface migration state
         // (dbVersion, lastWorkspaceMigrationId) so the CLI can capture
         // pre-upgrade migration state through the gateway.
         try {
           const upstream = await fetch(
-            `${config.assistantRuntimeBaseUrl}/healthz`,
+            `${config.assistantRuntimeBaseUrl}/v1/health`,
             { signal: AbortSignal.timeout(3000) },
           );
           if (upstream.ok) {


### PR DESCRIPTION
## Summary
- CLI now logs which service image is being pulled (e.g., `Pulling assistant: vellumai/vellum-assistant:v0.5.5`) so users can see exactly which image failed
- Updated Settings error guidance for IMAGE_PULL_FAILED to mention dev build limitations, but only when `DevModeManager.isDevMode` is active — regular users see a clean message about Docker and internet connectivity
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
