### PR TITLE
fix: update migration 016 test to expect throw on broker unavailability

### DIFF
--- a/assistant/src/__tests__/workspace-migration-016-migrate-credentials-from-keychain.test.ts
+++ b/assistant/src/__tests__/workspace-migration-016-migrate-credentials-from-keychain.test.ts
@@ -115,12 +115,14 @@ describe("016-migrate-credentials-from-keychain migration", () => {
   });
 
   test(
-    "returns silently when broker is not available (does not throw)",
+    "throws when broker is not available (skips checkpoint for retry)",
     async () => {
       isAvailableFn.mockReturnValue(false);
 
-      // Migration 016 returns silently (unlike 015 which throws)
-      await migrateCredentialsFromKeychainMigration.run(WORKSPACE_DIR);
+      // Throwing skips the checkpoint so the migration retries on next startup
+      await expect(
+        migrateCredentialsFromKeychainMigration.run(WORKSPACE_DIR),
+      ).rejects.toThrow("Keychain broker not available after waiting");
 
       // Should not proceed to list or migrate keys
       expect(brokerListFn).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Migration 016 intentionally throws when the keychain broker is unavailable (to skip the checkpoint and retry on next startup)
- The test still expected silent return from before 95b360ee1 changed the behavior — updated to use `rejects.toThrow()`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23417918979/job/68116940604