### PR TITLE
M2: Skip scroll callbacks for duplicate detectors

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -789,12 +789,14 @@ struct ScrollWheelDetector: NSViewRepresentable {
             if let registry = coordinator.registry,
                registry.hasDuplicates(conversationId: convId, windowId: winIdStr) {
                 let entries = registry.entries(conversationId: convId, windowId: winIdStr)
-                let mostRecent = entries.max(by: { $0.installedAt < $1.installedAt })
+                // lastUpdatedAt tracks which detector SwiftUI is actively managing.
+                // Per-frame races are transient; leaked detectors are caught by purgeStale().
+                let mostRecent = entries.max(by: { $0.lastUpdatedAt < $1.lastUpdatedAt })
                 if mostRecent?.detectorId != coordinator.detectorId {
-                    // This detector is stale — the newest one is active for the same conversation/window.
+                    // This detector is stale — the most recent one is active for the same conversation/window.
                     // Suppress callbacks to prevent competing scroll-state fights.
                     if coordinator.shouldRecordDiagnostic(kind: .detectorUpdate) {
-                        log.debug("ScrollWheelDetector: suppressing event for stale detector \(coordinator.detectorId) (newest: \(mostRecent?.detectorId ?? "nil"))")
+                        log.debug("ScrollWheelDetector: suppressing event for stale detector \(coordinator.detectorId) (most recent: \(mostRecent?.detectorId ?? "nil"))")
                     }
                     return event
                 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -789,12 +789,12 @@ struct ScrollWheelDetector: NSViewRepresentable {
             if let registry = coordinator.registry,
                registry.hasDuplicates(conversationId: convId, windowId: winIdStr) {
                 let entries = registry.entries(conversationId: convId, windowId: winIdStr)
-                let mostRecent = entries.max(by: { $0.lastUpdatedAt < $1.lastUpdatedAt })
+                let mostRecent = entries.max(by: { $0.installedAt < $1.installedAt })
                 if mostRecent?.detectorId != coordinator.detectorId {
-                    // This detector is stale — a newer one is active for the same conversation/window.
+                    // This detector is stale — the newest one is active for the same conversation/window.
                     // Suppress callbacks to prevent competing scroll-state fights.
                     if coordinator.shouldRecordDiagnostic(kind: .detectorUpdate) {
-                        log.debug("ScrollWheelDetector: suppressing event for stale detector \(coordinator.detectorId) (active: \(mostRecent?.detectorId ?? "nil"))")
+                        log.debug("ScrollWheelDetector: suppressing event for stale detector \(coordinator.detectorId) (newest: \(mostRecent?.detectorId ?? "nil"))")
                     }
                     return event
                 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -782,6 +782,24 @@ struct ScrollWheelDetector: NSViewRepresentable {
             let locationInView = view.convert(event.locationInWindow, from: nil)
             guard view.bounds.width > 0, view.bounds.contains(locationInView) else { return event }
 
+            // Skip this event if a duplicate detector exists and this one isn't the most recent.
+            let convId = coordinator.conversationId?.uuidString ?? "none"
+            let winId = window.windowNumber
+            let winIdStr = String(winId)
+            if let registry = coordinator.registry,
+               registry.hasDuplicates(conversationId: convId, windowId: winIdStr) {
+                let entries = registry.entries(conversationId: convId, windowId: winIdStr)
+                let mostRecent = entries.max(by: { $0.lastUpdatedAt < $1.lastUpdatedAt })
+                if mostRecent?.detectorId != coordinator.detectorId {
+                    // This detector is stale — a newer one is active for the same conversation/window.
+                    // Suppress callbacks to prevent competing scroll-state fights.
+                    if coordinator.shouldRecordDiagnostic(kind: .detectorUpdate) {
+                        log.debug("ScrollWheelDetector: suppressing event for stale detector \(coordinator.detectorId) (active: \(mostRecent?.detectorId ?? "nil"))")
+                    }
+                    return event
+                }
+            }
+
             if event.scrollingDeltaY > 3 && event.momentumPhase.isEmpty {
                 // Direct user scroll up (toward older content) — untether immediately.
                 // Momentum events are excluded so a flick doesn't accidentally untether.


### PR DESCRIPTION
## Summary
- When multiple `ScrollWheelDetector` instances exist for the same conversation/window pair, only the most recently updated detector processes scroll events
- Stale detectors skip all callbacks to prevent competing `onScrollUp`/`onScrollToBottom` calls that cause rapid `isNearBottom` toggling
- Uses the existing `ScrollWheelDetectorRegistry` to identify duplicates and determine which detector is most recent

## Test plan
- [ ] Open a conversation and scroll up/down — verify normal scroll behavior is unchanged
- [ ] Trigger duplicate detector scenario (e.g., rapid view recreation) — verify no rapid `isNearBottom` toggling
- [ ] Check console logs for "suppressing event for stale detector" messages when duplicates exist

Part of #20980.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
