### PR TITLE
fix: add explicit staleness baseline for "journal" memory kind

### DIFF
--- a/assistant/src/memory/search/staleness.ts
+++ b/assistant/src/memory/search/staleness.ts
@@ -8,6 +8,10 @@ const BASE_LIFETIME_MS: Record<string, number> = {
   project: 14 * 86_400_000, // 2 weeks
   decision: 14 * 86_400_000, // 2 weeks
   event: 3 * 86_400_000, // 3 days
+  // Journals are experiential reflections and forward-looking notes — more
+  // durable than ephemeral events or decisions, but not as permanent as
+  // identity. 90 days mirrors "preference" lifetime.
+  journal: 90 * 86_400_000, // 3 months
   capability: Infinity,
 };
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for journal-context-window.md.

**Gap:** Missing staleness baseline for "journal" kind
**What was expected:** BASE_LIFETIME_MS should have an explicit entry for "journal"
**What was found:** Journal items fell through to DEFAULT_LIFETIME_MS (30 days)

Adds an explicit `journal` entry to `BASE_LIFETIME_MS` with a 90-day (3-month) lifetime, matching the `preference` kind. Journal entries are experiential reflections and forward-looking notes — more durable than ephemeral events or short-lived decisions, but not as permanent as identity traits.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
