### PR TITLE
fix: skill-memory test DB restoration after table drop

### DIFF
--- a/assistant/src/__tests__/skill-memory.test.ts
+++ b/assistant/src/__tests__/skill-memory.test.ts
@@ -276,8 +276,14 @@ describe("upsertSkillCapabilityMemory", () => {
       upsertSkillCapabilityMemory("test-skill", makeSkill());
     }).not.toThrow();
 
-    // Restore DB state for subsequent tests
+    // Restore DB state for subsequent tests.
+    // Delete the entire DB so initializeDb recreates it from scratch — just
+    // resetting the connection leaves stale migration checkpoints that skip
+    // checkpoint-guarded ALTER TABLE migrations (e.g. source_type column).
     resetDb();
+    for (const ext of ["", "-wal", "-shm"]) {
+      rmSync(join(testDir, `test.db${ext}`), { force: true });
+    }
     initializeDb();
   });
 });
@@ -324,8 +330,12 @@ describe("deleteSkillCapabilityMemory", () => {
       deleteSkillCapabilityMemory("test-skill");
     }).not.toThrow();
 
-    // Restore DB state for subsequent tests
+    // Restore DB state for subsequent tests (see upsert "does not throw" test
+    // for rationale on why we delete the DB file).
     resetDb();
+    for (const ext of ["", "-wal", "-shm"]) {
+      rmSync(join(testDir, `test.db${ext}`), { force: true });
+    }
     initializeDb();
   });
 });
@@ -542,8 +552,12 @@ describe("seedCatalogSkillMemories", () => {
 
     await expect(seedCatalogSkillMemories()).resolves.toBeUndefined();
 
-    // Restore DB state for subsequent tests
+    // Restore DB state for subsequent tests (see upsert "does not throw" test
+    // for rationale on why we delete the DB file).
     resetDb();
+    for (const ext of ["", "-wal", "-shm"]) {
+      rmSync(join(testDir, `test.db${ext}`), { force: true });
+    }
     initializeDb();
   });
 });


### PR DESCRIPTION
## Summary
- The 'does not throw on DB error' tests in `skill-memory.test.ts` drop `memory_items` and call `initializeDb()` to restore state. However, migration checkpoints in `memory_checkpoints` survive the drop, causing `withCrashRecovery`-guarded migrations (like the `source_type` column addition) to be skipped on re-initialization.
- Fix: delete the DB file entirely before calling `initializeDb()` so all migrations run from scratch against a clean database.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23420655744/job/68124821448