### PR TITLE
fix: handle parentheses in link URLs and preserve code fence content in sanitizeForTts

### DIFF
--- a/assistant/src/calls/__tests__/tts-text-sanitizer.test.ts
+++ b/assistant/src/calls/__tests__/tts-text-sanitizer.test.ts
@@ -22,6 +22,20 @@ describe("sanitizeForTts", () => {
       );
       expect(sanitizeForTts("[breath] ok")).toBe("[breath] ok");
     });
+
+    test("handles URLs with balanced parentheses (e.g. Wikipedia)", () => {
+      expect(
+        sanitizeForTts(
+          "See [Function](https://en.wikipedia.org/wiki/Function_(mathematics))",
+        ),
+      ).toBe("See Function");
+    });
+
+    test("handles URLs with multiple balanced parentheses groups", () => {
+      expect(
+        sanitizeForTts("[link](http://example.com/a_(b)_c_(d))"),
+      ).toBe("link");
+    });
   });
 
   describe("bold and italic", () => {
@@ -98,6 +112,20 @@ describe("sanitizeForTts", () => {
     test("strips inline code backticks", () => {
       expect(sanitizeForTts("Use `console.log` here")).toBe(
         "Use console.log here",
+      );
+    });
+
+    test("preserves # comments inside code fences", () => {
+      const input = "Example:\n```python\n# This is a comment\nprint('hi')\n```\nDone.";
+      expect(sanitizeForTts(input)).toBe(
+        "Example:\n# This is a comment\nprint('hi')\nDone.",
+      );
+    });
+
+    test("preserves shell comments inside code fences", () => {
+      const input = "Run:\n```bash\n## Install deps\napt-get install curl\n```";
+      expect(sanitizeForTts(input)).toBe(
+        "Run:\n## Install deps\napt-get install curl\n",
       );
     });
   });

--- a/assistant/src/calls/tts-text-sanitizer.ts
+++ b/assistant/src/calls/tts-text-sanitizer.ts
@@ -10,7 +10,11 @@ export function sanitizeForTts(text: string): string {
   // 1. Markdown links: [text](url) → text
   //    Only matches the full [...](...) pattern — plain brackets like
   //    Fish Audio S2 annotations ([laughter], [breath]) pass through.
-  result = result.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+  //    Handles one level of balanced parentheses in URLs (e.g. Wikipedia links).
+  result = result.replace(
+    /\[([^\]]+)\]\([^()]*(?:\([^()]*\))*[^()]*\)/g,
+    "$1",
+  );
 
   // 2. Bold+italic: ***text*** or ___text___ → text
   result = result.replace(/\*{3}(.+?)\*{3}/g, "$1");
@@ -20,11 +24,12 @@ export function sanitizeForTts(text: string): string {
   result = result.replace(/\*{2}(.+?)\*{2}/g, "$1");
   result = result.replace(/_{2}(.+?)_{2}/g, "$1");
 
-  // 4. Headers: strip leading # characters at line starts
-  result = result.replace(/^#{1,6}\s+/gm, "");
-
-  // 5. Code fences: strip ```...``` fences but keep content
+  // 4. Code fences: strip ```...``` fences but keep content
+  //    Must run before header stripping so # comments inside code blocks are preserved.
   result = result.replace(/```[^\n]*\n([\s\S]*?)```\n?/g, "$1");
+
+  // 5. Headers: strip leading # characters at line starts
+  result = result.replace(/^#{1,6}\s+/gm, "");
 
   // 6. Inline code: strip single backticks
   result = result.replace(/`([^`]+)`/g, "$1");


### PR DESCRIPTION
Fixes two edge cases in sanitizeForTts:
1. Link-stripping regex now handles balanced parentheses in URLs (e.g. Wikipedia links like `Function_(mathematics)`)
2. Code fences are stripped before header removal to preserve `#` comments inside code blocks

Addressed in follow-up to #20731
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
