### PR TITLE
fix: throw on broker unavailability in migration 016 to force retry

### DIFF
--- a/assistant/src/workspace/migrations/016-migrate-credentials-from-keychain.ts
+++ b/assistant/src/workspace/migrations/016-migrate-credentials-from-keychain.ts
@@ -105,10 +105,10 @@ export const migrateCredentialsFromKeychainMigration: WorkspaceMigration = {
     }
 
     if (!brokerAvailable) {
-      // Unlike migration 015, we return silently here. If the broker is not
-      // available, credentials may already be in the encrypted store from
-      // before migration 015 ran, or from a non-desktop environment.
-      return;
+      throw new Error(
+        "Keychain broker not available after waiting — credential migration " +
+          "will be retried on next startup",
+      );
     }
 
     const { setKey } = await import("../../security/encrypted-store.js");


### PR DESCRIPTION
Addresses feedback from PR #20578. Migration 016 now throws when the keychain broker is unavailable instead of returning early, matching migration 015's behavior. This ensures the migration retries on next startup rather than being marked complete with credentials still stranded in Keychain.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
