### PR TITLE
fix: inline dist assets for multifile TSX apps in app_open

### DIFF
--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -2,7 +2,10 @@ import { v4 as uuid } from "uuid";
 
 import {
   getApp,
+  getAppDirPath,
   getAppPreview,
+  inlineDistAssets,
+  isMultifileApp,
   resolveAppDir,
   updateApp,
 } from "../memory/app-store.js";
@@ -1364,8 +1367,34 @@ export async function surfaceProxyResolver(
 
     const storedPreview = getAppPreview(app.id);
     const { dirName } = resolveAppDir(app.id);
+
+    // For multifile TSX apps, resolve HTML from compiled dist/index.html
+    // rather than the root index.html (which is empty for formatVersion 2).
+    let html = app.htmlDefinition;
+    if (isMultifileApp(app)) {
+      const { existsSync, readFileSync } = await import("node:fs");
+      const { join } = await import("node:path");
+      const appDir = getAppDirPath(app.id);
+      const distIndex = join(appDir, "dist", "index.html");
+      if (!existsSync(distIndex)) {
+        const { compileApp } = await import("../bundler/app-compiler.js");
+        const result = await compileApp(appDir);
+        if (!result.ok) {
+          log.warn(
+            { appId, errors: result.errors },
+            "Auto-compile failed on app_open",
+          );
+        }
+      }
+      if (existsSync(distIndex)) {
+        html = inlineDistAssets(appDir, readFileSync(distIndex, "utf-8"));
+      } else {
+        html = `<p>App compilation failed. Edit a source file to trigger a rebuild.</p>`;
+      }
+    }
+
     const surfaceData: DynamicPageSurfaceData = {
-      html: app.htmlDefinition,
+      html,
       appId: app.id,
       dirName,
       preview: {

--- a/assistant/src/memory/app-store.ts
+++ b/assistant/src/memory/app-store.ts
@@ -64,6 +64,37 @@ export function isMultifileApp(app: AppDefinition): boolean {
   return app.formatVersion === 2;
 }
 
+/**
+ * Inline dist assets (main.js, main.css) into the compiled HTML so it can be
+ * delivered as a self-contained string via loadHTMLString/SSE without needing
+ * the client to resolve external script/stylesheet URLs.
+ */
+export function inlineDistAssets(appDir: string, html: string): string {
+  const distDir = join(appDir, "dist");
+
+  // Inline main.js
+  const jsPath = join(distDir, "main.js");
+  if (existsSync(jsPath)) {
+    const js = readFileSync(jsPath, "utf-8");
+    html = html.replace(
+      /<script\s+type="module"\s+src="main\.js"\s*><\/script>/,
+      `<script type="module">${js}</script>`,
+    );
+  }
+
+  // Inline main.css
+  const cssPath = join(distDir, "main.css");
+  if (existsSync(cssPath)) {
+    const css = readFileSync(cssPath, "utf-8");
+    html = html.replace(
+      /<link\s+rel="stylesheet"\s+href="main\.css"\s*>/,
+      `<style>${css}</style>`,
+    );
+  }
+
+  return html;
+}
+
 export interface AppRecord {
   id: string;
   appId: string;

--- a/assistant/src/runtime/routes/app-management-routes.ts
+++ b/assistant/src/runtime/routes/app-management-routes.ts
@@ -36,6 +36,7 @@ import {
   getApp,
   getAppDirPath,
   getAppPreview,
+  inlineDistAssets,
   isMultifileApp,
   listApps,
   queryAppRecords,
@@ -684,7 +685,7 @@ export function appManagementRouteDefinitions(): RouteDefinition[] {
               }
             }
             if (existsSync(distIndex)) {
-              html = readFileSync(distIndex, "utf-8");
+              html = inlineDistAssets(appDir, readFileSync(distIndex, "utf-8"));
             } else {
               html = `<p>App compilation failed. Edit a source file to trigger a rebuild.</p>`;
             }


### PR DESCRIPTION
## Summary
- The `app_open` tool handler was sending empty HTML for multifile TSX apps because it read from the root `index.html` (0 bytes) instead of compiling and reading `dist/index.html`
- Even when compiled HTML was returned (via `POST /apps/:id/open`), the `<script src="main.js">` tag couldn't be resolved by the WebView since it loads inline with a fake origin URL
- Added `inlineDistAssets()` helper that embeds compiled JS/CSS directly into the HTML, making it self-contained for inline delivery via `loadHTMLString`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
