### PR TITLE
perf: fix main thread stall during message send

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -941,7 +941,7 @@ struct MessageListView: View {
                     }
 
                     let _ = recordScrollLoopEvent(.bodyEvaluation)
-                    os_signpost(.event, log: stallLog, name: "MessageList.bodyEval")
+                    let _ = os_signpost(.event, log: stallLog, name: "MessageList.bodyEval")
                     let state = precomputedState
                     let catalogHash = MessageCellView.hashCatalog(providerCatalog)
                     ForEach(state.displayMessages) { message in

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 import VellumAssistantShared
 
 private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "MessageListView")
+private let stallLog = OSLog(subsystem: "com.vellum.assistant", category: "LayoutStall")
 
 // MARK: - Scroll Suppression Environment
 
@@ -940,6 +941,7 @@ struct MessageListView: View {
                     }
 
                     let _ = recordScrollLoopEvent(.bodyEvaluation)
+                    os_signpost(.event, log: stallLog, name: "MessageList.bodyEval")
                     let state = precomputedState
                     let catalogHash = MessageCellView.hashCatalog(providerCatalog)
                     ForEach(state.displayMessages) { message in

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -431,26 +431,14 @@ struct MessageListView: View {
             return
         }
 
-        // Cooldown: suppress re-entrant applies within the spring animation window.
-        // Each avatarDisplayY mutation triggers a body re-evaluation → new layout →
-        // new tail anchor preference → deferred Task → updateAvatarFollower → back
-        // here. Without a cooldown, the spring animation (0.28s response) amplifies
-        // sub-pixel layout shifts into a feedback loop that trips the scroll loop
-        // guard (30+ avatarDisplayYApplied events in 2s) and freezes the UI.
-        // The cooldown matches the spring response time so the animation settles
-        // before the next position update is accepted.
-        if let lastApplied = scrollTracking.avatarLastAppliedAt {
-            let elapsed = Date().timeIntervalSince(lastApplied)
-            if elapsed < 0.28 {  // Match spring response time (ConversationAvatarFollower.spring)
-                return
-            }
-        }
-
         recordScrollLoopEvent(.avatarDisplayYApplied)
         scrollTracking.avatarLastAppliedAt = Date()
-        withAnimation(ConversationAvatarFollower.spring) {
-            avatarDisplayY = y
-        }
+        // Set @State without withAnimation — the spring animation is applied via
+        // .animation() on the avatar view's .offset() modifier instead. This avoids
+        // wrapping the mutation in an animation transaction, which would cause SwiftUI
+        // to re-evaluate the body on each spring interpolation frame and feed layout
+        // shifts back into the tail anchor preference → avatar update cycle.
+        avatarDisplayY = y
     }
 
     private func updateAvatarFollower(anchorY: CGFloat) {
@@ -544,6 +532,7 @@ struct MessageListView: View {
                     .frame(maxWidth: VSpacing.chatColumnMaxWidth)
                     .frame(maxWidth: .infinity)
                     .offset(y: avatarDisplayY)
+                    .animation(ConversationAvatarFollower.spring, value: avatarDisplayY)
                     .accessibilityHidden(true)
                     .onAppear {
                         if shouldPlayTailEntryAnimation {
@@ -560,6 +549,7 @@ struct MessageListView: View {
                 .frame(maxWidth: VSpacing.chatColumnMaxWidth)
                 .frame(maxWidth: .infinity)
                 .offset(y: avatarDisplayY)
+                .animation(ConversationAvatarFollower.spring, value: avatarDisplayY)
                 .allowsHitTesting(false)
                 .accessibilityHidden(true)
             }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -431,7 +431,23 @@ struct MessageListView: View {
             return
         }
 
+        // Cooldown: suppress re-entrant applies within the spring animation window.
+        // Each avatarDisplayY mutation triggers a body re-evaluation → new layout →
+        // new tail anchor preference → deferred Task → updateAvatarFollower → back
+        // here. Without a cooldown, the spring animation (0.28s response) amplifies
+        // sub-pixel layout shifts into a feedback loop that trips the scroll loop
+        // guard (30+ avatarDisplayYApplied events in 2s) and freezes the UI.
+        // The cooldown matches the spring response time so the animation settles
+        // before the next position update is accepted.
+        if let lastApplied = scrollTracking.avatarLastAppliedAt {
+            let elapsed = Date().timeIntervalSince(lastApplied)
+            if elapsed < 0.28 {  // Match spring response time (ConversationAvatarFollower.spring)
+                return
+            }
+        }
+
         recordScrollLoopEvent(.avatarDisplayYApplied)
+        scrollTracking.avatarLastAppliedAt = Date()
         withAnimation(ConversationAvatarFollower.spring) {
             avatarDisplayY = y
         }
@@ -487,7 +503,6 @@ struct MessageListView: View {
             avatarSmoothingTask?.cancel()
             avatarSmoothingTask = nil
             scrollTracking.pendingAvatarY = nil
-            scrollTracking.avatarLastAppliedAt = now
             applyAvatarDisplayY(forAnchorY: anchorY)
             return
         }
@@ -507,7 +522,6 @@ struct MessageListView: View {
                 return
             }
             scrollTracking.pendingAvatarY = nil
-            scrollTracking.avatarLastAppliedAt = Date()
             applyAvatarDisplayY(forAnchorY: pending)
             avatarSmoothingTask = nil
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -528,7 +528,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         conversations.remove(at: index)
         chatViewModels.removeValue(forKey: id)
         unsubscribeAllForConversation(id: id)
-        vmAccessOrder.removeAll { $0 == id }
+        if let idx = vmAccessOrder.firstIndex(of: id) {
+            vmAccessOrder.remove(at: idx)
+        }
         Self.clearRenderCaches()
 
         // Delete the conversation on the backend (fire-and-forget)
@@ -634,7 +636,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         conversations.remove(at: index)
         chatViewModels.removeValue(forKey: id)
         unsubscribeAllForConversation(id: id)
-        vmAccessOrder.removeAll { $0 == id }
+        if let idx = vmAccessOrder.firstIndex(of: id) {
+            vmAccessOrder.remove(at: idx)
+        }
 
         // Reclaim memory held by static caches that may reference
         // messages from the closed conversation.
@@ -688,7 +692,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             // Conversation ID already known — safe to release the view model.
             chatViewModels.removeValue(forKey: id)
             unsubscribeAllForConversation(id: id)
-            vmAccessOrder.removeAll { $0 == id }
+            if let idx = vmAccessOrder.firstIndex(of: id) {
+                vmAccessOrder.remove(at: idx)
+            }
         } else if chatViewModels[id]?.messages.contains(where: { $0.role == .user }) != true
                     && chatViewModels[id]?.isBootstrapping != true {
             chatViewModels[id]?.stopGenerating()
@@ -697,7 +703,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             // Clean up immediately.
             chatViewModels.removeValue(forKey: id)
             unsubscribeAllForConversation(id: id)
-            vmAccessOrder.removeAll { $0 == id }
+            if let idx = vmAccessOrder.firstIndex(of: id) {
+                vmAccessOrder.remove(at: idx)
+            }
         } else {
             // Conversation ID is nil but a conversation is expected (user messages exist
             // or bootstrap is in flight, e.g. a workspace refinement that
@@ -1361,7 +1369,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     func removeChatViewModel(for conversationId: UUID) {
         chatViewModels.removeValue(forKey: conversationId)
         unsubscribeAllForConversation(id: conversationId)
-        vmAccessOrder.removeAll { $0 == conversationId }
+        if let idx = vmAccessOrder.firstIndex(of: conversationId) {
+            vmAccessOrder.remove(at: idx)
+        }
     }
 
     /// Called when the user responds to a confirmation via the inline chat UI.
@@ -1812,7 +1822,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         conversations.removeAll { $0.id == previousId }
         chatViewModels.removeValue(forKey: previousId)
         unsubscribeAllForConversation(id: previousId)
-        vmAccessOrder.removeAll { $0 == previousId }
+        if let idx = vmAccessOrder.firstIndex(of: previousId) {
+            vmAccessOrder.remove(at: idx)
+        }
         log.info("Removed abandoned empty conversation \(previousId)")
     }
 
@@ -1842,7 +1854,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             archivedConversationIds = archived
             chatViewModels.removeValue(forKey: localId)
             unsubscribeAllForConversation(id: localId)
-            vmAccessOrder.removeAll { $0 == localId }
+            if let idx = vmAccessOrder.firstIndex(of: localId) {
+                vmAccessOrder.remove(at: idx)
+            }
         }
         // Re-send ordering now that this conversation has a conversation ID.
         // Any drag/pin actions performed before the daemon assigned
@@ -1994,7 +2008,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
 
     /// Move `conversationId` to the end of `vmAccessOrder` (most-recently-used position).
     private func touchVMAccessOrder(_ conversationId: UUID) {
-        vmAccessOrder.removeAll { $0 == conversationId }
+        if let idx = vmAccessOrder.firstIndex(of: conversationId) {
+            vmAccessOrder.remove(at: idx)
+        }
         vmAccessOrder.append(conversationId)
     }
 
@@ -2013,7 +2029,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             }
             chatViewModels.removeValue(forKey: victim)
             unsubscribeFromBusyState(for: victim)
-            vmAccessOrder.removeAll { $0 == victim }
+            if let idx = vmAccessOrder.firstIndex(of: victim) {
+                vmAccessOrder.remove(at: idx)
+            }
             evictedCount += 1
             log.info("LRU evicted VM for conversation \(victim)")
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -109,6 +109,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     private let maxCachedViewModels = 10
     /// Tracks access order for LRU eviction. Most-recently-accessed ID is at the end.
     private var vmAccessOrder: [UUID] = []
+    private var pendingEvictionTask: Task<Void, Never>?
     private let connectionManager: GatewayConnectionManager
     private let eventStreamClient: EventStreamClient
     private let conversationClient: ConversationClientProtocol
@@ -456,7 +457,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         subscribeToAssistantActivity(for: conversation.id, viewModel: viewModel)
         subscribeToInteractionState(for: conversation.id, viewModel: viewModel)
         touchVMAccessOrder(conversation.id)
-        evictStaleCachedViewModels()
+        scheduleEvictionIfNeeded()
         draftViewModel = nil
 
         // Increment only on actual user sends, not programmatic createConversation() calls.
@@ -506,7 +507,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         subscribeToAssistantActivity(for: conversation.id, viewModel: viewModel)
         subscribeToInteractionState(for: conversation.id, viewModel: viewModel)
         touchVMAccessOrder(conversation.id)
-        evictStaleCachedViewModels()
+        scheduleEvictionIfNeeded()
         activeConversationId = conversation.id
 
         // Immediately create a daemon conversation so the conversation is persisted
@@ -584,7 +585,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         subscribeToAssistantActivity(for: conversation.id, viewModel: viewModel)
         subscribeToInteractionState(for: conversation.id, viewModel: viewModel)
         touchVMAccessOrder(conversation.id)
-        evictStaleCachedViewModels()
+        scheduleEvictionIfNeeded()
 
         return conversation.id
     }
@@ -825,7 +826,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         if let hasMore = response.hasMore {
             hasMoreConversations = hasMore
         }
-        evictStaleCachedViewModels()
+        scheduleEvictionIfNeeded()
         isLoadingMoreConversations = false
     }
 
@@ -851,7 +852,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             subscribeToBusyState(for: id, viewModel: viewModel)
             subscribeToAssistantActivity(for: id, viewModel: viewModel)
             subscribeToInteractionState(for: id, viewModel: viewModel)
-            evictStaleCachedViewModels()
+            scheduleEvictionIfNeeded()
         }
 
         touchVMAccessOrder(id)
@@ -1031,7 +1032,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         subscribeToAssistantActivity(for: conversationModel.id, viewModel: viewModel)
         subscribeToInteractionState(for: conversationModel.id, viewModel: viewModel)
         touchVMAccessOrder(conversationModel.id)
-        evictStaleCachedViewModels()
+        scheduleEvictionIfNeeded()
         return conversationModel.id
     }
 
@@ -1359,7 +1360,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         subscribeToAssistantActivity(for: conversationId, viewModel: vm)
         subscribeToInteractionState(for: conversationId, viewModel: vm)
         touchVMAccessOrder(conversationId)
-        evictStaleCachedViewModels()
+        scheduleEvictionIfNeeded()
         // Re-subscribe if this is the active view model
         if conversationId == activeConversationId {
             subscribeToActiveViewModel()
@@ -2000,7 +2001,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         subscribeToAssistantActivity(for: conversationId, viewModel: viewModel)
         subscribeToInteractionState(for: conversationId, viewModel: viewModel)
         touchVMAccessOrder(conversationId)
-        evictStaleCachedViewModels()
+        scheduleEvictionIfNeeded()
         return viewModel
     }
 
@@ -2012,6 +2013,21 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             vmAccessOrder.remove(at: idx)
         }
         vmAccessOrder.append(conversationId)
+    }
+
+    /// Schedule a debounced eviction pass. Coalesces multiple eviction triggers
+    /// (e.g. rapid conversation creation, selection, SSE inserts) into a single
+    /// deferred call, preventing eviction state changes from compounding with
+    /// other `objectWillChange` publishers in the same run-loop tick.
+    private func scheduleEvictionIfNeeded() {
+        guard chatViewModels.count > maxCachedViewModels else { return }
+        guard pendingEvictionTask == nil else { return }
+        pendingEvictionTask = Task { @MainActor [weak self] in
+            defer { self?.pendingEvictionTask = nil }
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled else { return }
+            self?.evictStaleCachedViewModels()
+        }
     }
 
     /// Evict the oldest cached ChatViewModel that is not the active conversation,

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -6,6 +6,7 @@ import os
 import Combine
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ConversationManager")
+private let stallLog = OSLog(subsystem: "com.vellum.assistant", category: "LayoutStall")
 // Legacy UserDefaults key preserved from the session-to-conversation rename.
 private let archivedConversationsKey = "archivedSessionIds"
 // Intermediate builds may have written under this key before the compat fix.
@@ -2000,6 +2001,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     /// Evict the oldest cached ChatViewModel that is not the active conversation,
     /// keeping at most `maxCachedViewModels` entries in the dictionary.
     private func evictStaleCachedViewModels() {
+        var evictedCount = 0
         while chatViewModels.count > maxCachedViewModels {
             // Find the oldest non-active, non-busy VM so we never cancel an in-flight response
             // just because the user switched conversations.
@@ -2012,7 +2014,11 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             chatViewModels.removeValue(forKey: victim)
             unsubscribeFromBusyState(for: victim)
             vmAccessOrder.removeAll { $0 == victim }
+            evictedCount += 1
             log.info("LRU evicted VM for conversation \(victim)")
+        }
+        if evictedCount > 0 {
+            os_signpost(.event, log: stallLog, name: "LRU.evict", "%{public}d VMs", evictedCount)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -152,7 +152,7 @@ extension MainWindowView {
 
     /// Builds a `SidebarConversationItem` with all state pre-resolved and closures wired,
     /// so each row is a pure value view that can be skipped via `Equatable`.
-    func makeSidebarRow(
+    private func makeSidebarRow(
         conversation: ConversationModel,
         onSelect: (() -> Void)? = nil
     ) -> SidebarConversationItem {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -135,6 +135,70 @@ extension MainWindowView {
         }
     }
 
+    // MARK: - Sidebar Row Factory
+
+    private func isConversationSelected(_ conversation: ConversationModel) -> Bool {
+        switch windowState.selection {
+        case .panel:
+            return false
+        case .conversation(let id):
+            return id == conversation.id
+        case .appEditing(_, let conversationId):
+            return conversationId == conversation.id
+        case .app, .none:
+            return conversation.id == windowState.persistentConversationId
+        }
+    }
+
+    /// Builds a `SidebarConversationItem` with all state pre-resolved and closures wired,
+    /// so each row is a pure value view that can be skipped via `Equatable`.
+    func makeSidebarRow(
+        conversation: ConversationModel,
+        onSelect: (() -> Void)? = nil
+    ) -> SidebarConversationItem {
+        SidebarConversationItem(
+            conversation: conversation,
+            isSelected: isConversationSelected(conversation),
+            interactionState: conversationManager.interactionState(for: conversation.id),
+            isHovered: sidebar.isHoveredConversation == conversation.id,
+            isPendingDeletion: sidebar.conversationPendingDeletion == conversation.id,
+            selectConversation: { selectConversation(conversation) },
+            onSelect: onSelect,
+            onTogglePin: {
+                withAnimation(VAnimation.standard) {
+                    if conversation.isPinned {
+                        conversationManager.unpinConversation(id: conversation.id)
+                    } else {
+                        conversationManager.pinConversation(id: conversation.id)
+                    }
+                }
+            },
+            onArchive: { conversationManager.archiveConversation(id: conversation.id) },
+            onBeginArchive: { sidebar.conversationPendingDeletion = conversation.id },
+            onConfirmArchive: {
+                conversationManager.archiveConversation(id: conversation.id)
+                sidebar.conversationPendingDeletion = nil
+            },
+            onStartRename: {
+                sidebar.renamingConversationId = conversation.id
+                sidebar.renameText = conversation.title
+            },
+            onMarkUnread: { conversationManager.markConversationUnread(conversationId: conversation.id) },
+            onHoverChange: { hovering in
+                withAnimation(VAnimation.fast) {
+                    sidebar.setConversationHover(conversationId: conversation.id, hovering: hovering)
+                }
+            },
+            onDragStart: {
+                sidebar.draggingConversationId = conversation.id
+                sidebar.isHoveredConversation = nil
+            },
+            onShowFeedback: conversation.conversationId != nil && !LogExporter.isManagedAssistant ? {
+                AppDelegate.shared?.showLogReportWindow(scope: .conversation(conversationId: conversation.conversationId!, conversationTitle: conversation.title))
+            } : nil
+        )
+    }
+
     // MARK: - Pinned App Helpers
 
     /// A pinned app row — delegates layout to `SidebarPrimaryRow` for both
@@ -226,13 +290,8 @@ extension MainWindowView {
                     }
 
                     ForEach(displayedConversations) { conversation in
-                        SidebarConversationItem(
-                            conversation: conversation,
-                            conversationManager: conversationManager,
-                            windowState: windowState,
-                            sidebar: sidebar,
-                            selectConversation: { selectConversation(conversation) }
-                        )
+                        makeSidebarRow(conversation: conversation)
+                            .equatable()
                             .padding(.bottom, SidebarLayoutMetrics.listRowGap)
                             .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
                                 if sidebar.dropTargetConversationId == conversation.id {
@@ -296,13 +355,8 @@ extension MainWindowView {
                         ForEach(displayedScheduleGroups, id: \.key) { group in
                             if group.conversations.count == 1, let conversation = group.conversations.first {
                                 // Single-conversation group: render inline without a disclosure wrapper
-                                SidebarConversationItem(
-                                    conversation: conversation,
-                                    conversationManager: conversationManager,
-                                    windowState: windowState,
-                                    sidebar: sidebar,
-                                    selectConversation: { selectConversation(conversation) }
-                                )
+                                makeSidebarRow(conversation: conversation)
+                                    .equatable()
                                     .padding(.bottom, SidebarLayoutMetrics.listRowGap)
                                     .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
                                         if sidebar.dropTargetConversationId == conversation.id {
@@ -376,13 +430,8 @@ extension MainWindowView {
                                 // Expanded child rows
                                 if isGroupExpanded {
                                     ForEach(group.conversations) { conversation in
-                                        SidebarConversationItem(
-                                            conversation: conversation,
-                                            conversationManager: conversationManager,
-                                            windowState: windowState,
-                                            sidebar: sidebar,
-                                            selectConversation: { selectConversation(conversation) }
-                                        )
+                                        makeSidebarRow(conversation: conversation)
+                                            .equatable()
                                             .padding(.bottom, SidebarLayoutMetrics.listRowGap)
                                             .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
                                                 if sidebar.dropTargetConversationId == conversation.id {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -10,6 +10,19 @@ struct ConversationSwitcherDrawer: View {
     let selectConversation: (ConversationModel) -> Void
     let onDismiss: () -> Void
 
+    private func isConversationSelected(_ conversation: ConversationModel) -> Bool {
+        switch windowState.selection {
+        case .panel:
+            return false
+        case .conversation(let id):
+            return id == conversation.id
+        case .appEditing(_, let conversationId):
+            return conversationId == conversation.id
+        case .app, .none:
+            return conversation.id == windowState.persistentConversationId
+        }
+    }
+
     var body: some View {
         VStack(spacing: SidebarLayoutMetrics.listRowGap) {
             Text("\(regularConversations.count) conversations")
@@ -26,12 +39,46 @@ struct ConversationSwitcherDrawer: View {
             ForEach(regularConversations) { conversation in
                 SidebarConversationItem(
                     conversation: conversation,
-                    conversationManager: conversationManager,
-                    windowState: windowState,
-                    sidebar: sidebar,
+                    isSelected: isConversationSelected(conversation),
+                    interactionState: conversationManager.interactionState(for: conversation.id),
+                    isHovered: sidebar.isHoveredConversation == conversation.id,
+                    isPendingDeletion: sidebar.conversationPendingDeletion == conversation.id,
                     selectConversation: { selectConversation(conversation) },
-                    onSelect: onDismiss
+                    onSelect: onDismiss,
+                    onTogglePin: {
+                        withAnimation(VAnimation.standard) {
+                            if conversation.isPinned {
+                                conversationManager.unpinConversation(id: conversation.id)
+                            } else {
+                                conversationManager.pinConversation(id: conversation.id)
+                            }
+                        }
+                    },
+                    onArchive: { conversationManager.archiveConversation(id: conversation.id) },
+                    onBeginArchive: { sidebar.conversationPendingDeletion = conversation.id },
+                    onConfirmArchive: {
+                        conversationManager.archiveConversation(id: conversation.id)
+                        sidebar.conversationPendingDeletion = nil
+                    },
+                    onStartRename: {
+                        sidebar.renamingConversationId = conversation.id
+                        sidebar.renameText = conversation.title
+                    },
+                    onMarkUnread: { conversationManager.markConversationUnread(conversationId: conversation.id) },
+                    onHoverChange: { hovering in
+                        withAnimation(VAnimation.fast) {
+                            sidebar.setConversationHover(conversationId: conversation.id, hovering: hovering)
+                        }
+                    },
+                    onDragStart: {
+                        sidebar.draggingConversationId = conversation.id
+                        sidebar.isHoveredConversation = nil
+                    },
+                    onShowFeedback: conversation.conversationId != nil && !LogExporter.isManagedAssistant ? {
+                        AppDelegate.shared?.showLogReportWindow(scope: .conversation(conversationId: conversation.conversationId!, conversationTitle: conversation.title))
+                    } : nil
                 )
+                .equatable()
             }
         }
         .padding(VSpacing.sm)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -3,35 +3,38 @@ import VellumAssistantShared
 
 /// A single conversation row in the sidebar, handling hover, pin, archive, rename,
 /// and drag interactions.
-struct SidebarConversationItem: View {
+///
+/// This is a pure value view — all state is pre-resolved into value-type props
+/// and action closures, so SwiftUI can skip re-evaluation via `Equatable`.
+struct SidebarConversationItem: View, Equatable {
     let conversation: ConversationModel
-    @ObservedObject var conversationManager: ConversationManager
-    @ObservedObject var windowState: MainWindowState
-    var sidebar: SidebarInteractionState
-    /// Called when the user taps the conversation row (handles selection logic).
-    var selectConversation: () -> Void
-    /// Optional additional callback after selection (e.g. dismiss a popover).
-    var onSelect: (() -> Void)? = nil
+    let isSelected: Bool
+    let interactionState: ConversationInteractionState
+    let isHovered: Bool
+    let isPendingDeletion: Bool
 
-    private var isSelected: Bool {
-        switch windowState.selection {
-        case .panel:
-            return false
-        case .conversation(let id):
-            return id == conversation.id
-        case .appEditing(_, let conversationId):
-            return conversationId == conversation.id
-        case .app, .none:
-            // No explicit conversation in selection; fall back to the persistent conversation.
-            return conversation.id == windowState.persistentConversationId
-        }
+    // Action closures — not compared in Equatable
+    var selectConversation: () -> Void
+    var onSelect: (() -> Void)? = nil
+    var onTogglePin: () -> Void
+    var onArchive: () -> Void
+    var onBeginArchive: () -> Void
+    var onConfirmArchive: () -> Void
+    var onStartRename: () -> Void
+    var onMarkUnread: () -> Void
+    var onHoverChange: (Bool) -> Void
+    var onDragStart: () -> Void
+    var onShowFeedback: (() -> Void)?
+
+    static func == (lhs: SidebarConversationItem, rhs: SidebarConversationItem) -> Bool {
+        lhs.conversation == rhs.conversation &&
+        lhs.isSelected == rhs.isSelected &&
+        lhs.interactionState == rhs.interactionState &&
+        lhs.isHovered == rhs.isHovered &&
+        lhs.isPendingDeletion == rhs.isPendingDeletion
     }
 
-    private var isHovered: Bool { sidebar.isHoveredConversation == conversation.id }
-    private var interactionState: ConversationInteractionState { conversationManager.interactionState(for: conversation.id) }
-    // Reserve trailing space when hovered for archive button overlay.
-    private var hasTrailingIcon: Bool { isHovered || sidebar.conversationPendingDeletion == conversation.id }
-    private var isPendingDeletion: Bool { sidebar.conversationPendingDeletion == conversation.id }
+    private var hasTrailingIcon: Bool { isHovered || isPendingDeletion }
     private var canMarkUnread: Bool {
         !conversation.hasUnseenLatestAssistantMessage &&
             conversation.conversationId != nil &&
@@ -48,13 +51,7 @@ struct SidebarConversationItem: View {
                 // Hovered -> interactive pin button; not hovered -> status indicator.
                 if isHovered {
                     Button {
-                        withAnimation(VAnimation.standard) {
-                            if conversation.isPinned {
-                                conversationManager.unpinConversation(id: conversation.id)
-                            } else {
-                                conversationManager.pinConversation(id: conversation.id)
-                            }
-                        }
+                        onTogglePin()
                     } label: {
                         VIconView(.pin, size: 13)
                             .foregroundColor(conversation.isPinned ? VColor.contentTertiary : VColor.contentSecondary)
@@ -151,17 +148,16 @@ struct SidebarConversationItem: View {
             selectConversation()
         }
         .overlay(alignment: .trailing) {
-            if sidebar.conversationPendingDeletion == conversation.id {
+            if isPendingDeletion {
                 VButton(label: "Confirm", style: .dangerOutline, size: .pill) {
-                    conversationManager.archiveConversation(id: conversation.id)
-                    sidebar.conversationPendingDeletion = nil
+                    onConfirmArchive()
                 }
                 .fixedSize()
                 .padding(.trailing, VSpacing.xs)
                 .accessibilityLabel("Confirm archive \(conversation.title)")
             } else if isHovered {
                 Button {
-                    sidebar.conversationPendingDeletion = conversation.id
+                    onBeginArchive()
                 } label: {
                     VIconView(.archive, size: 13)
                         .foregroundColor(VColor.contentSecondary)
@@ -177,29 +173,22 @@ struct SidebarConversationItem: View {
         .padding(.horizontal, 0)
         .contextMenu {
             Button {
-                withAnimation(VAnimation.standard) {
-                    if conversation.isPinned {
-                        conversationManager.unpinConversation(id: conversation.id)
-                    } else {
-                        conversationManager.pinConversation(id: conversation.id)
-                    }
-                }
+                onTogglePin()
             } label: {
                 Label { Text(conversation.isPinned ? "Unpin" : "Pin") } icon: { VIconView(conversation.isPinned ? .pinOff : .pin, size: 14) }
             }
             Button {
-                sidebar.renamingConversationId = conversation.id
-                sidebar.renameText = conversation.title
+                onStartRename()
             } label: {
                 Label { Text("Rename") } icon: { VIconView(.pencil, size: 14) }
             }
             Button {
-                conversationManager.archiveConversation(id: conversation.id)
+                onArchive()
             } label: {
                 Label { Text("Archive") } icon: { VIconView(.archive, size: 14) }
             }
             Button {
-                conversationManager.markConversationUnread(conversationId: conversation.id)
+                onMarkUnread()
             } label: {
                 Label { Text("Mark as unread") } icon: { VIconView(.circle, size: 14) }
             }
@@ -208,22 +197,17 @@ struct SidebarConversationItem: View {
             Divider()
 
             Button {
-                guard let conversationId = conversation.conversationId else { return }
-                AppDelegate.shared?.showLogReportWindow(scope: .conversation(conversationId: conversationId, conversationTitle: conversation.title))
+                onShowFeedback?()
             } label: {
                 Label { Text("Share Feedback") } icon: { VIconView(.messageCircle, size: 14) }
             }
-            .disabled(conversation.conversationId == nil || LogExporter.isManagedAssistant)
+            .disabled(onShowFeedback == nil)
         }
         .pointerCursor { hovering in
-            withAnimation(VAnimation.fast) {
-                sidebar.setConversationHover(conversationId: conversation.id, hovering: hovering)
-            }
+            onHoverChange(hovering)
         }
         .onDrag {
-            sidebar.draggingConversationId = conversation.id
-            // Clear hover so icon-swap and archive-button animations stop during drag.
-            sidebar.isHoveredConversation = nil
+            onDragStart()
             return NSItemProvider(object: conversation.id.uuidString as NSString)
         } preview: {
             HStack(spacing: VSpacing.xs) {

--- a/clients/macos/vellum-assistantTests/ConversationManagerDebouncedEvictionTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerDebouncedEvictionTests.swift
@@ -30,9 +30,9 @@ final class ConversationManagerDebouncedEvictionTests: XCTestCase {
         // and the most recent ones should be retained.
         var insertedIds: [UUID] = []
 
-        // ConversationManager starts with one active conversation; that consumes
-        // one slot in the cache, so we need 12 additional VMs to exceed
-        // maxCachedViewModels (10) and trigger eviction.
+        // ConversationManager starts in draft mode (draftViewModel, not in
+        // chatViewModels), so chatViewModels starts empty. Insert 12 VMs to
+        // exceed maxCachedViewModels (10) and trigger eviction.
         for _ in 0..<12 {
             let id = UUID()
             let vm = conversationManager.makeViewModel()
@@ -85,9 +85,10 @@ final class ConversationManagerDebouncedEvictionTests: XCTestCase {
         // Wait for the single debounced eviction to complete.
         try await Task.sleep(for: .milliseconds(300))
 
-        // Count how many of our injected VMs survived. The cache should be
-        // trimmed to maxCachedViewModels (10), which includes the initial
-        // active conversation VM.
+        // Count how many of our injected VMs survived. ConversationManager
+        // starts in draft mode (draftViewModel, not in chatViewModels), so
+        // chatViewModels starts empty. After inserting 12 and evicting, the
+        // cache should be trimmed to maxCachedViewModels (10).
         var survivingCount = 0
         for id in insertedIds {
             if conversationManager.existingChatViewModel(for: id) != nil {
@@ -95,10 +96,7 @@ final class ConversationManagerDebouncedEvictionTests: XCTestCase {
             }
         }
 
-        // At most maxCachedViewModels - 1 of our injected VMs should survive
-        // (the initial conversation occupies one slot). Allow some flexibility
-        // since existingChatViewModel promotes to MRU.
-        XCTAssertLessThanOrEqual(survivingCount + 1, 10,
+        XCTAssertLessThanOrEqual(survivingCount, 10,
             "Cache should be trimmed to at most maxCachedViewModels entries")
     }
 }

--- a/clients/macos/vellum-assistantTests/ConversationManagerDebouncedEvictionTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerDebouncedEvictionTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class ConversationManagerDebouncedEvictionTests: XCTestCase {
+
+    private var connectionManager: GatewayConnectionManager!
+    private var conversationManager: ConversationManager!
+
+    override func setUp() {
+        super.setUp()
+        connectionManager = GatewayConnectionManager()
+        connectionManager.isConnected = true
+        conversationManager = ConversationManager(connectionManager: connectionManager, eventStreamClient: connectionManager.eventStreamClient)
+    }
+
+    override func tearDown() {
+        conversationManager = nil
+        connectionManager = nil
+        super.tearDown()
+    }
+
+    // MARK: - Debounced eviction behavior
+
+    /// Verify that eviction is deferred and fires after ~150ms, evicting old VMs
+    /// while retaining recently-accessed ones.
+    func testDebouncedEvictionEvictsOldVMsAfterDelay() async throws {
+        // Collect the UUIDs we inject. The first few should be evicted (oldest),
+        // and the most recent ones should be retained.
+        var insertedIds: [UUID] = []
+
+        // ConversationManager starts with one active conversation; that consumes
+        // one slot in the cache, so we need 12 additional VMs to exceed
+        // maxCachedViewModels (10) and trigger eviction.
+        for _ in 0..<12 {
+            let id = UUID()
+            let vm = conversationManager.makeViewModel()
+            // Ensure the VM is idle so the eviction guard doesn't skip it.
+            vm.isSending = false
+            vm.isThinking = false
+            vm.pendingQueuedCount = 0
+            conversationManager.setChatViewModel(vm, for: id)
+            insertedIds.append(id)
+        }
+
+        // Immediately after insertion, eviction should NOT have run yet because
+        // it is debounced. The earliest VMs should still be present.
+        let earlyId = insertedIds[0]
+        // Note: we access chatViewModels indirectly. existingChatViewModel(for:)
+        // would call touchVMAccessOrder, promoting the UUID to MRU. Instead we
+        // check existence AFTER the delay, as the plan instructs.
+
+        // Wait for the debounced eviction to fire (150ms delay + margin).
+        try await Task.sleep(for: .milliseconds(300))
+
+        // After eviction has fired, the earliest injected VMs should have been
+        // evicted because the cache exceeds maxCachedViewModels.
+        let earlyVM = conversationManager.existingChatViewModel(for: earlyId)
+        XCTAssertNil(earlyVM, "Early VM should have been evicted after debounced eviction fires")
+
+        // The most recently inserted VM should still be retained.
+        let recentId = insertedIds.last!
+        let recentVM = conversationManager.existingChatViewModel(for: recentId)
+        XCTAssertNotNil(recentVM, "Recent VM should be retained after eviction")
+    }
+
+    /// Verify that multiple rapid insertions coalesce into a single eviction pass.
+    func testMultipleInsertionsCoalesceIntoSingleEviction() async throws {
+        // Rapidly insert 12 VMs — each call to setChatViewModel triggers
+        // scheduleEvictionIfNeeded(), but only one eviction task should be
+        // created because the guard `pendingEvictionTask == nil` prevents
+        // duplicates.
+        var insertedIds: [UUID] = []
+        for _ in 0..<12 {
+            let id = UUID()
+            let vm = conversationManager.makeViewModel()
+            vm.isSending = false
+            vm.isThinking = false
+            vm.pendingQueuedCount = 0
+            conversationManager.setChatViewModel(vm, for: id)
+            insertedIds.append(id)
+        }
+
+        // Wait for the single debounced eviction to complete.
+        try await Task.sleep(for: .milliseconds(300))
+
+        // Count how many of our injected VMs survived. The cache should be
+        // trimmed to maxCachedViewModels (10), which includes the initial
+        // active conversation VM.
+        var survivingCount = 0
+        for id in insertedIds {
+            if conversationManager.existingChatViewModel(for: id) != nil {
+                survivingCount += 1
+            }
+        }
+
+        // At most maxCachedViewModels - 1 of our injected VMs should survive
+        // (the initial conversation occupies one slot). Allow some flexibility
+        // since existingChatViewModel promotes to MRU.
+        XCTAssertLessThanOrEqual(survivingCount + 1, 10,
+            "Cache should be trimmed to at most maxCachedViewModels entries")
+    }
+}

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -138,10 +138,13 @@ public final class ChatViewModel: ObservableObject {
     private func flushCoalescedPublish() {
         subManagerPublishTask?.cancel()
         subManagerPublishTask = nil
+        os_signpost(.event, log: Self.stallLog, name: "ChatVM.flush")
         objectWillChange.send()
     }
 
     // MARK: - Debug publish-rate counters
+
+    private static let stallLog = OSLog(subsystem: "com.vellum.assistant", category: "LayoutStall")
 
     #if DEBUG
     private static let perfLog = OSLog(subsystem: "com.vellum.assistant", category: "PerfCounters")
@@ -1241,6 +1244,7 @@ public final class ChatViewModel: ObservableObject {
     }
 
     public func sendMessage(hidden: Bool = false) {
+        os_signpost(.event, log: Self.stallLog, name: "sendMessage")
         let rawText = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
         let text = rawText
         let hasAttachments = !pendingAttachments.isEmpty


### PR DESCRIPTION
## Summary

Addresses a ~2.5s main thread freeze when sending a message. The hang sample showed the main thread blocked in SwiftUI's LazyVStack layout pass, triggered by a cascade of coalesced state mutations. This PR contains four categories of changes: instrumentation for diagnosis, sidebar invalidation reduction, LRU eviction cleanup, and fixing a scroll-layout feedback loop.

## Why these changes are needed

The original hang sample showed 2520ms blocked in `LazyStack.place(subviews:)`. Investigation revealed two compounding issues:

1. **Sidebar broad invalidation**: Every `ConversationManager.objectWillChange` or `MainWindowState.objectWillChange` caused ALL sidebar rows to re-evaluate their body, because `SidebarConversationItem` held `@ObservedObject` references to both. Even with only 10-20 conversations, this adds up when combined with other mutations in the same SwiftUI transaction.

2. **Avatar scroll-layout feedback loop**: The conversation tail avatar used `withAnimation(spring) { avatarDisplayY = y }` to animate position updates. `withAnimation` wraps the `@State` mutation in an animation transaction that propagates to ALL views reading that state during body re-evaluation. This caused SwiftUI to re-evaluate the body on each spring interpolation frame, which fired new tail anchor preferences, which triggered another avatar update — a feedback loop that tripped the scroll loop guard (30+ events in 2s) and froze the UI.

3. **LRU eviction stacking**: VM eviction ran synchronously on every `getOrCreateViewModel`, `selectConversation`, `appendConversations`, etc. — potentially compounding with the send path's `flushCoalescedPublish()` in the same run-loop tick.

## What each change does and why it's safe

### 1. Signpost instrumentation (ChatViewModel, ConversationManager, MessageListView)
- Adds `os_signpost(.event)` landmarks at `sendMessage()`, `flushCoalescedPublish()`, `MessageList.bodyEval`, and LRU eviction
- **Safety**: `os_signpost` has near-zero cost when Instruments is not attached (Apple-documented). No functional change.

### 2. SidebarConversationItem → pure value view
- **Before**: Held `@ObservedObject var conversationManager`, `@ObservedObject var windowState`, and `var sidebar: SidebarInteractionState` (@Observable). Any mutation to any of these objects invalidated every sidebar row.
- **After**: All state is pre-resolved into value-type props (`isSelected: Bool`, `interactionState`, `isHovered: Bool`, `isPendingDeletion: Bool`) and action closures in the parent's `makeSidebarRow()` factory. The row conforms to `Equatable` and uses `.equatable()` so SwiftUI skips re-evaluation when props haven't changed.
- **Safety**: This is a pure refactor of the data flow — no behavior changes. Every action the row previously performed via `conversationManager.pinConversation(...)` or `sidebar.conversationPendingDeletion = ...` is now performed via closure (`onTogglePin`, `onBeginArchive`, etc.) that does the exact same thing in the parent. The `isConversationSelected()` helper mirrors the original computed property exactly, including the `appEditing` guard. All four instantiation sites (3 in MainWindowView+Sidebar, 1 in ConversationSwitcherDrawer) are updated.

### 3. vmAccessOrder indexed removal
- **Before**: `vmAccessOrder.removeAll { $0 == id }` — scans and rebuilds the entire array even though only one element matches.
- **After**: `firstIndex(of:) + remove(at:)` — stops at the first match, single-element removal.
- **Safety**: Identical behavior. The array has at most 10 elements (maxCachedViewModels), so this is a clarity improvement, not a performance-critical change.

### 4. Debounced eviction
- **Before**: `evictStaleCachedViewModels()` called synchronously from 8 call sites, potentially compounding with send-path state mutations in the same run-loop tick.
- **After**: `scheduleEvictionIfNeeded()` defers eviction by 150ms via a `Task`. `defer { pendingEvictionTask = nil }` clears the task reference on every exit path. Multiple triggers coalesce into a single eviction pass.
- **Safety**: Eviction still runs — just 150ms later. The cache can temporarily exceed `maxCachedViewModels` by one batch of insertions, but the `while` loop in `evictStaleCachedViewModels` handles any accumulated excess. Behavioral test verifies old VMs are evicted after delay and recent VMs are retained.

### 5. Avatar animation: `withAnimation` → `.animation(_:value:)`
- **Before**: `withAnimation(spring) { avatarDisplayY = y }` — creates an animation transaction that propagates through the entire view hierarchy during body re-evaluation, causing per-frame body re-evals that feed layout shifts back into preferences.
- **After**: Direct `@State` write (`avatarDisplayY = y`) + `.animation(spring, value: avatarDisplayY)` on the avatar view's `.offset()` modifier.
- **Safety**: This is the [Apple-recommended pattern](https://developer.apple.com/documentation/swiftui/view/animation(_:value:)) for animating a specific view property. `.animation(_:value:)` scopes the animation to just the `.offset()` — the spring interpolation happens in SwiftUI's render pipeline without triggering body re-evaluations. The visual result is identical (same spring parameters), but without the feedback loop.
- **`avatarLastAppliedAt` consolidation**: Moved the timestamp write from two callers into `applyAvatarDisplayY` itself, so it's only recorded when an apply actually happens (not when the dead zone or downward-only clamp rejects it). This keeps the smoothing delay calculation accurate.

## Files changed
| File | What changed |
|------|-------------|
| `ChatViewModel.swift` | +2 signpost events (sendMessage, flushCoalescedPublish) |
| `MessageListView.swift` | +1 signpost, avatar animation moved to .animation() modifier |
| `ConversationManager.swift` | Indexed removal, debounced eviction, +1 signpost |
| `SidebarConversationItem.swift` | Pure value view refactor |
| `MainWindowView+Sidebar.swift` | makeSidebarRow factory, .equatable() at 3 sites |
| `ConversationSwitcherDrawer.swift` | Updated to new SidebarConversationItem interface |
| `ConversationManagerDebouncedEvictionTests.swift` | New: behavioral test for debounced eviction |

## Testing
- Build and run, send a message — no rainbow spinner
- Hover sidebar conversations — only hovered row should re-render
- Pin/unpin, archive, rename, drag-and-drop — all work as before
- Attach Instruments with os_signpost template to see LayoutStall landmarks

## Known follow-up
Avatar briefly disappears on send due to transient non-finite anchor during LazyVStack re-layout (pre-existing behavior, not introduced by this PR). Will address in a separate PR.

## PRs merged into feature branch
- #20934: perf: add signpost landmarks and invalidation counters
- #20935: refactor: replace vmAccessOrder.removeAll with indexed removal
- #20936: perf: convert SidebarConversationItem to pure value view
- #20937: perf: debounce VM eviction
- #20940: fix: make makeSidebarRow private
- #20943: fix: wrap os_signpost in let _ = (ViewBuilder build fix)
- #20944: fix: correct eviction test assertion
- #20949: fix: add cooldown to avatar Y updates (superseded by #20951)
- #20951: fix: move avatar spring animation to .animation() modifier

Part of plan: fix-main-thread-stall.md