### PR TITLE
fix: clear timeout timers and cancel reader on Fish Audio stream timeout

### DIFF
--- a/assistant/src/calls/fish-audio-client.ts
+++ b/assistant/src/calls/fish-audio-client.ts
@@ -87,21 +87,33 @@ export async function synthesizeWithFishAudio(
   const reader = response.body.getReader();
   let isFirstChunk = true;
 
-  while (true) {
-    const timeoutMs = isFirstChunk ? FIRST_CHUNK_TIMEOUT_MS : IDLE_TIMEOUT_MS;
-    const timeout = new Promise<never>((_, reject) =>
-      setTimeout(
-        () => reject(new Error(`Fish Audio read timed out after ${timeoutMs}ms`)),
-        timeoutMs,
-      ),
-    );
-    const { done, value } = await Promise.race([reader.read(), timeout]);
-    if (done) break;
-    if (value) {
-      isFirstChunk = false;
-      chunks.push(value);
-      options?.onChunk?.(value);
+  try {
+    while (true) {
+      const timeoutMs = isFirstChunk ? FIRST_CHUNK_TIMEOUT_MS : IDLE_TIMEOUT_MS;
+      let timerId: ReturnType<typeof setTimeout>;
+      const timeout = new Promise<never>((_, reject) => {
+        timerId = setTimeout(
+          () => reject(new Error(`Fish Audio read timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      });
+      let readResult: ReadableStreamReadResult<Uint8Array>;
+      try {
+        readResult = await Promise.race([reader.read(), timeout]);
+      } finally {
+        clearTimeout(timerId!);
+      }
+      const { done, value } = readResult;
+      if (done) break;
+      if (value) {
+        isFirstChunk = false;
+        chunks.push(value);
+        options?.onChunk?.(value);
+      }
     }
+  } catch (err) {
+    await reader.cancel();
+    throw err;
   }
 
   const totalLength = chunks.reduce((sum, c) => sum + c.byteLength, 0);


### PR DESCRIPTION
Addresses feedback from PR #20574. Timeout promises in the streaming loop are now properly cleared with clearTimeout after each Promise.race, preventing unhandled promise rejections. The reader is also cancelled on timeout to clean up the underlying HTTP connection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
