### PR TITLE
fix: wrap reader.cancel() in try-catch in Fish Audio stream error handler

### DIFF
--- a/assistant/src/calls/fish-audio-client.ts
+++ b/assistant/src/calls/fish-audio-client.ts
@@ -112,7 +112,7 @@ export async function synthesizeWithFishAudio(
       }
     }
   } catch (err) {
-    await reader.cancel();
+    try { await reader.cancel(); } catch { /* Ignore cancellation errors */ }
     throw err;
   }
 


### PR DESCRIPTION
Fixes error-swallowing bug identified in PR #20723 review: if `reader.cancel()` rejects in the catch block, the original error is lost. Now wraps it in try-catch to match the pattern in `web-fetch.ts:422-426`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
