### PR TITLE
fix: preserve broker-unreachable signal through daemon secret read endpoint

### DIFF
--- a/assistant/src/cli/lib/daemon-credential-client.ts
+++ b/assistant/src/cli/lib/daemon-credential-client.ts
@@ -151,11 +151,15 @@ export async function getSecureKeyResultViaDaemon(
   });
 
   if (res?.ok) {
-    const json = (await res.json()) as { found: boolean; value?: string };
+    const json = (await res.json()) as {
+      found: boolean;
+      value?: string;
+      unreachable?: boolean;
+    };
     if (json.found && json.value != null) {
       return { value: json.value, unreachable: false };
     }
-    return { value: undefined, unreachable: false };
+    return { value: undefined, unreachable: json.unreachable ?? false };
   }
 
   // Fall back to direct read when daemon is unreachable (null) OR returned

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -21,6 +21,7 @@ import { credentialKey } from "../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
   getSecureKeyAsync,
+  getSecureKeyResultAsync,
   listSecureKeysAsync,
   setSecureKeyAsync,
 } from "../../security/secure-keys.js";
@@ -350,13 +351,13 @@ export async function handleReadSecret(req: Request): Promise<Response> {
       );
     }
 
-    const value = await getSecureKeyAsync(accountKey);
+    const { value, unreachable } = await getSecureKeyResultAsync(accountKey);
     if (value === undefined) {
-      return Response.json({ found: false });
+      return Response.json({ found: false, unreachable });
     }
 
     if (reveal) {
-      return Response.json({ found: true, value });
+      return Response.json({ found: true, value, unreachable: false });
     }
 
     // Mask the value: show first 10 chars and last 4, hiding at least 3
@@ -366,7 +367,7 @@ export async function handleReadSecret(req: Request): Promise<Response> {
     const suffixLen = Math.min(4, Math.max(0, maxVisible - prefixLen));
     const masked = `${value.slice(0, prefixLen)}...${suffixLen > 0 ? value.slice(-suffixLen) : ""}`;
 
-    return Response.json({ found: true, masked });
+    return Response.json({ found: true, masked, unreachable: false });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err, type, name }, "Failed to read secret via HTTP");


### PR DESCRIPTION
The `handleReadSecret` daemon endpoint used `getSecureKeyAsync()` which discards the `unreachable` flag from the credential backend. When the keychain broker is down, this collapsed broker failures to `{found: false}`, and the CLI client hardcoded `unreachable: false` — so `assistant credentials inspect` showed "Credential not found" instead of the keychain broker recovery error.

**Changes:**
- `secret-routes.ts`: Switch `handleReadSecret` to `getSecureKeyResultAsync()` and include `unreachable` in the JSON response
- `daemon-credential-client.ts`: Read the `unreachable` field from the daemon response in `getSecureKeyResultViaDaemon`

Note: The other two issues from #20753 (fallback set/delete key format) were already fixed by `deriveCredentialStorageKey` in the daemon credential client.

Addressed in follow-up to #20753
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
