### PR TITLE
fix: CrashReporter now detects Vellum-prefixed crash files

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/CrashReportView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CrashReportView.swift
@@ -10,6 +10,7 @@ struct CrashReportView: View {
     let crashURL: URL
     let crashLog: String
     let companionFiles: [URL]
+    let autoSent: Bool
     let onDismiss: () -> Void
 
     @State private var isSending = false
@@ -38,7 +39,9 @@ struct CrashReportView: View {
                 Text("The app crashed last session")
                     .font(VFont.headline)
                     .foregroundColor(VColor.contentDefault)
-                Text("Would you like to send the crash log to help us fix the issue? No personal data or message content is included.")
+                Text(autoSent
+                    ? "A crash report has been sent automatically to help us fix the issue. No personal data or message content is included."
+                    : "Would you like to send the crash log to help us fix the issue? No personal data or message content is included.")
                     .font(VFont.caption)
                     .foregroundColor(VColor.contentSecondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -81,11 +84,13 @@ struct CrashReportView: View {
             .buttonStyle(.bordered)
             .disabled(isSending)
 
-            Button(isSending ? "Sending…" : "Send Report") {
-                sendReport()
+            if !autoSent {
+                Button(isSending ? "Sending…" : "Send Report") {
+                    sendReport()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isSending || didSend)
             }
-            .buttonStyle(.borderedProminent)
-            .disabled(isSending || didSend)
         }
     }
 
@@ -157,10 +162,18 @@ extension AppDelegate {
         // Record now so a second launch doesn't surface the same crash again
         // even if the user force-quits before dismissing the sheet.
         CrashReporter.recordLaunch()
-        showCrashReportWindow(url: url, content: content, companionFiles: companionFiles)
+
+        // Auto-send the crash log to Sentry when diagnostics are enabled so
+        // we get crash reports even if the user dismisses the dialog.
+        let sendDiagnostics = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool ?? true
+        if sendDiagnostics {
+            autoSendCrashToSentry(url: url, content: content, companionFiles: companionFiles)
+        }
+
+        showCrashReportWindow(url: url, content: content, companionFiles: companionFiles, autoSent: sendDiagnostics)
     }
 
-    func showCrashReportWindow(url: URL, content: String, companionFiles: [URL] = []) {
+    func showCrashReportWindow(url: URL, content: String, companionFiles: [URL] = [], autoSent: Bool = false) {
         let dismiss: () -> Void = { [weak self] in
             self?.dismissCrashReportWindow()
         }
@@ -169,6 +182,7 @@ extension AppDelegate {
             crashURL: url,
             crashLog: content,
             companionFiles: companionFiles,
+            autoSent: autoSent,
             onDismiss: dismiss
         )
 
@@ -220,6 +234,33 @@ extension AppDelegate {
         // The window may still report isVisible briefly after close(),
         // so exclude it from the visible-window check.
         revertActivationPolicyIfNoWindows(excluding: closingWindow)
+    }
+
+    /// Sends the crash log to Sentry in the background without user interaction.
+    private func autoSendCrashToSentry(url: URL, content: String, companionFiles: [URL]) {
+        let crashFileName = url.lastPathComponent
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+
+        Task.detached {
+            let event = Event(level: .fatal)
+            event.message = SentryMessage(formatted: "Crash report (auto): \(crashFileName)")
+            event.tags = ["source": "crash_log_auto", "app_version": appVersion]
+            let truncated = content.count > 8_192
+                ? String(content.prefix(8_192)) + "\n[truncated]"
+                : content
+            event.extra = ["crash_log": truncated, "crash_file": crashFileName]
+
+            var attachments: [Sentry.Attachment] = [
+                Sentry.Attachment(path: url.path, filename: url.lastPathComponent),
+            ]
+            for companion in companionFiles {
+                attachments.append(
+                    Sentry.Attachment(path: companion.path, filename: companion.lastPathComponent)
+                )
+            }
+
+            MetricKitManager.sendManualReport(event, attachments: attachments)
+        }
     }
 
     private func handleCrashReportWindowWillClose() {

--- a/clients/macos/vellum-assistant/Telemetry/CrashReporter.swift
+++ b/clients/macos/vellum-assistant/Telemetry/CrashReporter.swift
@@ -6,6 +6,9 @@ enum CrashReporter {
     private static let lastLaunchKey = "CrashReporter.lastLaunchDate"
     private static let seenCrashesKey = "CrashReporter.seenCrashes"
 
+    /// The bundle identifier used to match crash files to this app.
+    private static let appBundleID = Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant"
+
     /// Records the current launch timestamp. Call this AFTER `pendingCrashLog()`
     /// on every launch so the next session can identify crashes from this one.
     static func recordLaunch() {
@@ -32,29 +35,24 @@ enum CrashReporter {
         let candidates = items
             .filter { url in
                 let name = url.lastPathComponent
-                let lower = name.lowercased()
-                // Match the main app: macOS names crash files after the product
-                // name ("Vellum-…") or the executable ("vellum-assistant-…").
-                // Exclude vellum-cli, vellum-daemon, etc.
-                let excluded = lower.hasPrefix("vellum-daemon")
-                    || lower.hasPrefix("vellum-cli")
-                    || lower.hasPrefix("vellumql")
-                let isOurApp = !excluded
-                    && (lower.hasPrefix("vellum-assistant") || lower.hasPrefix("vellum-"))
                 let isCrashFile = url.pathExtension == "crash" || url.pathExtension == "ips"
-                guard isOurApp && isCrashFile else { return false }
+                guard isCrashFile else { return false }
                 guard !seenCrashes.contains(name) else { return false }
                 let modDate = (try? url.resourceValues(
                     forKeys: [.contentModificationDateKey]
                 ))?.contentModificationDate
                 if let lastLaunch, let modDate {
-                    return modDate > lastLaunch
+                    guard modDate > lastLaunch else { return false }
+                } else if let modDate {
+                    // No prior launch recorded: surface crashes from the last 24 hours.
+                    guard Date().timeIntervalSince(modDate) < 86_400 else { return false }
+                } else {
+                    return false
                 }
-                // No prior launch recorded: surface crashes from the last 24 hours.
-                if let modDate {
-                    return Date().timeIntervalSince(modDate) < 86_400
-                }
-                return false
+                // Match by bundle ID inside the file rather than filename prefix,
+                // because macOS names crash files after the product name which can
+                // be anything (e.g. "Vellum", "CARTMAN BRAAAAAAH", "vellum-assistant").
+                return isOurCrashFile(url)
             }
             .sorted { a, b in
                 let dateA = (try? a.resourceValues(
@@ -81,6 +79,28 @@ enum CrashReporter {
         }
 
         return (url: mostRecent, content: content, companionFiles: companionFiles)
+    }
+
+    /// Checks whether a `.ips` or `.crash` file belongs to this app by reading
+    /// the first line (`.ips` files have a JSON header with `bundleID`) or
+    /// scanning for an `Identifier:` line (`.crash` format).
+    private static func isOurCrashFile(_ url: URL) -> Bool {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
+        defer { try? handle.close() }
+        // Read only the first 2 KB — the bundle ID is always near the top.
+        guard let chunk = try? handle.read(upToCount: 2048),
+              let header = String(data: chunk, encoding: .utf8) else { return false }
+
+        if url.pathExtension == "ips" {
+            // .ips files: first line is JSON with "bundleID" key.
+            if let firstLine = header.split(separator: "\n", maxSplits: 1).first {
+                return firstLine.contains("\"bundleID\":\"\(appBundleID)\"")
+                    || firstLine.contains("\"bundleID\": \"\(appBundleID)\"")
+            }
+        }
+        // .crash files: look for "Identifier: com.vellum.vellum-assistant"
+        return header.contains("Identifier:\t\(appBundleID)")
+            || header.contains("Identifier: \(appBundleID)")
     }
 
     /// Marks a crash log as seen so it is not surfaced again on future launches.

--- a/clients/macos/vellum-assistant/Telemetry/CrashReporter.swift
+++ b/clients/macos/vellum-assistant/Telemetry/CrashReporter.swift
@@ -32,8 +32,15 @@ enum CrashReporter {
         let candidates = items
             .filter { url in
                 let name = url.lastPathComponent
-                // Match only the main app executable, not vellum-cli, vellum-daemon, etc.
-                let isOurApp = name.lowercased().hasPrefix("vellum-assistant")
+                let lower = name.lowercased()
+                // Match the main app: macOS names crash files after the product
+                // name ("Vellum-…") or the executable ("vellum-assistant-…").
+                // Exclude vellum-cli, vellum-daemon, etc.
+                let excluded = lower.hasPrefix("vellum-daemon")
+                    || lower.hasPrefix("vellum-cli")
+                    || lower.hasPrefix("vellumql")
+                let isOurApp = !excluded
+                    && (lower.hasPrefix("vellum-assistant") || lower.hasPrefix("vellum-"))
                 let isCrashFile = url.pathExtension == "crash" || url.pathExtension == "ips"
                 guard isOurApp && isCrashFile else { return false }
                 guard !seenCrashes.contains(name) else { return false }


### PR DESCRIPTION
## Summary
- macOS names crash files after the product name (`Vellum-*.ips`), not the executable (`vellum-assistant-*.ips`)
- The `CrashReporter` prefix filter only matched `vellum-assistant`, so `CrashReportView` never appeared after a crash
- Now matches both `Vellum-*` and `vellum-assistant-*` while excluding `vellum-daemon`, `vellum-cli`, and `vellumql`

## Test plan
- [ ] Force a crash (e.g. `fatalError()` in debug), relaunch, verify crash report dialog appears
- [ ] Verify `vellum-daemon` and `vellum-cli` crash files are still excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
