### PR TITLE
fix: make SSE progress messages generic for upgrade and rollback

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -927,7 +927,7 @@ async function upgradePrepare(
   await broadcastUpgradeEvent(
     entry.runtimeUrl,
     entry.assistantId,
-    buildProgressEvent("Installing the update…"),
+    buildProgressEvent(UPGRADE_PROGRESS.INSTALLING),
   );
 
   // 7. Output backup path to stdout for the macOS app to parse

--- a/cli/src/lib/upgrade-lifecycle.ts
+++ b/cli/src/lib/upgrade-lifecycle.ts
@@ -32,10 +32,10 @@ import { commitWorkspaceState } from "./workspace-git.js";
 
 /** User-facing progress messages shared across upgrade and rollback flows. */
 export const UPGRADE_PROGRESS = {
-  DOWNLOADING: "Downloading the update…",
+  DOWNLOADING: "Downloading…",
   BACKING_UP: "Saving a backup of your data…",
-  INSTALLING: "Installing the update…",
-  REVERTING: "The update didn't work. Reverting to the previous version…",
+  INSTALLING: "Installing…",
+  REVERTING: "Something went wrong. Reverting to the previous version…",
   REVERTING_MIGRATIONS: "Reverting database changes…",
   RESTORING: "Restoring your data…",
   SWITCHING: "Switching to the previous version…",

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -34,7 +34,7 @@ struct AssistantUpgradeSection: View {
     /// Whether a service group update is in progress (managed topology).
     var isServiceGroupUpdateInProgress: Bool = false
 
-    /// Progress message from service group update events (e.g. "Downloading the update…").
+    /// Progress message from service group update events (e.g. "Downloading…").
     var updateStatusMessage: String?
 
     /// Whether the healthz fetch has completed (regardless of success/failure).


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for version-mgmt-refactor.md.

**Gap:** SSE progress messages said "update" during rollback operations. Made them generic so they work for both upgrade and rollback contexts.

- `DOWNLOADING`: "Downloading the update..." -> "Downloading..."
- `INSTALLING`: "Installing the update..." -> "Installing..."
- `REVERTING`: "The update didn't work. Reverting to the previous version..." -> "Something went wrong. Reverting to the previous version..."
- Fixed a hardcoded progress string in `upgrade.ts` that wasn't using the shared constant
- Updated a Swift doc comment example to match the new string
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
