### PR TITLE
feat: add --prepare and --finalize flags to `vellum upgrade` for Sparkle lifecycle

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -54,12 +54,16 @@ import { commitWorkspaceState } from "../lib/workspace-git.js";
 interface UpgradeArgs {
   name: string | null;
   version: string | null;
+  prepare: boolean;
+  finalize: boolean;
 }
 
 function parseArgs(): UpgradeArgs {
   const args = process.argv.slice(3);
   let name: string | null = null;
   let version: string | null = null;
+  let prepare = false;
+  let finalize = false;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -76,6 +80,12 @@ function parseArgs(): UpgradeArgs {
       console.log("Options:");
       console.log(
         "  --version <version>  Target version to upgrade to (default: latest)",
+      );
+      console.log(
+        "  --prepare            Run pre-upgrade steps only (backup, notify) without swapping versions",
+      );
+      console.log(
+        "  --finalize           Run post-upgrade steps only (broadcast complete, workspace commit)",
       );
       console.log("");
       console.log("Examples:");
@@ -98,6 +108,10 @@ function parseArgs(): UpgradeArgs {
       }
       version = next;
       i++;
+    } else if (arg === "--prepare") {
+      prepare = true;
+    } else if (arg === "--finalize") {
+      finalize = true;
     } else if (!arg.startsWith("-")) {
       name = arg;
     } else {
@@ -107,7 +121,13 @@ function parseArgs(): UpgradeArgs {
     }
   }
 
-  return { name, version };
+  if (prepare && finalize) {
+    console.error("Error: --prepare and --finalize are mutually exclusive.");
+    emitCliError("UNKNOWN", "--prepare and --finalize are mutually exclusive");
+    process.exit(1);
+  }
+
+  return { name, version, prepare, finalize };
 }
 
 function resolveCloud(entry: AssistantEntry): string {
@@ -907,9 +927,134 @@ async function upgradePlatform(
   }
 }
 
+/**
+ * Pre-upgrade steps for Sparkle (macOS app) lifecycle.
+ * Runs the pre-update orchestration without actually swapping containers:
+ * broadcasts SSE events, creates a workspace commit, creates a backup,
+ * prunes old backups, and outputs the backup path.
+ */
+async function upgradePrepare(
+  entry: AssistantEntry,
+  version: string | null,
+): Promise<void> {
+  const targetVersion = version ?? entry.serviceGroupVersion ?? "unknown";
+  const currentVersion = entry.serviceGroupVersion ?? "unknown";
+  const workspaceDir = entry.resources
+    ? join(entry.resources.instanceDir, ".vellum", "workspace")
+    : null;
+
+  // 1. Broadcast "starting" so the UI shows the progress spinner
+  await broadcastUpgradeEvent(
+    entry.runtimeUrl,
+    entry.assistantId,
+    buildStartingEvent(targetVersion, 30),
+  );
+
+  // 2. Workspace commit: record pre-update state
+  if (workspaceDir) {
+    try {
+      await commitWorkspaceState(
+        workspaceDir,
+        `[sparkle-update] Starting: ${currentVersion} → ${targetVersion}`,
+      );
+    } catch (err) {
+      console.warn(
+        `⚠️  Failed to create pre-upgrade workspace commit: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  // 3. Progress: saving backup
+  await broadcastUpgradeEvent(
+    entry.runtimeUrl,
+    entry.assistantId,
+    buildProgressEvent("Saving a backup of your data…"),
+  );
+
+  // 4. Create backup
+  const backupPath = await createBackup(entry.runtimeUrl, entry.assistantId, {
+    prefix: `${entry.assistantId}-pre-upgrade`,
+    description: `Pre-upgrade snapshot before ${currentVersion} → ${targetVersion}`,
+  });
+
+  // 5. Prune old backups (keep 3)
+  pruneOldBackups(entry.assistantId, 3);
+
+  // 6. Progress: installing update
+  await broadcastUpgradeEvent(
+    entry.runtimeUrl,
+    entry.assistantId,
+    buildProgressEvent("Installing the update…"),
+  );
+
+  // 7. Output backup path to stdout for the macOS app to parse
+  if (backupPath) {
+    console.log(`BACKUP_PATH:${backupPath}`);
+  }
+}
+
+/**
+ * Post-upgrade steps for Sparkle (macOS app) lifecycle.
+ * Called after the app has been replaced and the daemon is back up.
+ * Broadcasts a "complete" SSE event and creates a workspace commit.
+ */
+async function upgradeFinalize(
+  entry: AssistantEntry,
+  version: string | null,
+): Promise<void> {
+  if (!version) {
+    console.error(
+      "Error: --finalize requires --version <from-version> to record the transition.",
+    );
+    emitCliError(
+      "UNKNOWN",
+      "--finalize requires --version <from-version> to record the transition",
+    );
+    process.exit(1);
+  }
+
+  const fromVersion = version;
+  const currentVersion = entry.serviceGroupVersion ?? "unknown";
+  const workspaceDir = entry.resources
+    ? join(entry.resources.instanceDir, ".vellum", "workspace")
+    : null;
+
+  // 1. Broadcast "complete" so the UI clears the progress spinner
+  await broadcastUpgradeEvent(
+    entry.runtimeUrl,
+    entry.assistantId,
+    buildCompleteEvent(currentVersion, true),
+  );
+
+  // 2. Workspace commit: record successful update
+  if (workspaceDir) {
+    try {
+      await commitWorkspaceState(
+        workspaceDir,
+        `[sparkle-update] Complete: ${fromVersion} → ${currentVersion}\n\nresult: success`,
+      );
+    } catch (err) {
+      console.warn(
+        `⚠️  Failed to create post-upgrade workspace commit: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}
+
 export async function upgrade(): Promise<void> {
-  const { name, version } = parseArgs();
+  const { name, version, prepare, finalize } = parseArgs();
   const entry = resolveTargetAssistant(name);
+
+  if (prepare) {
+    await upgradePrepare(entry, version);
+    return;
+  }
+
+  if (finalize) {
+    await upgradeFinalize(entry, version);
+    return;
+  }
+
   const cloud = resolveCloud(entry);
 
   try {

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -106,6 +106,12 @@ extension AppDelegate {
             try await self.vellumCli.wake(name: name)
         }
 
+        // Post-Sparkle-update: run CLI finalize to broadcast complete + workspace commit.
+        connectionManager.postSparkleUpdateHandler = { [weak self] name, fromVersion in
+            guard let self else { return }
+            try? await self.vellumCli.upgradeFinalize(name: name, fromVersion: fromVersion)
+        }
+
         // Rebind the menu bar icon observer after transport reconfiguration
         // so connection status changes continue to update the icon.
         rebindConnectionStatusObserver()
@@ -438,74 +444,29 @@ extension AppDelegate {
             guard let self else { return }
             let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
             let targetVersion = self.updateManager.pendingUpdateVersion ?? "unknown"
+            let name = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
 
-            // 1. Broadcast "starting" so the UI shows the progress spinner
-            _ = try? await GatewayHTTPClient.post(
-                path: "admin/upgrade-broadcast",
-                json: ["type": "starting", "targetVersion": targetVersion, "expectedDowntimeSeconds": 30],
-                timeout: 5
+            // Single CLI call replaces 8 steps of pre-update orchestration
+            let backupPath = try? await self.vellumCli.upgradePrepare(
+                name: name,
+                targetVersion: targetVersion
             )
 
-            // 2. Workspace commit: record pre-update state
-            _ = try? await GatewayHTTPClient.post(
-                path: "admin/workspace-commit",
-                json: ["message": "[sparkle-update] Starting: \(currentVersion) → \(targetVersion)"],
-                timeout: 10
-            )
-
-            // 3. Progress: saving backup
-            _ = try? await GatewayHTTPClient.post(
-                path: "admin/upgrade-broadcast",
-                json: ["type": "progress", "statusMessage": "Saving a backup of your data…"],
-                timeout: 5
-            )
-
-            // 4. Create backup via gateway
-            if let response = try? await GatewayHTTPClient.post(path: "migrations/export", timeout: 120),
-               response.isSuccess {
-                let backupsDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-                    .appendingPathComponent("Vellum/backups", isDirectory: true)
-                try? FileManager.default.createDirectory(at: backupsDir, withIntermediateDirectories: true)
-                let formatter = DateFormatter()
-                formatter.dateFormat = "yyyy-MM-dd-HHmmss"
-                let filename = "pre-update-\(formatter.string(from: Date())).vbundle"
-                let fileURL = backupsDir.appendingPathComponent(filename)
-                try? response.data.write(to: fileURL)
-                UserDefaults.standard.set(fileURL.path, forKey: "preUpdateBackupPath")
-                Self.prunePreUpdateBackups(in: backupsDir, keep: 3)
+            // Store backup path for "Restore Pre-Update Data" button
+            if let backupPath {
+                UserDefaults.standard.set(backupPath, forKey: "preUpdateBackupPath")
             }
 
-            // 5. Progress: installing update
-            _ = try? await GatewayHTTPClient.post(
-                path: "admin/upgrade-broadcast",
-                json: ["type": "progress", "statusMessage": "Installing the update…"],
-                timeout: 5
-            )
-
-            // 6. Cache current version for post-update detection
+            // Cache current version for post-update detection
             UserDefaults.standard.set(currentVersion, forKey: "preUpdateVersion")
 
-            // 7. Stop daemon — after this, no more broadcasts are possible
+            // Stop daemon before app replacement
             #if !DEBUG
             self.keychainBroker?.stop()
             #endif
             self.vellumCli.stop()
         }
         updateManager.startAutomaticChecks()
-    }
-
-    /// Removes old pre-update backups, keeping only the most recent `keep` files.
-    static func prunePreUpdateBackups(in directory: URL, keep: Int) {
-        guard let contents = try? FileManager.default.contentsOfDirectory(
-            at: directory, includingPropertiesForKeys: nil
-        ) else { return }
-        let matching = contents
-            .filter { $0.lastPathComponent.hasPrefix("pre-update-") && $0.pathExtension == "vbundle" }
-            .sorted { $0.lastPathComponent < $1.lastPathComponent }
-        guard matching.count > keep else { return }
-        for file in matching.prefix(matching.count - keep) {
-            try? FileManager.default.removeItem(at: file)
-        }
     }
 
     // MARK: - CLI Symlink

--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -404,6 +404,51 @@ final class VellumCli {
         log.info("CLI upgrade completed successfully for '\(name, privacy: .public)'")
     }
 
+    /// Run pre-upgrade steps only (backup, SSE broadcast, workspace commit) without swapping versions.
+    /// Returns the backup path if one was created (parsed from stdout `BACKUP_PATH:` line).
+    func upgradePrepare(name: String, targetVersion: String? = nil) async throws -> String? {
+        guard let binaryURL = cliBinaryURL else {
+            log.info("No bundled CLI binary found — skipping upgradePrepare (dev mode)")
+            throw CLIError.binaryNotFound
+        }
+
+        var arguments = ["upgrade", name, "--prepare"]
+        if let targetVersion {
+            arguments += ["--version", targetVersion]
+        }
+        let (stdout, stderr, status) = try await runCLI(binaryURL: binaryURL, arguments: arguments)
+        if status != 0 {
+            if let cliError = Self.parseCliError(from: stderr) {
+                throw CLIError.structuredError(cliError)
+            }
+            throw CLIError.executionFailed(stderr)
+        }
+        // Parse BACKUP_PATH: line from stdout
+        for line in stdout.split(separator: "\n") {
+            if line.hasPrefix("BACKUP_PATH:") {
+                return String(line.dropFirst("BACKUP_PATH:".count))
+            }
+        }
+        return nil
+    }
+
+    /// Run post-upgrade steps only (broadcast complete, workspace commit).
+    func upgradeFinalize(name: String, fromVersion: String) async throws {
+        guard let binaryURL = cliBinaryURL else {
+            log.info("No bundled CLI binary found — skipping upgradeFinalize (dev mode)")
+            throw CLIError.binaryNotFound
+        }
+
+        let arguments = ["upgrade", name, "--finalize", "--version", fromVersion]
+        let (_, stderr, status) = try await runCLI(binaryURL: binaryURL, arguments: arguments)
+        if status != 0 {
+            if let cliError = Self.parseCliError(from: stderr) {
+                throw CLIError.structuredError(cliError)
+            }
+            throw CLIError.executionFailed(stderr)
+        }
+    }
+
     /// Roll back a specific Docker assistant to its previous version via the CLI.
     ///
     /// - Parameters:

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -87,6 +87,10 @@ public final class GatewayConnectionManager: ObservableObject {
     // MARK: - Auto-Wake
 
     public var wakeHandler: (@MainActor @Sendable () async throws -> Void)?
+    /// Handler called after a Sparkle update is detected.
+    /// Receives `(name: String, fromVersion: String)` so the macOS app can invoke
+    /// CLI `upgradeFinalize` without the shared module depending on `AppDelegate`.
+    public var postSparkleUpdateHandler: (@MainActor @Sendable (_ name: String, _ fromVersion: String) async -> Void)?
     public var recoveryPlatform: String?
     public var recoveryDeviceId: String?
 
@@ -554,8 +558,8 @@ public final class GatewayConnectionManager: ObservableObject {
     #if os(macOS)
     /// Detects whether the app was relaunched after a Sparkle update by checking
     /// the `preUpdateVersion` UserDefaults flag (set before the update started).
-    /// If the version has changed, broadcasts a `complete` event so the UI shows
-    /// a success toast and creates a workspace git commit recording the update.
+    /// If the version has changed, runs the CLI finalize command which broadcasts
+    /// a `complete` event and creates a workspace git commit recording the update.
     /// The flag is cleared after processing so this only runs once per update.
     private func handlePostSparkleUpdate() {
         guard let preUpdateVersion = UserDefaults.standard.string(forKey: "preUpdateVersion") else { return }
@@ -567,24 +571,11 @@ public final class GatewayConnectionManager: ObservableObject {
 
         log.info("Post-Sparkle-update detected: \(preUpdateVersion, privacy: .public) → \(currentVersion, privacy: .public)")
 
+        // Single CLI call replaces direct HTTP calls for broadcast + workspace commit
         Task {
-            // 1. Broadcast "complete" so the UI clears the progress spinner and shows the outcome
-            _ = try? await GatewayHTTPClient.post(
-                path: "admin/upgrade-broadcast",
-                json: [
-                    "type": "complete",
-                    "installedVersion": currentVersion,
-                    "success": true
-                ] as [String: Any],
-                timeout: 5
-            )
-
-            // 2. Workspace commit: record successful update
-            _ = try? await GatewayHTTPClient.post(
-                path: "admin/workspace-commit",
-                json: ["message": "[sparkle-update] Complete: \(preUpdateVersion) → \(currentVersion)\n\nresult: success"],
-                timeout: 10
-            )
+            guard let handler = postSparkleUpdateHandler,
+                  let name = UserDefaults.standard.string(forKey: "connectedAssistantId") else { return }
+            await handler(name, preUpdateVersion)
         }
     }
     #endif


### PR DESCRIPTION
## Summary
- Add `--prepare` flag to run pre-upgrade steps only (backup, SSE broadcast, workspace commit)
- Add `--finalize` flag to run post-upgrade steps only (SSE complete broadcast, workspace commit)
- Add `postSparkleUpdateHandler` closure to `GatewayConnectionManager` for dependency injection
- Replace macOS AppDelegate pre-update orchestration with single CLI call
- Replace macOS GatewayConnectionManager post-update orchestration with single CLI call via handler
- Remove `prunePreUpdateBackups()` from AppDelegate (now handled by CLI)

Part of plan: version-mgmt-refactor.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
