### PR TITLE
fix: resolve lint errors in CLI credential commands

### DIFF
--- a/assistant/src/cli/commands/avatar.ts
+++ b/assistant/src/cli/commands/avatar.ts
@@ -11,9 +11,9 @@ import {
 } from "../../avatar/traits-png-sync.js";
 import { setPlatformBaseUrl } from "../../config/env.js";
 import { credentialKey } from "../../security/credential-key.js";
-import { getSecureKeyViaDaemon } from "../lib/daemon-credential-client.js";
 import { generateAndSaveAvatar } from "../../tools/system/avatar-generator.js";
 import { getWorkspaceDir } from "../../util/platform.js";
+import { getSecureKeyViaDaemon } from "../lib/daemon-credential-client.js";
 import { log } from "../logger.js";
 import { writeOutput } from "../output.js";
 

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -13,12 +13,6 @@ import {
 } from "../../oauth/oauth-store.js";
 import { credentialKey } from "../../security/credential-key.js";
 import {
-  deleteSecureKeyViaDaemon,
-  getSecureKeyViaDaemon,
-  getSecureKeyResultViaDaemon,
-  setSecureKeyViaDaemon,
-} from "../lib/daemon-credential-client.js";
-import {
   assertMetadataWritable,
   type CredentialMetadata,
   deleteCredentialMetadata,
@@ -27,6 +21,12 @@ import {
   listCredentialMetadata,
   upsertCredentialMetadata,
 } from "../../tools/credentials/metadata-store.js";
+import {
+  deleteSecureKeyViaDaemon,
+  getSecureKeyResultViaDaemon,
+  getSecureKeyViaDaemon,
+  setSecureKeyViaDaemon,
+} from "../lib/daemon-credential-client.js";
 import { log } from "../logger.js";
 import { shouldOutputJson, writeOutput } from "../output.js";
 

--- a/assistant/src/cli/commands/doctor.ts
+++ b/assistant/src/cli/commands/doctor.ts
@@ -7,7 +7,6 @@ import { getRuntimeHttpPort } from "../../config/env.js";
 import { loadRawConfig } from "../../config/loader.js";
 import { shouldAutoStartDaemon } from "../../daemon/connection-policy.js";
 import { isHttpHealthy } from "../../daemon/daemon-control.js";
-import { getProviderKeyViaDaemon } from "../lib/daemon-credential-client.js";
 import {
   getDbPath,
   getHooksDir,
@@ -16,6 +15,7 @@ import {
   getWorkspaceDir,
   getWorkspaceSkillsDir,
 } from "../../util/platform.js";
+import { getProviderKeyViaDaemon } from "../lib/daemon-credential-client.js";
 import { log } from "../logger.js";
 
 export function registerDoctorCommand(program: Command): void {

--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -20,16 +20,16 @@ import {
   resolveService,
 } from "../../../oauth/provider-behaviors.js";
 import { credentialKey } from "../../../security/credential-key.js";
-import {
-  deleteSecureKeyViaDaemon,
-  getSecureKeyViaDaemon,
-} from "../../lib/daemon-credential-client.js";
 import { withValidToken } from "../../../security/token-manager.js";
 import {
   assertMetadataWritable,
   deleteCredentialMetadata,
 } from "../../../tools/credentials/metadata-store.js";
 import { isLinux, isMacOS } from "../../../util/platform.js";
+import {
+  deleteSecureKeyViaDaemon,
+  getSecureKeyViaDaemon,
+} from "../../lib/daemon-credential-client.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 

--- a/assistant/src/cli/lib/daemon-credential-client.ts
+++ b/assistant/src/cli/lib/daemon-credential-client.ts
@@ -19,15 +19,14 @@ import {
   mintDaemonDeliveryToken,
 } from "../../runtime/auth/token-service.js";
 import type { DeleteResult } from "../../security/credential-backend.js";
+import type { SecureKeyResult } from "../../security/secure-keys.js";
 import {
   deleteSecureKeyAsync,
-  getProviderKeyAsync,
   getSecureKeyAsync,
   getSecureKeyResultAsync,
   listSecureKeysAsync,
   setSecureKeyAsync,
 } from "../../security/secure-keys.js";
-import type { SecureKeyResult } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
 
 const log = getLogger("daemon-credential-client");


### PR DESCRIPTION
## Summary
- Auto-fixed import ordering in 5 CLI files that were introduced by the recent daemon credential client refactors
- Removed unused `getProviderKeyAsync` import from `daemon-credential-client.ts`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23416454069/job/68112773408
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
