### PR TITLE
Standardize health check endpoints across daemon, gateway, and CES

### DIFF
--- a/assistant/docs/credential-execution-service.md
+++ b/assistant/docs/credential-execution-service.md
@@ -251,11 +251,11 @@ To dark-launch CES in managed deployments without user impact:
 
 1. **Deploy the CES container image** via the `credential_executor_image` field in `POST /v1/internal/assistant-image-releases/`. The warm-pool manager picks it up and includes it in pod templates. The CES container starts, binds its bootstrap socket and health port (8090), but does nothing until an assistant connects.
 
-2. **Verify sidecar health** using kubelet probes: `/healthz` (liveness) and `/readyz` (readiness, always returns 200; includes `rpcConnected` field for observability). CES reports its protocol version in both probe responses.
+2. **Verify sidecar health** using kubelet probes: `/healthz` (liveness, returns `{"status": "ok"}`) and `/readyz` (readiness, always returns 200; includes `rpcConnected` field for observability).
 
 3. **Enable `ces-tools`** first on a test cohort. The assistant spawns a local CES child process and registers tools. Verify tool registration, grant creation, and audit logging work end-to-end without affecting existing workflows.
 
-4. **Enable `ces-managed-sidecar`** on the same cohort. The assistant switches from child-process transport to the bootstrap Unix socket. CES `/readyz` always returns 200; check the `rpcConnected` field in the response body to verify the assistant has connected.
+4. **Enable `ces-managed-sidecar`** on the same cohort. The assistant switches from child-process transport to the bootstrap Unix socket. CES `/readyz` always returns 200 with `{"status": "ok", "rpcConnected": <boolean>}`; check the `rpcConnected` field to verify the assistant has connected.
 
 5. **Progressive rollout**: Widen the cohort by enabling flags on more assistants. Monitor for grant failures, materializer errors, and egress proxy issues.
 

--- a/assistant/src/__tests__/migration-export-http.test.ts
+++ b/assistant/src/__tests__/migration-export-http.test.ts
@@ -527,9 +527,9 @@ describe("integration: existing routes unaffected", () => {
   });
 
   test("GET /v1/health still works (not intercepted by migration routes)", async () => {
-    const { handleHealth } =
+    const { handleDetailedHealth } =
       await import("../runtime/routes/identity-routes.js");
-    const res = handleHealth();
+    const res = handleDetailedHealth();
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(res.status).toBe(200);

--- a/assistant/src/__tests__/migration-import-commit-http.test.ts
+++ b/assistant/src/__tests__/migration-import-commit-http.test.ts
@@ -939,9 +939,9 @@ describe("route policy registration", () => {
 
 describe("integration: existing routes unaffected", () => {
   test("GET /v1/health still works", async () => {
-    const { handleHealth } =
+    const { handleDetailedHealth } =
       await import("../runtime/routes/identity-routes.js");
-    const res = handleHealth();
+    const res = handleDetailedHealth();
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(res.status).toBe(200);

--- a/assistant/src/__tests__/migration-import-preflight-http.test.ts
+++ b/assistant/src/__tests__/migration-import-preflight-http.test.ts
@@ -792,9 +792,9 @@ describe("route policy registration", () => {
 
 describe("integration: existing routes unaffected", () => {
   test("GET /v1/health still works", async () => {
-    const { handleHealth } =
+    const { handleDetailedHealth } =
       await import("../runtime/routes/identity-routes.js");
-    const res = handleHealth();
+    const res = handleDetailedHealth();
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(res.status).toBe(200);

--- a/assistant/src/__tests__/migration-validate-http.test.ts
+++ b/assistant/src/__tests__/migration-validate-http.test.ts
@@ -684,9 +684,9 @@ describe("route policy registration", () => {
 
 describe("integration: existing routes unaffected", () => {
   test("GET /v1/health still works (not intercepted by migration routes)", async () => {
-    const { handleHealth } =
+    const { handleDetailedHealth } =
       await import("../runtime/routes/identity-routes.js");
-    const res = handleHealth();
+    const res = handleDetailedHealth();
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(res.status).toBe(200);

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -145,7 +145,7 @@ import { handleGuardianRefresh } from "./routes/guardian-refresh-routes.js";
 import { hostBashRouteDefinitions } from "./routes/host-bash-routes.js";
 import { hostCuRouteDefinitions } from "./routes/host-cu-routes.js";
 import { hostFileRouteDefinitions } from "./routes/host-file-routes.js";
-import { handleHealth } from "./routes/identity-routes.js";
+import { handleHealth, handleReadyz } from "./routes/identity-routes.js";
 import { identityRouteDefinitions } from "./routes/identity-routes.js";
 import { slackChannelRouteDefinitions } from "./routes/integrations/slack/channel.js";
 import { slackShareRouteDefinitions } from "./routes/integrations/slack/share.js";
@@ -470,7 +470,10 @@ export class RuntimeHttpServer {
     server.timeout(req, 1800);
     // Skip request logging for health-check probes to reduce log noise.
     const url = new URL(req.url);
-    if (url.pathname === "/healthz" && req.method === "GET") {
+    if (
+      (url.pathname === "/healthz" || url.pathname === "/readyz") &&
+      req.method === "GET"
+    ) {
       return this.routeRequest(req, server);
     }
     return withRequestLogging(req, () => this.routeRequest(req, server));
@@ -485,6 +488,10 @@ export class RuntimeHttpServer {
 
     if (path === "/healthz" && req.method === "GET") {
       return handleHealth();
+    }
+
+    if (path === "/readyz" && req.method === "GET") {
+      return handleReadyz();
     }
 
     // WebSocket upgrade for the Chrome extension browser relay.

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -151,6 +151,10 @@ export function handleHealth(): Response {
   });
 }
 
+export function handleReadyz(): Response {
+  return Response.json({ status: "ok" });
+}
+
 export function handleGetIdentity(): Response {
   const identityPath = getWorkspacePromptPath("IDENTITY.md");
   if (!existsSync(identityPath)) {

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -136,6 +136,10 @@ function getPackageVersion(): string | undefined {
 }
 
 export function handleHealth(): Response {
+  return Response.json({ status: "ok" });
+}
+
+export function handleDetailedHealth(): Response {
   return Response.json({
     status: "healthy",
     timestamp: new Date().toISOString(),
@@ -240,7 +244,7 @@ export function identityRouteDefinitions(): RouteDefinition[] {
     {
       endpoint: "health",
       method: "GET",
-      handler: () => handleHealth(),
+      handler: () => handleDetailedHealth(),
     },
     {
       endpoint: "identity",

--- a/credential-executor/src/__tests__/managed-integration.test.ts
+++ b/credential-executor/src/__tests__/managed-integration.test.ts
@@ -351,13 +351,13 @@ describe("managed CES integration (real Unix socket)", () => {
         const url = new URL(req.url);
         if (url.pathname === "/healthz") {
           return new Response(
-            JSON.stringify({ status: "ok", version: CES_PROTOCOL_VERSION }),
+            JSON.stringify({ status: "ok" }),
             { headers: { "Content-Type": "application/json" } },
           );
         }
         if (url.pathname === "/readyz") {
           return new Response(
-            JSON.stringify({ ready: true, version: CES_PROTOCOL_VERSION }),
+            JSON.stringify({ status: "ok", rpcConnected: false }),
             { status: 200, headers: { "Content-Type": "application/json" } },
           );
         }
@@ -466,13 +466,11 @@ describe("managed CES integration (real Unix socket)", () => {
     expect(healthzResp.status).toBe(200);
     const healthzBody = await healthzResp.json();
     expect(healthzBody.status).toBe("ok");
-    expect(healthzBody.version).toBe(CES_PROTOCOL_VERSION);
 
     const readyzResp = await fetch(`http://localhost:${healthPort}/readyz`);
     expect(readyzResp.status).toBe(200);
     const readyzBody = await readyzResp.json();
-    expect(readyzBody.ready).toBe(true);
-    expect(readyzBody.version).toBe(CES_PROTOCOL_VERSION);
+    expect(readyzBody.status).toBe("ok");
 
     // -- Step 5: Unknown method returns METHOD_NOT_FOUND -----------------------
     const unknownRpcId = "rpc-3";

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -342,7 +342,7 @@ function startHealthServer(
       const url = new URL(req.url);
       if (url.pathname === "/healthz") {
         return new Response(
-          JSON.stringify({ status: "ok", version: CES_PROTOCOL_VERSION }),
+          JSON.stringify({ status: "ok" }),
           { headers: { "Content-Type": "application/json" } },
         );
       }
@@ -354,7 +354,7 @@ function startHealthServer(
         // without a connection anyway, so readiness is purely about the
         // process being up and able to accept a future connection.
         return new Response(
-          JSON.stringify({ ready: true, rpcConnected, version: CES_PROTOCOL_VERSION }),
+          JSON.stringify({ status: "ok", rpcConnected }),
           {
             status: 200,
             headers: { "Content-Type": "application/json" },

--- a/gateway/src/__tests__/probes.test.ts
+++ b/gateway/src/__tests__/probes.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, afterAll } from "bun:test";
+import { describe, test, expect, afterAll, spyOn, afterEach } from "bun:test";
 
 const env: Record<string, string> = {
   TELEGRAM_BOT_TOKEN: "test-tok",
@@ -78,6 +78,34 @@ describe("/readyz", () => {
       expect(body.status).toBe("draining");
     } finally {
       draining = false;
+    }
+  });
+});
+
+describe("/readyz upstream probe", () => {
+  afterEach(() => {
+    // Restore any spies after each test
+  });
+
+  test("probes upstream /readyz (not /healthz)", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      Response.json({ status: "ok" }),
+    );
+    try {
+      // Simulate the real /readyz handler from gateway/src/index.ts:
+      // it fetches `${config.assistantRuntimeBaseUrl}/readyz` with a 3s timeout.
+      const upstream = await fetch(`${config.assistantRuntimeBaseUrl}/readyz`, {
+        signal: AbortSignal.timeout(3000),
+      });
+      expect(upstream.ok).toBe(true);
+
+      // Verify the URL probed is /readyz, not /healthz
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const calledUrl = fetchSpy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/readyz");
+      expect(calledUrl).not.toContain("/healthz");
+    } finally {
+      fetchSpy.mockRestore();
     }
   });
 });

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1056,7 +1056,7 @@ async function main() {
         // know the full stack is ready, not just the gateway process.
         try {
           const upstream = await fetch(
-            `${config.assistantRuntimeBaseUrl}/healthz`,
+            `${config.assistantRuntimeBaseUrl}/readyz`,
             { signal: AbortSignal.timeout(3000) },
           );
           if (!upstream.ok) {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1018,12 +1018,12 @@ async function main() {
         if (!includeMigrations) {
           return Response.json({ status: "ok" });
         }
-        // Fetch the daemon's /healthz to surface migration state
+        // Fetch the daemon's /v1/health to surface migration state
         // (dbVersion, lastWorkspaceMigrationId) so the CLI can capture
         // pre-upgrade migration state through the gateway.
         try {
           const upstream = await fetch(
-            `${config.assistantRuntimeBaseUrl}/healthz`,
+            `${config.assistantRuntimeBaseUrl}/v1/health`,
             { signal: AbortSignal.timeout(3000) },
           );
           if (upstream.ok) {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -9,6 +9,7 @@ import {
 import {
   validateEdgeToken,
   mintBrowserRelayToken,
+  mintServiceToken,
 } from "./auth/token-exchange.js";
 import { ConfigFileCache } from "./config-file-cache.js";
 import { ConfigFileWatcher } from "./config-file-watcher.js";
@@ -1024,7 +1025,10 @@ async function main() {
         try {
           const upstream = await fetch(
             `${config.assistantRuntimeBaseUrl}/v1/health`,
-            { signal: AbortSignal.timeout(3000) },
+            {
+              signal: AbortSignal.timeout(3000),
+              headers: { authorization: `Bearer ${mintServiceToken()}` },
+            },
           );
           if (upstream.ok) {
             const body = (await upstream.json()) as {


### PR DESCRIPTION
## Summary
- Standardize health check endpoints across daemon, gateway, CES, and outbound proxy to follow Kubernetes best practices
- Strip daemon `/healthz` to bare `{"status":"ok"}` liveness probe; rich operational data now served exclusively on authenticated `/v1/health`
- Add daemon `/readyz` readiness probe endpoint
- Gateway `/readyz` now probes daemon `/readyz` (proper readiness semantics)
- Gateway `/healthz?include=migrations` now fetches from daemon `/v1/health` instead of `/healthz`
- Normalize CES probe responses for consistency (remove `version`, use `status: "ok"` instead of `ready: true`)

## PRs merged into feature branch
- #20709: refactor: gateway fetches migration state from daemon `/v1/health` instead of `/healthz`
- #20710: feat: add daemon `/readyz` readiness probe endpoint
- #20711: refactor: normalize CES health probe response shapes
- #20713: refactor: gateway `/readyz` probes daemon `/readyz` instead of `/healthz`
- #20714: refactor: strip daemon `/healthz` to bare liveness probe

## Self-review result
PASS — both plan faithfulness and integration review passed with no gaps found.

Part of plan: health-probe-cleanup.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
