### PR TITLE
refactor: replace getFailoverProvider calls with getProvider

### DIFF
--- a/assistant/src/daemon/approval-generators.ts
+++ b/assistant/src/daemon/approval-generators.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from "../config/loader.js";
-import { getFailoverProvider, listProviders } from "../providers/registry.js";
+import { getProvider, listProviders } from "../providers/registry.js";
 import {
   APPROVAL_COPY_MAX_TOKENS,
   APPROVAL_COPY_SYSTEM_PROMPT,
@@ -91,10 +91,7 @@ export function createApprovalCopyGenerator(): ApprovalCopyGenerator {
     const config = loadConfig();
     let provider;
     try {
-      provider = getFailoverProvider(
-        config.services.inference.provider,
-        config.providerOrder,
-      );
+      provider = getProvider(config.services.inference.provider);
     } catch {
       return null;
     }
@@ -148,10 +145,7 @@ export function createApprovalConversationGenerator(): ApprovalConversationGener
     if (!listProviders().includes(config.services.inference.provider)) {
       throw new Error("No provider available for approval conversation");
     }
-    const provider = getFailoverProvider(
-      config.services.inference.provider,
-      config.providerOrder,
-    );
+    const provider = getProvider(config.services.inference.provider);
 
     const pendingDescription = context.pendingApprovals
       .map((p) => `- Request ${p.requestId}: tool "${p.toolName}"`)

--- a/assistant/src/daemon/guardian-action-generators.ts
+++ b/assistant/src/daemon/guardian-action-generators.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from "../config/loader.js";
-import { getFailoverProvider } from "../providers/registry.js";
+import { getProvider } from "../providers/registry.js";
 import {
   buildGuardianActionGenerationPrompt,
   getGuardianActionFallbackMessage,
@@ -29,10 +29,7 @@ export function createGuardianActionCopyGenerator(): GuardianActionCopyGenerator
     const config = loadConfig();
     let provider;
     try {
-      provider = getFailoverProvider(
-        config.services.inference.provider,
-        config.providerOrder,
-      );
+      provider = getProvider(config.services.inference.provider);
     } catch {
       return null;
     }
@@ -134,10 +131,7 @@ const VALID_FOLLOWUP_DISPOSITIONS: ReadonlySet<string> = new Set([
 export function createGuardianFollowUpConversationGenerator(): GuardianFollowUpConversationGenerator {
   return async (context) => {
     const config = loadConfig();
-    const provider = getFailoverProvider(
-      config.services.inference.provider,
-      config.providerOrder,
-    );
+    const provider = getProvider(config.services.inference.provider);
 
     const userPrompt = [
       `Original question from the voice call: "${context.questionText}"`,

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -41,7 +41,7 @@ import { getOrCreateConversation } from "../memory/conversation-key-store.js";
 import { buildSystemPrompt } from "../prompts/system-prompt.js";
 import { RateLimitProvider } from "../providers/ratelimit.js";
 import {
-  getFailoverProvider,
+  getProvider,
   initializeProviders,
 } from "../providers/registry.js";
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
@@ -702,9 +702,8 @@ export class DaemonServer {
 
       const createPromise = (async () => {
         const config = getConfig();
-        let provider = getFailoverProvider(
+        let provider = getProvider(
           config.services.inference.provider,
-          config.providerOrder,
         );
         const { rateLimit } = config;
         if (rateLimit.maxRequestsPerMinute > 0) {

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -18,7 +18,7 @@ import {
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { RateLimitProvider } from "../providers/ratelimit.js";
-import { getFailoverProvider } from "../providers/registry.js";
+import { getProvider } from "../providers/registry.js";
 import { getLogger } from "../util/logger.js";
 import { getSandboxWorkingDir } from "../util/platform.js";
 import {
@@ -129,10 +129,7 @@ export class SubagentManager {
 
     // ── Build conversation dependencies ─────────────────────────────
     const appConfig = getConfig();
-    let provider = getFailoverProvider(
-      appConfig.services.inference.provider,
-      appConfig.providerOrder,
-    );
+    let provider = getProvider(appConfig.services.inference.provider);
     const { rateLimit } = appConfig;
     if (rateLimit.maxRequestsPerMinute > 0) {
       provider = new RateLimitProvider(


### PR DESCRIPTION
## Summary
- Replace `getFailoverProvider(config.services.inference.provider, config.providerOrder)` with `getProvider(config.services.inference.provider)` in 4 daemon files
- Remove unnecessary `config.providerOrder` references from call sites
- Part of removing unused FailoverProvider infrastructure

Part of plan: simplify-provider-abstraction.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
