### PR TITLE
fix: include local-source in CES discovery test expected modes

### DIFF
--- a/assistant/src/__tests__/credential-execution-client.test.ts
+++ b/assistant/src/__tests__/credential-execution-client.test.ts
@@ -84,6 +84,9 @@ describe("local CES discovery", () => {
     if (result.mode === "unavailable") {
       expect(result.reason).toContain("CES executable not found");
       expect(result.mode).toBe("unavailable");
+    } else if (result.mode === "local-source") {
+      // Source entry point exists in the monorepo — verify the success shape.
+      expect(result.sourcePath).toBeTruthy();
     } else {
       // Binary exists in this environment — verify the success shape.
       expect(result.mode).toBe("local");
@@ -95,9 +98,9 @@ describe("local CES discovery", () => {
 
   test("never returns a fallback or in-process mode", () => {
     const result = discoverLocalCes();
-    // The result must be either "local" (with a valid path) or "unavailable".
+    // The result must be "local", "local-source", or "unavailable".
     // There must never be a fallback mode like "in-process" or "degraded".
-    expect(["local", "unavailable"]).toContain(result.mode);
+    expect(["local", "local-source", "unavailable"]).toContain(result.mode);
   });
 });
 


### PR DESCRIPTION
Addresses remaining feedback from PR #20579. The path traversal fix was shipped in #20719, but the test at credential-execution-client.test.ts still excluded 'local-source' from expected discovery modes. Updates both test assertions to accept 'local-source' as a valid result.