### PR TITLE
test: add maxEntries=1 edge case for journal context

### DIFF
--- a/assistant/src/__tests__/journal-context.test.ts
+++ b/assistant/src/__tests__/journal-context.test.ts
@@ -230,6 +230,13 @@ describe("buildJournalContext", () => {
     expect(result).not.toContain("entry-4.md");
   });
 
+  test("maxEntries=1 with exactly one entry marks it MOST RECENT, not LEAVING CONTEXT", () => {
+    writeFileSync(join(journalDir, "solo.md"), "only entry");
+    const result = buildJournalContext(1)!;
+    expect(result).toContain("## solo.md — MOST RECENT");
+    expect(result).not.toContain("LEAVING CONTEXT");
+  });
+
   test("includes relative timestamps in headers", () => {
     const now = new Date();
 


### PR DESCRIPTION
## Summary
Add test for the boundary condition where maxEntries=1 and exactly one entry exists — verifies MOST RECENT takes priority over LEAVING CONTEXT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
