### PR TITLE
fix: pass avatarPath on avatar_updated so avatar changes apply immediately

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -256,8 +256,8 @@ extension AppDelegate {
                             "home": msg.home
                         ]
                     )
-                case .avatarUpdated:
-                    AvatarAppearanceManager.shared.reloadAvatar()
+                case .avatarUpdated(let msg):
+                    AvatarAppearanceManager.shared.reloadAvatar(avatarPath: msg.avatarPath)
                 // Host tool execution — run locally and post results back
                 case .hostBashRequest(let msg):
                     HostToolExecutor.executeHostBashRequest(msg)


### PR DESCRIPTION
## Summary
- The `avatar_updated` WebSocket message handler was not binding the message payload (`case .avatarUpdated:` instead of `case .avatarUpdated(let msg):`)
- This meant `reloadAvatar()` was called without the `avatarPath`, skipping the fast path that loads the new avatar image directly from disk
- The dock icon and chat avatar would not update until an async HTTP fetch completed — which could silently fail, leaving the old avatar visible

## Fix
Bind the `AvatarUpdated` message and pass `msg.avatarPath` to `reloadAvatar(avatarPath:)`, enabling the immediate disk-based update path.

## Test plan
- [ ] Change avatar via chat (e.g. "set your avatar to a cat")
- [ ] Verify dock icon updates immediately without needing to restart or manually refresh
- [ ] Verify chat avatar also reflects the new image

Fixes JARVIS-322

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
