### PR TITLE
fix: sort imports/exports in config schema.ts

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -44,8 +44,6 @@ export type { FishAudioConfig } from "./schemas/fish-audio.js";
 export { FishAudioConfigSchema } from "./schemas/fish-audio.js";
 export type { HeartbeatConfig } from "./schemas/heartbeat.js";
 export { HeartbeatConfigSchema } from "./schemas/heartbeat.js";
-export type { JournalConfig } from "./schemas/journal.js";
-export { JournalConfigSchema } from "./schemas/journal.js";
 export type {
   ContextOverflowRecoveryConfig,
   ContextWindowConfig,
@@ -70,6 +68,8 @@ export {
   IngressRateLimitConfigSchema,
   IngressWebhookConfigSchema,
 } from "./schemas/ingress.js";
+export type { JournalConfig } from "./schemas/journal.js";
+export { JournalConfigSchema } from "./schemas/journal.js";
 export type { AuditLogConfig, LogFileConfig } from "./schemas/logging.js";
 export {
   AuditLogConfigSchema,
@@ -197,7 +197,6 @@ import {
 import { ElevenLabsConfigSchema } from "./schemas/elevenlabs.js";
 import { FishAudioConfigSchema } from "./schemas/fish-audio.js";
 import { HeartbeatConfigSchema } from "./schemas/heartbeat.js";
-import { JournalConfigSchema } from "./schemas/journal.js";
 import {
   ContextWindowConfigSchema,
   EffortSchema,
@@ -205,6 +204,7 @@ import {
   ThinkingConfigSchema,
 } from "./schemas/inference.js";
 import { IngressConfigSchema } from "./schemas/ingress.js";
+import { JournalConfigSchema } from "./schemas/journal.js";
 import {
   AuditLogConfigSchema,
   LogFileConfigSchema,


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/exports` and `simple-import-sort/imports` lint errors in `assistant/src/config/schema.ts`
- Journal schema exports/imports were inserted out of alphabetical order; ESLint autofix moves them to the correct position

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23432411508/job/68161843932
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
