### PR TITLE
perf: cache NSSharingService discovery to fix scroll rainbow spinner

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -133,6 +133,44 @@ private enum ImageActions {
         NSWorkspace.shared.open(fileURL)
     }
 
+    /// Cache of sharing services by file extension. Services depend on file type,
+    /// not content, so one discovery per extension per app session is sufficient.
+    private static var sharingServicesCache: [String: [NSSharingService]] = [:]
+
+    /// Returns cached sharing services for the given filename's extension.
+    /// On first call per extension, writes a minimal valid image file and calls
+    /// `NSSharingService.sharingServices(forItems:)` once, caching the result.
+    /// A real (non-empty) probe file is used because some services validate
+    /// media content and return fewer results for zero-byte placeholders.
+    @available(macOS, deprecated: 13.0)
+    private static func cachedSharingServices(for filename: String) -> [NSSharingService] {
+        let ext = (filename as NSString).pathExtension.lowercased()
+        let key = ext.isEmpty ? "png" : ext
+        if let cached = sharingServicesCache[key] { return cached }
+        let probeURL = FileManager.default.temporaryDirectory.appendingPathComponent("vellum-share-probe.\(key)")
+        if !FileManager.default.fileExists(atPath: probeURL.path) {
+            // Write a minimal 1x1 PNG so services that validate content see a real image.
+            // NSImage(size:) without drawing produces no representations, so use
+            // init(size:flipped:drawingHandler:) to create actual pixel data.
+            let tiny = NSImage(size: NSSize(width: 1, height: 1), flipped: false) { _ in
+                NSColor.clear.set()
+                NSRect(x: 0, y: 0, width: 1, height: 1).fill()
+                return true
+            }
+            if let tiff = tiny.tiffRepresentation,
+               let rep = NSBitmapImageRep(data: tiff),
+               let data = rep.representation(using: .png, properties: [:]) {
+                try? data.write(to: probeURL)
+            } else {
+                // Fallback: create the file with empty data so the path exists.
+                FileManager.default.createFile(atPath: probeURL.path, contents: Data())
+            }
+        }
+        let services = NSSharingService.sharingServices(forItems: [probeURL])
+        sharingServicesCache[key] = services
+        return services
+    }
+
     /// Builds a SwiftUI context menu with Copy, Save As, and Open in Preview actions.
     @available(macOS, deprecated: 13.0)
     @ViewBuilder
@@ -159,38 +197,37 @@ private enum ImageActions {
             Label { Text("Open in Preview") } icon: { VIconView(.eye, size: 12) }
         }
 
-        // Write a temp file for sharing — NSSharingService.sharingServices
-        // returns far more services (AirDrop, Messages, Mail, etc.) when given
-        // a file URL vs a raw NSImage. The temp file write is lightweight
-        // (thumbnail image) to keep the view builder fast. Full-res file is
-        // written at action time when the user picks a service.
+        // Sharing services are cached per file extension to avoid synchronous
+        // XPC roundtrips on every render. Temp file writes are deferred to
+        // click time so the view builder stays fast.
         // NSSharingService.sharingServices is deprecated in macOS 13 but has
         // no functional replacement for custom share UI (see AppSharePanelView).
         // Silenced via @available on this method; see AppSharePanelView for the same pattern.
-        if let tempURL = writeTempFile(image, filename: filename) {
-            let services = NSSharingService.sharingServices(forItems: [tempURL])
-            if !services.isEmpty {
-                Divider()
-                Menu {
-                    ForEach(Array(services.enumerated()), id: \.offset) { _, service in
-                        Button {
-                            // Write full-res file at action time, then share
-                            if let fullResURL = writeTempFile(image, filename: filename, base64Data: base64Data) {
-                                service.perform(withItems: [fullResURL])
-                            } else {
-                                service.perform(withItems: [tempURL])
-                            }
-                        } label: {
-                            Label {
-                                Text(service.title)
-                            } icon: {
-                                Image(nsImage: service.image)
-                            }
+        let services = cachedSharingServices(for: filename)
+        if !services.isEmpty {
+            Divider()
+            Menu {
+                ForEach(Array(services.enumerated()), id: \.offset) { _, service in
+                    Button {
+                        // Write temp file at action time (not during render).
+                        // Try full-res first, fall back to thumbnail, fall back to
+                        // the probe file so the Share action is never a silent no-op.
+                        let shareURL = writeTempFile(image, filename: filename, base64Data: base64Data)
+                            ?? writeTempFile(image, filename: filename)
+                        let probeExt = (filename as NSString).pathExtension.lowercased()
+                        let fallback = FileManager.default.temporaryDirectory
+                            .appendingPathComponent("vellum-share-probe.\(probeExt.isEmpty ? "png" : probeExt)")
+                        service.perform(withItems: [shareURL ?? fallback])
+                    } label: {
+                        Label {
+                            Text(service.title)
+                        } icon: {
+                            Image(nsImage: service.image)
                         }
                     }
-                } label: {
-                    Label { Text("Share") } icon: { VIconView(.share, size: 12) }
                 }
+            } label: {
+                Label { Text("Share") } icon: { VIconView(.share, size: 12) }
             }
         }
 


### PR DESCRIPTION
## Summary
Fix the primary cause of rainbow spinners when scrolling up in conversations with images. CPU profiling showed `NSSharingService.sharingServicesForItems()` was called synchronously inside SwiftUI view bodies for every image on every render pass, triggering PlugInKit XPC roundtrips that accounted for 98% of main thread blocking during scroll.

## Changes
- Cache sharing service discovery per file extension (services depend on type, not content)
- Use a minimal 1x1 PNG probe file for discovery (services that validate content need real data)
- Defer temp file writes from render time to user click time
- Preserve fallback URL so Share action is never a silent no-op

## Milestone PRs
- #20875: perf: cache NSSharingService discovery to eliminate XPC calls during scroll

Closes #20873

## Test plan
- [ ] Open conversation with images, scroll up — no rainbow spinner
- [ ] Right-click image → Share submenu shows all expected services (AirDrop, Messages, etc.)
- [ ] Click a Share service — should work correctly (writes temp file at action time)
- [ ] Share menu works for different image types (PNG, JPEG)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
