### PR TITLE
fix: return silently when keychain broker unavailable in migration 016

### DIFF
--- a/assistant/src/workspace/migrations/016-migrate-credentials-from-keychain.ts
+++ b/assistant/src/workspace/migrations/016-migrate-credentials-from-keychain.ts
@@ -105,10 +105,11 @@ export const migrateCredentialsFromKeychainMigration: WorkspaceMigration = {
     }
 
     if (!brokerAvailable) {
-      throw new Error(
+      log.warn(
         "Keychain broker not available after waiting — credential migration " +
           "will be retried on next startup",
       );
+      return;
     }
 
     const { setKey } = await import("../../security/encrypted-store.js");


### PR DESCRIPTION
## Summary
- Migration 016 was throwing when the keychain broker wasn't available, but its contract (unlike migration 015) is to return silently and retry on next startup.
- Changed `throw new Error(...)` to `log.warn(...)` + `return` so the migration gracefully skips when the broker isn't reachable.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23415892160/job/68111186362