### PR TITLE
docs: update ARCHITECTURE.md transport table to reference /health instead of /healthz

### DIFF
--- a/clients/ARCHITECTURE.md
+++ b/clients/ARCHITECTURE.md
@@ -481,8 +481,8 @@ If managed bootstrap fails, the user stays on the onboarding screen with an erro
 
 | Mode | Route Pattern | Auth Header | When Used |
 |------|--------------|-------------|-----------|
-| `runtimeFlat` | `/healthz`, `/v1/messages`, `/v1/events` | `Authorization: Bearer {token}` | Local daemon, gateway-proxied remote |
-| `platformAssistantProxy` | `/v1/assistants/{id}/healthz/`, `/v1/assistants/{id}/messages/` | `X-Session-Token: {token}` | Platform-managed assistants (`cloud == "vellum"`) |
+| `runtimeFlat` | `/health`, `/v1/messages`, `/v1/events` | `Authorization: Bearer {token}` | Local daemon, gateway-proxied remote |
+| `platformAssistantProxy` | `/v1/assistants/{id}/health/`, `/v1/assistants/{id}/messages/` | `X-Session-Token: {token}` | Platform-managed assistants (`cloud == "vellum"`) |
 
 The route mode and auth mode are carried in `TransportMetadata` (defined in `DaemonConfig.swift`) and threaded through the `DaemonConfig` to the `HTTPDaemonClient`. `AppDelegate.configureDaemonTransport(for:)` selects the mode based on `LockfileAssistant.isManaged`.
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-healthz-endpoint-routing.md.

**Gap:** ARCHITECTURE.md stale route table references /healthz
**What was expected:** Documentation should reference correct health endpoint paths
**What was found:** Transport modes table still referenced /healthz and /v1/assistants/{id}/healthz/
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
