### PR TITLE
fix: add missing getSecureKeyResultAsync to oauth-cli test mock

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -155,6 +155,10 @@ mock.module("../oauth/oauth-store.js", () => ({
 // Stub out transitive dependencies that token-manager would normally pull in
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (account: string) => mockGetSecureKey(account),
+  getSecureKeyResultAsync: async (account: string) => ({
+    value: mockGetSecureKey(account),
+    unreachable: false,
+  }),
   setSecureKeyAsync: async () => true,
   deleteSecureKeyAsync: async (account: string) => {
     if (secureKeyStore.has(account)) {


### PR DESCRIPTION
## Summary
- Add `getSecureKeyResultAsync` to the `secure-keys.js` mock in `oauth-cli.test.ts`
- The mock was missing this export after `daemon-credential-client.ts` started importing it, causing a `SyntaxError` at module resolution time

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23416433002/job/68112712166
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
