### PR TITLE
fix: make memory_manage tool description proactive about saving memories

### DIFF
--- a/assistant/src/tools/memory/definitions.ts
+++ b/assistant/src/tools/memory/definitions.ts
@@ -59,7 +59,7 @@ const memoryManageProperties = {
 export const memoryManageDefinition: ToolDefinition = {
   name: "memory_manage",
   description:
-    "Save, update, or delete memory items. Memory does not survive session restarts - if you want to remember something, save it now. Use 'save' for new information worth remembering (facts, preferences, mistakes, discoveries, gotchas), 'update' to correct existing items, 'delete' to remove outdated items. When a user says 'remember this', save immediately. For user profile or personality changes, update workspace files (USER.md, SOUL.md) instead.",
+    "Save, update, or delete memory items. If you want to remember something, save it now. Use 'save' for new information worth remembering (facts, preferences, mistakes, discoveries, gotchas), 'update' to correct existing items, 'delete' to remove outdated items. When a user says 'remember this', save immediately. Be proactive: if you learn something important that may be useful in the future, always call this tool — don't just say or hope you'll remember it. This is not a substitute for updating workspace files when relevant - do both.",
   input_schema: {
     type: "object",
     properties: memoryManageProperties,


### PR DESCRIPTION
## Summary

- Updated `memory_manage` tool description to explicitly instruct the assistant to proactively save important information — not just when the user says "remember this"
- Added "don't just say or hope you'll remember it" to directly address the observed failure mode of talking about saving without calling the tool
- Changed workspace file guidance from "instead" to "do both" to eliminate the false dichotomy between memory items and workspace files

## Original prompt

Update the `memory_manage` tool description to make the assistant more proactive about calling the tool. The previous description only told the assistant to save when the user explicitly asked, leading to a pattern where the assistant would claim to be saving memories without actually invoking the tool.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
