### PR TITLE
feat: apply TTS text sanitization in message playback TTS endpoint

### DIFF
--- a/assistant/src/runtime/routes/tts-routes.ts
+++ b/assistant/src/runtime/routes/tts-routes.ts
@@ -8,6 +8,7 @@
  */
 
 import { synthesizeWithFishAudio } from "../../calls/fish-audio-client.js";
+import { sanitizeForTts } from "../../calls/tts-text-sanitizer.js";
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getConfig } from "../../config/loader.js";
 import { getMessageContent } from "../../daemon/handlers/conversation-history.js";
@@ -49,6 +50,15 @@ export function ttsRouteDefinitions(): RouteDefinition[] {
           return httpError("BAD_REQUEST", "Message has no text content", 400);
         }
 
+        const sanitizedText = sanitizeForTts(result.text);
+        if (!sanitizedText) {
+          return httpError(
+            "BAD_REQUEST",
+            "Message has no speakable text content",
+            400,
+          );
+        }
+
         const { fishAudio } = config;
         if (!fishAudio?.referenceId) {
           return httpError(
@@ -60,7 +70,7 @@ export function ttsRouteDefinitions(): RouteDefinition[] {
 
         try {
           const audioBuffer = await synthesizeWithFishAudio(
-            result.text,
+            sanitizedText,
             fishAudio,
           );
 


### PR DESCRIPTION
## Summary
- Wire `sanitizeForTts()` into the message playback TTS endpoint (`tts-routes.ts`)
- Sanitize stored message text before passing to Fish Audio synthesis
- Return 400 if message text is empty after sanitization

Part of plan: tts-text-sanitize.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
