### PR TITLE
fix: clean up stale failover references in tests and comments

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -614,7 +614,7 @@ describe("session-agent-loop", () => {
   });
 
   describe("LLM request log persistence", () => {
-    test("record request log prefers the actual provider from failover", async () => {
+    test("record request log captures the actual provider name", async () => {
       const events: ServerMessage[] = [];
       const rawRequest = {
         model: "gpt-4.1",
@@ -768,7 +768,7 @@ describe("session-agent-loop", () => {
   });
 
   describe("usage accounting", () => {
-    test("records the actual provider for failover-served usage", async () => {
+    test("records the actual provider for usage accounting", async () => {
       const events: ServerMessage[] = [];
 
       const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {

--- a/assistant/src/__tests__/provider-streaming.benchmark.test.ts
+++ b/assistant/src/__tests__/provider-streaming.benchmark.test.ts
@@ -1,8 +1,8 @@
 /**
  * Provider Streaming Benchmark
  *
- * Measures overhead introduced by the provider adapter layers (retry, failover,
- * stream timeout) on top of a simulated streaming source.
+ * Measures overhead introduced by the provider adapter layers (retry, stream
+ * timeout) on top of a simulated streaming source.
  *
  * Baseline targets:
  * - TTFT overhead < 50ms beyond source latency

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -151,7 +151,7 @@ mock.module("../providers/registry.js", () => {
   mockSendMessage = mock(createMockProviderResponse(["Hello"]));
   return {
     listProviders: () => ["anthropic"],
-    getFailoverProvider: () => ({
+    getProvider: () => ({
       name: "anthropic",
       sendMessage: (...args: unknown[]) => mockSendMessage(...args),
     }),

--- a/assistant/src/workspace/provider-commit-message-generator.ts
+++ b/assistant/src/workspace/provider-commit-message-generator.ts
@@ -113,7 +113,7 @@ export class ProviderCommitMessageGenerator {
 
     // ── Fallback check order (canonical) ──────────────────────────────
     // 1. disabled
-    // 2. resolve configured provider via fail-open selection:
+    // 2. resolve configured provider:
     //    - missing_provider_api_key OR provider_not_initialized
     // 3. selected-provider API key preflight (except keyless providers)
     // 4. breaker_open
@@ -130,7 +130,7 @@ export class ProviderCommitMessageGenerator {
       return buildDeterministicResult(context, "disabled");
     }
 
-    // Step 2: Resolve configured provider using fail-open semantics.
+    // Step 2: Resolve configured provider.
     // If nothing is resolvable, differentiate likely missing-key cases from
     // true registry/init failures.
     const resolved = await resolveConfiguredProvider();


### PR DESCRIPTION
## Summary
Fixes stale references to removed failover infrastructure found during plan review:
- Rename `getFailoverProvider` → `getProvider` in relay-server test mock
- Update test descriptions referencing failover in conversation-agent-loop tests
- Remove 'failover' from benchmark test comment
- Update fail-open selection comments in provider-commit-message-generator

Part of plan: simplify-provider-abstraction.md (review fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
