### PR TITLE
feat: lower tier thresholds to inject more memory items

### DIFF
--- a/assistant/src/memory/search/tier-classifier.ts
+++ b/assistant/src/memory/search/tier-classifier.ts
@@ -8,9 +8,17 @@ export interface TieredCandidate extends Candidate {
   sourceLabel?: string;
 }
 
+/**
+ * Map a composite relevance score to an injection tier.
+ *
+ * Thresholds are intentionally set lower than raw-embedding ceilings because
+ * the multiplicative scoring pipeline (semantic × recency × metadata) compresses
+ * the effective score range.  Lowering the gates lets moderately-relevant items
+ * surface rather than being silently dropped.
+ */
 export function classifyTier(score: number): Tier | null {
-  if (score > 0.8) return 1;
-  if (score > 0.6) return 2;
+  if (score > 0.6) return 1;
+  if (score > 0.4) return 2;
   return null;
 }
 


### PR DESCRIPTION
## Summary
- Lower tier 1 threshold from >0.8 to >0.6
- Lower tier 2 threshold from >0.6 to >0.4
- More memory items now reach injection, especially with the multiplicative scoring

Part of plan: memory-extraction-retrieval-improvements.md (PR 7 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
