### PR TITLE
fix: remove subject/statement truncation from memory extraction and tools

### DIFF
--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -450,8 +450,8 @@ async function extractItemsWithLLM(
         const resolvedKind = KIND_MIGRATION_MAP[raw.kind] ?? raw.kind;
         if (!VALID_KINDS.has(resolvedKind)) continue;
         if (!raw.subject || !raw.statement) continue;
-        const subject = truncate(String(raw.subject), 80, "");
-        const statement = truncate(String(raw.statement), 500, "");
+        const subject = String(raw.subject).trim();
+        const statement = String(raw.statement).trim();
         const confidence = clampUnitInterval(parseScore(raw.confidence, 0.5));
         const importance = clampUnitInterval(parseScore(raw.importance, 0.5));
         const fingerprint = computeMemoryFingerprint(
@@ -744,7 +744,7 @@ export async function extractAndUpsertMemoryItemsForMessage(
       .values({
         memoryItemId,
         messageId,
-        evidence: truncate(item.statement, 500, ""),
+        evidence: item.statement,
         createdAt: now,
       })
       .onConflictDoNothing()

--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -9,7 +9,6 @@ import { buildMemoryRecall } from "../../memory/retriever.js";
 import { memoryItems } from "../../memory/schema.js";
 import type { ScopePolicyOverride } from "../../memory/search/types.js";
 import { getLogger } from "../../util/logger.js";
-import { truncate } from "../../util/truncate.js";
 import type { ToolExecutionResult } from "../types.js";
 
 const log = getLogger("memory-tools");
@@ -60,14 +59,14 @@ export async function handleMemorySave(
 
   const subject =
     typeof args.subject === "string" && args.subject.trim().length > 0
-      ? truncate(args.subject.trim(), 80, "")
+      ? args.subject.trim()
       : inferSubjectFromStatement(statement.trim());
 
   try {
     const db = getDb();
     const id = uuid();
     const now = Date.now();
-    const trimmedStatement = truncate(statement.trim(), 500, "");
+    const trimmedStatement = statement.trim();
 
     const fingerprint = computeMemoryFingerprint(
       scopeId,
@@ -187,7 +186,7 @@ export async function handleMemoryUpdate(
     }
 
     const now = Date.now();
-    const trimmedStatement = truncate(statement.trim(), 500, "");
+    const trimmedStatement = statement.trim();
 
     const fingerprint = computeMemoryFingerprint(
       scopeId,
@@ -416,7 +415,7 @@ export async function handleMemoryDelete(
 function inferSubjectFromStatement(statement: string): string {
   // Take first few words as a subject label
   const words = statement.split(/\s+/).slice(0, 6).join(" ");
-  return truncate(words, 80, "");
+  return words;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Remove 80-char subject and 500-char statement truncation from extraction and memory tools
- LLM prompt already constrains output length; post-hoc truncation only damages items

Part of plan: memory-extraction-retrieval-improvements.md (PR 4 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
