### PR TITLE
fix: trigger conversation starters on journal memory early-return paths

### DIFF
--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -541,6 +541,25 @@ async function extractItemsWithLLM(
   return deduplicateItems(items);
 }
 
+/**
+ * Fire conversation starters generation when journal memories were created.
+ * Wrapped in try/catch so failures never propagate to the caller.
+ */
+function triggerConversationStartersIfNeeded(
+  count: number,
+  scopeId: string,
+): void {
+  if (count <= 0) return;
+  try {
+    maybeEnqueueConversationStartersJob(scopeId);
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Failed to check conversation starters cadence",
+    );
+  }
+}
+
 // ── Public API ─────────────────────────────────────────────────────────
 
 export async function extractAndUpsertMemoryItemsForMessage(
@@ -603,6 +622,7 @@ export async function extractAndUpsertMemoryItemsForMessage(
       { messageId },
       "Skipping extraction — message lacks semantic density",
     );
+    triggerConversationStartersIfNeeded(journalUpserted, effectiveScopeId);
     return journalUpserted;
   }
 
@@ -616,6 +636,7 @@ export async function extractAndUpsertMemoryItemsForMessage(
   const userPersona = resolveGuardianPersona();
 
   if (!extractionConfig.useLLM) {
+    triggerConversationStartersIfNeeded(journalUpserted, effectiveScopeId);
     return journalUpserted;
   }
 
@@ -628,7 +649,10 @@ export async function extractAndUpsertMemoryItemsForMessage(
     userPersona,
   );
 
-  if (extracted.length === 0) return journalUpserted;
+  if (extracted.length === 0) {
+    triggerConversationStartersIfNeeded(journalUpserted, effectiveScopeId);
+    return journalUpserted;
+  }
 
   // Guard: re-check after the async LLM call. The event loop yields during
   // extractItemsWithLLM, so another task could have marked the conversation
@@ -638,6 +662,7 @@ export async function extractAndUpsertMemoryItemsForMessage(
       { messageId, conversationId },
       "Skipping upsert — conversation marked failed during extraction",
     );
+    triggerConversationStartersIfNeeded(journalUpserted, effectiveScopeId);
     return journalUpserted;
   }
 
@@ -842,16 +867,7 @@ export async function extractAndUpsertMemoryItemsForMessage(
   );
 
   // Trigger conversation starters generation when new items are upserted
-  if (upserted > 0) {
-    try {
-      maybeEnqueueConversationStartersJob(effectiveScopeId);
-    } catch (err) {
-      log.warn(
-        { err: err instanceof Error ? err.message : String(err) },
-        "Failed to check conversation starters cadence",
-      );
-    }
-  }
+  triggerConversationStartersIfNeeded(upserted, effectiveScopeId);
 
   return upserted;
 }


### PR DESCRIPTION
## Summary
- **Gap:** Journal upserts on early-return paths skip conversation starters generation
- **What was expected:** `maybeEnqueueConversationStartersJob` should fire when journal memories are created
- **What was found:** Four early-return paths in `extractAndUpsertMemoryItemsForMessage` returned `journalUpserted` without triggering conversation starters
- Extracted `triggerConversationStartersIfNeeded(count, scopeId)` helper to avoid duplicating the try/catch block at each return site
- Added the trigger call before all four early-return paths (`!hasSemanticDensity`, `!useLLM`, `extracted.length === 0`, `isConversationFailed`) and refactored the existing bottom-of-function call to use the same helper

## Test plan
- [ ] Verify type-check passes (`bunx tsc --noEmit`)
- [ ] Confirm that journal memory creation on low-semantic-density messages (tool-use blocks) now triggers conversation starters refresh
- [ ] Confirm that the normal extraction path still triggers conversation starters as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
