### PR TITLE
feat: enable ces-managed-sidecar feature flag by default

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -111,7 +111,7 @@
       "key": "feature_flags.ces-managed-sidecar.enabled",
       "label": "CES Managed Sidecar Transport",
       "description": "Use managed sidecar transport for CES communication when running in a containerized environment",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "ces-credential-backend",


### PR DESCRIPTION
## Summary
- Flip `ces-managed-sidecar` flag from `defaultEnabled: false` to `true` in the feature flag registry
- Enables CES RPC transport via bootstrap socket in Docker/containerized environments
- Safe to enable now that managed CES has credential CRUD RPC handlers (PR #20800)

## Original prompt
feat: enable ces-managed-sidecar feature flag by default - flip defaultEnabled from false to true in meta/feature-flags/feature-flag-registry.json for the ces-managed-sidecar flag
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
