### PR TITLE
fix: sort imports in journal-memory.ts

### DIFF
--- a/assistant/src/memory/journal-memory.ts
+++ b/assistant/src/memory/journal-memory.ts
@@ -4,8 +4,8 @@ import { join } from "node:path";
 import { and, eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getWorkspaceDir } from "../util/platform.js";
 import { getLogger } from "../util/logger.js";
+import { getWorkspaceDir } from "../util/platform.js";
 import { getDb } from "./db.js";
 import { computeMemoryFingerprint } from "./fingerprint.js";
 import { enqueueMemoryJob } from "./jobs-store.js";


### PR DESCRIPTION
## Summary
- Fix ESLint `simple-import-sort/imports` error in `assistant/src/memory/journal-memory.ts` by reordering local imports alphabetically

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23461442111/job/68263812892
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
