### PR TITLE
fix: add error handling for unreadable journal files

### DIFF
--- a/assistant/src/prompts/journal-context.ts
+++ b/assistant/src/prompts/journal-context.ts
@@ -57,12 +57,17 @@ export function buildJournalContext(maxEntries: number): string | null {
     (f) => f.endsWith(".md") && f.toLowerCase() !== "readme.md",
   );
 
-  // Collect file info with mtime
+  // Collect file info with mtime, skipping unreadable entries
   const entries = mdFiles
-    .map((f) => {
-      const filepath = join(journalDir, f);
-      const stat = statSync(filepath);
-      return { filename: f, filepath, mtimeMs: stat.mtimeMs };
+    .flatMap((f) => {
+      try {
+        const filepath = join(journalDir, f);
+        const stat = statSync(filepath);
+        if (!stat.isFile()) return [];
+        return [{ filename: f, filepath, mtimeMs: stat.mtimeMs }];
+      } catch {
+        return [];
+      }
     })
     .sort((a, b) => b.mtimeMs - a.mtimeMs)
     .slice(0, maxEntries);
@@ -75,7 +80,12 @@ export function buildJournalContext(maxEntries: number): string | null {
 
   for (let i = 0; i < entries.length; i++) {
     const entry = entries[i];
-    const content = readFileSync(entry.filepath, "utf-8");
+    let content: string;
+    try {
+      content = readFileSync(entry.filepath, "utf-8");
+    } catch {
+      continue;
+    }
     const relativeTime = formatJournalRelativeTime(entry.mtimeMs);
 
     let header: string;


### PR DESCRIPTION
## Summary
- Wrap `statSync` in `.flatMap()` with try/catch so broken symlinks and permission errors are silently skipped instead of crashing the system prompt builder
- Add `stat.isFile()` check to filter out directories that happen to have `.md` names
- Wrap `readFileSync` in the rendering loop with try/catch to skip files that become unreadable between stat and read

## Test plan
- [x] Existing 18 journal-context tests pass
- [x] Type-check passes (`bunx tsc --noEmit`)