### PR TITLE
perf: cache resolved NSScrollView in ScrollWheelDetector

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -789,8 +789,12 @@ struct ScrollWheelDetector: NSViewRepresentable {
                 // layout pass can trigger an auto-scroll-to-bottom.
                 // Guard: only untether if content is actually scrollable (prevents false
                 // untethers on short conversations that can't scroll).
-                let (scrollView, lookupPath) = coordinator.findEnclosingScrollViewWithPath()
-                if let scrollView {
+                let wasCached = coordinator.cachedScrollView != nil
+                let (resolvedScrollView, lookupPath) = wasCached
+                    ? (coordinator.cachedScrollView, "cached")
+                    : coordinator.findEnclosingScrollViewWithPath()
+                if !wasCached { coordinator.cachedScrollView = resolvedScrollView }
+                if let scrollView = resolvedScrollView {
                     let clipHeight = scrollView.contentView.bounds.height
                     let docHeight = scrollView.documentView?.frame.height ?? 0
                     let isScrollable = docHeight > clipHeight
@@ -831,8 +835,12 @@ struct ScrollWheelDetector: NSViewRepresentable {
                 // Deferred to next run-loop tick so clipBounds reflects the post-scroll position;
                 // reading it synchronously in the event monitor sees the pre-scroll state.
                 DispatchQueue.main.async {
-                    let (scrollView, lookupPath) = coordinator.findEnclosingScrollViewWithPath()
-                    if let scrollView {
+                    let wasCached = coordinator.cachedScrollView != nil
+                    let (resolvedScrollView, lookupPath) = wasCached
+                        ? (coordinator.cachedScrollView, "cached")
+                        : coordinator.findEnclosingScrollViewWithPath()
+                    if !wasCached { coordinator.cachedScrollView = resolvedScrollView }
+                    if let scrollView = resolvedScrollView {
                         let clipBounds = scrollView.contentView.bounds
                         let docHeight = scrollView.documentView?.frame.height ?? 0
                         let distanceFromBottom = docHeight - clipBounds.maxY
@@ -930,6 +938,9 @@ struct ScrollWheelDetector: NSViewRepresentable {
         /// Reference to the registry for unregistration on dismantle.
         /// Weak-optional because the registry is @MainActor and may outlive the coordinator.
         var registry: ScrollWheelDetectorRegistry?
+        /// Cached scroll view to avoid repeated superview-chain walks on every scroll event.
+        /// Weak so it auto-nils when the scroll view is deallocated; the next event re-resolves.
+        weak var cachedScrollView: NSScrollView?
 
         /// Throttle interval for scroll-wheel diagnostics recording.
         /// Prevents synchronous JSON-encode + FileHandle.write on every tick.

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -841,11 +841,17 @@ struct ScrollWheelDetector: NSViewRepresentable {
                 // Deferred to next run-loop tick so clipBounds reflects the post-scroll position;
                 // reading it synchronously in the event monitor sees the pre-scroll state.
                 DispatchQueue.main.async {
-                    let wasCached = coordinator.cachedScrollView != nil
-                    let (resolvedScrollView, lookupPath) = wasCached
-                        ? (coordinator.cachedScrollView, "cached")
-                        : coordinator.findEnclosingScrollViewWithPath()
-                    if !wasCached { coordinator.cachedScrollView = resolvedScrollView }
+                    let resolvedScrollView: NSScrollView?
+                    let lookupPath: String
+                    if let cached = coordinator.cachedScrollView, cached.window != nil {
+                        resolvedScrollView = cached
+                        lookupPath = "cached"
+                    } else {
+                        let (found, path) = coordinator.findEnclosingScrollViewWithPath()
+                        coordinator.cachedScrollView = found
+                        resolvedScrollView = found
+                        lookupPath = path
+                    }
                     if let scrollView = resolvedScrollView {
                         let clipBounds = scrollView.contentView.bounds
                         let docHeight = scrollView.documentView?.frame.height ?? 0

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -789,11 +789,17 @@ struct ScrollWheelDetector: NSViewRepresentable {
                 // layout pass can trigger an auto-scroll-to-bottom.
                 // Guard: only untether if content is actually scrollable (prevents false
                 // untethers on short conversations that can't scroll).
-                let wasCached = coordinator.cachedScrollView != nil
-                let (resolvedScrollView, lookupPath) = wasCached
-                    ? (coordinator.cachedScrollView, "cached")
-                    : coordinator.findEnclosingScrollViewWithPath()
-                if !wasCached { coordinator.cachedScrollView = resolvedScrollView }
+                let resolvedScrollView: NSScrollView?
+                let lookupPath: String
+                if let cached = coordinator.cachedScrollView, cached.window != nil {
+                    resolvedScrollView = cached
+                    lookupPath = "cached"
+                } else {
+                    let (found, path) = coordinator.findEnclosingScrollViewWithPath()
+                    coordinator.cachedScrollView = found
+                    resolvedScrollView = found
+                    lookupPath = path
+                }
                 if let scrollView = resolvedScrollView {
                     let clipHeight = scrollView.contentView.bounds.height
                     let docHeight = scrollView.documentView?.frame.height ?? 0


### PR DESCRIPTION
## Summary
Cache the resolved NSScrollView in ScrollWheelDetector's Coordinator to avoid repeated AppKit view hierarchy traversals (~20 superview levels) on every scroll wheel event. Follows the identical pattern already used by ScrollWheelPassthrough.Coordinator in the same file.

## Changes
- Added `weak var cachedScrollView: NSScrollView?` to ScrollWheelDetector.Coordinator
- Both scroll event handler paths (untether on scroll-up, retether on scroll-down) check cache before calling `findEnclosingScrollViewWithPath()`
- `weak` reference auto-nils on deallocation for self-healing cache

## Milestone PRs
- #20975: Cache resolved NSScrollView in ScrollWheelDetector

## Project issue
Closes #20973

## Test plan
- [ ] Scroll up in long conversation — should detach from bottom normally
- [ ] Switch conversations, then scroll up — cache invalidates, new scroll view found
- [ ] Resize window, then scroll — layout rebuilds, cache recovers
- [ ] Scroll up during streaming — should detach, auto-scroll resumes at bottom
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20976" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
