### PR TITLE
Remove ellipsis from Hatch button label

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -811,7 +811,7 @@ struct SettingsDeveloperTab: View {
 
     private var hatchNewAssistantSection: some View {
         SettingsCard(title: "Hatch New Assistant", subtitle: "Starts the initial setup flow to create a new assistant.") {
-            VButton(label: "Hatch...", style: .primary) {
+            VButton(label: "Hatch", style: .primary) {
                 showingHatchConfirmation = true
             }
             .alert("Hatch New Assistant", isPresented: $showingHatchConfirmation) {


### PR DESCRIPTION
## Summary
- Remove trailing ellipsis from the "Hatch..." button label in Developer settings, changing it to "Hatch"

## Original prompt
in developer section in settings, there is Hatch... remove ellipsis from Hatch..., should just be Hatch
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
