### PR TITLE
fix: add unreachable flag to credential list

### DIFF
--- a/assistant/src/__tests__/browser-fill-credential.test.ts
+++ b/assistant/src/__tests__/browser-fill-credential.test.ts
@@ -61,7 +61,7 @@ mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (...args: unknown[]) => mockGetSecureKey(...args),
   setSecureKeyAsync: async () => true,
   deleteSecureKeyAsync: async () => "deleted",
-  listSecureKeysAsync: async () => [],
+  listSecureKeysAsync: async () => ({ accounts: [], unreachable: false }),
   _resetBackend: () => {},
 }));
 

--- a/assistant/src/__tests__/ces-rpc-credential-backend.test.ts
+++ b/assistant/src/__tests__/ces-rpc-credential-backend.test.ts
@@ -185,15 +185,15 @@ describe("CesRpcCredentialBackend", () => {
       const result = await backend.list();
 
       expect(callFn).toHaveBeenCalledWith(CesRpcMethod.ListCredentials, {});
-      expect(result).toEqual(["account-a", "account-b"]);
+      expect(result).toEqual({ accounts: ["account-a", "account-b"], unreachable: false });
     });
 
-    test("returns empty array when RPC call throws", async () => {
+    test("returns unreachable when RPC call throws", async () => {
       callFn.mockRejectedValue(new Error("transport error"));
 
       const result = await backend.list();
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({ accounts: [], unreachable: true });
     });
   });
 });

--- a/assistant/src/__tests__/conversation-messaging-secret-redirect.test.ts
+++ b/assistant/src/__tests__/conversation-messaging-secret-redirect.test.ts
@@ -28,7 +28,7 @@ mock.module("../security/secure-keys.js", () => ({
   setSecureKeyAsync: async (key?: string, value?: string) =>
     setSecureKeyMock(key, value),
   deleteSecureKeyAsync: async () => "deleted" as const,
-  listSecureKeysAsync: async () => [],
+  listSecureKeysAsync: async () => ({ accounts: [], unreachable: false }),
   _resetBackend: () => {},
 }));
 

--- a/assistant/src/__tests__/credential-security-e2e.test.ts
+++ b/assistant/src/__tests__/credential-security-e2e.test.ts
@@ -66,7 +66,7 @@ mock.module("../security/secure-keys.js", () => {
     setSecureKeyAsync: async (key: string, value: string) =>
       syncSet(key, value),
     deleteSecureKeyAsync: async (key: string) => syncDelete(key),
-    listSecureKeysAsync: async () => [...storedKeys.keys()],
+    listSecureKeysAsync: async () => ({ accounts: [...storedKeys.keys()], unreachable: false }),
   };
 });
 

--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -40,9 +40,10 @@ mock.module("../security/secure-keys.js", () => ({
     }
     return "not-found";
   },
-  listSecureKeysAsync: async (): Promise<string[]> => {
-    return [...secureKeyStore.keys()];
-  },
+  listSecureKeysAsync: async () => ({
+    accounts: [...secureKeyStore.keys()],
+    unreachable: false,
+  }),
   getSecureKeyAsync: async (account: string): Promise<string | undefined> => {
     return secureKeyStore.get(account);
   },

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -167,7 +167,7 @@ mock.module("../security/secure-keys.js", () => ({
     }
     return "not-found" as const;
   },
-  listSecureKeysAsync: async () => [...secureKeyStore.keys()],
+  listSecureKeysAsync: async () => ({ accounts: [...secureKeyStore.keys()], unreachable: false }),
   _resetBackend: () => {},
 }));
 

--- a/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
+++ b/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
@@ -35,7 +35,7 @@ mock.module("../security/secure-keys.js", () => ({
     Promise.resolve(secureKeyValues.get(account)),
   setSecureKeyAsync: () => Promise.resolve(true),
   deleteSecureKeyAsync: () => Promise.resolve("deleted"),
-  listSecureKeysAsync: async () => [],
+  listSecureKeysAsync: async () => ({ accounts: [], unreachable: false }),
   _resetBackend: () => {},
 }));
 

--- a/assistant/src/__tests__/secret-onetime-send.test.ts
+++ b/assistant/src/__tests__/secret-onetime-send.test.ts
@@ -66,7 +66,7 @@ mock.module("../security/secure-keys.js", () => {
     setSecureKeyAsync: async (key: string, value: string) =>
       syncSet(key, value),
     deleteSecureKeyAsync: async (key: string) => syncDelete(key),
-    listSecureKeysAsync: async () => [],
+    listSecureKeysAsync: async () => ({ accounts: [], unreachable: false }),
   };
 });
 

--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -214,10 +214,11 @@ describe("secure-keys", () => {
       encryptedStore.setKey("enc-key-1", "val1");
       encryptedStore.setKey("enc-key-2", "val2");
 
-      const keys = await listSecureKeysAsync();
-      expect(keys).toContain("enc-key-1");
-      expect(keys).toContain("enc-key-2");
-      expect(keys.length).toBe(2);
+      const result = await listSecureKeysAsync();
+      expect(result.unreachable).toBe(false);
+      expect(result.accounts).toContain("enc-key-1");
+      expect(result.accounts).toContain("enc-key-2");
+      expect(result.accounts.length).toBe(2);
     });
 
     test("returns encrypted store keys with VELLUM_DEV=1", async () => {
@@ -227,10 +228,11 @@ describe("secure-keys", () => {
       encryptedStore.setKey("dev-key-1", "val2");
       encryptedStore.setKey("dev-key-2", "val3");
 
-      const keys = await listSecureKeysAsync();
-      expect(keys).toContain("dev-key-1");
-      expect(keys).toContain("dev-key-2");
-      expect(keys.length).toBe(2);
+      const result = await listSecureKeysAsync();
+      expect(result.unreachable).toBe(false);
+      expect(result.accounts).toContain("dev-key-1");
+      expect(result.accounts).toContain("dev-key-2");
+      expect(result.accounts.length).toBe(2);
     });
 
     test("returns encrypted store keys with VELLUM_DESKTOP_APP=1", async () => {
@@ -240,15 +242,16 @@ describe("secure-keys", () => {
       encryptedStore.setKey("desktop-key-1", "val1");
       encryptedStore.setKey("desktop-key-2", "val2");
 
-      const keys = await listSecureKeysAsync();
-      expect(keys).toContain("desktop-key-1");
-      expect(keys).toContain("desktop-key-2");
-      expect(keys.length).toBe(2);
+      const result = await listSecureKeysAsync();
+      expect(result.unreachable).toBe(false);
+      expect(result.accounts).toContain("desktop-key-1");
+      expect(result.accounts).toContain("desktop-key-2");
+      expect(result.accounts.length).toBe(2);
     });
 
-    test("returns empty array when store is empty", async () => {
-      const keys = await listSecureKeysAsync();
-      expect(keys).toEqual([]);
+    test("returns empty accounts when store is empty", async () => {
+      const result = await listSecureKeysAsync();
+      expect(result).toEqual({ accounts: [], unreachable: false });
     });
   });
 

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -486,7 +486,13 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
 
 export async function handleListSecrets(): Promise<Response> {
   try {
-    const accounts = await listSecureKeysAsync();
+    const { accounts, unreachable } = await listSecureKeysAsync();
+    if (unreachable) {
+      return Response.json(
+        { error: "Credential store is unreachable" },
+        { status: 503 },
+      );
+    }
     return Response.json({ accounts });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/security/ces-credential-client.ts
+++ b/assistant/src/security/ces-credential-client.ts
@@ -19,6 +19,7 @@ import { getLogger } from "../util/logger.js";
 import type {
   CredentialBackend,
   CredentialGetResult,
+  CredentialListResult,
   DeleteResult,
 } from "./credential-backend.js";
 
@@ -181,22 +182,22 @@ export class CesCredentialBackend implements CredentialBackend {
     }
   }
 
-  async list(): Promise<string[]> {
+  async list(): Promise<CredentialListResult> {
     try {
       const res = await cesRequest("GET", "/v1/credentials");
-      if (!res) return [];
+      if (!res) return { accounts: [], unreachable: true };
       if (!res.ok) {
         log.warn(
           { status: res.status },
           "CES credential list returned non-OK status",
         );
-        return [];
+        return { accounts: [], unreachable: true };
       }
       const data = (await res.json()) as { accounts?: string[] };
-      return data.accounts ?? [];
+      return { accounts: data.accounts ?? [], unreachable: false };
     } catch (err) {
       log.warn({ err }, "CES credential list threw unexpectedly");
-      return [];
+      return { accounts: [], unreachable: true };
     }
   }
 }

--- a/assistant/src/security/ces-rpc-credential-backend.ts
+++ b/assistant/src/security/ces-rpc-credential-backend.ts
@@ -14,6 +14,7 @@ import { getLogger } from "../util/logger.js";
 import type {
   CredentialBackend,
   CredentialGetResult,
+  CredentialListResult,
   DeleteResult,
 } from "./credential-backend.js";
 
@@ -70,16 +71,16 @@ export class CesRpcCredentialBackend implements CredentialBackend {
     }
   }
 
-  async list(): Promise<string[]> {
+  async list(): Promise<CredentialListResult> {
     try {
       const result = await this.client.call(
         CesRpcMethod.ListCredentials,
         {},
       );
-      return result.accounts;
+      return { accounts: result.accounts, unreachable: false };
     } catch (err) {
       log.warn({ err }, "CES RPC credential list failed");
-      return [];
+      return { accounts: [], unreachable: true };
     }
   }
 }

--- a/assistant/src/security/credential-backend.ts
+++ b/assistant/src/security/credential-backend.ts
@@ -19,6 +19,12 @@ export interface CredentialGetResult {
   unreachable: boolean;
 }
 
+/** Result of a list operation — distinguishes unreachable from empty. */
+export interface CredentialListResult {
+  accounts: string[];
+  unreachable: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // Interface
 // ---------------------------------------------------------------------------
@@ -40,7 +46,7 @@ export interface CredentialBackend {
   delete(account: string): Promise<DeleteResult>;
 
   /** List all account names. */
-  list(): Promise<string[]>;
+  list(): Promise<CredentialListResult>;
 }
 
 // ---------------------------------------------------------------------------
@@ -78,11 +84,11 @@ export class EncryptedStoreBackend implements CredentialBackend {
     }
   }
 
-  async list(): Promise<string[]> {
+  async list(): Promise<CredentialListResult> {
     try {
-      return encryptedStore.listKeys();
+      return { accounts: encryptedStore.listKeys(), unreachable: false };
     } catch {
-      return [];
+      return { accounts: [], unreachable: true };
     }
   }
 }

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -25,10 +25,14 @@ import type { CesClient } from "../credential-execution/client.js";
 import { getLogger } from "../util/logger.js";
 import { createCesCredentialBackend } from "./ces-credential-client.js";
 import { CesRpcCredentialBackend } from "./ces-rpc-credential-backend.js";
-import type { CredentialBackend, DeleteResult } from "./credential-backend.js";
+import type {
+  CredentialBackend,
+  CredentialListResult,
+  DeleteResult,
+} from "./credential-backend.js";
 import { createEncryptedStoreBackend } from "./credential-backend.js";
 
-export type { DeleteResult } from "./credential-backend.js";
+export type { CredentialListResult, DeleteResult } from "./credential-backend.js";
 
 /**
  * Re-export shared-package secure-key abstractions so downstream consumers
@@ -115,7 +119,7 @@ async function doResolveBackend(): Promise<CredentialBackend> {
  *
  * Queries exactly one backend — no cross-store merge.
  */
-export async function listSecureKeysAsync(): Promise<string[]> {
+export async function listSecureKeysAsync(): Promise<CredentialListResult> {
   const backend = await resolveBackendAsync();
   return backend.list();
 }

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -428,7 +428,7 @@ class CredentialStoreTool implements Tool {
         // (e.g. keychain) and the encrypted store (legacy keys).
         let secureKeySet: Set<string> | undefined;
         try {
-          secureKeySet = new Set(await listSecureKeysAsync());
+          secureKeySet = new Set((await listSecureKeysAsync()).accounts);
         } catch (err) {
           log.error(
             { err },


### PR DESCRIPTION
## Summary
- Add `CredentialListResult` type with `accounts` + `unreachable` fields to `CredentialBackend.list()`
- Update all three backend implementations (encrypted-store, CES HTTP, CES RPC) and `listSecureKeysAsync()`
- `/v1/secrets` endpoint now returns 503 when credential store is unreachable instead of misleading empty list
- Update all test mocks to use the new return type

## Original prompt
Fix credential list silent error swallowing (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
