### PR TITLE
fix: make makeSidebarRow private

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -152,7 +152,7 @@ extension MainWindowView {
 
     /// Builds a `SidebarConversationItem` with all state pre-resolved and closures wired,
     /// so each row is a pure value view that can be skipped via `Equatable`.
-    func makeSidebarRow(
+    private func makeSidebarRow(
         conversation: ConversationModel,
         onSelect: (() -> Void)? = nil
     ) -> SidebarConversationItem {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-main-thread-stall.md.

**Gap:** makeSidebarRow is internal instead of private
**What was expected:** private func makeSidebarRow
**What was found:** func makeSidebarRow (internal access)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
