### PR TITLE
refactor: route avatar and doctor CLI credential reads through daemon HTTP API

### DIFF
--- a/assistant/src/cli/commands/avatar.ts
+++ b/assistant/src/cli/commands/avatar.ts
@@ -11,7 +11,7 @@ import {
 } from "../../avatar/traits-png-sync.js";
 import { setPlatformBaseUrl } from "../../config/env.js";
 import { credentialKey } from "../../security/credential-key.js";
-import { getSecureKeyAsync } from "../../security/secure-keys.js";
+import { getSecureKeyViaDaemon } from "../lib/daemon-credential-client.js";
 import { generateAndSaveAvatar } from "../../tools/system/avatar-generator.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import { log } from "../logger.js";
@@ -74,7 +74,7 @@ Examples:
       // without the daemon's in-memory state.
       try {
         const key = credentialKey("vellum", "platform_base_url");
-        const persisted = await getSecureKeyAsync(key);
+        const persisted = await getSecureKeyViaDaemon(key);
         if (persisted) {
           setPlatformBaseUrl(persisted);
         }

--- a/assistant/src/cli/commands/doctor.ts
+++ b/assistant/src/cli/commands/doctor.ts
@@ -7,7 +7,7 @@ import { getRuntimeHttpPort } from "../../config/env.js";
 import { loadRawConfig } from "../../config/loader.js";
 import { shouldAutoStartDaemon } from "../../daemon/connection-policy.js";
 import { isHttpHealthy } from "../../daemon/daemon-control.js";
-import { getProviderKeyAsync } from "../../security/secure-keys.js";
+import { getProviderKeyViaDaemon } from "../lib/daemon-credential-client.js";
 import {
   getDbPath,
   getHooksDir,
@@ -81,7 +81,7 @@ Examples:
         typeof rawInferenceProvider === "string"
           ? rawInferenceProvider
           : "anthropic";
-      const configKey = await getProviderKeyAsync(provider);
+      const configKey = await getProviderKeyViaDaemon(provider);
 
       if (provider === "ollama") {
         pass("Provider configured (Ollama; API key optional)");


### PR DESCRIPTION
## Summary
- Replace direct secure-keys.ts imports with daemon-credential-client.ts wrappers in avatar.ts and doctor.ts
- Credential reads now route through daemon HTTP API when available
- Falls back to direct secure-keys.ts reads when daemon is not running

Part of plan: cli-creds-via-daemon.md (PR 7 of 8)