### PR TITLE
feat: add journal config schema with contextWindowSize

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -44,6 +44,8 @@ export type { FishAudioConfig } from "./schemas/fish-audio.js";
 export { FishAudioConfigSchema } from "./schemas/fish-audio.js";
 export type { HeartbeatConfig } from "./schemas/heartbeat.js";
 export { HeartbeatConfigSchema } from "./schemas/heartbeat.js";
+export type { JournalConfig } from "./schemas/journal.js";
+export { JournalConfigSchema } from "./schemas/journal.js";
 export type {
   ContextOverflowRecoveryConfig,
   ContextWindowConfig,
@@ -195,6 +197,7 @@ import {
 import { ElevenLabsConfigSchema } from "./schemas/elevenlabs.js";
 import { FishAudioConfigSchema } from "./schemas/fish-audio.js";
 import { HeartbeatConfigSchema } from "./schemas/heartbeat.js";
+import { JournalConfigSchema } from "./schemas/journal.js";
 import {
   ContextWindowConfigSchema,
   EffortSchema,
@@ -266,6 +269,7 @@ export const AssistantConfigSchema = z
         "Custom pricing overrides for specific provider/model combinations",
       ),
     heartbeat: HeartbeatConfigSchema.default(HeartbeatConfigSchema.parse({})),
+    journal: JournalConfigSchema.default(JournalConfigSchema.parse({})),
     mcp: McpConfigSchema.default(McpConfigSchema.parse({})),
     acp: AcpConfigSchema.default(AcpConfigSchema.parse({})),
     skills: SkillsConfigSchema.default(SkillsConfigSchema.parse({})),

--- a/assistant/src/config/schemas/journal.ts
+++ b/assistant/src/config/schemas/journal.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const JournalConfigSchema = z
+  .object({
+    contextWindowSize: z
+      .number({ error: "journal.contextWindowSize must be a number" })
+      .int("journal.contextWindowSize must be an integer")
+      .min(0, "journal.contextWindowSize must be >= 0")
+      .default(10)
+      .describe(
+        "Number of recent journal entries to include in context (0 to disable)",
+      ),
+  })
+  .describe("Journal context window configuration");
+
+export type JournalConfig = z.infer<typeof JournalConfigSchema>;


### PR DESCRIPTION
## Summary
- Create `JournalConfigSchema` with `contextWindowSize` setting (default: 10, min: 0)
- Export schema and type from `config/schema.ts`
- Register in `AssistantConfigSchema` alongside existing config sections

Part of plan: journal-context-window.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20838" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
