### PR TITLE
fix: fall back to guardian lookup for managed desktop persona

### DIFF
--- a/assistant/src/prompts/persona-resolver.ts
+++ b/assistant/src/prompts/persona-resolver.ts
@@ -67,9 +67,8 @@ export function resolveUserPersona(
   let filename: string | null = null;
 
   if (trustContext === undefined) {
-    // Desktop / native — prefer the guardian with a "vellum" channel so we
-    // load the correct per-user persona when multiple guardians exist (e.g.
-    // one for the desktop app, another for phone).
+    // Desktop / native (no gateway) — resolve via guardian contact,
+    // preferring the vellum-channel guardian when multiple exist.
     const vellumGuardian = findGuardianForChannel("vellum");
     const guardian = vellumGuardian ?? listGuardianChannels();
     if (guardian) {
@@ -83,6 +82,14 @@ export function resolveUserPersona(
     );
     if (contactWithChannels) {
       filename = contactWithChannels.userFile ?? null;
+    } else if (trustContext.trustClass === "guardian") {
+      // Managed desktop: the JWT principal ID used as requesterExternalUserId
+      // may differ from the contact channel's external_user_id (they are
+      // separate identity concepts). Fall back to the channel-type guardian.
+      const guardian = findGuardianForChannel(trustContext.sourceChannel);
+      if (guardian) {
+        filename = guardian.contact.userFile ?? null;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- For managed desktop connections, the JWT principal UUID passed as `requesterExternalUserId` doesn't match the contact channel's `external_user_id` — they're separate identity concepts (auth principal vs channel identity).
- `findContactByChannelExternalId()` fails, causing `resolveUserPersona()` to fall through to `default.md` instead of loading the guardian's persona file.
- Added a fallback: when the channel lookup fails and the actor has `trustClass === "guardian"`, use `findGuardianForChannel()` to resolve the correct contact and persona file.