### PR TITLE
fix: use deterministic guardian selection in persona migration 017

### DIFF
--- a/assistant/src/workspace/migrations/017-seed-persona-dirs.ts
+++ b/assistant/src/workspace/migrations/017-seed-persona-dirs.ts
@@ -8,7 +8,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
-import { eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 
 import { generateUserFileSlug } from "../../contacts/contact-store.js";
 import { getDb } from "../../memory/db.js";
@@ -68,6 +68,7 @@ export const seedPersonaDirsMigration: WorkspaceMigration = {
         .select()
         .from(contacts)
         .where(eq(contacts.role, "guardian"))
+        .orderBy(desc(contacts.createdAt))
         .limit(1)
         .get();
 


### PR DESCRIPTION
Addresses feedback from PR #20603. The guardian contact lookup in migration 017 now uses ORDER BY created_at DESC to deterministically select the most recently created guardian, preventing stale/revoked guardian contacts from being chosen on workspaces with multiple guardian bindings.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
