### PR TITLE
fix: skip migration 016 checkpoint when keychain broker is unavailable

### DIFF
--- a/assistant/src/workspace/migrations/016-migrate-credentials-from-keychain.ts
+++ b/assistant/src/workspace/migrations/016-migrate-credentials-from-keychain.ts
@@ -105,11 +105,10 @@ export const migrateCredentialsFromKeychainMigration: WorkspaceMigration = {
     }
 
     if (!brokerAvailable) {
-      log.warn(
+      throw new Error(
         "Keychain broker not available after waiting — credential migration " +
           "will be retried on next startup",
       );
-      return;
     }
 
     const { setKey } = await import("../../security/encrypted-store.js");


### PR DESCRIPTION
Ensures migration 016 is retried on next startup when the keychain broker is temporarily unavailable, instead of being permanently checkpointed as completed with no credentials migrated.

When the broker is unavailable, `run()` now throws (matching the `down()` method's existing behavior) so the migration runner leaves the checkpoint at `started` status. On next startup, the runner detects the interrupted migration and re-runs it.

Addressed in follow-up to #20733
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
