### PR TITLE
fix: exclude journal from LLM extraction tool schema enum

### DIFF
--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -62,6 +62,13 @@ const VALID_KINDS = new Set<string>([
   "journal",
 ]);
 
+/**
+ * Kinds the LLM is allowed to produce during extraction. Excludes "journal"
+ * because journal memories are created directly from disk files — any
+ * LLM-produced journal items would be silently dropped, wasting tokens.
+ */
+const EXTRACTION_KINDS = [...VALID_KINDS].filter((k) => k !== "journal");
+
 /** Maps old kind names to their new equivalents for graceful migration. */
 const KIND_MIGRATION_MAP: Record<string, MemoryItemKind> = {
   profile: "identity",
@@ -419,7 +426,7 @@ async function extractItemsWithLLM(
                 properties: {
                   kind: {
                     type: "string",
-                    enum: [...VALID_KINDS],
+                    enum: EXTRACTION_KINDS,
                     description: "Category of memory item",
                   },
                   subject: {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for journal-raw-memories.md.

**Gap:** journal still listed in the LLM extraction tool schema enum despite being filtered out
**What was expected:** The extraction LLM should not see journal as a valid kind
**What was found:** VALID_KINDS (including journal) was spread into the tool schema, wasting tokens and risking misclassification
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20989" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
