### PR TITLE
fix: harden Slack setup skills to prevent incorrect OAuth/redirect URL instructions

### DIFF
--- a/assistant/src/config/bundled-skills/slack/SKILL.md
+++ b/assistant/src/config/bundled-skills/slack/SKILL.md
@@ -76,4 +76,4 @@ For setting up recurring digests, load the `slack-digest-setup` skill which cove
 
 ## Connection
 
-Before using any Slack tool, verify that Slack is connected. If not connected, guide the user through the Slack setup flow described in the messaging skill.
+Before using any Slack tool, verify that Slack is connected. If not connected, load the **slack-app-setup** skill (`skill_load` with `skill: "slack-app-setup"`) and follow its step-by-step guided flow. Do NOT improvise setup instructions — the `slack-app-setup` skill is the single source of truth for Slack connection setup. Slack uses Socket Mode (not OAuth) and does not require redirect URLs or any OAuth flow.

--- a/skills/oauth-setup/SKILL.md
+++ b/skills/oauth-setup/SKILL.md
@@ -46,7 +46,6 @@ Well-known services with dedicated setup skills (note: not all follow the `<serv
 | Service  | Skill ID                 |
 | -------- | ------------------------ |
 | gmail    | google-oauth-applescript |
-| slack    | **slack-app-setup**      |
 | notion   | notion-oauth-setup       |
 | twitter  | twitter-oauth-setup      |
 | github   | github-oauth-setup       |
@@ -60,7 +59,7 @@ Well-known services with dedicated setup skills (note: not all follow the `<serv
 | hubspot  | hubspot-oauth-setup      |
 | figma    | figma-oauth-setup        |
 
-**IMPORTANT: Slack uses Socket Mode, NOT OAuth. Its dedicated skill is `slack-app-setup` (not `slack-oauth-setup`). Always load the exact skill ID from the table above — do NOT guess the name or fall through to the generic OAuth flow.**
+**Slack does NOT use OAuth.** It connects via Socket Mode using the `slack-app-setup` skill. If the user asks to set up Slack, do NOT use this generic OAuth flow — load `slack-app-setup` instead.
 
 ## Step 3: Choose the flow based on setup metadata
 

--- a/skills/oauth-setup/SKILL.md
+++ b/skills/oauth-setup/SKILL.md
@@ -41,7 +41,26 @@ If no config is found, tell the user this service doesn't have a pre-configured 
 
 Check the available skills catalog for a dedicated `<service>-oauth-setup` skill matching this service name. If one exists, load that skill instead - it has provider-specific steps that are more reliable than the generic flow. Use `skill_load` with that skill ID and hand off completely.
 
-Well-known services with dedicated setup skills: `gmail` (google-oauth-applescript), `slack`, `notion`, `twitter`, `github`, `linear`, `spotify`, `todoist`, `discord`, `dropbox`, `asana`, `airtable`, `hubspot`, `figma`.
+Well-known services with dedicated setup skills (note: not all follow the `<service>-oauth-setup` naming convention):
+
+| Service    | Skill ID                    |
+| ---------- | --------------------------- |
+| gmail      | google-oauth-applescript    |
+| slack      | **slack-app-setup**         |
+| notion     | notion-oauth-setup          |
+| twitter    | twitter-oauth-setup         |
+| github     | github-oauth-setup          |
+| linear     | linear-oauth-setup          |
+| spotify    | spotify-oauth-setup         |
+| todoist    | todoist-oauth-setup         |
+| discord    | discord-oauth-setup         |
+| dropbox    | dropbox-oauth-setup         |
+| asana      | asana-oauth-setup           |
+| airtable   | airtable-oauth-setup        |
+| hubspot    | hubspot-oauth-setup         |
+| figma      | figma-oauth-setup           |
+
+**IMPORTANT: Slack uses Socket Mode, NOT OAuth. Its dedicated skill is `slack-app-setup` (not `slack-oauth-setup`). Always load the exact skill ID from the table above — do NOT guess the name or fall through to the generic OAuth flow.**
 
 ## Step 3: Choose the flow based on setup metadata
 

--- a/skills/oauth-setup/SKILL.md
+++ b/skills/oauth-setup/SKILL.md
@@ -43,22 +43,22 @@ Check the available skills catalog for a dedicated `<service>-oauth-setup` skill
 
 Well-known services with dedicated setup skills (note: not all follow the `<service>-oauth-setup` naming convention):
 
-| Service    | Skill ID                    |
-| ---------- | --------------------------- |
-| gmail      | google-oauth-applescript    |
-| slack      | **slack-app-setup**         |
-| notion     | notion-oauth-setup          |
-| twitter    | twitter-oauth-setup         |
-| github     | github-oauth-setup          |
-| linear     | linear-oauth-setup          |
-| spotify    | spotify-oauth-setup         |
-| todoist    | todoist-oauth-setup         |
-| discord    | discord-oauth-setup         |
-| dropbox    | dropbox-oauth-setup         |
-| asana      | asana-oauth-setup           |
-| airtable   | airtable-oauth-setup        |
-| hubspot    | hubspot-oauth-setup         |
-| figma      | figma-oauth-setup           |
+| Service  | Skill ID                 |
+| -------- | ------------------------ |
+| gmail    | google-oauth-applescript |
+| slack    | **slack-app-setup**      |
+| notion   | notion-oauth-setup       |
+| twitter  | twitter-oauth-setup      |
+| github   | github-oauth-setup       |
+| linear   | linear-oauth-setup       |
+| spotify  | spotify-oauth-setup      |
+| todoist  | todoist-oauth-setup      |
+| discord  | discord-oauth-setup      |
+| dropbox  | dropbox-oauth-setup      |
+| asana    | asana-oauth-setup        |
+| airtable | airtable-oauth-setup     |
+| hubspot  | hubspot-oauth-setup      |
+| figma    | figma-oauth-setup        |
 
 **IMPORTANT: Slack uses Socket Mode, NOT OAuth. Its dedicated skill is `slack-app-setup` (not `slack-oauth-setup`). Always load the exact skill ID from the table above — do NOT guess the name or fall through to the generic OAuth flow.**
 

--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -72,11 +72,7 @@ Generate the manifest JSON:
   },
   "settings": {
     "event_subscriptions": {
-      "bot_events": [
-        "app_mention",
-        "message.channels",
-        "message.im"
-      ]
+      "bot_events": ["app_mention", "message.channels", "message.im"]
     },
     "interactivity": { "is_enabled": true },
     "org_deploy_enabled": false,

--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -11,6 +11,8 @@ metadata:
 
 You are helping your user connect a Slack bot to the Vellum Assistant via Socket Mode. Walk through each step below.
 
+**CRITICAL: Follow these steps strictly in order. Do NOT combine steps, skip ahead, or ask for multiple tokens at once. Each step must be completed and confirmed before moving to the next. The bot token does NOT exist until the app is installed — you cannot collect it early.**
+
 ## Value Classification
 
 | Value     | Type       | Storage method            | Secret? |
@@ -96,6 +98,8 @@ Wait for the user to confirm they've created the app before proceeding.
 
 ## Step 2: Generate App Token & Collect It
 
+**Do NOT skip ahead to the bot token. The app token must be collected first — the bot token does not exist yet.**
+
 Tell the user to navigate to **Settings > Basic Information > App-Level Tokens** in their newly created Slack app, then:
 
 1. Click **Generate Token and Scopes**
@@ -115,9 +119,11 @@ The `slack_channel` secure prompt already routes through the same Slack settings
 
 ## Step 3: Install App & Collect Bot Token
 
+**IMPORTANT: The bot token only becomes available AFTER the app is installed. The user MUST install the app first — do NOT ask for the bot token before this step. The bot token is found under Install App (NOT under OAuth & Permissions).**
+
 Tell the user to navigate to **Settings > Install App** in the sidebar, then click **Install to Workspace** and authorize the requested permissions (already pre-configured from the manifest).
 
-After installation, collect the bot token securely:
+After installation, the **Bot User OAuth Token** will appear on the same Install App page. Collect it securely:
 
 - Call `credential_store` with `action: "prompt"`, `service: "slack_channel"`, `field: "bot_token"`, `label: "Bot User OAuth Token"`, `placeholder: "xoxb-..."`, `description: "Paste the Bot User OAuth Token shown after installing"`
 
@@ -201,7 +207,11 @@ Verify that `message.channels` event subscription is enabled in your Slack app s
 
 ## Implementation Rules
 
-All token collection goes through `credential_store` prompts. Do NOT use `ui_show`, `ui_update`, `assistant credentials reveal`, `curl`, or `assistant config set slack.*` in chat to collect or manipulate tokens. Do NOT ask the user to paste them in chat — always use the secure credential prompt.
+- All token collection goes through `credential_store` prompts. Do NOT use `ui_show`, `ui_update`, `assistant credentials reveal`, `curl`, or `assistant config set slack.*` in chat to collect or manipulate tokens. Do NOT ask the user to paste them in chat — always use the secure credential prompt.
+- **Do NOT combine multiple steps into a single message.** Each step must be its own turn in the conversation. Wait for the user to confirm completion before moving on.
+- **Do NOT ask for both tokens at once.** Collect the app token (Step 2) first, then install the app (Step 3), then collect the bot token. The bot token literally does not exist until the app is installed.
+- **Do NOT tell the user to find the bot token under "OAuth & Permissions".** The bot token appears on the **Install App** page after installation.
+- **Do NOT tell the user to set up a redirect URL.** Socket Mode does not require redirect URLs, OAuth redirect URLs, or any publicly reachable endpoints. The manifest already configures Socket Mode — no additional URL configuration is needed.
 
 ## Clearing Credentials
 


### PR DESCRIPTION
## Summary
- **Bundled `slack` skill** pointed vaguely to "the messaging skill" for setup, so the model improvised its own flow (OAuth, redirect URLs, wrong token order)
- **`oauth-setup` skill** relied on `<service>-oauth-setup` naming convention which doesn't match `slack-app-setup`, causing fallthrough to the generic OAuth flow
- **`slack-app-setup` skill** lacked guardrails against combining steps, collecting tokens out of order, or mentioning redirect URLs

## Changes
- `assistant/src/config/bundled-skills/slack/SKILL.md` — direct reference to `slack-app-setup` with explicit "no OAuth, no redirect URLs" note
- `skills/oauth-setup/SKILL.md` — replaced free-text service list with explicit skill ID mapping table; added warning that Slack is Socket Mode, not OAuth
- `skills/slack-app-setup/SKILL.md` — added critical ordering guardrails, step-level warnings, and implementation rules against combining steps, wrong token location, and redirect URLs

## Test plan
- [ ] Run Slack setup from scratch and verify the assistant follows each step in order
- [ ] Verify no mention of redirect URLs or OAuth flow during setup
- [ ] Verify bot token is collected after app installation, not before
- [ ] Verify tokens are collected one at a time via `credential_store`, not pasted in chat

Closes JARVIS-327

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
