### PR TITLE
fix: snapshot persona context per-run and skip resolution when overridden

### DIFF
--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -351,21 +351,28 @@ export class Conversation {
     const hasSystemPromptOverride = systemPrompt !== buildSystemPrompt();
     this.hasSystemPromptOverride = hasSystemPromptOverride;
 
+    // Snapshot persona inputs at run start so later tool turns can't pick up
+    // a different actor's context if a concurrent request mutates the fields.
+    const snapshotTrustContext = this.trustContext;
+    const snapshotChannelCapabilities = this.channelCapabilities;
+
     const resolveSystemPromptCallback = (
       _history: import("../providers/types.js").Message[],
     ): ResolvedSystemPrompt => {
-      const persona = resolvePersonaContext(
-        this.trustContext,
-        this.channelCapabilities,
-      );
       const resolved = {
         systemPrompt: hasSystemPromptOverride
           ? systemPrompt
-          : buildSystemPrompt({
-              hasNoClient: this.hasNoClient,
-              userPersona: persona.userPersona,
-              channelPersona: persona.channelPersona,
-            }),
+          : (() => {
+              const persona = resolvePersonaContext(
+                snapshotTrustContext,
+                snapshotChannelCapabilities,
+              );
+              return buildSystemPrompt({
+                hasNoClient: this.hasNoClient,
+                userPersona: persona.userPersona,
+                channelPersona: persona.channelPersona,
+              });
+            })(),
         maxTokens: configuredMaxTokens,
       };
       return resolved;


### PR DESCRIPTION
Addresses feedback from PR #20605. Persona context (trustContext, channelCapabilities) is now snapshotted once when the run starts, preventing cross-turn identity bleed from concurrent requests. Also moves resolvePersonaContext inside the else branch so DB queries and file I/O are skipped when a system prompt override is active.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
