### PR TITLE
perf: gate reflectScrolledClipView on actual value changes

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1983,6 +1983,7 @@ private struct ConversationScrollbarVisibilityController: NSViewRepresentable, E
         }
 
         func update(isAppActive: Bool, suppressScrollbar: Bool) {
+            guard isAppActive != self.isAppActive || suppressScrollbar != self.suppressScrollbar else { return }
             let wasActive = self.isAppActive
             self.isAppActive = isAppActive
             self.suppressScrollbar = suppressScrollbar


### PR DESCRIPTION
ConversationScrollbarVisibilityController.update() was calling updateVisibility() (which triggers reflectScrolledClipView) on every MessageListView body re-evaluation, even when isAppActive and suppressScrollbar hadn't changed. Add early return guard.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
