### PR TITLE
refactor: strip daemon `/healthz` to bare liveness probe

### DIFF
--- a/assistant/src/__tests__/migration-export-http.test.ts
+++ b/assistant/src/__tests__/migration-export-http.test.ts
@@ -527,9 +527,9 @@ describe("integration: existing routes unaffected", () => {
   });
 
   test("GET /v1/health still works (not intercepted by migration routes)", async () => {
-    const { handleHealth } =
+    const { handleDetailedHealth } =
       await import("../runtime/routes/identity-routes.js");
-    const res = handleHealth();
+    const res = handleDetailedHealth();
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(res.status).toBe(200);

--- a/assistant/src/__tests__/migration-import-commit-http.test.ts
+++ b/assistant/src/__tests__/migration-import-commit-http.test.ts
@@ -939,9 +939,9 @@ describe("route policy registration", () => {
 
 describe("integration: existing routes unaffected", () => {
   test("GET /v1/health still works", async () => {
-    const { handleHealth } =
+    const { handleDetailedHealth } =
       await import("../runtime/routes/identity-routes.js");
-    const res = handleHealth();
+    const res = handleDetailedHealth();
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(res.status).toBe(200);

--- a/assistant/src/__tests__/migration-import-preflight-http.test.ts
+++ b/assistant/src/__tests__/migration-import-preflight-http.test.ts
@@ -792,9 +792,9 @@ describe("route policy registration", () => {
 
 describe("integration: existing routes unaffected", () => {
   test("GET /v1/health still works", async () => {
-    const { handleHealth } =
+    const { handleDetailedHealth } =
       await import("../runtime/routes/identity-routes.js");
-    const res = handleHealth();
+    const res = handleDetailedHealth();
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(res.status).toBe(200);

--- a/assistant/src/__tests__/migration-validate-http.test.ts
+++ b/assistant/src/__tests__/migration-validate-http.test.ts
@@ -684,9 +684,9 @@ describe("route policy registration", () => {
 
 describe("integration: existing routes unaffected", () => {
   test("GET /v1/health still works (not intercepted by migration routes)", async () => {
-    const { handleHealth } =
+    const { handleDetailedHealth } =
       await import("../runtime/routes/identity-routes.js");
-    const res = handleHealth();
+    const res = handleDetailedHealth();
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(res.status).toBe(200);

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -136,6 +136,10 @@ function getPackageVersion(): string | undefined {
 }
 
 export function handleHealth(): Response {
+  return Response.json({ status: "ok" });
+}
+
+export function handleDetailedHealth(): Response {
   return Response.json({
     status: "healthy",
     timestamp: new Date().toISOString(),
@@ -240,7 +244,7 @@ export function identityRouteDefinitions(): RouteDefinition[] {
     {
       endpoint: "health",
       method: "GET",
-      handler: () => handleHealth(),
+      handler: () => handleDetailedHealth(),
     },
     {
       endpoint: "identity",


### PR DESCRIPTION
## Summary
- Strip daemon `/healthz` to return bare `{"status": "ok"}` (no disk, memory, CPU, or migration data)
- Rename rich handler to `handleDetailedHealth()` serving `/v1/health` (authenticated, via router)
- All consumers of rich health data now use `/v1/health` through the gateway

Part of plan: health-probe-cleanup.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
