### PR TITLE
fix: restore ProviderNotConfiguredError in getProvider for actionable error messages

### DIFF
--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -1,5 +1,5 @@
 import { getProviderKeyAsync } from "../security/secure-keys.js";
-import { ConfigError } from "../util/errors.js";
+import { ProviderNotConfiguredError } from "../util/errors.js";
 import { AnthropicProvider } from "./anthropic/client.js";
 import { FireworksProvider } from "./fireworks/client.js";
 import { GeminiProvider } from "./gemini/client.js";
@@ -24,9 +24,7 @@ export function registerProvider(name: string, provider: Provider): void {
 export function getProvider(name: string): Provider {
   const provider = providers.get(name);
   if (!provider) {
-    throw new ConfigError(
-      `Provider "${name}" not found. Available: ${listProviders().join(", ")}`,
-    );
+    throw new ProviderNotConfiguredError(name, listProviders());
   }
   return provider;
 }


### PR DESCRIPTION
## Summary
- Change `getProvider()` to throw `ProviderNotConfiguredError` instead of `ConfigError`
- Restores actionable error message telling users how to set up their API key
- The error handler in `error-handler.ts` already knows how to format this error

Part of plan: simplify-provider-abstraction.md (review fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
