### PR TITLE
fix: remove dead assistantDSN property from MetricKitManager

### DIFF
--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -65,10 +65,6 @@ import os
     /// empty string disables Sentry.
     nonisolated static let macosDSN: String =
         ProcessInfo.processInfo.environment["SENTRY_DSN_MACOS"] ?? ""
-    /// DSN for the assistant Sentry project. Read from SENTRY_DSN_ASSISTANT env var;
-    /// empty string disables Sentry for this project.
-    nonisolated static let assistantDSN: String =
-        ProcessInfo.processInfo.environment["SENTRY_DSN_ASSISTANT"] ?? ""
 
     /// Sends a manual problem report unconditionally, even when the user has
     /// opted out of automatic crash reporting.  The SDK is temporarily started


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rm-sentry-feedback.md.

**Gap:** Dead code — MetricKitManager.assistantDSN has no remaining consumers
**What was expected:** Dead code from the Sentry feedback removal should be cleaned up
**What was found:** assistantDSN only had consumers in the removed LogExporter Sentry routing logic
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
