### PR TITLE
fix: move auth check before SSE broadcast in rollbackPlatform

### DIFF
--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -206,6 +206,19 @@ async function rollbackPlatform(
     }
   }
 
+  // Authenticate before broadcasting any SSE events so that a missing
+  // token does not leave connected clients showing a perpetual spinner.
+  const token = readPlatformToken();
+  if (!token) {
+    const msg =
+      "Error: Not logged in. Run `vellum login --token <token>` first.";
+    console.error(msg);
+    emitCliError("AUTH_FAILED", msg);
+    process.exit(1);
+  }
+
+  const orgId = await fetchOrganizationId(token);
+
   console.log(
     `🔄 Rolling back platform-hosted assistant '${entry.assistantId}' to ${version}...\n`,
   );
@@ -217,18 +230,6 @@ async function rollbackPlatform(
     entry.assistantId,
     buildStartingEvent(version, 90),
   );
-
-  // Authenticate and call the platform API
-  const token = readPlatformToken();
-  if (!token) {
-    const msg =
-      "Error: Not logged in. Run `vellum login --token <token>` first.";
-    console.error(msg);
-    emitCliError("AUTH_FAILED", msg);
-    process.exit(1);
-  }
-
-  const orgId = await fetchOrganizationId(token);
 
   const url = `${getPlatformUrl()}/v1/assistants/upgrade/`;
   const body = {


### PR DESCRIPTION
## Summary
Fixes bug where SSE 'starting' event was broadcast before auth token check in rollbackPlatform(). If auth fails, connected clients were left with a perpetual loading spinner because no 'complete' event was sent.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
