### PR TITLE
fix: only show save button when audio data exists on disk

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineAudioAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineAudioAttachmentView.swift
@@ -97,7 +97,7 @@ struct InlineAudioAttachmentView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
 
             // Right: time display or save button
-            if isHovering {
+            if isHovering && (failure == nil || localFileURL != nil || cachedFileURL != nil) {
                 Button(action: saveAudio) {
                     if isSaving {
                         ProgressView()


### PR DESCRIPTION
Addresses feedback from PR #20570. The save button guard now checks for actual data availability (localFileURL or cachedFileURL) instead of allowing save for all failure states, preventing silent save failures on fetch_failed attachments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
