### PR TITLE
fix: only apply downgrade guard in upgradePlatform when --version is explicit

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -731,11 +731,13 @@ async function upgradePlatform(
 
   // Reject downgrades — `vellum upgrade` only handles forward version changes.
   // Users should use `vellum rollback --version <version>` for downgrades.
-  const versionTag = version ?? (cliPkg.version ? `v${cliPkg.version}` : null);
+  // Only enforce this guard when the user explicitly passed `--version`.
+  // When version is null the platform API decides the actual target, so
+  // we must not block the request based on the local CLI version.
   const currentVersion = entry.serviceGroupVersion;
-  if (currentVersion && versionTag) {
+  if (version && currentVersion) {
     const current = parseVersion(currentVersion);
-    const target = parseVersion(versionTag);
+    const target = parseVersion(version);
     if (current && target) {
       const isOlder =
         target.major < current.major ||
@@ -744,7 +746,7 @@ async function upgradePlatform(
           target.minor === current.minor &&
           target.patch < current.patch);
       if (isOlder) {
-        const msg = `Cannot upgrade to an older version (${versionTag} < ${currentVersion}). Use \`vellum rollback --version ${versionTag}\` instead.`;
+        const msg = `Cannot upgrade to an older version (${version} < ${currentVersion}). Use \`vellum rollback --version ${version}\` instead.`;
         console.error(msg);
         emitCliError("VERSION_DIRECTION", msg);
         process.exit(1);


### PR DESCRIPTION
## Summary
Fixes bug where plain `vellum upgrade` for managed assistants was incorrectly blocked when the local CLI version was older than the running service group. The downgrade guard now only applies when `--version` was explicitly passed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
