### PR TITLE
perf: cache NSSharingService discovery to eliminate XPC calls during scroll

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -138,8 +138,10 @@ private enum ImageActions {
     private static var sharingServicesCache: [String: [NSSharingService]] = [:]
 
     /// Returns cached sharing services for the given filename's extension.
-    /// On first call per extension, creates a lightweight probe file and calls
+    /// On first call per extension, writes a minimal valid image file and calls
     /// `NSSharingService.sharingServices(forItems:)` once, caching the result.
+    /// A real (non-empty) probe file is used because some services validate
+    /// media content and return fewer results for zero-byte placeholders.
     @available(macOS, deprecated: 13.0)
     private static func cachedSharingServices(for filename: String) -> [NSSharingService] {
         let ext = (filename as NSString).pathExtension.lowercased()
@@ -147,7 +149,16 @@ private enum ImageActions {
         if let cached = sharingServicesCache[key] { return cached }
         let probeURL = FileManager.default.temporaryDirectory.appendingPathComponent("vellum-share-probe.\(key)")
         if !FileManager.default.fileExists(atPath: probeURL.path) {
-            FileManager.default.createFile(atPath: probeURL.path, contents: Data())
+            // Write a minimal 1x1 PNG so services that validate content see a real image.
+            let tiny = NSImage(size: NSSize(width: 1, height: 1))
+            if let tiff = tiny.tiffRepresentation,
+               let rep = NSBitmapImageRep(data: tiff),
+               let data = rep.representation(using: .png, properties: [:]) {
+                try? data.write(to: probeURL)
+            } else {
+                // Fallback: create the file with empty data so the path exists.
+                FileManager.default.createFile(atPath: probeURL.path, contents: Data())
+            }
         }
         let services = NSSharingService.sharingServices(forItems: [probeURL])
         sharingServicesCache[key] = services
@@ -192,11 +203,15 @@ private enum ImageActions {
             Menu {
                 ForEach(Array(services.enumerated()), id: \.offset) { _, service in
                     Button {
-                        // Write temp file at action time (not during render)
-                        if let shareURL = writeTempFile(image, filename: filename, base64Data: base64Data)
-                            ?? writeTempFile(image, filename: filename) {
-                            service.perform(withItems: [shareURL])
-                        }
+                        // Write temp file at action time (not during render).
+                        // Try full-res first, fall back to thumbnail, fall back to
+                        // the probe file so the Share action is never a silent no-op.
+                        let shareURL = writeTempFile(image, filename: filename, base64Data: base64Data)
+                            ?? writeTempFile(image, filename: filename)
+                        let probeExt = (filename as NSString).pathExtension.lowercased()
+                        let fallback = FileManager.default.temporaryDirectory
+                            .appendingPathComponent("vellum-share-probe.\(probeExt.isEmpty ? "png" : probeExt)")
+                        service.perform(withItems: [shareURL ?? fallback])
                     } label: {
                         Label {
                             Text(service.title)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -150,7 +150,13 @@ private enum ImageActions {
         let probeURL = FileManager.default.temporaryDirectory.appendingPathComponent("vellum-share-probe.\(key)")
         if !FileManager.default.fileExists(atPath: probeURL.path) {
             // Write a minimal 1x1 PNG so services that validate content see a real image.
-            let tiny = NSImage(size: NSSize(width: 1, height: 1))
+            // NSImage(size:) without drawing produces no representations, so use
+            // init(size:flipped:drawingHandler:) to create actual pixel data.
+            let tiny = NSImage(size: NSSize(width: 1, height: 1), flipped: false) { _ in
+                NSColor.clear.set()
+                NSRect(x: 0, y: 0, width: 1, height: 1).fill()
+                return true
+            }
             if let tiff = tiny.tiffRepresentation,
                let rep = NSBitmapImageRep(data: tiff),
                let data = rep.representation(using: .png, properties: [:]) {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -133,6 +133,27 @@ private enum ImageActions {
         NSWorkspace.shared.open(fileURL)
     }
 
+    /// Cache of sharing services by file extension. Services depend on file type,
+    /// not content, so one discovery per extension per app session is sufficient.
+    private static var sharingServicesCache: [String: [NSSharingService]] = [:]
+
+    /// Returns cached sharing services for the given filename's extension.
+    /// On first call per extension, creates a lightweight probe file and calls
+    /// `NSSharingService.sharingServices(forItems:)` once, caching the result.
+    @available(macOS, deprecated: 13.0)
+    private static func cachedSharingServices(for filename: String) -> [NSSharingService] {
+        let ext = (filename as NSString).pathExtension.lowercased()
+        let key = ext.isEmpty ? "png" : ext
+        if let cached = sharingServicesCache[key] { return cached }
+        let probeURL = FileManager.default.temporaryDirectory.appendingPathComponent("vellum-share-probe.\(key)")
+        if !FileManager.default.fileExists(atPath: probeURL.path) {
+            FileManager.default.createFile(atPath: probeURL.path, contents: Data())
+        }
+        let services = NSSharingService.sharingServices(forItems: [probeURL])
+        sharingServicesCache[key] = services
+        return services
+    }
+
     /// Builds a SwiftUI context menu with Copy, Save As, and Open in Preview actions.
     @available(macOS, deprecated: 13.0)
     @ViewBuilder
@@ -159,38 +180,33 @@ private enum ImageActions {
             Label { Text("Open in Preview") } icon: { VIconView(.eye, size: 12) }
         }
 
-        // Write a temp file for sharing — NSSharingService.sharingServices
-        // returns far more services (AirDrop, Messages, Mail, etc.) when given
-        // a file URL vs a raw NSImage. The temp file write is lightweight
-        // (thumbnail image) to keep the view builder fast. Full-res file is
-        // written at action time when the user picks a service.
+        // Sharing services are cached per file extension to avoid synchronous
+        // XPC roundtrips on every render. Temp file writes are deferred to
+        // click time so the view builder stays fast.
         // NSSharingService.sharingServices is deprecated in macOS 13 but has
         // no functional replacement for custom share UI (see AppSharePanelView).
         // Silenced via @available on this method; see AppSharePanelView for the same pattern.
-        if let tempURL = writeTempFile(image, filename: filename) {
-            let services = NSSharingService.sharingServices(forItems: [tempURL])
-            if !services.isEmpty {
-                Divider()
-                Menu {
-                    ForEach(Array(services.enumerated()), id: \.offset) { _, service in
-                        Button {
-                            // Write full-res file at action time, then share
-                            if let fullResURL = writeTempFile(image, filename: filename, base64Data: base64Data) {
-                                service.perform(withItems: [fullResURL])
-                            } else {
-                                service.perform(withItems: [tempURL])
-                            }
-                        } label: {
-                            Label {
-                                Text(service.title)
-                            } icon: {
-                                Image(nsImage: service.image)
-                            }
+        let services = cachedSharingServices(for: filename)
+        if !services.isEmpty {
+            Divider()
+            Menu {
+                ForEach(Array(services.enumerated()), id: \.offset) { _, service in
+                    Button {
+                        // Write temp file at action time (not during render)
+                        if let shareURL = writeTempFile(image, filename: filename, base64Data: base64Data)
+                            ?? writeTempFile(image, filename: filename) {
+                            service.perform(withItems: [shareURL])
+                        }
+                    } label: {
+                        Label {
+                            Text(service.title)
+                        } icon: {
+                            Image(nsImage: service.image)
                         }
                     }
-                } label: {
-                    Label { Text("Share") } icon: { VIconView(.share, size: 12) }
                 }
+            } label: {
+                Label { Text("Share") } icon: { VIconView(.share, size: 12) }
             }
         }
 


### PR DESCRIPTION
## Summary
- Cache `NSSharingService.sharingServices(forItems:)` results per file extension so the expensive synchronous XPC roundtrip only happens once per extension per app session
- Defer temp file writes from SwiftUI view body evaluation to button click time, keeping the render path lightweight
- Use a lightweight probe file for service discovery instead of writing the actual image data

## Test plan
- [ ] Open a conversation with multiple image attachments
- [ ] Scroll up and down rapidly — verify no rainbow spinners / hangs
- [ ] Right-click an image and verify the Share submenu appears with correct services (AirDrop, Messages, Mail, etc.)
- [ ] Click a sharing service and verify it receives the correct image file
- [ ] Test with different image types (PNG, JPEG, WebP) to verify per-extension caching works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
