### PR TITLE
fix: scroll to bottom when conversation history loads after layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -613,7 +613,7 @@ struct MessageListView: View {
                 log.debug("Scroll restore: stage 2 (200ms) — retrying via coordinator")
             } else {
                 os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=2 action=skipped")
-                log.debug("Scroll restore: stage 2 skipped (anchor=\(String(describing: anchorMessageId)) scrollEvent=\(hasReceivedScrollEvent))")
+                log.debug("Scroll restore: stage 2 skipped (anchor=\(String(describing: anchorMessageId), privacy: .public) scrollEvent=\(hasReceivedScrollEvent) outcome=\(String(describing: restoreOutcome), privacy: .public) anchorMinY=\(anchorTracker.lastMinY) viewportH=\(scrollViewportHeight) msgCount=\(messages.count))")
             }
 
             if !Task.isCancelled { scrollRestoreTask = nil }
@@ -1174,7 +1174,17 @@ struct MessageListView: View {
                     os_signpost(.begin, log: PerfSignposts.log, name: "anchorMinYPreferenceChange")
                     recordScrollLoopEvent(.anchorPreferenceChange)
                     anchorTracker.update(minY: accepted, viewportHeight: scrollViewportHeight)
-                    if !hasFreshAnchorMeasurement { hasFreshAnchorMeasurement = true }
+                    if !hasFreshAnchorMeasurement {
+                        hasFreshAnchorMeasurement = true
+                        // First finite anchor measurement after a conversation switch.
+                        // LazyVStack may report the anchor as "within viewport" before
+                        // materializing message cells, causing the coordinator to skip
+                        // the scrollTo. Bypass the coordinator and scroll directly so
+                        // messages are visible without user interaction.
+                        if !hasReceivedScrollEvent && anchorMessageId == nil {
+                            proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                        }
+                    }
                     scheduleTranscriptSnapshot()
                     // Geometry tracking only — no per-frame scrollTo calls here.
                     // All bottom-follow work is handled by the ChatBottomPinCoordinator
@@ -1451,6 +1461,7 @@ struct MessageListView: View {
                     // History just loaded but the coordinator's initial-restore session
                     // may have already expired (500ms timeout). Force a fresh scroll-to-bottom
                     // so messages are visible without requiring user scroll interaction.
+                    log.debug("Scroll restore fallback: messages.count=\(messages.count) isNearBottom=\(isNearBottom) isSuppressing=\(isSuppressingBottomScroll)")
                     requestBottomPin(reason: .initialRestore, proxy: proxy)
                 } else if isSuppressingBottomScroll {
                     log.debug("Auto-scroll suppressed (bottom-scroll suppression active)")

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -613,7 +613,7 @@ struct MessageListView: View {
                 log.debug("Scroll restore: stage 2 (200ms) — retrying via coordinator")
             } else {
                 os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=2 action=skipped")
-                log.debug("Scroll restore: stage 2 skipped (anchor=\(String(describing: anchorMessageId), privacy: .public) scrollEvent=\(hasReceivedScrollEvent) outcome=\(String(describing: restoreOutcome), privacy: .public) anchorMinY=\(anchorTracker.lastMinY) viewportH=\(scrollViewportHeight) msgCount=\(messages.count))")
+                log.debug("Scroll restore: stage 2 skipped (anchor=\(String(describing: anchorMessageId)) scrollEvent=\(hasReceivedScrollEvent))")
             }
 
             if !Task.isCancelled { scrollRestoreTask = nil }
@@ -1461,7 +1461,6 @@ struct MessageListView: View {
                     // History just loaded but the coordinator's initial-restore session
                     // may have already expired (500ms timeout). Force a fresh scroll-to-bottom
                     // so messages are visible without requiring user scroll interaction.
-                    log.debug("Scroll restore fallback: messages.count=\(messages.count) isNearBottom=\(isNearBottom) isSuppressing=\(isSuppressingBottomScroll)")
                     requestBottomPin(reason: .initialRestore, proxy: proxy)
                 } else if isSuppressingBottomScroll {
                     log.debug("Auto-scroll suppressed (bottom-scroll suppression active)")

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1447,6 +1447,11 @@ struct MessageListView: View {
                 }
                 if isNearBottom && !isSuppressingBottomScroll && anchorMessageId == nil {
                     requestBottomPin(reason: .messageCount, proxy: proxy, animated: true)
+                } else if !hasReceivedScrollEvent && anchorMessageId == nil && !messages.isEmpty {
+                    // History just loaded but the coordinator's initial-restore session
+                    // may have already expired (500ms timeout). Force a fresh scroll-to-bottom
+                    // so messages are visible without requiring user scroll interaction.
+                    requestBottomPin(reason: .initialRestore, proxy: proxy)
                 } else if isSuppressingBottomScroll {
                     log.debug("Auto-scroll suppressed (bottom-scroll suppression active)")
                 }


### PR DESCRIPTION
## Summary
Fix messages not appearing when switching conversations — the user sees an empty chat until they manually scroll.

### Root cause
When switching conversations, `restoreScrollToBottom` fires immediately but messages are empty (history hasn't loaded yet). The `ChatBottomPinCoordinator` retries for 500ms then gives up. When history finally loads, `LazyVStack` reports the `scroll-bottom-anchor` as "within viewport" before materializing message cells, so the coordinator's policy returns `.anchored` and skips the `scrollTo` call. Messages exist in the data but are below the fold in unmaterialized LazyVStack placeholders.

### Fix
1. When `AnchorMinYKey` reports its first finite measurement after a conversation switch (`hasFreshAnchorMeasurement` transitions to true), call `proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)` directly — bypassing the coordinator's "already anchored" policy check
2. Add a fallback in `onChange(of: messages.count)` for cases where the coordinator session expired before history loaded

Both paths only fire when the user hasn't scrolled yet (`!hasReceivedScrollEvent`) and no deep-link anchor is active.

## Changes
- `MessageListView.swift`: Direct `scrollTo` on first anchor measurement + fallback on message count change

## Test plan
- [ ] Open app, click on a conversation — messages appear at bottom immediately
- [ ] Switch between conversations quickly — messages appear each time
- [ ] Scroll up in a conversation, switch away and back — scroll position resets to bottom
- [ ] Deep-link to a specific message — still scrolls to that message (not bottom)
- [ ] Send a message while at bottom — auto-scrolls to show new message
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
