### PR TITLE
refactor: replace vmAccessOrder.removeAll with indexed removal across all call sites

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -527,7 +527,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         conversations.remove(at: index)
         chatViewModels.removeValue(forKey: id)
         unsubscribeAllForConversation(id: id)
-        vmAccessOrder.removeAll { $0 == id }
+        if let idx = vmAccessOrder.firstIndex(of: id) {
+            vmAccessOrder.remove(at: idx)
+        }
         Self.clearRenderCaches()
 
         // Delete the conversation on the backend (fire-and-forget)
@@ -633,7 +635,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         conversations.remove(at: index)
         chatViewModels.removeValue(forKey: id)
         unsubscribeAllForConversation(id: id)
-        vmAccessOrder.removeAll { $0 == id }
+        if let idx = vmAccessOrder.firstIndex(of: id) {
+            vmAccessOrder.remove(at: idx)
+        }
 
         // Reclaim memory held by static caches that may reference
         // messages from the closed conversation.
@@ -687,7 +691,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             // Conversation ID already known — safe to release the view model.
             chatViewModels.removeValue(forKey: id)
             unsubscribeAllForConversation(id: id)
-            vmAccessOrder.removeAll { $0 == id }
+            if let idx = vmAccessOrder.firstIndex(of: id) {
+                vmAccessOrder.remove(at: idx)
+            }
         } else if chatViewModels[id]?.messages.contains(where: { $0.role == .user }) != true
                     && chatViewModels[id]?.isBootstrapping != true {
             chatViewModels[id]?.stopGenerating()
@@ -696,7 +702,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             // Clean up immediately.
             chatViewModels.removeValue(forKey: id)
             unsubscribeAllForConversation(id: id)
-            vmAccessOrder.removeAll { $0 == id }
+            if let idx = vmAccessOrder.firstIndex(of: id) {
+                vmAccessOrder.remove(at: idx)
+            }
         } else {
             // Conversation ID is nil but a conversation is expected (user messages exist
             // or bootstrap is in flight, e.g. a workspace refinement that
@@ -1360,7 +1368,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     func removeChatViewModel(for conversationId: UUID) {
         chatViewModels.removeValue(forKey: conversationId)
         unsubscribeAllForConversation(id: conversationId)
-        vmAccessOrder.removeAll { $0 == conversationId }
+        if let idx = vmAccessOrder.firstIndex(of: conversationId) {
+            vmAccessOrder.remove(at: idx)
+        }
     }
 
     /// Called when the user responds to a confirmation via the inline chat UI.
@@ -1811,7 +1821,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         conversations.removeAll { $0.id == previousId }
         chatViewModels.removeValue(forKey: previousId)
         unsubscribeAllForConversation(id: previousId)
-        vmAccessOrder.removeAll { $0 == previousId }
+        if let idx = vmAccessOrder.firstIndex(of: previousId) {
+            vmAccessOrder.remove(at: idx)
+        }
         log.info("Removed abandoned empty conversation \(previousId)")
     }
 
@@ -1841,7 +1853,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             archivedConversationIds = archived
             chatViewModels.removeValue(forKey: localId)
             unsubscribeAllForConversation(id: localId)
-            vmAccessOrder.removeAll { $0 == localId }
+            if let idx = vmAccessOrder.firstIndex(of: localId) {
+                vmAccessOrder.remove(at: idx)
+            }
         }
         // Re-send ordering now that this conversation has a conversation ID.
         // Any drag/pin actions performed before the daemon assigned
@@ -1993,7 +2007,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
 
     /// Move `conversationId` to the end of `vmAccessOrder` (most-recently-used position).
     private func touchVMAccessOrder(_ conversationId: UUID) {
-        vmAccessOrder.removeAll { $0 == conversationId }
+        if let idx = vmAccessOrder.firstIndex(of: conversationId) {
+            vmAccessOrder.remove(at: idx)
+        }
         vmAccessOrder.append(conversationId)
     }
 
@@ -2011,7 +2027,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             }
             chatViewModels.removeValue(forKey: victim)
             unsubscribeFromBusyState(for: victim)
-            vmAccessOrder.removeAll { $0 == victim }
+            if let idx = vmAccessOrder.firstIndex(of: victim) {
+                vmAccessOrder.remove(at: idx)
+            }
             log.info("LRU evicted VM for conversation \(victim)")
         }
     }


### PR DESCRIPTION
## Summary
- Replace all `vmAccessOrder.removeAll { $0 == id }` calls with `firstIndex(of:)` + `remove(at:)` 
- Covers `touchVMAccessOrder`, `evictStaleCachedViewModels`, `removePrivateConversation`, `removeChatViewModel`, `closeConversation`, `removeAbandonedEmptyConversation`, and `onConversationCreated`
- Clearer intent (single-element removal) and avoids full array filter+rebuild

Part of plan: fix-main-thread-stall.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
