### PR TITLE
fix: rename formatRelativeTime to formatJournalRelativeTime

### DIFF
--- a/assistant/src/__tests__/journal-context.test.ts
+++ b/assistant/src/__tests__/journal-context.test.ts
@@ -17,46 +17,46 @@ mock.module("../util/platform.js", () => ({
   getWorkspaceDir: () => TEST_DIR,
 }));
 
-const { buildJournalContext, formatRelativeTime } = await import(
+const { buildJournalContext, formatJournalRelativeTime } = await import(
   "../prompts/journal-context.js"
 );
 
-describe("formatRelativeTime", () => {
+describe("formatJournalRelativeTime", () => {
   test("returns 'just now' for times less than 60 seconds ago", () => {
     const now = Date.now();
-    expect(formatRelativeTime(now - 30_000)).toBe("just now");
-    expect(formatRelativeTime(now - 1_000)).toBe("just now");
-    expect(formatRelativeTime(now)).toBe("just now");
+    expect(formatJournalRelativeTime(now - 30_000)).toBe("just now");
+    expect(formatJournalRelativeTime(now - 1_000)).toBe("just now");
+    expect(formatJournalRelativeTime(now)).toBe("just now");
   });
 
   test("returns minutes for times between 1-59 minutes ago", () => {
     const now = Date.now();
-    expect(formatRelativeTime(now - 60_000)).toBe("1 minute ago");
-    expect(formatRelativeTime(now - 5 * 60_000)).toBe("5 minutes ago");
-    expect(formatRelativeTime(now - 59 * 60_000)).toBe("59 minutes ago");
+    expect(formatJournalRelativeTime(now - 60_000)).toBe("1 minute ago");
+    expect(formatJournalRelativeTime(now - 5 * 60_000)).toBe("5 minutes ago");
+    expect(formatJournalRelativeTime(now - 59 * 60_000)).toBe("59 minutes ago");
   });
 
   test("returns hours for times between 1-23 hours ago", () => {
     const now = Date.now();
-    expect(formatRelativeTime(now - 60 * 60_000)).toBe("1 hour ago");
-    expect(formatRelativeTime(now - 3 * 60 * 60_000)).toBe("3 hours ago");
-    expect(formatRelativeTime(now - 23 * 60 * 60_000)).toBe("23 hours ago");
+    expect(formatJournalRelativeTime(now - 60 * 60_000)).toBe("1 hour ago");
+    expect(formatJournalRelativeTime(now - 3 * 60 * 60_000)).toBe("3 hours ago");
+    expect(formatJournalRelativeTime(now - 23 * 60 * 60_000)).toBe("23 hours ago");
   });
 
   test("returns days for times between 1-6 days ago", () => {
     const now = Date.now();
-    expect(formatRelativeTime(now - 24 * 60 * 60_000)).toBe("1 day ago");
-    expect(formatRelativeTime(now - 3 * 24 * 60 * 60_000)).toBe("3 days ago");
-    expect(formatRelativeTime(now - 6 * 24 * 60 * 60_000)).toBe("6 days ago");
+    expect(formatJournalRelativeTime(now - 24 * 60 * 60_000)).toBe("1 day ago");
+    expect(formatJournalRelativeTime(now - 3 * 24 * 60 * 60_000)).toBe("3 days ago");
+    expect(formatJournalRelativeTime(now - 6 * 24 * 60 * 60_000)).toBe("6 days ago");
   });
 
   test("returns weeks for times 7 or more days ago", () => {
     const now = Date.now();
-    expect(formatRelativeTime(now - 7 * 24 * 60 * 60_000)).toBe("1 week ago");
-    expect(formatRelativeTime(now - 14 * 24 * 60 * 60_000)).toBe(
+    expect(formatJournalRelativeTime(now - 7 * 24 * 60 * 60_000)).toBe("1 week ago");
+    expect(formatJournalRelativeTime(now - 14 * 24 * 60 * 60_000)).toBe(
       "2 weeks ago",
     );
-    expect(formatRelativeTime(now - 30 * 24 * 60 * 60_000)).toBe(
+    expect(formatJournalRelativeTime(now - 30 * 24 * 60 * 60_000)).toBe(
       "4 weeks ago",
     );
   });

--- a/assistant/src/prompts/journal-context.ts
+++ b/assistant/src/prompts/journal-context.ts
@@ -7,7 +7,7 @@ import { getWorkspaceDir } from "../util/platform.js";
  * Return a human-readable relative timestamp from a Unix-epoch millisecond
  * value to "now".
  */
-export function formatRelativeTime(mtime: number): string {
+export function formatJournalRelativeTime(mtime: number): string {
   const diffMs = Date.now() - mtime;
   const diffSec = Math.floor(diffMs / 1000);
 
@@ -76,7 +76,7 @@ export function buildJournalContext(maxEntries: number): string | null {
   for (let i = 0; i < entries.length; i++) {
     const entry = entries[i];
     const content = readFileSync(entry.filepath, "utf-8");
-    const relativeTime = formatRelativeTime(entry.mtimeMs);
+    const relativeTime = formatJournalRelativeTime(entry.mtimeMs);
 
     let header: string;
     if (i === 0) {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for journal-context-window.md.

**Gap:** Duplicate formatRelativeTime function with divergent behavior
**What was expected:** No naming collision between journal-context and memory/search/formatting
**What was found:** Both modules export formatRelativeTime with different behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
