### PR TITLE
fix: add provider validation and elevate scope for secrets read endpoint

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -260,7 +260,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   // Secrets
   { endpoint: "secrets", scopes: ["settings.write"] },
   { endpoint: "secrets:GET", scopes: ["settings.read"] },
-  { endpoint: "secrets/read", scopes: ["settings.read"] },
+  { endpoint: "secrets/read", scopes: ["settings.write"] },
 
   // Pairing (authenticated)
   { endpoint: "pairing/register", scopes: ["settings.write"] },

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -329,6 +329,17 @@ export async function handleReadSecret(req: Request): Promise<Response> {
     let accountKey: string;
 
     if (type === "api_key") {
+      if (
+        !API_KEY_PROVIDERS.includes(name as (typeof API_KEY_PROVIDERS)[number])
+      ) {
+        return httpError(
+          "BAD_REQUEST",
+          `Unknown API key provider: ${name}. Valid providers: ${API_KEY_PROVIDERS.join(
+            ", ",
+          )}`,
+          400,
+        );
+      }
       accountKey = name;
     } else if (type === "credential") {
       const colonIdx = name.lastIndexOf(":");


### PR DESCRIPTION
Adds API_KEY_PROVIDERS validation to handleReadSecret and elevates the route policy to settings.write to prevent arbitrary key reads and secret exfiltration through low-privilege tokens.\n\nAddressed in follow-up to #20745
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20796" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
