### PR TITLE
fix: snapshot kind when entering edit mode for stable picker options

### DIFF
--- a/clients/ios/Views/Intelligence/MemoryItemDetailView.swift
+++ b/clients/ios/Views/Intelligence/MemoryItemDetailView.swift
@@ -153,7 +153,7 @@ struct MemoryItemDetailView: View {
         Section("Classification") {
             if isEditing {
                 Picker("Kind", selection: $editKind) {
-                    ForEach(MemoryKind.editableKinds(current: liveItem.kind)) { kind in
+                    ForEach(MemoryKind.editableKinds(current: editBaseline?.kind ?? liveItem.kind)) { kind in
                         Text(kind.label).tag(kind.rawValue)
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Content.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Content.swift
@@ -131,7 +131,7 @@ extension MemoryItemDetailSheet {
                 VDropdown(
                     placeholder: "Kind",
                     selection: $editKind,
-                    options: MemoryKind.editableKinds(current: displayItem.kind).map { ($0.label, $0.rawValue) }
+                    options: MemoryKind.editableKinds(current: editBaseline?.kind ?? displayItem.kind).map { ($0.label, $0.rawValue) }
                 )
             }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Footer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Footer.swift
@@ -9,17 +9,18 @@ extension MemoryItemDetailSheet {
     }
 
     func save() {
+        guard let baseline = editBaseline else { return }
         isSaving = true
         errorMessage = nil
         Task {
-            let newSubject = editSubject != item.subject ? editSubject : nil
-            let newStatement = editStatement != item.statement ? editStatement : nil
-            let newKind = editKind != item.kind ? editKind : nil
-            let newStatus = editStatus != item.status ? editStatus : nil
-            let newImportance = editImportance != (item.importance ?? 0.5) ? editImportance : nil
+            let newSubject = editSubject != baseline.subject ? editSubject : nil
+            let newStatement = editStatement != baseline.statement ? editStatement : nil
+            let newKind = editKind != baseline.kind ? editKind : nil
+            let newStatus = editStatus != baseline.status ? editStatus : nil
+            let newImportance = editImportance != (baseline.importance ?? 0.5) ? editImportance : nil
 
             let result = await store.updateItem(
-                id: item.id,
+                id: baseline.id,
                 subject: newSubject,
                 statement: newStatement,
                 kind: newKind,
@@ -29,6 +30,7 @@ extension MemoryItemDetailSheet {
 
             isSaving = false
             if result != nil {
+                editBaseline = nil
                 onDismiss()
             } else {
                 errorMessage = "Failed to save changes. Please try again."

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet.swift
@@ -13,6 +13,7 @@ struct MemoryItemDetailSheet: View {
     @State var editStatus: String
     @State var editImportance: Double
     @State var detailItem: MemoryItemPayload?
+    @State var editBaseline: MemoryItemPayload?
     @State var isSaving = false
     @State var showDeleteConfirm = false
     @State var errorMessage: String?
@@ -58,11 +59,12 @@ struct MemoryItemDetailSheet: View {
                         VButton(label: "Cancel", style: .outlined) {
                             isEditing = false
                             errorMessage = nil
-                            editSubject = item.subject
-                            editStatement = item.statement
-                            editKind = item.kind
-                            editStatus = item.status
-                            editImportance = item.importance ?? 0.5
+                            editBaseline = nil
+                            editSubject = displayItem.subject
+                            editStatement = displayItem.statement
+                            editKind = displayItem.kind
+                            editStatus = displayItem.status
+                            editImportance = displayItem.importance ?? 0.5
                         }
                         VButton(
                             label: isSaving ? "Saving..." : "Save",
@@ -88,6 +90,12 @@ struct MemoryItemDetailSheet: View {
                             leftIcon: VIcon.pencil.rawValue,
                             style: .primary
                         ) {
+                            editBaseline = displayItem
+                            editSubject = displayItem.subject
+                            editStatement = displayItem.statement
+                            editKind = displayItem.kind
+                            editStatus = displayItem.status
+                            editImportance = displayItem.importance ?? 0.5
                             isEditing = true
                         }
                     }


### PR DESCRIPTION
Captures the memory item kind when entering edit mode so dropdown options remain stable during async detail fetches, preventing picker selection from becoming invalid mid-edit.

**iOS**: Use `editBaseline?.kind` (already captured) instead of `liveItem.kind` for dropdown options.

**macOS**: Add `editBaseline` property, snapshot `displayItem` when entering edit mode, use baseline kind for dropdown options, and diff against baseline in save. Also fixes pre-existing issue where Edit button didn't refresh edit fields from `displayItem`.

Addressed in follow-up to #20757
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
