### PR TITLE
refactor: remove failover health from debug endpoint and providerOrder from config

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -42,7 +42,6 @@ mock.module("../config/loader.js", () => {
     ui: {},
 
     provider: "anthropic",
-    providerOrder: ["anthropic"],
     calls: {
       enabled: true,
       provider: "twilio",

--- a/assistant/src/__tests__/config-schema-cmd.test.ts
+++ b/assistant/src/__tests__/config-schema-cmd.test.ts
@@ -204,7 +204,6 @@ describe("z.toJSONSchema integration", () => {
     expect(properties).toBeDefined();
     // Check that top-level keys are present
     expect(properties.services).toBeDefined();
-    expect(properties.providerOrder).toBeDefined();
     expect(properties.maxTokens).toBeDefined();
     expect(properties.calls).toBeDefined();
     expect(properties.memory).toBeDefined();

--- a/assistant/src/__tests__/provider-commit-message-generator.test.ts
+++ b/assistant/src/__tests__/provider-commit-message-generator.test.ts
@@ -407,7 +407,6 @@ describe("ProviderCommitMessageGenerator", () => {
   // 15. Fail-open fallback provider uses fallback provider's fast-model mapping
   test("configured provider unavailable -> selected fallback provider model mapping is used", async () => {
     currentConfig.services.inference.provider = "anthropic";
-    currentConfig.providerOrder = ["openai"];
     mockSecureKeys = { openai: "sk-openai" };
     resolvedProvider = {
       provider: mockProvider,

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -87,7 +87,6 @@ mock.module("../prompts/user-reference.js", () => ({
 
 const mockConfig = {
   provider: "anthropic",
-  providerOrder: ["anthropic"],
   secretDetection: { enabled: false },
   calls: {
     enabled: true,

--- a/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
+++ b/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
@@ -54,7 +54,6 @@ mock.module("../config/loader.js", () => ({
     ui: {},
 
     provider: "anthropic",
-    providerOrder: ["anthropic"],
     calls: {
       enabled: true,
       provider: "twilio",

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -219,10 +219,7 @@ import {
   PermissionsConfigSchema,
   SecretDetectionConfigSchema,
 } from "./schemas/security.js";
-import {
-  ServicesSchema,
-  VALID_INFERENCE_PROVIDERS,
-} from "./schemas/services.js";
+import { ServicesSchema } from "./schemas/services.js";
 import { SkillsConfigSchema } from "./schemas/skills.js";
 import {
   RateLimitConfigSchema,
@@ -233,18 +230,6 @@ import { WorkspaceGitConfigSchema } from "./schemas/workspace-git.js";
 export const AssistantConfigSchema = z
   .object({
     services: ServicesSchema.default(ServicesSchema.parse({})),
-    providerOrder: z
-      .array(
-        z.enum(VALID_INFERENCE_PROVIDERS, {
-          error: `Each providerOrder entry must be one of: ${VALID_INFERENCE_PROVIDERS.join(
-            ", ",
-          )}`,
-        }),
-      )
-      .default([])
-      .describe(
-        "Fallback order of LLM providers — the assistant tries each in sequence if the previous one fails",
-      ),
     maxTokens: z
       .number({ error: "maxTokens must be a number" })
       .int("maxTokens must be an integer")

--- a/assistant/src/runtime/routes/debug-routes.ts
+++ b/assistant/src/runtime/routes/debug-routes.ts
@@ -8,7 +8,10 @@ import { getConfig } from "../../config/loader.js";
 import { countConversations } from "../../memory/conversation-queries.js";
 import { rawAll } from "../../memory/db.js";
 import { getMemoryJobCounts } from "../../memory/jobs-store.js";
-import { getProviderDebugStatus } from "../../providers/registry.js";
+import {
+  getProviderRoutingSource,
+  listProviders,
+} from "../../providers/registry.js";
 import { countSchedules } from "../../schedule/schedule-store.js";
 import { getDbPath } from "../../util/platform.js";
 import type { RouteDefinition } from "../http-router.js";
@@ -48,13 +51,11 @@ function handleDebug(): Response {
   const scheduleCounts = countSchedules();
 
   const config = getConfig();
-  const providerOrder = Array.isArray(config.providerOrder)
-    ? config.providerOrder
-    : [];
-  const providerStatus = getProviderDebugStatus(
-    config.services.inference.provider,
-    providerOrder,
-  );
+  const registeredProviders = listProviders();
+  const routingSources: Record<string, string | undefined> = {};
+  for (const name of registeredProviders) {
+    routingSources[name] = getProviderRoutingSource(name);
+  }
 
   return Response.json({
     session: {
@@ -62,7 +63,9 @@ function handleDebug(): Response {
       startedAt: new Date(startedAt).toISOString(),
     },
     provider: {
-      ...providerStatus,
+      configuredProvider: config.services.inference.provider,
+      registeredProviders,
+      routingSources,
       inferenceMode: config.services.inference.mode,
     },
     memory: {

--- a/assistant/src/workspace/provider-commit-message-generator.ts
+++ b/assistant/src/workspace/provider-commit-message-generator.ts
@@ -52,15 +52,7 @@ const KEYLESS_PROVIDERS = new Set(["ollama"]);
 const deterministicProvider = new DefaultCommitMessageProvider();
 
 function getProviderCandidates(config: ReturnType<typeof getConfig>): string[] {
-  const order = Array.isArray(config.providerOrder) ? config.providerOrder : [];
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const name of [config.services.inference.provider, ...order]) {
-    if (seen.has(name)) continue;
-    seen.add(name);
-    out.push(name);
-  }
-  return out;
+  return [config.services.inference.provider];
 }
 
 function buildDeterministicResult(

--- a/skills/vellum-self-knowledge/references/inference.md
+++ b/skills/vellum-self-knowledge/references/inference.md
@@ -47,6 +47,6 @@ assistant config get services.inference.provider
 
 ## How Inference Routing Works
 
-The assistant initializes a provider registry on startup, with a primary provider from config and fallback providers ordered by `providerOrder`. When a request is made, the primary provider is used first; if it fails, fallbacks are tried in order.
+The assistant initializes a provider registry on startup with the configured provider from config. Available providers are determined by which API keys are present. Model intents route to appropriate models within the configured provider.
 
 Model intents (`latency-optimized`, `quality-optimized`, `vision-optimized`) can select different models within the same provider, allowing the system to route to a faster or more capable model depending on the task without switching providers.


### PR DESCRIPTION
## Summary
- Simplify debug endpoint to show provider status without failover health tracking
- Remove `providerOrder` field from `AssistantConfigSchema` (always defaulted to empty array)
- Clean up any remaining `providerOrder` references in test fixtures

Part of plan: simplify-provider-abstraction.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
