### PR TITLE
fix: fall back to full basename for date-only journal filenames

### DIFF
--- a/assistant/src/memory/journal-memory.ts
+++ b/assistant/src/memory/journal-memory.ts
@@ -64,7 +64,9 @@ export function upsertJournalMemoriesFromDisk(
         const withoutDate = basename.replace(/^\d{4}-\d{2}-\d{2}-?/, "");
         const withSpaces = withoutDate.replace(/-/g, " ");
         const subject =
-          withSpaces.charAt(0).toUpperCase() + withSpaces.slice(1);
+          withSpaces.length > 0
+            ? withSpaces.charAt(0).toUpperCase() + withSpaces.slice(1)
+            : basename;
 
         const fingerprint = computeMemoryFingerprint(
           scopeId,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for journal-raw-memories.md.

**Gap:** Empty subject from date-only journal filenames
**What was expected:** Every journal memory item should have a meaningful subject
**What was found:** A file like 2025-01-15.md produced an empty subject after stripping the date prefix
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
