### PR TITLE
fix: normalize userFile slug collision check to case-insensitive

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -47,7 +47,7 @@ export function generateUserFileSlug(displayName: string): string {
     .where(like(contacts.userFile, `${escapeLike(slug)}%`))
     .all();
 
-  const taken = new Set(rows.map((r) => r.userFile));
+  const taken = new Set(rows.map((r) => r.userFile?.toLowerCase()));
 
   const base = `${slug}.md`;
   if (!taken.has(base)) return base;


### PR DESCRIPTION
Addresses feedback from PR #20601. The slug collision check in generateUserFileSlug now uses case-insensitive comparison by lowercasing values in the `taken` set, preventing duplicate filenames on case-insensitive filesystems like macOS APFS.

Closes #20601 (review comment)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
