### PR TITLE
feat: debounce memory summary generation to reduce churn

### DIFF
--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -7,7 +7,7 @@ import type { TrustClass } from "../runtime/actor-trust-resolver.js";
 import { getLogger } from "../util/logger.js";
 import { getDb } from "./db.js";
 import { selectedBackendSupportsMultimodal } from "./embedding-backend.js";
-import { enqueueMemoryJob } from "./jobs-store.js";
+import { enqueueMemoryJob, upsertDebouncedJob } from "./jobs-store.js";
 import {
   extractMediaBlockMeta,
   extractTextFromStoredMessageContent,
@@ -16,6 +16,11 @@ import { memorySegments } from "./schema.js";
 import { segmentText } from "./segmenter.js";
 
 const log = getLogger("memory-indexer");
+
+/** Delay before a conversation summary job becomes eligible to run.
+ *  Each new message in the same conversation resets the timer, so the
+ *  summary is only built once the conversation has been idle for this long. */
+const SUMMARY_DEBOUNCE_MS = 3 * 60 * 1000; // 3 minutes
 
 export interface IndexMessageInput {
   messageId: string;
@@ -54,9 +59,11 @@ export async function indexMessageNow(
 
   const text = extractTextFromStoredMessageContent(input.content);
   if (text.length === 0) {
-    enqueueMemoryJob("build_conversation_summary", {
-      conversationId: input.conversationId,
-    });
+    upsertDebouncedJob(
+      "build_conversation_summary",
+      { conversationId: input.conversationId },
+      Date.now() + SUMMARY_DEBOUNCE_MS,
+    );
     return { indexedSegments: 0, enqueuedJobs: 1 };
   }
 
@@ -152,13 +159,15 @@ export async function indexMessageNow(
         tx,
       );
     }
-    enqueueMemoryJob(
-      "build_conversation_summary",
-      { conversationId: input.conversationId },
-      Date.now(),
-      tx,
-    );
   });
+
+  // Debounced outside the transaction — each new message pushes the summary
+  // job's runAfter forward so it only fires once the conversation is idle.
+  upsertDebouncedJob(
+    "build_conversation_summary",
+    { conversationId: input.conversationId },
+    Date.now() + SUMMARY_DEBOUNCE_MS,
+  );
 
   if (skippedEmbedJobs > 0) {
     log.debug(

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray, lte, notInArray } from "drizzle-orm";
+import { and, asc, eq, inArray, lte, notInArray, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getLogger } from "../util/logger.js";
@@ -84,6 +84,38 @@ export function enqueueMemoryJob(
     })
     .run();
   return id;
+}
+
+/**
+ * Upsert a debounced job: if a pending job of the same type and conversation
+ * already exists, push its `runAfter` forward instead of creating a duplicate.
+ * This prevents rapid message indexing from spawning redundant jobs.
+ */
+export function upsertDebouncedJob(
+  type: MemoryJobType,
+  payload: { conversationId: string },
+  runAfter: number,
+): void {
+  const db = getDb();
+  const existing = db
+    .select()
+    .from(memoryJobs)
+    .where(
+      and(
+        eq(memoryJobs.type, type),
+        eq(memoryJobs.status, "pending"),
+        sql`json_extract(${memoryJobs.payload}, '$.conversationId') = ${payload.conversationId}`,
+      ),
+    )
+    .get();
+  if (existing) {
+    db.update(memoryJobs)
+      .set({ runAfter, updatedAt: Date.now() })
+      .where(eq(memoryJobs.id, existing.id))
+      .run();
+  } else {
+    enqueueMemoryJob(type, payload, runAfter);
+  }
 }
 
 export function enqueueCleanupStaleSupersededItemsJob(


### PR DESCRIPTION
## Summary
- Debounce summary generation: only runs 3 minutes after last message in conversation
- Existing pending summary job for same conversation gets its runAfter updated instead of creating duplicates
- Reduces unnecessary LLM calls during active conversations

Part of plan: memory-extraction-retrieval-improvements.md (PR 12 of 15)