### PR TITLE
fix: restore verificationState dual-write and prevent sourceType demotion

### DIFF
--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -643,6 +643,20 @@ export async function extractAndUpsertMemoryItemsForMessage(
     if (existing) {
       memoryItemId = existing.id;
       effectiveStatus = "active";
+      // Preserve sourceType for tool-sourced items — extraction should not
+      // demote items the user explicitly saved.
+      const effectiveSourceType =
+        existing.sourceType === "tool" ? "tool" : "extraction";
+
+      // Dual-write verificationState alongside sourceType for client compat.
+      // Promote from assistant_inferred → user_reported when re-seen from user.
+      const effectiveVerificationState =
+        message.role === "user" || existing.verificationState === "user_reported"
+          ? "user_reported"
+          : existing.verificationState === "user_confirmed"
+            ? "user_confirmed"
+            : "assistant_inferred";
+
       db.update(memoryItems)
         .set({
           status: effectiveStatus,
@@ -653,8 +667,9 @@ export async function extractAndUpsertMemoryItemsForMessage(
             Math.max(existing.importance ?? 0, item.importance),
           ),
           lastSeenAt: Math.max(existing.lastSeenAt, seenAt),
-          sourceType: "extraction",
+          sourceType: effectiveSourceType,
           sourceMessageRole: message.role,
+          verificationState: effectiveVerificationState,
         })
         .where(eq(memoryItems.id, existing.id))
         .run();
@@ -672,6 +687,9 @@ export async function extractAndUpsertMemoryItemsForMessage(
           fingerprint: item.fingerprint,
           sourceType: "extraction",
           sourceMessageRole: message.role,
+          // Dual-write verificationState for client compat
+          verificationState:
+            message.role === "user" ? "user_reported" : "assistant_inferred",
           scopeId: effectiveScopeId,
           firstSeenAt: message.createdAt,
           lastSeenAt: seenAt,

--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -488,6 +488,7 @@ export async function handleCreateMemoryItem(
       importance: importance ?? 0.8,
       fingerprint,
       sourceType: "tool",
+      verificationState: "user_confirmed",
       scopeId,
       firstSeenAt: now,
       lastSeenAt: now,
@@ -530,6 +531,7 @@ export async function handleUpdateMemoryItem(
     status?: string;
     importance?: number;
     sourceType?: string;
+    verificationState?: string;
   };
 
   const db = getDb();
@@ -579,6 +581,22 @@ export async function handleUpdateMemoryItem(
   }
   if (body.sourceType !== undefined) {
     set.sourceType = body.sourceType;
+  }
+
+  // Accept verificationState from clients that haven't migrated to sourceType yet.
+  // Map verificationState → sourceType for forward compat, and write both fields.
+  if (body.verificationState !== undefined) {
+    set.verificationState = body.verificationState;
+    // Map verificationState to sourceType if sourceType wasn't explicitly provided
+    if (body.sourceType === undefined) {
+      set.sourceType =
+        body.verificationState === "user_confirmed" ? "tool" : "extraction";
+    }
+  }
+  // If sourceType was set (either directly or via mapping), also write verificationState
+  if (body.sourceType !== undefined && body.verificationState === undefined) {
+    set.verificationState =
+      body.sourceType === "tool" ? "user_confirmed" : "assistant_inferred";
   }
 
   // If subject, statement, or kind changed, recompute fingerprint

--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -93,6 +93,7 @@ export async function handleMemorySave(
           importance: 0.8,
           lastSeenAt: now,
           sourceType: "tool",
+          verificationState: "user_confirmed",
         })
         .where(eq(memoryItems.id, existing.id))
         .run();
@@ -115,6 +116,7 @@ export async function handleMemorySave(
         importance: 0.8, // explicit saves are high importance
         fingerprint,
         sourceType: "tool",
+        verificationState: "user_confirmed",
         scopeId,
         firstSeenAt: now,
         lastSeenAt: now,
@@ -221,6 +223,7 @@ export async function handleMemoryUpdate(
         lastSeenAt: now,
         importance: 0.8,
         sourceType: "tool",
+        verificationState: "user_confirmed",
       })
       .where(eq(memoryItems.id, existing.id))
       .run();


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for memory-extraction-retrieval-improvements.md.

- Restore verificationState writes alongside sourceType (dual-write) — clients still depend on this field
- Prevent extraction from demoting tool-sourced items by preserving existing sourceType
- Accept both verificationState and sourceType in PATCH handler for client compat
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
