### PR TITLE
fix: keep avatar visible during transient non-finite anchor on send

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -569,7 +569,15 @@ struct MessageListView: View {
             avatarSmoothingTask = nil
             scrollTracking.pendingAvatarY = nil
             scrollTracking.avatarLastAppliedAt = nil
-            if avatarDisplayY != .infinity { avatarDisplayY = .infinity }
+            // During an active send, the LazyVStack may transiently deallocate
+            // the tail anchor view during re-layout (e.g. thinking indicator
+            // insertion, rich UI expansion), producing a non-finite preference.
+            // Keep the avatar at its last known position so it doesn't flash
+            // off-screen and back. Once the layout settles, a finite anchor
+            // will arrive and the avatar resumes normal tracking.
+            if !isSending && avatarDisplayY != .infinity {
+                avatarDisplayY = .infinity
+            }
             return
         }
 


### PR DESCRIPTION
## Summary
- During an active send, skip resetting avatarDisplayY to .infinity when the tail anchor transiently reports non-finite
- The avatar holds its last known position instead of flashing off-screen
- Once layout settles and a finite anchor returns, normal tracking resumes

## Why this is safe
The guard only suppresses the .infinity reset when `isSending` is true — i.e. the assistant is actively processing. Outside of sends (conversation switches, scroll away, etc.), the avatar still hides immediately on non-finite anchors as before. The worst case during a send is the avatar stays at a slightly stale Y for ~600ms until the layout settles — visually imperceptible since the content is actively scrolling.

## What caused the flash
LazyVStack deallocates off-screen views during re-layout. When new content is inserted (user message, thinking indicator, tool confirmation), the `conversation-tail-anchor` view gets briefly deallocated, causing `ConversationTailAnchorYKey` to report `.infinity`. The old code immediately set `avatarDisplayY = .infinity`, hiding the avatar overlay.

Closes #20992
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
