### PR TITLE
fix: defer avatar follower update to prevent infinite layout cycle

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1193,7 +1193,15 @@ struct MessageListView: View {
                 guard case .accept(let accepted) = decision else { return }
                 recordScrollLoopEvent(.tailAnchorPreferenceChange)
                 scrollTracking.lastTailAnchorY = accepted
-                updateAvatarFollower(anchorY: accepted)
+                // Defer to next run loop to prevent synchronous layout re-entry
+                // on macOS. This preference fires during placeSubviews; calling
+                // withAnimation (inside applyAvatarDisplayY) synchronously causes
+                // _PaddingLayout.sizeThatFits to be re-entered, creating an infinite
+                // layout cycle when avatar properties change concurrently with a
+                // ToolConfirmationBubble in the message list.
+                Task { @MainActor in
+                    updateAvatarFollower(anchorY: accepted)
+                }
             }
             .transaction { $0.disablesAnimations = true }
             .onPreferenceChange(PaginationSentinelMinYKey.self) { sentinelMinY in


### PR DESCRIPTION
When ConversationTailAnchorYKey fires during a layout pass, updateAvatarFollower calls withAnimation{avatarDisplayY=y} which on macOS AppKit SwiftUI synchronously re-enters _PaddingLayout.sizeThatFits, creating an infinite layout recursion. This triggers when avatar properties change while a ToolConfirmationBubble is visible. Fix by deferring updateAvatarFollower to the next run loop cycle via Task{@MainActor}. Dead-zone tracking remains synchronous. Adds ~16ms delay to avatar position updates — imperceptible.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
