### PR TITLE
feat: show assistant display name in sidebar and panel header

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -434,7 +434,7 @@ extension AppDelegate {
             CommandPaletteAction(id: "app-directory", icon: VIcon.layoutGrid.rawValue, label: "Library", shortcutHint: nil) { [weak self] in
                 self?.mainWindow?.windowState.showPanel(.apps)
             },
-            CommandPaletteAction(id: "intelligence", icon: VIcon.brain.rawValue, label: AssistantDisplayName.resolve(IdentityInfo.load()?.name), shortcutHint: nil) { [weak self] in
+            CommandPaletteAction(id: "intelligence", icon: VIcon.brain.rawValue, label: AssistantDisplayName.resolve(IdentityInfo.load()?.name, fallback: "Your Assistant"), shortcutHint: nil) { [weak self] in
                 self?.mainWindow?.windowState.showPanel(.intelligence)
             },
             CommandPaletteAction(id: "navigate-back", icon: VIcon.chevronLeft.rawValue, label: "Back", shortcutHint: "\u{2318}[") { [weak self] in

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -434,7 +434,7 @@ extension AppDelegate {
             CommandPaletteAction(id: "app-directory", icon: VIcon.layoutGrid.rawValue, label: "Library", shortcutHint: nil) { [weak self] in
                 self?.mainWindow?.windowState.showPanel(.apps)
             },
-            CommandPaletteAction(id: "intelligence", icon: VIcon.brain.rawValue, label: "Intelligence", shortcutHint: nil) { [weak self] in
+            CommandPaletteAction(id: "intelligence", icon: VIcon.brain.rawValue, label: AssistantDisplayName.resolve(IdentityInfo.load()?.name), shortcutHint: nil) { [weak self] in
                 self?.mainWindow?.windowState.showPanel(.intelligence)
             },
             CommandPaletteAction(id: "navigate-back", icon: VIcon.chevronLeft.rawValue, label: "Back", shortcutHint: "\u{2318}[") { [weak self] in

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -184,7 +184,7 @@ extension MainWindowView {
             }
 
             // MARK: Nav Items (fixed)
-            SidebarNavRow(icon: VIcon.brain.rawValue, label: AssistantDisplayName.resolve(IdentityInfo.load()?.name, fallback: "Your Assistant"), isActive: windowState.selection == .panel(.intelligence)) {
+            SidebarNavRow(icon: VIcon.brain.rawValue, label: cachedAssistantName, isActive: windowState.selection == .panel(.intelligence)) {
                 windowState.showPanel(.intelligence)
             }
             SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Library", isActive: windowState.selection == .panel(.apps)) {
@@ -466,7 +466,7 @@ extension MainWindowView {
                 sidebarSectionDivider()
             }
 
-            SidebarNavRow(icon: VIcon.brain.rawValue, label: AssistantDisplayName.resolve(IdentityInfo.load()?.name, fallback: "Your Assistant"), isActive: windowState.selection == .panel(.intelligence), isExpanded: false) {
+            SidebarNavRow(icon: VIcon.brain.rawValue, label: cachedAssistantName, isActive: windowState.selection == .panel(.intelligence), isExpanded: false) {
                 windowState.showPanel(.intelligence)
             }
             SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Library", isActive: windowState.selection == .panel(.apps), isExpanded: false) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -184,7 +184,7 @@ extension MainWindowView {
             }
 
             // MARK: Nav Items (fixed)
-            SidebarNavRow(icon: VIcon.brain.rawValue, label: AssistantDisplayName.resolve(IdentityInfo.load()?.name), isActive: windowState.selection == .panel(.intelligence)) {
+            SidebarNavRow(icon: VIcon.brain.rawValue, label: AssistantDisplayName.resolve(IdentityInfo.load()?.name, fallback: "Your Assistant"), isActive: windowState.selection == .panel(.intelligence)) {
                 windowState.showPanel(.intelligence)
             }
             SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Library", isActive: windowState.selection == .panel(.apps)) {
@@ -466,7 +466,7 @@ extension MainWindowView {
                 sidebarSectionDivider()
             }
 
-            SidebarNavRow(icon: VIcon.brain.rawValue, label: AssistantDisplayName.resolve(IdentityInfo.load()?.name), isActive: windowState.selection == .panel(.intelligence), isExpanded: false) {
+            SidebarNavRow(icon: VIcon.brain.rawValue, label: AssistantDisplayName.resolve(IdentityInfo.load()?.name, fallback: "Your Assistant"), isActive: windowState.selection == .panel(.intelligence), isExpanded: false) {
                 windowState.showPanel(.intelligence)
             }
             SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Library", isActive: windowState.selection == .panel(.apps), isExpanded: false) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -184,7 +184,7 @@ extension MainWindowView {
             }
 
             // MARK: Nav Items (fixed)
-            SidebarNavRow(icon: VIcon.brain.rawValue, label: "Intelligence", isActive: windowState.selection == .panel(.intelligence)) {
+            SidebarNavRow(icon: VIcon.brain.rawValue, label: AssistantDisplayName.resolve(IdentityInfo.load()?.name), isActive: windowState.selection == .panel(.intelligence)) {
                 windowState.showPanel(.intelligence)
             }
             SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Library", isActive: windowState.selection == .panel(.apps)) {
@@ -466,7 +466,7 @@ extension MainWindowView {
                 sidebarSectionDivider()
             }
 
-            SidebarNavRow(icon: VIcon.brain.rawValue, label: "Intelligence", isActive: windowState.selection == .panel(.intelligence), isExpanded: false) {
+            SidebarNavRow(icon: VIcon.brain.rawValue, label: AssistantDisplayName.resolve(IdentityInfo.load()?.name), isActive: windowState.selection == .panel(.intelligence), isExpanded: false) {
                 windowState.showPanel(.intelligence)
             }
             SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Library", isActive: windowState.selection == .panel(.apps), isExpanded: false) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -58,6 +58,10 @@ struct MainWindowView: View {
 
     @State var showConversationSwitcher = false
     @State var conversationSwitcherTriggerFrame: CGRect = .zero
+
+    /// Cached assistant display name, loaded once on appear and when the
+    /// intelligence panel is shown (to pick up identity changes).
+    @State var cachedAssistantName: String = AssistantDisplayName.resolve(fallback: "Your Assistant")
     /// Whether the "coming alive" overlay is currently showing.
     @State private var showComingAlive: Bool
     /// Whether the daemon-loading skeleton overlay is currently showing.
@@ -785,6 +789,7 @@ struct MainWindowView: View {
         // Without this, isAppChatOpen could remain persisted as true with
         // no UI to disable it, leaving panels stuck in split mode.
         isAppChatOpen = false
+        cachedAssistantName = AssistantDisplayName.resolve(IdentityInfo.load()?.name, fallback: "Your Assistant")
         refreshWindowAPIStatus(isConnected: connectionManager.isConnected, isAuthenticated: authManager.isAuthenticated)
         selectedConversationId = conversationManager.activeConversationId
         if let activeId = conversationManager.activeConversationId {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -3,6 +3,10 @@ import SwiftUI
 import VellumAssistantShared
 import UniformTypeIdentifiers
 
+extension Notification.Name {
+    static let identityFileDidChange = Notification.Name("identityFileDidChange")
+}
+
 struct MainWindowView: View {
     @ObservedObject var conversationManager: ConversationManager
     @ObservedObject var appListManager: AppListManager
@@ -59,9 +63,10 @@ struct MainWindowView: View {
     @State var showConversationSwitcher = false
     @State var conversationSwitcherTriggerFrame: CGRect = .zero
 
-    /// Cached assistant display name, loaded once on appear and when the
-    /// intelligence panel is shown (to pick up identity changes).
-    @State var cachedAssistantName: String = AssistantDisplayName.resolve(fallback: "Your Assistant")
+    /// Cached assistant display name, refreshed when IDENTITY.md changes on disk.
+    @State var cachedAssistantName: String = AssistantDisplayName.resolve(IdentityInfo.load()?.name, fallback: "Your Assistant")
+    /// File watcher for IDENTITY.md — fires when the assistant's name changes.
+    @State private var identityFileWatcher: DispatchSourceFileSystemObject?
     /// Whether the "coming alive" overlay is currently showing.
     @State private var showComingAlive: Bool
     /// Whether the daemon-loading skeleton overlay is currently showing.
@@ -696,6 +701,9 @@ struct MainWindowView: View {
         content
             .onAppear { handleCoreLayoutAppear() }
             .onDisappear { handleCoreLayoutDisappear() }
+            .onReceive(NotificationCenter.default.publisher(for: .identityFileDidChange)) { _ in
+                cachedAssistantName = AssistantDisplayName.resolve(IdentityInfo.load()?.name, fallback: "Your Assistant")
+            }
             .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
                 refreshWindowAPIStatus(isConnected: connectionManager.isConnected, isAuthenticated: authManager.isAuthenticated)
             }
@@ -790,6 +798,7 @@ struct MainWindowView: View {
         // no UI to disable it, leaving panels stuck in split mode.
         isAppChatOpen = false
         cachedAssistantName = AssistantDisplayName.resolve(IdentityInfo.load()?.name, fallback: "Your Assistant")
+        startIdentityFileWatcher()
         refreshWindowAPIStatus(isConnected: connectionManager.isConnected, isAuthenticated: authManager.isAuthenticated)
         selectedConversationId = conversationManager.activeConversationId
         if let activeId = conversationManager.activeConversationId {
@@ -822,7 +831,36 @@ struct MainWindowView: View {
         sharing.credentialPollTimer?.invalidate()
         sharing.credentialPollTimer = nil
         sharing.pendingPublish = nil
+        identityFileWatcher?.cancel()
+        identityFileWatcher = nil
         eventStreamClient.stopSSE()
+    }
+
+    /// Watch ~/.vellum/workspace/IDENTITY.md for writes and refresh the
+    /// cached assistant display name when the file changes on disk.
+    private func startIdentityFileWatcher() {
+        identityFileWatcher?.cancel()
+        identityFileWatcher = nil
+
+        let identityPath = NSHomeDirectory() + "/.vellum/workspace/IDENTITY.md"
+        let fd = open(identityPath, O_EVTONLY)
+        guard fd >= 0 else { return }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .delete, .rename],
+            queue: .global(qos: .utility)
+        )
+        // Post a notification so the SwiftUI view can pick up the change
+        // without capturing `self` (which is a struct).
+        source.setEventHandler {
+            NotificationCenter.default.post(name: .identityFileDidChange, object: nil)
+        }
+        source.setCancelHandler {
+            close(fd)
+        }
+        source.resume()
+        identityFileWatcher = source
     }
 
     private func refreshWindowAPIStatus(isConnected: Bool, isAuthenticated: Bool) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -105,7 +105,7 @@ enum AssistantDisplayName {
             guard let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines),
                   !trimmed.isEmpty else { continue }
             if trimmed.hasPrefix(hiddenBootstrapPrefix) {
-                return placeholder
+                continue
             }
             return trimmed
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -22,6 +22,11 @@ struct IdentityPanel: View {
     @State private var introTask: Task<Void, Never>? = nil
     @State private var bootstrapCheckTask: Task<Void, Never>? = nil
     @State private var isBootstrapActive: Bool = true
+    @State private var isEditingName: Bool = false
+    @State private var editingNameText: String = ""
+    @State private var isEditingRole: Bool = false
+    @State private var editingRoleText: String = ""
+    @State private var isSavingIdentityField: Bool = false
 
     private let sidebarMinWidth: CGFloat = 200
     private let sidebarMaxWidth: CGFloat = 280
@@ -33,9 +38,15 @@ struct IdentityPanel: View {
         AssistantDisplayName.resolve(
             remoteIdentity?.name.nilIfEmpty,
             identity?.name,
-            lockfileAssistant?.assistantId,
-            fallback: "Unknown"
+            fallback: "Your Assistant"
         )
+    }
+
+    private var hasRealName: Bool {
+        AssistantDisplayName.firstUserFacing(from: [
+            remoteIdentity?.name.nilIfEmpty,
+            identity?.name
+        ]) != nil
     }
 
     var body: some View {
@@ -48,13 +59,38 @@ struct IdentityPanel: View {
                     VStack(spacing: 0) {
                         VStack(spacing: 0) {
                             // Intro heading — show daemon-generated text, fall back to static name
-                            Text(introText ?? "I'm \(assistantDisplayName)!")
-                                .font(.system(size: 22, weight: .regular, design: .rounded))
-                                .foregroundColor(VColor.contentDefault)
-                                .multilineTextAlignment(.center)
+                            if isEditingName {
+                                inlineEditField(
+                                    text: $editingNameText,
+                                    placeholder: "Enter a name",
+                                    font: .system(size: 22, weight: .regular, design: .rounded),
+                                    isSaving: isSavingIdentityField,
+                                    onSave: { saveIdentityField(field: "Name", value: editingNameText) },
+                                    onCancel: { isEditingName = false }
+                                )
+                                .padding(.top, VSpacing.xxl)
+                                .padding(.horizontal, VSpacing.lg)
+                            } else {
+                                HStack(spacing: VSpacing.xs) {
+                                    Text(introText ?? (hasRealName ? "I'm \(assistantDisplayName)!" : "I need a name!"))
+                                        .font(.system(size: 22, weight: .regular, design: .rounded))
+                                        .foregroundColor(VColor.contentDefault)
+                                        .multilineTextAlignment(.center)
+
+                                    VButton(
+                                        label: "Edit name",
+                                        iconOnly: VIcon.pencil.rawValue,
+                                        style: .ghost,
+                                        size: .compact
+                                    ) {
+                                        editingNameText = hasRealName ? assistantDisplayName : ""
+                                        isEditingName = true
+                                    }
+                                }
                                 .frame(maxWidth: .infinity, alignment: .center)
                                 .padding(.top, VSpacing.xxl)
                                 .padding(.horizontal, VSpacing.lg)
+                            }
 
                             Spacer()
 
@@ -84,9 +120,38 @@ struct IdentityPanel: View {
 
                             // Role + Hatched date
                             VStack(alignment: .leading, spacing: VSpacing.lg) {
-                                let role = remoteIdentity?.role.nilIfEmpty ?? identity?.role
-                                if let role, !role.isEmpty {
-                                    identityInfoRow(label: "Role", value: role)
+                                let role = AssistantDisplayName.firstUserFacing(from: [
+                                    remoteIdentity?.role.nilIfEmpty,
+                                    identity?.role
+                                ])
+                                if isEditingRole {
+                                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                                        Text("Role")
+                                            .font(VFont.caption)
+                                            .foregroundColor(VColor.contentTertiary)
+                                        inlineEditField(
+                                            text: $editingRoleText,
+                                            placeholder: "Enter a role",
+                                            font: VFont.caption,
+                                            isSaving: isSavingIdentityField,
+                                            onSave: { saveIdentityField(field: "Role", value: editingRoleText) },
+                                            onCancel: { isEditingRole = false }
+                                        )
+                                    }
+                                } else {
+                                    HStack(spacing: VSpacing.xs) {
+                                        identityInfoRow(label: "Role", value: role ?? "Not set")
+                                        Spacer()
+                                        VButton(
+                                            label: "Edit role",
+                                            iconOnly: VIcon.pencil.rawValue,
+                                            style: .ghost,
+                                            size: .compact
+                                        ) {
+                                            editingRoleText = role ?? ""
+                                            isEditingRole = true
+                                        }
+                                    }
                                 }
                                 if let date = metadata?.createdAt {
                                     identityInfoRow(label: "Hatched", value: formatHatchedDate(date))
@@ -189,6 +254,91 @@ struct IdentityPanel: View {
         }
     }
 
+    // MARK: - Inline Editing
+
+    @ViewBuilder
+    private func inlineEditField(
+        text: Binding<String>,
+        placeholder: String,
+        font: Font,
+        isSaving: Bool,
+        onSave: @escaping () -> Void,
+        onCancel: @escaping () -> Void
+    ) -> some View {
+        HStack(spacing: VSpacing.xs) {
+            TextField(placeholder, text: text)
+                .font(font)
+                .foregroundColor(VColor.contentDefault)
+                .textFieldStyle(.plain)
+                .onSubmit { onSave() }
+
+            if isSaving {
+                ProgressView()
+                    .controlSize(.small)
+            } else {
+                VButton(label: "Save", iconOnly: VIcon.check.rawValue, style: .ghost, size: .compact) {
+                    onSave()
+                }
+                VButton(label: "Cancel", iconOnly: VIcon.x.rawValue, style: .ghost, size: .compact) {
+                    onCancel()
+                }
+            }
+        }
+    }
+
+    /// Save a field in IDENTITY.md (e.g. "Name", "Role") via the workspace API.
+    private func saveIdentityField(field: String, value: String) {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !isSavingIdentityField else { return }
+        isSavingIdentityField = true
+
+        Task {
+            defer { isSavingIdentityField = false }
+
+            let fileResponse = await workspaceClient.fetchWorkspaceFile(path: "IDENTITY.md", showHidden: false)
+            guard let content = fileResponse?.content else {
+                isEditingName = false
+                isEditingRole = false
+                return
+            }
+
+            let key = "- **\(field.lowercased()):**"
+            let lines = content.components(separatedBy: "\n")
+            let updatedLines = lines.map { line -> String in
+                if line.trimmingCharacters(in: .whitespaces).lowercased().hasPrefix(key) {
+                    return "- **\(field):** \(trimmed)"
+                }
+                return line
+            }
+            let updatedContent = updatedLines.joined(separator: "\n")
+
+            let success = await workspaceClient.writeWorkspaceFile(
+                path: "IDENTITY.md",
+                content: updatedContent.data(using: .utf8) ?? Data()
+            )
+
+            if success {
+                identity = IdentityInfo.load()
+                isEditingName = false
+                isEditingRole = false
+
+                if field == "Name" {
+                    introText = nil
+                    if !isBootstrapActive {
+                        if let soulIntro = IdentityInfo.loadIdentityIntro() {
+                            introText = soulIntro
+                        } else {
+                            generateIntro()
+                        }
+                    }
+                }
+            } else {
+                isEditingName = false
+                isEditingRole = false
+            }
+        }
+    }
+
     // MARK: - Intro Generation
 
     private func generateIntro() {
@@ -208,12 +358,12 @@ struct IdentityPanel: View {
                     result += delta
                 }
                 let trimmed = result.trimmingCharacters(in: .whitespacesAndNewlines)
-                self.introText = trimmed.isEmpty ? "I'm \(assistantDisplayName)!" : trimmed
+                self.introText = trimmed.isEmpty ? (hasRealName ? "I'm \(assistantDisplayName)!" : "I need a name!") : trimmed
             } catch is CancellationError {
                 return
             } catch {
                 guard !Task.isCancelled else { return }
-                self.introText = "I'm \(assistantDisplayName)!"
+                self.introText = hasRealName ? "I'm \(assistantDisplayName)!" : "I need a name!"
             }
         }
     }
@@ -250,14 +400,20 @@ struct IdentityPanel: View {
             }
 
             // Role: remote > local (truncated with tooltip for long values)
-            let role = remoteIdentity?.role.nilIfEmpty ?? identity?.role
-            if let role, !role.isEmpty {
+            let role = AssistantDisplayName.firstUserFacing(from: [
+                remoteIdentity?.role.nilIfEmpty,
+                identity?.role
+            ])
+            if let role {
                 idRow(label: "Role", value: role, truncate: true)
             }
 
             // Personality: remote > local
-            let personality = remoteIdentity?.personality.nilIfEmpty ?? identity?.personality
-            if let personality, !personality.isEmpty {
+            let personality = AssistantDisplayName.firstUserFacing(from: [
+                remoteIdentity?.personality.nilIfEmpty,
+                identity?.personality
+            ])
+            if let personality {
                 idRow(label: "Personality", value: personality)
             }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -47,7 +47,7 @@ struct IntelligencePanel: View {
         VStack(alignment: .leading, spacing: 0) {
             // Header
             HStack(alignment: .center) {
-                Text("About \(AssistantDisplayName.resolve(IdentityInfo.load()?.name))")
+                Text("About \(AssistantDisplayName.resolve(IdentityInfo.load()?.name, fallback: "Your Assistant"))")
                     .font(VFont.panelTitle)
                     .foregroundColor(VColor.contentEmphasized)
                 Spacer()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -47,7 +47,7 @@ struct IntelligencePanel: View {
         VStack(alignment: .leading, spacing: 0) {
             // Header
             HStack(alignment: .center) {
-                Text("Intelligence")
+                Text("About \(AssistantDisplayName.resolve(IdentityInfo.load()?.name))")
                     .font(VFont.panelTitle)
                     .foregroundColor(VColor.contentEmphasized)
                 Spacer()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -15,6 +15,7 @@ struct IntelligencePanel: View {
     @Binding var pendingMemoryId: String?
 
     @State private var selectedTab: IntelligenceTab
+    @State private var cachedAssistantName: String = AssistantDisplayName.resolve(IdentityInfo.load()?.name, fallback: "Your Assistant")
     @State private var isContactsEnabled: Bool = false
     @State private var isEmailEnabled: Bool = false
     private static let contactsFeatureFlagKey = "feature_flags.contacts.enabled"
@@ -47,7 +48,7 @@ struct IntelligencePanel: View {
         VStack(alignment: .leading, spacing: 0) {
             // Header
             HStack(alignment: .center) {
-                Text("About \(AssistantDisplayName.resolve(IdentityInfo.load()?.name, fallback: "Your Assistant"))")
+                Text("About \(cachedAssistantName)")
                     .font(VFont.panelTitle)
                     .foregroundColor(VColor.contentEmphasized)
                 Spacer()

--- a/clients/macos/vellum-assistantTests/AssistantDisplayNameTests.swift
+++ b/clients/macos/vellum-assistantTests/AssistantDisplayNameTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class AssistantDisplayNameTests: XCTestCase {
+
+    // MARK: - firstUserFacing
+
+    func testRealNameReturned() {
+        let result = AssistantDisplayName.firstUserFacing(from: ["Luna"])
+        XCTAssertEqual(result, "Luna")
+    }
+
+    func testNilSkipped() {
+        let result = AssistantDisplayName.firstUserFacing(from: [nil, "Luna"])
+        XCTAssertEqual(result, "Luna")
+    }
+
+    func testEmptyStringSkipped() {
+        let result = AssistantDisplayName.firstUserFacing(from: ["", "Luna"])
+        XCTAssertEqual(result, "Luna")
+    }
+
+    func testWhitespaceOnlySkipped() {
+        let result = AssistantDisplayName.firstUserFacing(from: ["  ", "Luna"])
+        XCTAssertEqual(result, "Luna")
+    }
+
+    func testBootstrapPrefixSkipped() {
+        let result = AssistantDisplayName.firstUserFacing(from: ["_(not yet chosen)_"])
+        XCTAssertNil(result)
+    }
+
+    func testBootstrapPrefixFallsThrough() {
+        let result = AssistantDisplayName.firstUserFacing(from: ["_(not yet chosen)_", "Luna"])
+        XCTAssertEqual(result, "Luna")
+    }
+
+    func testAllNilReturnsNil() {
+        let result = AssistantDisplayName.firstUserFacing(from: [nil, nil])
+        XCTAssertNil(result)
+    }
+
+    func testEmptyArrayReturnsNil() {
+        let result = AssistantDisplayName.firstUserFacing(from: [])
+        XCTAssertNil(result)
+    }
+
+    // MARK: - resolve
+
+    func testResolveWithName() {
+        let result = AssistantDisplayName.resolve("Luna")
+        XCTAssertEqual(result, "Luna")
+    }
+
+    func testResolveWithBootstrapUsesDefaultFallback() {
+        let result = AssistantDisplayName.resolve("_(not yet chosen)_")
+        XCTAssertEqual(result, AssistantDisplayName.placeholder)
+    }
+
+    func testResolveWithBootstrapUsesCustomFallback() {
+        let result = AssistantDisplayName.resolve("_(not yet chosen)_", fallback: "Your Assistant")
+        XCTAssertEqual(result, "Your Assistant")
+    }
+
+    func testResolveWithNilUsesCustomFallback() {
+        let name: String? = nil
+        let result = AssistantDisplayName.resolve(name, fallback: "Your Assistant")
+        XCTAssertEqual(result, "Your Assistant")
+    }
+
+    func testResolveFirstValidCandidate() {
+        let name: String? = nil
+        let result = AssistantDisplayName.resolve(name, "_(bootstrap)_", "Luna", fallback: "Fallback")
+        XCTAssertEqual(result, "Luna")
+    }
+}


### PR DESCRIPTION
## Summary
- Sidebar nav row (expanded + collapsed): shows the assistant's configured name instead of "Intelligence"
- Command palette: same
- Panel header: reads "About Pax" (or "About Assistant" as fallback) instead of "Intelligence"

Uses `AssistantDisplayName.resolve(IdentityInfo.load()?.name)` — the same pattern used elsewhere in the codebase.

## Test plan
- [ ] Sidebar shows the assistant's name (e.g. "Pax")
- [ ] Panel header reads "About Pax"
- [ ] Command palette shows the assistant's name
- [ ] With no name configured, sidebar shows "Assistant" and header shows "About Assistant"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20868" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
