### PR TITLE
fix: correct eviction test assertion — draftViewModel doesn't occupy chatViewModels slot

### DIFF
--- a/clients/macos/vellum-assistantTests/ConversationManagerDebouncedEvictionTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationManagerDebouncedEvictionTests.swift
@@ -30,9 +30,9 @@ final class ConversationManagerDebouncedEvictionTests: XCTestCase {
         // and the most recent ones should be retained.
         var insertedIds: [UUID] = []
 
-        // ConversationManager starts with one active conversation; that consumes
-        // one slot in the cache, so we need 12 additional VMs to exceed
-        // maxCachedViewModels (10) and trigger eviction.
+        // ConversationManager starts in draft mode (draftViewModel, not in
+        // chatViewModels), so chatViewModels starts empty. Insert 12 VMs to
+        // exceed maxCachedViewModels (10) and trigger eviction.
         for _ in 0..<12 {
             let id = UUID()
             let vm = conversationManager.makeViewModel()
@@ -85,9 +85,10 @@ final class ConversationManagerDebouncedEvictionTests: XCTestCase {
         // Wait for the single debounced eviction to complete.
         try await Task.sleep(for: .milliseconds(300))
 
-        // Count how many of our injected VMs survived. The cache should be
-        // trimmed to maxCachedViewModels (10), which includes the initial
-        // active conversation VM.
+        // Count how many of our injected VMs survived. ConversationManager
+        // starts in draft mode (draftViewModel, not in chatViewModels), so
+        // chatViewModels starts empty. After inserting 12 and evicting, the
+        // cache should be trimmed to maxCachedViewModels (10).
         var survivingCount = 0
         for id in insertedIds {
             if conversationManager.existingChatViewModel(for: id) != nil {
@@ -95,10 +96,7 @@ final class ConversationManagerDebouncedEvictionTests: XCTestCase {
             }
         }
 
-        // At most maxCachedViewModels - 1 of our injected VMs should survive
-        // (the initial conversation occupies one slot). Allow some flexibility
-        // since existingChatViewModel promotes to MRU.
-        XCTAssertLessThanOrEqual(survivingCount + 1, 10,
+        XCTAssertLessThanOrEqual(survivingCount, 10,
             "Cache should be trimmed to at most maxCachedViewModels entries")
     }
 }


### PR DESCRIPTION
## Summary
Fixes test assertion flagged by both Devin and Codex reviewers on PR #20942.

**Issue:** `survivingCount + 1 <= 10` always fails because ConversationManager.init() enters draft mode (stores VM in draftViewModel, not chatViewModels). After inserting 12 VMs and evicting down to 10, survivingCount = 10, making 11 <= 10 false.

**Fix:** Changed to `survivingCount <= 10` and corrected misleading comments about 'initial active conversation occupying a slot'.

Part of plan: fix-main-thread-stall.md (review feedback fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
