### PR TITLE
refactor: unify PLATFORM_BASE_URL → VELLUM_PLATFORM_URL

### DIFF
--- a/assistant/.env.example
+++ b/assistant/.env.example
@@ -16,8 +16,8 @@ OLLAMA_BASE_URL=
 # Enable the runtime HTTP server (required for web local mode).
 # RUNTIME_HTTP_PORT=7821
 
-# Platform base URL (defaults to empty string)
-# PLATFORM_BASE_URL=
+# Vellum platform URL (used by the desktop app; defaults to https://platform.vellum.ai in release builds)
+VELLUM_PLATFORM_URL=https://dev-platform.vellum.ai
 
 # --- Sentry (crash reporting) ---
 # Omit to disable Sentry.

--- a/assistant/src/cli/commands/platform.ts
+++ b/assistant/src/cli/commands/platform.ts
@@ -24,7 +24,7 @@ export function registerPlatformCommand(program: Command): void {
     `
 The platform subsystem manages callback routing, containerized deployment
 context, and webhook forwarding for assistants running inside platform
-containers. When IS_CONTAINERIZED=true with a configured PLATFORM_BASE_URL
+containers. When IS_CONTAINERIZED=true with a configured VELLUM_PLATFORM_URL
 and PLATFORM_ASSISTANT_ID, external service callbacks (Telegram webhooks,
 Twilio webhooks, OAuth redirects) route through the platform's gateway proxy
 instead of hitting the assistant directly.
@@ -51,7 +51,7 @@ running.
 
 Fields:
   containerized       Whether IS_CONTAINERIZED is set (boolean)
-  baseUrl             PLATFORM_BASE_URL — the platform gateway base URL
+  baseUrl             VELLUM_PLATFORM_URL — the platform gateway base URL
   assistantId         PLATFORM_ASSISTANT_ID — this assistant's platform UUID
   hasInternalApiKey   Whether PLATFORM_INTERNAL_API_KEY is set (boolean,
                       value not disclosed)
@@ -136,7 +136,7 @@ Known callback path/type combinations:
   --path oauth/callback             --type oauth
 
 Requires a containerized environment (IS_CONTAINERIZED=true) with
-PLATFORM_BASE_URL and PLATFORM_ASSISTANT_ID configured. Returns the
+VELLUM_PLATFORM_URL and PLATFORM_ASSISTANT_ID configured. Returns the
 platform-provided stable callback URL that external services should use.
 
 Examples:

--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -144,7 +144,7 @@ export function setPlatformBaseUrl(value: string | undefined): void {
 }
 
 export function getPlatformBaseUrl(): string {
-  return str("PLATFORM_BASE_URL") ?? _platformBaseUrlOverride ?? "";
+  return str("VELLUM_PLATFORM_URL") ?? _platformBaseUrlOverride ?? "";
 }
 
 let _platformAssistantIdOverride: string | undefined;

--- a/assistant/src/inbound/platform-callback-registration.ts
+++ b/assistant/src/inbound/platform-callback-registration.ts
@@ -2,7 +2,7 @@
  * Platform callback route registration for containerized deployments.
  *
  * When the assistant daemon runs inside a container (IS_CONTAINERIZED=true)
- * with a configured PLATFORM_BASE_URL and PLATFORM_ASSISTANT_ID, external
+ * with a configured VELLUM_PLATFORM_URL and PLATFORM_ASSISTANT_ID, external
  * service callbacks (Twilio webhooks, OAuth redirects, Telegram webhooks, etc.)
  * must route through the platform's gateway proxy instead of hitting the
  * assistant directly.
@@ -12,7 +12,7 @@
  * webhooks to the correct containerized assistant instance.
  *
  * The platform endpoint is:
- *   POST {PLATFORM_BASE_URL}/v1/internal/gateway/callback-routes/register/
+ *   POST {VELLUM_PLATFORM_URL}/v1/internal/gateway/callback-routes/register/
  *
  * It accepts { assistant_id, callback_path, type } and returns a stable
  * callback_url that external services should use.
@@ -30,7 +30,7 @@ const log = getLogger("platform-callback-registration");
 
 /**
  * Whether the daemon should register callback routes with the platform.
- * True when IS_CONTAINERIZED, PLATFORM_BASE_URL, and PLATFORM_ASSISTANT_ID
+ * True when IS_CONTAINERIZED, VELLUM_PLATFORM_URL, and PLATFORM_ASSISTANT_ID
  * are all set. Intentionally does **not** require the managed proxy API key
  * so that callback-only flows (OAuth transport, Telegram/Twilio callback
  * registration) work during partial bootstrap before the key is injected.

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -10,7 +10,10 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { setIngressPublicBaseUrl } from "../../config/env.js";
+import {
+  getPlatformBaseUrl,
+  setIngressPublicBaseUrl,
+} from "../../config/env.js";
 import { loadRawConfig, saveRawConfig } from "../../config/loader.js";
 import { loadSkillCatalog } from "../../config/skills.js";
 import {
@@ -736,7 +739,8 @@ export function settingsRouteDefinitions(): RouteDefinition[] {
       handler: () => {
         const raw = loadRawConfig();
         const platform = (raw?.platform ?? {}) as Record<string, unknown>;
-        const baseUrl = (platform.baseUrl as string | undefined) ?? "";
+        const baseUrl =
+          (platform.baseUrl as string | undefined) || getPlatformBaseUrl();
         return Response.json({ baseUrl, success: true });
       },
     },

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -939,7 +939,7 @@ export async function startLocalDaemon(
         "ANTHROPIC_API_KEY",
         "APP_VERSION",
         "BASE_DATA_DIR",
-        "PLATFORM_BASE_URL",
+        "VELLUM_PLATFORM_URL",
         "QDRANT_HTTP_PORT",
         "QDRANT_URL",
         "RUNTIME_HTTP_PORT",

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -110,7 +110,7 @@ function buildHandlers(sessionIdRef: SessionIdRef, apiKeyRef: ApiKeyRef): RpcHan
   // from the bootstrap handshake (the assistant forwards it after hatch).
   // We use a lazy getter so the handshake-provided key takes effect even
   // though handlers are built before the handshake completes.
-  const platformBaseUrl = process.env["PLATFORM_BASE_URL"] ?? "";
+  const platformBaseUrl = process.env["VELLUM_PLATFORM_URL"] ?? "";
   const assistantId = process.env["PLATFORM_ASSISTANT_ID"] ?? "";
 
   const { getAssistantApiKey, getManagedSubjectOptions, getManagedMaterializerOptions } =
@@ -123,7 +123,7 @@ function buildHandlers(sessionIdRef: SessionIdRef, apiKeyRef: ApiKeyRef): RpcHan
 
   if (!platformBaseUrl || !assistantId) {
     warn(
-      "PLATFORM_BASE_URL and/or PLATFORM_ASSISTANT_ID not set. " +
+      "VELLUM_PLATFORM_URL and/or PLATFORM_ASSISTANT_ID not set. " +
         "Managed credential materialisation will depend on the handshake-provided API key.",
     );
   }
@@ -207,7 +207,7 @@ function buildHandlers(sessionIdRef: SessionIdRef, apiKeyRef: ApiKeyRef): RpcHan
               return {
                 ok: false as const,
                 error:
-                  "PLATFORM_BASE_URL and/or ASSISTANT_API_KEY not set. " +
+                  "VELLUM_PLATFORM_URL and/or ASSISTANT_API_KEY not set. " +
                   "Managed credential materialisation is not available.",
               };
             }


### PR DESCRIPTION
## Summary
- Standardize on `VELLUM_PLATFORM_URL` as the single env var for the platform URL, replacing the split between `PLATFORM_BASE_URL` (containerized) and `VELLUM_PLATFORM_URL` (desktop). Updated across assistant daemon, CLI env forwarding, and credential-executor.
- Make the GET `/config/platform` endpoint fall back to `getPlatformBaseUrl()` (which reads the env var) when no workspace config is saved, so the Developer tab in Settings correctly initializes with the env var default instead of showing empty.
- Update `assistant/.env.example` to include `VELLUM_PLATFORM_URL=https://dev-platform.vellum.ai`.

## Original prompt
Unify PLATFORM_BASE_URL and VELLUM_PLATFORM_URL env vars to just VELLUM_PLATFORM_URL across the entire codebase. Also make the GET /config/platform endpoint fall back to the env var when no workspace config is saved, so the Settings Developer tab shows the correct default. And add VELLUM_PLATFORM_URL=https://dev-platform.vellum.ai to assistant/.env.example.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
