### PR TITLE
fix: snapshot persona context at message-processing time to prevent cross-actor races

### DIFF
--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -31,7 +31,10 @@ import { routeGuardianReply } from "../runtime/guardian-reply-router.js";
 import { getLogger } from "../util/logger.js";
 import type { MessageQueue } from "./conversation-queue-manager.js";
 import type { QueueDrainReason } from "./conversation-queue-manager.js";
-import type { TrustContext } from "./conversation-runtime-assembly.js";
+import type {
+  ChannelCapabilities,
+  TrustContext,
+} from "./conversation-runtime-assembly.js";
 import { resolveSlash, type SlashContext } from "./conversation-slash.js";
 import { getModelInfo } from "./handlers/config-model.js";
 import type {
@@ -80,6 +83,11 @@ export interface ProcessConversationContext {
   /** Assistant identity — used for scoping notification preferences. */
   readonly assistantId?: string;
   trustContext?: TrustContext;
+  channelCapabilities?: ChannelCapabilities;
+  /** Per-turn snapshot of trustContext, frozen at message-processing start. */
+  currentTurnTrustContext?: TrustContext;
+  /** Per-turn snapshot of channelCapabilities, frozen at message-processing start. */
+  currentTurnChannelCapabilities?: ChannelCapabilities;
   ensureActorScopedHistory(): Promise<void>;
   persistUserMessage(
     content: string,
@@ -281,6 +289,11 @@ export async function drainQueue(
       conversation.addPreactivatedSkillId("computer-use");
     }
   }
+
+  // Snapshot persona context at turn start so later tool turns can't pick up
+  // a different actor's context if a concurrent request mutates the live fields.
+  conversation.currentTurnTrustContext = conversation.trustContext;
+  conversation.currentTurnChannelCapabilities = conversation.channelCapabilities;
 
   // Resolve slash commands for queued messages
   const slashResult = await resolveSlash(
@@ -561,6 +574,10 @@ export async function processMessage(
   displayContent?: string,
 ): Promise<string> {
   await conversation.ensureActorScopedHistory();
+  // Snapshot persona context at turn start so later tool turns can't pick up
+  // a different actor's context if a concurrent request mutates the live fields.
+  conversation.currentTurnTrustContext = conversation.trustContext;
+  conversation.currentTurnChannelCapabilities = conversation.channelCapabilities;
   conversation.currentActiveSurfaceId = activeSurfaceId;
   conversation.currentPage = currentPage;
   const trimmedContent = content.trim();

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -176,6 +176,14 @@ export class Conversation {
   /** @internal */ currentPage?: string;
   /** @internal */ channelCapabilities?: ChannelCapabilities;
   /** @internal */ trustContext?: TrustContext;
+  /**
+   * Per-turn snapshots of persona-relevant context, captured at the start of
+   * each message processing turn. The system prompt callback reads these
+   * instead of the live fields so that a concurrent request cannot swap
+   * another actor's persona mid-turn.
+   */
+  /** @internal */ currentTurnTrustContext?: TrustContext;
+  /** @internal */ currentTurnChannelCapabilities?: ChannelCapabilities;
   /** @internal */ authContext?: AuthContext;
   /** @internal */ loadedHistoryTrustClass?: TrustClass;
   /** @internal */ voiceCallControlPrompt?: string;
@@ -359,8 +367,8 @@ export class Conversation {
           ? systemPrompt
           : (() => {
               const persona = resolvePersonaContext(
-                this.trustContext,
-                this.channelCapabilities,
+                this.currentTurnTrustContext,
+                this.currentTurnChannelCapabilities,
               );
               return buildSystemPrompt({
                 hasNoClient: this.hasNoClient,


### PR DESCRIPTION
Introduces per-turn snapshots of trustContext and channelCapabilities, set when message processing begins and read in the system prompt callback. This prevents concurrent requests from swapping persona context mid-turn.

The previous code read `this.trustContext` and `this.channelCapabilities` live inside `resolveSystemPromptCallback`, which is re-invoked on each LLM turn. A concurrent request calling `setTrustContext()` could overwrite the fields while the first request's agent loop was still running, causing later turns to use a different actor's persona.

The fix captures `currentTurnTrustContext` and `currentTurnChannelCapabilities` at the start of both `processMessage` and `drainQueue`, and reads from these frozen snapshots in the callback.

Addressed in follow-up to #20760
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
