### PR TITLE
refactor: remove usedFallbackPrimary from provider result type

### DIFF
--- a/assistant/src/__tests__/provider-commit-message-generator.test.ts
+++ b/assistant/src/__tests__/provider-commit-message-generator.test.ts
@@ -69,13 +69,9 @@ const mockProvider: Provider = {
 let resolvedProvider: {
   provider: Provider;
   configuredProviderName: string;
-  selectedProviderName: string;
-  usedFallbackPrimary: boolean;
 } | null = {
   provider: mockProvider,
   configuredProviderName: "anthropic",
-  selectedProviderName: "anthropic",
-  usedFallbackPrimary: false,
 };
 
 mock.module("../providers/provider-send-message.js", () => ({
@@ -130,8 +126,6 @@ describe("ProviderCommitMessageGenerator", () => {
     resolvedProvider = {
       provider: mockProvider,
       configuredProviderName: "anthropic",
-      selectedProviderName: "anthropic",
-      usedFallbackPrimary: false,
     };
   });
 
@@ -343,8 +337,6 @@ describe("ProviderCommitMessageGenerator", () => {
     resolvedProvider = {
       provider: mockProvider,
       configuredProviderName: "ollama",
-      selectedProviderName: "ollama",
-      usedFallbackPrimary: false,
     };
     const gen = getCommitMessageGenerator();
     const result = await gen.generateCommitMessage(baseContext, {
@@ -364,8 +356,6 @@ describe("ProviderCommitMessageGenerator", () => {
     resolvedProvider = {
       provider: mockProvider,
       configuredProviderName: "exotic-provider",
-      selectedProviderName: "exotic-provider",
-      usedFallbackPrimary: false,
     };
     const gen = getCommitMessageGenerator();
     const result = await gen.generateCommitMessage(baseContext, {
@@ -383,8 +373,6 @@ describe("ProviderCommitMessageGenerator", () => {
     resolvedProvider = {
       provider: mockProvider,
       configuredProviderName: "ollama",
-      selectedProviderName: "ollama",
-      usedFallbackPrimary: false,
     };
     currentConfig.workspaceGit.commitMessageLLM.providerFastModelOverrides = {
       ollama: "llama3.2:3b",
@@ -404,28 +392,4 @@ describe("ProviderCommitMessageGenerator", () => {
     expect(options.config.model).toBe("llama3.2:3b");
   });
 
-  // 15. Fail-open fallback provider uses fallback provider's fast-model mapping
-  test("configured provider unavailable -> selected fallback provider model mapping is used", async () => {
-    currentConfig.services.inference.provider = "anthropic";
-    mockSecureKeys = { openai: "sk-openai" };
-    resolvedProvider = {
-      provider: mockProvider,
-      configuredProviderName: "anthropic",
-      selectedProviderName: "openai",
-      usedFallbackPrimary: true,
-    };
-    mockSendMessage.mockResolvedValueOnce(
-      makeSuccessResponse("fix: fail-open commit"),
-    );
-
-    const gen = getCommitMessageGenerator();
-    const result = await gen.generateCommitMessage(baseContext, {
-      changedFiles: baseContext.changedFiles,
-    });
-
-    expect(result.source).toBe("llm");
-    const callArgs = mockSendMessage.mock.calls[0];
-    const options = callArgs[3] as { config: { model: string } };
-    expect(options.config.model).toBe("gpt-4o-mini");
-  });
 });

--- a/assistant/src/providers/provider-send-message.ts
+++ b/assistant/src/providers/provider-send-message.ts
@@ -21,8 +21,6 @@ import type {
 export interface ConfiguredProviderResult {
   provider: Provider;
   configuredProviderName: string;
-  selectedProviderName: string;
-  usedFallbackPrimary: boolean;
 }
 
 /**
@@ -63,8 +61,6 @@ export async function resolveConfiguredProvider(): Promise<ConfiguredProviderRes
     return {
       provider,
       configuredProviderName: inferenceProvider,
-      selectedProviderName: inferenceProvider,
-      usedFallbackPrimary: false,
     };
   } catch {
     return null;

--- a/assistant/src/workspace/provider-commit-message-generator.ts
+++ b/assistant/src/workspace/provider-commit-message-generator.ts
@@ -160,18 +160,17 @@ export class ProviderCommitMessageGenerator {
     }
 
     const provider = resolved.provider;
-    const selectedProviderName = resolved.selectedProviderName;
+    const providerName = resolved.configuredProviderName;
 
-    // Step 2b: API key preflight for the selected provider (skip keyless).
-    if (!KEYLESS_PROVIDERS.has(selectedProviderName)) {
-      const providerApiKey = await getSecureKeyAsync(selectedProviderName);
+    // Step 2b: API key preflight for the configured provider (skip keyless).
+    if (!KEYLESS_PROVIDERS.has(providerName)) {
+      const providerApiKey = await getSecureKeyAsync(providerName);
       if (!providerApiKey) {
         log.debug(
           {
-            selectedProvider: selectedProviderName,
-            configuredProvider: config.services.inference.provider,
+            provider: providerName,
           },
-          "Selected provider API key missing; falling back to deterministic",
+          "Provider API key missing; falling back to deterministic",
         );
         return buildDeterministicResult(context, "missing_provider_api_key");
       }
@@ -203,13 +202,13 @@ export class ProviderCommitMessageGenerator {
 
     // Step 5: Fast model preflight — resolve before any provider call
     const fastModel =
-      llmConfig.providerFastModelOverrides[selectedProviderName] ??
-      PROVIDER_DEFAULT_FAST_MODELS[selectedProviderName];
+      llmConfig.providerFastModelOverrides[providerName] ??
+      PROVIDER_DEFAULT_FAST_MODELS[providerName];
 
     if (!fastModel) {
       log.debug(
         {
-          provider: selectedProviderName,
+          provider: providerName,
           configuredProvider: config.services.inference.provider,
         },
         "No fast model resolvable for provider; falling back to deterministic",


### PR DESCRIPTION
## Summary
- Remove `usedFallbackPrimary` (always `false`) from `ConfiguredProviderResult`
- Remove `selectedProviderName` (always identical to `configuredProviderName`) from `ConfiguredProviderResult`
- Update `ProviderCommitMessageGenerator` to use `configuredProviderName` instead of the removed `selectedProviderName`
- Remove obsolete fail-open fallback test (test 15) that tested dead failover behavior

Part of plan: simplify-provider-abstraction.md (PR 6 of 6)