### PR TITLE
fix: remove VELLUM_DEV guard so catalog skills work in macOS app

### DIFF
--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -54,12 +54,10 @@ export function getSkillsIndexPath(): string {
 }
 
 /**
- * Resolve the repo-level skills/ directory when running in dev mode.
- * Returns the path if VELLUM_DEV is set and the directory exists, or undefined.
+ * Resolve the repo-level skills/ directory when running from the source tree.
+ * Returns the path if skills/catalog.json exists relative to this file, or undefined.
  */
 export function getRepoSkillsDir(): string | undefined {
-  if (!process.env.VELLUM_DEV) return undefined;
-
   // assistant/src/skills/catalog-install.ts -> ../../../skills/
   const candidate = join(import.meta.dir, "..", "..", "..", "skills");
   if (existsSync(join(candidate, "catalog.json"))) {

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -167,8 +167,20 @@ export class SkillLoadTool implements Tool {
       !loaded.skill &&
       (loaded.errorCode === "not_found" || loaded.errorCode === "empty_catalog")
     ) {
+      log.info(
+        {
+          skillId: selector,
+          errorCode: loaded.errorCode,
+          vellumDev: process.env.VELLUM_DEV,
+        },
+        "Skill not found locally, attempting auto-install from catalog",
+      );
       try {
         const installed = await autoInstallFromCatalog(selector);
+        log.info(
+          { skillId: selector, installed },
+          "Auto-install from catalog result",
+        );
         if (installed) {
           log.info({ skillId: selector }, "Auto-installed skill from catalog");
           loaded = loadSkillBySelector(selector);
@@ -184,6 +196,11 @@ export class SkillLoadTool implements Tool {
           isError: true,
         };
       }
+    } else if (!loaded.skill) {
+      log.warn(
+        { skillId: selector, errorCode: loaded.errorCode, error: loaded.error },
+        "Skill not found but errorCode did not match auto-install conditions",
+      );
     }
 
     if (!loaded.skill) {


### PR DESCRIPTION
## Summary
- Remove the `VELLUM_DEV` guard from `getRepoSkillsDir()` in `catalog-install.ts` — the `existsSync` check on `catalog.json` is sufficient to determine if the repo skills directory is available
- Add debug logging to the `skill_load` auto-install path for easier future diagnosis

## Context
The `VELLUM_DEV` guard prevented the macOS app from discovering repo-local skills via `catalog.json`. Combined with the recent removal of the hardcoded platform URL fallback, this meant all 33 catalog-only skills (slack-app-setup, gmail, google-calendar, etc.) were broken when running from the macOS app.

Closes JARVIS-329

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
