### PR TITLE
fix: make STT hint contact lookup direction-aware and add guardian name fallback

### DIFF
--- a/assistant/src/calls/stt-hints.ts
+++ b/assistant/src/calls/stt-hints.ts
@@ -1,4 +1,9 @@
-import { findContactByAddress, listContacts } from "../contacts/contact-store.js";
+import {
+  findContactByAddress,
+  findGuardianForChannel,
+  listContacts,
+  listGuardianChannels,
+} from "../contacts/contact-store.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import { DEFAULT_USER_REFERENCE, resolveGuardianName } from "../prompts/user-reference.js";
 import { getLogger } from "../util/logger.js";
@@ -113,38 +118,48 @@ export function resolveCallHints(
     task: string | null;
     toNumber: string;
     fromNumber: string;
+    direction: "inbound" | "outbound";
     inviteFriendName: string | null;
     inviteGuardianName: string | null;
   } | null,
   staticHints: string[],
 ): string {
   const assistantName = getAssistantName();
-  const guardianName = resolveGuardianName();
+
+  // Look up the guardian contact for a displayName fallback (mirrors relay-server pattern)
+  let guardianDisplayName: string | undefined;
+  try {
+    const voiceGuardian = findGuardianForChannel("phone");
+    const guardianChannels = voiceGuardian ? null : listGuardianChannels();
+    const guardianContact = voiceGuardian?.contact ?? guardianChannels?.contact;
+    guardianDisplayName = guardianContact?.displayName;
+  } catch (err) {
+    logger.warn({ err }, "Failed to look up guardian contact for STT hints");
+  }
+  const guardianName = resolveGuardianName(guardianDisplayName);
 
   let targetContactName: string | null = null;
   let callerContactName: string | null = null;
   let recentContactNames: string[] = [];
 
+  // For inbound calls, fromNumber is the caller (the interesting party);
+  // toNumber is the assistant's own Twilio number (not useful for contact lookup).
+  // For outbound calls, toNumber is who we're calling.
   try {
     if (session) {
-      const targetContact = findContactByAddress("phone", session.toNumber);
-      if (targetContact) {
-        targetContactName = targetContact.displayName;
+      const otherPartyNumber =
+        session.direction === "inbound" ? session.fromNumber : session.toNumber;
+      const otherPartyContact = findContactByAddress("phone", otherPartyNumber);
+      if (otherPartyContact) {
+        if (session.direction === "inbound") {
+          callerContactName = otherPartyContact.displayName;
+        } else {
+          targetContactName = otherPartyContact.displayName;
+        }
       }
     }
   } catch (err) {
-    logger.warn({ err }, "Failed to look up target contact for STT hints");
-  }
-
-  try {
-    if (session) {
-      const callerContact = findContactByAddress("phone", session.fromNumber);
-      if (callerContact) {
-        callerContactName = callerContact.displayName;
-      }
-    }
-  } catch (err) {
-    logger.warn({ err }, "Failed to look up caller contact for STT hints");
+    logger.warn({ err }, "Failed to look up contact for STT hints");
   }
 
   try {

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -190,6 +190,7 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
         task: session.task,
         toNumber: callerTo,
         fromNumber: callerFrom,
+        direction: "inbound",
         inviteFriendName: null,
         inviteGuardianName: null,
       },
@@ -224,6 +225,7 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
       task: session.task,
       toNumber: session.toNumber,
       fromNumber: session.fromNumber,
+      direction: "outbound",
       inviteFriendName: session.inviteFriendName,
       inviteGuardianName: session.inviteGuardianName,
     },
@@ -247,6 +249,7 @@ function buildVoiceWebhookTwiml(
     task: string | null;
     toNumber: string;
     fromNumber: string;
+    direction: "inbound" | "outbound";
     inviteFriendName: string | null;
     inviteGuardianName: string | null;
   } | null,


### PR DESCRIPTION
Fixes three issues in `resolveCallHints` identified in PR #20739 review: (1) contact lookup used `toNumber` for all calls, missing the caller on inbound calls, (2) `resolveGuardianName()` called without fallback display name, (3) `fromNumber` was declared but unused.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
