### PR TITLE
feat: add absolute timestamp to journal entry headers

### DIFF
--- a/assistant/src/__tests__/journal-context.test.ts
+++ b/assistant/src/__tests__/journal-context.test.ts
@@ -17,9 +17,11 @@ mock.module("../util/platform.js", () => ({
   getWorkspaceDir: () => TEST_DIR,
 }));
 
-const { buildJournalContext, formatJournalRelativeTime } = await import(
-  "../prompts/journal-context.js"
-);
+const {
+  buildJournalContext,
+  formatJournalRelativeTime,
+  formatJournalAbsoluteTime,
+} = await import("../prompts/journal-context.js");
 
 describe("formatJournalRelativeTime", () => {
   test("returns 'just now' for times less than 60 seconds ago", () => {
@@ -59,6 +61,25 @@ describe("formatJournalRelativeTime", () => {
     expect(formatJournalRelativeTime(now - 30 * 24 * 60 * 60_000)).toBe(
       "4 weeks ago",
     );
+  });
+});
+
+describe("formatJournalAbsoluteTime", () => {
+  test("formats a timestamp as MM/DD/YY HH:MM", () => {
+    // 2025-03-15 14:30:00 UTC
+    const ts = new Date(2025, 2, 15, 14, 30, 0).getTime();
+    expect(formatJournalAbsoluteTime(ts)).toBe("03/15/25 14:30");
+  });
+
+  test("zero-pads single-digit months, days, hours, and minutes", () => {
+    // 2025-01-05 09:05:00
+    const ts = new Date(2025, 0, 5, 9, 5, 0).getTime();
+    expect(formatJournalAbsoluteTime(ts)).toBe("01/05/25 09:05");
+  });
+
+  test("handles midnight", () => {
+    const ts = new Date(2025, 5, 20, 0, 0, 0).getTime();
+    expect(formatJournalAbsoluteTime(ts)).toBe("06/20/25 00:00");
   });
 });
 
@@ -237,7 +258,7 @@ describe("buildJournalContext", () => {
     expect(result).not.toContain("LEAVING CONTEXT");
   });
 
-  test("includes relative timestamps in headers", () => {
+  test("includes both absolute and relative timestamps in headers", () => {
     const now = new Date();
 
     writeFileSync(join(journalDir, "recent.md"), "recent content");
@@ -246,6 +267,9 @@ describe("buildJournalContext", () => {
 
     const result = buildJournalContext(10)!;
     expect(result).toContain("3 hours ago");
+    // Should also contain the absolute timestamp in MM/DD/YY HH:MM format
+    const expected = formatJournalAbsoluteTime(recentTime.getTime());
+    expect(result).toContain(expected);
   });
 
   test("middle entries have plain headers with relative time", () => {
@@ -274,6 +298,7 @@ describe("buildJournalContext", () => {
 
     const result = buildJournalContext(3)!;
     // Middle entry should have plain header format (no MOST RECENT, no LEAVING CONTEXT)
-    expect(result).toMatch(/## middle\.md \(\d+ hours? ago\)/);
+    // Format: ## middle.md (MM/DD/YY HH:MM, N hours ago)
+    expect(result).toMatch(/## middle\.md \(\d{2}\/\d{2}\/\d{2} \d{2}:\d{2}, \d+ hours? ago\)/);
   });
 });

--- a/assistant/src/prompts/journal-context.ts
+++ b/assistant/src/prompts/journal-context.ts
@@ -4,6 +4,19 @@ import { join } from "node:path";
 import { getWorkspaceDir } from "../util/platform.js";
 
 /**
+ * Format a Unix-epoch millisecond value as "MM/DD/YY HH:MM".
+ */
+export function formatJournalAbsoluteTime(mtime: number): string {
+  const d = new Date(mtime);
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  const yy = String(d.getFullYear() % 100).padStart(2, "0");
+  const hh = String(d.getHours()).padStart(2, "0");
+  const min = String(d.getMinutes()).padStart(2, "0");
+  return `${mm}/${dd}/${yy} ${hh}:${min}`;
+}
+
+/**
  * Return a human-readable relative timestamp from a Unix-epoch millisecond
  * value to "now".
  */
@@ -87,17 +100,19 @@ export function buildJournalContext(maxEntries: number): string | null {
       continue;
     }
     const relativeTime = formatJournalRelativeTime(entry.mtimeMs);
+    const absoluteTime = formatJournalAbsoluteTime(entry.mtimeMs);
+    const timestamp = `${absoluteTime}, ${relativeTime}`;
 
     let header: string;
     if (i === 0) {
-      header = `## ${entry.filename} — MOST RECENT (${relativeTime})`;
+      header = `## ${entry.filename} — MOST RECENT (${timestamp})`;
     } else if (i === entries.length - 1 && entries.length === maxEntries) {
-      header = `## ${entry.filename} — LEAVING CONTEXT (${relativeTime})`;
+      header = `## ${entry.filename} — LEAVING CONTEXT (${timestamp})`;
       header +=
         "\nNOTE: This is the oldest entry in your active context. When you write your next journal entry, carry forward anything from here that still matters to you — after that, this entry will only be available via the filesystem and memory recall.";
       header += "\n";
     } else {
-      header = `## ${entry.filename} (${relativeTime})`;
+      header = `## ${entry.filename} (${timestamp})`;
     }
 
     sections.push(header + "\n" + content);


### PR DESCRIPTION
## Summary
- Add `formatJournalAbsoluteTime()` that formats timestamps as `MM/DD/YY HH:MM`
- Journal entry headers now show both absolute and relative time: `## entry.md — MOST RECENT (03/15/25 14:30, 3 hours ago)`
- Add unit tests for the new formatter

## Original prompt
In addition to the approximate time delta, let's add the time the file was created in MM/DD/YY HH:MM format
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
