### PR TITLE
fix: include current kind in memory edit dropdown for capability items

### DIFF
--- a/clients/ios/Views/Intelligence/MemoryItemDetailView.swift
+++ b/clients/ios/Views/Intelligence/MemoryItemDetailView.swift
@@ -153,7 +153,7 @@ struct MemoryItemDetailView: View {
         Section("Classification") {
             if isEditing {
                 Picker("Kind", selection: $editKind) {
-                    ForEach(MemoryKind.allCases) { kind in
+                    ForEach(MemoryKind.editableKinds(current: editKind)) { kind in
                         Text(kind.label).tag(kind.rawValue)
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Content.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Content.swift
@@ -131,7 +131,7 @@ extension MemoryItemDetailSheet {
                 VDropdown(
                     placeholder: "Kind",
                     selection: $editKind,
-                    options: MemoryKind.userCreatableKinds.map { ($0.label, $0.rawValue) }
+                    options: MemoryKind.editableKinds(current: editKind).map { ($0.label, $0.rawValue) }
                 )
             }
 

--- a/clients/shared/Features/Memory/MemoryKindStyle.swift
+++ b/clients/shared/Features/Memory/MemoryKindStyle.swift
@@ -18,6 +18,16 @@ public enum MemoryKind: String, CaseIterable, Identifiable, Sendable {
         allCases.filter { $0 != .capability }
     }
 
+    /// Kinds to show when editing an existing item.
+    /// Includes `userCreatableKinds` plus the item's current kind if not already present.
+    public static func editableKinds(current rawValue: String) -> [MemoryKind] {
+        var kinds = userCreatableKinds
+        if let current = MemoryKind(rawValue: rawValue), !kinds.contains(current) {
+            kinds.append(current)
+        }
+        return kinds
+    }
+
     /// Capitalised display label for the kind.
     public var label: String {
         switch self {


### PR DESCRIPTION
Addresses feedback from PR #20573. The Kind dropdown in the memory edit view now includes the item's current kind even when it's not user-creatable, preventing silent kind changes when editing capability (Skill) memory items.

## Changes
- Added `MemoryKind.editableKinds(current:)` that returns `userCreatableKinds` plus the current item's kind if not already present
- macOS: Updated `MemoryItemDetailSheet+Content.swift` to use `editableKinds(current:)` instead of `userCreatableKinds`
- iOS: Updated `MemoryItemDetailView.swift` to use `editableKinds(current:)` instead of `allCases` for consistency
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
