### PR TITLE
fix: resolve ReadableStream type mismatch in fish-audio-client

### DIFF
--- a/assistant/src/calls/fish-audio-client.ts
+++ b/assistant/src/calls/fish-audio-client.ts
@@ -97,13 +97,13 @@ export async function synthesizeWithFishAudio(
           timeoutMs,
         );
       });
-      let readResult: ReadableStreamReadResult<Uint8Array>;
+      let done: boolean;
+      let value: Uint8Array | undefined;
       try {
-        readResult = await Promise.race([reader.read(), timeout]);
+        ({ done, value } = await Promise.race([reader.read(), timeout]));
       } finally {
         clearTimeout(timerId!);
       }
-      const { done, value } = readResult;
       if (done) break;
       if (value) {
         isFirstChunk = false;


### PR DESCRIPTION
## Summary
- Fixed TypeScript type error where `ReadableStreamDefaultReadResult` was not assignable to `ReadableStreamReadResult` due to the `value` property being optional vs required in the done result types
- Destructured `done` and `value` directly from `reader.read()` instead of using an explicit intermediate type annotation, avoiding the type incompatibility

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23415892160/job/68111186375
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
