### PR TITLE
feat: use actual assistant name in extraction message prefixes

### DIFF
--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -2,6 +2,7 @@ import { and, eq, like, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getConfig } from "../config/loader.js";
+import { getAssistantName } from "../daemon/identity-helpers.js";
 import type { MemoryExtractionConfig } from "../config/types.js";
 import { resolveGuardianPersona } from "../prompts/persona-resolver.js";
 import { buildCoreIdentityContext } from "../prompts/system-prompt.js";
@@ -342,10 +343,11 @@ async function extractItemsWithLLM(
         userPersona,
       );
 
+      const assistantName = getAssistantName() ?? "the assistant";
       const messagePrefix =
         messageRole === "assistant"
-          ? "[This message is from the assistant]\n\n"
-          : "";
+          ? `[This message is from ${assistantName}]\n\n`
+          : `[This message is from the user]\n\n`;
       const response = await provider.sendMessage(
         [userMessage(`${messagePrefix}${text}`)],
         [


### PR DESCRIPTION
## Summary
- Use actual assistant name (from IDENTITY.md) instead of generic 'the assistant'
- Add [This message is from the user] prefix for user messages too

Part of plan: memory-extraction-retrieval-improvements.md (PR 9 of 15)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
