### PR TITLE
perf: cache resolved NSScrollView in ScrollWheelDetector

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -789,8 +789,12 @@ struct ScrollWheelDetector: NSViewRepresentable {
                 // layout pass can trigger an auto-scroll-to-bottom.
                 // Guard: only untether if content is actually scrollable (prevents false
                 // untethers on short conversations that can't scroll).
-                let (scrollView, lookupPath) = coordinator.findEnclosingScrollViewWithPath()
-                if let scrollView {
+                let wasCached = coordinator.cachedScrollView != nil
+                let (resolvedScrollView, lookupPath) = wasCached
+                    ? (coordinator.cachedScrollView, "cached")
+                    : coordinator.findEnclosingScrollViewWithPath()
+                if !wasCached { coordinator.cachedScrollView = resolvedScrollView }
+                if let scrollView = resolvedScrollView {
                     let clipHeight = scrollView.contentView.bounds.height
                     let docHeight = scrollView.documentView?.frame.height ?? 0
                     let isScrollable = docHeight > clipHeight
@@ -831,8 +835,12 @@ struct ScrollWheelDetector: NSViewRepresentable {
                 // Deferred to next run-loop tick so clipBounds reflects the post-scroll position;
                 // reading it synchronously in the event monitor sees the pre-scroll state.
                 DispatchQueue.main.async {
-                    let (scrollView, lookupPath) = coordinator.findEnclosingScrollViewWithPath()
-                    if let scrollView {
+                    let wasCached = coordinator.cachedScrollView != nil
+                    let (resolvedScrollView, lookupPath) = wasCached
+                        ? (coordinator.cachedScrollView, "cached")
+                        : coordinator.findEnclosingScrollViewWithPath()
+                    if !wasCached { coordinator.cachedScrollView = resolvedScrollView }
+                    if let scrollView = resolvedScrollView {
                         let clipBounds = scrollView.contentView.bounds
                         let docHeight = scrollView.documentView?.frame.height ?? 0
                         let distanceFromBottom = docHeight - clipBounds.maxY
@@ -930,6 +938,9 @@ struct ScrollWheelDetector: NSViewRepresentable {
         /// Reference to the registry for unregistration on dismantle.
         /// Weak-optional because the registry is @MainActor and may outlive the coordinator.
         var registry: ScrollWheelDetectorRegistry?
+        /// Cached scroll view to avoid repeated superview-chain walks on every scroll event.
+        /// Weak so it auto-nils when the scroll view is deallocated; the next event re-resolves.
+        weak var cachedScrollView: NSScrollView?
 
         /// Throttle interval for scroll-wheel diagnostics recording.
         /// Prevents synchronous JSON-encode + FileHandle.write on every tick.


### PR DESCRIPTION
## Summary
- `ScrollWheelDetector.Coordinator` called `findEnclosingScrollViewWithPath()` on every scroll wheel event, walking the AppKit superview chain (~20 levels) synchronously on the main thread.
- Cache the resolved `NSScrollView` as a `weak var cachedScrollView` property, following the identical pattern already used by `ScrollWheelPassthrough.Coordinator` in the same file.
- The `weak` reference auto-nils on deallocation, so stale references self-heal on the next event.

## Test plan
- [ ] Verify scroll-up untethering still works correctly in chat conversations
- [ ] Verify scroll-down re-tethering still works correctly when reaching bottom
- [ ] Verify diagnostic signposts now report `lookup=cached` after the first scroll event
- [ ] Verify no regressions when switching between conversations (weak ref auto-nils)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20975" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
