### PR TITLE
feat: bypass extraction layer for journal memories — store raw content directly

### DIFF
--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -18,6 +18,7 @@ import { maybeEnqueueConversationStartersJob } from "./conversation-starters-cad
 import { getDb } from "./db.js";
 import { computeMemoryFingerprint } from "./fingerprint.js";
 import { enqueueMemoryJob } from "./jobs-store.js";
+import { upsertJournalMemoriesFromDisk } from "./journal-memory.js";
 import { extractTextFromStoredMessageContent } from "./message-content.js";
 import { withQdrantBreaker } from "./qdrant-circuit-breaker.js";
 import { getQdrantClient } from "./qdrant-client.js";
@@ -167,7 +168,6 @@ Extract items in these categories:
 - decision: Choices made, approaches selected, trade-offs resolved
 - constraint: Rules, requirements, things that must/must not be done, explicit directives on how the assistant should behave
 - event: Deadlines, milestones, meetings, releases, dates
-- journal: Experiential reflections, journal-style notes, upcoming events, things the user or assistant explicitly wants to carry forward
 
 For each item, provide:
 - kind: One of the categories above
@@ -231,9 +231,6 @@ Good extractions from assistant messages:
 
 - "I've refactored the auth middleware to use JWT validation and added rate limiting to the login endpoint."
   → kind: project, subject: "Auth middleware changes", statement: "Auth middleware was refactored to use JWT validation with rate limiting on the login endpoint"
-
-- "I just wrote a journal entry about the project kickoff — feeling optimistic about the timeline"
-  → kind: journal, subject: "Project kickoff reflection", statement: "Feeling optimistic about the project timeline after the kickoff meeting"
 
 Do NOT extract:
 - "I'll check that file for you" → assistant operational statement with no lasting information
@@ -497,6 +494,7 @@ async function extractItemsWithLLM(
   for (const raw of input.items) {
     // Apply kind migration map for old kind names, then validate
     const resolvedKind = KIND_MIGRATION_MAP[raw.kind] ?? raw.kind;
+    if (resolvedKind === "journal") continue; // journal memories created directly from disk
     if (!VALID_KINDS.has(resolvedKind)) continue;
     if (!raw.subject || !raw.statement) continue;
     const subject = String(raw.subject).trim();
@@ -820,6 +818,16 @@ export async function extractAndUpsertMemoryItemsForMessage(
       .run();
 
     enqueueMemoryJob("embed_item", { itemId: memoryItemId });
+  }
+
+  // Directly create journal memories from any journal files written during
+  // this message, bypassing LLM extraction (which would summarize/rewrite them).
+  if (message.role === "assistant") {
+    upserted += upsertJournalMemoriesFromDisk(
+      message.createdAt,
+      effectiveScopeId,
+      messageId,
+    );
   }
 
   log.debug(

--- a/assistant/src/memory/journal-memory.ts
+++ b/assistant/src/memory/journal-memory.ts
@@ -1,0 +1,151 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { and, eq } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import { getWorkspaceDir } from "../util/platform.js";
+import { getLogger } from "../util/logger.js";
+import { getDb } from "./db.js";
+import { computeMemoryFingerprint } from "./fingerprint.js";
+import { enqueueMemoryJob } from "./jobs-store.js";
+import { memoryItems, memoryItemSources } from "./schema.js";
+
+const log = getLogger("memory-journal");
+
+/**
+ * Scan the journal directory for `.md` files created during (or after) the
+ * given message timestamp and upsert them as journal memory items with the
+ * raw, unedited file content as the `statement`.
+ *
+ * This bypasses the LLM extraction layer entirely — journal memories are
+ * stored verbatim so they are never summarised or rewritten.
+ *
+ * Returns the number of newly inserted items.
+ */
+export function upsertJournalMemoriesFromDisk(
+  messageCreatedAt: number,
+  scopeId: string,
+  messageId: string,
+): number {
+  try {
+    const journalDir = join(getWorkspaceDir(), "journal");
+
+    let files: string[];
+    try {
+      files = readdirSync(journalDir);
+    } catch {
+      // Directory doesn't exist — no journal entries
+      return 0;
+    }
+
+    // Filter for .md files, excluding readme.md (case-insensitive)
+    const mdFiles = files.filter(
+      (f) => f.endsWith(".md") && f.toLowerCase() !== "readme.md",
+    );
+
+    let upserted = 0;
+    const db = getDb();
+
+    for (const filename of mdFiles) {
+      try {
+        const filepath = join(journalDir, filename);
+        const stat = statSync(filepath);
+        if (!stat.isFile()) continue;
+
+        // Only process files created during or after this message
+        if (stat.birthtimeMs < messageCreatedAt) continue;
+
+        const content = readFileSync(filepath, "utf-8");
+
+        // Derive subject from filename:
+        // strip .md extension, strip leading date prefix, replace hyphens with spaces, capitalize first letter
+        const basename = filename.replace(/\.md$/, "");
+        const withoutDate = basename.replace(/^\d{4}-\d{2}-\d{2}-?/, "");
+        const withSpaces = withoutDate.replace(/-/g, " ");
+        const subject =
+          withSpaces.charAt(0).toUpperCase() + withSpaces.slice(1);
+
+        const fingerprint = computeMemoryFingerprint(
+          scopeId,
+          "journal",
+          subject,
+          content,
+        );
+
+        const existing = db
+          .select()
+          .from(memoryItems)
+          .where(
+            and(
+              eq(memoryItems.fingerprint, fingerprint),
+              eq(memoryItems.scopeId, scopeId),
+            ),
+          )
+          .get();
+
+        let memoryItemId: string;
+
+        if (existing) {
+          memoryItemId = existing.id;
+          db.update(memoryItems)
+            .set({
+              lastSeenAt: messageCreatedAt,
+              status: "active",
+            })
+            .where(eq(memoryItems.id, existing.id))
+            .run();
+        } else {
+          memoryItemId = uuid();
+          db.insert(memoryItems)
+            .values({
+              id: memoryItemId,
+              kind: "journal",
+              subject,
+              statement: content,
+              status: "active",
+              confidence: 0.95,
+              importance: 0.8,
+              fingerprint,
+              sourceType: "extraction",
+              sourceMessageRole: "assistant",
+              verificationState: "assistant_inferred",
+              scopeId,
+              firstSeenAt: messageCreatedAt,
+              lastSeenAt: messageCreatedAt,
+              lastUsedAt: null,
+              supersedes: null,
+              overrideConfidence: null,
+            })
+            .run();
+          upserted += 1;
+        }
+
+        db.insert(memoryItemSources)
+          .values({
+            memoryItemId,
+            messageId,
+            evidence: content,
+            createdAt: Date.now(),
+          })
+          .onConflictDoNothing()
+          .run();
+
+        enqueueMemoryJob("embed_item", { itemId: memoryItemId });
+      } catch (err) {
+        log.warn(
+          { filename, err: err instanceof Error ? err.message : String(err) },
+          "Failed to process journal file for memory — skipping",
+        );
+      }
+    }
+
+    return upserted;
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Failed to scan journal directory for memories",
+    );
+    return 0;
+  }
+}


### PR DESCRIPTION
## Summary
- Journal memory items are now created directly from raw journal file content, bypassing the LLM extraction layer that previously summarized/rewritten them
- Added `upsertJournalMemoriesFromDisk()` helper that scans the journal directory for newly created files during assistant messages
- Removed journal from the LLM extraction prompt categories and filtered journal-kind items from extraction output

## Original prompt
The journal memories should just be the raw unedited content of the journal entries instead of being extracted / summarized / rewritten

Part of plan: journal-raw-memories.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
