### PR TITLE
Add copy button to code blocks in chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -67,26 +67,15 @@ struct MarkdownSegmentView: View, Equatable {
                         .padding(.top, level == 1 ? 4 : 2)
 
                 case .codeBlock(let language, let code):
-                    VStack(alignment: .leading, spacing: 0) {
-                        if let language, !language.isEmpty {
-                            Text(language)
-                                .font(.system(size: scaledCodeLabelSize, weight: .medium))
-                                .foregroundColor(mutedTextColor)
-                                .padding(.horizontal, VSpacing.sm)
-                                .padding(.top, VSpacing.xs)
-                        }
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            Text(code)
-                                .font(.custom("DMMono-Regular", size: 13))
-                                .foregroundColor(textColor)
-                                .textSelection(.enabled)
-                                .fixedSize(horizontal: true, vertical: true)
-                                .padding(VSpacing.sm)
-                        }
-                    }
-                    .optionalMaxWidth(maxContentWidth)
-                    .background(codeBackgroundColor)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    CodeBlockView(
+                        language: language,
+                        code: code,
+                        scaledCodeLabelSize: scaledCodeLabelSize,
+                        textColor: textColor,
+                        mutedTextColor: mutedTextColor,
+                        codeBackgroundColor: codeBackgroundColor,
+                        maxContentWidth: maxContentWidth
+                    )
 
                 case .table(let headers, let rows):
                     MarkdownTableView(headers: headers, rows: rows, maxWidth: maxContentWidth ?? .infinity)
@@ -375,6 +364,62 @@ struct MarkdownSegmentView: View, Equatable {
         }
 
         return result
+    }
+}
+
+// MARK: - Code Block View
+
+/// Renders a fenced code block with an optional language label and a
+/// hover-revealed copy-to-clipboard button.
+private struct CodeBlockView: View {
+    let language: String?
+    let code: String
+    let scaledCodeLabelSize: CGFloat
+    let textColor: Color
+    let mutedTextColor: Color
+    let codeBackgroundColor: Color
+    let maxContentWidth: CGFloat?
+
+    @State private var isHovered = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let language, !language.isEmpty {
+                // Header bar with language label + copy button
+                HStack {
+                    Text(language)
+                        .font(.system(size: scaledCodeLabelSize, weight: .medium))
+                        .foregroundStyle(mutedTextColor)
+                    Spacer()
+                    VCopyButton(text: code, size: .compact)
+                        .opacity(isHovered ? 1 : 0)
+                        .animation(VAnimation.fast, value: isHovered)
+                }
+                .padding(.horizontal, VSpacing.sm)
+                .padding(.top, VSpacing.xs)
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                Text(code)
+                    .font(.custom("DMMono-Regular", size: 13))
+                    .foregroundStyle(textColor)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: true, vertical: true)
+                    .padding(VSpacing.sm)
+            }
+        }
+        .optionalMaxWidth(maxContentWidth)
+        .background(codeBackgroundColor)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(alignment: .topTrailing) {
+            if language == nil || language?.isEmpty == true {
+                VCopyButton(text: code, size: .compact)
+                    .opacity(isHovered ? 1 : 0)
+                    .animation(VAnimation.fast, value: isHovered)
+                    .padding(VSpacing.xs)
+            }
+        }
+        .onHover { isHovered = $0 }
     }
 }
 


### PR DESCRIPTION
## Summary
Adds a hover-revealed copy-to-clipboard button to fenced code blocks in the macOS chat UI. When the assistant responds with code (especially bash/terminal commands), a copy button appears on hover in the top-right corner of the code block — matching the standard UX pattern from ChatGPT, GitHub, and docs sites.

Uses the existing `VCopyButton` design system component (compact size, ghost style) with `.foregroundStyle()` per the deprecated API watchlist.

## Changes
- Extracted a private `CodeBlockView` struct from `MarkdownSegmentView.swift`
- Code blocks with a language label: header bar with language (left) + copy button (right)
- Code blocks without a language label: copy button overlaid in top-right corner (no extra spacing)
- Copy button fades in on hover using `VAnimation.fast`
- Migrated `.foregroundColor()` to `.foregroundStyle()` in the new struct

## Milestone PRs (merged into feature branch)
- #20959: M1: Add copy button to code blocks in chat

## Project issue
Closes #20957

## Linear
LUM-383

## Test plan
- [ ] Send a message that triggers a code block response (e.g., ask for a bash command)
- [ ] Verify copy button appears on hover in the top-right corner
- [ ] Click copy button — verify text is copied and checkmark animation plays
- [ ] Verify code blocks without language labels have no extra spacing when not hovering
- [ ] Verify code blocks with language labels show language on left, copy on right
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
