### PR TITLE
M1: Replace segmentCache with NSCache in ChatBubbleTextContent

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -583,28 +583,21 @@ struct ChatBubble: View {
             let text = message.text
             guard !message.isStreaming,
                   text.count > Self.asyncParseThreshold,
-                  Self.segmentCache[text] == nil,
+                  Self.segmentCache.object(forKey: text as NSString) == nil,
                   asyncSegments[text] == nil else { return }
             let result = await MarkdownParseActor.shared.parse(text)
             guard !Task.isCancelled else { return }
             asyncSegments[text] = result
-            // Backfill synchronous cache with guardrails (size limit, byte
-            // tracking, eviction) — mirrors the logic in cachedSegments.
-            // Re-check cache after await to avoid double-counting bytes when
+            // Backfill synchronous cache with cost tracking.
+            // Re-check cache after await to avoid double-inserting when
             // multiple bubbles parse the same text concurrently.
             if text.count <= Self.maxCacheableTextLength,
-               Self.segmentCache[text] == nil {
-                if Self.segmentCache.count >= Self.maxCacheSize {
-                    if let lruKey = Self.segmentCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
-                        Self.estimatedCacheBytes -= Self.estimatedBytes(for: lruKey)
-                        Self.segmentCache.removeValue(forKey: lruKey)
-                    }
-                }
-                Self.lruCounter += 1
-                let cost = Self.estimatedBytes(for: text)
-                Self.segmentCache[text] = (result, Self.lruCounter)
-                Self.estimatedCacheBytes += cost
-                Self.evictIfOverBudget()
+               Self.segmentCache.object(forKey: text as NSString) == nil {
+                Self.segmentCache.setObject(
+                    SegmentCacheEntry(result),
+                    forKey: text as NSString,
+                    cost: text.utf8.count * 10
+                )
             }
         }
     }
@@ -639,58 +632,41 @@ struct ChatBubble: View {
     /// miss, reducing scroll jank from synchronous markdown parsing.
     static let asyncParseThreshold = 500
 
-    // MARK: - LRU Caches
+    // MARK: - Segment Cache
     //
-    // Each cache entry stores (value, accessTime) where accessTime is a
-    // monotonically increasing counter. On eviction the entry with the
-    // lowest accessTime is removed (least-recently-used).
+    // NSCache handles eviction automatically based on countLimit and
+    // totalCostLimit, eliminating the O(n) min(by:) scans of the old
+    // hand-rolled LRU dictionary.
 
-    // UInt64 to avoid silent overflow after billions of cache accesses in long-running sessions.
-    @MainActor static var lruCounter: UInt64 = 0
-
-    @MainActor static var segmentCache = [String: (value: [MarkdownSegment], accessTime: UInt64)]()
-    static let maxCacheSize = 100
+    @MainActor static var segmentCache: NSCache<NSString, SegmentCacheEntry> = {
+        let cache = NSCache<NSString, SegmentCacheEntry>()
+        cache.countLimit = 500
+        cache.totalCostLimit = 5_000_000
+        return cache
+    }()
 
     // MARK: - Cache Guardrails
     //
     // Prevents a single huge message from consuming disproportionate cache
     // space.  Text over `maxCacheableTextLength` is parsed but never stored.
-    // `estimatedCacheBytes` tracks a rough byte budget across the segment
-    // cache; when it exceeds `maxCacheBytes` the oldest entries are evicted.
 
     static let maxCacheableTextLength = 10_000
-    static let maxCacheBytes = 5_000_000
-    /// Rough byte estimate of all entries in segmentCache.  Updated on insert/evict.
-    @MainActor static var estimatedCacheBytes: Int = 0
-
-    /// Estimate the in-memory cost of caching the given text's parsed result.
-    /// Uses `utf8.count * 10` as a conservative multiplier: parsed MarkdownSegment
-    /// arrays carry overhead beyond raw bytes (segment structs, string copies,
-    /// enum metadata), so 3x was too low and allowed the budget to be exceeded.
-    static func estimatedBytes(for text: String) -> Int {
-        text.utf8.count * 10
-    }
-
-    /// Evicts the oldest entries from segmentCache until
-    /// `estimatedCacheBytes` drops below `maxCacheBytes`.
-    @MainActor static func evictIfOverBudget() {
-        while estimatedCacheBytes > maxCacheBytes {
-            guard let lruKey = segmentCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key else { break }
-            let cost = estimatedBytes(for: lruKey)
-            segmentCache.removeValue(forKey: lruKey)
-            estimatedCacheBytes -= cost
-        }
-    }
 
     // MARK: - Streaming Dedup Caches
     //
-    // During streaming, the LRU caches above skip storing results to avoid
+    // During streaming, the segment cache skips storing results to avoid
     // filling up with intermediate text states. However SwiftUI reevaluates
     // view bodies multiple times per token, often with identical text.
     // These single-entry caches hold the last-parsed streaming result so
     // redundant reevaluations return instantly without re-parsing.
 
     @MainActor static var lastStreamingSegments: (text: String, value: [MarkdownSegment])?
+}
+
+/// NSObject wrapper for `[MarkdownSegment]` to satisfy NSCache's NSObject value requirement.
+final class SegmentCacheEntry: NSObject {
+    let segments: [MarkdownSegment]
+    init(_ segments: [MarkdownSegment]) { self.segments = segments }
 }
 
 /// Applies `.compositingGroup()` only when active, to avoid re-compositing during streaming.

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -25,28 +25,21 @@ extension ChatBubble {
             // Only run async parsing for large, non-streaming text with a cache miss
             guard !streaming,
                   segmentText.count > Self.asyncParseThreshold,
-                  Self.segmentCache[segmentText] == nil,
+                  Self.segmentCache.object(forKey: segmentText as NSString) == nil,
                   asyncSegments[segmentText] == nil else { return }
             let result = await MarkdownParseActor.shared.parse(segmentText)
             guard !Task.isCancelled else { return }
             asyncSegments[segmentText] = result
-            // Backfill the synchronous cache with guardrails (size limit,
-            // byte tracking, eviction) — mirrors the logic in cachedSegments.
-            // Re-check cache after await to avoid double-counting bytes when
+            // Backfill the synchronous cache with cost tracking.
+            // Re-check cache after await to avoid double-inserting when
             // multiple bubbles parse the same text concurrently.
             if segmentText.count <= Self.maxCacheableTextLength,
-               Self.segmentCache[segmentText] == nil {
-                if Self.segmentCache.count >= Self.maxCacheSize {
-                    if let lruKey = Self.segmentCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
-                        Self.estimatedCacheBytes -= Self.estimatedBytes(for: lruKey)
-                        Self.segmentCache.removeValue(forKey: lruKey)
-                    }
-                }
-                Self.lruCounter += 1
-                let cost = Self.estimatedBytes(for: segmentText)
-                Self.segmentCache[segmentText] = (result, Self.lruCounter)
-                Self.estimatedCacheBytes += cost
-                Self.evictIfOverBudget()
+               Self.segmentCache.object(forKey: segmentText as NSString) == nil {
+                Self.segmentCache.setObject(
+                    SegmentCacheEntry(result),
+                    forKey: segmentText as NSString,
+                    cost: segmentText.utf8.count * 10
+                )
             }
         }
     }
@@ -55,10 +48,8 @@ extension ChatBubble {
     /// large messages that haven't been synchronously cached yet.
     func resolveSegments(for text: String, isStreaming: Bool) -> [MarkdownSegment] {
         // Check the synchronous cache first (fast path for all sizes)
-        if let cached = Self.segmentCache[text] {
-            Self.lruCounter += 1
-            Self.segmentCache[text] = (cached.value, Self.lruCounter)
-            return cached.value
+        if let cached = Self.segmentCache.object(forKey: text as NSString) {
+            return cached.segments
         }
         // For large text with a cache miss, return async result or plain placeholder
         if !isStreaming, text.count > Self.asyncParseThreshold {
@@ -73,15 +64,13 @@ extension ChatBubble {
     }
 
     /// Cached markdown segment parser to avoid re-parsing on every render.
-    /// When `isStreaming` is true the result is not stored in the main LRU
+    /// When `isStreaming` is true the result is not stored in the main
     /// cache (to avoid filling it with intermediate text states), but a
     /// single-entry dedup cache returns the previous result when the text
     /// hasn't changed between SwiftUI reevaluations.
     static func cachedSegments(for text: String, isStreaming: Bool = false) -> [MarkdownSegment] {
-        if let cached = segmentCache[text] {
-            lruCounter += 1
-            segmentCache[text] = (cached.value, lruCounter)
-            return cached.value
+        if let cached = segmentCache.object(forKey: text as NSString) {
+            return cached.segments
         }
         // Streaming dedup: return the last-parsed result when text is unchanged.
         if isStreaming, let last = lastStreamingSegments, last.text == text {
@@ -95,18 +84,11 @@ extension ChatBubble {
         // Skip caching for very long text to avoid a single huge entry
         // evicting many smaller, more frequently accessed entries.
         if text.count > maxCacheableTextLength { return result }
-        if segmentCache.count >= maxCacheSize {
-            // Evict the least-recently-used entry (lowest accessTime).
-            if let lruKey = segmentCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
-                estimatedCacheBytes -= estimatedBytes(for: lruKey)
-                segmentCache.removeValue(forKey: lruKey)
-            }
-        }
-        lruCounter += 1
-        let cost = estimatedBytes(for: text)
-        segmentCache[text] = (result, lruCounter)
-        estimatedCacheBytes += cost
-        evictIfOverBudget()
+        segmentCache.setObject(
+            SegmentCacheEntry(result),
+            forKey: text as NSString,
+            cost: text.utf8.count * 10
+        )
         return result
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -1082,8 +1082,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     /// Called on conversation close, archive, and switch to prevent unbounded
     /// growth of cached `AttributedString` / segment data across conversations.
     private static func clearRenderCaches() {
-        ChatBubble.segmentCache.removeAll()
-        ChatBubble.estimatedCacheBytes = 0
+        ChatBubble.segmentCache.removeAllObjects()
         ChatBubble.lastStreamingSegments = nil
         MarkdownSegmentView.clearAttributedStringCache()
     }


### PR DESCRIPTION
## Summary
Replace the hand-rolled LRU segmentCache dictionary with NSCache, eliminating O(n) eviction scans and manual byte tracking. Increases cache capacity from 100 to 500.

## Changes
- Created SegmentCacheEntry NSObject wrapper for NSCache compatibility
- Replaced segmentCache dictionary with NSCache<NSString, SegmentCacheEntry>
- Removed lruCounter, estimatedCacheBytes, estimatedBytes(for:), evictIfOverBudget()
- Updated resolveSegments, cachedSegments, and async backfill in ChatBubble
- Kept streaming dedup cache and maxCacheableTextLength guard unchanged

Closes #20995

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/20999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
