### PR TITLE
feat: add profanityFilter and interruptSensitivity to ConversationRelay TwiML

### DIFF
--- a/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
+++ b/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
@@ -128,6 +128,8 @@ describe("TwiML parameter propagation", () => {
     transcriptionProvider: "deepgram",
     ttsProvider: "google",
     voice: "en-US-Standard-A",
+    profanityFilter: false,
+    interruptSensitivity: "low",
   };
 
   test("includes verificationSessionId as Parameter when provided", () => {

--- a/assistant/src/__tests__/twilio-routes-twiml.test.ts
+++ b/assistant/src/__tests__/twilio-routes-twiml.test.ts
@@ -2,7 +2,8 @@
  * Unit tests for TwiML generation with voice quality profiles.
  *
  * Tests that generateTwiML correctly uses profile values for
- * ttsProvider, voice, language, and transcriptionProvider.
+ * ttsProvider, voice, language, transcriptionProvider,
+ * profanityFilter, and interruptSensitivity.
  */
 import { describe, expect, mock, test } from "bun:test";
 
@@ -26,6 +27,8 @@ describe("generateTwiML with voice quality profile", () => {
       transcriptionProvider: "Deepgram",
       ttsProvider: "Google",
       voice: "Google.en-US-Journey-O",
+      profanityFilter: false,
+      interruptSensitivity: "low",
     });
 
     expect(twiml).toContain('ttsProvider="Google"');
@@ -40,6 +43,8 @@ describe("generateTwiML with voice quality profile", () => {
       transcriptionProvider: "Deepgram",
       ttsProvider: "ElevenLabs",
       voice: "voice123-turbo_v2_5-1_0.5_0.75",
+      profanityFilter: false,
+      interruptSensitivity: "low",
     });
 
     expect(twiml).toContain('ttsProvider="ElevenLabs"');
@@ -52,6 +57,8 @@ describe("generateTwiML with voice quality profile", () => {
       transcriptionProvider: "Deepgram",
       ttsProvider: "Google",
       voice: "Google.en-US-Journey-O",
+      profanityFilter: false,
+      interruptSensitivity: "low",
     });
 
     expect(twiml).toContain('voice="Google.en-US-Journey-O"');
@@ -63,6 +70,8 @@ describe("generateTwiML with voice quality profile", () => {
       transcriptionProvider: "Deepgram",
       ttsProvider: "ElevenLabs",
       voice: "abc123-turbo_v2_5-1_0.5_0.75",
+      profanityFilter: false,
+      interruptSensitivity: "low",
     });
 
     expect(twiml).toContain('voice="abc123-turbo_v2_5-1_0.5_0.75"');
@@ -74,6 +83,8 @@ describe("generateTwiML with voice quality profile", () => {
       transcriptionProvider: "Google",
       ttsProvider: "Google",
       voice: "Google.es-MX-Standard-A",
+      profanityFilter: false,
+      interruptSensitivity: "low",
     });
 
     expect(twiml).toContain('language="es-MX"');
@@ -85,6 +96,8 @@ describe("generateTwiML with voice quality profile", () => {
       transcriptionProvider: "Google",
       ttsProvider: "Google",
       voice: "Google.en-US-Journey-O",
+      profanityFilter: false,
+      interruptSensitivity: "low",
     });
 
     expect(twiml).toContain('transcriptionProvider="Google"');
@@ -96,6 +109,8 @@ describe("generateTwiML with voice quality profile", () => {
       transcriptionProvider: "Deepgram",
       ttsProvider: "Google",
       voice: 'voice<>&"test',
+      profanityFilter: false,
+      interruptSensitivity: "low",
     });
 
     expect(twiml).toContain('voice="voice&lt;&gt;&amp;&quot;test"');
@@ -108,6 +123,8 @@ describe("generateTwiML with voice quality profile", () => {
       transcriptionProvider: "Deepgram",
       ttsProvider: "Google",
       voice: "Google.en-US-Journey-O",
+      profanityFilter: false,
+      interruptSensitivity: "low",
     });
 
     expect(twiml).toContain(`callSessionId=${callSessionId}`);
@@ -119,6 +136,8 @@ describe("generateTwiML with voice quality profile", () => {
       transcriptionProvider: "Deepgram",
       ttsProvider: "Google",
       voice: "Google.en-US-Journey-O",
+      profanityFilter: false,
+      interruptSensitivity: "low",
     });
 
     expect(twiml).toContain('interruptible="true"');
@@ -131,8 +150,70 @@ describe("generateTwiML with voice quality profile", () => {
       transcriptionProvider: "Deepgram",
       ttsProvider: "Google",
       voice: "Google.en-US-Journey-O",
+      profanityFilter: false,
+      interruptSensitivity: "low",
     });
 
     expect(twiml).not.toContain("welcomeGreeting=");
+  });
+
+  test('TwiML includes profanityFilter="false"', () => {
+    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
+      language: "en-US",
+      transcriptionProvider: "Deepgram",
+      ttsProvider: "Google",
+      voice: "Google.en-US-Journey-O",
+      profanityFilter: false,
+      interruptSensitivity: "low",
+    });
+
+    expect(twiml).toContain('profanityFilter="false"');
+  });
+
+  test('TwiML includes interruptSensitivity="low" when profile has low', () => {
+    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
+      language: "en-US",
+      transcriptionProvider: "Deepgram",
+      ttsProvider: "Google",
+      voice: "Google.en-US-Journey-O",
+      profanityFilter: false,
+      interruptSensitivity: "low",
+    });
+
+    expect(twiml).toContain('interruptSensitivity="low"');
+  });
+
+  test("custom interruptSensitivity values are reflected correctly", () => {
+    const twimlMedium = generateTwiML(
+      callSessionId,
+      relayUrl,
+      welcomeGreeting,
+      {
+        language: "en-US",
+        transcriptionProvider: "Deepgram",
+        ttsProvider: "Google",
+        voice: "Google.en-US-Journey-O",
+        profanityFilter: false,
+        interruptSensitivity: "medium",
+      },
+    );
+
+    expect(twimlMedium).toContain('interruptSensitivity="medium"');
+
+    const twimlHigh = generateTwiML(
+      callSessionId,
+      relayUrl,
+      welcomeGreeting,
+      {
+        language: "en-US",
+        transcriptionProvider: "Deepgram",
+        ttsProvider: "Google",
+        voice: "Google.en-US-Journey-O",
+        profanityFilter: false,
+        interruptSensitivity: "high",
+      },
+    );
+
+    expect(twimlHigh).toContain('interruptSensitivity="high"');
   });
 });

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -52,6 +52,8 @@ export function generateTwiML(
     speechModel?: string;
     ttsProvider: string;
     voice: string;
+    profanityFilter: boolean;
+    interruptSensitivity: string;
   },
   relayToken?: string,
   customParameters?: Record<string, string>,
@@ -96,6 +98,8 @@ ${greetingAttr}
       ttsProvider="${escapeXml(profile.ttsProvider)}"
       interruptible="true"
       dtmfDetection="true"
+      profanityFilter="${profile.profanityFilter}"
+      interruptSensitivity="${escapeXml(profile.interruptSensitivity)}"
     ${relayClose}
   </Connect>
 </Response>`;

--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -6,6 +6,8 @@ export interface VoiceQualityProfile {
   speechModel?: string;
   ttsProvider: string;
   voice: string;
+  profanityFilter: boolean;
+  interruptSensitivity: string;
 }
 
 /**
@@ -75,6 +77,8 @@ export function resolveVoiceQualityProfile(
     speechModel: effectiveSpeechModel,
     ttsProvider: fishAudio ? "Google" : "ElevenLabs",
     voice: fishAudio ? "" : buildElevenLabsVoiceSpec(cfg.elevenlabs),
+    profanityFilter: false,
+    interruptSensitivity: voice.interruptSensitivity ?? "low",
   };
 }
 


### PR DESCRIPTION
## Summary
- Extend VoiceQualityProfile with profanityFilter (hardcoded false) and interruptSensitivity (from config, default low)
- Emit both attributes in ConversationRelay TwiML output
- profanityFilter=false prevents Twilio from masking words with asterisks
- interruptSensitivity=low reduces false interrupts from background noise

Part of plan: stt-accuracy.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
