### PR TITLE
fix: restore verificationState dual-write in playbook skills

### DIFF
--- a/assistant/src/config/bundled-skills/playbooks/tools/playbook-create.ts
+++ b/assistant/src/config/bundled-skills/playbooks/tools/playbook-create.ts
@@ -101,6 +101,7 @@ export async function executePlaybookCreate(
         importance: 0.8,
         fingerprint,
         sourceType: "tool",
+        verificationState: "user_confirmed",
         scopeId,
         firstSeenAt: now,
         lastSeenAt: now,

--- a/assistant/src/config/bundled-skills/playbooks/tools/playbook-update.ts
+++ b/assistant/src/config/bundled-skills/playbooks/tools/playbook-update.ts
@@ -126,6 +126,7 @@ export async function executePlaybookUpdate(
         fingerprint,
         lastSeenAt: now,
         sourceType: "tool",
+        verificationState: "user_confirmed",
       })
       .where(eq(memoryItems.id, existing.id))
       .run();


### PR DESCRIPTION
## Summary
Fixes gap from plan review: playbook-create and playbook-update skills write sourceType but were missing verificationState dual-write, causing wrong client UI badges.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
