### PR TITLE
fix: update memory-item-routes test to expect no truncation

### DIFF
--- a/assistant/src/runtime/routes/memory-item-routes.test.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.test.ts
@@ -754,7 +754,7 @@ describe("Memory Item Routes", () => {
       expect(res.status).toBe(400);
     });
 
-    test("truncates long subject and statement", async () => {
+    test("preserves long subject and statement without truncation", async () => {
       const longSubject = "a".repeat(200);
       const longStatement = "b".repeat(1000);
       const ctx = makeJsonCtx("memory-items", "POST", {
@@ -767,8 +767,8 @@ describe("Memory Item Routes", () => {
       const body = (await res.json()) as {
         item: { subject: string; statement: string };
       };
-      expect(body.item.subject.length).toBeLessThanOrEqual(80);
-      expect(body.item.statement.length).toBeLessThanOrEqual(500);
+      expect(body.item.subject).toBe(longSubject);
+      expect(body.item.statement).toBe(longStatement);
     });
 
     test("enqueues embed job on create", async () => {


### PR DESCRIPTION
## Summary
Fixes gap from plan review: test still asserted subject/statement truncation after truncation was removed from HTTP API routes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
