### PR TITLE
fix(security): fix TS2552 resolveBackend reference in getActiveBackendName

### DIFF
--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -32,7 +32,10 @@ import type {
 } from "./credential-backend.js";
 import { createEncryptedStoreBackend } from "./credential-backend.js";
 
-export type { CredentialListResult, DeleteResult } from "./credential-backend.js";
+export type {
+  CredentialListResult,
+  DeleteResult,
+} from "./credential-backend.js";
 
 /**
  * Re-export shared-package secure-key abstractions so downstream consumers
@@ -93,7 +96,9 @@ async function doResolveBackend(): Promise<CredentialBackend> {
       _resolvedBackend = cesRpc;
       return cesRpc;
     }
-    log.warn("CES RPC client is set but not ready — falling back to local credential store");
+    log.warn(
+      "CES RPC client is set but not ready — falling back to local credential store",
+    );
   }
 
   // 2. CES HTTP — containerized / Docker / managed mode
@@ -250,7 +255,7 @@ export async function getMaskedProviderKey(
  * Useful for diagnostic messages when credential operations fail.
  */
 export function getActiveBackendName(): string {
-  return resolveBackend().name;
+  return _resolvedBackend?.name ?? "none";
 }
 
 /** @internal Test-only: reset the cached backends so they're re-created. */


### PR DESCRIPTION
## Summary
- `getActiveBackendName()` called a non-existent synchronous `resolveBackend()` — the actual function is `resolveBackendAsync()` (async)
- Fixed by returning `_resolvedBackend?.name ?? "none"` which uses the already-cached resolved backend, matching the diagnostic intent of the helper

## Original prompt
Fix this typecheck quickly src/security/secure-keys.ts(253,10): error TS2552: Cannot find name 'resolveBackend'. Did you mean '_resolvedBackend'?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
