### PR TITLE
fix: correct type errors in stt-hints test makeContact helper

### DIFF
--- a/assistant/src/__tests__/stt-hints.test.ts
+++ b/assistant/src/__tests__/stt-hints.test.ts
@@ -252,13 +252,19 @@ describe("buildSttHints", () => {
 // ---------------------------------------------------------------------------
 
 function makeContact(displayName: string): ContactWithChannels {
+  const now = Date.now();
   return {
     id: `contact-${displayName.toLowerCase()}`,
     displayName,
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
-    role: "friend",
-    contactType: "person",
+    notes: null,
+    lastInteraction: null,
+    interactionCount: 0,
+    createdAt: now,
+    updatedAt: now,
+    role: "contact",
+    contactType: "human",
+    principalId: null,
+    userFile: null,
     channels: [],
   };
 }


### PR DESCRIPTION
## Summary
Fixes type errors in stt-hints.test.ts makeContact helper.

**Gap:** makeContact used wrong types for createdAt/updatedAt, role, contactType, and omitted required fields
**Fix:** Updated to use correct types matching ContactWithChannels