### PR TITLE
fix: add migration 018 to credential security allowlist

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -210,6 +210,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "memory/embedding-backend.ts", // embedding backend API key lookup
       "daemon/providers-setup.ts", // provider initialization API key lookup
       "workspace/migrations/006-services-config.ts", // services config migration reads provider API keys
+      "workspace/migrations/018-rekey-compound-credential-keys.ts", // re-key compound credential storage keys
       "config/bundled-skills/slack/tools/shared.ts", // Slack skill bot token lookup
       "daemon/conversation-process.ts", // masked provider key display
       "daemon/handlers/config-model.ts", // masked provider key display


### PR DESCRIPTION
## Summary
- Add `workspace/migrations/018-rekey-compound-credential-keys.ts` to the `ALLOWED_IMPORTERS` set in the credential security invariants test — the migration legitimately imports from `secure-keys` to re-key compound credential storage keys.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23418082592/job/68117416183
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
