### PR TITLE
fix: read persona context at callback invocation time, not constructor

### DIFF
--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -351,11 +351,6 @@ export class Conversation {
     const hasSystemPromptOverride = systemPrompt !== buildSystemPrompt();
     this.hasSystemPromptOverride = hasSystemPromptOverride;
 
-    // Snapshot persona inputs at run start so later tool turns can't pick up
-    // a different actor's context if a concurrent request mutates the fields.
-    const snapshotTrustContext = this.trustContext;
-    const snapshotChannelCapabilities = this.channelCapabilities;
-
     const resolveSystemPromptCallback = (
       _history: import("../providers/types.js").Message[],
     ): ResolvedSystemPrompt => {
@@ -364,8 +359,8 @@ export class Conversation {
           ? systemPrompt
           : (() => {
               const persona = resolvePersonaContext(
-                snapshotTrustContext,
-                snapshotChannelCapabilities,
+                this.trustContext,
+                this.channelCapabilities,
               );
               return buildSystemPrompt({
                 hasNoClient: this.hasNoClient,


### PR DESCRIPTION
Fixes critical bug identified in PR #20729 review: `trustContext` and `channelCapabilities` were snapshotted in the constructor when both are `undefined` (they're set later by `prepareConversationForMessage`). This caused persona resolution to always use default paths. Reverts to reading the live instance fields at callback invocation time.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
