### PR TITLE
fix: add path traversal guard and try/catch to persona file reads

### DIFF
--- a/assistant/src/prompts/persona-resolver.ts
+++ b/assistant/src/prompts/persona-resolver.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 import {
   findContactByChannelExternalId,
@@ -31,9 +31,16 @@ export interface PersonaContext {
  */
 function readPersonaFile(filePath: string): string | null {
   if (!existsSync(filePath)) return null;
-  const raw = readFileSync(filePath, "utf-8");
-  const content = stripCommentLines(raw).trim();
-  return content.length > 0 ? content : null;
+
+  try {
+    const content = stripCommentLines(readFileSync(filePath, "utf-8")).trim();
+    if (content.length === 0) return null;
+    log.debug({ path: filePath }, "Loaded persona file");
+    return content;
+  } catch (err) {
+    log.warn({ err, path: filePath }, "Failed to read persona file");
+    return null;
+  }
 }
 
 // ── User persona ───────────────────────────────────────────────────
@@ -75,8 +82,15 @@ export function resolveUserPersona(
     }
   }
 
-  // Resolve file path
+  // Resolve file path — validate basename to prevent path traversal
   if (filename) {
+    if (basename(filename) !== filename || filename.includes("..")) {
+      log.warn(
+        { userFile: filename },
+        "Contact userFile contains path traversal; ignoring",
+      );
+      return readPersonaFile(defaultPath);
+    }
     const filePath = join(usersDir, filename);
     if (existsSync(filePath)) {
       return readPersonaFile(filePath);


### PR DESCRIPTION
Addresses feedback from PR #20602. Adds basename validation to prevent path traversal when resolving user persona files (security fix). Also wraps readFileSync in try/catch matching the readPromptFile pattern, preventing I/O errors from crashing the system prompt pipeline.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
