### PR TITLE
feat: add VTag component and separate tag/badge concerns

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactTypeBadge.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactTypeBadge.swift
@@ -1,13 +1,13 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// A badge pill showing a contact's classification (Guardian, Assistant, Human)
-/// with a distinguishing icon. Thin wrapper around VBadge.
+/// A tag showing a contact's classification (Guardian, Assistant, Human)
+/// with a distinguishing icon. Thin wrapper around VTag.
 struct ContactTypeBadge: View {
     let role: String?
 
     var body: some View {
-        VBadge(label: label, icon: icon, iconColor: VColor.primaryBase, tone: .neutral)
+        VTag(label, color: VColor.primaryBase, icon: icon)
     }
 
     private var label: String {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Helpers.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Helpers.swift
@@ -8,10 +8,9 @@ extension MemoryItemDetailSheet {
     }
 
     var kindBadge: some View {
-        VBadge(
-            label: memoryKind?.label ?? displayItem.kind.capitalized,
-            color: memoryKind?.color ?? VColor.contentTertiary,
-            shape: .rounded
+        VTag(
+            memoryKind?.label ?? displayItem.kind.capitalized,
+            color: memoryKind?.color ?? VColor.contentTertiary
         )
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -35,7 +35,7 @@ struct MemoryItemRow: View {
                         kindTag
 
                         if let scopeLabel = item.scopeLabel {
-                            VBadge(label: scopeLabel, icon: .lock, tone: .neutral, emphasis: .subtle, shape: .pill)
+                            VTag(scopeLabel, color: VColor.contentSecondary, icon: .lock)
                         }
 
                         VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerGhost, action: onDelete)
@@ -74,10 +74,9 @@ struct MemoryItemRow: View {
     // MARK: - Kind Tag
 
     private var kindTag: some View {
-        VBadge(
-            label: memoryKind?.label ?? item.kind.capitalized,
-            color: memoryKind?.color ?? VColor.contentTertiary,
-            shape: .pill
+        VTag(
+            memoryKind?.label ?? item.kind.capitalized,
+            color: memoryKind?.color ?? VColor.contentTertiary
         )
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/OAuthProviderServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/OAuthProviderServiceCard.swift
@@ -419,7 +419,7 @@ struct OAuthProviderServiceCard: View {
 
             Spacer()
 
-            VBadge(label: "Connected", icon: .circleCheck, tone: .positive, emphasis: .subtle)
+            VTag("Connected", color: VColor.systemPositiveStrong, icon: .circleCheck)
 
             VButton(label: "Disconnect", style: .danger, size: .compact) {
                 disconnectConnection = conn

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -220,10 +220,7 @@ struct ToolPermissionTesterView: View {
                 HStack(spacing: VSpacing.sm) {
                     decisionBadge(result.decision)
 
-                    VBadge(
-                        style: .label(result.riskLevel.capitalized),
-                        color: riskColor(result.riskLevel)
-                    )
+                    VTag(result.riskLevel.capitalized, color: riskColor(result.riskLevel))
 
                     if let ruleId = result.matchedRuleId {
                         Text("Rule: \(ruleId)")

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -240,7 +240,7 @@ struct RecordingSourcePickerView: View {
                             .foregroundColor(VColor.contentDefault)
                             .lineLimit(1)
                         if display.isCurrentDisplay {
-                            VBadge(style: .label("This display"), color: VColor.primaryBase)
+                            VTag("This display", color: VColor.primaryBase)
                         }
                     }
                     Text(display.subtitle)

--- a/clients/shared/DesignSystem/Core/Feedback/VBadge.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VBadge.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 
+/// Compact status indicator: count, dot, or text label with semantic tone.
+/// For categorization with colored backgrounds and icons, use `VTag` instead.
 public struct VBadge: View {
     public enum Style {
         case count(Int)
@@ -30,8 +32,6 @@ public struct VBadge: View {
     public var tone: Tone?
     public var emphasis: Emphasis = .solid
     public var shape: Shape = .pill
-    public var icon: VIcon?
-    public var iconColor: Color?
 
     public init(style: Style, color: Color = VColor.primaryBase, shape: Shape = .pill) {
         self.style = style
@@ -39,22 +39,11 @@ public struct VBadge: View {
         self.shape = shape
     }
 
-    public init(label: String, icon: VIcon? = nil, iconColor: Color? = nil, tone: Tone = .accent, emphasis: Emphasis = .subtle, shape: Shape = .pill) {
+    public init(label: String, tone: Tone = .accent, emphasis: Emphasis = .subtle, shape: Shape = .pill) {
         self.style = .label(label)
         self.color = VColor.primaryBase
         self.tone = tone
         self.emphasis = emphasis
-        self.shape = shape
-        self.icon = icon
-        self.iconColor = iconColor
-    }
-
-    /// Custom-colored label badge. Uses the provided color at 20% opacity
-    /// as the background with `contentEmphasized` foreground text.
-    public init(label: String, color: Color, shape: Shape = .pill) {
-        self.style = .label(label)
-        self.color = color
-        self.emphasis = .subtle
         self.shape = shape
     }
 
@@ -76,20 +65,14 @@ public struct VBadge: View {
                 .frame(width: 8, height: 8)
 
         case .label(let text):
-            HStack(spacing: VSpacing.xxs) {
-                if let icon {
-                    VIconView(icon, size: 12)
-                        .foregroundColor(iconColor ?? labelForegroundColor)
-                }
-                Text(text)
-                    .font(VFont.caption)
-                    .foregroundColor(labelForegroundColor)
-            }
-            .padding(.horizontal, VSpacing.sm)
-            .padding(.vertical, labelVerticalPadding)
-            .background(labelBackgroundColor)
-            .modifier(LabelShapeModifier(shape: shape, borderColor: labelBorderColor, borderWidth: labelBorderWidth))
-            .accessibilityLabel(text)
+            Text(text)
+                .font(VFont.caption)
+                .foregroundColor(labelForegroundColor)
+                .padding(.horizontal, VSpacing.sm)
+                .padding(.vertical, labelVerticalPadding)
+                .background(labelBackgroundColor)
+                .modifier(LabelShapeModifier(shape: shape, borderColor: labelBorderColor, borderWidth: labelBorderWidth))
+                .accessibilityLabel(text)
         }
     }
 

--- a/clients/shared/DesignSystem/Core/Feedback/VTag.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VTag.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// A colored tag for categorizing items. Unlike `VBadge` (which conveys status
+/// or counts), `VTag` labels an item's *kind* using a pastel background derived
+/// from the tag's color.
+///
+/// Figma spec: 6 pt corner radius, 8 pt horizontal / 4 pt vertical padding,
+/// DM Sans SemiBold 12 pt text, optional leading icon, optional trailing chevron.
+public struct VTag: View {
+    public let label: String
+    public var color: Color
+    public var icon: VIcon?
+
+    /// Creates a tag with a pastel background derived from `color`.
+    public init(_ label: String, color: Color, icon: VIcon? = nil) {
+        self.label = label
+        self.color = color
+        self.icon = icon
+    }
+
+    public var body: some View {
+        HStack(spacing: VSpacing.xs) {
+            if let icon {
+                VIconView(icon, size: 12)
+                    .foregroundColor(color)
+            }
+            Text(label)
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.contentDefault)
+        }
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.xs)
+        .background(color.opacity(0.2))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .accessibilityLabel(label)
+    }
+}

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -80,6 +80,7 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
         case .feedback:
             return [
                 GalleryComponent("vBadge", "VBadge", keywords: ["badge"], description: "Notification count badge with semantic color variants."),
+                GalleryComponent("vTag", "VTag", keywords: ["tag", "category", "kind"], description: "Colored tag for categorizing items with pastel backgrounds."),
                 GalleryComponent("vLoadingIndicator", "VLoadingIndicator", keywords: ["loading", "spinner"], description: "Spinning indicator for inline loading states. Use VSkeletonBone for structured loading layouts."),
                 GalleryComponent("vToast", "VToast", keywords: ["toast", "notification"], description: "Temporary notification banner with auto-dismiss and action support."),
                 GalleryComponent("vInlineMessage", "VInlineMessage", keywords: ["inline message", "alert"], description: "Persistent inline alert with icon and semantic color (info, warning, error, success)."),

--- a/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -61,48 +61,66 @@ struct FeedbackGallerySection: View {
                             }
                         }
 
-                        // Label row
-                        HStack(spacing: VSpacing.lg) {
-                            VBadge(style: .label("New"), color: VColor.primaryBase)
-                            VBadge(style: .label("Beta"), color: VColor.systemPositiveStrong)
-                            VBadge(style: .label("Error"), color: VColor.systemNegativeStrong)
-                            VBadge(style: .label("Warn"), color: VColor.systemMidStrong)
-                        }
-
-                        // Icon label row
-                        HStack(spacing: VSpacing.lg) {
-                            VStack(spacing: VSpacing.xs) {
-                                Text("With iconColor").font(VFont.caption).foregroundColor(VColor.contentTertiary)
-                                VBadge(label: "Guardian", icon: .shieldCheck, iconColor: VColor.primaryBase, tone: .neutral)
-                            }
-                            VStack(spacing: VSpacing.xs) {
-                                Text("Default iconColor").font(VFont.caption).foregroundColor(VColor.contentTertiary)
-                                VBadge(label: "Status", icon: .sparkles, tone: .accent)
+                        // Label with tone (subtle)
+                        VStack(alignment: .leading, spacing: VSpacing.sm) {
+                            Text("Subtle labels").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                            HStack(spacing: VSpacing.lg) {
+                                VBadge(label: "Accent", tone: .accent)
+                                VBadge(label: "Neutral", tone: .neutral)
+                                VBadge(label: "Positive", tone: .positive)
+                                VBadge(label: "Warning", tone: .warning)
+                                VBadge(label: "Danger", tone: .danger)
                             }
                         }
 
                         Divider().background(VColor.borderBase)
 
-                        // Rounded shape
+                        // Label with tone (solid)
                         VStack(alignment: .leading, spacing: VSpacing.sm) {
-                            Text("Rounded shape").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                            Text("Solid labels").font(VFont.caption).foregroundColor(VColor.contentTertiary)
                             HStack(spacing: VSpacing.lg) {
-                                VBadge(label: "Identity", color: VColor.funTeal, shape: .rounded)
-                                VBadge(label: "Preference", color: VColor.funPurple, shape: .rounded)
-                                VBadge(label: "Project", color: VColor.funGreen, shape: .rounded)
-                                VBadge(label: "Decision", color: VColor.funYellow, shape: .rounded)
-                                VBadge(label: "Constraint", color: VColor.funCoral, shape: .rounded)
-                                VBadge(label: "Event", color: VColor.funPink, shape: .rounded)
+                                VBadge(label: "Accent", tone: .accent, emphasis: .solid)
+                                VBadge(label: "Neutral", tone: .neutral, emphasis: .solid)
+                                VBadge(label: "Positive", tone: .positive, emphasis: .solid)
+                                VBadge(label: "Warning", tone: .warning, emphasis: .solid)
+                                VBadge(label: "Danger", tone: .danger, emphasis: .solid)
                             }
                         }
+                    }
+                }
+            }
 
-                        // Pill shape with custom color
+            if filter == nil || filter == "vTag" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+                // MARK: - VTag
+                GallerySectionHeader(
+                    title: "VTag",
+                    description: "Colored tag for categorizing items (e.g. memory kinds)."
+                )
+
+                VCard {
+                    VStack(alignment: .leading, spacing: VSpacing.xl) {
+                        HStack(spacing: VSpacing.lg) {
+                            VTag("Identity", color: VColor.funTeal)
+                            VTag("Preference", color: VColor.funPurple)
+                            VTag("Project", color: VColor.funGreen)
+                            VTag("Decision", color: VColor.funYellow)
+                            VTag("Constraint", color: VColor.funCoral)
+                            VTag("Event", color: VColor.funPink)
+                            VTag("Skill", color: VColor.funRed)
+                        }
+
+                        Divider().background(VColor.borderBase)
+
+                        // With icon
                         VStack(alignment: .leading, spacing: VSpacing.sm) {
-                            Text("Pill shape with custom color").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                            Text("With icon").font(VFont.caption).foregroundColor(VColor.contentTertiary)
                             HStack(spacing: VSpacing.lg) {
-                                VBadge(label: "Teal", color: VColor.funTeal)
-                                VBadge(label: "Purple", color: VColor.funPurple)
-                                VBadge(label: "Coral", color: VColor.funCoral)
+                                VTag("Identity", color: VColor.funTeal, icon: .user)
+                                VTag("Event", color: VColor.funPink, icon: .calendar)
+                                VTag("Project", color: VColor.funGreen, icon: .folder)
                             }
                         }
                     }
@@ -478,6 +496,7 @@ extension FeedbackGallerySection {
     static func componentPage(_ id: String) -> some View {
         switch id {
         case "vBadge": FeedbackGallerySection(filter: "vBadge")
+        case "vTag": FeedbackGallerySection(filter: "vTag")
         case "vLoadingIndicator": FeedbackGallerySection(filter: "vLoadingIndicator")
         case "vToast": FeedbackGallerySection(filter: "vToast")
         case "vInlineMessage": FeedbackGallerySection(filter: "vInlineMessage")


### PR DESCRIPTION
## Summary
- Adds a new `VTag` design system component for categorizing items with colored pastel backgrounds and optional icons (matching Figma spec)
- Simplifies `VBadge` by removing icon/iconColor support — VBadge now focuses on counts, dots, and tone-based status labels
- Migrates all icon+label and custom-color VBadge usages to VTag across the app (memories, contacts, settings, recording)
- Updates the component gallery with dedicated VTag and cleaned-up VBadge sections

## Test plan
- [ ] Open the app and navigate to the Memories tab — verify kind tags render with colored backgrounds
- [ ] Check the memory detail sheet — kind tag should use VTag styling
- [ ] Navigate to Contacts — verify Guardian/Assistant/Human tags render correctly with icons
- [ ] Check OAuth settings — "Connected" tag should show with checkmark icon
- [ ] Open Component Gallery > Feedback — verify VBadge and VTag sections display correctly
- [ ] Verify dark mode renders properly for all tag/badge variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
