### PR TITLE
fix: remove unsupported profanityFilter from ConversationRelay TwiML

### DIFF
--- a/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
+++ b/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
@@ -128,7 +128,6 @@ describe("TwiML parameter propagation", () => {
     transcriptionProvider: "deepgram",
     ttsProvider: "google",
     voice: "en-US-Standard-A",
-    profanityFilter: false,
     interruptSensitivity: "low",
   };
 

--- a/assistant/src/__tests__/twilio-routes-twiml.test.ts
+++ b/assistant/src/__tests__/twilio-routes-twiml.test.ts
@@ -3,7 +3,7 @@
  *
  * Tests that generateTwiML correctly uses profile values for
  * ttsProvider, voice, language, transcriptionProvider,
- * profanityFilter, and interruptSensitivity.
+ * and interruptSensitivity.
  */
 import { describe, expect, mock, test } from "bun:test";
 
@@ -27,7 +27,6 @@ describe("generateTwiML with voice quality profile", () => {
       transcriptionProvider: "Deepgram",
       ttsProvider: "Google",
       voice: "Google.en-US-Journey-O",
-      profanityFilter: false,
       interruptSensitivity: "low",
     });
 
@@ -43,7 +42,6 @@ describe("generateTwiML with voice quality profile", () => {
       transcriptionProvider: "Deepgram",
       ttsProvider: "ElevenLabs",
       voice: "voice123-turbo_v2_5-1_0.5_0.75",
-      profanityFilter: false,
       interruptSensitivity: "low",
     });
 
@@ -57,7 +55,6 @@ describe("generateTwiML with voice quality profile", () => {
       transcriptionProvider: "Deepgram",
       ttsProvider: "Google",
       voice: "Google.en-US-Journey-O",
-      profanityFilter: false,
       interruptSensitivity: "low",
     });
 
@@ -70,7 +67,6 @@ describe("generateTwiML with voice quality profile", () => {
       transcriptionProvider: "Deepgram",
       ttsProvider: "ElevenLabs",
       voice: "abc123-turbo_v2_5-1_0.5_0.75",
-      profanityFilter: false,
       interruptSensitivity: "low",
     });
 
@@ -83,7 +79,6 @@ describe("generateTwiML with voice quality profile", () => {
       transcriptionProvider: "Google",
       ttsProvider: "Google",
       voice: "Google.es-MX-Standard-A",
-      profanityFilter: false,
       interruptSensitivity: "low",
     });
 
@@ -96,7 +91,6 @@ describe("generateTwiML with voice quality profile", () => {
       transcriptionProvider: "Google",
       ttsProvider: "Google",
       voice: "Google.en-US-Journey-O",
-      profanityFilter: false,
       interruptSensitivity: "low",
     });
 
@@ -109,7 +103,6 @@ describe("generateTwiML with voice quality profile", () => {
       transcriptionProvider: "Deepgram",
       ttsProvider: "Google",
       voice: 'voice<>&"test',
-      profanityFilter: false,
       interruptSensitivity: "low",
     });
 
@@ -123,7 +116,6 @@ describe("generateTwiML with voice quality profile", () => {
       transcriptionProvider: "Deepgram",
       ttsProvider: "Google",
       voice: "Google.en-US-Journey-O",
-      profanityFilter: false,
       interruptSensitivity: "low",
     });
 
@@ -136,7 +128,6 @@ describe("generateTwiML with voice quality profile", () => {
       transcriptionProvider: "Deepgram",
       ttsProvider: "Google",
       voice: "Google.en-US-Journey-O",
-      profanityFilter: false,
       interruptSensitivity: "low",
     });
 
@@ -150,24 +141,10 @@ describe("generateTwiML with voice quality profile", () => {
       transcriptionProvider: "Deepgram",
       ttsProvider: "Google",
       voice: "Google.en-US-Journey-O",
-      profanityFilter: false,
       interruptSensitivity: "low",
     });
 
     expect(twiml).not.toContain("welcomeGreeting=");
-  });
-
-  test('TwiML includes profanityFilter="false"', () => {
-    const twiml = generateTwiML(callSessionId, relayUrl, welcomeGreeting, {
-      language: "en-US",
-      transcriptionProvider: "Deepgram",
-      ttsProvider: "Google",
-      voice: "Google.en-US-Journey-O",
-      profanityFilter: false,
-      interruptSensitivity: "low",
-    });
-
-    expect(twiml).toContain('profanityFilter="false"');
   });
 
   test('TwiML includes interruptSensitivity="low" when profile has low', () => {
@@ -176,7 +153,6 @@ describe("generateTwiML with voice quality profile", () => {
       transcriptionProvider: "Deepgram",
       ttsProvider: "Google",
       voice: "Google.en-US-Journey-O",
-      profanityFilter: false,
       interruptSensitivity: "low",
     });
 
@@ -193,7 +169,6 @@ describe("generateTwiML with voice quality profile", () => {
         transcriptionProvider: "Deepgram",
         ttsProvider: "Google",
         voice: "Google.en-US-Journey-O",
-        profanityFilter: false,
         interruptSensitivity: "medium",
       },
     );
@@ -209,7 +184,6 @@ describe("generateTwiML with voice quality profile", () => {
         transcriptionProvider: "Deepgram",
         ttsProvider: "Google",
         voice: "Google.en-US-Journey-O",
-        profanityFilter: false,
         interruptSensitivity: "high",
       },
     );
@@ -227,7 +201,6 @@ describe("generateTwiML with voice quality profile", () => {
         transcriptionProvider: "Deepgram",
         ttsProvider: "ElevenLabs",
         voice: "voice123",
-        profanityFilter: false,
         interruptSensitivity: "low",
       },
       undefined,
@@ -248,7 +221,6 @@ describe("generateTwiML with voice quality profile", () => {
         transcriptionProvider: "Deepgram",
         ttsProvider: "ElevenLabs",
         voice: "voice123",
-        profanityFilter: false,
         interruptSensitivity: "low",
       },
       undefined,
@@ -269,7 +241,6 @@ describe("generateTwiML with voice quality profile", () => {
         transcriptionProvider: "Deepgram",
         ttsProvider: "ElevenLabs",
         voice: "voice123",
-        profanityFilter: false,
         interruptSensitivity: "low",
       },
       undefined,
@@ -290,7 +261,6 @@ describe("generateTwiML with voice quality profile", () => {
         transcriptionProvider: "Deepgram",
         ttsProvider: "ElevenLabs",
         voice: "voice123",
-        profanityFilter: false,
         interruptSensitivity: "low",
       },
       undefined,

--- a/assistant/src/__tests__/voice-quality.test.ts
+++ b/assistant/src/__tests__/voice-quality.test.ts
@@ -125,20 +125,6 @@ describe("resolveVoiceQualityProfile", () => {
     expect(profile.voice).toBe("voice1-turbo_v2_5-0.9_0.8_0.9");
   });
 
-  test("profanityFilter is always false", () => {
-    mockConfig = {
-      elevenlabs: { voiceId: "abc" },
-      calls: {
-        voice: {
-          language: "en-US",
-          transcriptionProvider: "Deepgram",
-        },
-      },
-    };
-    const profile = resolveVoiceQualityProfile();
-    expect(profile.profanityFilter).toBe(false);
-  });
-
   test("interruptSensitivity defaults to 'low' when not configured", () => {
     mockConfig = {
       elevenlabs: { voiceId: "abc" },

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -53,7 +53,6 @@ export function generateTwiML(
     speechModel?: string;
     ttsProvider: string;
     voice: string;
-    profanityFilter: boolean;
     interruptSensitivity: string;
   },
   relayToken?: string,
@@ -100,7 +99,6 @@ ${greetingAttr}
       ttsProvider="${escapeXml(profile.ttsProvider)}"
       interruptible="true"
       dtmfDetection="true"
-      profanityFilter="${profile.profanityFilter}"
       interruptSensitivity="${escapeXml(profile.interruptSensitivity)}"${hints ? `\n      hints="${escapeXml(hints)}"` : ""}
     ${relayClose}
   </Connect>

--- a/assistant/src/calls/voice-quality.ts
+++ b/assistant/src/calls/voice-quality.ts
@@ -6,7 +6,6 @@ export interface VoiceQualityProfile {
   speechModel?: string;
   ttsProvider: string;
   voice: string;
-  profanityFilter: boolean;
   interruptSensitivity: string;
   hints: string[];
 }
@@ -78,7 +77,6 @@ export function resolveVoiceQualityProfile(
     speechModel: effectiveSpeechModel,
     ttsProvider: fishAudio ? "Google" : "ElevenLabs",
     voice: fishAudio ? "" : buildElevenLabsVoiceSpec(cfg.elevenlabs),
-    profanityFilter: false,
     interruptSensitivity: voice.interruptSensitivity ?? "low",
     hints: voice.hints ?? [],
   };


### PR DESCRIPTION
## Summary
- Removed `profanityFilter` attribute from `<ConversationRelay>` TwiML output — it's only supported on `<Gather>`, not on `<ConversationRelay>` per [Twilio docs](https://www.twilio.com/docs/voice/twiml/connect/conversationrelay)
- Removed from `VoiceQualityProfile` interface, `resolveVoiceQualityProfile()`, `generateTwiML()` profile param, and all test fixtures
- `interruptSensitivity` is retained (documented as supported)

## Test plan
- [x] All test files updated to remove profanityFilter from profile objects
- [x] Dedicated profanityFilter test removed
- [x] Grep confirms zero remaining references to profanityFilter in src/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
