### PR TITLE
M1: Add copy button to code blocks in chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -384,25 +384,25 @@ private struct CodeBlockView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Header bar: language label (left) + copy button (right)
-            HStack {
-                if let language, !language.isEmpty {
+            if let language, !language.isEmpty {
+                // Header bar with language label + copy button
+                HStack {
                     Text(language)
                         .font(.system(size: scaledCodeLabelSize, weight: .medium))
-                        .foregroundColor(mutedTextColor)
+                        .foregroundStyle(mutedTextColor)
+                    Spacer()
+                    VCopyButton(text: code, size: .compact)
+                        .opacity(isHovered ? 1 : 0)
+                        .animation(VAnimation.fast, value: isHovered)
                 }
-                Spacer()
-                VCopyButton(text: code, size: .compact)
-                    .opacity(isHovered ? 1 : 0)
-                    .animation(VAnimation.fast, value: isHovered)
+                .padding(.horizontal, VSpacing.sm)
+                .padding(.top, VSpacing.xs)
             }
-            .padding(.horizontal, VSpacing.sm)
-            .padding(.top, VSpacing.xs)
 
             ScrollView(.horizontal, showsIndicators: false) {
                 Text(code)
                     .font(.custom("DMMono-Regular", size: 13))
-                    .foregroundColor(textColor)
+                    .foregroundStyle(textColor)
                     .textSelection(.enabled)
                     .fixedSize(horizontal: true, vertical: true)
                     .padding(VSpacing.sm)
@@ -411,6 +411,14 @@ private struct CodeBlockView: View {
         .optionalMaxWidth(maxContentWidth)
         .background(codeBackgroundColor)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(alignment: .topTrailing) {
+            if language == nil || language?.isEmpty == true {
+                VCopyButton(text: code, size: .compact)
+                    .opacity(isHovered ? 1 : 0)
+                    .animation(VAnimation.fast, value: isHovered)
+                    .padding(VSpacing.xs)
+            }
+        }
         .onHover { isHovered = $0 }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -67,26 +67,15 @@ struct MarkdownSegmentView: View, Equatable {
                         .padding(.top, level == 1 ? 4 : 2)
 
                 case .codeBlock(let language, let code):
-                    VStack(alignment: .leading, spacing: 0) {
-                        if let language, !language.isEmpty {
-                            Text(language)
-                                .font(.system(size: scaledCodeLabelSize, weight: .medium))
-                                .foregroundColor(mutedTextColor)
-                                .padding(.horizontal, VSpacing.sm)
-                                .padding(.top, VSpacing.xs)
-                        }
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            Text(code)
-                                .font(.custom("DMMono-Regular", size: 13))
-                                .foregroundColor(textColor)
-                                .textSelection(.enabled)
-                                .fixedSize(horizontal: true, vertical: true)
-                                .padding(VSpacing.sm)
-                        }
-                    }
-                    .optionalMaxWidth(maxContentWidth)
-                    .background(codeBackgroundColor)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    CodeBlockView(
+                        language: language,
+                        code: code,
+                        scaledCodeLabelSize: scaledCodeLabelSize,
+                        textColor: textColor,
+                        mutedTextColor: mutedTextColor,
+                        codeBackgroundColor: codeBackgroundColor,
+                        maxContentWidth: maxContentWidth
+                    )
 
                 case .table(let headers, let rows):
                     MarkdownTableView(headers: headers, rows: rows, maxWidth: maxContentWidth ?? .infinity)
@@ -375,6 +364,54 @@ struct MarkdownSegmentView: View, Equatable {
         }
 
         return result
+    }
+}
+
+// MARK: - Code Block View
+
+/// Renders a fenced code block with an optional language label and a
+/// hover-revealed copy-to-clipboard button.
+private struct CodeBlockView: View {
+    let language: String?
+    let code: String
+    let scaledCodeLabelSize: CGFloat
+    let textColor: Color
+    let mutedTextColor: Color
+    let codeBackgroundColor: Color
+    let maxContentWidth: CGFloat?
+
+    @State private var isHovered = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header bar: language label (left) + copy button (right)
+            HStack {
+                if let language, !language.isEmpty {
+                    Text(language)
+                        .font(.system(size: scaledCodeLabelSize, weight: .medium))
+                        .foregroundColor(mutedTextColor)
+                }
+                Spacer()
+                VCopyButton(text: code, size: .compact)
+                    .opacity(isHovered ? 1 : 0)
+                    .animation(VAnimation.fast, value: isHovered)
+            }
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.top, VSpacing.xs)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                Text(code)
+                    .font(.custom("DMMono-Regular", size: 13))
+                    .foregroundColor(textColor)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: true, vertical: true)
+                    .padding(VSpacing.sm)
+            }
+        }
+        .optionalMaxWidth(maxContentWidth)
+        .background(codeBackgroundColor)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .onHover { isHovered = $0 }
     }
 }
 


### PR DESCRIPTION
## Summary
- Extract a private `CodeBlockView` struct from `MarkdownSegmentView` to add a hover-revealed copy-to-clipboard button to fenced code blocks
- Uses the existing `VCopyButton` design system component with `.compact` size
- The button appears on hover in the top-right corner of the code block header bar, alongside the language label, using `VAnimation.fast` for fade in/out

## Test plan
- [ ] Verify code blocks render with the same visual appearance (background, corner radius, horizontal scroll)
- [ ] Hover over a code block and confirm the copy button fades in
- [ ] Move cursor away and confirm the copy button fades out
- [ ] Click the copy button and verify code is copied to clipboard
- [ ] Verify the checkmark feedback appears after clicking copy
- [ ] Test with code blocks that have a language label (e.g. ```swift)
- [ ] Test with code blocks that have no language label

Part of #20957, closes #20958.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
