### PR TITLE
fix: throw on URL construction failure in uploadFeedbackToPlatform

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -94,7 +94,7 @@ enum LogExporter {
         let baseURL = AuthService.shared.baseURL
         guard let url = URL(string: "\(baseURL)/v1/feedback/") else {
             log.warning("Failed to construct platform feedback URL")
-            return
+            throw URLError(.badURL)
         }
 
         var request = URLRequest(url: url)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rm-sentry-feedback.md.

**Gap:** Silent success on URL construction failure
**What was expected:** uploadFeedbackToPlatform should throw when URL construction fails
**What was found:** guard-else returned instead of throwing, causing false 'Feedback sent' toast
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
