### PR TITLE
fix: add missing direction property to STT hints test sessions

### DIFF
--- a/assistant/src/__tests__/stt-hints.test.ts
+++ b/assistant/src/__tests__/stt-hints.test.ts
@@ -323,6 +323,7 @@ describe("resolveCallHints", () => {
       task: "Call Alice at Acme",
       toNumber: "+15551234567",
       fromNumber: "+15559876543",
+      direction: "outbound" as const,
       inviteFriendName: "Dave",
       inviteGuardianName: "Eve",
     };
@@ -351,6 +352,7 @@ describe("resolveCallHints", () => {
       task: null,
       toNumber: "+15551234567",
       fromNumber: "+15559876543",
+      direction: "outbound" as const,
       inviteFriendName: null,
       inviteGuardianName: null,
     };
@@ -375,6 +377,7 @@ describe("resolveCallHints", () => {
       task: null,
       toNumber: "+15551234567",
       fromNumber: "+15559876543",
+      direction: "outbound" as const,
       inviteFriendName: null,
       inviteGuardianName: null,
     };


### PR DESCRIPTION
## Summary
- Add missing `direction: "outbound"` to three test session objects in `stt-hints.test.ts` that were not updated when the `resolveCallHints` signature gained a required `direction` parameter

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23416701824/job/68113476634
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
