### PR TITLE
fix: guard @Observable nil-writes in AvatarAppearanceManager to prevent scroll loop

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -184,7 +184,7 @@ final class AvatarAppearanceManager {
                 timeout: 10
             )
             guard response.isSuccess, !response.data.isEmpty else {
-                customAvatarImage = nil
+                if customAvatarImage != nil { customAvatarImage = nil }
                 cachedChatAvatar = nil
                 updateDockIcon()
                 return
@@ -194,7 +194,7 @@ final class AvatarAppearanceManager {
             updateDockIcon()
         } catch {
             log.warning("Failed to fetch avatar via HTTP: \(error.localizedDescription)")
-            customAvatarImage = nil
+            if customAvatarImage != nil { customAvatarImage = nil }
             cachedChatAvatar = nil
             updateDockIcon()
         }
@@ -209,9 +209,9 @@ final class AvatarAppearanceManager {
                 timeout: 10
             )
             guard response.isSuccess, !response.data.isEmpty else {
-                characterBodyShape = nil
-                characterEyeStyle = nil
-                characterColor = nil
+                if characterBodyShape != nil { characterBodyShape = nil }
+                if characterEyeStyle != nil { characterEyeStyle = nil }
+                if characterColor != nil { characterColor = nil }
                 cachedFallbackAvatar = nil
                 cachedFullFallbackAvatar = nil
                 updateDockIcon()
@@ -228,9 +228,9 @@ final class AvatarAppearanceManager {
             updateDockIcon()
         } catch {
             log.warning("Failed to fetch character traits via HTTP: \(error.localizedDescription)")
-            characterBodyShape = nil
-            characterEyeStyle = nil
-            characterColor = nil
+            if characterBodyShape != nil { characterBodyShape = nil }
+            if characterEyeStyle != nil { characterEyeStyle = nil }
+            if characterColor != nil { characterColor = nil }
             cachedFallbackAvatar = nil
             cachedFullFallbackAvatar = nil
             updateDockIcon()


### PR DESCRIPTION
## Summary
- Guard nil-writes to `@Observable` stored properties (`customAvatarImage`, `characterBodyShape`, `characterEyeStyle`, `characterColor`) in error/404 paths of `fetchAvatarViaHTTP()` and `fetchTraitsViaHTTP()` with inequality checks
- Prevents Swift `@Observable` from firing spurious change notifications when writing nil to an already-nil property, which was causing cascading `MessageListView.body` re-evaluations that tripped `ChatScrollLoopGuard`

## Test plan
- [ ] Verify avatar still loads correctly when workspace has a custom avatar
- [ ] Verify avatar clears correctly when custom avatar is removed
- [ ] Verify no scroll loop occurs on 404 responses (no custom avatar uploaded)
- [ ] Verify `resetForDisconnect()` and `clearCustomAvatar()` still work (those paths are unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
