### PR TITLE
feat: use multiplicative scoring so metadata amplifies relevance without substituting

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -443,16 +443,18 @@ export async function buildMemoryRecall(
   // Compute RRF-style final scores for the merged candidates
   const allCandidates = [...candidateMap.values()];
   for (const c of allCandidates) {
-    // Simple weighted combination — hybrid search already applies RRF fusion
-    // at the Qdrant level; here we combine the fused semantic score with recency.
-    c.finalScore = c.semantic * 0.7 + c.recency * 0.2 + c.confidence * 0.1;
+    // Multiplicative scoring: importance, confidence, and recency amplify semantic
+    // relevance but can't substitute for it. An irrelevant item (semantic ≈ 0)
+    // stays low regardless of metadata. Multiplier range: 0.4 (all zero) to 1.0.
+    const metadataMultiplier = 0.4 + c.importance * 0.25 + c.confidence * 0.15 + c.recency * 0.2;
+    c.finalScore = c.semantic * metadataMultiplier;
   }
   allCandidates.sort((a, b) => b.finalScore - a.finalScore);
 
   // ── Step 6: Tier classification ─────────────────────────────────
-  // Recency-only candidates (semantic=0) can never reach the tier 2 threshold
-  // (>0.6) since their max finalScore is 0.3. Promote them directly to tier 2
-  // so recent conversation context is preserved even without semantic signal.
+  // Recency-only candidates (semantic=0) always score 0 under multiplicative
+  // scoring. Promote them directly to tier 2 so recent conversation context
+  // is preserved even without semantic signal.
   const recencyOnlyKeys = new Set(
     allCandidates
       .filter((c) => c.semantic === 0 && c.recency > 0)


### PR DESCRIPTION
## Summary
- Replace additive scoring (semantic*0.7 + recency*0.2 + confidence*0.1) with multiplicative
- New formula: semantic * (0.4 + importance*0.25 + confidence*0.15 + recency*0.2)
- Metadata amplifies relevance but can't substitute for it — irrelevant items stay low

Part of plan: memory-extraction-retrieval-improvements.md (PR 6 of 15)