### PR TITLE
fix: preserve error details in gateway API clients

### DIFF
--- a/gateway/src/telegram/api.ts
+++ b/gateway/src/telegram/api.ts
@@ -114,29 +114,43 @@ async function retryableFetch<T>(
     }
 
     if (!isRetryable(response.status) && !response.ok) {
-      const data = (await response
-        .json()
-        .catch(() => ({}))) as TelegramApiResponse<T>;
+      const body = await response.text().catch(() => "");
+      let description: string | undefined;
+      try {
+        const data = JSON.parse(body) as TelegramApiResponse<T>;
+        description = data.description;
+      } catch {
+        // Response body is not JSON — include raw text if available
+      }
       throw new Error(
-        data.description
-          ? `Telegram ${method} failed: ${data.description}`
-          : `Telegram ${method} failed with status ${response.status}`,
+        description
+          ? `Telegram ${method} failed: ${description}`
+          : body
+            ? `Telegram ${method} failed with status ${response.status}: ${body}`
+            : `Telegram ${method} failed with status ${response.status}`,
       );
     }
 
     if (isRetryable(response.status)) {
-      const data = (await response
-        .json()
-        .catch(() => ({}))) as TelegramApiResponse<T>;
+      const body = await response.text().catch(() => "");
+      let description: string | undefined;
+      let retryAfterParam: number | undefined;
+      try {
+        const data = JSON.parse(body) as TelegramApiResponse<T>;
+        description = data.description;
+        retryAfterParam = data.parameters?.retry_after;
+      } catch {
+        // Response body is not JSON
+      }
       lastRetryAfter =
         response.headers.get("retry-after") ??
-        (data.parameters?.retry_after != null
-          ? String(data.parameters.retry_after)
-          : null);
+        (retryAfterParam != null ? String(retryAfterParam) : null);
       lastError = new Error(
-        data.description
-          ? `Telegram ${method} failed: ${data.description}`
-          : `Telegram ${method} failed with status ${response.status}`,
+        description
+          ? `Telegram ${method} failed: ${description}`
+          : body
+            ? `Telegram ${method} failed with status ${response.status}: ${body}`
+            : `Telegram ${method} failed with status ${response.status}`,
       );
       log.warn(
         {
@@ -150,9 +164,17 @@ async function retryableFetch<T>(
       continue;
     }
 
-    const data = (await response
-      .json()
-      .catch(() => ({}))) as TelegramApiResponse<T>;
+    const body = await response.text().catch(() => "");
+    let data: TelegramApiResponse<T>;
+    try {
+      data = JSON.parse(body) as TelegramApiResponse<T>;
+    } catch {
+      throw new Error(
+        body
+          ? `Telegram ${method} failed: unparseable response body: ${body}`
+          : `Telegram ${method} failed with status ${response.status}: empty response`,
+      );
+    }
     if (!data.ok || data.result === undefined) {
       throw new Error(
         data.description

--- a/gateway/src/whatsapp/api.ts
+++ b/gateway/src/whatsapp/api.ts
@@ -97,12 +97,19 @@ async function retryableWhatsAppFetch<T>(
     }
 
     if (!isRetryable(response.status) && !response.ok) {
-      const data = (await response
-        .json()
-        .catch(() => ({}))) as WhatsAppApiErrorResponse;
-      const message = data.error?.message
-        ? `WhatsApp ${operation} failed: ${data.error.message}`
-        : `WhatsApp ${operation} failed with status ${response.status}`;
+      const body = await response.text().catch(() => "");
+      let errorMessage: string | undefined;
+      try {
+        const data = JSON.parse(body) as WhatsAppApiErrorResponse;
+        errorMessage = data.error?.message;
+      } catch {
+        // Response body is not JSON — include raw text if available
+      }
+      const message = errorMessage
+        ? `WhatsApp ${operation} failed: ${errorMessage}`
+        : body
+          ? `WhatsApp ${operation} failed with status ${response.status}: ${body}`
+          : `WhatsApp ${operation} failed with status ${response.status}`;
 
       // Auth/permission errors (401/403) are transient — propagate as regular
       // errors so the webhook returns 500 and Meta retries within its window.
@@ -115,13 +122,20 @@ async function retryableWhatsAppFetch<T>(
 
     if (isRetryable(response.status)) {
       lastRetryAfter = response.headers.get("retry-after");
-      const data = (await response
-        .json()
-        .catch(() => ({}))) as WhatsAppApiErrorResponse;
+      const body = await response.text().catch(() => "");
+      let errorMessage: string | undefined;
+      try {
+        const data = JSON.parse(body) as WhatsAppApiErrorResponse;
+        errorMessage = data.error?.message;
+      } catch {
+        // Response body is not JSON
+      }
       lastError = new Error(
-        data.error?.message
-          ? `WhatsApp ${operation} failed: ${data.error.message}`
-          : `WhatsApp ${operation} failed with status ${response.status}`,
+        errorMessage
+          ? `WhatsApp ${operation} failed: ${errorMessage}`
+          : body
+            ? `WhatsApp ${operation} failed with status ${response.status}: ${body}`
+            : `WhatsApp ${operation} failed with status ${response.status}`,
       );
       log.warn(
         {


### PR DESCRIPTION
## Summary
- Replace `.catch(() => ({}))` with text-first-then-parse pattern in WhatsApp and Telegram API clients
- When response body is not valid JSON (HTML error pages, timeouts), include raw body text in error messages instead of silently discarding it
- Aligns `retryableWhatsAppFetch` with the pattern already used in `retryableWhatsAppRawFetch`

## Original prompt
Fix silent error swallowing in gateway API clients (PR 1 of 3)