### PR TITLE
fix: add activation-hints to mcp-setup skill (JARVIS-323)

### DIFF
--- a/skills/mcp-setup/SKILL.md
+++ b/skills/mcp-setup/SKILL.md
@@ -6,6 +6,14 @@ metadata:
   emoji: "🔌"
   vellum:
     display-name: "MCP Setup"
+    activation-hints:
+      - "User wants to connect, set up, add, or remove an MCP server (e.g. 'connect Linear via MCP', 'set up MCP', 'add an MCP server')"
+      - "User asks about MCP tools, MCP integration, or what MCP servers are configured"
+      - "An MCP tool call fails with auth/token errors -- run `assistant mcp auth` to re-authenticate"
+      - "Uses `assistant mcp` CLI commands via host_bash -- do NOT improvise MCP setup from general knowledge, load this skill first"
+    avoid-when:
+      - "User is asking how to use an already-connected MCP tool (just call the tool directly)"
+      - "General questions about what MCP is (answer from general knowledge)"
 ---
 
 Help users configure MCP servers so external tools (e.g. Linear, GitHub, Notion) become available in conversations.


### PR DESCRIPTION
## Summary
- **Bug**: The model didn't load the `mcp-setup` skill on first ask (e.g., "connect Linear via MCP") because the skill's SKILL.md frontmatter had no `activation-hints`, so the model had no routing cues in the system prompt's available skills listing.
- **Fix**: Added `activation-hints` covering MCP setup/connect/auth requests and `avoid-when` to prevent false matches on general tool usage questions.

## Test plan
- [ ] Ask "connect Linear via MCP" in a fresh conversation and verify the model loads the mcp-setup skill on the first turn
- [ ] Ask "set up MCP" and verify the skill is loaded
- [ ] Ask "what MCP servers do I have?" and verify routing
- [ ] Ask "how do I use the Linear tool?" (already connected) and verify the skill is NOT loaded
- [ ] Ask "what is MCP?" and verify the skill is NOT loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
