### PR TITLE
perf: convert SidebarConversationItem to pure value view to stop broad invalidation

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -135,6 +135,70 @@ extension MainWindowView {
         }
     }
 
+    // MARK: - Sidebar Row Factory
+
+    private func isConversationSelected(_ conversation: ConversationModel) -> Bool {
+        switch windowState.selection {
+        case .panel:
+            return false
+        case .conversation(let id):
+            return id == conversation.id
+        case .appEditing(_, let conversationId):
+            return conversationId == conversation.id
+        case .app, .none:
+            return conversation.id == windowState.persistentConversationId
+        }
+    }
+
+    /// Builds a `SidebarConversationItem` with all state pre-resolved and closures wired,
+    /// so each row is a pure value view that can be skipped via `Equatable`.
+    func makeSidebarRow(
+        conversation: ConversationModel,
+        onSelect: (() -> Void)? = nil
+    ) -> SidebarConversationItem {
+        SidebarConversationItem(
+            conversation: conversation,
+            isSelected: isConversationSelected(conversation),
+            interactionState: conversationManager.interactionState(for: conversation.id),
+            isHovered: sidebar.isHoveredConversation == conversation.id,
+            isPendingDeletion: sidebar.conversationPendingDeletion == conversation.id,
+            selectConversation: { selectConversation(conversation) },
+            onSelect: onSelect,
+            onTogglePin: {
+                withAnimation(VAnimation.standard) {
+                    if conversation.isPinned {
+                        conversationManager.unpinConversation(id: conversation.id)
+                    } else {
+                        conversationManager.pinConversation(id: conversation.id)
+                    }
+                }
+            },
+            onArchive: { conversationManager.archiveConversation(id: conversation.id) },
+            onBeginArchive: { sidebar.conversationPendingDeletion = conversation.id },
+            onConfirmArchive: {
+                conversationManager.archiveConversation(id: conversation.id)
+                sidebar.conversationPendingDeletion = nil
+            },
+            onStartRename: {
+                sidebar.renamingConversationId = conversation.id
+                sidebar.renameText = conversation.title
+            },
+            onMarkUnread: { conversationManager.markConversationUnread(conversationId: conversation.id) },
+            onHoverChange: { hovering in
+                withAnimation(VAnimation.fast) {
+                    sidebar.setConversationHover(conversationId: conversation.id, hovering: hovering)
+                }
+            },
+            onDragStart: {
+                sidebar.draggingConversationId = conversation.id
+                sidebar.isHoveredConversation = nil
+            },
+            onShowFeedback: conversation.conversationId != nil && !LogExporter.isManagedAssistant ? {
+                AppDelegate.shared?.showLogReportWindow(scope: .conversation(conversationId: conversation.conversationId!, conversationTitle: conversation.title))
+            } : nil
+        )
+    }
+
     // MARK: - Pinned App Helpers
 
     /// A pinned app row — delegates layout to `SidebarPrimaryRow` for both
@@ -226,13 +290,8 @@ extension MainWindowView {
                     }
 
                     ForEach(displayedConversations) { conversation in
-                        SidebarConversationItem(
-                            conversation: conversation,
-                            conversationManager: conversationManager,
-                            windowState: windowState,
-                            sidebar: sidebar,
-                            selectConversation: { selectConversation(conversation) }
-                        )
+                        makeSidebarRow(conversation: conversation)
+                            .equatable()
                             .padding(.bottom, SidebarLayoutMetrics.listRowGap)
                             .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
                                 if sidebar.dropTargetConversationId == conversation.id {
@@ -296,13 +355,8 @@ extension MainWindowView {
                         ForEach(displayedScheduleGroups, id: \.key) { group in
                             if group.conversations.count == 1, let conversation = group.conversations.first {
                                 // Single-conversation group: render inline without a disclosure wrapper
-                                SidebarConversationItem(
-                                    conversation: conversation,
-                                    conversationManager: conversationManager,
-                                    windowState: windowState,
-                                    sidebar: sidebar,
-                                    selectConversation: { selectConversation(conversation) }
-                                )
+                                makeSidebarRow(conversation: conversation)
+                                    .equatable()
                                     .padding(.bottom, SidebarLayoutMetrics.listRowGap)
                                     .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
                                         if sidebar.dropTargetConversationId == conversation.id {
@@ -376,13 +430,8 @@ extension MainWindowView {
                                 // Expanded child rows
                                 if isGroupExpanded {
                                     ForEach(group.conversations) { conversation in
-                                        SidebarConversationItem(
-                                            conversation: conversation,
-                                            conversationManager: conversationManager,
-                                            windowState: windowState,
-                                            sidebar: sidebar,
-                                            selectConversation: { selectConversation(conversation) }
-                                        )
+                                        makeSidebarRow(conversation: conversation)
+                                            .equatable()
                                             .padding(.bottom, SidebarLayoutMetrics.listRowGap)
                                             .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
                                                 if sidebar.dropTargetConversationId == conversation.id {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -10,6 +10,19 @@ struct ConversationSwitcherDrawer: View {
     let selectConversation: (ConversationModel) -> Void
     let onDismiss: () -> Void
 
+    private func isConversationSelected(_ conversation: ConversationModel) -> Bool {
+        switch windowState.selection {
+        case .panel:
+            return false
+        case .conversation(let id):
+            return id == conversation.id
+        case .appEditing(_, let conversationId):
+            return conversationId == conversation.id
+        case .app, .none:
+            return conversation.id == windowState.persistentConversationId
+        }
+    }
+
     var body: some View {
         VStack(spacing: SidebarLayoutMetrics.listRowGap) {
             Text("\(regularConversations.count) conversations")
@@ -26,12 +39,46 @@ struct ConversationSwitcherDrawer: View {
             ForEach(regularConversations) { conversation in
                 SidebarConversationItem(
                     conversation: conversation,
-                    conversationManager: conversationManager,
-                    windowState: windowState,
-                    sidebar: sidebar,
+                    isSelected: isConversationSelected(conversation),
+                    interactionState: conversationManager.interactionState(for: conversation.id),
+                    isHovered: sidebar.isHoveredConversation == conversation.id,
+                    isPendingDeletion: sidebar.conversationPendingDeletion == conversation.id,
                     selectConversation: { selectConversation(conversation) },
-                    onSelect: onDismiss
+                    onSelect: onDismiss,
+                    onTogglePin: {
+                        withAnimation(VAnimation.standard) {
+                            if conversation.isPinned {
+                                conversationManager.unpinConversation(id: conversation.id)
+                            } else {
+                                conversationManager.pinConversation(id: conversation.id)
+                            }
+                        }
+                    },
+                    onArchive: { conversationManager.archiveConversation(id: conversation.id) },
+                    onBeginArchive: { sidebar.conversationPendingDeletion = conversation.id },
+                    onConfirmArchive: {
+                        conversationManager.archiveConversation(id: conversation.id)
+                        sidebar.conversationPendingDeletion = nil
+                    },
+                    onStartRename: {
+                        sidebar.renamingConversationId = conversation.id
+                        sidebar.renameText = conversation.title
+                    },
+                    onMarkUnread: { conversationManager.markConversationUnread(conversationId: conversation.id) },
+                    onHoverChange: { hovering in
+                        withAnimation(VAnimation.fast) {
+                            sidebar.setConversationHover(conversationId: conversation.id, hovering: hovering)
+                        }
+                    },
+                    onDragStart: {
+                        sidebar.draggingConversationId = conversation.id
+                        sidebar.isHoveredConversation = nil
+                    },
+                    onShowFeedback: conversation.conversationId != nil && !LogExporter.isManagedAssistant ? {
+                        AppDelegate.shared?.showLogReportWindow(scope: .conversation(conversationId: conversation.conversationId!, conversationTitle: conversation.title))
+                    } : nil
                 )
+                .equatable()
             }
         }
         .padding(VSpacing.sm)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -3,35 +3,38 @@ import VellumAssistantShared
 
 /// A single conversation row in the sidebar, handling hover, pin, archive, rename,
 /// and drag interactions.
-struct SidebarConversationItem: View {
+///
+/// This is a pure value view — all state is pre-resolved into value-type props
+/// and action closures, so SwiftUI can skip re-evaluation via `Equatable`.
+struct SidebarConversationItem: View, Equatable {
     let conversation: ConversationModel
-    @ObservedObject var conversationManager: ConversationManager
-    @ObservedObject var windowState: MainWindowState
-    var sidebar: SidebarInteractionState
-    /// Called when the user taps the conversation row (handles selection logic).
-    var selectConversation: () -> Void
-    /// Optional additional callback after selection (e.g. dismiss a popover).
-    var onSelect: (() -> Void)? = nil
+    let isSelected: Bool
+    let interactionState: ConversationInteractionState
+    let isHovered: Bool
+    let isPendingDeletion: Bool
 
-    private var isSelected: Bool {
-        switch windowState.selection {
-        case .panel:
-            return false
-        case .conversation(let id):
-            return id == conversation.id
-        case .appEditing(_, let conversationId):
-            return conversationId == conversation.id
-        case .app, .none:
-            // No explicit conversation in selection; fall back to the persistent conversation.
-            return conversation.id == windowState.persistentConversationId
-        }
+    // Action closures — not compared in Equatable
+    var selectConversation: () -> Void
+    var onSelect: (() -> Void)? = nil
+    var onTogglePin: () -> Void
+    var onArchive: () -> Void
+    var onBeginArchive: () -> Void
+    var onConfirmArchive: () -> Void
+    var onStartRename: () -> Void
+    var onMarkUnread: () -> Void
+    var onHoverChange: (Bool) -> Void
+    var onDragStart: () -> Void
+    var onShowFeedback: (() -> Void)?
+
+    static func == (lhs: SidebarConversationItem, rhs: SidebarConversationItem) -> Bool {
+        lhs.conversation == rhs.conversation &&
+        lhs.isSelected == rhs.isSelected &&
+        lhs.interactionState == rhs.interactionState &&
+        lhs.isHovered == rhs.isHovered &&
+        lhs.isPendingDeletion == rhs.isPendingDeletion
     }
 
-    private var isHovered: Bool { sidebar.isHoveredConversation == conversation.id }
-    private var interactionState: ConversationInteractionState { conversationManager.interactionState(for: conversation.id) }
-    // Reserve trailing space when hovered for archive button overlay.
-    private var hasTrailingIcon: Bool { isHovered || sidebar.conversationPendingDeletion == conversation.id }
-    private var isPendingDeletion: Bool { sidebar.conversationPendingDeletion == conversation.id }
+    private var hasTrailingIcon: Bool { isHovered || isPendingDeletion }
     private var canMarkUnread: Bool {
         !conversation.hasUnseenLatestAssistantMessage &&
             conversation.conversationId != nil &&
@@ -48,13 +51,7 @@ struct SidebarConversationItem: View {
                 // Hovered -> interactive pin button; not hovered -> status indicator.
                 if isHovered {
                     Button {
-                        withAnimation(VAnimation.standard) {
-                            if conversation.isPinned {
-                                conversationManager.unpinConversation(id: conversation.id)
-                            } else {
-                                conversationManager.pinConversation(id: conversation.id)
-                            }
-                        }
+                        onTogglePin()
                     } label: {
                         VIconView(.pin, size: 13)
                             .foregroundColor(conversation.isPinned ? VColor.contentTertiary : VColor.contentSecondary)
@@ -151,17 +148,16 @@ struct SidebarConversationItem: View {
             selectConversation()
         }
         .overlay(alignment: .trailing) {
-            if sidebar.conversationPendingDeletion == conversation.id {
+            if isPendingDeletion {
                 VButton(label: "Confirm", style: .dangerOutline, size: .pill) {
-                    conversationManager.archiveConversation(id: conversation.id)
-                    sidebar.conversationPendingDeletion = nil
+                    onConfirmArchive()
                 }
                 .fixedSize()
                 .padding(.trailing, VSpacing.xs)
                 .accessibilityLabel("Confirm archive \(conversation.title)")
             } else if isHovered {
                 Button {
-                    sidebar.conversationPendingDeletion = conversation.id
+                    onBeginArchive()
                 } label: {
                     VIconView(.archive, size: 13)
                         .foregroundColor(VColor.contentSecondary)
@@ -177,29 +173,22 @@ struct SidebarConversationItem: View {
         .padding(.horizontal, 0)
         .contextMenu {
             Button {
-                withAnimation(VAnimation.standard) {
-                    if conversation.isPinned {
-                        conversationManager.unpinConversation(id: conversation.id)
-                    } else {
-                        conversationManager.pinConversation(id: conversation.id)
-                    }
-                }
+                onTogglePin()
             } label: {
                 Label { Text(conversation.isPinned ? "Unpin" : "Pin") } icon: { VIconView(conversation.isPinned ? .pinOff : .pin, size: 14) }
             }
             Button {
-                sidebar.renamingConversationId = conversation.id
-                sidebar.renameText = conversation.title
+                onStartRename()
             } label: {
                 Label { Text("Rename") } icon: { VIconView(.pencil, size: 14) }
             }
             Button {
-                conversationManager.archiveConversation(id: conversation.id)
+                onArchive()
             } label: {
                 Label { Text("Archive") } icon: { VIconView(.archive, size: 14) }
             }
             Button {
-                conversationManager.markConversationUnread(conversationId: conversation.id)
+                onMarkUnread()
             } label: {
                 Label { Text("Mark as unread") } icon: { VIconView(.circle, size: 14) }
             }
@@ -208,22 +197,17 @@ struct SidebarConversationItem: View {
             Divider()
 
             Button {
-                guard let conversationId = conversation.conversationId else { return }
-                AppDelegate.shared?.showLogReportWindow(scope: .conversation(conversationId: conversationId, conversationTitle: conversation.title))
+                onShowFeedback?()
             } label: {
                 Label { Text("Share Feedback") } icon: { VIconView(.messageCircle, size: 14) }
             }
-            .disabled(conversation.conversationId == nil || LogExporter.isManagedAssistant)
+            .disabled(onShowFeedback == nil)
         }
         .pointerCursor { hovering in
-            withAnimation(VAnimation.fast) {
-                sidebar.setConversationHover(conversationId: conversation.id, hovering: hovering)
-            }
+            onHoverChange(hovering)
         }
         .onDrag {
-            sidebar.draggingConversationId = conversation.id
-            // Clear hover so icon-swap and archive-button animations stop during drag.
-            sidebar.isHoveredConversation = nil
+            onDragStart()
             return NSItemProvider(object: conversation.id.uuidString as NSString)
         } preview: {
             HStack(spacing: VSpacing.xs) {


### PR DESCRIPTION
## Summary
- Remove @ObservedObject conversationManager, @ObservedObject windowState, and @Observable SidebarInteractionState from SidebarConversationItem
- Replace with pre-resolved value-type props (isSelected, interactionState, isHovered, isPendingDeletion) and action closures
- Add Equatable conformance and .equatable() modifier at all four instantiation sites
- Create makeSidebarRow factory helper to share closure wiring across sites

Part of plan: fix-main-thread-stall.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
