### PR TITLE
fix: return 400 for malformed JSON request bodies

### DIFF
--- a/assistant/src/runtime/routes/channel-readiness-routes.ts
+++ b/assistant/src/runtime/routes/channel-readiness-routes.ts
@@ -63,10 +63,15 @@ export async function handleGetChannelReadiness(url: URL): Promise<Response> {
 export async function handleRefreshChannelReadiness(
   req: Request,
 ): Promise<Response> {
-  const body = (await req.json().catch(() => ({}))) as {
-    channel?: ChannelId;
-    includeRemote?: boolean;
-  };
+  let body: { channel?: ChannelId; includeRemote?: boolean };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return Response.json(
+      { success: false, error: "Invalid JSON in request body" },
+      { status: 400 },
+    );
+  }
 
   const service = getReadinessService();
 

--- a/assistant/src/runtime/routes/integrations/twilio.ts
+++ b/assistant/src/runtime/routes/integrations/twilio.ts
@@ -91,10 +91,19 @@ export async function handleGetTwilioConfig(): Promise<Response> {
 export async function handleSetTwilioCredentials(
   req: Request,
 ): Promise<Response> {
-  const body = (await req.json().catch(() => ({}))) as {
-    accountSid?: string;
-    authToken?: string;
-  };
+  let body: { accountSid?: string; authToken?: string };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return Response.json(
+      {
+        success: false,
+        hasCredentials: await hasTwilioCredentials(),
+        error: "Invalid JSON in request body",
+      },
+      { status: 400 },
+    );
+  }
 
   if (!body.accountSid || !body.authToken) {
     return Response.json(
@@ -261,10 +270,19 @@ export async function handleProvisionTwilioNumber(
     });
   }
 
-  const body = (await req.json().catch(() => ({}))) as {
-    country?: string;
-    areaCode?: string;
-  };
+  let body: { country?: string; areaCode?: string };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return Response.json(
+      {
+        success: false,
+        hasCredentials: await hasTwilioCredentials(),
+        error: "Invalid JSON in request body",
+      },
+      { status: 400 },
+    );
+  }
   const { accountSid, authToken } = await getTwilioCredentials();
   const country = body.country ?? "US";
 
@@ -318,7 +336,19 @@ export async function handleProvisionTwilioNumber(
 export async function handleAssignTwilioNumber(
   req: Request,
 ): Promise<Response> {
-  const body = (await req.json().catch(() => ({}))) as { phoneNumber?: string };
+  let body: { phoneNumber?: string };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return Response.json(
+      {
+        success: false,
+        hasCredentials: await hasTwilioCredentials(),
+        error: "Invalid JSON in request body",
+      },
+      { status: 400 },
+    );
+  }
 
   if (!body.phoneNumber) {
     return Response.json(
@@ -375,7 +405,19 @@ export async function handleReleaseTwilioNumber(
     });
   }
 
-  const body = (await req.json().catch(() => ({}))) as { phoneNumber?: string };
+  let body: { phoneNumber?: string };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return Response.json(
+      {
+        success: false,
+        hasCredentials: await hasTwilioCredentials(),
+        error: "Invalid JSON in request body",
+      },
+      { status: 400 },
+    );
+  }
   const raw = loadRawConfig();
   const twilio = (raw?.twilio ?? {}) as Record<string, unknown>;
   const phoneNumber = body.phoneNumber || (twilio.phoneNumber as string) || "";


### PR DESCRIPTION
## Summary
- Replace `req.json().catch(() => ({}))` with explicit try/catch in Twilio and channel readiness route handlers
- Malformed JSON now returns 400 with "Invalid JSON in request body" instead of falling through to misleading field validation errors
- Affects 5 route handlers across twilio.ts and channel-readiness-routes.ts

## Original prompt
Fix request body parse error swallowing (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)