### PR TITLE
fix: update memory recall tests for removed recency search

### DIFF
--- a/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
+++ b/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
@@ -44,10 +44,31 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+// Stub the local embedding backend so the real ONNX model never loads
+mock.module("../memory/embedding-local.js", () => ({
+  LocalEmbeddingBackend: class {
+    readonly provider = "local" as const;
+    readonly model: string;
+    constructor(model: string) {
+      this.model = model;
+    }
+    async embed(texts: string[]): Promise<number[][]> {
+      return texts.map(() => new Array(384).fill(0));
+    }
+  },
+}));
+
+// Dynamic Qdrant mock: tests can push results to be returned by searchWithFilter/hybridSearch
+let mockQdrantResults: Array<{
+  id: string;
+  score: number;
+  payload: Record<string, unknown>;
+}> = [];
+
 mock.module("../memory/qdrant-client.js", () => ({
   getQdrantClient: () => ({
-    searchWithFilter: async () => [],
-    hybridSearch: async () => [],
+    searchWithFilter: async () => mockQdrantResults,
+    hybridSearch: async () => mockQdrantResults,
     upsertPoints: async () => {},
     deletePoints: async () => {},
   }),
@@ -60,7 +81,6 @@ const TEST_CONFIG = {
     ...DEFAULT_CONFIG.memory,
     embeddings: {
       ...DEFAULT_CONFIG.memory.embeddings,
-      provider: "openai" as const,
       required: false,
     },
     extraction: {
@@ -115,6 +135,7 @@ describe("Memory lifecycle E2E regression", () => {
     db.run("DELETE FROM conversations");
     db.run("DELETE FROM memory_jobs");
     db.run("DELETE FROM memory_checkpoints");
+    mockQdrantResults = [];
     resetCleanupScheduleThrottle();
     resetStaleSweepThrottle();
   });
@@ -339,15 +360,47 @@ describe("Memory lifecycle E2E regression", () => {
       })
       .run();
 
-    db.run(`
-      INSERT INTO memory_segments (
-        id, message_id, conversation_id, role, segment_index, text, token_estimate, scope_id, created_at, updated_at
-      ) VALUES (
-        'seg-injection-seed', 'msg-injection-seed', '${conversationId}', 'user', 0,
-        'My preferred timezone is America/Los_Angeles.', 10, 'default',
-        ${now + 10}, ${now + 10}
-      )
-    `);
+    // Seed a memory item so the semantic search path can find it
+    db.insert(memoryItems)
+      .values({
+        id: "item-timezone-pref",
+        kind: "preference",
+        subject: "timezone preference",
+        statement: "My preferred timezone is America/Los_Angeles.",
+        status: "active",
+        confidence: 0.9,
+        importance: 0.8,
+        fingerprint: "fp-item-timezone-pref",
+        firstSeenAt: now + 10,
+        lastSeenAt: now + 10,
+      })
+      .run();
+
+    db.insert(memoryItemSources)
+      .values({
+        memoryItemId: "item-timezone-pref",
+        messageId: "msg-injection-seed",
+        evidence: "timezone preference evidence",
+        createdAt: now + 10,
+      })
+      .run();
+
+    // Mock Qdrant to return the timezone preference item
+    mockQdrantResults = [
+      {
+        id: "emb-timezone-pref",
+        score: 0.92,
+        payload: {
+          target_type: "item",
+          target_id: "item-timezone-pref",
+          text: "My preferred timezone is America/Los_Angeles.",
+          kind: "preference",
+          status: "active",
+          created_at: now + 10,
+          last_seen_at: now + 10,
+        },
+      },
+    ];
 
     const recall = await buildMemoryRecall(
       "timezone",

--- a/assistant/src/__tests__/memory-recall-quality.test.ts
+++ b/assistant/src/__tests__/memory-recall-quality.test.ts
@@ -667,12 +667,29 @@ describe("Memory Recall Quality", () => {
         firstSeenAt: now - 50_000,
       });
 
+      // Mock Qdrant to return the active item as a semantic search result
+      mockQdrantResults = [
+        {
+          id: "emb-framework-active",
+          score: 0.92,
+          payload: {
+            target_type: "item",
+            target_id: "item-framework-active",
+            text: "Framework preference is React for this codebase",
+            kind: "preference",
+            status: "active",
+            created_at: now,
+            last_seen_at: now,
+          },
+        },
+      ];
+
       const recall = await buildMemoryRecall(
         "framework preference",
         "conv-invalid-status",
         TEST_CONFIG,
       );
-      // Active segment content should be injected; invalidated item should not leak
+      // Active item should be injected via semantic search; invalidated item should not leak
       expect(recall.injectedText).toContain("React");
       expect(recall.injectedText).not.toContain("Angular");
     });
@@ -979,7 +996,7 @@ describe("Memory Recall Quality", () => {
       );
     });
 
-    test("precision@k guard verifies pipeline completes with seeded segments", async () => {
+    test("precision@k guard verifies pipeline completes with seeded items", async () => {
       const db = getDb();
       const now = 1_700_000_700_000;
       insertConversation(db, "conv-pk", now, 3);
@@ -987,17 +1004,17 @@ describe("Memory Recall Quality", () => {
       const prefs = [
         {
           msg: "msg-pk-1",
-          seg: "seg-pk-1",
+          item: "item-pk-1",
           text: "I prefer dark mode over light mode",
         },
         {
           msg: "msg-pk-2",
-          seg: "seg-pk-2",
+          item: "item-pk-2",
           text: "I like using TypeScript for all projects",
         },
         {
           msg: "msg-pk-3",
-          seg: "seg-pk-3",
+          item: "item-pk-3",
           text: "I prefer tabs over spaces for indentation",
         },
       ];
@@ -1006,8 +1023,31 @@ describe("Memory Recall Quality", () => {
         const p = prefs[i]!;
         const t = now + i * 1000;
         insertMessage(db, p.msg, "conv-pk", "user", p.text, t);
-        insertSegment(db, p.seg, p.msg, "conv-pk", "user", p.text, t);
+        insertItem(db, {
+          id: p.item,
+          kind: "preference",
+          subject: `preference-${i}`,
+          statement: p.text,
+          importance: 0.8,
+          firstSeenAt: t,
+        });
+        insertItemSource(db, p.item, p.msg, t);
       }
+
+      // Mock Qdrant to return all three preference items
+      mockQdrantResults = prefs.map((p, i) => ({
+        id: `emb-pk-${i}`,
+        score: 0.9 - i * 0.05,
+        payload: {
+          target_type: "item",
+          target_id: p.item,
+          text: p.text,
+          kind: "preference",
+          status: "active",
+          created_at: now + i * 1000,
+          last_seen_at: now + i * 1000,
+        },
+      }));
 
       const recall = await buildMemoryRecall(
         "what do I prefer",
@@ -1015,8 +1055,8 @@ describe("Memory Recall Quality", () => {
         TEST_CONFIG,
       );
 
-      // Recency-only candidates are promoted to tier 2 and injected.
-      // Verify the pipeline recalled the preference content.
+      // Semantic search returns all three preference items which pass
+      // tier classification and are injected.
       expect(recall.enabled).toBe(true);
       assertPrecisionAtK(
         recall.injectedText,


### PR DESCRIPTION
## Summary
Fix 3 failing tests in memory-recall-quality and memory-lifecycle-e2e that depended on the now-removed conversation-scoped recency search.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
