### PR TITLE
fix: remove trim from sanitizeForTts to preserve inter-word whitespace in streaming chunks

### DIFF
--- a/assistant/src/calls/__tests__/tts-text-sanitizer.test.ts
+++ b/assistant/src/calls/__tests__/tts-text-sanitizer.test.ts
@@ -118,12 +118,12 @@ describe("sanitizeForTts", () => {
 
   describe("emojis", () => {
     test("strips simple emojis", () => {
-      expect(sanitizeForTts("Hello world 👋")).toBe("Hello world");
+      expect(sanitizeForTts("Hello world 👋")).toBe("Hello world ");
     });
 
     test("strips compound emojis (ZWJ sequences)", () => {
       // Family emoji: man + ZWJ + woman + ZWJ + girl
-      expect(sanitizeForTts("Family: 👨‍👩‍👧")).toBe("Family:");
+      expect(sanitizeForTts("Family: 👨‍👩‍👧")).toBe("Family: ");
     });
 
     test("strips emojis with skin tone modifiers", () => {
@@ -163,7 +163,7 @@ describe("sanitizeForTts", () => {
 
   describe("combined transformations", () => {
     test("acceptance: Hello **world** with emoji", () => {
-      expect(sanitizeForTts("Hello **world** 👋")).toBe("Hello world");
+      expect(sanitizeForTts("Hello **world** 👋")).toBe("Hello world ");
     });
 
     test("acceptance: markdown link", () => {
@@ -186,7 +186,7 @@ describe("sanitizeForTts", () => {
       const input =
         "# Welcome 🎉\n\nHello **world**! Check [docs](http://x.com).\n\n- Item *one*\n- Item `two`";
       const expected =
-        "Welcome\n\nHello world! Check docs.\n\nItem one\nItem two";
+        "Welcome \n\nHello world! Check docs.\n\nItem one\nItem two";
       expect(sanitizeForTts(input)).toBe(expected);
     });
   });
@@ -214,6 +214,13 @@ describe("sanitizeForTts", () => {
       const once = sanitizeForTts(input);
       const twice = sanitizeForTts(once);
       expect(twice).toBe(once);
+    });
+
+    test("preserves trailing whitespace for streaming chunks", () => {
+      // Streaming chunks must keep trailing spaces so word boundaries survive
+      // concatenation: "Hello " + "world" = "Hello world", not "Helloworld"
+      expect(sanitizeForTts("Hello ")).toBe("Hello ");
+      expect(sanitizeForTts("the quick ")).toBe("the quick ");
     });
   });
 });

--- a/assistant/src/calls/tts-text-sanitizer.ts
+++ b/assistant/src/calls/tts-text-sanitizer.ts
@@ -46,13 +46,11 @@ export function sanitizeForTts(text: string): string {
   result = result.replace(/[\u{1F1E6}-\u{1F1FF}]/gu, "");
 
   // 10. Collapse whitespace: multiple spaces → single space,
-  //     multiple blank lines → single newline
+  //     multiple blank lines → single newline.
+  //     Does NOT trim trailing whitespace — callers handle trimming so that
+  //     streaming chunks preserve inter-word spaces (e.g. "Hello " + "world").
   result = result.replace(/ {2,}/g, " ");
   result = result.replace(/\n{3,}/g, "\n\n");
-  // Trim trailing whitespace from each line
-  result = result.replace(/[ \t]+$/gm, "");
-  // Collapse resulting consecutive blank lines
-  result = result.replace(/\n{3,}/g, "\n\n");
 
-  return result.trim();
+  return result;
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for tts-text-sanitize.md.

**Gap:** sanitizeForTts trim strips inter-word whitespace in streaming chunks
**What was expected:** Streaming chunks preserve trailing whitespace for word boundaries
**What was found:** .trim() at the end of sanitizeForTts strips trailing spaces, causing 'Helloworld' instead of 'Hello world' when chunks are concatenated