### PR TITLE
fix: move avatar spring animation from withAnimation to .animation() modifier to break layout feedback loop

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -431,26 +431,14 @@ struct MessageListView: View {
             return
         }
 
-        // Cooldown: suppress re-entrant applies within the spring animation window.
-        // Each avatarDisplayY mutation triggers a body re-evaluation → new layout →
-        // new tail anchor preference → deferred Task → updateAvatarFollower → back
-        // here. Without a cooldown, the spring animation (0.28s response) amplifies
-        // sub-pixel layout shifts into a feedback loop that trips the scroll loop
-        // guard (30+ avatarDisplayYApplied events in 2s) and freezes the UI.
-        // The cooldown matches the spring response time so the animation settles
-        // before the next position update is accepted.
-        if let lastApplied = scrollTracking.avatarLastAppliedAt {
-            let elapsed = Date().timeIntervalSince(lastApplied)
-            if elapsed < 0.28 {  // Match spring response time (ConversationAvatarFollower.spring)
-                return
-            }
-        }
-
         recordScrollLoopEvent(.avatarDisplayYApplied)
         scrollTracking.avatarLastAppliedAt = Date()
-        withAnimation(ConversationAvatarFollower.spring) {
-            avatarDisplayY = y
-        }
+        // Set @State without withAnimation — the spring animation is applied via
+        // .animation() on the avatar view's .offset() modifier instead. This avoids
+        // wrapping the mutation in an animation transaction, which would cause SwiftUI
+        // to re-evaluate the body on each spring interpolation frame and feed layout
+        // shifts back into the tail anchor preference → avatar update cycle.
+        avatarDisplayY = y
     }
 
     private func updateAvatarFollower(anchorY: CGFloat) {
@@ -544,6 +532,7 @@ struct MessageListView: View {
                     .frame(maxWidth: VSpacing.chatColumnMaxWidth)
                     .frame(maxWidth: .infinity)
                     .offset(y: avatarDisplayY)
+                    .animation(ConversationAvatarFollower.spring, value: avatarDisplayY)
                     .accessibilityHidden(true)
                     .onAppear {
                         if shouldPlayTailEntryAnimation {
@@ -560,6 +549,7 @@ struct MessageListView: View {
                 .frame(maxWidth: VSpacing.chatColumnMaxWidth)
                 .frame(maxWidth: .infinity)
                 .offset(y: avatarDisplayY)
+                .animation(ConversationAvatarFollower.spring, value: avatarDisplayY)
                 .allowsHitTesting(false)
                 .accessibilityHidden(true)
             }


### PR DESCRIPTION
## Summary
- Replace `withAnimation(spring) { avatarDisplayY = y }` with direct @State write
- Add `.animation(ConversationAvatarFollower.spring, value: avatarDisplayY)` on both avatar view offset sites
- Remove the 0.28s time-based cooldown (too aggressive, blocked avatar from following content)
- `.animation(_:value:)` scopes animation to just the offset property, avoiding animation transactions that propagate through body re-evaluation and feed layout shifts back into the preference → avatar update cycle

Part of plan: fix-main-thread-stall.md (scroll loop fix v2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20951" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
