### PR TITLE
fix: narrow path traversal guard to exact dot-dot/dot filenames

### DIFF
--- a/assistant/src/prompts/persona-resolver.ts
+++ b/assistant/src/prompts/persona-resolver.ts
@@ -84,7 +84,7 @@ export function resolveUserPersona(
 
   // Resolve file path — validate basename to prevent path traversal
   if (filename) {
-    if (basename(filename) !== filename || filename.includes("..")) {
+    if (basename(filename) !== filename || filename === ".." || filename === ".") {
       log.warn(
         { userFile: filename },
         "Contact userFile contains path traversal; ignoring",


### PR DESCRIPTION
Fixes false positive in path traversal guard identified in PR #20727 review: `includes("..")` rejects valid filenames like `notes..md`. Now checks `filename === ".." || filename === "."` instead, since `basename(filename) !== filename` already handles directory-based traversals.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
