### PR TITLE
fix: guard @Observable nil-writes and encode probe file per extension

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -184,7 +184,7 @@ final class AvatarAppearanceManager {
                 timeout: 10
             )
             guard response.isSuccess, !response.data.isEmpty else {
-                customAvatarImage = nil
+                if customAvatarImage != nil { customAvatarImage = nil }
                 cachedChatAvatar = nil
                 updateDockIcon()
                 return
@@ -194,7 +194,7 @@ final class AvatarAppearanceManager {
             updateDockIcon()
         } catch {
             log.warning("Failed to fetch avatar via HTTP: \(error.localizedDescription)")
-            customAvatarImage = nil
+            if customAvatarImage != nil { customAvatarImage = nil }
             cachedChatAvatar = nil
             updateDockIcon()
         }
@@ -209,9 +209,9 @@ final class AvatarAppearanceManager {
                 timeout: 10
             )
             guard response.isSuccess, !response.data.isEmpty else {
-                characterBodyShape = nil
-                characterEyeStyle = nil
-                characterColor = nil
+                if characterBodyShape != nil { characterBodyShape = nil }
+                if characterEyeStyle != nil { characterEyeStyle = nil }
+                if characterColor != nil { characterColor = nil }
                 cachedFallbackAvatar = nil
                 cachedFullFallbackAvatar = nil
                 updateDockIcon()
@@ -228,9 +228,9 @@ final class AvatarAppearanceManager {
             updateDockIcon()
         } catch {
             log.warning("Failed to fetch character traits via HTTP: \(error.localizedDescription)")
-            characterBodyShape = nil
-            characterEyeStyle = nil
-            characterColor = nil
+            if characterBodyShape != nil { characterBodyShape = nil }
+            if characterEyeStyle != nil { characterEyeStyle = nil }
+            if characterColor != nil { characterColor = nil }
             cachedFallbackAvatar = nil
             cachedFullFallbackAvatar = nil
             updateDockIcon()

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -133,6 +133,18 @@ private enum ImageActions {
         NSWorkspace.shared.open(fileURL)
     }
 
+    /// Maps a file extension to the corresponding `NSBitmapImageRep.FileType`
+    /// so that probe files are encoded in the correct format for their extension.
+    private static func bitmapFileType(for extension: String) -> NSBitmapImageRep.FileType {
+        switch `extension`.lowercased() {
+        case "jpg", "jpeg": return .jpeg
+        case "gif": return .gif
+        case "bmp": return .bmp
+        case "tiff", "tif": return .tiff
+        default: return .png
+        }
+    }
+
     /// Cache of sharing services by file extension. Services depend on file type,
     /// not content, so one discovery per extension per app session is sufficient.
     private static var sharingServicesCache: [String: [NSSharingService]] = [:]
@@ -159,7 +171,7 @@ private enum ImageActions {
             }
             if let tiff = tiny.tiffRepresentation,
                let rep = NSBitmapImageRep(data: tiff),
-               let data = rep.representation(using: .png, properties: [:]) {
+               let data = rep.representation(using: bitmapFileType(for: key), properties: [:]) {
                 try? data.write(to: probeURL)
             } else {
                 // Fallback: create the file with empty data so the path exists.


### PR DESCRIPTION
## Summary
Two fixes for scroll performance:

1. **Guard @Observable nil-writes in AvatarAppearanceManager** — On 404 responses from `workspace/file/content`, the manager unconditionally wrote nil to `@Observable` stored properties even when already nil. Swift's `@Observable` fires change notifications on every assignment regardless of equality, causing cascading `MessageListView.body` re-evaluations that tripped `ChatScrollLoopGuard` (40+ body evals in 2s → rainbow spinner). Fixed by guarding nil-writes with inequality checks.

2. **Encode sharing services probe file in correct format per extension** — The probe file was always PNG-encoded regardless of filename extension. For `.jpg`/`.heic` inputs, this wrote mismatched content which may cause `NSSharingService` to return reduced results. Fixed by mapping extensions to `NSBitmapImageRep.FileType`.

## Milestone PRs
- #20908: fix: guard @Observable nil-writes in AvatarAppearanceManager
- #20909: fix: encode sharing services probe file in correct format per extension

Closes #20905

## Test plan
- [ ] Open conversation, scroll up — no rainbow spinner or scroll loop guard tripping
- [ ] Check console logs — no repeated "Scroll loop detected" messages
- [ ] Right-click image → Share — all services appear for PNG, JPG, GIF files
- [ ] Click a Share service — works correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
