### PR TITLE
fix: normalize secret identifiers in GET /v1/secrets response

### DIFF
--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -484,6 +484,8 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
   }
 }
 
+const CREDENTIAL_KEY_PREFIX = "credential/";
+
 export async function handleListSecrets(): Promise<Response> {
   try {
     const { accounts, unreachable } = await listSecureKeysAsync();
@@ -493,7 +495,24 @@ export async function handleListSecrets(): Promise<Response> {
         { status: 503 },
       );
     }
-    return Response.json({ accounts });
+
+    const secrets = accounts.map((account) => {
+      if (account.startsWith(CREDENTIAL_KEY_PREFIX)) {
+        // credential/{service}/{field} → service:field
+        const rest = account.slice(CREDENTIAL_KEY_PREFIX.length);
+        const slashIdx = rest.indexOf("/");
+        if (slashIdx > 0 && slashIdx < rest.length - 1) {
+          return {
+            type: "credential" as const,
+            name: `${rest.slice(0, slashIdx)}:${rest.slice(slashIdx + 1)}`,
+          };
+        }
+      }
+      // API key providers are stored with their raw provider name
+      return { type: "api_key" as const, name: account };
+    });
+
+    return Response.json({ secrets });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return httpError("INTERNAL_ERROR", message, 500);


### PR DESCRIPTION
Normalizes the list endpoint response to return identifiers in the format expected by the write/delete endpoints, and includes the secret type for each entry.

- Credential keys (`credential/{service}/{field}`) are normalized to `service:field` format
- API key entries are returned with their provider name
- Each entry includes a `type` field (`api_key` or `credential`)
- Response uses `secrets` array of `{type, name}` objects instead of raw `accounts` array

Addressed in follow-up to #20744
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
