### PR TITLE
fix: use original persisted kind for memory edit dropdown options

### DIFF
--- a/clients/ios/Views/Intelligence/MemoryItemDetailView.swift
+++ b/clients/ios/Views/Intelligence/MemoryItemDetailView.swift
@@ -153,7 +153,7 @@ struct MemoryItemDetailView: View {
         Section("Classification") {
             if isEditing {
                 Picker("Kind", selection: $editKind) {
-                    ForEach(MemoryKind.editableKinds(current: editKind)) { kind in
+                    ForEach(MemoryKind.editableKinds(current: liveItem.kind)) { kind in
                         Text(kind.label).tag(kind.rawValue)
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Content.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Content.swift
@@ -131,7 +131,7 @@ extension MemoryItemDetailSheet {
                 VDropdown(
                     placeholder: "Kind",
                     selection: $editKind,
-                    options: MemoryKind.editableKinds(current: editKind).map { ($0.label, $0.rawValue) }
+                    options: MemoryKind.editableKinds(current: displayItem.kind).map { ($0.label, $0.rawValue) }
                 )
             }
 


### PR DESCRIPTION
Fixes the picker state bug identified in PR #20722 review: the mutable `editKind` binding was passed to `editableKinds(current:)`, causing system-managed kinds to vanish on selection change. Now uses the persisted `liveItem.kind` (iOS) and `displayItem.kind` (macOS) instead.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
