### PR TITLE
fix: exempt protocol markers from voice prompt special-character ban

### DIFF
--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -212,7 +212,7 @@ function buildVoiceCallControlPrompt(opts: {
   lines.push(
     "9. After the opening greeting turn, treat the Task field as background context only — do not re-execute its instructions on subsequent turns.",
     '10. Do not make up information. If you are unsure, use [ASK_GUARDIAN: your question] to consult your guardian. For tool permission requests, use [ASK_GUARDIAN_APPROVAL: {"question":"...","toolName":"...","input":{...}}].',
-    "11. Your text is sent directly to a text-to-speech engine. Never use markdown formatting (asterisks, headers, backticks, links), emojis, or special characters. Write plain conversational text only.",
+    "11. Your text is sent directly to a text-to-speech engine. Never use markdown formatting (asterisks, headers, backticks, links) or emojis in your spoken responses. Write plain conversational text only. Protocol markers like [ASK_GUARDIAN: ...] and [END_CALL] are not spoken text and should still be used normally.",
     "</voice_call_control>",
   );
 


### PR DESCRIPTION
Fixes conflict identified in PR #20730 review: rule 11's "Never use special characters" instruction could cause the model to suppress critical control protocol markers (`[ASK_GUARDIAN: ...]`, `[END_CALL]`). Now scopes the ban to spoken prose and explicitly exempts protocol markers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
