### PR TITLE
fix: add missing CLI error guidance and fix rollback terminology

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -403,7 +403,7 @@ struct AssistantUpgradeSection: View {
             }
         } message: {
             if isRollback {
-                Text("Roll back to version \(effectiveSelectedVersion ?? "unknown")? The assistant will be briefly unavailable.")
+                Text("Rollback to version \(effectiveSelectedVersion ?? "unknown")? The assistant will be briefly unavailable.")
             } else {
                 Text("Upgrade to version \(effectiveSelectedVersion ?? "latest")? The assistant will be briefly unavailable during the upgrade.")
             }
@@ -618,6 +618,12 @@ struct AssistantUpgradeSection: View {
             return "Could not find the assistant. Make sure it's still configured."
         case "UNSUPPORTED_TOPOLOGY":
             return "This assistant type doesn't support automatic upgrades. Upgrade your infrastructure manually."
+        case "VERSION_DIRECTION":
+            return "Cannot upgrade to an older version. Use the rollback option instead."
+        case "INVALID_VERSION":
+            return "The selected version is not valid for this operation."
+        case "MISSING_VERSION":
+            return "A target version is required. Select a version from the picker."
         default:
             return "Something went wrong. Share feedback to send logs to the team."
         }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for version-mgmt-refactor.md.

**Gap 1:** Add `VERSION_DIRECTION`, `INVALID_VERSION`, and `MISSING_VERSION` to `guidanceForError()` in Swift UI.
**Gap 2:** Fix "Roll back" → "Rollback" in confirmation alert message.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
