### PR TITLE
feat: add sanitizeForTts utility for stripping markdown and emojis from voice text

### DIFF
--- a/assistant/src/calls/__tests__/tts-text-sanitizer.test.ts
+++ b/assistant/src/calls/__tests__/tts-text-sanitizer.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, test } from "bun:test";
+import { sanitizeForTts } from "../tts-text-sanitizer.js";
+
+describe("sanitizeForTts", () => {
+  describe("markdown links", () => {
+    test("strips markdown links, keeping link text", () => {
+      expect(sanitizeForTts("Check [this link](https://example.com)")).toBe(
+        "Check this link",
+      );
+    });
+
+    test("handles multiple links", () => {
+      expect(
+        sanitizeForTts("See [foo](http://a.com) and [bar](http://b.com)"),
+      ).toBe("See foo and bar");
+    });
+
+    test("preserves Fish Audio S2 bracket annotations", () => {
+      expect(sanitizeForTts("Hello [laughter] world")).toBe(
+        "Hello [laughter] world",
+      );
+      expect(sanitizeForTts("[breath] ok")).toBe("[breath] ok");
+    });
+  });
+
+  describe("bold and italic", () => {
+    test("strips bold (asterisks)", () => {
+      expect(sanitizeForTts("Hello **world**")).toBe("Hello world");
+    });
+
+    test("strips bold (underscores)", () => {
+      expect(sanitizeForTts("Hello __world__")).toBe("Hello world");
+    });
+
+    test("strips italic (asterisks)", () => {
+      expect(sanitizeForTts("Hello *world*")).toBe("Hello world");
+    });
+
+    test("strips italic (underscores)", () => {
+      expect(sanitizeForTts("Hello _world_")).toBe("Hello world");
+    });
+
+    test("strips bold+italic (asterisks)", () => {
+      expect(sanitizeForTts("Hello ***world***")).toBe("Hello world");
+    });
+
+    test("strips bold+italic (underscores)", () => {
+      expect(sanitizeForTts("Hello ___world___")).toBe("Hello world");
+    });
+
+    test("preserves arithmetic asterisks", () => {
+      expect(sanitizeForTts("5 * 3 = 15")).toBe("5 * 3 = 15");
+    });
+
+    test("preserves identifiers with underscores", () => {
+      expect(sanitizeForTts("The my_var variable")).toBe(
+        "The my_var variable",
+      );
+    });
+
+    test("preserves snake_case identifiers", () => {
+      expect(sanitizeForTts("use some_function_name here")).toBe(
+        "use some_function_name here",
+      );
+    });
+  });
+
+  describe("headers", () => {
+    test("strips h1", () => {
+      expect(sanitizeForTts("# Header\n\nSome text")).toBe(
+        "Header\n\nSome text",
+      );
+    });
+
+    test("strips h2", () => {
+      expect(sanitizeForTts("## Sub Header")).toBe("Sub Header");
+    });
+
+    test("strips h3 through h6", () => {
+      expect(sanitizeForTts("### H3")).toBe("H3");
+      expect(sanitizeForTts("#### H4")).toBe("H4");
+      expect(sanitizeForTts("##### H5")).toBe("H5");
+      expect(sanitizeForTts("###### H6")).toBe("H6");
+    });
+
+    test("does not strip # in middle of line", () => {
+      expect(sanitizeForTts("Issue #42")).toBe("Issue #42");
+    });
+  });
+
+  describe("code", () => {
+    test("strips code fences, keeping content", () => {
+      const input = "Here:\n```js\nconst x = 1;\n```\nDone.";
+      expect(sanitizeForTts(input)).toBe("Here:\nconst x = 1;\nDone.");
+    });
+
+    test("strips inline code backticks", () => {
+      expect(sanitizeForTts("Use `console.log` here")).toBe(
+        "Use console.log here",
+      );
+    });
+  });
+
+  describe("bullet markers", () => {
+    test("strips dash bullets", () => {
+      expect(sanitizeForTts("- First\n- Second")).toBe("First\nSecond");
+    });
+
+    test("strips asterisk bullets", () => {
+      expect(sanitizeForTts("* First\n* Second")).toBe("First\nSecond");
+    });
+
+    test("does not strip dashes mid-line", () => {
+      expect(sanitizeForTts("well-known fact")).toBe("well-known fact");
+    });
+  });
+
+  describe("emojis", () => {
+    test("strips simple emojis", () => {
+      expect(sanitizeForTts("Hello world 👋")).toBe("Hello world");
+    });
+
+    test("strips compound emojis (ZWJ sequences)", () => {
+      // Family emoji: man + ZWJ + woman + ZWJ + girl
+      expect(sanitizeForTts("Family: 👨‍👩‍👧")).toBe("Family:");
+    });
+
+    test("strips emojis with skin tone modifiers", () => {
+      expect(sanitizeForTts("Wave 👋🏽 hello")).toBe("Wave hello");
+    });
+
+    test("strips flag emojis", () => {
+      // Flags are regional indicator sequences (Extended_Pictographic)
+      expect(sanitizeForTts("Hello 🇺🇸 world")).toBe("Hello world");
+    });
+
+    test("strips emojis with variation selectors", () => {
+      // Heart with variation selector
+      expect(sanitizeForTts("Love ❤️ you")).toBe("Love you");
+    });
+
+    test("preserves numbers and currency", () => {
+      expect(sanitizeForTts("$100.50 and €200")).toBe("$100.50 and €200");
+    });
+
+    test("preserves punctuation", () => {
+      expect(sanitizeForTts("Hello, world! How are you?")).toBe(
+        "Hello, world! How are you?",
+      );
+    });
+  });
+
+  describe("whitespace collapsing", () => {
+    test("collapses multiple spaces to single space", () => {
+      expect(sanitizeForTts("Hello    world")).toBe("Hello world");
+    });
+
+    test("collapses multiple blank lines to single newline", () => {
+      expect(sanitizeForTts("Hello\n\n\n\nworld")).toBe("Hello\n\nworld");
+    });
+  });
+
+  describe("combined transformations", () => {
+    test("acceptance: Hello **world** with emoji", () => {
+      expect(sanitizeForTts("Hello **world** 👋")).toBe("Hello world");
+    });
+
+    test("acceptance: markdown link", () => {
+      expect(
+        sanitizeForTts("Check [this link](https://example.com)"),
+      ).toBe("Check this link");
+    });
+
+    test("acceptance: arithmetic preserved", () => {
+      expect(sanitizeForTts("5 * 3 = 15")).toBe("5 * 3 = 15");
+    });
+
+    test("acceptance: header with text", () => {
+      expect(sanitizeForTts("# Header\n\nSome text")).toBe(
+        "Header\n\nSome text",
+      );
+    });
+
+    test("complex mixed markdown and emojis", () => {
+      const input =
+        "# Welcome 🎉\n\nHello **world**! Check [docs](http://x.com).\n\n- Item *one*\n- Item `two`";
+      const expected =
+        "Welcome\n\nHello world! Check docs.\n\nItem one\nItem two";
+      expect(sanitizeForTts(input)).toBe(expected);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("empty string", () => {
+      expect(sanitizeForTts("")).toBe("");
+    });
+
+    test("already-clean text", () => {
+      const clean = "Hello, this is plain text.";
+      expect(sanitizeForTts(clean)).toBe(clean);
+    });
+
+    test("nested markdown (bold inside italic)", () => {
+      expect(sanitizeForTts("*Hello **world***")).toBe("Hello world");
+    });
+
+    test("partial markdown (unmatched asterisks)", () => {
+      expect(sanitizeForTts("Hello **world")).toBe("Hello **world");
+    });
+
+    test("idempotency: applying twice gives same result", () => {
+      const input = "# Hello **world** 👋\n\n- Item *one*\n- [link](http://x.com)";
+      const once = sanitizeForTts(input);
+      const twice = sanitizeForTts(once);
+      expect(twice).toBe(once);
+    });
+  });
+});

--- a/assistant/src/calls/tts-text-sanitizer.ts
+++ b/assistant/src/calls/tts-text-sanitizer.ts
@@ -1,0 +1,58 @@
+/**
+ * Sanitizes text for TTS synthesis by stripping markdown formatting and emojis.
+ *
+ * Preserves arithmetic expressions (e.g. `5 * 3`), identifiers with underscores
+ * (e.g. `my_var`), and Fish Audio S2 bracket annotations (e.g. `[laughter]`).
+ */
+export function sanitizeForTts(text: string): string {
+  let result = text;
+
+  // 1. Markdown links: [text](url) → text
+  //    Only matches the full [...](...) pattern — plain brackets like
+  //    Fish Audio S2 annotations ([laughter], [breath]) pass through.
+  result = result.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+
+  // 2. Bold+italic: ***text*** or ___text___ → text
+  result = result.replace(/\*{3}(.+?)\*{3}/g, "$1");
+  result = result.replace(/_{3}(.+?)_{3}/g, "$1");
+
+  // 3. Bold: **text** or __text__ → text
+  result = result.replace(/\*{2}(.+?)\*{2}/g, "$1");
+  result = result.replace(/_{2}(.+?)_{2}/g, "$1");
+
+  // 4. Headers: strip leading # characters at line starts
+  result = result.replace(/^#{1,6}\s+/gm, "");
+
+  // 5. Code fences: strip ```...``` fences but keep content
+  result = result.replace(/```[^\n]*\n([\s\S]*?)```\n?/g, "$1");
+
+  // 6. Inline code: strip single backticks
+  result = result.replace(/`([^`]+)`/g, "$1");
+
+  // 7. Bullet markers: strip `- ` or `* ` at line starts
+  //    Must run before italic stripping so `* item` is treated as a bullet.
+  result = result.replace(/^[-*]\s+/gm, "");
+
+  // 8. Italic: *text* or _text_ → text
+  //    Word-boundary-aware to preserve arithmetic like `5 * 3` and identifiers like `my_var`.
+  result = result.replace(/(?<!\w)\*([^*]+)\*(?!\w)/g, "$1");
+  result = result.replace(/(?<!\w)_([^_]+)_(?!\w)/g, "$1");
+
+  // 9. Emojis: strip extended pictographic characters, variation selectors,
+  //    zero-width joiners, skin tone modifiers, and regional indicator symbols (flags).
+  result = result.replace(/[\u200D\uFE00-\uFE0F]/gu, "");
+  result = result.replace(/[\u{1F3FB}-\u{1F3FF}]/gu, "");
+  result = result.replace(/\p{Extended_Pictographic}/gu, "");
+  result = result.replace(/[\u{1F1E6}-\u{1F1FF}]/gu, "");
+
+  // 10. Collapse whitespace: multiple spaces → single space,
+  //     multiple blank lines → single newline
+  result = result.replace(/ {2,}/g, " ");
+  result = result.replace(/\n{3,}/g, "\n\n");
+  // Trim trailing whitespace from each line
+  result = result.replace(/[ \t]+$/gm, "");
+  // Collapse resulting consecutive blank lines
+  result = result.replace(/\n{3,}/g, "\n\n");
+
+  return result.trim();
+}


### PR DESCRIPTION
## Summary
- Add `sanitizeForTts()` utility that strips markdown formatting (bold, italic, headers, links, code, bullets) and emojis from text before TTS synthesis
- Preserves arithmetic expressions, identifiers, and Fish Audio S2 bracket annotations
- Comprehensive test suite covering all transformations and edge cases

Part of plan: tts-text-sanitize.md (PR 1 of 4)