### PR TITLE
fix: treat legacy nova-3 speechModel as unset when provider is Google

### DIFF
--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -59,12 +59,20 @@ export function resolveVoiceQualityProfile(
   const voice = cfg.calls.voice;
   const configuredTts = voice.ttsProvider ?? "elevenlabs";
   const fishAudio = configuredTts === "fish-audio";
+  const isGoogle = voice.transcriptionProvider === "Google";
+  // Treat the legacy Deepgram default ("nova-3") as unset when provider is
+  // Google — upgraded workspaces may still have it persisted from prior defaults.
+  const effectiveSpeechModel =
+    voice.speechModel == null ||
+    (voice.speechModel === "nova-3" && isGoogle)
+      ? isGoogle
+        ? undefined
+        : "nova-3"
+      : voice.speechModel;
   return {
     language: voice.language,
     transcriptionProvider: voice.transcriptionProvider,
-    speechModel:
-      voice.speechModel ??
-      (voice.transcriptionProvider === "Google" ? undefined : "nova-3"),
+    speechModel: effectiveSpeechModel,
     ttsProvider: fishAudio ? "Google" : "ElevenLabs",
     voice: fishAudio ? "" : buildElevenLabsVoiceSpec(cfg.elevenlabs),
   };


### PR DESCRIPTION
Addresses feedback from PR #20571. When transcriptionProvider is Google, persisted 'nova-3' values from prior Deepgram defaults are now treated as unset so the correct Google default model is used.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
