### PR TITLE
Mitigate managed workspace git ownership on startup

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -92,6 +92,7 @@ ENV IS_CONTAINERIZED=true
 
 # Copy from builder
 COPY --from=builder /app /app
+RUN chmod +x /app/assistant/docker-entrypoint.sh
 
 # Run the daemon + http server
-CMD ["bun", "run", "src/daemon/main.ts"]
+CMD ["/app/assistant/docker-entrypoint.sh"]

--- a/assistant/docker-entrypoint.sh
+++ b/assistant/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ "$(id -u)" = "0" ] && [ "${WORKSPACE_DIR:-}" = "/workspace" ] && [ -d /workspace ]; then
+  git config --global --add safe.directory /workspace >/dev/null 2>&1 || true
+fi
+
+exec bun run src/daemon/main.ts


### PR DESCRIPTION
## Summary
- add a small assistant container entrypoint that marks `/workspace` as a safe git directory before startup when managed containers run as root
- switch the assistant image startup command to use the entrypoint wrapper so the daemon starts after the git mitigation is applied

## Original prompt
--safe Short-term mitigation: add git config --global --add safe.directory /workspace at container startup if root is intentional.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
