### PR TITLE
fix: correct monorepo root resolution in CES source discovery

### DIFF
--- a/assistant/src/credential-execution/executable-discovery.ts
+++ b/assistant/src/credential-execution/executable-discovery.ts
@@ -127,7 +127,7 @@ export function discoverLocalCes():
   }
 
   // Fallback: check for source entry point in the monorepo
-  const monorepoRoot = join(import.meta.dir, "..", "..", "..", "..");
+  const monorepoRoot = join(import.meta.dir, "..", "..", "..");
   const sourceEntry = join(
     monorepoRoot,
     "credential-executor",


### PR DESCRIPTION
## Summary
- Fix off-by-one in monorepo root path resolution: `join(import.meta.dir, "..", "..", "..")` instead of 4 levels up
- `import.meta.dir` is `assistant/src/credential-execution/`, so 3 levels up is the monorepo root, not 4
- Without this fix, CES source-based discovery always fails because it looks for `credential-executor/src/main.ts` one directory too high

## Original prompt
fix: correct monorepo root resolution in CES source discovery - the path walked up 4 levels from import.meta.dir instead of 3, landing at the parent of the monorepo instead of the monorepo root
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
