### PR TITLE
fix: pass correct key format in oauth disconnect daemon client calls

### DIFF
--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -19,7 +19,6 @@ import {
   getProviderBehavior,
   resolveService,
 } from "../../../oauth/provider-behaviors.js";
-import { credentialKey } from "../../../security/credential-key.js";
 import { withValidToken } from "../../../security/token-manager.js";
 import {
   assertMetadataWritable,
@@ -538,8 +537,7 @@ Examples:
             "client_secret",
           ];
           for (const field of legacyFields) {
-            const key = credentialKey(providerKey, field);
-            const result = await deleteSecureKeyViaDaemon("credential", key);
+            const result = await deleteSecureKeyViaDaemon("credential", `${providerKey}:${field}`);
             if (result === "deleted") cleanedUp = true;
 
             const metaDeleted = deleteCredentialMetadata(providerKey, field);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for cli-creds-via-daemon.md.

**Gap:** oauth/connections.ts passes pre-derived credential key where daemon expects service:field format
**What was expected:** Delete calls should use format compatible with daemon endpoint
**What was found:** Pre-derived credential/provider/field format caused 400 errors on daemon path
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
