### PR TITLE
fix: improve new conversation greeting prompt

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1494,7 +1494,7 @@ public final class ChatViewModel: ObservableObject {
             var result = ""
             do {
                 let stream = self.btwClient.sendMessage(
-                    content: "Generate a short, casual greeting for when the user opens a new conversation (under 8 words). Match your personality. Output ONLY the greeting text — no quotes, no formatting.",
+                    content: "Generate a short, casual greeting in your voice from you to your user. This will be displayed when the user opens a new conversation (under 8 words). Match your personality. Output ONLY the greeting text — no quotes, no formatting.",
                     conversationKey: key
                 )
                 for try await delta in stream {


### PR DESCRIPTION
## Summary
- Rewords the greeting generation prompt to better communicate context: the greeting is *from* the assistant *to* the user, displayed when opening a new conversation
- Previous wording ("casual greeting for when the user opens a new conversation") was ambiguous about who the greeting is from
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20853" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
