### PR TITLE
feat: add GET `/v1/secrets` endpoint for listing credentials

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -259,6 +259,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
 
   // Secrets
   { endpoint: "secrets", scopes: ["settings.write"] },
+  { endpoint: "secrets:GET", scopes: ["settings.read"] },
 
   // Pairing (authenticated)
   { endpoint: "pairing/register", scopes: ["settings.write"] },

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -21,6 +21,7 @@ import { credentialKey } from "../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
   getSecureKeyAsync,
+  listSecureKeysAsync,
   setSecureKeyAsync,
 } from "../../security/secure-keys.js";
 import {
@@ -418,6 +419,16 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
   }
 }
 
+export async function handleListSecrets(): Promise<Response> {
+  try {
+    const accounts = await listSecureKeysAsync();
+    return Response.json({ accounts });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return httpError("INTERNAL_ERROR", message, 500);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
@@ -440,6 +451,11 @@ export function secretRouteDefinitions(
       endpoint: "secrets",
       method: "DELETE",
       handler: async ({ req }) => handleDeleteSecret(req),
+    },
+    {
+      endpoint: "secrets",
+      method: "GET",
+      handler: async () => handleListSecrets(),
     },
   ];
 }


### PR DESCRIPTION
## Summary
- Add handleListSecrets handler that calls listSecureKeysAsync() and returns account names
- Register GET /v1/secrets route in secretRouteDefinitions()
- Add settings.read scope policy for the GET endpoint

Part of plan: cli-creds-via-daemon.md (PR 1 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
