### PR TITLE
Add platform API helpers for migration export/import and rollback

### DIFF
--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -127,3 +127,187 @@ export async function fetchCurrentUser(token: string): Promise<PlatformUser> {
   const body = (await response.json()) as AllauthSessionResponse;
   return body.data.user;
 }
+
+// ---------------------------------------------------------------------------
+// Rollback
+// ---------------------------------------------------------------------------
+
+interface RollbackResponse {
+  detail: string;
+  version: string | null;
+}
+
+export async function rollbackPlatformAssistant(
+  token: string,
+  orgId: string,
+  version?: string,
+): Promise<{ detail: string; version: string | null }> {
+  const platformUrl = requirePlatformUrl();
+  const response = await fetch(`${platformUrl}/v1/assistants/rollback/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Session-Token": token,
+      "Vellum-Organization-Id": orgId,
+    },
+    body: JSON.stringify(version ? { version } : {}),
+  });
+
+  const body = (await response.json()) as RollbackResponse & {
+    detail?: string;
+  };
+
+  if (response.status === 200) {
+    return { detail: body.detail, version: body.version };
+  }
+
+  if (response.status === 400) {
+    throw new Error(body.detail ?? "Rollback failed: bad request");
+  }
+
+  if (response.status === 404) {
+    throw new Error(body.detail ?? "Rollback target not found");
+  }
+
+  if (response.status === 502) {
+    throw new Error(body.detail ?? "Rollback failed: transport error");
+  }
+
+  throw new Error(`Rollback failed: ${response.status} ${response.statusText}`);
+}
+
+// ---------------------------------------------------------------------------
+// Migration export
+// ---------------------------------------------------------------------------
+
+export async function platformInitiateExport(
+  token: string,
+  orgId: string,
+  description?: string,
+): Promise<{ jobId: string; status: string }> {
+  const platformUrl = requirePlatformUrl();
+  const response = await fetch(`${platformUrl}/v1/migrations/export/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Session-Token": token,
+      "Vellum-Organization-Id": orgId,
+    },
+    body: JSON.stringify({ description: description ?? "CLI backup" }),
+  });
+
+  if (response.status !== 201) {
+    const body = (await response.json().catch(() => ({}))) as {
+      detail?: string;
+    };
+    throw new Error(
+      body.detail ??
+        `Export initiation failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const body = (await response.json()) as {
+    job_id: string;
+    status: string;
+  };
+  return { jobId: body.job_id, status: body.status };
+}
+
+export async function platformPollExportStatus(
+  jobId: string,
+  token: string,
+  orgId: string,
+): Promise<{ status: string; downloadUrl?: string; error?: string }> {
+  const platformUrl = requirePlatformUrl();
+  const response = await fetch(
+    `${platformUrl}/v1/migrations/export/${jobId}/status/`,
+    {
+      headers: {
+        "X-Session-Token": token,
+        "Vellum-Organization-Id": orgId,
+      },
+    },
+  );
+
+  if (response.status === 404) {
+    throw new Error("Export job not found");
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Export status check failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const body = (await response.json()) as {
+    status: string;
+    download_url?: string;
+    error?: string;
+  };
+  return {
+    status: body.status,
+    downloadUrl: body.download_url,
+    error: body.error,
+  };
+}
+
+export async function platformDownloadExport(
+  downloadUrl: string,
+): Promise<Response> {
+  const response = await fetch(downloadUrl);
+  if (!response.ok) {
+    throw new Error(
+      `Download failed: ${response.status} ${response.statusText}`,
+    );
+  }
+  return response;
+}
+
+// ---------------------------------------------------------------------------
+// Migration import
+// ---------------------------------------------------------------------------
+
+export async function platformImportPreflight(
+  bundleData: Uint8Array,
+  token: string,
+  orgId: string,
+): Promise<{ statusCode: number; body: Record<string, unknown> }> {
+  const platformUrl = requirePlatformUrl();
+  const response = await fetch(
+    `${platformUrl}/v1/migrations/import-preflight/`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/octet-stream",
+        "X-Session-Token": token,
+        "Vellum-Organization-Id": orgId,
+      },
+      body: bundleData,
+      signal: AbortSignal.timeout(120_000),
+    },
+  );
+
+  const body = (await response.json()) as Record<string, unknown>;
+  return { statusCode: response.status, body };
+}
+
+export async function platformImportBundle(
+  bundleData: Uint8Array,
+  token: string,
+  orgId: string,
+): Promise<{ statusCode: number; body: Record<string, unknown> }> {
+  const platformUrl = requirePlatformUrl();
+  const response = await fetch(`${platformUrl}/v1/migrations/import/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/octet-stream",
+      "X-Session-Token": token,
+      "Vellum-Organization-Id": orgId,
+    },
+    body: bundleData,
+    signal: AbortSignal.timeout(120_000),
+  });
+
+  const body = (await response.json()) as Record<string, unknown>;
+  return { statusCode: response.status, body };
+}

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -268,7 +268,7 @@ export async function platformDownloadExport(
 // ---------------------------------------------------------------------------
 
 export async function platformImportPreflight(
-  bundleData: Uint8Array,
+  bundleData: Buffer,
   token: string,
   orgId: string,
 ): Promise<{ statusCode: number; body: Record<string, unknown> }> {
@@ -292,7 +292,7 @@ export async function platformImportPreflight(
 }
 
 export async function platformImportBundle(
-  bundleData: Uint8Array,
+  bundleData: Buffer,
   token: string,
   orgId: string,
 ): Promise<{ statusCode: number; body: Record<string, unknown> }> {

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -268,7 +268,7 @@ export async function platformDownloadExport(
 // ---------------------------------------------------------------------------
 
 export async function platformImportPreflight(
-  bundleData: Buffer,
+  bundleData: Uint8Array<ArrayBuffer>,
   token: string,
   orgId: string,
 ): Promise<{ statusCode: number; body: Record<string, unknown> }> {
@@ -282,7 +282,7 @@ export async function platformImportPreflight(
         "X-Session-Token": token,
         "Vellum-Organization-Id": orgId,
       },
-      body: bundleData,
+      body: new Blob([bundleData]),
       signal: AbortSignal.timeout(120_000),
     },
   );
@@ -292,7 +292,7 @@ export async function platformImportPreflight(
 }
 
 export async function platformImportBundle(
-  bundleData: Buffer,
+  bundleData: Uint8Array<ArrayBuffer>,
   token: string,
   orgId: string,
 ): Promise<{ statusCode: number; body: Record<string, unknown> }> {
@@ -304,7 +304,7 @@ export async function platformImportBundle(
       "X-Session-Token": token,
       "Vellum-Organization-Id": orgId,
     },
-    body: bundleData,
+    body: new Blob([bundleData]),
     signal: AbortSignal.timeout(120_000),
   });
 


### PR DESCRIPTION
## Summary
- Add rollbackPlatformAssistant() for version-less and targeted rollback via dedicated endpoint
- Add platformInitiateExport/PollExportStatus/DownloadExport for async backup via Django migration API
- Add platformImportPreflight/ImportBundle for restore via Django migration API

Part of plan: platform-backup-restore.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
