### PR TITLE
M1: Remove Built on Vellum branding badge

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -632,7 +632,3 @@ When the user wants to triage or bulk-act on items, generate an interactive UI w
 ## External Links
 
 Use `vellum.openLink(url, metadata)` to make items clickable. Construct deep-link URLs when possible. Include `metadata.provider` and `metadata.type` for context.
-
-## Branding
-
-A "Built on Vellum" badge is auto-injected into every page. Do NOT add your own.

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -410,27 +410,6 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             contentController.addUserScript(insetScript)
         }
 
-        // Inject "Built on Vellum" branding badge at document end.
-        let brandingScript = WKUserScript(
-            source: """
-                (function() {
-                    function injectBranding() {
-                        if (document.getElementById('vellum-branding')) return;
-                        var el = document.createElement('div');
-                        el.id = 'vellum-branding';
-                        el.setAttribute('data-vellum-injected', '1');
-                        el.innerHTML = 'Built on <a onclick="event.preventDefault(); if(window.vellum&&vellum.openLink){vellum.openLink(\\'https://vellum.ai\\',{provider:\\'vellum\\',type:\\'branding\\'})}else{window.open(\\'https://vellum.ai\\',\\'_blank\\')}" href="https://vellum.ai">Vellum</a>';
-                        document.body.appendChild(el);
-                    }
-                    if (document.body) injectBranding();
-                    else document.addEventListener('DOMContentLoaded', injectBranding);
-                })();
-                """,
-            injectionTime: .atDocumentEnd,
-            forMainFrameOnly: true
-        )
-        contentController.addUserScript(brandingScript)
-
         onCoordinatorReady?(context.coordinator)
         // Use a per-app origin so localStorage/sessionStorage work natively,
         // isolated per app. Non-app surfaces get a shared fallback origin.

--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -146,7 +146,7 @@ body {
   justify-content: center;
   -webkit-font-smoothing: antialiased;
 }
-body > *:not(#vellum-bottom-fade):not(#vellum-branding):not(#v-toast-container) {
+body > *:not(#vellum-bottom-fade):not(#v-toast-container) {
   width: 100%;
   max-width: 900px;
 }
@@ -1920,38 +1920,3 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
 }
 
 } /* end @layer vellum-design-system */
-
-/* ── Built on Vellum — auto-injected branding badge ────────────
-     Intentionally OUTSIDE @layer so un-layered app CSS cannot
-     override it (un-layered styles beat layered styles, but these
-     are also un-layered and use !important on critical props). ── */
-#vellum-branding {
-  position: fixed !important;
-  display: block !important;
-  visibility: visible !important;
-  bottom: 12px;
-  right: 16px;
-  z-index: 99998;
-  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, sans-serif;
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.01em;
-  color: var(--v-content-tertiary, #9ca3af);
-  opacity: 0.7 !important;
-  transition: opacity 0.2s ease;
-  pointer-events: auto;
-  user-select: none;
-  -webkit-user-select: none;
-}
-#vellum-branding:hover {
-  opacity: 1 !important;
-}
-#vellum-branding a {
-  color: var(--v-primary-base, #216C37);
-  text-decoration: none;
-  font-weight: 600;
-  cursor: pointer;
-}
-#vellum-branding a:hover {
-  text-decoration: underline;
-}


### PR DESCRIPTION
Remove the auto-injected 'Built on Vellum' branding badge from app pages. The badge was overlapping with app content (especially in the text editor feature). Removes the WKUserScript injection in DynamicPageSurfaceView.swift, all #vellum-branding CSS styles, and the SKILL.md branding section.

Part of LUM-333
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
