### PR TITLE
fix: remove dead try/catch blocks around commitWorkspaceViaGateway calls

### DIFF
--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -177,24 +177,18 @@ async function rollbackPlatform(
   }
 
   // Workspace commit: BEFORE broadcast, matching upgradePlatform() order
-  try {
-    await commitWorkspaceViaGateway(
-      entry.runtimeUrl,
-      entry.assistantId,
-      buildUpgradeCommitMessage({
-        action: "rollback",
-        phase: "starting",
-        from: currentVersion ?? "unknown",
-        to: version,
-        topology: "managed",
-        assistantId: entry.assistantId,
-      }),
-    );
-  } catch (err) {
-    console.warn(
-      `⚠️  Failed to create pre-rollback workspace commit: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
+  await commitWorkspaceViaGateway(
+    entry.runtimeUrl,
+    entry.assistantId,
+    buildUpgradeCommitMessage({
+      action: "rollback",
+      phase: "starting",
+      from: currentVersion ?? "unknown",
+      to: version,
+      topology: "managed",
+      assistantId: entry.assistantId,
+    }),
+  );
 
   // Authenticate before broadcasting any SSE events so that a missing
   // token does not leave connected clients showing a perpetual spinner.
@@ -260,25 +254,19 @@ async function rollbackPlatform(
   // the client detects completion via healthz polling.
 
   // Workspace commit: Complete
-  try {
-    await commitWorkspaceViaGateway(
-      entry.runtimeUrl,
-      entry.assistantId,
-      buildUpgradeCommitMessage({
-        action: "rollback",
-        phase: "complete",
-        from: currentVersion ?? "unknown",
-        to: version,
-        topology: "managed",
-        assistantId: entry.assistantId,
-        result: "success",
-      }),
-    );
-  } catch (err) {
-    console.warn(
-      `⚠️  Failed to create post-rollback workspace commit: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
+  await commitWorkspaceViaGateway(
+    entry.runtimeUrl,
+    entry.assistantId,
+    buildUpgradeCommitMessage({
+      action: "rollback",
+      phase: "complete",
+      from: currentVersion ?? "unknown",
+      to: version,
+      topology: "managed",
+      assistantId: entry.assistantId,
+      result: "success",
+    }),
+  );
 
   console.log("Rollback initiated. The assistant may be briefly unavailable.");
 }
@@ -373,24 +361,18 @@ export async function rollback(): Promise<void> {
 
   try {
     // Record rollback start in workspace git history
-    try {
-      await commitWorkspaceViaGateway(
-        entry.runtimeUrl,
-        entry.assistantId,
-        buildUpgradeCommitMessage({
-          action: "rollback",
-          phase: "starting",
-          from: entry.serviceGroupVersion ?? "unknown",
-          to: entry.previousServiceGroupVersion ?? "unknown",
-          topology: "docker",
-          assistantId: entry.assistantId,
-        }),
-      );
-    } catch (err) {
-      console.warn(
-        `⚠️  Failed to create pre-rollback workspace commit: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
+    await commitWorkspaceViaGateway(
+      entry.runtimeUrl,
+      entry.assistantId,
+      buildUpgradeCommitMessage({
+        action: "rollback",
+        phase: "starting",
+        from: entry.serviceGroupVersion ?? "unknown",
+        to: entry.previousServiceGroupVersion ?? "unknown",
+        topology: "docker",
+        assistantId: entry.assistantId,
+      }),
+    );
 
     console.log(
       `🔄 Rolling back Docker assistant '${instanceName}' to ${entry.previousServiceGroupVersion}...\n`,
@@ -536,25 +518,19 @@ export async function rollback(): Promise<void> {
       );
 
       // Record successful rollback in workspace git history
-      try {
-        await commitWorkspaceViaGateway(
-          entry.runtimeUrl,
-          entry.assistantId,
-          buildUpgradeCommitMessage({
-            action: "rollback",
-            phase: "complete",
-            from: entry.serviceGroupVersion ?? "unknown",
-            to: entry.previousServiceGroupVersion ?? "unknown",
-            topology: "docker",
-            assistantId: entry.assistantId,
-            result: "success",
-          }),
-        );
-      } catch (err) {
-        console.warn(
-          `⚠️  Failed to create post-rollback workspace commit: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
+      await commitWorkspaceViaGateway(
+        entry.runtimeUrl,
+        entry.assistantId,
+        buildUpgradeCommitMessage({
+          action: "rollback",
+          phase: "complete",
+          from: entry.serviceGroupVersion ?? "unknown",
+          to: entry.previousServiceGroupVersion ?? "unknown",
+          topology: "docker",
+          assistantId: entry.assistantId,
+          result: "success",
+        }),
+      );
 
       console.log(
         `\n✅ Docker assistant '${instanceName}' rolled back to ${entry.previousServiceGroupVersion}.`,

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -274,24 +274,18 @@ async function upgradeDocker(
   }
 
   // Record version transition start in workspace git history
-  try {
-    await commitWorkspaceViaGateway(
-      entry.runtimeUrl,
-      entry.assistantId,
-      buildUpgradeCommitMessage({
-        action: "upgrade",
-        phase: "starting",
-        from: entry.serviceGroupVersion ?? "unknown",
-        to: versionTag,
-        topology: "docker",
-        assistantId: entry.assistantId,
-      }),
-    );
-  } catch (err) {
-    console.warn(
-      `⚠️  Failed to create pre-upgrade workspace commit: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
+  await commitWorkspaceViaGateway(
+    entry.runtimeUrl,
+    entry.assistantId,
+    buildUpgradeCommitMessage({
+      action: "upgrade",
+      phase: "starting",
+      from: entry.serviceGroupVersion ?? "unknown",
+      to: versionTag,
+      topology: "docker",
+      assistantId: entry.assistantId,
+    }),
+  );
 
   console.log("💾 Capturing existing container environment...");
   const capturedEnv = await captureContainerEnv(res.assistantContainer);
@@ -478,25 +472,19 @@ async function upgradeDocker(
     );
 
     // Record successful upgrade in workspace git history
-    try {
-      await commitWorkspaceViaGateway(
-        entry.runtimeUrl,
-        entry.assistantId,
-        buildUpgradeCommitMessage({
-          action: "upgrade",
-          phase: "complete",
-          from: entry.serviceGroupVersion ?? "unknown",
-          to: versionTag,
-          topology: "docker",
-          assistantId: entry.assistantId,
-          result: "success",
-        }),
-      );
-    } catch (err) {
-      console.warn(
-        `⚠️  Failed to create post-upgrade workspace commit: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
+    await commitWorkspaceViaGateway(
+      entry.runtimeUrl,
+      entry.assistantId,
+      buildUpgradeCommitMessage({
+        action: "upgrade",
+        phase: "complete",
+        from: entry.serviceGroupVersion ?? "unknown",
+        to: versionTag,
+        topology: "docker",
+        assistantId: entry.assistantId,
+        result: "success",
+      }),
+    );
 
     console.log(
       `\n✅ Docker assistant '${instanceName}' upgraded to ${versionTag}.`,
@@ -729,24 +717,18 @@ async function upgradePlatform(
   }
 
   // Record version transition start in workspace git history
-  try {
-    await commitWorkspaceViaGateway(
-      entry.runtimeUrl,
-      entry.assistantId,
-      buildUpgradeCommitMessage({
-        action: "upgrade",
-        phase: "starting",
-        from: entry.serviceGroupVersion ?? "unknown",
-        to: version ?? "latest",
-        topology: "managed",
-        assistantId: entry.assistantId,
-      }),
-    );
-  } catch (err) {
-    console.warn(
-      `⚠️  Failed to create pre-upgrade workspace commit: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
+  await commitWorkspaceViaGateway(
+    entry.runtimeUrl,
+    entry.assistantId,
+    buildUpgradeCommitMessage({
+      action: "upgrade",
+      phase: "starting",
+      from: entry.serviceGroupVersion ?? "unknown",
+      to: version ?? "latest",
+      topology: "managed",
+      assistantId: entry.assistantId,
+    }),
+  );
 
   console.log(
     `🔄 Upgrading platform-hosted assistant '${entry.assistantId}'...\n`,
@@ -818,25 +800,19 @@ async function upgradePlatform(
   // version actually appears after the platform restarts the service group.
 
   // Record successful upgrade in workspace git history
-  try {
-    await commitWorkspaceViaGateway(
-      entry.runtimeUrl,
-      entry.assistantId,
-      buildUpgradeCommitMessage({
-        action: "upgrade",
-        phase: "complete",
-        from: entry.serviceGroupVersion ?? "unknown",
-        to: version ?? "latest",
-        topology: "managed",
-        assistantId: entry.assistantId,
-        result: "success",
-      }),
-    );
-  } catch (err) {
-    console.warn(
-      `⚠️  Failed to create post-upgrade workspace commit: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
+  await commitWorkspaceViaGateway(
+    entry.runtimeUrl,
+    entry.assistantId,
+    buildUpgradeCommitMessage({
+      action: "upgrade",
+      phase: "complete",
+      from: entry.serviceGroupVersion ?? "unknown",
+      to: version ?? "latest",
+      topology: "managed",
+      assistantId: entry.assistantId,
+      result: "success",
+    }),
+  );
 
   console.log(`✅ ${result.detail}`);
   if (result.version) {
@@ -865,17 +841,11 @@ async function upgradePrepare(
   );
 
   // 2. Workspace commit: record pre-update state
-  try {
-    await commitWorkspaceViaGateway(
-      entry.runtimeUrl,
-      entry.assistantId,
-      `[sparkle-update] Starting: ${currentVersion} → ${targetVersion}`,
-    );
-  } catch (err) {
-    console.warn(
-      `⚠️  Failed to create pre-upgrade workspace commit: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
+  await commitWorkspaceViaGateway(
+    entry.runtimeUrl,
+    entry.assistantId,
+    `[sparkle-update] Starting: ${currentVersion} → ${targetVersion}`,
+  );
 
   // 3. Progress: saving backup
   await broadcastUpgradeEvent(
@@ -941,17 +911,11 @@ async function upgradeFinalize(
   );
 
   // 2. Workspace commit: record successful update
-  try {
-    await commitWorkspaceViaGateway(
-      entry.runtimeUrl,
-      entry.assistantId,
-      `[sparkle-update] Complete: ${fromVersion} → ${currentVersion}\n\nresult: success`,
-    );
-  } catch (err) {
-    console.warn(
-      `⚠️  Failed to create post-upgrade workspace commit: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
+  await commitWorkspaceViaGateway(
+    entry.runtimeUrl,
+    entry.assistantId,
+    `[sparkle-update] Complete: ${fromVersion} → ${currentVersion}\n\nresult: success`,
+  );
 }
 
 export async function upgrade(): Promise<void> {

--- a/cli/src/lib/upgrade-lifecycle.ts
+++ b/cli/src/lib/upgrade-lifecycle.ts
@@ -428,24 +428,18 @@ export async function performDockerRollback(
   }
 
   // Record rollback start in workspace git history
-  try {
-    await commitWorkspaceViaGateway(
-      entry.runtimeUrl,
-      entry.assistantId,
-      buildUpgradeCommitMessage({
-        action: "rollback",
-        phase: "starting",
-        from: currentVersion ?? "unknown",
-        to: targetVersion,
-        topology: "docker",
-        assistantId: entry.assistantId,
-      }),
-    );
-  } catch (err) {
-    console.warn(
-      `⚠️  Failed to create pre-rollback workspace commit: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
+  await commitWorkspaceViaGateway(
+    entry.runtimeUrl,
+    entry.assistantId,
+    buildUpgradeCommitMessage({
+      action: "rollback",
+      phase: "starting",
+      from: currentVersion ?? "unknown",
+      to: targetVersion,
+      topology: "docker",
+      assistantId: entry.assistantId,
+    }),
+  );
 
   console.log(
     `🔄 Rolling back Docker assistant '${instanceName}' to ${targetVersion}...\n`,
@@ -656,25 +650,19 @@ export async function performDockerRollback(
     );
 
     // Record successful rollback in workspace git history
-    try {
-      await commitWorkspaceViaGateway(
-        entry.runtimeUrl,
-        entry.assistantId,
-        buildUpgradeCommitMessage({
-          action: "rollback",
-          phase: "complete",
-          from: currentVersion ?? "unknown",
-          to: targetVersion,
-          topology: "docker",
-          assistantId: entry.assistantId,
-          result: "success",
-        }),
-      );
-    } catch (err) {
-      console.warn(
-        `⚠️  Failed to create post-rollback workspace commit: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
+    await commitWorkspaceViaGateway(
+      entry.runtimeUrl,
+      entry.assistantId,
+      buildUpgradeCommitMessage({
+        action: "rollback",
+        phase: "complete",
+        from: currentVersion ?? "unknown",
+        to: targetVersion,
+        topology: "docker",
+        assistantId: entry.assistantId,
+        result: "success",
+      }),
+    );
 
     console.log(
       `\n✅ Docker assistant '${instanceName}' rolled back to ${targetVersion}.`,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for cli-ws-commit-api.md.

**Gap:** 12 dead try/catch + console.warn blocks around commitWorkspaceViaGateway calls
**What was expected:** Call sites should match broadcastUpgradeEvent pattern (no caller-side error handling)
**What was found:** All 12 call sites wrapped in unreachable try/catch since commitWorkspaceViaGateway internally swallows errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
