### PR TITLE
fix: prevent double-encoding of canonical credential keys and add storage key migration

### DIFF
--- a/assistant/src/cli/lib/daemon-credential-client.ts
+++ b/assistant/src/cli/lib/daemon-credential-client.ts
@@ -98,6 +98,13 @@ async function daemonFetch(
  * field name is extracted correctly.
  */
 function deriveCredentialStorageKey(name: string): string {
+  // Already a canonical storage key (credential/service/field) — return as-is
+  // to avoid double-encoding (e.g. "credential/integration:google/access_token"
+  // would otherwise become "credential/credential/integration/google/access_token").
+  if (name.startsWith("credential/")) {
+    return name;
+  }
+
   const colonIdx = name.lastIndexOf(":");
   if (colonIdx < 1 || colonIdx === name.length - 1) {
     // Malformed — return raw name so the caller stores *something*.

--- a/assistant/src/workspace/migrations/018-rekey-compound-credential-keys.ts
+++ b/assistant/src/workspace/migrations/018-rekey-compound-credential-keys.ts
@@ -1,0 +1,184 @@
+import { credentialKey } from "../../security/credential-key.js";
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("workspace-migrations");
+const CREDENTIAL_PREFIX = "credential/";
+
+/**
+ * Re-key compound credential storage keys from the old indexOf-based split
+ * to the new lastIndexOf-based split.
+ *
+ * The old code split "integration:google:access_token" at the first colon:
+ *   service = "integration", field = "google:access_token"
+ *   → key = "credential/integration/google:access_token"
+ *
+ * The new code splits at the last colon:
+ *   service = "integration:google", field = "access_token"
+ *   → key = "credential/integration:google/access_token"
+ *
+ * Detection heuristic: if the field portion of a stored key contains a colon,
+ * it was stored with the old indexOf logic and needs re-keying. Simple
+ * service:field names (single colon) produce the same key with both methods
+ * and don't need migration.
+ */
+export const rekeyCompoundCredentialKeysMigration: WorkspaceMigration = {
+  id: "018-rekey-compound-credential-keys",
+  description:
+    "Re-key compound credential keys from indexOf to lastIndexOf split format",
+
+  async run(_workspaceDir: string): Promise<void> {
+    const {
+      listSecureKeysAsync,
+      getSecureKeyAsync,
+      setSecureKeyAsync,
+      deleteSecureKeyAsync,
+    } = await import("../../security/secure-keys.js");
+
+    const { accounts, unreachable } = await listSecureKeysAsync();
+    if (unreachable) {
+      throw new Error(
+        "Credential store unreachable — migration will be retried on next startup",
+      );
+    }
+
+    let migratedCount = 0;
+    let failedCount = 0;
+
+    for (const account of accounts) {
+      if (!account.startsWith(CREDENTIAL_PREFIX)) continue;
+
+      const rest = account.slice(CREDENTIAL_PREFIX.length);
+      const slashIdx = rest.indexOf("/");
+      if (slashIdx < 1 || slashIdx >= rest.length - 1) continue;
+
+      const oldService = rest.slice(0, slashIdx);
+      const oldField = rest.slice(slashIdx + 1);
+
+      // Only migrate keys where the field contains a colon — these were
+      // stored using the old indexOf(":") split and need re-keying.
+      if (!oldField.includes(":")) continue;
+
+      // Reconstruct the original "service:field" name and re-split with lastIndexOf
+      const originalName = `${oldService}:${oldField}`;
+      const lastColonIdx = originalName.lastIndexOf(":");
+      const newService = originalName.slice(0, lastColonIdx);
+      const newField = originalName.slice(lastColonIdx + 1);
+      const newKey = credentialKey(newService, newField);
+
+      // Skip if the key format didn't actually change
+      if (account === newKey) continue;
+
+      // Skip if the new key already exists (idempotent — may have been
+      // partially migrated or the user already stored under the new format)
+      const existingNewValue = await getSecureKeyAsync(newKey);
+      if (existingNewValue !== undefined) {
+        // New key exists — just clean up the old orphaned key
+        await deleteSecureKeyAsync(account);
+        log.info(
+          { oldKey: account, newKey },
+          "Deleted orphaned old-format credential key (new key already exists)",
+        );
+        migratedCount++;
+        continue;
+      }
+
+      const value = await getSecureKeyAsync(account);
+      if (value === undefined) continue;
+
+      // Write new key first, then delete old key (crash-safe order)
+      const stored = await setSecureKeyAsync(newKey, value);
+      if (!stored) {
+        log.warn(
+          { oldKey: account, newKey },
+          "Failed to write re-keyed credential — skipping",
+        );
+        failedCount++;
+        continue;
+      }
+
+      await deleteSecureKeyAsync(account);
+      migratedCount++;
+      log.info({ oldKey: account, newKey }, "Re-keyed compound credential");
+    }
+
+    if (migratedCount > 0 || failedCount > 0) {
+      log.info(
+        { migratedCount, failedCount },
+        "Compound credential key migration complete",
+      );
+    }
+  },
+
+  async down(_workspaceDir: string): Promise<void> {
+    // Reverse: re-key from lastIndexOf format back to indexOf format.
+    // Keys where the service contains ":" were migrated from old format.
+    const {
+      listSecureKeysAsync,
+      getSecureKeyAsync,
+      setSecureKeyAsync,
+      deleteSecureKeyAsync,
+    } = await import("../../security/secure-keys.js");
+
+    const { accounts, unreachable } = await listSecureKeysAsync();
+    if (unreachable) {
+      throw new Error(
+        "Credential store unreachable — rollback will be retried on next startup",
+      );
+    }
+
+    let rolledBackCount = 0;
+    let failedCount = 0;
+
+    for (const account of accounts) {
+      if (!account.startsWith(CREDENTIAL_PREFIX)) continue;
+
+      const rest = account.slice(CREDENTIAL_PREFIX.length);
+      const slashIdx = rest.indexOf("/");
+      if (slashIdx < 1 || slashIdx >= rest.length - 1) continue;
+
+      const service = rest.slice(0, slashIdx);
+      const field = rest.slice(slashIdx + 1);
+
+      // Only rollback keys where the service contains ":" — these are in
+      // the new lastIndexOf format and need reverting to indexOf format.
+      if (!service.includes(":")) continue;
+
+      // Reconstruct the original name and re-split with indexOf (old format)
+      const originalName = `${service}:${field}`;
+      const firstColonIdx = originalName.indexOf(":");
+      const oldService = originalName.slice(0, firstColonIdx);
+      const oldField = originalName.slice(firstColonIdx + 1);
+      const oldKey = credentialKey(oldService, oldField);
+
+      if (account === oldKey) continue;
+
+      const value = await getSecureKeyAsync(account);
+      if (value === undefined) continue;
+
+      const stored = await setSecureKeyAsync(oldKey, value);
+      if (!stored) {
+        log.warn(
+          { newKey: account, oldKey },
+          "Failed to rollback re-keyed credential — skipping",
+        );
+        failedCount++;
+        continue;
+      }
+
+      await deleteSecureKeyAsync(account);
+      rolledBackCount++;
+      log.info(
+        { newKey: account, oldKey },
+        "Rolled back compound credential key",
+      );
+    }
+
+    if (rolledBackCount > 0 || failedCount > 0) {
+      log.info(
+        { rolledBackCount, failedCount },
+        "Compound credential key rollback complete",
+      );
+    }
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -14,6 +14,7 @@ import { migrateCredentialsToKeychainMigration } from "./015-migrate-credentials
 import { extractFeatureFlagsToProtectedMigration } from "./016-extract-feature-flags-to-protected.js";
 import { migrateCredentialsFromKeychainMigration } from "./016-migrate-credentials-from-keychain.js";
 import { seedPersonaDirsMigration } from "./017-seed-persona-dirs.js";
+import { rekeyCompoundCredentialKeysMigration } from "./018-rekey-compound-credential-keys.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -39,4 +40,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   migrateCredentialsFromKeychainMigration,
   seedPersonaDirsMigration,
   extractFeatureFlagsToProtectedMigration,
+  rekeyCompoundCredentialKeysMigration,
 ];


### PR DESCRIPTION
## Summary
- Fixes `deriveCredentialStorageKey()` in `daemon-credential-client.ts` to detect already-canonical keys (starting with `credential/`) and skip derivation, preventing double-encoding
- Adds idempotent workspace migration `018-rekey-compound-credential-keys` that re-keys credentials from the old `indexOf`-based split format to the new `lastIndexOf`-based format
- Migration includes a `down()` rollback that reverses the re-keying

Addressed in follow-up to #20768

## Test plan
- [ ] Verify `deriveCredentialStorageKey("credential/integration:google/access_token")` returns the input unchanged
- [ ] Verify `deriveCredentialStorageKey("integration:google:access_token")` returns `credential/integration:google/access_token`
- [ ] Verify migration 018 re-keys `credential/integration/google:access_token` → `credential/integration:google/access_token`
- [ ] Verify migration is idempotent (safe to re-run)
- [ ] Verify migration down() reverses the re-keying

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
