### PR TITLE
fix: send credential reads to /v1/secrets/read with the right type

### DIFF
--- a/assistant/src/__tests__/daemon-credential-client.test.ts
+++ b/assistant/src/__tests__/daemon-credential-client.test.ts
@@ -74,7 +74,6 @@ beforeEach(() => {
       );
     },
   );
-  mockFetch.preconnect = originalFetch.preconnect;
   globalThis.fetch = mockFetch as unknown as typeof globalThis.fetch;
 });
 

--- a/assistant/src/__tests__/daemon-credential-client.test.ts
+++ b/assistant/src/__tests__/daemon-credential-client.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { credentialKey } from "../security/credential-key.js";
+
+let fallbackValues = new Map<string, string>();
+
+mock.module("../config/env.js", () => ({
+  getRuntimeHttpHost: () => "127.0.0.1",
+  getRuntimeHttpPort: () => 4123,
+}));
+
+mock.module("../daemon/daemon-control.js", () => ({
+  healthCheckHost: (host: string) => host,
+  isHttpHealthy: async () => true,
+}));
+
+mock.module("../runtime/auth/token-service.js", () => ({
+  initAuthSigningKey: () => {},
+  loadOrCreateSigningKey: () => "signing-key",
+  mintDaemonDeliveryToken: () => "daemon-token",
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  deleteSecureKeyAsync: async () => "deleted" as const,
+  getSecureKeyAsync: async (account: string) => fallbackValues.get(account),
+  getSecureKeyResultAsync: async (account: string) => ({
+    value: fallbackValues.get(account),
+    unreachable: false,
+  }),
+  setSecureKeyAsync: async () => true,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  getSecureKeyResultViaDaemon,
+  getSecureKeyViaDaemon,
+} from "../cli/lib/daemon-credential-client.js";
+
+const originalFetch = globalThis.fetch;
+const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+
+function getRequestBody(index = 0): Record<string, unknown> {
+  const body = fetchCalls[index]?.init?.body;
+  if (typeof body !== "string") {
+    throw new Error("Expected fetch body to be a JSON string");
+  }
+  return JSON.parse(body) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  fallbackValues = new Map();
+  fetchCalls.length = 0;
+  globalThis.fetch = mock(
+    async (input: string | URL | Request, init?: RequestInit) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      fetchCalls.push({ url, init });
+      return new Response(
+        JSON.stringify({ found: true, value: "secret-value" }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    },
+  ) as typeof globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("daemon credential read requests", () => {
+  test("keeps provider secrets on the api_key path", async () => {
+    const value = await getSecureKeyViaDaemon("openai");
+
+    expect(value).toBe("secret-value");
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]?.url).toBe("http://127.0.0.1:4123/v1/secrets/read");
+    expect(getRequestBody()).toEqual({
+      type: "api_key",
+      name: "openai",
+      reveal: true,
+    });
+  });
+
+  test("converts canonical credential keys into credential reads", async () => {
+    const value = await getSecureKeyViaDaemon(
+      credentialKey("vellum", "platform_base_url"),
+    );
+
+    expect(value).toBe("secret-value");
+    expect(getRequestBody()).toEqual({
+      type: "credential",
+      name: "vellum:platform_base_url",
+      reveal: true,
+    });
+  });
+
+  test("preserves compound credential service names on metadata reads", async () => {
+    const result = await getSecureKeyResultViaDaemon(
+      credentialKey("integration:google", "client_secret"),
+    );
+
+    expect(result).toEqual({ value: "secret-value", unreachable: false });
+    expect(getRequestBody()).toEqual({
+      type: "credential",
+      name: "integration:google:client_secret",
+      reveal: true,
+    });
+  });
+});

--- a/assistant/src/__tests__/daemon-credential-client.test.ts
+++ b/assistant/src/__tests__/daemon-credential-client.test.ts
@@ -56,7 +56,7 @@ function getRequestBody(index = 0): Record<string, unknown> {
 beforeEach(() => {
   fallbackValues = new Map();
   fetchCalls.length = 0;
-  globalThis.fetch = mock(
+  const mockFetch = mock(
     async (input: string | URL | Request, init?: RequestInit) => {
       const url =
         typeof input === "string"
@@ -73,7 +73,9 @@ beforeEach(() => {
         },
       );
     },
-  ) as typeof globalThis.fetch;
+  );
+  mockFetch.preconnect = originalFetch.preconnect;
+  globalThis.fetch = mockFetch as unknown as typeof globalThis.fetch;
 });
 
 afterEach(() => {

--- a/assistant/src/cli/lib/daemon-credential-client.ts
+++ b/assistant/src/cli/lib/daemon-credential-client.ts
@@ -9,10 +9,8 @@
 
 import providerEnvVarsRegistry from "../../../../meta/provider-env-vars.json" with { type: "json" };
 import { getRuntimeHttpHost, getRuntimeHttpPort } from "../../config/env.js";
-import {
-  healthCheckHost,
-  isHttpHealthy,
-} from "../../daemon/daemon-control.js";
+import { API_KEY_PROVIDERS } from "../../config/loader.js";
+import { healthCheckHost, isHttpHealthy } from "../../daemon/daemon-control.js";
 import {
   initAuthSigningKey,
   loadOrCreateSigningKey,
@@ -30,6 +28,7 @@ import {
 import { getLogger } from "../../util/logger.js";
 
 const log = getLogger("daemon-credential-client");
+const CREDENTIAL_KEY_PREFIX = "credential/";
 
 const PROVIDER_ENV_VARS: Record<string, string> =
   providerEnvVarsRegistry.providers;
@@ -117,6 +116,31 @@ function deriveCredentialStorageKey(name: string): string {
   return credentialKey(service, field);
 }
 
+function deriveReadSecretRequest(account: string): {
+  type: "api_key" | "credential";
+  name: string;
+} {
+  if (account.startsWith(CREDENTIAL_KEY_PREFIX)) {
+    const rest = account.slice(CREDENTIAL_KEY_PREFIX.length);
+    const slashIdx = rest.indexOf("/");
+    if (slashIdx > 0 && slashIdx < rest.length - 1) {
+      return {
+        type: "credential",
+        name: `${rest.slice(0, slashIdx)}:${rest.slice(slashIdx + 1)}`,
+      };
+    }
+  }
+
+  if (
+    account.includes(":") &&
+    !API_KEY_PROVIDERS.includes(account as (typeof API_KEY_PROVIDERS)[number])
+  ) {
+    return { type: "credential", name: account };
+  }
+
+  return { type: "api_key", name: account };
+}
+
 // ---------------------------------------------------------------------------
 // Exported wrapper functions
 // ---------------------------------------------------------------------------
@@ -129,9 +153,10 @@ function deriveCredentialStorageKey(name: string): string {
 export async function getSecureKeyViaDaemon(
   account: string,
 ): Promise<string | undefined> {
+  const request = deriveReadSecretRequest(account);
   const res = await daemonFetch("/v1/secrets/read", {
     method: "POST",
-    body: JSON.stringify({ type: "api_key", name: account, reveal: true }),
+    body: JSON.stringify({ ...request, reveal: true }),
   });
 
   if (res?.ok) {
@@ -152,9 +177,10 @@ export async function getSecureKeyViaDaemon(
 export async function getSecureKeyResultViaDaemon(
   account: string,
 ): Promise<SecureKeyResult> {
+  const request = deriveReadSecretRequest(account);
   const res = await daemonFetch("/v1/secrets/read", {
     method: "POST",
-    body: JSON.stringify({ type: "api_key", name: account, reveal: true }),
+    body: JSON.stringify({ ...request, reveal: true }),
   });
 
   if (res?.ok) {
@@ -203,7 +229,8 @@ export async function setSecureKeyViaDaemon(
   // Daemon unreachable — fall back to direct write.
   // For credentials, derive the canonical storage key (credential/service/field)
   // to match the daemon path which uses credentialKey().
-  const storageKey = type === "credential" ? deriveCredentialStorageKey(name) : name;
+  const storageKey =
+    type === "credential" ? deriveCredentialStorageKey(name) : name;
   return setSecureKeyAsync(storageKey, value);
 }
 
@@ -235,7 +262,8 @@ export async function deleteSecureKeyViaDaemon(
   // Daemon unreachable — fall back to direct delete.
   // For credentials, derive the canonical storage key (credential/service/field)
   // to match the daemon path which uses credentialKey().
-  const storageKey = type === "credential" ? deriveCredentialStorageKey(name) : name;
+  const storageKey =
+    type === "credential" ? deriveCredentialStorageKey(name) : name;
   return deleteSecureKeyAsync(storageKey);
 }
 


### PR DESCRIPTION
## Summary
- fix daemon credential reads to infer whether a lookup is for an API provider key or a stored credential path before calling `/v1/secrets/read`
- convert canonical `credential/...` keys into the `service:field` format the runtime secret route expects, including compound service names
- add a focused regression test covering provider keys, canonical credential keys, and compound credential services

## Original prompt
--safe Fix the daemon secret-read helper so credential-backed lookups stop sending `type: "api_key"` and returning 400s from `/v1/secrets/read`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
