### PR TITLE
fix: add pointer cursor to Intelligence panel tabs

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -148,6 +148,7 @@ struct IntelligencePanel: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .pointerCursor()
     }
 
     // MARK: - Tab Content


### PR DESCRIPTION
## Summary
Add `.pointerCursor()` modifier to the Intelligence panel tab buttons so they show a hand cursor on hover, matching the design system convention used by `VTab`, `VSegmentedControl`, and other clickable tab components.

## Changes
- Added `.pointerCursor()` to `tabButton` in `IntelligencePanel.swift` (after `.buttonStyle(.plain)`)

## Milestone PRs (merged into feature branch)
- #20889: fix: add pointer cursor to Intelligence panel tabs

## Project issue
Closes #20887

## Test plan
- [ ] Open Intelligence panel, hover over Identity/Skills/Workspace/Contacts/Memories tabs — verify hand cursor appears
- [ ] Verify cursor reverts to default arrow when moving off tabs
- [ ] Verify other interactive elements in the Intelligence panel still work correctly

Closes LUM-359
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
