### PR TITLE
fix: increase user file slug limit to avoid truncating UUIDs

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -38,7 +38,7 @@ export function generateUserFileSlug(displayName: string): string {
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, "-")
       .replace(/^-+|-+$/g, "")
-      .slice(0, 50) || "user";
+      .slice(0, 100) || "user";
 
   const db = getDb();
   const rows = db


### PR DESCRIPTION
## Summary

- `generateUserFileSlug()` truncated slugs at 50 chars, clipping UUID-based display names (53 chars) and producing incomplete filenames like `vellum-principal-325d5479-2bc6-4e0d-808d-0dc1f5b3f.md`.
- Increased limit to 100 chars, which accommodates full UUID display names while staying well within filesystem filename limits (255 bytes).

## Original prompt

Fix the `.slice(0, 50)` truncation in `generateUserFileSlug` — UUIDs in display names (like `vellum-principal-325d5479-2bc6-4e0d-808d-0dc1f5b3fd92`) get clipped to 50 chars, losing the tail. Increase the limit to accommodate full UUID-based display names.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
