### PR TITLE
Revert "feat: show assistant display name in sidebar and panel header"

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -434,7 +434,7 @@ extension AppDelegate {
             CommandPaletteAction(id: "app-directory", icon: VIcon.layoutGrid.rawValue, label: "Library", shortcutHint: nil) { [weak self] in
                 self?.mainWindow?.windowState.showPanel(.apps)
             },
-            CommandPaletteAction(id: "intelligence", icon: VIcon.brain.rawValue, label: AssistantDisplayName.resolve(IdentityInfo.load()?.name), shortcutHint: nil) { [weak self] in
+            CommandPaletteAction(id: "intelligence", icon: VIcon.brain.rawValue, label: "Intelligence", shortcutHint: nil) { [weak self] in
                 self?.mainWindow?.windowState.showPanel(.intelligence)
             },
             CommandPaletteAction(id: "navigate-back", icon: VIcon.chevronLeft.rawValue, label: "Back", shortcutHint: "\u{2318}[") { [weak self] in

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -184,7 +184,7 @@ extension MainWindowView {
             }
 
             // MARK: Nav Items (fixed)
-            SidebarNavRow(icon: VIcon.brain.rawValue, label: AssistantDisplayName.resolve(IdentityInfo.load()?.name), isActive: windowState.selection == .panel(.intelligence)) {
+            SidebarNavRow(icon: VIcon.brain.rawValue, label: "Intelligence", isActive: windowState.selection == .panel(.intelligence)) {
                 windowState.showPanel(.intelligence)
             }
             SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Library", isActive: windowState.selection == .panel(.apps)) {
@@ -466,7 +466,7 @@ extension MainWindowView {
                 sidebarSectionDivider()
             }
 
-            SidebarNavRow(icon: VIcon.brain.rawValue, label: AssistantDisplayName.resolve(IdentityInfo.load()?.name), isActive: windowState.selection == .panel(.intelligence), isExpanded: false) {
+            SidebarNavRow(icon: VIcon.brain.rawValue, label: "Intelligence", isActive: windowState.selection == .panel(.intelligence), isExpanded: false) {
                 windowState.showPanel(.intelligence)
             }
             SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Library", isActive: windowState.selection == .panel(.apps), isExpanded: false) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -47,7 +47,7 @@ struct IntelligencePanel: View {
         VStack(alignment: .leading, spacing: 0) {
             // Header
             HStack(alignment: .center) {
-                Text(AssistantDisplayName.resolve(IdentityInfo.load()?.name))
+                Text("Intelligence")
                     .font(VFont.panelTitle)
                     .foregroundColor(VColor.contentEmphasized)
                 Spacer()


### PR DESCRIPTION
Reverts vellum-ai/vellum-assistant#20863
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20866" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
