### PR TITLE
feat: full-width tabbed raw payload view with full-height content

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPayloadView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPayloadView.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 struct MessageInspectorPayloadView: View {
     let title: String
     @Binding var model: MessageInspectorPayloadModel
-    let viewportHeight: CGFloat
+    var viewportHeight: CGFloat?
 
     @State private var isActivelyEditing = false
     @State private var expandAllTrigger = 0
@@ -89,7 +89,7 @@ struct MessageInspectorPayloadView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             }
         }
-        .frame(maxWidth: .infinity)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .frame(height: viewportHeight)
         .background(VColor.surfaceBase)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))

--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
@@ -131,17 +131,7 @@ struct MessageInspectorView: View {
                     Spacer()
                 }
 
-                ViewThatFits(in: .horizontal) {
-                    HStack(alignment: .top, spacing: VSpacing.lg) {
-                        skeletonPayloadColumn
-                        skeletonPayloadColumn
-                    }
-
-                    VStack(alignment: .leading, spacing: VSpacing.lg) {
-                        skeletonPayloadColumn
-                        skeletonPayloadColumn
-                    }
-                }
+                skeletonPayloadColumn
 
                 Spacer()
             }
@@ -334,36 +324,39 @@ struct MessageInspectorView: View {
     }
 
     private func rawPayloadTab(for entry: LLMRequestLogEntry) -> some View {
-        ScrollView {
-            ViewThatFits(in: .horizontal) {
-                HStack(alignment: .top, spacing: VSpacing.lg) {
-                    payloadSection(
-                        title: "Request",
-                        key: payloadKey(for: entry.id, kind: "request")
-                    )
+        VStack(spacing: 0) {
+            HStack {
+                VSegmentedControl(
+                    items: RawPayloadPane.allCases.map { (label: $0.label, tag: $0) },
+                    selection: rawPaneBinding,
+                    style: .pill,
+                    size: .compact
+                )
+                .fixedSize()
 
-                    payloadSection(
-                        title: "Response",
-                        key: payloadKey(for: entry.id, kind: "response")
-                    )
-                }
-
-                VStack(alignment: .leading, spacing: VSpacing.lg) {
-                    payloadSection(
-                        title: "Request",
-                        key: payloadKey(for: entry.id, kind: "request")
-                    )
-
-                    payloadSection(
-                        title: "Response",
-                        key: payloadKey(for: entry.id, kind: "response")
-                    )
-                }
+                Spacer()
             }
-            .padding(VSpacing.lg)
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.sm)
+
+            MessageInspectorPayloadView(
+                title: viewState.selectedRawPane.label,
+                model: payloadBinding(
+                    for: payloadKey(for: entry.id, kind: viewState.selectedRawPane.rawValue)
+                )
+            )
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.bottom, VSpacing.lg)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(VColor.surfaceBase)
+    }
+
+    private var rawPaneBinding: Binding<RawPayloadPane> {
+        Binding(
+            get: { viewState.selectedRawPane },
+            set: { viewState.selectRawPane($0) }
+        )
     }
 
     private func payloadSection(title: String, key: String) -> some View {
@@ -538,6 +531,18 @@ enum MessageInspectorLoadState: Equatable {
     case loaded
 }
 
+enum RawPayloadPane: String, CaseIterable {
+    case request
+    case response
+
+    var label: String {
+        switch self {
+        case .request: return "Request"
+        case .response: return "Response"
+        }
+    }
+}
+
 enum MessageInspectorDetailTab: String, CaseIterable {
     case overview
     case prompt
@@ -576,6 +581,7 @@ struct MessageInspectorViewState {
     private(set) var logs: [LLMRequestLogEntry] = []
     private(set) var selectedLogID: String?
     private(set) var selectedDetailTab: MessageInspectorDetailTab = .overview
+    private(set) var selectedRawPane: RawPayloadPane = .request
     private(set) var activeLoadToken: UUID?
 
     var selectedLog: LLMRequestLogEntry? {
@@ -642,6 +648,10 @@ struct MessageInspectorViewState {
 
     mutating func selectDetailTab(_ tab: MessageInspectorDetailTab) {
         selectedDetailTab = tab
+    }
+
+    mutating func selectRawPane(_ pane: RawPayloadPane) {
+        selectedRawPane = pane
     }
 
     static func ordered(_ logs: [LLMRequestLogEntry]) -> [LLMRequestLogEntry] {


### PR DESCRIPTION
## Summary
- Replace side-by-side Request/Response columns in the Raw tab with a segmented control to switch between them, each taking full width
- Make the payload content fill all available vertical space instead of using a fixed 560px height
- Update loading skeleton to match the single-column layout

## Original prompt
I want it to take up the full height as well (marked the issue in red)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20950" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
