### PR TITLE
fix: wrap os_signpost in let _ = to avoid SwiftUI ViewBuilder type-check timeout

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -941,7 +941,7 @@ struct MessageListView: View {
                     }
 
                     let _ = recordScrollLoopEvent(.bodyEvaluation)
-                    os_signpost(.event, log: stallLog, name: "MessageList.bodyEval")
+                    let _ = os_signpost(.event, log: stallLog, name: "MessageList.bodyEval")
                     let state = precomputedState
                     let catalogHash = MessageCellView.hashCatalog(providerCatalog)
                     ForEach(state.displayMessages) { message in


### PR DESCRIPTION
## Summary
The bare os_signpost() call in MessageListView's body caused Swift's type checker to time out — it was being interpreted as a view expression in the ViewBuilder context. Wrapping in `let _ =` (matching the existing recordScrollLoopEvent pattern on the line above) discards the return value and prevents the type-checker ambiguity.

Part of plan: fix-main-thread-stall.md (build fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
