### PR TITLE
fix: align rollback backup prefix with pruning logic

### DIFF
--- a/cli/src/lib/upgrade-lifecycle.ts
+++ b/cli/src/lib/upgrade-lifecycle.ts
@@ -428,7 +428,7 @@ export async function performDockerRollback(
     entry.runtimeUrl,
     entry.assistantId,
     {
-      prefix: `${entry.assistantId}-pre-rollback`,
+      prefix: `${entry.assistantId}-pre-upgrade`,
       description: `Pre-rollback snapshot before ${currentVersion ?? "unknown"} → ${targetVersion}`,
     },
   );


### PR DESCRIPTION
## Summary
Fixes unbounded disk growth from rollback backups. Changed pre-rollback backup prefix to match the pattern that pruneOldBackups() scans, so rollback backups are properly pruned.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
