### PR TITLE
fix: add pointer cursor to Intelligence panel tabs

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -148,6 +148,7 @@ struct IntelligencePanel: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .pointerCursor()
     }
 
     // MARK: - Tab Content


### PR DESCRIPTION
## Summary
- Add `.pointerCursor()` modifier to `tabButton` in `IntelligencePanel.swift` so hovering over Intelligence tabs (Identity, Skills, Workspace, Contacts, Memories) shows a hand cursor
- Matches the convention used by `VTab` and `VSegmentedControl`
- Part of LUM-359

## Test plan
- [ ] Hover over each Intelligence panel tab and verify the pointer (hand) cursor appears
- [ ] Confirm cursor reverts to default arrow when moving off the tab buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
