### PR TITLE
fix: encode sharing services probe file in correct format per extension

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -133,6 +133,18 @@ private enum ImageActions {
         NSWorkspace.shared.open(fileURL)
     }
 
+    /// Maps a file extension to the corresponding `NSBitmapImageRep.FileType`
+    /// so that probe files are encoded in the correct format for their extension.
+    private static func bitmapFileType(for extension: String) -> NSBitmapImageRep.FileType {
+        switch `extension`.lowercased() {
+        case "jpg", "jpeg": return .jpeg
+        case "gif": return .gif
+        case "bmp": return .bmp
+        case "tiff", "tif": return .tiff
+        default: return .png
+        }
+    }
+
     /// Cache of sharing services by file extension. Services depend on file type,
     /// not content, so one discovery per extension per app session is sufficient.
     private static var sharingServicesCache: [String: [NSSharingService]] = [:]
@@ -159,7 +171,7 @@ private enum ImageActions {
             }
             if let tiff = tiny.tiffRepresentation,
                let rep = NSBitmapImageRep(data: tiff),
-               let data = rep.representation(using: .png, properties: [:]) {
+               let data = rep.representation(using: bitmapFileType(for: key), properties: [:]) {
                 try? data.write(to: probeURL)
             } else {
                 // Fallback: create the file with empty data so the path exists.


### PR DESCRIPTION
## Summary
- The sharing services probe file was always PNG-encoded regardless of filename extension
- For .jpg/.gif/.bmp/.tiff inputs, this wrote mismatched content which may cause `NSSharingService` to return reduced results
- Added a `bitmapFileType(for:)` helper that maps file extensions to `NSBitmapImageRep.FileType`, and updated the probe encoding call to use it

## Test plan
- [ ] Verify sharing menu for PNG images still works correctly
- [ ] Verify sharing menu for JPEG images shows correct sharing services
- [ ] Verify sharing menu for other image types (GIF, BMP, TIFF) shows correct services

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
