### PR TITLE
fix: use correct credential key in daemon client fallback path

### DIFF
--- a/assistant/src/cli/lib/daemon-credential-client.ts
+++ b/assistant/src/cli/lib/daemon-credential-client.ts
@@ -92,9 +92,13 @@ async function daemonFetch(
 /**
  * Derive the canonical credential storage key from a "service:field" name.
  * Mirrors the parsing in secret-routes.ts handleAddSecret / handleDeleteSecret.
+ *
+ * Uses lastIndexOf to split on the *last* colon so compound service names
+ * (e.g. "integration:google") are preserved intact while the single-segment
+ * field name is extracted correctly.
  */
 function deriveCredentialStorageKey(name: string): string {
-  const colonIdx = name.indexOf(":");
+  const colonIdx = name.lastIndexOf(":");
   if (colonIdx < 1 || colonIdx === name.length - 1) {
     // Malformed — return raw name so the caller stores *something*.
     // The daemon would reject this with a 400, so this only fires in

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -191,7 +191,7 @@ export async function handleAddSecret(
     }
 
     if (type === "credential") {
-      const colonIdx = name.indexOf(":");
+      const colonIdx = name.lastIndexOf(":");
       if (colonIdx < 1 || colonIdx === name.length - 1) {
         return httpError(
           "BAD_REQUEST",
@@ -331,7 +331,7 @@ export async function handleReadSecret(req: Request): Promise<Response> {
     if (type === "api_key") {
       accountKey = name;
     } else if (type === "credential") {
-      const colonIdx = name.indexOf(":");
+      const colonIdx = name.lastIndexOf(":");
       if (colonIdx < 1 || colonIdx === name.length - 1) {
         return httpError(
           "BAD_REQUEST",
@@ -424,7 +424,7 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
     }
 
     if (type === "credential") {
-      const colonIdx = name.indexOf(":");
+      const colonIdx = name.lastIndexOf(":");
       if (colonIdx < 1 || colonIdx === name.length - 1) {
         return httpError(
           "BAD_REQUEST",


### PR DESCRIPTION
## Summary
- Fix daemon-credential-client fallback to reconstruct `credentialKey(service, field)` instead of passing the raw `service:field` name to `setSecureKeyAsync`/`deleteSecureKeyAsync`
- Fix compound service name parsing (e.g. `integration:google`) by splitting on the last colon in both the daemon client fallback and the daemon's secret-routes handler
- Fixes 4 failing tests in `credentials-cli.test.ts`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23416568991/job/68113106355
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
