### PR TITLE
feat: redesign memories page with sidebar filters and full-width cards

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -68,11 +68,10 @@ struct MemoriesPanel: View {
     @StateObject private var store: MemoryItemsStore
     @State private var showCreateSheet = false
     @State private var selectedItem: MemoryItemPayload?
-    @State private var selectedKinds: Set<MemoryKind> = []
+    @State private var selectedKind: MemoryKind?
     @State private var statusFilter: MemoryStatusFilter = .active
     @State private var sortOption: MemorySortOption = .newest
     @State private var searchDebounceTask: Task<Void, Never>?
-    @State private var showKindFilterPopover = false
     @State private var showStatusFilterPopover = false
     @State private var showSortPopover = false
 
@@ -82,11 +81,20 @@ struct MemoriesPanel: View {
         _store = StateObject(wrappedValue: MemoryItemsStore(memoryItemClient: MemoryItemClient()))
     }
 
+    /// Kinds to show in the sidebar filter. Excludes system-managed kinds.
+    private static let filterableKinds: [MemoryKind] = [
+        .identity, .preference, .project, .decision, .constraint, .event
+    ]
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             filterBar
-            contentView
-                .padding(.top, VSpacing.lg)
+            HStack(alignment: .top, spacing: VSpacing.xxl) {
+                kindSidebar
+                    .frame(width: 220)
+                contentView
+            }
+            .padding(.top, VSpacing.lg)
         }
         .task { await store.loadItems() }
         .task(id: focusedMemoryId) {
@@ -142,14 +150,11 @@ struct MemoriesPanel: View {
                     }
                 }
 
-            kindFilterDropdown
-                .frame(width: 200)
-
             statusFilterDropdown
-                .frame(width: 140)
+                .frame(width: 158)
 
             sortFilterDropdown
-                .frame(width: 160)
+                .frame(width: 158)
 
             VButton(label: "New", icon: VIcon.plus.rawValue, style: .primary) {
                 showCreateSheet = true
@@ -159,127 +164,44 @@ struct MemoriesPanel: View {
         .padding(.top, VSpacing.sm)
     }
 
-    // MARK: - Kind Filter Dropdown
+    // MARK: - Kind Sidebar
 
-    private var kindFilterLabel: String {
-        if selectedKinds.isEmpty {
-            return "All"
-        }
-        let sorted = MemoryKind.allCases.filter { selectedKinds.contains($0) }
-        if sorted.count <= 2 {
-            return sorted.map(\.label).joined(separator: ", ")
-        }
-        return "\(sorted.count) kinds"
-    }
-
-    private var kindFilterDropdown: some View {
-        Button {
-            showKindFilterPopover.toggle()
-        } label: {
-            HStack(spacing: VSpacing.md) {
-                HStack(spacing: VSpacing.sm) {
-                    VIconView(.filter, size: 13)
-                        .foregroundColor(VColor.contentTertiary)
-                    Text(kindFilterLabel)
-                        .foregroundColor(VColor.contentDefault)
-                }
-                .font(VFont.body)
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-                VIconView(.chevronDown, size: 13)
-                    .foregroundColor(VColor.contentTertiary)
-                    .accessibilityHidden(true)
+    private var kindSidebar: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            kindFilterRow(label: "All", kind: nil)
+            ForEach(Self.filterableKinds) { kind in
+                kindFilterRow(label: kind.label, kind: kind)
             }
-            .padding(.horizontal, VSpacing.md)
-            .padding(.vertical, VSpacing.xs)
-            .frame(height: 32)
-            .vInputChrome()
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Filter by kind: \(kindFilterLabel)")
-        .popover(isPresented: $showKindFilterPopover, arrowEdge: .bottom) {
-            VStack(alignment: .leading, spacing: 0) {
-                Button {
-                    withAnimation(VAnimation.fast) {
-                        selectedKinds.removeAll()
-                    }
-                    store.kindFilter = nil
-                    Task { await store.loadItems() }
-                } label: {
-                    HStack(spacing: VSpacing.sm) {
-                        VIconView(.layoutGrid, size: 14)
-                            .foregroundColor(VColor.contentDefault)
-                            .frame(width: 20)
-                        Text("All")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.contentDefault)
-                        Spacer()
-                    }
-                    .padding(.horizontal, VSpacing.md)
-                    .padding(.vertical, VSpacing.sm)
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("All kinds")
-                .accessibilityAddTraits(selectedKinds.isEmpty ? .isSelected : [])
-
-                Divider().padding(.horizontal, VSpacing.sm)
-
-                ForEach(MemoryKind.allCases.sorted { $0.label < $1.label }) { kind in
-                    Button {
-                        withAnimation(VAnimation.fast) {
-                            if selectedKinds.contains(kind) {
-                                selectedKinds.remove(kind)
-                            } else {
-                                selectedKinds.insert(kind)
-                            }
-                            // All selected = same as none selected (show all)
-                            if selectedKinds.count == MemoryKind.allCases.count {
-                                selectedKinds.removeAll()
-                            }
-                        }
-                        // Single kind selected → use API filter; otherwise filter client-side
-                        if selectedKinds.count == 1, let only = selectedKinds.first {
-                            store.kindFilter = only.rawValue
-                        } else {
-                            store.kindFilter = nil
-                        }
-                        Task { await store.loadItems() }
-                    } label: {
-                        HStack(spacing: VSpacing.sm) {
-                            if let icon = VIcon(rawValue: kind.icon) {
-                                VIconView(icon, size: 14)
-                                    .foregroundColor(VColor.contentDefault)
-                                    .frame(width: 20)
-                            }
-                            Text(kind.label)
-                                .font(VFont.body)
-                                .foregroundColor(VColor.contentDefault)
-                            Spacer()
-                            if selectedKinds.contains(kind) {
-                                VIconView(.check, size: 12)
-                                    .foregroundColor(VColor.primaryBase)
-                            }
-                        }
-                        .padding(.horizontal, VSpacing.md)
-                        .padding(.vertical, VSpacing.sm)
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("\(kind.label) filter")
-                    .accessibilityAddTraits(selectedKinds.contains(kind) ? .isSelected : [])
-                }
-            }
-            .padding(.vertical, VSpacing.sm)
-            .frame(width: 220)
         }
     }
 
-    /// Items filtered by selected kinds (client-side, for multi-select).
+    private func kindFilterRow(label: String, kind: MemoryKind?) -> some View {
+        VSidebarRow(
+            label: label,
+            isActive: selectedKind == kind,
+            action: {
+                withAnimation(VAnimation.fast) { selectedKind = kind }
+                store.kindFilter = kind?.rawValue
+                Task { await store.loadItems() }
+            }
+        ) {
+            Text("\(kindCount(for: kind))")
+                .font(.custom("Inter", size: 11))
+                .foregroundColor(VColor.contentTertiary)
+        }
+        .accessibilityLabel("\(label) filter")
+        .accessibilityAddTraits(selectedKind == kind ? .isSelected : [])
+    }
+
+    private func kindCount(for kind: MemoryKind?) -> Int {
+        guard let kind else { return store.items.count }
+        return store.items.filter { $0.kind == kind.rawValue }.count
+    }
+
+    /// Items filtered by selected kind.
     private var filteredItems: [MemoryItemPayload] {
-        guard selectedKinds.count > 1 else { return store.items }
-        let kindValues = Set(selectedKinds.map(\.rawValue))
-        return store.items.filter { kindValues.contains($0.kind) }
+        guard let kind = selectedKind else { return store.items }
+        return store.items.filter { $0.kind == kind.rawValue }
     }
 
     // MARK: - Status Filter Dropdown
@@ -289,20 +211,16 @@ struct MemoriesPanel: View {
             showStatusFilterPopover.toggle()
         } label: {
             HStack(spacing: VSpacing.md) {
-                HStack(spacing: VSpacing.sm) {
-                    VIconView(statusFilter.icon, size: 13)
-                        .foregroundColor(VColor.contentTertiary)
-                    Text(statusFilter.rawValue)
-                        .foregroundColor(VColor.contentDefault)
-                }
-                .font(VFont.body)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                Text(statusFilter.rawValue)
+                    .foregroundColor(VColor.contentDefault)
+                    .font(VFont.body)
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
                 VIconView(.chevronDown, size: 13)
                     .foregroundColor(VColor.contentTertiary)
                     .accessibilityHidden(true)
             }
-            .padding(.horizontal, VSpacing.md)
+            .padding(.horizontal, VSpacing.sm)
             .padding(.vertical, VSpacing.xs)
             .frame(height: 32)
             .vInputChrome()
@@ -352,20 +270,16 @@ struct MemoriesPanel: View {
             showSortPopover.toggle()
         } label: {
             HStack(spacing: VSpacing.md) {
-                HStack(spacing: VSpacing.sm) {
-                    VIconView(sortOption.icon, size: 13)
-                        .foregroundColor(VColor.contentTertiary)
-                    Text(sortOption.rawValue)
-                        .foregroundColor(VColor.contentDefault)
-                }
-                .font(VFont.body)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                Text(sortOption.rawValue)
+                    .foregroundColor(VColor.contentDefault)
+                    .font(VFont.body)
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
                 VIconView(.chevronDown, size: 13)
                     .foregroundColor(VColor.contentTertiary)
                     .accessibilityHidden(true)
             }
-            .padding(.horizontal, VSpacing.md)
+            .padding(.horizontal, VSpacing.sm)
             .padding(.vertical, VSpacing.xs)
             .frame(height: 32)
             .vInputChrome()
@@ -422,21 +336,15 @@ struct MemoriesPanel: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if filteredItems.isEmpty {
             VEmptyState(
-                title: selectedKinds.isEmpty ? "No Memories Yet" : "No Memories in Selected Kinds",
-                subtitle: selectedKinds.isEmpty
+                title: selectedKind == nil ? "No Memories Yet" : "No \(selectedKind!.label) Memories",
+                subtitle: selectedKind == nil
                     ? "Your assistant learns and remembers things from your conversations. Memories will appear here as they're created."
-                    : "Try selecting different kinds or clearing the filter.",
+                    : "Try selecting a different kind or clearing the filter.",
                 icon: VIcon.bookOpen.rawValue
             )
         } else {
             ScrollView {
-                LazyVGrid(
-                    columns: [
-                        GridItem(.flexible(), spacing: VSpacing.md),
-                        GridItem(.flexible(), spacing: VSpacing.md)
-                    ],
-                    spacing: VSpacing.md
-                ) {
+                LazyVStack(spacing: VSpacing.sm) {
                     ForEach(filteredItems) { item in
                         MemoryItemRow(
                             item: item,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -83,7 +83,7 @@ struct MemoriesPanel: View {
 
     /// Kinds to show in the sidebar filter. Excludes system-managed kinds.
     private static let filterableKinds: [MemoryKind] = [
-        .identity, .preference, .project, .decision, .constraint, .event
+        .identity, .preference, .project, .decision, .constraint, .event, .journal
     ]
 
     var body: some View {
@@ -185,8 +185,8 @@ struct MemoriesPanel: View {
             }
         ) {
             Text("\(kindCount(for: kind))")
-                .font(.custom("Inter", size: 11))
-                .foregroundColor(VColor.contentTertiary)
+                .font(VFont.caption)
+                .foregroundStyle(VColor.contentTertiary)
         }
         .accessibilityLabel("\(label) filter")
         .accessibilityAddTraits(selectedKind == kind ? .isSelected : [])

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -167,22 +167,21 @@ struct MemoriesPanel: View {
     // MARK: - Kind Sidebar
 
     private var kindSidebar: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            kindFilterRow(label: "All", kind: nil)
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            kindFilterRow(icon: VIcon.layoutGrid.rawValue, label: "All", kind: nil)
             ForEach(Self.filterableKinds) { kind in
-                kindFilterRow(label: kind.label, kind: kind)
+                kindFilterRow(icon: kind.icon, label: kind.label, kind: kind)
             }
         }
     }
 
-    private func kindFilterRow(label: String, kind: MemoryKind?) -> some View {
+    private func kindFilterRow(icon: String, label: String, kind: MemoryKind?) -> some View {
         VSidebarRow(
+            icon: icon,
             label: label,
             isActive: selectedKind == kind,
             action: {
                 withAnimation(VAnimation.fast) { selectedKind = kind }
-                store.kindFilter = kind?.rawValue
-                Task { await store.loadItems() }
             }
         ) {
             Text("\(kindCount(for: kind))")
@@ -198,7 +197,7 @@ struct MemoriesPanel: View {
         return store.items.filter { $0.kind == kind.rawValue }.count
     }
 
-    /// Items filtered by selected kind.
+    /// Items filtered by selected kind (client-side only — store always holds all items).
     private var filteredItems: [MemoryItemPayload] {
         guard let kind = selectedKind else { return store.items }
         return store.items.filter { $0.kind == kind.rawValue }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -11,12 +11,12 @@ struct MemoryItemRow: View {
     }
 
     var body: some View {
-        Button(action: onSelect) {
+        VCard(padding: VSpacing.lg, action: onSelect) {
             HStack(alignment: .center, spacing: VSpacing.lg) {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     HStack(alignment: .center, spacing: VSpacing.sm) {
                         Text(item.subject)
-                            .font(VFont.display)
+                            .font(VFont.headline)
                             .foregroundColor(VColor.contentEmphasized)
                             .lineLimit(1)
                             .truncationMode(.tail)
@@ -28,7 +28,7 @@ struct MemoryItemRow: View {
                     }
 
                     Text(item.statement)
-                        .font(VFont.body)
+                        .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)
                         .lineLimit(1)
                         .multilineTextAlignment(.leading)
@@ -43,16 +43,7 @@ struct MemoryItemRow: View {
                 VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerOutline, action: onDelete)
                     .accessibilityLabel("Delete memory")
             }
-            .padding(VSpacing.lg)
-            .background(Color.clear)
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.xl)
-                    .stroke(VColor.borderDisabled, lineWidth: 2)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
-            .contentShape(RoundedRectangle(cornerRadius: VRadius.xl))
         }
-        .buttonStyle(.plain)
         .contextMenu {
             Button("Delete", role: .destructive, action: onDelete)
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -11,35 +11,20 @@ struct MemoryItemRow: View {
     }
 
     var body: some View {
-        VInteractiveCard(action: onSelect) {
+        Button(action: onSelect) {
             HStack(alignment: .center, spacing: VSpacing.lg) {
-                kindIcon
-
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
                     HStack(alignment: .center, spacing: VSpacing.sm) {
-                        VStack(alignment: .leading, spacing: 0) {
-                            Text(item.subject)
-                                .font(VFont.bodyBold)
-                                .foregroundColor(VColor.contentDefault)
-                                .lineLimit(1)
-                                .truncationMode(.tail)
+                        Text(item.subject)
+                            .font(VFont.display)
+                            .foregroundColor(VColor.contentEmphasized)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
 
-                            Text(item.relativeLastSeen)
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.contentTertiary)
-                                .padding(.top, -1)
-                        }
-
-                        Spacer()
-
-                        kindTag
-
-                        if let scopeLabel = item.scopeLabel {
-                            VTag(scopeLabel, color: VColor.contentSecondary, icon: .lock)
-                        }
-
-                        VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerGhost, action: onDelete)
-                            .accessibilityLabel("Delete memory")
+                        VTag(
+                            memoryKind?.label ?? item.kind.capitalized,
+                            color: memoryKind?.color ?? VColor.contentTertiary
+                        )
                     }
 
                     Text(item.statement)
@@ -48,35 +33,29 @@ struct MemoryItemRow: View {
                         .lineLimit(1)
                         .multilineTextAlignment(.leading)
                 }
+
+                Spacer()
+
+                Text(item.relativeLastSeen)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+
+                VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerOutline, action: onDelete)
+                    .accessibilityLabel("Delete memory")
             }
+            .padding(VSpacing.lg)
+            .background(Color.clear)
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.xl)
+                    .stroke(VColor.borderDisabled, lineWidth: 2)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+            .contentShape(RoundedRectangle(cornerRadius: VRadius.xl))
         }
+        .buttonStyle(.plain)
         .contextMenu {
             Button("Delete", role: .destructive, action: onDelete)
         }
         .accessibilityElement(children: .combine)
-    }
-
-    // MARK: - Kind Icon
-
-    @ViewBuilder
-    private var kindIcon: some View {
-        if let kind = memoryKind, let icon = VIcon(rawValue: kind.icon) {
-            VIconView(icon, size: 20)
-                .foregroundColor(kind.color)
-                .frame(width: 40, height: 40)
-        } else {
-            VIconView(.brain, size: 20)
-                .foregroundColor(VColor.contentTertiary)
-                .frame(width: 40, height: 40)
-        }
-    }
-
-    // MARK: - Kind Tag
-
-    private var kindTag: some View {
-        VTag(
-            memoryKind?.label ?? item.kind.capitalized,
-            color: memoryKind?.color ?? VColor.contentTertiary
-        )
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -17,7 +17,7 @@ struct MemoryItemRow: View {
                     HStack(alignment: .center, spacing: VSpacing.sm) {
                         Text(item.subject)
                             .font(VFont.headline)
-                            .foregroundColor(VColor.contentEmphasized)
+                            .foregroundStyle(VColor.contentEmphasized)
                             .lineLimit(1)
                             .truncationMode(.tail)
 
@@ -29,7 +29,7 @@ struct MemoryItemRow: View {
 
                     Text(item.statement)
                         .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                         .lineLimit(1)
                         .multilineTextAlignment(.leading)
                 }
@@ -38,7 +38,7 @@ struct MemoryItemRow: View {
 
                 Text(item.relativeLastSeen)
                     .font(VFont.caption)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
 
                 VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerOutline, action: onDelete)
                     .accessibilityLabel("Delete memory")

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarPrimaryRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarPrimaryRow.swift
@@ -12,14 +12,24 @@ struct SidebarPrimaryRow: View {
     let action: () -> Void
 
     var body: some View {
-        VSidebarRow(
-            icon: icon,
-            label: label,
-            isActive: isActive,
-            trailingIcon: trailingIcon,
-            isExpanded: isExpanded,
-            action: action
-        )
+        if let trailingIcon {
+            VSidebarRow(
+                icon: icon,
+                label: label,
+                isActive: isActive,
+                trailingIcon: trailingIcon,
+                isExpanded: isExpanded,
+                action: action
+            )
+        } else {
+            VSidebarRow(
+                icon: icon,
+                label: label,
+                isActive: isActive,
+                isExpanded: isExpanded,
+                action: action
+            )
+        }
     }
 }
 

--- a/clients/shared/DesignSystem/Components/Display/VCard.swift
+++ b/clients/shared/DesignSystem/Components/Display/VCard.swift
@@ -2,22 +2,46 @@ import SwiftUI
 
 public struct VCard<Content: View>: View {
     public var padding: CGFloat = VSpacing.xl
+    public var isActive: Bool = false
+    public var action: (() -> Void)?
     @ViewBuilder public let content: () -> Content
 
-    public init(padding: CGFloat = VSpacing.xl, @ViewBuilder content: @escaping () -> Content) {
+    @State private var isHovered = false
+
+    public init(
+        padding: CGFloat = VSpacing.xl,
+        isActive: Bool = false,
+        action: (() -> Void)? = nil,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
         self.padding = padding
+        self.isActive = isActive
+        self.action = action
         self.content = content
+    }
+
+    private var backgroundColor: Color {
+        if isActive { return VColor.surfaceActive }
+        if isHovered && action != nil { return VColor.surfaceBase }
+        return VColor.surfaceOverlay
     }
 
     public var body: some View {
         content()
             .padding(padding)
-            .background(VColor.surfaceBase)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .background(backgroundColor)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
             .overlay(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .stroke(VColor.borderBase, lineWidth: 1)
+                RoundedRectangle(cornerRadius: VRadius.xl)
+                    .strokeBorder(VColor.borderDisabled, lineWidth: 2)
             )
+            .contentShape(RoundedRectangle(cornerRadius: VRadius.xl))
+            .onHover { isHovered = $0 }
+            .animation(VAnimation.fast, value: isHovered)
+            .if(action != nil) { view in
+                view
+                    .onTapGesture { action?() }
+                    .pointerCursor()
+            }
     }
 }
-

--- a/clients/shared/DesignSystem/Core/Navigation/VSidebarRow.swift
+++ b/clients/shared/DesignSystem/Core/Navigation/VSidebarRow.swift
@@ -10,40 +10,42 @@ import SwiftUI
 /// VSidebarRow(icon: VIcon.brain.rawValue, label: "Intelligence", isActive: true) {
 ///     showPanel(.intelligence)
 /// }
+///
+/// // With trailing content:
+/// VSidebarRow(label: "Identity", isActive: true, action: { }) {
+///     Text("5").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+/// }
 /// ```
-public struct VSidebarRow: View {
+public struct VSidebarRow<Trailing: View>: View {
     public let icon: String?
     public let label: String
     public var isActive: Bool
-    public var trailingIcon: String?
-    public var trailingIconRotation: Angle
     public var isExpanded: Bool
     public let action: () -> Void
+    public let trailing: Trailing
 
     @State private var isHovered = false
 
     /// Icon slot size — all leading icons occupy a uniform 20x20 frame.
-    private static let iconSlotSize: CGFloat = 20
+    private static var iconSlotSize: CGFloat { 20 }
 
     /// Minimum row height to ensure touch/click targets remain accessible.
-    private static let rowMinHeight: CGFloat = 32
+    private static var rowMinHeight: CGFloat { 32 }
 
     public init(
         icon: String? = nil,
         label: String,
         isActive: Bool = false,
-        trailingIcon: String? = nil,
-        trailingIconRotation: Angle = .zero,
         isExpanded: Bool = true,
-        action: @escaping () -> Void
+        action: @escaping () -> Void,
+        @ViewBuilder trailing: () -> Trailing
     ) {
         self.icon = icon
         self.label = label
         self.isActive = isActive
-        self.trailingIcon = trailingIcon
-        self.trailingIconRotation = trailingIconRotation
         self.isExpanded = isExpanded
         self.action = action
+        self.trailing = trailing()
     }
 
     private var iconColor: Color {
@@ -72,12 +74,7 @@ public struct VSidebarRow: View {
                 .allowsHitTesting(false)
             if isExpanded {
                 Spacer()
-                if let trailingIcon {
-                    VIconView(.resolve(trailingIcon), size: 10)
-                        .foregroundColor(iconColor)
-                        .rotationEffect(trailingIconRotation)
-                        .animation(VAnimation.fast, value: trailingIconRotation)
-                }
+                trailing
             }
         }
         .padding(.leading, isExpanded ? VSpacing.xs : 0)
@@ -98,5 +95,62 @@ public struct VSidebarRow: View {
         .padding(.horizontal, 0)
         .help(isExpanded ? "" : label)
         .pointerCursor()
+    }
+}
+
+// MARK: - Convenience initializers
+
+public extension VSidebarRow where Trailing == EmptyView {
+    /// Simple row with no trailing content.
+    init(
+        icon: String? = nil,
+        label: String,
+        isActive: Bool = false,
+        isExpanded: Bool = true,
+        action: @escaping () -> Void
+    ) {
+        self.init(icon: icon, label: label, isActive: isActive, isExpanded: isExpanded, action: action) {
+            EmptyView()
+        }
+    }
+}
+
+public extension VSidebarRow where Trailing == VSidebarRowTrailingIcon {
+    /// Row with a trailing icon and optional rotation (used by the main sidebar for disclosure arrows).
+    init(
+        icon: String? = nil,
+        label: String,
+        isActive: Bool = false,
+        trailingIcon: String,
+        trailingIconRotation: Angle = .zero,
+        isExpanded: Bool = true,
+        action: @escaping () -> Void
+    ) {
+        let active = isActive
+        self.init(icon: icon, label: label, isActive: isActive, isExpanded: isExpanded, action: action) {
+            VSidebarRowTrailingIcon(
+                icon: trailingIcon,
+                rotation: trailingIconRotation,
+                isActive: active
+            )
+        }
+    }
+}
+
+/// Trailing icon view extracted so the convenience init can reference a concrete type.
+public struct VSidebarRowTrailingIcon: View {
+    let icon: String
+    var rotation: Angle = .zero
+    var isActive: Bool = false
+
+    private var iconColor: Color {
+        isActive ? VColor.primaryActive : VColor.primaryBase
+    }
+
+    public var body: some View {
+        VIconView(.resolve(icon), size: 10)
+            .foregroundColor(iconColor)
+            .rotationEffect(rotation)
+            .animation(VAnimation.fast, value: rotation)
     }
 }

--- a/clients/shared/DesignSystem/Core/Navigation/VSidebarRow.swift
+++ b/clients/shared/DesignSystem/Core/Navigation/VSidebarRow.swift
@@ -149,7 +149,7 @@ public struct VSidebarRowTrailingIcon: View {
 
     public var body: some View {
         VIconView(.resolve(icon), size: 10)
-            .foregroundColor(iconColor)
+            .foregroundStyle(iconColor)
             .rotationEffect(rotation)
             .animation(VAnimation.fast, value: rotation)
     }

--- a/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
@@ -167,6 +167,28 @@ struct NavigationGallerySection: View {
 
                 VCard {
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
+                        Text("Trailing Content").font(VFont.headline).foregroundColor(VColor.contentSecondary)
+
+                        VSidebarRow(label: "All", isActive: true, action: {}) {
+                            Text("42")
+                                .font(.custom("Inter", size: 11))
+                                .foregroundColor(VColor.contentTertiary)
+                        }
+                        VSidebarRow(label: "Identity", action: {}) {
+                            Text("12")
+                                .font(.custom("Inter", size: 11))
+                                .foregroundColor(VColor.contentTertiary)
+                        }
+                        VSidebarRow(label: "Preference", action: {}) {
+                            Text("8")
+                                .font(.custom("Inter", size: 11))
+                                .foregroundColor(VColor.contentTertiary)
+                        }
+                    }
+                }
+
+                VCard {
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
                         Text("Collapsed Mode").font(VFont.headline).foregroundColor(VColor.contentSecondary)
 
                         HStack(spacing: VSpacing.md) {


### PR DESCRIPTION
## Summary
- Replaces the kind filter dropdown with a left sidebar using `VSidebarRow`, matching the main app sidebar pattern
- Switches memory items from a 2-column grid to full-width bordered cards with title, tag, description, timestamp, and delete button
- Makes `VSidebarRow` generic over trailing content via `@ViewBuilder`, with convenience inits for backward compatibility (empty, trailing icon)
- Simplifies status/sort dropdowns by removing leading icons

## Test plan
- [ ] Navigate to Memories page — verify left sidebar shows kind filters with counts
- [ ] Click kind filters — verify memories list filters correctly
- [ ] Verify memory cards display full-width with subject, kind tag, description, timestamp, and delete button
- [ ] Verify main sidebar still works correctly (trailing icon disclosure arrows)
- [ ] Check component gallery VSidebarRow section for new "Trailing Content" examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
