### PR TITLE
fix: add topology check to `vellum restore --version`

### DIFF
--- a/cli/src/commands/restore.ts
+++ b/cli/src/commands/restore.ts
@@ -299,6 +299,18 @@ export async function restore(): Promise<void> {
   } else {
     // Version rollback (when --version is specified)
     if (version) {
+      const cloud =
+        entry.cloud ||
+        (entry.project ? "gcp" : entry.sshUser ? "custom" : "local");
+      if (cloud !== "docker") {
+        console.error(
+          "Restore with --version is only supported for Docker assistants. " +
+            "For managed assistants, use `vellum rollback --version <version>` to change the version, " +
+            "then `vellum restore --from <path>` to import data.",
+        );
+        process.exit(1);
+      }
+
       console.log(`Rolling back to version ${version}...`);
       await performDockerRollback(entry, { targetVersion: version });
       console.log("");


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for version-mgmt-refactor.md.

**Gap:** `vellum restore --version` calls Docker-specific rollback without checking topology. Adds a check that rejects non-Docker assistants with a clear error message.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
