### PR TITLE
fix: deep clone config parse result to isolate schema defaults

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -47,7 +47,9 @@ function ensureMigratedDataDir(): void {
  * single parse is sufficient to cascade defaults through every nesting level.
  */
 export function applyNestedDefaults(config: unknown): AssistantConfig {
-  return AssistantConfigSchema.parse(config) as AssistantConfig;
+  return structuredClone(
+    AssistantConfigSchema.parse(config),
+  ) as AssistantConfig;
 }
 
 function cloneDefaultConfig(): AssistantConfig {


### PR DESCRIPTION
Adds structuredClone() to the config loader's applyNestedDefaults() so that mutations to config objects in production code don't leak back into Zod schema defaults and affect subsequent loadConfig() calls.

Addressed in follow-up to #20771
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
