### PR TITLE
perf: cache isAnimatedGIF result in @State instead of computing in body

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
@@ -16,6 +16,7 @@ struct AnimatedImageView: View {
     @State private var loadedImage: NSImage?
     @State private var imageData: Data?
     @State private var isLoading = true
+    @State private var isGIF: Bool = false
     @Environment(\.displayScale) private var displayScale
 
     // MARK: - In-memory cache
@@ -49,7 +50,7 @@ struct AnimatedImageView: View {
 
     var body: some View {
         Group {
-            if let data = imageData, isAnimatedGIF(data) {
+            if let data = imageData, isGIF {
                 GIFView(data: data)
                     .frame(
                         width: min(gifSize.width, maxDimension),
@@ -150,6 +151,7 @@ struct AnimatedImageView: View {
         if let entry = Self.cache.object(forKey: effectiveKey) {
             self.loadedImage = entry.image
             self.imageData = entry.gifData
+            self.isGIF = entry.gifData != nil
             return
         }
 
@@ -157,6 +159,7 @@ struct AnimatedImageView: View {
         if let fileURL = localFileURL {
             imageData = try? Data(contentsOf: fileURL)
             loadedImage = imageData.flatMap { NSImage(data: $0) }
+            if let data = imageData { isGIF = isAnimatedGIF(data) }
             cacheLoadedImage(forKey: effectiveKey)
             return
         }
@@ -168,6 +171,7 @@ struct AnimatedImageView: View {
             let data = try await ImageCache.shared.imageData(for: url)
             self.imageData = data
             self.loadedImage = NSImage(data: data)
+            self.isGIF = isAnimatedGIF(data)
             cacheLoadedImage(forKey: effectiveKey)
         } catch {
             // Keep placeholder on failure
@@ -185,8 +189,8 @@ struct AnimatedImageView: View {
         let pixelWidth = rep?.pixelsWide ?? Int(image.size.width)
         let pixelHeight = rep?.pixelsHigh ?? Int(image.size.height)
         let imageCost = pixelWidth * pixelHeight * 4
-        let gifDataCost = imageData.map { isAnimatedGIF($0) ? $0.count : 0 } ?? 0
-        let gifData = imageData.flatMap { isAnimatedGIF($0) ? $0 : nil }
+        let gifDataCost = imageData.map { isGIF ? $0.count : 0 } ?? 0
+        let gifData = imageData.flatMap { isGIF ? $0 : nil }
 
         let entry = CachedImageEntry(image: image, gifData: gifData)
         Self.cache.setObject(entry, forKey: key, cost: imageCost + gifDataCost)


### PR DESCRIPTION
## Summary
- Cache the `isAnimatedGIF` result in a `@State private var isGIF` property instead of calling `CGImageSourceCreateWithData` on every SwiftUI body evaluation
- `isGIF` is computed once when image data is loaded (local file, remote URL, or cache hit) and reused in `body` and `cacheLoadedImage`

## Test plan
- [ ] Load a conversation containing animated GIFs — verify they still animate correctly
- [ ] Load a conversation with static images — verify they render correctly (not treated as GIFs)
- [ ] Scroll rapidly through a conversation with mixed images — confirm smoother performance
- [ ] Verify cache hits restore GIF state correctly (navigate away and back to a conversation with GIFs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
