### PR TITLE
feat: add "journal" memory kind to memory_manage tool

### DIFF
--- a/assistant/src/tools/memory/definitions.ts
+++ b/assistant/src/tools/memory/definitions.ts
@@ -46,9 +46,10 @@ const memoryManageProperties = {
       "decision",
       "constraint",
       "event",
+      "journal",
     ],
     description:
-      'Category of the memory item (required for save). Use "constraint" for mistakes, gotchas, discoveries, and working solutions - write as advice to your future self.',
+      'Category of the memory item (required for save). Use "constraint" for mistakes, gotchas, discoveries, and working solutions - write as advice to your future self. Use "journal" for journal-style memories — experiential snapshots, upcoming events, things to carry forward.',
   },
   subject: {
     type: "string" as const,

--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -38,6 +38,7 @@ export async function handleMemorySave(
     "decision",
     "constraint",
     "event",
+    "journal",
   ]);
   if (typeof rawKind !== "string") {
     return {


### PR DESCRIPTION
## Summary
- Add `"journal"` to the `kind` enum in `memory_manage` tool definition
- Add `"journal"` to the `validKinds` set in the memory save handler
- Enables assistants to save journal-style memory items (experiential snapshots, upcoming events, things to carry forward)

Part of plan: journal-context-window.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
