### PR TITLE
fix: rename HealthzVersionResponse and update stale doc comment

### DIFF
--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -3,8 +3,8 @@ import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "GatewayConnectionManager")
 
-/// Minimal decode of the healthz response to extract the version field.
-private struct HealthzVersionResponse: Decodable {
+/// Minimal decode of the /v1/health response to extract the version field.
+private struct HealthVersionResponse: Decodable {
     let version: String?
 }
 
@@ -266,7 +266,7 @@ public final class GatewayConnectionManager: ObservableObject {
                 throw ConnectionError.healthCheckFailed
             }
 
-            if let decoded = try? JSONDecoder().decode(HealthzVersionResponse.self, from: response.data) {
+            if let decoded = try? JSONDecoder().decode(HealthVersionResponse.self, from: response.data) {
                 if let newVersion = decoded.version, newVersion != assistantVersion {
                     assistantVersion = newVersion
                     if let id = UserDefaults.standard.string(forKey: "connectedAssistantId"), !id.isEmpty {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-healthz-endpoint-routing.md.

**Gap:** Stale HealthzVersionResponse naming in GatewayConnectionManager.swift
**What was expected:** All healthz-related doc comments should reference /v1/health instead of /healthz
**What was found:** Line 6 still references 'healthz response' and struct is named HealthzVersionResponse
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
