### PR TITLE
feat: add "journal" kind to memory extraction pipeline

### DIFF
--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -33,7 +33,8 @@ export type MemoryItemKind =
   | "project"
   | "decision"
   | "constraint"
-  | "event";
+  | "event"
+  | "journal";
 
 export type OverrideConfidence = "explicit" | "tentative" | "inferred";
 
@@ -57,6 +58,7 @@ const VALID_KINDS = new Set<string>([
   "decision",
   "constraint",
   "event",
+  "journal",
 ]);
 
 /** Maps old kind names to their new equivalents for graceful migration. */
@@ -165,6 +167,7 @@ Extract items in these categories:
 - decision: Choices made, approaches selected, trade-offs resolved
 - constraint: Rules, requirements, things that must/must not be done, explicit directives on how the assistant should behave
 - event: Deadlines, milestones, meetings, releases, dates
+- journal: Experiential reflections, journal-style notes, upcoming events, things the user or assistant explicitly wants to carry forward
 
 For each item, provide:
 - kind: One of the categories above
@@ -228,6 +231,9 @@ Good extractions from assistant messages:
 
 - "I've refactored the auth middleware to use JWT validation and added rate limiting to the login endpoint."
   → kind: project, subject: "Auth middleware changes", statement: "Auth middleware was refactored to use JWT validation with rate limiting on the login endpoint"
+
+- "I just wrote a journal entry about the project kickoff — feeling optimistic about the timeline"
+  → kind: journal, subject: "Project kickoff reflection", statement: "Feeling optimistic about the project timeline after the kickoff meeting"
 
 Do NOT extract:
 - "I'll check that file for you" → assistant operational statement with no lasting information


### PR DESCRIPTION
## Summary
- Add `"journal"` to `MemoryItemKind` type union and `VALID_KINDS` set in the items extractor
- Add journal category to the extraction system prompt with description and example
- Enables the LLM extraction pipeline to recognize and extract journal-style content

Part of plan: journal-context-window.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20839" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
