### PR TITLE
fix: move journal disk scan before extraction guards

### DIFF
--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -582,18 +582,32 @@ export async function extractAndUpsertMemoryItemsForMessage(
         .reverse()
     : [];
 
+  const effectiveScopeId = scopeId ?? "default";
+
+  // Directly create journal memories from any journal files written during
+  // this message, bypassing LLM extraction (which would summarize/rewrite them).
+  // This must run before the extraction guards (semantic density, useLLM, etc.)
+  // because journal disk scanning is independent of LLM extraction.
+  let journalUpserted = 0;
+  if (message.role === "assistant") {
+    journalUpserted = upsertJournalMemoriesFromDisk(
+      message.createdAt,
+      effectiveScopeId,
+      messageId,
+    );
+  }
+
   const text = extractTextFromStoredMessageContent(message.content);
   if (!hasSemanticDensity(text)) {
     log.debug(
       { messageId },
       "Skipping extraction — message lacks semantic density",
     );
-    return 0;
+    return journalUpserted;
   }
 
   const config = getConfig();
   const extractionConfig = config.memory.extraction;
-  const effectiveScopeId = scopeId ?? "default";
 
   // Resolve the guardian's persona to provide personality-aware extraction
   // context. Currently uses the guardian persona for all conversations —
@@ -602,7 +616,7 @@ export async function extractAndUpsertMemoryItemsForMessage(
   const userPersona = resolveGuardianPersona();
 
   if (!extractionConfig.useLLM) {
-    return 0;
+    return journalUpserted;
   }
 
   const extracted = await extractItemsWithLLM(
@@ -614,7 +628,7 @@ export async function extractAndUpsertMemoryItemsForMessage(
     userPersona,
   );
 
-  if (extracted.length === 0) return 0;
+  if (extracted.length === 0) return journalUpserted;
 
   // Guard: re-check after the async LLM call. The event loop yields during
   // extractItemsWithLLM, so another task could have marked the conversation
@@ -624,7 +638,7 @@ export async function extractAndUpsertMemoryItemsForMessage(
       { messageId, conversationId },
       "Skipping upsert — conversation marked failed during extraction",
     );
-    return 0;
+    return journalUpserted;
   }
 
   let upserted = 0;
@@ -820,15 +834,7 @@ export async function extractAndUpsertMemoryItemsForMessage(
     enqueueMemoryJob("embed_item", { itemId: memoryItemId });
   }
 
-  // Directly create journal memories from any journal files written during
-  // this message, bypassing LLM extraction (which would summarize/rewrite them).
-  if (message.role === "assistant") {
-    upserted += upsertJournalMemoriesFromDisk(
-      message.createdAt,
-      effectiveScopeId,
-      messageId,
-    );
-  }
+  upserted += journalUpserted;
 
   log.debug(
     { messageId, extracted: extracted.length, upserted },


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for journal-raw-memories.md.

**Gap:** Journal disk scan unreachable when LLM extraction returns zero items or is gated out
**What was expected:** upsertJournalMemoriesFromDisk() should always run for assistant messages
**What was found:** The call was placed after multiple early returns (semantic density, useLLM, extracted.length === 0) that prevented it from running in common cases
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
