### PR TITLE
feat: add ACP agent permission prompt UI

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -174,6 +174,11 @@ extension AppDelegate {
                     }
                 case .navigateSettings(let msg):
                     self.showSettingsTab(msg.tab)
+                case .acpPermissionRequest(let msg):
+                    if self.acpPermissionWindow == nil {
+                        self.acpPermissionWindow = AcpPermissionWindow()
+                    }
+                    self.acpPermissionWindow?.show(message: msg)
                 case .pairingApprovalRequest(let msg):
                     if self.pairingApprovalWindow == nil {
                         self.pairingApprovalWindow = PairingApprovalWindow()
@@ -256,8 +261,8 @@ extension AppDelegate {
                             "home": msg.home
                         ]
                     )
-                case .avatarUpdated:
-                    AvatarAppearanceManager.shared.reloadAvatar()
+                case .avatarUpdated(let msg):
+                    AvatarAppearanceManager.shared.reloadAvatar(avatarPath: msg.avatarPath)
                 // Host tool execution — run locally and post results back
                 case .hostBashRequest(let msg):
                     HostToolExecutor.executeHostBashRequest(msg)

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -90,6 +90,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var bundleConfirmationWindow: BundleConfirmationWindow?
 
     var pairingApprovalWindow: PairingApprovalWindow?
+    var acpPermissionWindow: AcpPermissionWindow?
     var crashReportWindow: NSWindow?
     var crashReportWindowObserver: NSObjectProtocol?
     var logReportWindow: NSWindow?

--- a/clients/macos/vellum-assistant/Features/Chat/AcpPermissionView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AcpPermissionView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// SwiftUI content for an ACP agent permission prompt.
+/// Shows the tool details and action buttons derived from the ACP options.
+struct AcpPermissionView: View {
+    let toolTitle: String
+    let toolKind: String
+    let rawInput: String?
+    let options: [AcpPermissionRequestMessage.Option]
+    let onDecision: (String) -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            VIconView(.shieldCheck, size: 40)
+                .foregroundColor(.secondary)
+
+            Text("Agent Permission Request")
+                .font(.headline)
+
+            Text("An ACP agent wants to use: **\(toolTitle)**")
+                .font(.body)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if let rawInput, !rawInput.isEmpty {
+                ScrollView {
+                    Text(rawInput)
+                        .font(.system(.caption, design: .monospaced))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(8)
+                }
+                .frame(maxHeight: 120)
+                .background(Color(nsColor: .controlBackgroundColor))
+                .cornerRadius(6)
+            }
+
+            HStack(spacing: 12) {
+                // Render reject options first, then allow options
+                ForEach(rejectOptions, id: \.optionId) { option in
+                    Button(option.name) {
+                        onDecision(option.optionId)
+                    }
+                    .keyboardShortcut(.cancelAction)
+                }
+
+                ForEach(allowOptions, id: \.optionId) { option in
+                    let isDefault = option.kind == "allow_always" || (allowOptions.count == 1)
+                    Button(option.name) {
+                        onDecision(option.optionId)
+                    }
+                    .keyboardShortcut(isDefault ? .defaultAction : .none)
+                }
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 400)
+    }
+
+    private var rejectOptions: [AcpPermissionRequestMessage.Option] {
+        options.filter { $0.kind.hasPrefix("reject") }
+    }
+
+    private var allowOptions: [AcpPermissionRequestMessage.Option] {
+        options.filter { $0.kind.hasPrefix("allow") }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/AcpPermissionWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AcpPermissionWindow.swift
@@ -1,0 +1,141 @@
+import AppKit
+import SwiftUI
+import VellumAssistantShared
+
+/// Manages a floating NSWindow for ACP agent permission prompts.
+/// Auto-centers, activates app, idempotent show/close.
+@MainActor
+final class AcpPermissionWindow {
+    private var window: NSWindow?
+    private var currentRequestId: String?
+    private var responseSent: Bool = false
+    private var windowDelegate: AcpPermissionWindowCloseDelegate?
+
+    /// Show the permission approval prompt for an ACP tool call.
+    /// If a window is already showing for a different request, it is closed first
+    /// (one prompt at a time) and the first reject option is sent for the superseded request.
+    /// If the same requestId is delivered again (daemon retry/rebroadcast),
+    /// the existing prompt is kept as-is.
+    func show(message: AcpPermissionRequestMessage) {
+        // Same request ID redelivered — keep current prompt.
+        if message.requestId == currentRequestId, window != nil {
+            return
+        }
+
+        // Close any existing prompt before showing a new one.
+        close(defaultOptionId: findRejectOptionId(message.options))
+
+        let rawInputString: String? = {
+            guard let rawInput = message.rawInput?.value else { return nil }
+            if let str = rawInput as? String { return str }
+            if let data = try? JSONSerialization.data(withJSONObject: rawInput, options: [.prettyPrinted, .sortedKeys]),
+               let str = String(data: data, encoding: .utf8) {
+                return str
+            }
+            return String(describing: rawInput)
+        }()
+
+        let rejectOptionId = findRejectOptionId(message.options)
+        let requestId = message.requestId
+
+        let view = AcpPermissionView(
+            toolTitle: message.toolTitle,
+            toolKind: message.toolKind,
+            rawInput: rawInputString,
+            options: message.options
+        ) { [weak self] optionId in
+            guard let self else { return }
+            self.responseSent = true
+            Task {
+                _ = await InteractionClient().sendAcpPermissionResponse(
+                    requestId: requestId,
+                    optionId: optionId
+                )
+            }
+            self.close()
+        }
+
+        let hostingController = NSHostingController(rootView: view)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 440, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+
+        window.contentViewController = hostingController
+        window.title = "Agent Permission Request"
+        window.level = .floating
+        window.isReleasedWhenClosed = false
+        window.center()
+
+        // Delegate catches X-button close and sends reject if no response was sent.
+        let delegate = AcpPermissionWindowCloseDelegate { [weak self] in
+            self?.handleWindowClosed(rejectOptionId: rejectOptionId)
+        }
+        window.delegate = delegate
+        self.windowDelegate = delegate
+
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+
+        self.window = window
+        self.currentRequestId = message.requestId
+        self.responseSent = false
+    }
+
+    var isVisible: Bool {
+        window?.isVisible ?? false
+    }
+
+    func close(defaultOptionId: String? = nil) {
+        rejectIfNeeded(optionId: defaultOptionId)
+        window?.close()
+        window = nil
+        windowDelegate = nil
+    }
+
+    // MARK: - Private
+
+    private func findRejectOptionId(_ options: [AcpPermissionRequestMessage.Option]) -> String? {
+        options.first(where: { $0.kind.hasPrefix("reject") })?.optionId
+    }
+
+    /// Sends a reject for the current request if no explicit response has been sent yet.
+    private func rejectIfNeeded(optionId: String? = nil) {
+        guard let requestId = currentRequestId, !responseSent else { return }
+        guard let rejectId = optionId else { return }
+        responseSent = true
+        Task {
+            _ = await InteractionClient().sendAcpPermissionResponse(
+                requestId: requestId,
+                optionId: rejectId
+            )
+        }
+    }
+
+    /// Called by the window delegate when the user clicks the X button.
+    private func handleWindowClosed(rejectOptionId: String?) {
+        rejectIfNeeded(optionId: rejectOptionId)
+        window = nil
+        windowDelegate = nil
+    }
+}
+
+// MARK: - AcpPermissionWindowCloseDelegate
+
+/// Lightweight NSWindowDelegate that forwards windowWillClose to a closure.
+private final class AcpPermissionWindowCloseDelegate: NSObject, NSWindowDelegate {
+    private let onClose: @MainActor () -> Void
+
+    init(onClose: @escaping @MainActor () -> Void) {
+        self.onClose = onClose
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        MainActor.assumeIsolated {
+            onClose()
+        }
+    }
+}

--- a/clients/shared/Network/InteractionClient.swift
+++ b/clients/shared/Network/InteractionClient.swift
@@ -45,6 +45,28 @@ public struct InteractionClient: InteractionClientProtocol {
     }
 
     @discardableResult
+    public func sendAcpPermissionResponse(
+        requestId: String,
+        optionId: String
+    ) async -> Bool {
+        do {
+            let body: [String: Any] = [
+                "requestId": requestId,
+                "optionId": optionId,
+            ]
+            let response = try await GatewayHTTPClient.post(path: "acp/permission", json: body, timeout: 10)
+            if !response.isSuccess {
+                log.error("sendAcpPermissionResponse failed (HTTP \(response.statusCode))")
+                return false
+            }
+            return true
+        } catch {
+            log.error("sendAcpPermissionResponse error: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    @discardableResult
     public func sendSecretResponse(
         requestId: String,
         value: String? = nil,

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2155,6 +2155,7 @@ public enum ServerMessage: Decodable, Sendable {
     case serviceGroupUpdateProgress(ServiceGroupUpdateProgressMessage)
     case serviceGroupUpdateComplete(ServiceGroupUpdateCompleteMessage)
     case conversationIdResolved(localId: String, serverId: String)
+    case acpPermissionRequest(AcpPermissionRequestMessage)
     case pong
     case unknown(String)
 
@@ -2591,6 +2592,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "service_group_update_complete":
             let message = try ServiceGroupUpdateCompleteMessage(from: decoder)
             self = .serviceGroupUpdateComplete(message)
+        case "acp_permission_request":
+            let message = try AcpPermissionRequestMessage(from: decoder)
+            self = .acpPermissionRequest(message)
         case "pong":
             self = .pong
         default:
@@ -2650,6 +2654,24 @@ public struct SlotContentWire: Decodable, Sendable {
     public let type: String
     public let panel: String?
     public let surfaceId: String?
+}
+
+// MARK: - ACP Permission Messages
+
+/// Server → Client: an ACP-spawned agent requests permission to use a tool.
+public struct AcpPermissionRequestMessage: Decodable, Sendable {
+    public struct Option: Decodable, Sendable {
+        public let optionId: String
+        public let name: String
+        public let kind: String // "allow_once", "allow_always", "reject_once", "reject_always"
+    }
+
+    public let acpSessionId: String
+    public let requestId: String
+    public let toolTitle: String
+    public let toolKind: String
+    public let rawInput: AnyCodable?
+    public let options: [Option]
 }
 
 // MARK: - Pairing Messages


### PR DESCRIPTION
## Summary
- Added floating `AcpPermissionWindow` that shows when an ACP-spawned agent requests tool permission
- `AcpPermissionView` renders tool title, kind, raw input preview, and allow/reject buttons with keyboard shortcuts
- Auto-rejects on window close (X button) to prevent dangling requests
- Idempotent: same `requestId` redelivered keeps existing prompt; new request supersedes old one
- Added `AcpPermissionRequestMessage` type and `sendAcpPermissionResponse` client method
- Wired into `AppDelegate` via `acpPermissionRequest` server message handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20938" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
