### PR TITLE
chore: fix stale comment and consolidate import in health probe code

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -145,8 +145,11 @@ import { handleGuardianRefresh } from "./routes/guardian-refresh-routes.js";
 import { hostBashRouteDefinitions } from "./routes/host-bash-routes.js";
 import { hostCuRouteDefinitions } from "./routes/host-cu-routes.js";
 import { hostFileRouteDefinitions } from "./routes/host-file-routes.js";
-import { handleHealth, handleReadyz } from "./routes/identity-routes.js";
-import { identityRouteDefinitions } from "./routes/identity-routes.js";
+import {
+  handleHealth,
+  handleReadyz,
+  identityRouteDefinitions,
+} from "./routes/identity-routes.js";
 import { slackChannelRouteDefinitions } from "./routes/integrations/slack/channel.js";
 import { slackShareRouteDefinitions } from "./routes/integrations/slack/share.js";
 import { telegramRouteDefinitions } from "./routes/integrations/telegram.js";

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -89,7 +89,7 @@ interface CpuInfo {
   maxCores: number;
 }
 
-// Track CPU usage over a rolling window so /healthz reports near-real-time
+// Track CPU usage over a rolling window so /v1/health reports near-real-time
 // utilization instead of a lifetime average (total CPU time / total uptime).
 const CPU_SAMPLE_INTERVAL_MS = 5_000;
 let _lastCpuUsage: NodeJS.CpuUsage = process.cpuUsage();


### PR DESCRIPTION
## Summary
- Fix stale comment referencing `/healthz` instead of `/v1/health` for CPU sampling
- Consolidate duplicate import from `identity-routes.js` into single statement

Follow-up to #20717
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
