### PR TITLE
feat: add platform OAuth connect and disconnect CLI commands

### DIFF
--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -24,7 +24,7 @@ import {
   assertMetadataWritable,
   deleteCredentialMetadata,
 } from "../../../tools/credentials/metadata-store.js";
-import { isLinux, isMacOS } from "../../../util/platform.js";
+import { openInBrowser } from "../../../util/browser.js";
 import {
   deleteSecureKeyViaDaemon,
   getSecureKeyViaDaemon,
@@ -537,7 +537,10 @@ Examples:
             "client_secret",
           ];
           for (const field of legacyFields) {
-            const result = await deleteSecureKeyViaDaemon("credential", `${providerKey}:${field}`);
+            const result = await deleteSecureKeyViaDaemon(
+              "credential",
+              `${providerKey}:${field}`,
+            );
             if (result === "deleted") cleanedUp = true;
 
             const metaDeleted = deleteCredentialMetadata(providerKey, field);
@@ -683,26 +686,7 @@ Examples:
             clientId,
             clientSecret,
             isInteractive: !!opts.openBrowser,
-            openUrl: opts.openBrowser
-              ? (url) => {
-                  if (isMacOS()) {
-                    Bun.spawn(["open", url], {
-                      stdout: "ignore",
-                      stderr: "ignore",
-                    });
-                  } else if (isLinux()) {
-                    Bun.spawn(["xdg-open", url], {
-                      stdout: "ignore",
-                      stderr: "ignore",
-                    });
-                  } else {
-                    // Fallback: print URL for manual opening (stderr to keep --json stdout clean)
-                    process.stderr.write(
-                      `Open this URL to authorize:\n\n${url}\n`,
-                    );
-                  }
-                }
-              : undefined,
+            openUrl: opts.openBrowser ? openInBrowser : undefined,
             ...(opts.scopes ? { requestedScopes: opts.scopes } : {}),
           });
 

--- a/assistant/src/cli/commands/oauth/platform.ts
+++ b/assistant/src/cli/commands/oauth/platform.ts
@@ -50,11 +50,15 @@ function toBareProvider(provider: string): string {
 }
 
 /**
- * Validate that a provider supports managed OAuth and that managed mode is
- * enabled. Returns the managed config key on success, or writes an error and
- * returns null.
+ * Validate that a provider supports managed OAuth (has a managedServiceConfigKey).
+ * Does NOT check whether managed mode is currently enabled — use this for
+ * operations that should work regardless of the current mode (e.g. disconnect).
+ * Returns the managed config key on success, or writes an error and returns null.
  */
-function requireManagedProvider(provider: string, cmd: Command): string | null {
+function requireManagedCapableProvider(
+  provider: string,
+  cmd: Command,
+): string | null {
   const providerKey = toProviderKey(provider);
   const providerRow = getProvider(providerKey);
 
@@ -67,6 +71,19 @@ function requireManagedProvider(provider: string, cmd: Command): string | null {
     process.exitCode = 1;
     return null;
   }
+
+  return managedKey;
+}
+
+/**
+ * Validate that a provider supports managed OAuth AND that managed mode is
+ * currently enabled. Use this for operations that require active managed
+ * mode (e.g. connect). Returns the managed config key on success, or writes
+ * an error and returns null.
+ */
+function requireManagedProvider(provider: string, cmd: Command): string | null {
+  const managedKey = requireManagedCapableProvider(provider, cmd);
+  if (!managedKey) return null;
 
   const services: Services = getConfig().services;
   const managedEnabled =
@@ -421,7 +438,7 @@ Examples:
         cmd: Command,
       ) => {
         try {
-          if (!requireManagedProvider(provider, cmd)) return;
+          if (!requireManagedCapableProvider(provider, cmd)) return;
 
           const client = await requirePlatformClient(cmd);
           if (!client) return;

--- a/assistant/src/cli/commands/oauth/platform.ts
+++ b/assistant/src/cli/commands/oauth/platform.ts
@@ -274,7 +274,7 @@ function registerConnectCommand(platform: Command): void {
     )
     .option(
       "--scopes <scopes...>",
-      "Specific OAuth scopes to request (e.g. calendar.readonly gmail.send)",
+      "Exact OAuth scopes to request (must be a subset of the provider's allowed scopes)",
     )
     .addHelpText(
       "after",
@@ -290,9 +290,16 @@ callback, token exchange, and credential storage.
 The provider must support managed OAuth and managed mode must be enabled in
 the services config.
 
+Scope behavior:
+  Without --scopes, the platform requests ALL of the provider's allowed scopes.
+  With --scopes, only the specified scopes are requested (no merging with
+  defaults). Each scope must be in the provider's allowed set or the platform
+  will reject it. Use full scope URLs where required (e.g. Google scopes use
+  https://www.googleapis.com/auth/... format).
+
 Examples:
   $ assistant oauth platform connect google
-  $ assistant oauth platform connect google --scopes calendar.readonly gmail.send
+  $ assistant oauth platform connect google --scopes https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/calendar.events
   $ assistant oauth platform connect google --json`,
     )
     .action(

--- a/assistant/src/cli/commands/oauth/platform.ts
+++ b/assistant/src/cli/commands/oauth/platform.ts
@@ -7,10 +7,26 @@ import {
 } from "../../../config/schemas/services.js";
 import { getProvider } from "../../../oauth/oauth-store.js";
 import { VellumPlatformClient } from "../../../platform/client.js";
+import { openInBrowser } from "../../../util/browser.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 
 const log = getCliLogger("cli");
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+interface PlatformConnectionEntry {
+  id: string;
+  account_label?: string;
+  scopes_granted?: string[];
+  status?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
 
 /**
  * Normalize a bare provider name (e.g. "google") into the canonical provider
@@ -22,17 +38,116 @@ function toProviderKey(provider: string): string {
     : `integration:${provider}`;
 }
 
+/**
+ * Validate that a provider supports managed OAuth and that managed mode is
+ * enabled. Returns the managed config key on success, or writes an error and
+ * returns null.
+ */
+function requireManagedProvider(provider: string, cmd: Command): string | null {
+  const providerKey = toProviderKey(provider);
+  const providerRow = getProvider(providerKey);
+
+  const managedKey = providerRow?.managedServiceConfigKey;
+  if (!managedKey || !(managedKey in ServicesSchema.shape)) {
+    writeOutput(cmd, {
+      ok: false,
+      error: `Provider "${provider}" does not support platform-managed OAuth`,
+    });
+    process.exitCode = 1;
+    return null;
+  }
+
+  const services: Services = getConfig().services;
+  const managedEnabled =
+    services[managedKey as keyof Services].mode === "managed";
+
+  if (!managedEnabled) {
+    writeOutput(cmd, {
+      ok: false,
+      error: `Provider "${provider}" supports managed OAuth but is set to "your-own" mode`,
+    });
+    process.exitCode = 1;
+    return null;
+  }
+
+  return managedKey;
+}
+
+/**
+ * Create an authenticated platform client, or write an error and return null.
+ */
+async function requirePlatformClient(
+  cmd: Command,
+): Promise<VellumPlatformClient | null> {
+  const client = await VellumPlatformClient.create();
+  if (!client || !client.platformAssistantId) {
+    writeOutput(cmd, {
+      ok: false,
+      error:
+        "Platform prerequisites not met (not logged in or missing assistant ID)",
+    });
+    process.exitCode = 1;
+    return null;
+  }
+  return client;
+}
+
+/**
+ * Fetch active platform connections for a provider. Returns the parsed entries
+ * or writes an error and returns null.
+ */
+async function fetchActiveConnections(
+  client: VellumPlatformClient,
+  provider: string,
+  cmd: Command,
+): Promise<PlatformConnectionEntry[] | null> {
+  const params = new URLSearchParams();
+  params.set("provider", provider);
+  params.set("status", "ACTIVE");
+
+  const path = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/connections/?${params.toString()}`;
+  const response = await client.fetch(path);
+
+  if (!response.ok) {
+    writeOutput(cmd, {
+      ok: false,
+      error: `Platform returned HTTP ${response.status}`,
+    });
+    process.exitCode = 1;
+    return null;
+  }
+
+  const body = (await response.json()) as unknown;
+
+  // The platform returns either a flat array or a {results: [...]} wrapper.
+  return (
+    Array.isArray(body)
+      ? body
+      : ((body as Record<string, unknown>).results ?? [])
+  ) as PlatformConnectionEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
 export function registerPlatformCommands(oauth: Command): void {
   const platform = oauth
     .command("platform")
     .description(
-      "Query platform-managed OAuth provider status and connections",
+      "Manage platform-managed OAuth provider status and connections",
     );
 
-  // ---------------------------------------------------------------------------
-  // platform status <provider>
-  // ---------------------------------------------------------------------------
+  registerStatusCommand(platform);
+  registerConnectCommand(platform);
+  registerDisconnectCommand(platform);
+}
 
+// ---------------------------------------------------------------------------
+// platform status <provider>
+// ---------------------------------------------------------------------------
+
+function registerStatusCommand(platform: Command): void {
   platform
     .command("status <provider>")
     .description(
@@ -102,46 +217,15 @@ Examples:
           }
 
           // 3. Fetch active connections from the platform
-          const client = await VellumPlatformClient.create();
-          if (!client || !client.platformAssistantId) {
-            writeOutput(cmd, {
-              ok: false,
-              error:
-                "Platform prerequisites not met (not logged in or missing assistant ID)",
-            });
-            process.exitCode = 1;
-            return;
-          }
+          const client = await requirePlatformClient(cmd);
+          if (!client) return;
 
-          const params = new URLSearchParams();
-          params.set("provider", provider);
-          params.set("status", "ACTIVE");
-
-          const path = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/connections/?${params.toString()}`;
-          const response = await client.fetch(path);
-
-          if (!response.ok) {
-            writeOutput(cmd, {
-              ok: false,
-              error: `Platform returned HTTP ${response.status}`,
-            });
-            process.exitCode = 1;
-            return;
-          }
-
-          const body = (await response.json()) as unknown;
-
-          // The platform returns either a flat array or a {results: [...]} wrapper.
-          const rawEntries = (
-            Array.isArray(body)
-              ? body
-              : ((body as Record<string, unknown>).results ?? [])
-          ) as Array<{
-            id: string;
-            account_label?: string;
-            scopes_granted?: string[];
-            status?: string;
-          }>;
+          const rawEntries = await fetchActiveConnections(
+            client,
+            provider,
+            cmd,
+          );
+          if (!rawEntries) return;
 
           const connections = rawEntries.map((c) => ({
             id: c.id,
@@ -168,6 +252,220 @@ Examples:
                 `Provider "${provider}": ${connections.length} active connection(s)`,
               );
             }
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          writeOutput(cmd, { ok: false, error: message });
+          process.exitCode = 1;
+        }
+      },
+    );
+}
+
+// ---------------------------------------------------------------------------
+// platform connect <provider>
+// ---------------------------------------------------------------------------
+
+function registerConnectCommand(platform: Command): void {
+  platform
+    .command("connect <provider>")
+    .description(
+      "Initiate a platform-managed OAuth flow for a provider and open the browser",
+    )
+    .option(
+      "--scopes <scopes...>",
+      "Specific OAuth scopes to request (e.g. calendar.readonly gmail.send)",
+    )
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  provider   Provider name (e.g. google, slack, twitter)
+
+Starts a platform-managed OAuth authorization flow by calling the platform's
+/start/ endpoint, then opens the returned authorization URL in the user's
+browser. The user completes consent in the browser; the platform handles the
+callback, token exchange, and credential storage.
+
+The provider must support managed OAuth and managed mode must be enabled in
+the services config.
+
+Examples:
+  $ assistant oauth platform connect google
+  $ assistant oauth platform connect google --scopes calendar.readonly gmail.send
+  $ assistant oauth platform connect google --json`,
+    )
+    .action(
+      async (provider: string, opts: { scopes?: string[] }, cmd: Command) => {
+        try {
+          if (!requireManagedProvider(provider, cmd)) return;
+
+          const client = await requirePlatformClient(cmd);
+          if (!client) return;
+
+          // Call the platform's OAuth start endpoint
+          const startPath = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/${encodeURIComponent(provider)}/start/`;
+
+          const body: Record<string, unknown> = {};
+          if (opts.scopes && opts.scopes.length > 0) {
+            body.requested_scopes = opts.scopes;
+          }
+
+          const response = await client.fetch(startPath, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          });
+
+          if (!response.ok) {
+            const errorText = await response.text().catch(() => "");
+            writeOutput(cmd, {
+              ok: false,
+              error: `Platform returned HTTP ${response.status}${errorText ? `: ${errorText}` : ""}`,
+            });
+            process.exitCode = 1;
+            return;
+          }
+
+          const result = (await response.json()) as {
+            connect_url?: string;
+          };
+
+          if (!result.connect_url) {
+            writeOutput(cmd, {
+              ok: false,
+              error:
+                "Platform did not return a connect URL — the OAuth flow could not be started",
+            });
+            process.exitCode = 1;
+            return;
+          }
+
+          openInBrowser(result.connect_url);
+
+          writeOutput(cmd, {
+            ok: true,
+            provider,
+            connectUrl: result.connect_url,
+          });
+
+          if (!shouldOutputJson(cmd)) {
+            log.info(
+              `Opening browser to connect ${provider}. Complete the authorization in your browser.`,
+            );
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          writeOutput(cmd, { ok: false, error: message });
+          process.exitCode = 1;
+        }
+      },
+    );
+}
+
+// ---------------------------------------------------------------------------
+// platform disconnect <provider>
+// ---------------------------------------------------------------------------
+
+function registerDisconnectCommand(platform: Command): void {
+  platform
+    .command("disconnect <provider>")
+    .description(
+      "Disconnect a platform-managed OAuth connection for a provider",
+    )
+    .option(
+      "--connection-id <id>",
+      "Specific connection ID to disconnect (required when multiple active connections exist)",
+    )
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  provider   Provider name (e.g. google, slack, twitter)
+
+Disconnects a platform-managed OAuth connection by calling the platform's
+/disconnect/ endpoint, which revokes the connection.
+
+If the provider has multiple active connections, use --connection-id to specify
+which one to disconnect. Without --connection-id, the command disconnects the
+sole active connection or fails with a list of active connections if there are
+multiple.
+
+Examples:
+  $ assistant oauth platform disconnect google
+  $ assistant oauth platform disconnect google --connection-id conn_abc123
+  $ assistant oauth platform disconnect google --json`,
+    )
+    .action(
+      async (
+        provider: string,
+        opts: { connectionId?: string },
+        cmd: Command,
+      ) => {
+        try {
+          if (!requireManagedProvider(provider, cmd)) return;
+
+          const client = await requirePlatformClient(cmd);
+          if (!client) return;
+
+          let connectionId = opts.connectionId;
+
+          // If no connection ID given, resolve it from active connections
+          if (!connectionId) {
+            const entries = await fetchActiveConnections(client, provider, cmd);
+            if (!entries) return;
+
+            if (entries.length === 0) {
+              writeOutput(cmd, {
+                ok: false,
+                error: `No active connections found for provider "${provider}"`,
+              });
+              process.exitCode = 1;
+              return;
+            }
+
+            if (entries.length > 1) {
+              const connectionList = entries.map((c) => ({
+                id: c.id,
+                accountLabel: c.account_label ?? null,
+              }));
+              writeOutput(cmd, {
+                ok: false,
+                error: `Multiple active connections for "${provider}". Use --connection-id to specify which one to disconnect.`,
+                connections: connectionList,
+              });
+              process.exitCode = 1;
+              return;
+            }
+
+            connectionId = entries[0].id;
+          }
+
+          // Disconnect the connection
+          const disconnectPath = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/connections/${encodeURIComponent(connectionId)}/disconnect/`;
+          const disconnectResponse = await client.fetch(disconnectPath, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+          });
+
+          if (!disconnectResponse.ok) {
+            const errorText = await disconnectResponse.text().catch(() => "");
+            writeOutput(cmd, {
+              ok: false,
+              error: `Platform returned HTTP ${disconnectResponse.status}${errorText ? `: ${errorText}` : ""}`,
+            });
+            process.exitCode = 1;
+            return;
+          }
+
+          writeOutput(cmd, {
+            ok: true,
+            provider,
+            connectionId,
+          });
+
+          if (!shouldOutputJson(cmd)) {
+            log.info(`Disconnected ${provider} connection ${connectionId}`);
           }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/cli/commands/oauth/platform.ts
+++ b/assistant/src/cli/commands/oauth/platform.ts
@@ -380,6 +380,7 @@ Examples:
 
           writeOutput(cmd, {
             ok: true,
+            deferred: true,
             provider,
             connectUrl: result.connect_url,
           });

--- a/assistant/src/cli/commands/oauth/platform.ts
+++ b/assistant/src/cli/commands/oauth/platform.ts
@@ -426,13 +426,25 @@ Examples:
           const client = await requirePlatformClient(cmd);
           if (!client) return;
 
+          // Always fetch active connections for the provider so we can
+          // verify --connection-id belongs to it (prevents cross-provider
+          // disconnects from typos or stale IDs).
+          const entries = await fetchActiveConnections(client, provider, cmd);
+          if (!entries) return;
+
           let connectionId = opts.connectionId;
 
-          // If no connection ID given, resolve it from active connections
-          if (!connectionId) {
-            const entries = await fetchActiveConnections(client, provider, cmd);
-            if (!entries) return;
-
+          if (connectionId) {
+            // Verify the supplied ID belongs to this provider
+            if (!entries.some((c) => c.id === connectionId)) {
+              writeOutput(cmd, {
+                ok: false,
+                error: `Connection "${connectionId}" is not an active ${provider} connection`,
+              });
+              process.exitCode = 1;
+              return;
+            }
+          } else {
             if (entries.length === 0) {
               writeOutput(cmd, {
                 ok: false,

--- a/assistant/src/cli/commands/oauth/platform.ts
+++ b/assistant/src/cli/commands/oauth/platform.ts
@@ -39,6 +39,17 @@ function toProviderKey(provider: string): string {
 }
 
 /**
+ * Extract the bare provider slug (e.g. "google") from either a raw CLI
+ * argument or a canonical provider key (e.g. "integration:google").
+ * Platform API paths expect the bare slug, not the internal key.
+ */
+function toBareProvider(provider: string): string {
+  return provider.startsWith("integration:")
+    ? provider.slice("integration:".length)
+    : provider;
+}
+
+/**
  * Validate that a provider supports managed OAuth and that managed mode is
  * enabled. Returns the managed config key on success, or writes an error and
  * returns null.
@@ -102,7 +113,7 @@ async function fetchActiveConnections(
   cmd: Command,
 ): Promise<PlatformConnectionEntry[] | null> {
   const params = new URLSearchParams();
-  params.set("provider", provider);
+  params.set("provider", toBareProvider(provider));
   params.set("status", "ACTIVE");
 
   const path = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/connections/?${params.toString()}`;
@@ -311,7 +322,7 @@ Examples:
           if (!client) return;
 
           // Call the platform's OAuth start endpoint
-          const startPath = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/${encodeURIComponent(provider)}/start/`;
+          const startPath = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/${encodeURIComponent(toBareProvider(provider))}/start/`;
 
           const body: Record<string, unknown> = {};
           if (opts.scopes && opts.scopes.length > 0) {

--- a/assistant/src/util/browser.ts
+++ b/assistant/src/util/browser.ts
@@ -1,0 +1,15 @@
+import { isLinux, isMacOS } from "./platform.js";
+
+/**
+ * Open a URL in the user's default browser, falling back to printing the URL
+ * to stderr on unsupported platforms.
+ */
+export function openInBrowser(url: string): void {
+  if (isMacOS()) {
+    Bun.spawn(["open", url], { stdout: "ignore", stderr: "ignore" });
+  } else if (isLinux()) {
+    Bun.spawn(["xdg-open", url], { stdout: "ignore", stderr: "ignore" });
+  } else {
+    process.stderr.write(`Open this URL to authorize:\n\n${url}\n`);
+  }
+}


### PR DESCRIPTION
## Summary

- Add `assistant oauth platform connect <provider>` command that initiates a platform-managed OAuth flow by calling the `/start/` endpoint and opening the returned URL in the browser. Supports `--scopes` for requesting specific OAuth scopes.
- Add `assistant oauth platform disconnect <provider>` command that revokes a platform-managed connection via `POST .../disconnect/`. Auto-resolves the connection when only one is active; requires `--connection-id` when multiple exist.
- Extract shared helpers (`requireManagedProvider`, `requirePlatformClient`, `fetchActiveConnections`) to reduce duplication across the three platform subcommands.
- Extract `openInBrowser()` to `util/browser.ts` as a shared utility, replacing duplicate implementations in `platform.ts` and `connections.ts`.

## Test plan

- [ ] Run `assistant oauth platform connect google` and verify it opens the browser with the consent URL
- [ ] Run `assistant oauth platform connect google --scopes calendar.readonly` and verify scopes are passed
- [ ] Run `assistant oauth platform disconnect google` with a single active connection and verify it disconnects
- [ ] Run `assistant oauth platform disconnect google` with multiple connections and verify it lists them with an error
- [ ] Run `assistant oauth platform disconnect google --connection-id <id>` and verify it disconnects the specific connection
- [ ] Run `assistant oauth platform status google` and verify it still works as before
- [ ] Verify `assistant oauth connections connect gmail --open-browser` still works with the refactored `openInBrowser` import

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
