### PR TITLE
fix: add "journal" case to Swift MemoryKind enum

### DIFF
--- a/clients/macos/AGENTS.md
+++ b/clients/macos/AGENTS.md
@@ -197,7 +197,7 @@ All design system types use the `V` prefix (VButton, VColor, VFont, etc.). Alway
 - Primary: `primaryDisabled`, `primaryBase`, `primaryHover`, `primaryActive`
 - System: `systemPositiveStrong`/`Weak`, `systemNegativeStrong`/`Hover`/`Weak`, `systemMidStrong`/`Weak`
 - Utility: `auxWhite`, `auxBlack` (non-adaptive)
-- Fun: `funYellow`, `funRed`, `funPurple`, `funPink`, `funCoral`, `funTeal`, `funGreen` (non-adaptive, decorative)
+- Fun: `funYellow`, `funRed`, `funPurple`, `funPink`, `funCoral`, `funTeal`, `funGreen`, `funBlue` (non-adaptive, decorative)
 - Raw palettes (Moss, Stone/Slate, Forest/Sage, Emerald, Danger, Amber) are internal — use semantic tokens above.
 
 **VFont** — macOS HIG-aligned type scale:

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -388,6 +388,7 @@ public enum VColor {
     public static let funCoral  = Color(hex: 0xE9642F)
     public static let funTeal   = Color(hex: 0x0E9B8B)
     public static let funGreen  = Color(hex: 0x4C9B50)
+    public static let funBlue   = Color(hex: 0x3B82F6)
 
     // Role tag backgrounds — adaptive pastel backgrounds for contact role badges
     public static let tagAssistant = adaptiveColor(light: Color(hex: 0xF0D9E0), dark: Color(hex: 0x3D2A35))

--- a/clients/shared/Features/Memory/MemoryKindStyle.swift
+++ b/clients/shared/Features/Memory/MemoryKindStyle.swift
@@ -8,6 +8,7 @@ public enum MemoryKind: String, CaseIterable, Identifiable, Sendable {
     case decision
     case constraint
     case event
+    case journal
     case capability
 
     public var id: String { rawValue }
@@ -45,6 +46,7 @@ public enum MemoryKind: String, CaseIterable, Identifiable, Sendable {
         case .decision:   return VColor.funYellow
         case .constraint: return VColor.funCoral
         case .event:      return VColor.funPink
+        case .journal:    return VColor.funBlue
         case .capability: return VColor.funRed
         }
     }
@@ -58,6 +60,7 @@ public enum MemoryKind: String, CaseIterable, Identifiable, Sendable {
         case .decision:   return VIcon.gitBranch.rawValue
         case .constraint: return VIcon.shield.rawValue
         case .event:      return VIcon.calendar.rawValue
+        case .journal:    return VIcon.bookOpen.rawValue
         case .capability: return VIcon.zap.rawValue
         }
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for journal-context-window.md.

**Gap:** Swift MemoryKind enum missing "journal" case
**What was expected:** MemoryKind should include .journal for filtering and display
**What was found:** MemoryKind only had identity, preference, project, decision, constraint, event, capability

### Changes
- Added `.journal` case to `MemoryKind` enum with label "Journal", blue color (`funBlue`), and book-open icon
- Added `funBlue` color token (`0x3B82F6`) to `ColorTokens.swift` since all 7 existing fun colors were already assigned
- Updated AGENTS.md color reference to include `funBlue`
- Journal is included in `userCreatableKinds` (not system-managed like `.capability`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
