### PR TITLE
feat: pass dynamic STT hints to ConversationRelay TwiML

### DIFF
--- a/assistant/src/__tests__/twilio-routes-twiml.test.ts
+++ b/assistant/src/__tests__/twilio-routes-twiml.test.ts
@@ -216,4 +216,91 @@ describe("generateTwiML with voice quality profile", () => {
 
     expect(twimlHigh).toContain('interruptSensitivity="high"');
   });
+
+  test("hints attribute present when hints string is non-empty", () => {
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      welcomeGreeting,
+      {
+        language: "en-US",
+        transcriptionProvider: "Deepgram",
+        ttsProvider: "ElevenLabs",
+        voice: "voice123",
+        profanityFilter: false,
+        interruptSensitivity: "low",
+      },
+      undefined,
+      undefined,
+      "Alice,Bob,Vellum",
+    );
+
+    expect(twiml).toContain('hints="Alice,Bob,Vellum"');
+  });
+
+  test("hints attribute omitted when hints string is empty", () => {
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      welcomeGreeting,
+      {
+        language: "en-US",
+        transcriptionProvider: "Deepgram",
+        ttsProvider: "ElevenLabs",
+        voice: "voice123",
+        profanityFilter: false,
+        interruptSensitivity: "low",
+      },
+      undefined,
+      undefined,
+      "",
+    );
+
+    expect(twiml).not.toContain("hints=");
+  });
+
+  test("hints attribute omitted when hints parameter is undefined", () => {
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      welcomeGreeting,
+      {
+        language: "en-US",
+        transcriptionProvider: "Deepgram",
+        ttsProvider: "ElevenLabs",
+        voice: "voice123",
+        profanityFilter: false,
+        interruptSensitivity: "low",
+      },
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(twiml).not.toContain("hints=");
+  });
+
+  test("XML special characters in hints are escaped properly", () => {
+    const twiml = generateTwiML(
+      callSessionId,
+      relayUrl,
+      welcomeGreeting,
+      {
+        language: "en-US",
+        transcriptionProvider: "Deepgram",
+        ttsProvider: "ElevenLabs",
+        voice: "voice123",
+        profanityFilter: false,
+        interruptSensitivity: "low",
+      },
+      undefined,
+      undefined,
+      'O\'Brien,Smith & Jones,"Dr. Lee"',
+    );
+
+    expect(twiml).toContain(
+      'hints="O&apos;Brien,Smith &amp; Jones,&quot;Dr. Lee&quot;"',
+    );
+    expect(twiml).not.toContain("hints=\"O'Brien");
+  });
 });

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -27,6 +27,7 @@ import {
   updateCallSession,
 } from "./call-store.js";
 import type { CallStatus } from "./types.js";
+import { resolveCallHints } from "./stt-hints.js";
 import { resolveVoiceQualityProfile } from "./voice-quality.js";
 
 const log = getLogger("twilio-routes");
@@ -57,6 +58,7 @@ export function generateTwiML(
   },
   relayToken?: string,
   customParameters?: Record<string, string>,
+  hints?: string,
 ): string {
   const greetingAttr =
     welcomeGreeting && welcomeGreeting.trim().length > 0
@@ -99,7 +101,7 @@ ${greetingAttr}
       interruptible="true"
       dtmfDetection="true"
       profanityFilter="${profile.profanityFilter}"
-      interruptSensitivity="${escapeXml(profile.interruptSensitivity)}"
+      interruptSensitivity="${escapeXml(profile.interruptSensitivity)}"${hints ? `\n      hints="${escapeXml(hints)}"` : ""}
     ${relayClose}
   </Connect>
 </Response>`;
@@ -184,7 +186,13 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
 
     return buildVoiceWebhookTwiml(
       session.id,
-      session.task,
+      {
+        task: session.task,
+        toNumber: callerTo,
+        fromNumber: callerFrom,
+        inviteFriendName: null,
+        inviteGuardianName: null,
+      },
       session.verificationSessionId,
     );
   }
@@ -212,7 +220,13 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
 
   return buildVoiceWebhookTwiml(
     callSessionId,
-    session.task,
+    {
+      task: session.task,
+      toNumber: session.toNumber,
+      fromNumber: session.fromNumber,
+      inviteFriendName: session.inviteFriendName,
+      inviteGuardianName: session.inviteGuardianName,
+    },
     session.verificationSessionId,
   );
 }
@@ -229,10 +243,18 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
  */
 function buildVoiceWebhookTwiml(
   callSessionId: string,
-  task: string | null,
+  sessionContext: {
+    task: string | null;
+    toNumber: string;
+    fromNumber: string;
+    inviteFriendName: string | null;
+    inviteGuardianName: string | null;
+  } | null,
   verificationSessionId?: string | null,
 ): Response {
   const profile = resolveVoiceQualityProfile(loadConfig());
+
+  const hints = resolveCallHints(sessionContext, profile.hints);
 
   log.info(
     { callSessionId, ttsProvider: profile.ttsProvider, voice: profile.voice },
@@ -240,7 +262,7 @@ function buildVoiceWebhookTwiml(
   );
 
   const relayUrl = getTwilioRelayUrl(loadConfig());
-  const welcomeGreeting = buildWelcomeGreeting(task);
+  const welcomeGreeting = buildWelcomeGreeting(sessionContext?.task ?? null);
 
   const relayToken = mintEdgeRelayToken();
 
@@ -257,6 +279,7 @@ function buildVoiceWebhookTwiml(
     profile,
     relayToken,
     customParameters,
+    hints || undefined,
   );
 
   log.info({ callSessionId }, "Returning ConversationRelay TwiML");

--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -8,6 +8,7 @@ export interface VoiceQualityProfile {
   voice: string;
   profanityFilter: boolean;
   interruptSensitivity: string;
+  hints: string[];
 }
 
 /**
@@ -79,6 +80,7 @@ export function resolveVoiceQualityProfile(
     voice: fishAudio ? "" : buildElevenLabsVoiceSpec(cfg.elevenlabs),
     profanityFilter: false,
     interruptSensitivity: voice.interruptSensitivity ?? "low",
+    hints: voice.hints ?? [],
   };
 }
 


### PR DESCRIPTION
## Summary
- Add `hints` to VoiceQualityProfile (from config static hints)
- Pass dynamic hints (contact names, assistant/guardian names, task terms) to ConversationRelay TwiML
- Hints assembled via `resolveCallHints()` which pulls from contacts DB, identity helpers, and config
- TwiML `hints` attribute only emitted when non-empty

Part of plan: stt-accuracy.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
