### PR TITLE
feat: add "max" effort level for inference

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -23,7 +23,7 @@ export interface AgentLoopConfig {
   maxTokens: number;
   maxInputTokens?: number; // context window size for tool result truncation
   thinking?: { enabled: boolean };
-  effort: "low" | "medium" | "high";
+  effort: "low" | "medium" | "high" | "max";
   toolChoice?:
     | { type: "auto" }
     | { type: "any" }

--- a/assistant/src/config/schemas/inference.ts
+++ b/assistant/src/config/schemas/inference.ts
@@ -26,8 +26,8 @@ export const ThinkingConfigSchema = z
   .describe("Extended thinking (chain-of-thought) configuration");
 
 export const EffortSchema = z
-  .enum(["low", "medium", "high"], {
-    error: 'effort must be "low", "medium", or "high"',
+  .enum(["low", "medium", "high", "max"], {
+    error: 'effort must be "low", "medium", "high", or "max"',
   })
   .default("high")
   .describe(

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -130,7 +130,7 @@ export type ProviderEvent =
 export interface SendMessageConfig {
   model?: string;
   modelIntent?: ModelIntent;
-  effort?: "low" | "medium" | "high";
+  effort?: "low" | "medium" | "high" | "max";
   [key: string]: unknown;
 }
 

--- a/skills/vellum-self-knowledge/references/inference.md
+++ b/skills/vellum-self-knowledge/references/inference.md
@@ -35,7 +35,7 @@ Relevant config paths and what they control:
 | `services.inference.model` | The active model ID (e.g. `claude-opus-4-6`, `gpt-5.2`) |
 | `services.inference.provider` | The active provider: `anthropic`, `openai`, `gemini`, `ollama`, `fireworks`, `openrouter` |
 | `services.inference.mode` | `"your-own"` (user's API key) vs `"managed"` (platform proxy) |
-| `effort` | Inference effort level: `"low"`, `"medium"`, `"high"` |
+| `effort` | Inference effort level: `"low"`, `"medium"`, `"high"`, `"max"` |
 | `thinking.enabled` | Whether extended thinking (chain-of-thought) is active |
 
 Read any of these with `assistant config get <path>`, e.g.:


### PR DESCRIPTION
## Summary
- Add `"max"` to the `EffortSchema` enum, `AgentLoopConfig`, and `SendMessageConfig` type
- Update self-knowledge reference docs to list the new level
- The Anthropic SDK already supports `"max"` in `output_config.effort` — no provider changes needed

## Original prompt
add support for "max" effort
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
