### PR TITLE
fix: look up inbound caller contact name for STT hints

### DIFF
--- a/assistant/src/__tests__/stt-hints.test.ts
+++ b/assistant/src/__tests__/stt-hints.test.ts
@@ -9,6 +9,7 @@ function emptyInput(): SttHintsInput {
     guardianName: null,
     taskDescription: null,
     targetContactName: null,
+    callerContactName: null,
     inviteFriendName: null,
     inviteGuardianName: null,
     recentContactNames: [],
@@ -66,6 +67,12 @@ describe("buildSttHints", () => {
     const input = emptyInput();
     input.targetContactName = "Charlie";
     expect(buildSttHints(input)).toBe("Charlie");
+  });
+
+  test("caller contact name included", () => {
+    const input = emptyInput();
+    input.callerContactName = "Diana";
+    expect(buildSttHints(input)).toBe("Diana");
   });
 
   test("recent contact names included", () => {
@@ -147,6 +154,7 @@ describe("buildSttHints", () => {
       guardianName: "Sidd",
       taskDescription: "Call John at Acme",
       targetContactName: "Target",
+      callerContactName: "Caller",
       inviteFriendName: "Friend",
       inviteGuardianName: "Guardian",
       recentContactNames: ["Recent"],
@@ -160,6 +168,7 @@ describe("buildSttHints", () => {
     expect(parts).toContain("John");
     expect(parts).toContain("Acme");
     expect(parts).toContain("Target");
+    expect(parts).toContain("Caller");
     expect(parts).toContain("Friend");
     expect(parts).toContain("Guardian");
     expect(parts).toContain("Recent");

--- a/assistant/src/calls/stt-hints.ts
+++ b/assistant/src/calls/stt-hints.ts
@@ -11,6 +11,7 @@ export interface SttHintsInput {
   guardianName: string | null;
   taskDescription: string | null;
   targetContactName: string | null;
+  callerContactName: string | null;
   inviteFriendName: string | null;
   inviteGuardianName: string | null;
   recentContactNames: string[];
@@ -49,6 +50,10 @@ export function buildSttHints(input: SttHintsInput): string {
 
   if (input.targetContactName != null && input.targetContactName.trim().length > 0) {
     hints.push(input.targetContactName.trim());
+  }
+
+  if (input.callerContactName != null && input.callerContactName.trim().length > 0) {
+    hints.push(input.callerContactName.trim());
   }
 
   // Extract potential proper nouns from task description.
@@ -117,6 +122,7 @@ export function resolveCallHints(
   const guardianName = resolveGuardianName();
 
   let targetContactName: string | null = null;
+  let callerContactName: string | null = null;
   let recentContactNames: string[] = [];
 
   try {
@@ -128,6 +134,17 @@ export function resolveCallHints(
     }
   } catch (err) {
     logger.warn({ err }, "Failed to look up target contact for STT hints");
+  }
+
+  try {
+    if (session) {
+      const callerContact = findContactByAddress("phone", session.fromNumber);
+      if (callerContact) {
+        callerContactName = callerContact.displayName;
+      }
+    }
+  } catch (err) {
+    logger.warn({ err }, "Failed to look up caller contact for STT hints");
   }
 
   try {
@@ -143,6 +160,7 @@ export function resolveCallHints(
     guardianName,
     taskDescription: session?.task ?? null,
     targetContactName,
+    callerContactName,
     inviteFriendName: session?.inviteFriendName ?? null,
     inviteGuardianName: session?.inviteGuardianName ?? null,
     recentContactNames,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for stt-accuracy.md.

**Gap:** Inbound calls do not look up caller contact name for hints
**What was expected:** Caller's contact name included as STT hint for inbound calls
**What was found:** Only toNumber was looked up, which is the assistant's own number for inbound calls