### PR TITLE
perf: add signpost landmarks and invalidation counters for layout stall diagnosis

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 import VellumAssistantShared
 
 private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "MessageListView")
+private let stallLog = OSLog(subsystem: "com.vellum.assistant", category: "LayoutStall")
 
 // MARK: - Scroll Suppression Environment
 
@@ -940,6 +941,7 @@ struct MessageListView: View {
                     }
 
                     let _ = recordScrollLoopEvent(.bodyEvaluation)
+                    os_signpost(.event, log: stallLog, name: "MessageList.bodyEval")
                     let state = precomputedState
                     let catalogHash = MessageCellView.hashCatalog(providerCatalog)
                     ForEach(state.displayMessages) { message in

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -6,6 +6,7 @@ import os
 import Combine
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ConversationManager")
+private let stallLog = OSLog(subsystem: "com.vellum.assistant", category: "LayoutStall")
 // Legacy UserDefaults key preserved from the session-to-conversation rename.
 private let archivedConversationsKey = "archivedSessionIds"
 // Intermediate builds may have written under this key before the compat fix.
@@ -2000,6 +2001,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     /// Evict the oldest cached ChatViewModel that is not the active conversation,
     /// keeping at most `maxCachedViewModels` entries in the dictionary.
     private func evictStaleCachedViewModels() {
+        var evictedCount = 0
         while chatViewModels.count > maxCachedViewModels {
             // Find the oldest non-active, non-busy VM so we never cancel an in-flight response
             // just because the user switched conversations.
@@ -2012,7 +2014,11 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             chatViewModels.removeValue(forKey: victim)
             unsubscribeFromBusyState(for: victim)
             vmAccessOrder.removeAll { $0 == victim }
+            evictedCount += 1
             log.info("LRU evicted VM for conversation \(victim)")
+        }
+        if evictedCount > 0 {
+            os_signpost(.event, log: stallLog, name: "LRU.evict", "%{public}d VMs", evictedCount)
         }
     }
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -138,10 +138,13 @@ public final class ChatViewModel: ObservableObject {
     private func flushCoalescedPublish() {
         subManagerPublishTask?.cancel()
         subManagerPublishTask = nil
+        os_signpost(.event, log: Self.stallLog, name: "ChatVM.flush")
         objectWillChange.send()
     }
 
     // MARK: - Debug publish-rate counters
+
+    private static let stallLog = OSLog(subsystem: "com.vellum.assistant", category: "LayoutStall")
 
     #if DEBUG
     private static let perfLog = OSLog(subsystem: "com.vellum.assistant", category: "PerfCounters")
@@ -1241,6 +1244,7 @@ public final class ChatViewModel: ObservableObject {
     }
 
     public func sendMessage(hidden: Bool = false) {
+        os_signpost(.event, log: Self.stallLog, name: "sendMessage")
         let rawText = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
         let text = rawText
         let hasAttachments = !pendingAttachments.isEmpty


### PR DESCRIPTION
## Summary
- Add os_signpost timeline landmarks at sendMessage(), flushCoalescedPublish(), and LRU eviction in ConversationManager
- Add body-evaluation signpost in MessageListView at the existing recordScrollLoopEvent site
- All signposts use consistent 'com.vellum.assistant' subsystem and 'LayoutStall' category for unified Instruments filtering

Part of plan: fix-main-thread-stall.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20934" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
