### PR TITLE
fix: sort imports in auth guard tests

### DIFF
--- a/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
+++ b/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
@@ -16,12 +16,12 @@ import { readFileSync } from "node:fs";
 import { basename, resolve } from "node:path";
 import { describe, expect, test } from "bun:test";
 
-import { CURRENT_POLICY_EPOCH } from "../policy.js";
-import { resolveScopeProfile } from "../scopes.js";
-import type { Scope, ScopeProfile } from "../types.js";
 // Cross-package import: gateway duplicates the epoch constant and both must
 // stay in sync. Importing directly is more reliable than regex-extracting.
 import { CURRENT_POLICY_EPOCH as GATEWAY_POLICY_EPOCH } from "../../../../../gateway/src/auth/policy.js";
+import { CURRENT_POLICY_EPOCH } from "../policy.js";
+import { resolveScopeProfile } from "../scopes.js";
+import type { Scope, ScopeProfile } from "../types.js";
 
 // ---------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
## Summary
- Auto-fix import sort order in `guard-tests.test.ts` — the cross-package gateway import was in the wrong group, causing `simple-import-sort/imports` lint failure.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23417258770/job/68115059964