### PR TITLE
fix: validate --version requires a value in `vellum restore`

### DIFF
--- a/cli/src/commands/restore.ts
+++ b/cli/src/commands/restore.ts
@@ -65,8 +65,13 @@ function parseArgs(argv: string[]): {
     if (args[i] === "--from" && args[i + 1]) {
       fromPath = args[i + 1];
       i++; // skip the value
-    } else if (args[i] === "--version" && args[i + 1]) {
-      version = args[i + 1];
+    } else if (args[i] === "--version") {
+      const next = args[i + 1];
+      if (!next || next.startsWith("-")) {
+        console.error("Error: --version requires a value");
+        process.exit(1);
+      }
+      version = next;
       i++; // skip the value
     } else if (args[i] === "--dry-run") {
       // already handled above


### PR DESCRIPTION
## Summary
Fixes silent degradation when `--version` is passed without a value to `vellum restore`. Now exits with a clear error instead of silently skipping the version rollback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20904" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
