### PR TITLE
feat: add version parameter to VellumCli.rollback() for targeted rollback

### DIFF
--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -405,14 +405,23 @@ final class VellumCli {
     }
 
     /// Roll back a specific Docker assistant to its previous version via the CLI.
-    func rollback(name: String) async throws {
+    ///
+    /// - Parameters:
+    ///   - name: The assistant name to roll back.
+    ///   - version: Optional target version to roll back to. When `nil`, rolls back to the previous version.
+    func rollback(name: String, version: String? = nil) async throws {
         guard let binaryURL = cliBinaryURL else {
             log.info("No bundled CLI binary found — skipping rollback (dev mode)")
             throw CLIError.binaryNotFound
         }
 
-        log.info("Running rollback via CLI for '\(name, privacy: .public)'")
-        let (_, stderr, status) = try await runCLI(binaryURL: binaryURL, arguments: ["rollback", name])
+        let versionSuffix = version.map { " to \($0)" } ?? ""
+        log.info("Running rollback via CLI for '\(name, privacy: .public)'\(versionSuffix, privacy: .public)")
+        var arguments = ["rollback", name]
+        if let version {
+            arguments += ["--version", version]
+        }
+        let (_, stderr, status) = try await runCLI(binaryURL: binaryURL, arguments: arguments)
 
         if status != 0 {
             log.error("CLI rollback failed with exit code \(status, privacy: .public): \(stderr, privacy: .private)")


### PR DESCRIPTION
## Summary
- Add optional `version` parameter to `VellumCli.rollback()` Swift wrapper
- When version is provided, passes `--version` flag to CLI binary
- Update audit log to include version when present

Part of plan: version-mgmt-refactor.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
