### PR TITLE
M1: Extend circuit breaker to suppress avatar follower feedback loop

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -551,15 +551,14 @@ struct MessageListView: View {
     }
 
     private func updateAvatarFollower(anchorY: CGFloat) {
-        // Circuit breaker: suppress avatar follower updates when a scroll loop is detected.
-        let convIdString = conversationId?.uuidString ?? "unknown"
-        if scrollLoopGuard.isTripped(conversationId: convIdString) { return }
-
         recordScrollLoopEvent(.avatarFollowerUpdate)
-        // Compute visibility once and update @State only on boundary crossings.
+
+        // Compute visibility (but only mutate @State if circuit breaker isn't tripped)
         let nowVisible = anchorY.isFinite
             && ConversationAvatarFollower.shouldShow(anchorY: anchorY, viewportHeight: scrollViewportHeight)
-        if isAvatarVisible != nowVisible {
+        let convIdString = conversationId?.uuidString ?? "unknown"
+        let isTripped = scrollLoopGuard.isTripped(conversationId: convIdString)
+        if !isTripped && isAvatarVisible != nowVisible {
             isAvatarVisible = nowVisible
         }
 
@@ -577,7 +576,8 @@ struct MessageListView: View {
             avatarSmoothingTask = nil
             scrollTracking.pendingAvatarY = nil
             scrollTracking.avatarLastAppliedAt = nil
-            if avatarDisplayY != .infinity { avatarDisplayY = .infinity }
+            // Only mutate @State avatarDisplayY when circuit breaker isn't tripped
+            if !isTripped && avatarDisplayY != .infinity { avatarDisplayY = .infinity }
             return
         }
 
@@ -604,7 +604,10 @@ struct MessageListView: View {
             avatarSmoothingTask?.cancel()
             avatarSmoothingTask = nil
             scrollTracking.pendingAvatarY = nil
-            applyAvatarDisplayY(forAnchorY: anchorY)
+            // Only apply @State avatar position when circuit breaker isn't tripped
+            if !isTripped {
+                applyAvatarDisplayY(forAnchorY: anchorY)
+            }
             return
         }
 
@@ -623,7 +626,10 @@ struct MessageListView: View {
                 return
             }
             scrollTracking.pendingAvatarY = nil
-            applyAvatarDisplayY(forAnchorY: pending)
+            // Only apply @State avatar position when circuit breaker isn't tripped
+            if !scrollLoopGuard.isTripped(conversationId: conversationId?.uuidString ?? "unknown") {
+                applyAvatarDisplayY(forAnchorY: pending)
+            }
             avatarSmoothingTask = nil
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -553,13 +553,17 @@ struct MessageListView: View {
     private func updateAvatarFollower(anchorY: CGFloat) {
         recordScrollLoopEvent(.avatarFollowerUpdate)
 
-        // Compute visibility (but only mutate @State if circuit breaker isn't tripped)
+        // Compute visibility
         let nowVisible = anchorY.isFinite
             && ConversationAvatarFollower.shouldShow(anchorY: anchorY, viewportHeight: scrollViewportHeight)
         let convIdString = conversationId?.uuidString ?? "unknown"
         let isTripped = scrollLoopGuard.isTripped(conversationId: convIdString)
-        if !isTripped && isAvatarVisible != nowVisible {
-            isAvatarVisible = nowVisible
+        if isAvatarVisible != nowVisible {
+            // When tripped, only allow hiding (removing UI is safe and prevents stale state).
+            // Showing (false→true) adds layout that could feed the loop — suppress it.
+            if !isTripped || !nowVisible {
+                isAvatarVisible = nowVisible
+            }
         }
 
         // Update non-reactive tracking position (no body re-evaluation).

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -520,6 +520,10 @@ struct MessageListView: View {
     }
 
     private func applyAvatarDisplayY(forAnchorY anchorY: CGFloat) {
+        // Circuit breaker: suppress @State mutations when a scroll loop is detected.
+        let convIdString = conversationId?.uuidString ?? "unknown"
+        if scrollLoopGuard.isTripped(conversationId: convIdString) { return }
+
         let y = anchorY + ConversationAvatarFollower.verticalOffset
         // Dead-zone: skip @State update when position hasn't moved meaningfully.
         // Each avatarDisplayY change triggers a MessageListView body re-evaluation;
@@ -547,6 +551,10 @@ struct MessageListView: View {
     }
 
     private func updateAvatarFollower(anchorY: CGFloat) {
+        // Circuit breaker: suppress avatar follower updates when a scroll loop is detected.
+        let convIdString = conversationId?.uuidString ?? "unknown"
+        if scrollLoopGuard.isTripped(conversationId: convIdString) { return }
+
         recordScrollLoopEvent(.avatarFollowerUpdate)
         // Compute visibility once and update @State only on boundary crossings.
         let nowVisible = anchorY.isFinite


### PR DESCRIPTION
## Summary
- Adds `scrollLoopGuard.isTripped()` early-return checks to `applyAvatarDisplayY(forAnchorY:)` and `updateAvatarFollower(anchorY:)` in `MessageListView.swift`
- When the scroll loop guard is tripped, these functions return early to prevent `@State` mutations (`avatarDisplayY`, `isAvatarVisible`) that would trigger body re-evaluations and perpetuate the feedback loop
- Follows the same pattern already used in `configureBottomPinCoordinator` (line ~938)

## Test plan
- [ ] Verify that avatar follower still works normally when scroll loop guard is NOT tripped
- [ ] Verify that when scroll loop guard IS tripped, avatar position and visibility mutations are suppressed
- [ ] Confirm no regressions in normal chat scrolling behavior

Part of #20980.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
