### PR TITLE
feat: add source_type and source_message_role columns to memory_items

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
@@ -51,6 +51,7 @@ function upsertMemoryItem(opts: {
         ),
         lastSeenAt: now,
         verificationState: "assistant_inferred",
+        sourceType: "extraction",
       })
       .where(eq(memoryItems.id, existing.id))
       .run();
@@ -68,6 +69,7 @@ function upsertMemoryItem(opts: {
         importance: clampUnitInterval(opts.importance),
         fingerprint,
         verificationState: "assistant_inferred",
+        sourceType: "extraction",
         scopeId: opts.scopeId,
         firstSeenAt: now,
         lastSeenAt: now,

--- a/assistant/src/config/bundled-skills/playbooks/tools/playbook-create.ts
+++ b/assistant/src/config/bundled-skills/playbooks/tools/playbook-create.ts
@@ -101,6 +101,7 @@ export async function executePlaybookCreate(
         importance: 0.8,
         fingerprint,
         verificationState: "user_confirmed",
+        sourceType: "tool",
         scopeId,
         firstSeenAt: now,
         lastSeenAt: now,

--- a/assistant/src/config/bundled-skills/playbooks/tools/playbook-update.ts
+++ b/assistant/src/config/bundled-skills/playbooks/tools/playbook-update.ts
@@ -126,6 +126,7 @@ export async function executePlaybookUpdate(
         fingerprint,
         lastSeenAt: now,
         verificationState: "user_confirmed",
+        sourceType: "tool",
       })
       .where(eq(memoryItems.id, existing.id))
       .run();

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -54,6 +54,7 @@ import {
   migrateContactsNotesColumn,
   migrateContactsRolePrincipal,
   migrateContactsUserFileColumn,
+  migrateAddSourceTypeColumns,
   migrateConversationForkLineage,
   migrateConversationsThreadTypeIndex,
   migrateCreateThreadStartersTable,
@@ -503,6 +504,9 @@ export function initializeDb(): void {
 
   // 89. Add user_file column to contacts for per-user persona file mapping
   migrateContactsUserFileColumn(database);
+
+  // 90. Add source_type and source_message_role columns to memory_items
+  migrateAddSourceTypeColumns(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -609,6 +609,8 @@ export async function extractAndUpsertMemoryItemsForMessage(
           ),
           lastSeenAt: Math.max(existing.lastSeenAt, seenAt),
           verificationState: promotedState,
+          sourceType: "extraction",
+          sourceMessageRole: message.role,
         })
         .where(eq(memoryItems.id, existing.id))
         .run();
@@ -625,6 +627,8 @@ export async function extractAndUpsertMemoryItemsForMessage(
           importance: item.importance,
           fingerprint: item.fingerprint,
           verificationState,
+          sourceType: "extraction",
+          sourceMessageRole: message.role,
           scopeId: effectiveScopeId,
           firstSeenAt: message.createdAt,
           lastSeenAt: seenAt,

--- a/assistant/src/memory/migrations/193-add-source-type-columns.ts
+++ b/assistant/src/memory/migrations/193-add-source-type-columns.ts
@@ -1,0 +1,85 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+/**
+ * Add source_type and source_message_role columns to memory_items.
+ *
+ * - source_type: "extraction" (default) or "tool" — distinguishes how the
+ *   memory was created (LLM/pattern extraction vs explicit tool/API save).
+ * - source_message_role: the role of the source message (e.g. "user",
+ *   "assistant") when the item was created via extraction.
+ *
+ * Backfills:
+ * 1. Items with verification_state = "user_confirmed" → source_type = "tool"
+ * 2. source_message_role from the earliest source message's role via subquery
+ */
+export function migrateAddSourceTypeColumns(database: DrizzleDb): void {
+  withCrashRecovery(
+    database,
+    "migration_add_source_type_columns_v1",
+    () => {
+      const raw = getSqliteFrom(database);
+
+      // Add source_type column if it doesn't exist
+      if (!tableHasColumn(database, "memory_items", "source_type")) {
+        raw.exec(
+          /*sql*/ `ALTER TABLE memory_items ADD COLUMN source_type TEXT NOT NULL DEFAULT 'extraction'`,
+        );
+      }
+
+      // Add source_message_role column if it doesn't exist
+      if (!tableHasColumn(database, "memory_items", "source_message_role")) {
+        raw.exec(
+          /*sql*/ `ALTER TABLE memory_items ADD COLUMN source_message_role TEXT`,
+        );
+      }
+
+      // Backfill source_type = 'tool' for items that were explicitly saved
+      raw.exec(
+        /*sql*/ `UPDATE memory_items SET source_type = 'tool' WHERE verification_state = 'user_confirmed'`,
+      );
+
+      // Backfill source_message_role from the earliest source message's role.
+      // Only backfill where source_message_role is currently NULL and a source
+      // message exists.
+      raw.exec(/*sql*/ `
+        UPDATE memory_items
+        SET source_message_role = (
+          SELECT m.role
+          FROM memory_item_sources mis
+          JOIN messages m ON m.id = mis.message_id
+          WHERE mis.memory_item_id = memory_items.id
+          ORDER BY mis.created_at ASC
+          LIMIT 1
+        )
+        WHERE source_message_role IS NULL
+          AND EXISTS (
+            SELECT 1
+            FROM memory_item_sources mis
+            WHERE mis.memory_item_id = memory_items.id
+          )
+      `);
+    },
+  );
+}
+
+/**
+ * Reverse: drop source_type and source_message_role columns.
+ *
+ * SQLite doesn't support DROP COLUMN on older versions, but modern SQLite
+ * (3.35.0+) does. Since Bun bundles a modern SQLite, this is safe.
+ */
+export function migrateAddSourceTypeColumnsDown(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  if (tableHasColumn(database, "memory_items", "source_type")) {
+    raw.exec(/*sql*/ `ALTER TABLE memory_items DROP COLUMN source_type`);
+  }
+  if (tableHasColumn(database, "memory_items", "source_message_role")) {
+    raw.exec(
+      /*sql*/ `ALTER TABLE memory_items DROP COLUMN source_message_role`,
+    );
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -131,6 +131,7 @@ export { migrateDropSimplifiedMemory } from "./189-drop-simplified-memory.js";
 export { migrateCallSessionSkipDisclosure } from "./190-call-session-skip-disclosure.js";
 export { migrateBackfillAudioAttachmentMimeTypes } from "./191-backfill-audio-attachment-mime-types.js";
 export { migrateContactsUserFileColumn } from "./192-contacts-user-file-column.js";
+export { migrateAddSourceTypeColumns } from "./193-add-source-type-columns.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -37,6 +37,7 @@ import { migrateDropCapabilityCardStateDown } from "./176-drop-capability-card-s
 import { migrateBackfillInlineAttachmentsToDiskDown } from "./180-backfill-inline-attachments-to-disk.js";
 import { migrateRenameThreadStartersCheckpointsDown } from "./181-rename-thread-starters-checkpoints.js";
 import { migrateBackfillAudioAttachmentMimeTypesDown } from "./191-backfill-audio-attachment-mime-types.js";
+import { migrateAddSourceTypeColumnsDown } from "./193-add-source-type-columns.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -324,6 +325,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Backfill correct MIME types for audio attachments stored as application/octet-stream due to missing extension map entries",
     down: migrateBackfillAudioAttachmentMimeTypesDown,
+  },
+  {
+    key: "migration_add_source_type_columns_v1",
+    version: 37,
+    description:
+      "Add source_type and source_message_role columns to memory_items with backfill from verification_state and source messages",
+    down: migrateAddSourceTypeColumnsDown,
   },
 ];
 

--- a/assistant/src/memory/schema/memory-core.ts
+++ b/assistant/src/memory/schema/memory-core.ts
@@ -56,6 +56,8 @@ export const memoryItems = sqliteTable(
     supersedes: text("supersedes"),
     supersededBy: text("superseded_by"),
     overrideConfidence: text("override_confidence").default("inferred"),
+    sourceType: text("source_type").notNull().default("extraction"),
+    sourceMessageRole: text("source_message_role"),
   },
   (table) => [
     index("idx_memory_items_scope_id").on(table.scopeId),

--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -493,6 +493,7 @@ export async function handleCreateMemoryItem(
       importance: importance ?? 0.8,
       fingerprint,
       verificationState: "user_confirmed",
+      sourceType: "tool",
       scopeId,
       firstSeenAt: now,
       lastSeenAt: now,

--- a/assistant/src/skills/skill-memory.ts
+++ b/assistant/src/skills/skill-memory.ts
@@ -123,6 +123,7 @@ export function upsertSkillCapabilityMemory(
         confidence,
         importance,
         fingerprint,
+        sourceType: "extraction",
         scopeId,
         firstSeenAt: now,
         lastSeenAt: now,

--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -94,6 +94,7 @@ export async function handleMemorySave(
           importance: 0.8,
           lastSeenAt: now,
           verificationState: "user_confirmed",
+          sourceType: "tool",
         })
         .where(eq(memoryItems.id, existing.id))
         .run();
@@ -116,6 +117,7 @@ export async function handleMemorySave(
         importance: 0.8, // explicit saves are high importance
         fingerprint,
         verificationState: "user_confirmed",
+        sourceType: "tool",
         scopeId,
         firstSeenAt: now,
         lastSeenAt: now,
@@ -222,6 +224,7 @@ export async function handleMemoryUpdate(
         lastSeenAt: now,
         importance: 0.8,
         verificationState: "user_confirmed",
+        sourceType: "tool",
       })
       .where(eq(memoryItems.id, existing.id))
       .run();


### PR DESCRIPTION
## Summary
- Add source_type (tool/extraction) and source_message_role columns to memory_items
- Idempotent migration with backfill from existing verification_state
- Dual-write: both old and new columns written during transition

Part of plan: memory-extraction-retrieval-improvements.md (PR 10 of 15)