### PR TITLE
fix: defer avatar follower update to prevent infinite layout cycle

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1193,7 +1193,15 @@ struct MessageListView: View {
                 guard case .accept(let accepted) = decision else { return }
                 recordScrollLoopEvent(.tailAnchorPreferenceChange)
                 scrollTracking.lastTailAnchorY = accepted
-                updateAvatarFollower(anchorY: accepted)
+                // Defer to next run loop to prevent synchronous layout re-entry
+                // on macOS. This preference fires during placeSubviews; calling
+                // withAnimation (inside applyAvatarDisplayY) synchronously causes
+                // _PaddingLayout.sizeThatFits to be re-entered, creating an infinite
+                // layout cycle when avatar properties change concurrently with a
+                // ToolConfirmationBubble in the message list.
+                Task { @MainActor in
+                    updateAvatarFollower(anchorY: accepted)
+                }
             }
             .transaction { $0.disablesAnimations = true }
             .onPreferenceChange(PaginationSentinelMinYKey.self) { sentinelMinY in


### PR DESCRIPTION
## Summary
Fix an infinite SwiftUI layout cycle triggered when the user changes their avatar while a permission notification (ToolConfirmationBubble) is visible. The `ConversationTailAnchorYKey` preference fires during a layout pass, and `updateAvatarFollower` calls `withAnimation{avatarDisplayY=y}` which on macOS AppKit SwiftUI synchronously re-enters `_PaddingLayout.sizeThatFits`, creating infinite recursion (100% CPU, rainbow spinner, app frozen).

## Changes
- Defer `updateAvatarFollower(anchorY:)` call to the next run loop cycle via `Task { @MainActor in }` in the `ConversationTailAnchorYKey` preference handler
- Dead-zone tracking (`scrollTracking.lastTailAnchorY`) remains synchronous so preference filtering is unaffected
- Adds ~16ms (one frame) delay to avatar position updates — imperceptible

## Test plan
- [ ] Paste an image in chat, have assistant set it as avatar while a permission notification is showing — app should not freeze
- [ ] Scroll up/down — avatar should still follow the conversation tail smoothly
- [ ] Rapid avatar changes — no CPU spike or layout hang
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
