### PR TITLE
fix: improve version validation in performDockerRollback for same-version case

### DIFF
--- a/cli/src/lib/upgrade-lifecycle.ts
+++ b/cli/src/lib/upgrade-lifecycle.ts
@@ -302,11 +302,21 @@ export async function performDockerRollback(
       const isNewer = (() => {
         if (target.major !== current.major) return target.major > current.major;
         if (target.minor !== current.minor) return target.minor > current.minor;
-        return target.patch >= current.patch;
+        return target.patch > current.patch;
       })();
       if (isNewer) {
         const msg =
           "Cannot roll back to a newer version. Use `vellum upgrade` instead.";
+        console.error(msg);
+        emitCliError("VERSION_DIRECTION", msg);
+        process.exit(1);
+      }
+      const isSame =
+        target.major === current.major &&
+        target.minor === current.minor &&
+        target.patch === current.patch;
+      if (isSame) {
+        const msg = `Already on version ${targetVersion}. Nothing to roll back to.`;
         console.error(msg);
         emitCliError("VERSION_DIRECTION", msg);
         process.exit(1);


### PR DESCRIPTION
## Summary
Fixes misleading error when rolling back to the same version. Changes patch comparison from >= to > and adds a separate same-version check with a clear message.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
