### PR TITLE
feat: load journal entries into system prompt dynamic section

### DIFF
--- a/assistant/src/__tests__/journal-context.test.ts
+++ b/assistant/src/__tests__/journal-context.test.ts
@@ -1,0 +1,272 @@
+import {
+  mkdirSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const TEST_DIR = join(tmpdir(), `vellum-journal-test-${crypto.randomUUID()}`);
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realPlatform = require("../util/platform.js");
+mock.module("../util/platform.js", () => ({
+  ...realPlatform,
+  getWorkspaceDir: () => TEST_DIR,
+}));
+
+const { buildJournalContext, formatRelativeTime } = await import(
+  "../prompts/journal-context.js"
+);
+
+describe("formatRelativeTime", () => {
+  test("returns 'just now' for times less than 60 seconds ago", () => {
+    const now = Date.now();
+    expect(formatRelativeTime(now - 30_000)).toBe("just now");
+    expect(formatRelativeTime(now - 1_000)).toBe("just now");
+    expect(formatRelativeTime(now)).toBe("just now");
+  });
+
+  test("returns minutes for times between 1-59 minutes ago", () => {
+    const now = Date.now();
+    expect(formatRelativeTime(now - 60_000)).toBe("1 minute ago");
+    expect(formatRelativeTime(now - 5 * 60_000)).toBe("5 minutes ago");
+    expect(formatRelativeTime(now - 59 * 60_000)).toBe("59 minutes ago");
+  });
+
+  test("returns hours for times between 1-23 hours ago", () => {
+    const now = Date.now();
+    expect(formatRelativeTime(now - 60 * 60_000)).toBe("1 hour ago");
+    expect(formatRelativeTime(now - 3 * 60 * 60_000)).toBe("3 hours ago");
+    expect(formatRelativeTime(now - 23 * 60 * 60_000)).toBe("23 hours ago");
+  });
+
+  test("returns days for times between 1-6 days ago", () => {
+    const now = Date.now();
+    expect(formatRelativeTime(now - 24 * 60 * 60_000)).toBe("1 day ago");
+    expect(formatRelativeTime(now - 3 * 24 * 60 * 60_000)).toBe("3 days ago");
+    expect(formatRelativeTime(now - 6 * 24 * 60 * 60_000)).toBe("6 days ago");
+  });
+
+  test("returns weeks for times 7 or more days ago", () => {
+    const now = Date.now();
+    expect(formatRelativeTime(now - 7 * 24 * 60 * 60_000)).toBe("1 week ago");
+    expect(formatRelativeTime(now - 14 * 24 * 60 * 60_000)).toBe(
+      "2 weeks ago",
+    );
+    expect(formatRelativeTime(now - 30 * 24 * 60 * 60_000)).toBe(
+      "4 weeks ago",
+    );
+  });
+});
+
+describe("buildJournalContext", () => {
+  const journalDir = join(TEST_DIR, "journal");
+
+  beforeEach(() => {
+    mkdirSync(journalDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  test("returns null when maxEntries is 0", () => {
+    writeFileSync(join(journalDir, "entry.md"), "content");
+    expect(buildJournalContext(0)).toBeNull();
+  });
+
+  test("returns null when maxEntries is negative", () => {
+    writeFileSync(join(journalDir, "entry.md"), "content");
+    expect(buildJournalContext(-1)).toBeNull();
+  });
+
+  test("returns null when journal directory does not exist", () => {
+    rmSync(journalDir, { recursive: true, force: true });
+    expect(buildJournalContext(10)).toBeNull();
+  });
+
+  test("returns null when journal directory has no .md files", () => {
+    writeFileSync(join(journalDir, "notes.txt"), "not markdown");
+    expect(buildJournalContext(10)).toBeNull();
+  });
+
+  test("excludes README.md (case-insensitive)", () => {
+    writeFileSync(join(journalDir, "README.md"), "readme content");
+    writeFileSync(join(journalDir, "readme.md"), "readme content lower");
+    expect(buildJournalContext(10)).toBeNull();
+  });
+
+  test("returns formatted journal context with single entry", () => {
+    writeFileSync(join(journalDir, "goals.md"), "My goals for this week.");
+    const result = buildJournalContext(10);
+    expect(result).not.toBeNull();
+    expect(result).toContain("# Journal");
+    expect(result).toContain(
+      "Your journal entries, most recent first. These are YOUR words from past conversations.",
+    );
+    expect(result).toContain("## goals.md — MOST RECENT");
+    expect(result).toContain("My goals for this week.");
+    // Single entry, window not full — should NOT have LEAVING CONTEXT
+    expect(result).not.toContain("LEAVING CONTEXT");
+  });
+
+  test("sorts entries by mtime, newest first", () => {
+    const now = new Date();
+
+    writeFileSync(join(journalDir, "old.md"), "old entry");
+    const oldTime = new Date(now.getTime() - 3 * 24 * 60 * 60_000);
+    utimesSync(join(journalDir, "old.md"), oldTime, oldTime);
+
+    writeFileSync(join(journalDir, "mid.md"), "mid entry");
+    const midTime = new Date(now.getTime() - 1 * 24 * 60 * 60_000);
+    utimesSync(join(journalDir, "mid.md"), midTime, midTime);
+
+    writeFileSync(join(journalDir, "new.md"), "new entry");
+    const newTime = new Date(now.getTime() - 60_000);
+    utimesSync(join(journalDir, "new.md"), newTime, newTime);
+
+    const result = buildJournalContext(10)!;
+    const newIdx = result.indexOf("new.md");
+    const midIdx = result.indexOf("mid.md");
+    const oldIdx = result.indexOf("old.md");
+    expect(newIdx).toBeLessThan(midIdx);
+    expect(midIdx).toBeLessThan(oldIdx);
+  });
+
+  test("marks most recent entry with MOST RECENT", () => {
+    const now = new Date();
+
+    writeFileSync(join(journalDir, "older.md"), "older");
+    const olderTime = new Date(now.getTime() - 2 * 24 * 60 * 60_000);
+    utimesSync(join(journalDir, "older.md"), olderTime, olderTime);
+
+    writeFileSync(join(journalDir, "newest.md"), "newest");
+    const newestTime = new Date(now.getTime() - 60_000);
+    utimesSync(join(journalDir, "newest.md"), newestTime, newestTime);
+
+    const result = buildJournalContext(10)!;
+    expect(result).toContain("## newest.md — MOST RECENT");
+    expect(result).not.toContain("## older.md — MOST RECENT");
+  });
+
+  test("marks oldest entry with LEAVING CONTEXT when window is full", () => {
+    const now = new Date();
+
+    writeFileSync(join(journalDir, "a.md"), "entry a");
+    utimesSync(
+      join(journalDir, "a.md"),
+      new Date(now.getTime() - 60_000),
+      new Date(now.getTime() - 60_000),
+    );
+
+    writeFileSync(join(journalDir, "b.md"), "entry b");
+    utimesSync(
+      join(journalDir, "b.md"),
+      new Date(now.getTime() - 2 * 60 * 60_000),
+      new Date(now.getTime() - 2 * 60 * 60_000),
+    );
+
+    writeFileSync(join(journalDir, "c.md"), "entry c");
+    utimesSync(
+      join(journalDir, "c.md"),
+      new Date(now.getTime() - 3 * 24 * 60 * 60_000),
+      new Date(now.getTime() - 3 * 24 * 60 * 60_000),
+    );
+
+    // maxEntries = 3 matches the number of files, so window is full
+    const result = buildJournalContext(3)!;
+    expect(result).toContain("## a.md — MOST RECENT");
+    expect(result).toContain("## c.md — LEAVING CONTEXT");
+    expect(result).toContain(
+      "NOTE: This is the oldest entry in your active context.",
+    );
+    expect(result).toContain(
+      "carry forward anything from here that still matters to you",
+    );
+  });
+
+  test("does NOT mark oldest entry with LEAVING CONTEXT when window is not full", () => {
+    const now = new Date();
+
+    writeFileSync(join(journalDir, "a.md"), "entry a");
+    utimesSync(
+      join(journalDir, "a.md"),
+      new Date(now.getTime() - 60_000),
+      new Date(now.getTime() - 60_000),
+    );
+
+    writeFileSync(join(journalDir, "b.md"), "entry b");
+    utimesSync(
+      join(journalDir, "b.md"),
+      new Date(now.getTime() - 2 * 60 * 60_000),
+      new Date(now.getTime() - 2 * 60 * 60_000),
+    );
+
+    // maxEntries = 5, only 2 files — window is NOT full
+    const result = buildJournalContext(5)!;
+    expect(result).toContain("## a.md — MOST RECENT");
+    expect(result).not.toContain("LEAVING CONTEXT");
+  });
+
+  test("limits entries to maxEntries", () => {
+    const now = new Date();
+
+    for (let i = 0; i < 5; i++) {
+      const filename = `entry-${i}.md`;
+      writeFileSync(join(journalDir, filename), `content ${i}`);
+      const time = new Date(now.getTime() - i * 60 * 60_000);
+      utimesSync(join(journalDir, filename), time, time);
+    }
+
+    const result = buildJournalContext(3)!;
+    // Should contain only 3 entries (entry-0, entry-1, entry-2)
+    expect(result).toContain("entry-0.md");
+    expect(result).toContain("entry-1.md");
+    expect(result).toContain("entry-2.md");
+    expect(result).not.toContain("entry-3.md");
+    expect(result).not.toContain("entry-4.md");
+  });
+
+  test("includes relative timestamps in headers", () => {
+    const now = new Date();
+
+    writeFileSync(join(journalDir, "recent.md"), "recent content");
+    const recentTime = new Date(now.getTime() - 3 * 60 * 60_000);
+    utimesSync(join(journalDir, "recent.md"), recentTime, recentTime);
+
+    const result = buildJournalContext(10)!;
+    expect(result).toContain("3 hours ago");
+  });
+
+  test("middle entries have plain headers with relative time", () => {
+    const now = new Date();
+
+    writeFileSync(join(journalDir, "first.md"), "first");
+    utimesSync(
+      join(journalDir, "first.md"),
+      new Date(now.getTime() - 60_000),
+      new Date(now.getTime() - 60_000),
+    );
+
+    writeFileSync(join(journalDir, "middle.md"), "middle");
+    utimesSync(
+      join(journalDir, "middle.md"),
+      new Date(now.getTime() - 2 * 60 * 60_000),
+      new Date(now.getTime() - 2 * 60 * 60_000),
+    );
+
+    writeFileSync(join(journalDir, "last.md"), "last");
+    utimesSync(
+      join(journalDir, "last.md"),
+      new Date(now.getTime() - 3 * 24 * 60 * 60_000),
+      new Date(now.getTime() - 3 * 24 * 60 * 60_000),
+    );
+
+    const result = buildJournalContext(3)!;
+    // Middle entry should have plain header format (no MOST RECENT, no LEAVING CONTEXT)
+    expect(result).toMatch(/## middle\.md \(\d+ hours? ago\)/);
+  });
+});

--- a/assistant/src/prompts/journal-context.ts
+++ b/assistant/src/prompts/journal-context.ts
@@ -1,0 +1,97 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { getWorkspaceDir } from "../util/platform.js";
+
+/**
+ * Return a human-readable relative timestamp from a Unix-epoch millisecond
+ * value to "now".
+ */
+export function formatRelativeTime(mtime: number): string {
+  const diffMs = Date.now() - mtime;
+  const diffSec = Math.floor(diffMs / 1000);
+
+  if (diffSec < 60) return "just now";
+
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) {
+    return diffMin === 1 ? "1 minute ago" : `${diffMin} minutes ago`;
+  }
+
+  const diffHours = Math.floor(diffMin / 60);
+  if (diffHours < 24) {
+    return diffHours === 1 ? "1 hour ago" : `${diffHours} hours ago`;
+  }
+
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) {
+    return diffDays === 1 ? "1 day ago" : `${diffDays} days ago`;
+  }
+
+  const diffWeeks = Math.floor(diffDays / 7);
+  return diffWeeks === 1 ? "1 week ago" : `${diffWeeks} weeks ago`;
+}
+
+/**
+ * Build a journal context section for inclusion in the system prompt.
+ *
+ * Reads `{workspaceDir}/journal/*.md` files, sorts by mtime (newest first),
+ * and returns a formatted string with relative timestamps. Returns `null`
+ * when no entries are available.
+ */
+export function buildJournalContext(maxEntries: number): string | null {
+  if (maxEntries <= 0) return null;
+
+  const journalDir = join(getWorkspaceDir(), "journal");
+
+  let files: string[];
+  try {
+    files = readdirSync(journalDir);
+  } catch {
+    // Directory doesn't exist — no journal entries
+    return null;
+  }
+
+  // Filter for .md files, excluding README.md (case-insensitive)
+  const mdFiles = files.filter(
+    (f) => f.endsWith(".md") && f.toLowerCase() !== "readme.md",
+  );
+
+  // Collect file info with mtime
+  const entries = mdFiles
+    .map((f) => {
+      const filepath = join(journalDir, f);
+      const stat = statSync(filepath);
+      return { filename: f, filepath, mtimeMs: stat.mtimeMs };
+    })
+    .sort((a, b) => b.mtimeMs - a.mtimeMs)
+    .slice(0, maxEntries);
+
+  if (entries.length === 0) return null;
+
+  const sections: string[] = [
+    "# Journal\n\nYour journal entries, most recent first. These are YOUR words from past conversations.",
+  ];
+
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    const content = readFileSync(entry.filepath, "utf-8");
+    const relativeTime = formatRelativeTime(entry.mtimeMs);
+
+    let header: string;
+    if (i === 0) {
+      header = `## ${entry.filename} — MOST RECENT (${relativeTime})`;
+    } else if (i === entries.length - 1 && entries.length === maxEntries) {
+      header = `## ${entry.filename} — LEAVING CONTEXT (${relativeTime})`;
+      header +=
+        "\nNOTE: This is the oldest entry in your active context. When you write your next journal entry, carry forward anything from here that still matters to you — after that, this entry will only be available via the filesystem and memory recall.";
+      header += "\n";
+    } else {
+      header = `## ${entry.filename} (${relativeTime})`;
+    }
+
+    sections.push(header + "\n" + content);
+  }
+
+  return sections.join("\n\n");
+}

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -15,6 +15,7 @@ import {
   isMacOS,
 } from "../util/platform.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "./cache-boundary.js";
+import { buildJournalContext } from "./journal-context.js";
 
 export { SYSTEM_PROMPT_CACHE_BOUNDARY };
 
@@ -218,6 +219,11 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // and phone-calls skill SKILL.md files.
   const integrationSection = buildIntegrationSection();
   if (integrationSection) dynamicParts.push(integrationSection);
+
+  const journalContext = buildJournalContext(
+    getConfig().journal?.contextWindowSize ?? 10,
+  );
+  if (journalContext) dynamicParts.push(journalContext);
 
   const dynamicWithSkills = appendSkillsCatalog(dynamicParts.join("\n\n"));
 


### PR DESCRIPTION
## Summary
- Create `buildJournalContext()` in `assistant/src/prompts/journal-context.ts` that reads `{workspaceDir}/journal/*.md` files
- Sort by mtime (newest first), mark MOST RECENT and LEAVING CONTEXT entries with relative timestamps
- Wire into `buildSystemPrompt()` dynamic section, controlled by `config.journal.contextWindowSize` (default 10)
- Add unit tests for `buildJournalContext` and `formatRelativeTime`

Part of plan: journal-context-window.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
