### PR TITLE
fix: remove ellipsis from Uninstall Vellum button

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -215,7 +215,7 @@ struct SettingsGeneralTab: View {
             title: "Uninstall",
             subtitle: "Stops all assistants, archives your data, and moves Vellum to the Trash"
         ) {
-            VButton(label: "Uninstall Vellum...", style: .danger) {
+            VButton(label: "Uninstall Vellum", style: .danger) {
                 AppDelegate.shared?.performUninstall()
             }
         }


### PR DESCRIPTION
## Summary
- Remove trailing ellipsis from "Uninstall Vellum..." button in Settings General tab so it reads "Uninstall Vellum"

## Original prompt
remove ellipsis from Uninstall Vellum... button, should just Say Uninstall Vellum
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
