### PR TITLE
fix: sort imports in stt-hints test, call-controller, and twilio-routes

### DIFF
--- a/assistant/src/__tests__/stt-hints.test.ts
+++ b/assistant/src/__tests__/stt-hints.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+
 import { buildSttHints, type SttHintsInput } from "../calls/stt-hints.js";
 
 function emptyInput(): SttHintsInput {

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -46,11 +46,11 @@ import {
 } from "./call-store.js";
 import { finalizeCall } from "./finalize-call.js";
 import { synthesizeWithFishAudio } from "./fish-audio-client.js";
-import { sanitizeForTts } from "./tts-text-sanitizer.js";
 import { sendGuardianExpiryNotices } from "./guardian-action-sweep.js";
 import { dispatchGuardianQuestion } from "./guardian-dispatch.js";
 import type { RelayConnection } from "./relay-server.js";
 import type { PromptSpeakerContext } from "./speaker-identification.js";
+import { sanitizeForTts } from "./tts-text-sanitizer.js";
 import {
   ASK_GUARDIAN_CAPTURE_REGEX,
   CALL_OPENING_ACK_MARKER,

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -26,8 +26,8 @@ import {
   releaseCallbackClaim,
   updateCallSession,
 } from "./call-store.js";
-import type { CallStatus } from "./types.js";
 import { resolveCallHints } from "./stt-hints.js";
+import type { CallStatus } from "./types.js";
 import { resolveVoiceQualityProfile } from "./voice-quality.js";
 
 const log = getLogger("twilio-routes");


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint errors in `stt-hints.test.ts` (missing blank line between import groups), `call-controller.ts` and `twilio-routes.ts` (alphabetical import ordering).

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23416145018/job/68111883453
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
