### PR TITLE
fix: remove subject/statement truncation from memory HTTP API routes

### DIFF
--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -28,7 +28,6 @@ import {
   memoryItems,
 } from "../../memory/schema.js";
 import { getLogger } from "../../util/logger.js";
-import { truncate } from "../../util/truncate.js";
 import { httpError } from "../http-errors.js";
 import type { RouteContext, RouteDefinition } from "../http-router.js";
 
@@ -442,8 +441,8 @@ export async function handleCreateMemoryItem(
     );
   }
 
-  const trimmedSubject = truncate(subject.trim(), 80, "");
-  const trimmedStatement = truncate(statement.trim(), 500, "");
+  const trimmedSubject = subject.trim();
+  const trimmedStatement = statement.trim();
 
   const scopeId = "default";
   const fingerprint = computeMemoryFingerprint(
@@ -554,13 +553,13 @@ export async function handleUpdateMemoryItem(
     if (typeof body.subject !== "string") {
       return httpError("BAD_REQUEST", "subject must be a string", 400);
     }
-    set.subject = truncate(body.subject.trim(), 80, "");
+    set.subject = body.subject.trim();
   }
   if (body.statement !== undefined) {
     if (typeof body.statement !== "string") {
       return httpError("BAD_REQUEST", "statement must be a string", 400);
     }
-    set.statement = truncate(body.statement.trim(), 500, "");
+    set.statement = body.statement.trim();
   }
   if (body.kind !== undefined) {
     if (!isValidKind(body.kind)) {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for memory-extraction-retrieval-improvements.md.

**Gap:** HTTP API routes still truncate subject/statement
**What was expected:** Truncation removed from all write paths
**What was found:** POST and PATCH handlers still truncate to 80/500 chars
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
