### PR TITLE
fix: route all client health checks through /v1/health instead of broken /v1/healthz

### DIFF
--- a/clients/macos/vellum-assistant/App/UpdateManager.swift
+++ b/clients/macos/vellum-assistant/App/UpdateManager.swift
@@ -196,9 +196,9 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
                 return
             }
 
-            // Fetch the current service group version from healthz
+            // Fetch the current service group version from health endpoint
             let (decoded, _): (DaemonHealthz?, _) = try await GatewayHTTPClient.get(
-                path: "assistants/\(connectedId)/healthz",
+                path: "health",
                 timeout: 10
             ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -357,7 +357,7 @@ struct OnboardingFlowView: View {
         while CFAbsoluteTimeGetCurrent() - start < timeout {
             do {
                 let (_, response): (DaemonHealthz?, _) = try await GatewayHTTPClient.get(
-                    path: "assistants/\(assistantId)/healthz",
+                    path: "health",
                     timeout: 5
                 ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
                 if response.isSuccess {

--- a/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
@@ -34,7 +34,7 @@ struct AboutVellumView: View {
     }
 
     /// Resolved service group version — prefers the reactive connectionManager value,
-    /// falls back to the one-shot healthz fetch.
+    /// falls back to the one-shot health fetch.
     private var serviceVersion: String? {
         connectionManager?.assistantVersion ?? healthz?.version
     }
@@ -301,7 +301,7 @@ struct AboutVellumView: View {
         guard !selectedAssistantId.isEmpty else { return }
         do {
             let (decoded, _): (DaemonHealthz?, _) = try await GatewayHTTPClient.get(
-                path: "assistants/\(selectedAssistantId)/healthz",
+                path: "health",
                 timeout: 10
             ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
             healthz = decoded ?? DaemonHealthz()

--- a/clients/macos/vellum-assistant/Features/Settings/DaemonHealthz.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/DaemonHealthz.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Health status response from the daemon's `/healthz` endpoint.
+/// Health status response from the daemon's `/v1/health` endpoint.
 struct DaemonHealthz: Decodable {
     let status: String
     let timestamp: String?
@@ -9,7 +9,7 @@ struct DaemonHealthz: Decodable {
     let memory: MemoryInfo?
     let cpu: CpuInfo?
 
-    /// Empty instance used when the healthz endpoint is unreachable.
+    /// Empty instance used when the health endpoint is unreachable.
     init(status: String = "unavailable", timestamp: String? = nil, version: String? = nil, disk: DiskInfo? = nil, memory: MemoryInfo? = nil, cpu: CpuInfo? = nil) {
         self.status = status
         self.timestamp = timestamp

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -333,7 +333,7 @@ struct SettingsDeveloperTab: View {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
     }
 
-    /// The assistant version reported by the healthz endpoint, if available.
+    /// The assistant version reported by the health endpoint, if available.
     private var effectiveVersion: String? {
         if let version = healthz?.version, !version.isEmpty {
             return version
@@ -448,7 +448,7 @@ struct SettingsDeveloperTab: View {
     private func fetchHealthz() async {
         do {
             let (decoded, _): (DaemonHealthz?, _) = try await GatewayHTTPClient.get(
-                path: "assistants/\(selectedAssistantId)/healthz",
+                path: "health",
                 timeout: 10
             ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
             healthz = decoded ?? DaemonHealthz()

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -156,7 +156,7 @@ struct SettingsGeneralTab: View {
         guard !selectedAssistantId.isEmpty else { return }
         do {
             let (decoded, _): (DaemonHealthz?, _) = try await GatewayHTTPClient.get(
-                path: "assistants/\(selectedAssistantId)/healthz",
+                path: "health",
                 timeout: 10
             ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
             healthz = decoded ?? DaemonHealthz()

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Consolidates URL construction, auth headers, org-id injection, and
 /// request execution so callers can simply write:
 ///
-///     let response = try await GatewayHTTPClient.get(path: "assistants/\(id)/healthz")
+///     let response = try await GatewayHTTPClient.get(path: "health")
 ///     let response = try await GatewayHTTPClient.post(path: "assistants/upgrade")
 @MainActor
 public enum GatewayHTTPClient {
@@ -38,7 +38,7 @@ public enum GatewayHTTPClient {
     /// Performs an authenticated GET request against the gateway.
     ///
     /// - Parameters:
-    ///   - path: Path segment after `/v1/` (e.g. `"assistants/{id}/healthz"`).
+    ///   - path: Path segment after `/v1/` (e.g. `"health"`).
     ///   - params: Optional query parameters. Keys and values are percent-encoded
     ///     using a restricted character set that escapes `&`, `=`, `+`, and `#`.
     ///   - timeout: Request timeout in seconds. Defaults to 30.

--- a/clients/shared/Network/HealthCheckClient.swift
+++ b/clients/shared/Network/HealthCheckClient.swift
@@ -15,7 +15,7 @@ public enum HealthCheckClient {
     public static func isReachable(timeout: TimeInterval = 3) async -> Bool {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/healthz",
+                path: "health",
                 timeout: timeout
             )
             return response.isSuccess
@@ -46,7 +46,7 @@ public enum HealthCheckClient {
         if assistant.isRemote {
             do {
                 let response = try await GatewayHTTPClient.get(
-                    path: "assistants/\(assistant.assistantId)/healthz",
+                    path: "health",
                     timeout: timeout
                 )
                 return response.isSuccess


### PR DESCRIPTION
## Summary
- Fix 7 call sites in macOS client that hit nonexistent /v1/healthz daemon route by routing them through /v1/health instead
- Fixes toolbar Update button never appearing for Docker topology, Developer tab missing resource metrics, and HealthCheckClient reporting services as unreachable
- Updates doc comments to reference the correct endpoint

Part of plan: fix-healthz-endpoint-routing.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
