### PR TITLE
fix: trim sanitized text when checking for speakable content in TTS routes

### DIFF
--- a/assistant/src/runtime/routes/tts-routes.ts
+++ b/assistant/src/runtime/routes/tts-routes.ts
@@ -51,7 +51,7 @@ export function ttsRouteDefinitions(): RouteDefinition[] {
         }
 
         const sanitizedText = sanitizeForTts(result.text);
-        if (!sanitizedText) {
+        if (!sanitizedText.trim()) {
           return httpError(
             "BAD_REQUEST",
             "Message has no speakable text content",


### PR DESCRIPTION
Adds .trim() to the emptiness check in TTS routes so whitespace-only sanitized text correctly returns 400 instead of invoking Fish Audio with empty content.

Addressed in follow-up to #20743
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
