### PR TITLE
perf: use static DateFormatter instances in ChatBubble and TimestampDivider

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -212,6 +212,7 @@ struct ChatBubble: View {
 
     private static let timeFormatter: DateFormatter = {
         let f = DateFormatter()
+        f.locale = .autoupdatingCurrent
         f.dateStyle = .none
         f.timeStyle = .short
         return f
@@ -219,12 +220,14 @@ struct ChatBubble: View {
 
     private static let dayFormatter: DateFormatter = {
         let f = DateFormatter()
+        f.locale = .autoupdatingCurrent
         f.dateFormat = "MMM d"
         return f
     }()
 
     private static let detailedFormatter: DateFormatter = {
         let f = DateFormatter()
+        f.locale = .autoupdatingCurrent
         f.dateStyle = .full
         f.timeStyle = .long
         return f

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -210,32 +210,44 @@ struct ChatBubble: View {
             .frame(maxWidth: message.isError ? .infinity : VSpacing.chatBubbleMaxWidth, alignment: isUser ? .trailing : .leading)
     }
 
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .none
+        f.timeStyle = .short
+        return f
+    }()
+
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"
+        return f
+    }()
+
+    private static let detailedFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .full
+        f.timeStyle = .long
+        return f
+    }()
+
     private var formattedTimestamp: String {
         let tz = ChatTimestampTimeZone.resolve()
         var calendar = Calendar.current
         calendar.timeZone = tz
-        let formatter = DateFormatter()
-        formatter.timeZone = tz
-        formatter.dateStyle = .none
-        formatter.timeStyle = .short
-        let timeString = formatter.string(from: message.timestamp)
+        Self.timeFormatter.timeZone = tz
+        let timeString = Self.timeFormatter.string(from: message.timestamp)
         if calendar.isDateInToday(message.timestamp) {
             return "Today, \(timeString)"
         } else {
-            let dayFormatter = DateFormatter()
-            dayFormatter.timeZone = tz
-            dayFormatter.dateFormat = "MMM d"
-            return "\(dayFormatter.string(from: message.timestamp)), \(timeString)"
+            Self.dayFormatter.timeZone = tz
+            return "\(Self.dayFormatter.string(from: message.timestamp)), \(timeString)"
         }
     }
 
     private var detailedTimestamp: String {
         let tz = ChatTimestampTimeZone.resolve()
-        let formatter = DateFormatter()
-        formatter.timeZone = tz
-        formatter.dateStyle = .full
-        formatter.timeStyle = .long
-        return formatter.string(from: message.timestamp)
+        Self.detailedFormatter.timeZone = tz
+        return Self.detailedFormatter.string(from: message.timestamp)
     }
 
     /// Surfaces not currently shown in the floating overlay, computed once per body evaluation.

--- a/clients/macos/vellum-assistant/Features/Chat/TimestampDivider.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/TimestampDivider.swift
@@ -55,12 +55,14 @@ struct TimestampDivider: View {
 
     private static let timeFormatter: DateFormatter = {
         let f = DateFormatter()
+        f.locale = .autoupdatingCurrent
         f.dateFormat = "h:mm a"
         return f
     }()
 
     private static let dayFormatter: DateFormatter = {
         let f = DateFormatter()
+        f.locale = .autoupdatingCurrent
         f.dateFormat = "MMM d"
         return f
     }()

--- a/clients/macos/vellum-assistant/Features/Chat/TimestampDivider.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/TimestampDivider.swift
@@ -53,23 +53,31 @@ enum ChatTimestampTimeZone {
 struct TimestampDivider: View {
     let date: Date
 
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "h:mm a"
+        return f
+    }()
+
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"
+        return f
+    }()
+
     private var formattedTime: String {
         let tz = ChatTimestampTimeZone.resolve()
         var calendar = Calendar.current
         calendar.timeZone = tz
-        let formatter = DateFormatter()
-        formatter.timeZone = tz
-        formatter.dateFormat = "h:mm a"
-        let timeString = formatter.string(from: date)
+        Self.timeFormatter.timeZone = tz
+        let timeString = Self.timeFormatter.string(from: date)
         if calendar.isDateInToday(date) {
             return "Today at \(timeString)"
         } else if calendar.isDateInYesterday(date) {
             return "Yesterday at \(timeString)"
         } else {
-            let dayFormatter = DateFormatter()
-            dayFormatter.timeZone = tz
-            dayFormatter.dateFormat = "MMM d"
-            return "\(dayFormatter.string(from: date)) at \(timeString)"
+            Self.dayFormatter.timeZone = tz
+            return "\(Self.dayFormatter.string(from: date)) at \(timeString)"
         }
     }
 


### PR DESCRIPTION
Replace per-body DateFormatter() allocations with static let instances. DateFormatter init is one of the most expensive ObjC bridge operations — with 50 visible bubbles this eliminates 100+ allocations per render pass. Timezone is still set per-call since it can change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
