### PR TITLE
feat: add --version flag to `vellum rollback` for targeted Docker rollback

### DIFF
--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -22,7 +22,6 @@ import {
   loadBootstrapSecret,
   saveBootstrapSecret,
 } from "../lib/guardian-token";
-import { restoreBackup } from "../lib/backup-ops.js";
 import { emitCliError, categorizeUpgradeError } from "../lib/cli-error.js";
 import {
   broadcastUpgradeEvent,
@@ -32,36 +31,57 @@ import {
   buildUpgradeCommitMessage,
   captureContainerEnv,
   CONTAINER_ENV_EXCLUDE_KEYS,
+  performDockerRollback,
   rollbackMigrations,
   UPGRADE_PROGRESS,
   waitForReady,
 } from "../lib/upgrade-lifecycle.js";
 import { commitWorkspaceState } from "../lib/workspace-git.js";
 
-function parseArgs(): { name: string | null } {
+function parseArgs(): { name: string | null; version: string | null } {
   const args = process.argv.slice(3);
   let name: string | null = null;
+  let version: string | null = null;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg === "--help" || arg === "-h") {
-      console.log("Usage: vellum rollback [<name>]");
+      console.log("Usage: vellum rollback [<name>] [--version <version>]");
       console.log("");
-      console.log("Roll back a Docker assistant to the previous version.");
+      console.log(
+        "Roll back an assistant to a previous version. Data is preserved.",
+      );
       console.log("");
       console.log("Arguments:");
       console.log(
-        "  <name>  Name of the assistant to roll back (default: active or only assistant)",
+        "  <name>               Name of the assistant (default: active or only assistant)",
+      );
+      console.log("");
+      console.log("Options:");
+      console.log(
+        "  --version <version>  Target version to roll back to (default: previous version)",
       );
       console.log("");
       console.log("Examples:");
       console.log(
-        "  vellum rollback                # Roll back the active assistant",
+        "  vellum rollback                              # Roll back to the previous version",
       );
       console.log(
-        "  vellum rollback my-assistant   # Roll back a specific assistant by name",
+        "  vellum rollback my-assistant                  # Roll back a specific assistant",
+      );
+      console.log(
+        "  vellum rollback my-assistant --version v1.2.3 # Roll back to a specific version",
       );
       process.exit(0);
+    } else if (arg === "--version") {
+      const next = args[i + 1];
+      if (!next || next.startsWith("-")) {
+        console.error("Error: --version requires a value");
+        emitCliError("UNKNOWN", "--version requires a value");
+        process.exit(1);
+      }
+      version = next;
+      i++;
     } else if (!arg.startsWith("-")) {
       name = arg;
     } else {
@@ -71,7 +91,7 @@ function parseArgs(): { name: string | null } {
     }
   }
 
-  return { name };
+  return { name, version };
 }
 
 function resolveCloud(entry: AssistantEntry): string {
@@ -130,7 +150,7 @@ function resolveTargetAssistant(nameArg: string | null): AssistantEntry {
 }
 
 export async function rollback(): Promise<void> {
-  const { name } = parseArgs();
+  const { name, version } = parseArgs();
   const entry = resolveTargetAssistant(name);
   const cloud = resolveCloud(entry);
 
@@ -142,6 +162,26 @@ export async function rollback(): Promise<void> {
     emitCliError("UNSUPPORTED_TOPOLOGY", msg);
     process.exit(1);
   }
+
+  // ---------- Targeted version rollback (--version specified) ----------
+  if (version) {
+    try {
+      await performDockerRollback(entry, { targetVersion: version });
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      console.error(`\n❌ Rollback failed: ${detail}`);
+      await broadcastUpgradeEvent(
+        entry.runtimeUrl,
+        entry.assistantId,
+        buildCompleteEvent(entry.serviceGroupVersion ?? "unknown", false),
+      );
+      emitCliError(categorizeUpgradeError(err), "Rollback failed", detail);
+      process.exit(1);
+    }
+    return;
+  }
+
+  // ---------- Saved-state rollback (no --version) ----------
 
   // Verify rollback state exists
   if (!entry.previousServiceGroupVersion || !entry.previousContainerInfo) {
@@ -317,40 +357,6 @@ export async function rollback(): Promise<void> {
     const ready = await waitForReady(entry.runtimeUrl);
 
     if (ready) {
-      // Restore data from the backup created for the specific upgrade being
-      // rolled back. We use the persisted preUpgradeBackupPath rather than
-      // scanning for the latest backup on disk — if the most recent upgrade's
-      // backup failed, a global scan would find a stale backup from a prior
-      // cycle and overwrite newer user data.
-      const backupPath = entry.preUpgradeBackupPath as string | undefined;
-      if (backupPath) {
-        // Progress: restoring data (gateway is back up at this point)
-        await broadcastUpgradeEvent(
-          entry.runtimeUrl,
-          entry.assistantId,
-          buildProgressEvent(UPGRADE_PROGRESS.RESTORING),
-        );
-
-        console.log(`📦 Restoring data from pre-upgrade backup...`);
-        console.log(`   Source: ${backupPath}`);
-        const restored = await restoreBackup(
-          entry.runtimeUrl,
-          entry.assistantId,
-          backupPath,
-        );
-        if (restored) {
-          console.log("   ✅ Data restored successfully\n");
-        } else {
-          console.warn(
-            "   ⚠️  Data restore failed (rollback continues without data restoration)\n",
-          );
-        }
-      } else {
-        console.log(
-          "ℹ️  No pre-upgrade backup was created for this upgrade, skipping data restoration\n",
-        );
-      }
-
       // Capture new digests from the rolled-back containers
       const newDigests = await captureImageRefs(res);
 
@@ -407,6 +413,9 @@ export async function rollback(): Promise<void> {
 
       console.log(
         `\n✅ Docker assistant '${instanceName}' rolled back to ${entry.previousServiceGroupVersion}.`,
+      );
+      console.log(
+        "\nTip: To also restore data from before the upgrade, use `vellum restore --from <backup-path>`.",
       );
     } else {
       console.error(

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -70,9 +70,7 @@ function printHelp(): void {
   console.log("  recover  Restore a previously retired local assistant");
   console.log("  restore  Restore a .vbundle backup into a running assistant");
   console.log("  retire   Delete an assistant instance");
-  console.log(
-    "  rollback  Roll back a Docker assistant to the previous version",
-  );
+  console.log("  rollback  Roll back an assistant to a previous version");
   console.log("  setup    Configure API keys interactively");
   console.log("  sleep    Stop the assistant process");
   console.log("  ssh      SSH into a remote assistant instance");

--- a/cli/src/lib/upgrade-lifecycle.ts
+++ b/cli/src/lib/upgrade-lifecycle.ts
@@ -1,6 +1,30 @@
-import { DOCKER_READY_TIMEOUT_MS } from "./docker.js";
-import { loadGuardianToken } from "./guardian-token.js";
-import { execOutput } from "./step-runner.js";
+import { randomBytes } from "crypto";
+import { join } from "path";
+
+import type { AssistantEntry } from "./assistant-config.js";
+import { saveAssistantEntry } from "./assistant-config.js";
+import { createBackup, pruneOldBackups, restoreBackup } from "./backup-ops.js";
+import { emitCliError } from "./cli-error.js";
+import {
+  captureImageRefs,
+  DOCKER_READY_TIMEOUT_MS,
+  dockerResourceNames,
+  GATEWAY_INTERNAL_PORT,
+  migrateCesSecurityFiles,
+  migrateGatewaySecurityFiles,
+  startContainers,
+  stopContainers,
+} from "./docker.js";
+import {
+  loadBootstrapSecret,
+  loadGuardianToken,
+  saveBootstrapSecret,
+} from "./guardian-token.js";
+import { getPlatformUrl } from "./platform-client.js";
+import { resolveImageRefs } from "./platform-releases.js";
+import { exec, execOutput } from "./step-runner.js";
+import { parseVersion } from "./version-compat.js";
+import { commitWorkspaceState } from "./workspace-git.js";
 
 // ---------------------------------------------------------------------------
 // Shared constants & builders for upgrade / rollback lifecycle events
@@ -233,5 +257,606 @@ export async function rollbackMigrations(
     const msg = err instanceof Error ? err.message : String(err);
     console.warn(`⚠️  Migration rollback failed: ${msg}`);
     return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared Docker rollback orchestration
+// ---------------------------------------------------------------------------
+
+export interface PerformDockerRollbackOptions {
+  /** Specific version to roll back to. */
+  targetVersion?: string;
+  /** Path to a .vbundle to restore after the version change (used by restore command). */
+  restoreBackupPath?: string;
+}
+
+/**
+ * Perform a Docker rollback to a target version. Reusable by both `rollback.ts`
+ * (targeted version rollback) and `restore.ts` (version + data restore).
+ *
+ * This function handles the full lifecycle:
+ * - Version validation (target must be older than current)
+ * - Image resolution and pulling
+ * - Migration ceiling lookup and pre-swap rollback
+ * - Container stop/start with target images
+ * - Readiness check
+ * - Lockfile update with rollback state
+ * - Auto-rollback on failure
+ * - Backup restore (if restoreBackupPath is provided)
+ */
+export async function performDockerRollback(
+  entry: AssistantEntry,
+  options: PerformDockerRollbackOptions,
+): Promise<void> {
+  const { targetVersion, restoreBackupPath } = options;
+
+  if (!targetVersion) {
+    throw new Error("targetVersion is required for performDockerRollback");
+  }
+
+  const currentVersion = entry.serviceGroupVersion;
+
+  // Validate target version < current version
+  if (currentVersion) {
+    const current = parseVersion(currentVersion);
+    const target = parseVersion(targetVersion);
+    if (current && target) {
+      const isNewer = (() => {
+        if (target.major !== current.major) return target.major > current.major;
+        if (target.minor !== current.minor) return target.minor > current.minor;
+        return target.patch >= current.patch;
+      })();
+      if (isNewer) {
+        const msg =
+          "Cannot roll back to a newer version. Use `vellum upgrade` instead.";
+        console.error(msg);
+        emitCliError("UNKNOWN", msg);
+        process.exit(1);
+      }
+    }
+  }
+
+  const instanceName = entry.assistantId;
+  const res = dockerResourceNames(instanceName);
+  const workspaceDir = entry.resources
+    ? join(entry.resources.instanceDir, ".vellum", "workspace")
+    : undefined;
+
+  // Resolve Docker image refs for the target version
+  console.log("🔍 Resolving image references...");
+  const { imageTags: targetImageTags } = await resolveImageRefs(targetVersion);
+
+  // Fetch target migration ceiling from releases API
+  let targetMigrationCeiling: {
+    dbVersion?: number;
+    workspaceMigrationId?: string;
+  } = {};
+  try {
+    const platformUrl = getPlatformUrl();
+    const releasesResp = await fetch(
+      `${platformUrl}/v1/releases/?stable=true`,
+      { signal: AbortSignal.timeout(10000) },
+    );
+    if (releasesResp.ok) {
+      const releases = (await releasesResp.json()) as Array<{
+        version: string;
+        db_migration_version?: number | null;
+        last_workspace_migration_id?: string;
+      }>;
+      const normalizedTag = targetVersion.replace(/^v/, "");
+      const targetRelease = releases.find(
+        (r) => r.version?.replace(/^v/, "") === normalizedTag,
+      );
+      if (
+        targetRelease?.db_migration_version != null ||
+        targetRelease?.last_workspace_migration_id
+      ) {
+        targetMigrationCeiling = {
+          dbVersion: targetRelease.db_migration_version ?? undefined,
+          workspaceMigrationId:
+            targetRelease.last_workspace_migration_id || undefined,
+        };
+      }
+    }
+  } catch {
+    // Best-effort — fall back to rollbackToRegistryCeiling post-swap
+  }
+
+  // Capture current image digests for auto-rollback on failure
+  console.log("📸 Capturing current image references for rollback...");
+  const currentImageRefs = await captureImageRefs(res);
+
+  // Capture current migration state for rollback targeting
+  let preMigrationState: {
+    dbVersion?: number;
+    lastWorkspaceMigrationId?: string;
+  } = {};
+  try {
+    const healthResp = await fetch(
+      `${entry.runtimeUrl}/healthz?include=migrations`,
+      { signal: AbortSignal.timeout(5000) },
+    );
+    if (healthResp.ok) {
+      const health = (await healthResp.json()) as {
+        migrations?: { dbVersion?: number; lastWorkspaceMigrationId?: string };
+      };
+      preMigrationState = health.migrations ?? {};
+    }
+  } catch {
+    // Best-effort
+  }
+
+  // Persist rollback state to lockfile BEFORE any destructive changes
+  if (entry.serviceGroupVersion && entry.containerInfo) {
+    const rollbackEntry: AssistantEntry = {
+      ...entry,
+      previousServiceGroupVersion: entry.serviceGroupVersion,
+      previousContainerInfo: { ...entry.containerInfo },
+      previousDbMigrationVersion: preMigrationState.dbVersion,
+      previousWorkspaceMigrationId: preMigrationState.lastWorkspaceMigrationId,
+    };
+    saveAssistantEntry(rollbackEntry);
+    console.log(`   Saved rollback state: ${entry.serviceGroupVersion}\n`);
+  }
+
+  // Record rollback start in workspace git history
+  if (workspaceDir) {
+    try {
+      await commitWorkspaceState(
+        workspaceDir,
+        buildUpgradeCommitMessage({
+          action: "rollback",
+          phase: "starting",
+          from: currentVersion ?? "unknown",
+          to: targetVersion,
+          topology: "docker",
+          assistantId: entry.assistantId,
+        }),
+      );
+    } catch (err) {
+      console.warn(
+        `⚠️  Failed to create pre-rollback workspace commit: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  console.log(
+    `🔄 Rolling back Docker assistant '${instanceName}' to ${targetVersion}...\n`,
+  );
+
+  // Create a pre-rollback backup as a safety net
+  console.log("📦 Creating pre-rollback backup...");
+  const preRollbackBackupPath = await createBackup(
+    entry.runtimeUrl,
+    entry.assistantId,
+    {
+      prefix: `${entry.assistantId}-pre-rollback`,
+      description: `Pre-rollback snapshot before ${currentVersion ?? "unknown"} → ${targetVersion}`,
+    },
+  );
+  if (preRollbackBackupPath) {
+    console.log(`   Backup saved: ${preRollbackBackupPath}\n`);
+    pruneOldBackups(entry.assistantId, 3);
+  } else {
+    console.warn("⚠️  Pre-rollback backup failed (continuing with rollback)\n");
+  }
+
+  // Capture container env, extract secrets
+  console.log("💾 Capturing existing container environment...");
+  const capturedEnv = await captureContainerEnv(res.assistantContainer);
+  console.log(
+    `   Captured ${Object.keys(capturedEnv).length} env var(s) from ${res.assistantContainer}\n`,
+  );
+
+  const cesServiceToken =
+    capturedEnv["CES_SERVICE_TOKEN"] || randomBytes(32).toString("hex");
+
+  const loadedSecret = loadBootstrapSecret(instanceName);
+  const bootstrapSecret = loadedSecret || randomBytes(32).toString("hex");
+  if (!loadedSecret) {
+    saveBootstrapSecret(instanceName, bootstrapSecret);
+  }
+
+  const signingKey =
+    capturedEnv["ACTOR_TOKEN_SIGNING_KEY"] || randomBytes(32).toString("hex");
+
+  // Build extra env vars, excluding keys managed by serviceDockerRunArgs
+  const envKeysSetByRunArgs = new Set(CONTAINER_ENV_EXCLUDE_KEYS);
+  for (const envVar of ["ANTHROPIC_API_KEY", "VELLUM_PLATFORM_URL"]) {
+    if (process.env[envVar]) {
+      envKeysSetByRunArgs.add(envVar);
+    }
+  }
+  const extraAssistantEnv: Record<string, string> = {};
+  for (const [key, value] of Object.entries(capturedEnv)) {
+    if (!envKeysSetByRunArgs.has(key)) {
+      extraAssistantEnv[key] = value;
+    }
+  }
+
+  // Parse gateway port from entry's runtimeUrl
+  let gatewayPort = GATEWAY_INTERNAL_PORT;
+  try {
+    const parsed = new URL(entry.runtimeUrl);
+    const port = parseInt(parsed.port, 10);
+    if (!isNaN(port)) {
+      gatewayPort = port;
+    }
+  } catch {
+    // use default
+  }
+
+  // Broadcast SSE "starting" event
+  console.log("📢 Notifying connected clients...");
+  await broadcastUpgradeEvent(
+    entry.runtimeUrl,
+    entry.assistantId,
+    buildStartingEvent(targetVersion),
+  );
+  // Brief pause for SSE delivery
+  await new Promise((r) => setTimeout(r, 500));
+
+  // Pull target version Docker images
+  await broadcastUpgradeEvent(
+    entry.runtimeUrl,
+    entry.assistantId,
+    buildProgressEvent(UPGRADE_PROGRESS.DOWNLOADING),
+  );
+  console.log("📦 Pulling target Docker images...");
+  const pullImages: Array<[string, string]> = [
+    ["assistant", targetImageTags.assistant],
+    ["gateway", targetImageTags.gateway],
+    ["credential-executor", targetImageTags["credential-executor"]],
+  ];
+  try {
+    for (const [service, image] of pullImages) {
+      console.log(`   Pulling ${service}: ${image}`);
+      await exec("docker", ["pull", image]);
+    }
+  } catch (pullErr) {
+    const detail = pullErr instanceof Error ? pullErr.message : String(pullErr);
+    console.error(`\n❌ Failed to pull Docker images: ${detail}`);
+    await broadcastUpgradeEvent(
+      entry.runtimeUrl,
+      entry.assistantId,
+      buildCompleteEvent(currentVersion ?? "unknown", false),
+    );
+    emitCliError("IMAGE_PULL_FAILED", "Failed to pull Docker images", detail);
+    process.exit(1);
+  }
+  console.log("✅ Docker images pulled\n");
+
+  // Pre-swap migration rollback to target ceiling on the CURRENT (newer) daemon
+  let preSwapRollbackOk = true;
+  if (
+    targetMigrationCeiling.dbVersion !== undefined ||
+    targetMigrationCeiling.workspaceMigrationId !== undefined
+  ) {
+    console.log("🔄 Reverting database changes...");
+    await broadcastUpgradeEvent(
+      entry.runtimeUrl,
+      entry.assistantId,
+      buildProgressEvent(UPGRADE_PROGRESS.REVERTING_MIGRATIONS),
+    );
+    preSwapRollbackOk = await rollbackMigrations(
+      entry.runtimeUrl,
+      entry.assistantId,
+      targetMigrationCeiling.dbVersion,
+      targetMigrationCeiling.workspaceMigrationId,
+    );
+  }
+
+  // Progress: switching version
+  await broadcastUpgradeEvent(
+    entry.runtimeUrl,
+    entry.assistantId,
+    buildProgressEvent(UPGRADE_PROGRESS.SWITCHING),
+  );
+
+  // Stop containers, migrate security files, start with target images
+  console.log("🛑 Stopping existing containers...");
+  await stopContainers(res);
+  console.log("✅ Containers stopped\n");
+
+  console.log("🔄 Migrating security files to gateway volume...");
+  await migrateGatewaySecurityFiles(res, (msg) => console.log(msg));
+
+  console.log("🔄 Migrating credential files to CES security volume...");
+  await migrateCesSecurityFiles(res, (msg) => console.log(msg));
+
+  console.log("🚀 Starting containers with target version...");
+  await startContainers(
+    {
+      signingKey,
+      bootstrapSecret,
+      cesServiceToken,
+      extraAssistantEnv,
+      gatewayPort,
+      imageTags: targetImageTags,
+      instanceName,
+      res,
+    },
+    (msg) => console.log(msg),
+  );
+  console.log("✅ Containers started\n");
+
+  // Wait for readiness
+  console.log("Waiting for assistant to become ready...");
+  const ready = await waitForReady(entry.runtimeUrl);
+
+  if (ready) {
+    // Success path
+
+    // Post-swap migration rollback fallback: if pre-swap rollback failed
+    // or no ceiling metadata was available, ask the now-running old daemon
+    // to roll back migrations above its own registry ceiling.
+    if (
+      !preSwapRollbackOk ||
+      (targetMigrationCeiling.dbVersion === undefined &&
+        targetMigrationCeiling.workspaceMigrationId === undefined)
+    ) {
+      await rollbackMigrations(
+        entry.runtimeUrl,
+        entry.assistantId,
+        undefined,
+        undefined,
+        true,
+      );
+    }
+
+    // Restore backup if a restoreBackupPath was provided
+    if (restoreBackupPath) {
+      await broadcastUpgradeEvent(
+        entry.runtimeUrl,
+        entry.assistantId,
+        buildProgressEvent(UPGRADE_PROGRESS.RESTORING),
+      );
+      console.log(`📦 Restoring data from backup...`);
+      console.log(`   Source: ${restoreBackupPath}`);
+      const restored = await restoreBackup(
+        entry.runtimeUrl,
+        entry.assistantId,
+        restoreBackupPath,
+      );
+      if (restored) {
+        console.log("   ✅ Data restored successfully\n");
+      } else {
+        console.warn(
+          "   ⚠️  Data restore failed (rollback continues without data restoration)\n",
+        );
+      }
+    }
+
+    // Capture new digests from the rolled-back containers
+    const newDigests = await captureImageRefs(res);
+
+    // Swap current/previous state to enable "rollback the rollback"
+    const updatedEntry: AssistantEntry = {
+      ...entry,
+      serviceGroupVersion: targetVersion,
+      containerInfo: {
+        assistantImage: targetImageTags.assistant,
+        gatewayImage: targetImageTags.gateway,
+        cesImage: targetImageTags["credential-executor"],
+        assistantDigest: newDigests?.assistant,
+        gatewayDigest: newDigests?.gateway,
+        cesDigest: newDigests?.["credential-executor"],
+        networkName: res.network,
+      },
+      previousServiceGroupVersion: entry.serviceGroupVersion,
+      previousContainerInfo: entry.containerInfo,
+      previousDbMigrationVersion: preMigrationState.dbVersion,
+      previousWorkspaceMigrationId: preMigrationState.lastWorkspaceMigrationId,
+      preUpgradeBackupPath: undefined,
+    };
+    saveAssistantEntry(updatedEntry);
+
+    // Notify clients that the rollback succeeded
+    await broadcastUpgradeEvent(
+      entry.runtimeUrl,
+      entry.assistantId,
+      buildCompleteEvent(targetVersion, true),
+    );
+
+    // Record successful rollback in workspace git history
+    if (workspaceDir) {
+      try {
+        await commitWorkspaceState(
+          workspaceDir,
+          buildUpgradeCommitMessage({
+            action: "rollback",
+            phase: "complete",
+            from: currentVersion ?? "unknown",
+            to: targetVersion,
+            topology: "docker",
+            assistantId: entry.assistantId,
+            result: "success",
+          }),
+        );
+      } catch (err) {
+        console.warn(
+          `⚠️  Failed to create post-rollback workspace commit: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    console.log(
+      `\n✅ Docker assistant '${instanceName}' rolled back to ${targetVersion}.`,
+    );
+  } else {
+    // Failure path — attempt auto-rollback to original version
+    console.error(`\n❌ Containers failed to become ready within the timeout.`);
+
+    if (currentImageRefs) {
+      await broadcastUpgradeEvent(
+        entry.runtimeUrl,
+        entry.assistantId,
+        buildProgressEvent(UPGRADE_PROGRESS.REVERTING),
+      );
+      console.log(`\n🔄 Rolling back to original version...`);
+      try {
+        // Attempt to roll back migrations before reverting containers
+        if (
+          preMigrationState.dbVersion !== undefined ||
+          preMigrationState.lastWorkspaceMigrationId !== undefined
+        ) {
+          console.log("🔄 Reverting database changes...");
+          await broadcastUpgradeEvent(
+            entry.runtimeUrl,
+            entry.assistantId,
+            buildProgressEvent(UPGRADE_PROGRESS.REVERTING_MIGRATIONS),
+          );
+          await rollbackMigrations(
+            entry.runtimeUrl,
+            entry.assistantId,
+            preMigrationState.dbVersion,
+            preMigrationState.lastWorkspaceMigrationId,
+          );
+        }
+
+        await stopContainers(res);
+
+        await migrateGatewaySecurityFiles(res, (msg) => console.log(msg));
+        await migrateCesSecurityFiles(res, (msg) => console.log(msg));
+
+        await startContainers(
+          {
+            signingKey,
+            bootstrapSecret,
+            cesServiceToken,
+            extraAssistantEnv,
+            gatewayPort,
+            imageTags: currentImageRefs,
+            instanceName,
+            res,
+          },
+          (msg) => console.log(msg),
+        );
+
+        const revertReady = await waitForReady(entry.runtimeUrl);
+        if (revertReady) {
+          // Restore from pre-rollback backup on failure
+          if (preRollbackBackupPath) {
+            await broadcastUpgradeEvent(
+              entry.runtimeUrl,
+              entry.assistantId,
+              buildProgressEvent(UPGRADE_PROGRESS.RESTORING),
+            );
+            console.log(`📦 Restoring data from pre-rollback backup...`);
+            console.log(`   Source: ${preRollbackBackupPath}`);
+            const restored = await restoreBackup(
+              entry.runtimeUrl,
+              entry.assistantId,
+              preRollbackBackupPath,
+            );
+            if (restored) {
+              console.log("   ✅ Data restored successfully\n");
+            } else {
+              console.warn(
+                "   ⚠️  Data restore failed (auto-rollback continues without data restoration)\n",
+              );
+            }
+          }
+
+          // Restore lockfile state
+          const revertDigests = await captureImageRefs(res);
+          const revertedEntry: AssistantEntry = {
+            ...entry,
+            containerInfo: {
+              assistantImage:
+                entry.containerInfo?.assistantImage ??
+                currentImageRefs.assistant,
+              gatewayImage:
+                entry.containerInfo?.gatewayImage ?? currentImageRefs.gateway,
+              cesImage:
+                entry.containerInfo?.cesImage ??
+                currentImageRefs["credential-executor"],
+              assistantDigest:
+                revertDigests?.assistant ?? currentImageRefs.assistant,
+              gatewayDigest: revertDigests?.gateway ?? currentImageRefs.gateway,
+              cesDigest:
+                revertDigests?.["credential-executor"] ??
+                currentImageRefs["credential-executor"],
+              networkName: res.network,
+            },
+            previousServiceGroupVersion: undefined,
+            previousContainerInfo: undefined,
+            previousDbMigrationVersion: undefined,
+            previousWorkspaceMigrationId: undefined,
+            preUpgradeBackupPath: undefined,
+          };
+          saveAssistantEntry(revertedEntry);
+
+          await broadcastUpgradeEvent(
+            entry.runtimeUrl,
+            entry.assistantId,
+            buildCompleteEvent(
+              currentVersion ?? "unknown",
+              false,
+              currentVersion,
+            ),
+          );
+
+          console.log(
+            `\n⚠️  Rolled back to original version. Rollback to ${targetVersion} failed.`,
+          );
+          emitCliError(
+            "READINESS_TIMEOUT",
+            `Rollback to ${targetVersion} failed: containers did not become ready. Rolled back to original version.`,
+          );
+        } else {
+          console.error(
+            `\n❌ Auto-rollback also failed. Manual intervention required.`,
+          );
+          console.log(
+            `   Check logs with: docker logs -f ${res.assistantContainer}`,
+          );
+          await broadcastUpgradeEvent(
+            entry.runtimeUrl,
+            entry.assistantId,
+            buildCompleteEvent(currentVersion ?? "unknown", false),
+          );
+          emitCliError(
+            "ROLLBACK_FAILED",
+            "Auto-rollback also failed after readiness timeout. Manual intervention required.",
+          );
+        }
+      } catch (revertErr) {
+        const revertDetail =
+          revertErr instanceof Error ? revertErr.message : String(revertErr);
+        console.error(`\n❌ Auto-rollback failed: ${revertDetail}`);
+        console.error(`   Manual intervention required.`);
+        console.log(
+          `   Check logs with: docker logs -f ${res.assistantContainer}`,
+        );
+        await broadcastUpgradeEvent(
+          entry.runtimeUrl,
+          entry.assistantId,
+          buildCompleteEvent(currentVersion ?? "unknown", false),
+        );
+        emitCliError(
+          "ROLLBACK_FAILED",
+          "Auto-rollback failed after readiness timeout. Manual intervention required.",
+          revertDetail,
+        );
+      }
+    } else {
+      console.log(`   No previous images available for auto-rollback.`);
+      console.log(
+        `   Check logs with: docker logs -f ${res.assistantContainer}`,
+      );
+      await broadcastUpgradeEvent(
+        entry.runtimeUrl,
+        entry.assistantId,
+        buildCompleteEvent(currentVersion ?? "unknown", false),
+      );
+      emitCliError(
+        "ROLLBACK_NO_STATE",
+        "Containers failed to become ready and no previous images available for auto-rollback.",
+      );
+    }
+
+    process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- Add `--version` flag to `vellum rollback` for targeted Docker rollback to any prior version
- Extract `performDockerRollback()` into `upgrade-lifecycle.ts` for reuse by restore command
- Remove data restore from saved-state rollback path (rollback = version change only)

Part of plan: version-mgmt-refactor.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
