### PR TITLE
fix: preserve surnames after abbreviations and non-ASCII letters in STT hints

### DIFF
--- a/assistant/src/__tests__/stt-hints.test.ts
+++ b/assistant/src/__tests__/stt-hints.test.ts
@@ -236,6 +236,41 @@ describe("buildSttHints", () => {
     expect(parts).toContain("Recent");
   });
 
+  test("surnames after abbreviation periods are preserved", () => {
+    const input = emptyInput();
+    input.taskDescription = "Call Dr. Smith at Acme";
+    const result = buildSttHints(input);
+    expect(result).toContain("Smith");
+    expect(result).toContain("Acme");
+    // "Dr" should also appear as a capitalized word
+    expect(result).toContain("Dr");
+  });
+
+  test("multiple abbreviation titles preserve following names", () => {
+    const input = emptyInput();
+    input.taskDescription = "Meet Mr. Johnson and Mrs. Williams at the office";
+    const result = buildSttHints(input);
+    expect(result).toContain("Johnson");
+    expect(result).toContain("Williams");
+  });
+
+  test("non-ASCII letters preserved in names", () => {
+    const input = emptyInput();
+    input.taskDescription = "Call José García and Łukasz Nowak";
+    const result = buildSttHints(input);
+    expect(result).toContain("José");
+    expect(result).toContain("García");
+    expect(result).toContain("Łukasz");
+    expect(result).toContain("Nowak");
+  });
+
+  test("accented uppercase letters detected as proper nouns", () => {
+    const input = emptyInput();
+    input.taskDescription = "Talk to Zoë about the project";
+    const result = buildSttHints(input);
+    expect(result).toContain("Zoë");
+  });
+
   test("null and empty string names are excluded", () => {
     const input = emptyInput();
     input.assistantName = "";

--- a/assistant/src/calls/stt-hints.ts
+++ b/assistant/src/calls/stt-hints.ts
@@ -60,13 +60,19 @@ export function buildSttHints(input: SttHintsInput): string {
   // Split on sentence boundaries, then for each sentence take words
   // after the first that start with an uppercase letter.
   if (input.taskDescription != null && input.taskDescription.trim().length > 0) {
-    const sentences = input.taskDescription.split(/[.!?]\s+/);
+    // Split on sentence-ending punctuation followed by whitespace, but avoid
+    // splitting on periods after common abbreviations (Dr., Mr., etc.) so that
+    // names like "Dr. Smith" aren't fragmented and dropped by the first-word skip.
+    const sentences = input.taskDescription.split(
+      /(?<!\b(?:Mr|Mrs|Ms|Dr|Jr|Sr|St|Rev|Prof|Gen|Sgt|Lt|Col))[.]\s+|[!?]\s+/,
+    );
     for (const sentence of sentences) {
       const words = sentence.trim().split(/\s+/);
       // Skip the first word (always capitalized at sentence start)
       for (let i = 1; i < words.length; i++) {
-        const word = words[i].replace(/[^a-zA-Z'-]/g, "");
-        if (word.length > 0 && /^[A-Z]/.test(word)) {
+        // Use Unicode-aware \p{L} to preserve accented/non-Latin letters (José, Łukasz, etc.)
+        const word = words[i].replace(/[^\p{L}'-]/gu, "");
+        if (word.length > 0 && /^\p{Lu}/u.test(word)) {
           hints.push(word);
         }
       }


### PR DESCRIPTION
Fixes two edge cases in `buildSttHints` identified in PR #20736 review: (1) abbreviation-period splitting dropped surnames (e.g. 'Dr. Smith'), (2) ASCII-only sanitizer mangled international names. Now uses smarter boundary detection and Unicode-aware character class.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
