### PR TITLE
fix: use file creation time instead of modified time for journal entries

### DIFF
--- a/assistant/src/__tests__/journal-context.test.ts
+++ b/assistant/src/__tests__/journal-context.test.ts
@@ -1,9 +1,4 @@
-import {
-  mkdirSync,
-  rmSync,
-  utimesSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -23,6 +18,9 @@ const {
   formatJournalAbsoluteTime,
 } = await import("../prompts/journal-context.js");
 
+/** Small delay to ensure distinct file birthtimes on APFS. */
+const tick = () => Bun.sleep(5);
+
 describe("formatJournalRelativeTime", () => {
   test("returns 'just now' for times less than 60 seconds ago", () => {
     const now = Date.now();
@@ -41,20 +39,32 @@ describe("formatJournalRelativeTime", () => {
   test("returns hours for times between 1-23 hours ago", () => {
     const now = Date.now();
     expect(formatJournalRelativeTime(now - 60 * 60_000)).toBe("1 hour ago");
-    expect(formatJournalRelativeTime(now - 3 * 60 * 60_000)).toBe("3 hours ago");
-    expect(formatJournalRelativeTime(now - 23 * 60 * 60_000)).toBe("23 hours ago");
+    expect(formatJournalRelativeTime(now - 3 * 60 * 60_000)).toBe(
+      "3 hours ago",
+    );
+    expect(formatJournalRelativeTime(now - 23 * 60 * 60_000)).toBe(
+      "23 hours ago",
+    );
   });
 
   test("returns days for times between 1-6 days ago", () => {
     const now = Date.now();
-    expect(formatJournalRelativeTime(now - 24 * 60 * 60_000)).toBe("1 day ago");
-    expect(formatJournalRelativeTime(now - 3 * 24 * 60 * 60_000)).toBe("3 days ago");
-    expect(formatJournalRelativeTime(now - 6 * 24 * 60 * 60_000)).toBe("6 days ago");
+    expect(formatJournalRelativeTime(now - 24 * 60 * 60_000)).toBe(
+      "1 day ago",
+    );
+    expect(formatJournalRelativeTime(now - 3 * 24 * 60 * 60_000)).toBe(
+      "3 days ago",
+    );
+    expect(formatJournalRelativeTime(now - 6 * 24 * 60 * 60_000)).toBe(
+      "6 days ago",
+    );
   });
 
   test("returns weeks for times 7 or more days ago", () => {
     const now = Date.now();
-    expect(formatJournalRelativeTime(now - 7 * 24 * 60 * 60_000)).toBe("1 week ago");
+    expect(formatJournalRelativeTime(now - 7 * 24 * 60 * 60_000)).toBe(
+      "1 week ago",
+    );
     expect(formatJournalRelativeTime(now - 14 * 24 * 60 * 60_000)).toBe(
       "2 weeks ago",
     );
@@ -66,7 +76,7 @@ describe("formatJournalRelativeTime", () => {
 
 describe("formatJournalAbsoluteTime", () => {
   test("formats a timestamp as MM/DD/YY HH:MM", () => {
-    // 2025-03-15 14:30:00 UTC
+    // 2025-03-15 14:30:00
     const ts = new Date(2025, 2, 15, 14, 30, 0).getTime();
     expect(formatJournalAbsoluteTime(ts)).toBe("03/15/25 14:30");
   });
@@ -134,20 +144,13 @@ describe("buildJournalContext", () => {
     expect(result).not.toContain("LEAVING CONTEXT");
   });
 
-  test("sorts entries by mtime, newest first", () => {
-    const now = new Date();
-
+  test("sorts entries by creation time, newest first", async () => {
+    // Small delays between writes ensure distinct birthtimes.
     writeFileSync(join(journalDir, "old.md"), "old entry");
-    const oldTime = new Date(now.getTime() - 3 * 24 * 60 * 60_000);
-    utimesSync(join(journalDir, "old.md"), oldTime, oldTime);
-
+    await tick();
     writeFileSync(join(journalDir, "mid.md"), "mid entry");
-    const midTime = new Date(now.getTime() - 1 * 24 * 60 * 60_000);
-    utimesSync(join(journalDir, "mid.md"), midTime, midTime);
-
+    await tick();
     writeFileSync(join(journalDir, "new.md"), "new entry");
-    const newTime = new Date(now.getTime() - 60_000);
-    utimesSync(join(journalDir, "new.md"), newTime, newTime);
 
     const result = buildJournalContext(10)!;
     const newIdx = result.indexOf("new.md");
@@ -157,45 +160,23 @@ describe("buildJournalContext", () => {
     expect(midIdx).toBeLessThan(oldIdx);
   });
 
-  test("marks most recent entry with MOST RECENT", () => {
-    const now = new Date();
-
+  test("marks most recent entry with MOST RECENT", async () => {
     writeFileSync(join(journalDir, "older.md"), "older");
-    const olderTime = new Date(now.getTime() - 2 * 24 * 60 * 60_000);
-    utimesSync(join(journalDir, "older.md"), olderTime, olderTime);
-
+    await tick();
     writeFileSync(join(journalDir, "newest.md"), "newest");
-    const newestTime = new Date(now.getTime() - 60_000);
-    utimesSync(join(journalDir, "newest.md"), newestTime, newestTime);
 
     const result = buildJournalContext(10)!;
     expect(result).toContain("## newest.md — MOST RECENT");
     expect(result).not.toContain("## older.md — MOST RECENT");
   });
 
-  test("marks oldest entry with LEAVING CONTEXT when window is full", () => {
-    const now = new Date();
-
-    writeFileSync(join(journalDir, "a.md"), "entry a");
-    utimesSync(
-      join(journalDir, "a.md"),
-      new Date(now.getTime() - 60_000),
-      new Date(now.getTime() - 60_000),
-    );
-
-    writeFileSync(join(journalDir, "b.md"), "entry b");
-    utimesSync(
-      join(journalDir, "b.md"),
-      new Date(now.getTime() - 2 * 60 * 60_000),
-      new Date(now.getTime() - 2 * 60 * 60_000),
-    );
-
+  test("marks oldest entry with LEAVING CONTEXT when window is full", async () => {
+    // Create in chronological order: c (oldest), b, a (newest)
     writeFileSync(join(journalDir, "c.md"), "entry c");
-    utimesSync(
-      join(journalDir, "c.md"),
-      new Date(now.getTime() - 3 * 24 * 60 * 60_000),
-      new Date(now.getTime() - 3 * 24 * 60 * 60_000),
-    );
+    await tick();
+    writeFileSync(join(journalDir, "b.md"), "entry b");
+    await tick();
+    writeFileSync(join(journalDir, "a.md"), "entry a");
 
     // maxEntries = 3 matches the number of files, so window is full
     const result = buildJournalContext(3)!;
@@ -209,22 +190,10 @@ describe("buildJournalContext", () => {
     );
   });
 
-  test("does NOT mark oldest entry with LEAVING CONTEXT when window is not full", () => {
-    const now = new Date();
-
-    writeFileSync(join(journalDir, "a.md"), "entry a");
-    utimesSync(
-      join(journalDir, "a.md"),
-      new Date(now.getTime() - 60_000),
-      new Date(now.getTime() - 60_000),
-    );
-
+  test("does NOT mark oldest entry with LEAVING CONTEXT when window is not full", async () => {
     writeFileSync(join(journalDir, "b.md"), "entry b");
-    utimesSync(
-      join(journalDir, "b.md"),
-      new Date(now.getTime() - 2 * 60 * 60_000),
-      new Date(now.getTime() - 2 * 60 * 60_000),
-    );
+    await tick();
+    writeFileSync(join(journalDir, "a.md"), "entry a");
 
     // maxEntries = 5, only 2 files — window is NOT full
     const result = buildJournalContext(5)!;
@@ -232,23 +201,20 @@ describe("buildJournalContext", () => {
     expect(result).not.toContain("LEAVING CONTEXT");
   });
 
-  test("limits entries to maxEntries", () => {
-    const now = new Date();
-
+  test("limits entries to maxEntries", async () => {
+    // Create files 0-4 sequentially; file 4 is newest
     for (let i = 0; i < 5; i++) {
-      const filename = `entry-${i}.md`;
-      writeFileSync(join(journalDir, filename), `content ${i}`);
-      const time = new Date(now.getTime() - i * 60 * 60_000);
-      utimesSync(join(journalDir, filename), time, time);
+      writeFileSync(join(journalDir, `entry-${i}.md`), `content ${i}`);
+      if (i < 4) await tick();
     }
 
     const result = buildJournalContext(3)!;
-    // Should contain only 3 entries (entry-0, entry-1, entry-2)
-    expect(result).toContain("entry-0.md");
-    expect(result).toContain("entry-1.md");
+    // Should contain only 3 newest entries (entry-4, entry-3, entry-2)
+    expect(result).toContain("entry-4.md");
+    expect(result).toContain("entry-3.md");
     expect(result).toContain("entry-2.md");
-    expect(result).not.toContain("entry-3.md");
-    expect(result).not.toContain("entry-4.md");
+    expect(result).not.toContain("entry-1.md");
+    expect(result).not.toContain("entry-0.md");
   });
 
   test("maxEntries=1 with exactly one entry marks it MOST RECENT, not LEAVING CONTEXT", () => {
@@ -259,46 +225,30 @@ describe("buildJournalContext", () => {
   });
 
   test("includes both absolute and relative timestamps in headers", () => {
-    const now = new Date();
-
     writeFileSync(join(journalDir, "recent.md"), "recent content");
-    const recentTime = new Date(now.getTime() - 3 * 60 * 60_000);
-    utimesSync(join(journalDir, "recent.md"), recentTime, recentTime);
 
     const result = buildJournalContext(10)!;
-    expect(result).toContain("3 hours ago");
-    // Should also contain the absolute timestamp in MM/DD/YY HH:MM format
-    const expected = formatJournalAbsoluteTime(recentTime.getTime());
+    // File was just created, so relative time should be "just now"
+    expect(result).toContain("just now");
+    // Absolute time should match the file's birthtime
+    const birthtime = statSync(join(journalDir, "recent.md")).birthtimeMs;
+    const expected = formatJournalAbsoluteTime(birthtime);
     expect(result).toContain(expected);
   });
 
-  test("middle entries have plain headers with relative time", () => {
-    const now = new Date();
-
-    writeFileSync(join(journalDir, "first.md"), "first");
-    utimesSync(
-      join(journalDir, "first.md"),
-      new Date(now.getTime() - 60_000),
-      new Date(now.getTime() - 60_000),
-    );
-
-    writeFileSync(join(journalDir, "middle.md"), "middle");
-    utimesSync(
-      join(journalDir, "middle.md"),
-      new Date(now.getTime() - 2 * 60 * 60_000),
-      new Date(now.getTime() - 2 * 60 * 60_000),
-    );
-
+  test("middle entries have plain headers with timestamps", async () => {
+    // Create in chronological order: last (oldest), middle, first (newest)
     writeFileSync(join(journalDir, "last.md"), "last");
-    utimesSync(
-      join(journalDir, "last.md"),
-      new Date(now.getTime() - 3 * 24 * 60 * 60_000),
-      new Date(now.getTime() - 3 * 24 * 60 * 60_000),
-    );
+    await tick();
+    writeFileSync(join(journalDir, "middle.md"), "middle");
+    await tick();
+    writeFileSync(join(journalDir, "first.md"), "first");
 
     const result = buildJournalContext(3)!;
     // Middle entry should have plain header format (no MOST RECENT, no LEAVING CONTEXT)
-    // Format: ## middle.md (MM/DD/YY HH:MM, N hours ago)
-    expect(result).toMatch(/## middle\.md \(\d{2}\/\d{2}\/\d{2} \d{2}:\d{2}, \d+ hours? ago\)/);
+    // Format: ## middle.md (MM/DD/YY HH:MM, <relative time>)
+    expect(result).toMatch(
+      /## middle\.md \(\d{2}\/\d{2}\/\d{2} \d{2}:\d{2}, .+\)/,
+    );
   });
 });

--- a/assistant/src/prompts/journal-context.ts
+++ b/assistant/src/prompts/journal-context.ts
@@ -48,9 +48,9 @@ export function formatJournalRelativeTime(mtime: number): string {
 /**
  * Build a journal context section for inclusion in the system prompt.
  *
- * Reads `{workspaceDir}/journal/*.md` files, sorts by mtime (newest first),
- * and returns a formatted string with relative timestamps. Returns `null`
- * when no entries are available.
+ * Reads `{workspaceDir}/journal/*.md` files, sorts by creation time
+ * (newest first), and returns a formatted string with timestamps.
+ * Returns `null` when no entries are available.
  */
 export function buildJournalContext(maxEntries: number): string | null {
   if (maxEntries <= 0) return null;
@@ -70,19 +70,19 @@ export function buildJournalContext(maxEntries: number): string | null {
     (f) => f.endsWith(".md") && f.toLowerCase() !== "readme.md",
   );
 
-  // Collect file info with mtime, skipping unreadable entries
+  // Collect file info with birthtime (creation time), skipping unreadable entries
   const entries = mdFiles
     .flatMap((f) => {
       try {
         const filepath = join(journalDir, f);
         const stat = statSync(filepath);
         if (!stat.isFile()) return [];
-        return [{ filename: f, filepath, mtimeMs: stat.mtimeMs }];
+        return [{ filename: f, filepath, birthtimeMs: stat.birthtimeMs }];
       } catch {
         return [];
       }
     })
-    .sort((a, b) => b.mtimeMs - a.mtimeMs)
+    .sort((a, b) => b.birthtimeMs - a.birthtimeMs)
     .slice(0, maxEntries);
 
   if (entries.length === 0) return null;
@@ -99,8 +99,8 @@ export function buildJournalContext(maxEntries: number): string | null {
     } catch {
       continue;
     }
-    const relativeTime = formatJournalRelativeTime(entry.mtimeMs);
-    const absoluteTime = formatJournalAbsoluteTime(entry.mtimeMs);
+    const relativeTime = formatJournalRelativeTime(entry.birthtimeMs);
+    const absoluteTime = formatJournalAbsoluteTime(entry.birthtimeMs);
     const timestamp = `${absoluteTime}, ${relativeTime}`;
 
     let header: string;


### PR DESCRIPTION
## Summary
- Switch journal entry sorting and timestamps from `mtimeMs` (modified time) to `birthtimeMs` (creation time)
- Creation time better represents when the entry was written — editing a journal entry shouldn't change its position in the timeline
- Update tests to use file creation order with small delays for deterministic birthtime ordering

## Original prompt
we should use the created timestamp not the modified timestamp for the journal entries
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
