### PR TITLE
feat: add hints and interruptSensitivity to voice config schema

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -638,6 +638,8 @@ describe("AssistantConfigSchema", () => {
         language: "en-US",
         transcriptionProvider: "Deepgram",
         ttsProvider: "elevenlabs",
+        hints: [],
+        interruptSensitivity: "low",
       },
       callerIdentity: {
         allowPerCallOverride: true,

--- a/assistant/src/config/schemas/calls.ts
+++ b/assistant/src/config/schemas/calls.ts
@@ -70,6 +70,23 @@ export const CallsVoiceConfigSchema = z
       })
       .default("elevenlabs")
       .describe("Text-to-speech provider for phone calls"),
+    hints: z
+      .array(
+        z.string({ error: "calls.voice.hints values must be strings" }),
+      )
+      .default([])
+      .describe(
+        "Static vocabulary hints for speech recognition — proper nouns, domain terms, and other words the STT provider should prioritize",
+      ),
+    interruptSensitivity: z
+      .enum(["low", "medium", "high"], {
+        error:
+          "calls.voice.interruptSensitivity must be one of: low, medium, high",
+      })
+      .default("low")
+      .describe(
+        "How aggressively the STT provider detects the start of caller speech — low reduces false interrupts from background noise",
+      ),
   })
   .describe("Voice and speech settings for phone calls");
 


### PR DESCRIPTION
## Summary
- Add `hints` (string array) and `interruptSensitivity` (low/medium/high enum) to `CallsVoiceConfigSchema`
- Defaults: hints=[], interruptSensitivity=low

Part of plan: stt-accuracy.md (PR 1 of 5)