### PR TITLE
refactor: route OAuth CLI credential reads through daemon HTTP API

### DIFF
--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -21,9 +21,9 @@ import {
 } from "../../../oauth/provider-behaviors.js";
 import { credentialKey } from "../../../security/credential-key.js";
 import {
-  deleteSecureKeyAsync,
-  getSecureKeyAsync,
-} from "../../../security/secure-keys.js";
+  deleteSecureKeyViaDaemon,
+  getSecureKeyViaDaemon,
+} from "../../lib/daemon-credential-client.js";
 import { withValidToken } from "../../../security/token-manager.js";
 import {
   assertMetadataWritable,
@@ -539,7 +539,7 @@ Examples:
           ];
           for (const field of legacyFields) {
             const key = credentialKey(providerKey, field);
-            const result = await deleteSecureKeyAsync(key);
+            const result = await deleteSecureKeyViaDaemon("credential", key);
             if (result === "deleted") cleanedUp = true;
 
             const metaDeleted = deleteCredentialMetadata(providerKey, field);
@@ -633,7 +633,7 @@ Examples:
 
           if (dbApp) {
             if (!clientId) clientId = dbApp.clientId;
-            const storedSecret = await getSecureKeyAsync(
+            const storedSecret = await getSecureKeyViaDaemon(
               dbApp.clientSecretCredentialPath,
             );
             if (storedSecret) clientSecret = storedSecret;


### PR DESCRIPTION
## Summary
- Replace direct secure-keys.ts imports with daemon-credential-client.ts wrappers
- Client secret reads and legacy key cleanup now route through daemon HTTP API
- Falls back to direct secure-keys.ts reads when daemon is not running
- Token manager path left unchanged (documented as known gap)

Part of plan: cli-creds-via-daemon.md (PR 6 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
