### PR TITLE
fix: resolve desktop persona from vellum-channel guardian

### DIFF
--- a/assistant/src/prompts/persona-resolver.ts
+++ b/assistant/src/prompts/persona-resolver.ts
@@ -3,6 +3,7 @@ import { basename, join } from "node:path";
 
 import {
   findContactByChannelExternalId,
+  findGuardianForChannel,
   listGuardianChannels,
 } from "../contacts/contact-store.js";
 import type {
@@ -66,8 +67,11 @@ export function resolveUserPersona(
   let filename: string | null = null;
 
   if (trustContext === undefined) {
-    // Desktop / native — resolve via guardian contact
-    const guardian = listGuardianChannels();
+    // Desktop / native — prefer the guardian with a "vellum" channel so we
+    // load the correct per-user persona when multiple guardians exist (e.g.
+    // one for the desktop app, another for phone).
+    const vellumGuardian = findGuardianForChannel("vellum");
+    const guardian = vellumGuardian ?? listGuardianChannels();
     if (guardian) {
       filename = guardian.contact.userFile ?? null;
     }


### PR DESCRIPTION
## Summary

- When multiple guardian contacts exist (desktop + phone), `resolveUserPersona()` was picking the guardian with the most recently verified channel — which could be the phone guardian, loading the wrong persona file.
- In desktop/native mode, now prefer the guardian with a `"vellum"` channel via `findGuardianForChannel("vellum")`, falling back to `listGuardianChannels()` if none exists.

## Original prompt

this then /do the bugfix