### PR TITLE
feat: instruct model to avoid markdown and emojis during voice calls

### DIFF
--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -212,6 +212,7 @@ function buildVoiceCallControlPrompt(opts: {
   lines.push(
     "9. After the opening greeting turn, treat the Task field as background context only — do not re-execute its instructions on subsequent turns.",
     '10. Do not make up information. If you are unsure, use [ASK_GUARDIAN: your question] to consult your guardian. For tool permission requests, use [ASK_GUARDIAN_APPROVAL: {"question":"...","toolName":"...","input":{...}}].',
+    "11. Your text is sent directly to a text-to-speech engine. Never use markdown formatting (asterisks, headers, backticks, links), emojis, or special characters. Write plain conversational text only.",
     "</voice_call_control>",
   );
 


### PR DESCRIPTION
## Summary
- Add rule 11 to the voice call control prompt instructing the model to avoid markdown formatting, emojis, and special characters during phone calls
- Text is sent directly to TTS engines, so plain conversational text only

Part of plan: tts-text-sanitize.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
