### PR TITLE
fix: add cooldown to avatar display Y updates to break scroll layout feedback loop

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -431,7 +431,23 @@ struct MessageListView: View {
             return
         }
 
+        // Cooldown: suppress re-entrant applies within the spring animation window.
+        // Each avatarDisplayY mutation triggers a body re-evaluation → new layout →
+        // new tail anchor preference → deferred Task → updateAvatarFollower → back
+        // here. Without a cooldown, the spring animation (0.28s response) amplifies
+        // sub-pixel layout shifts into a feedback loop that trips the scroll loop
+        // guard (30+ avatarDisplayYApplied events in 2s) and freezes the UI.
+        // The cooldown matches the spring response time so the animation settles
+        // before the next position update is accepted.
+        if let lastApplied = scrollTracking.avatarLastAppliedAt {
+            let elapsed = Date().timeIntervalSince(lastApplied)
+            if elapsed < 0.28 {  // Match spring response time (ConversationAvatarFollower.spring)
+                return
+            }
+        }
+
         recordScrollLoopEvent(.avatarDisplayYApplied)
+        scrollTracking.avatarLastAppliedAt = Date()
         withAnimation(ConversationAvatarFollower.spring) {
             avatarDisplayY = y
         }
@@ -487,7 +503,6 @@ struct MessageListView: View {
             avatarSmoothingTask?.cancel()
             avatarSmoothingTask = nil
             scrollTracking.pendingAvatarY = nil
-            scrollTracking.avatarLastAppliedAt = now
             applyAvatarDisplayY(forAnchorY: anchorY)
             return
         }
@@ -507,7 +522,6 @@ struct MessageListView: View {
                 return
             }
             scrollTracking.pendingAvatarY = nil
-            scrollTracking.avatarLastAppliedAt = Date()
             applyAvatarDisplayY(forAnchorY: pending)
             avatarSmoothingTask = nil
         }


### PR DESCRIPTION
## Summary
- Add 0.28s cooldown (matching spring animation response time) between successive avatarDisplayY @State mutations
- Each mutation triggers body re-eval → layout → tail anchor preference → avatar update → back to apply — a feedback loop that freezes the UI
- Cooldown lets the spring animation settle before accepting the next position update
- Consolidate avatarLastAppliedAt writes into applyAvatarDisplayY so timestamp only updates on actual applies

Part of plan: fix-main-thread-stall.md (scroll loop fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
