### PR TITLE
fix: add "journal" to REST API VALID_KINDS

### DIFF
--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -45,6 +45,7 @@ const VALID_KINDS = [
   "constraint",
   "event",
   "capability",
+  "journal",
 ] as const;
 
 type MemoryItemKind = (typeof VALID_KINDS)[number];


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for journal-context-window.md.

**Gap:** REST API VALID_KINDS rejects "journal" kind
**What was expected:** The REST API should accept "journal" as a valid memory item kind
**What was found:** memory-item-routes.ts VALID_KINDS array did not include "journal"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
