### PR TITLE
fix: re-export JournalConfig from config/types.ts

### DIFF
--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -12,6 +12,7 @@ export type {
   ImageGenerationService,
   InferenceService,
   IngressConfig,
+  JournalConfig,
   LogFileConfig,
   MemoryConfig,
   MemoryEmbeddingsConfig,


### PR DESCRIPTION
## Summary
Add JournalConfig to the barrel re-exports in config/types.ts, matching the pattern used by all other config sub-types.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20846" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
