### PR TITLE
fix: also guard isAvatarVisible during send to prevent avatar flash

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -549,10 +549,16 @@ struct MessageListView: View {
     private func updateAvatarFollower(anchorY: CGFloat) {
         recordScrollLoopEvent(.avatarFollowerUpdate)
         // Compute visibility once and update @State only on boundary crossings.
+        // During an active send, don't hide the avatar on transient non-finite
+        // anchors — the LazyVStack briefly deallocates the anchor view during
+        // re-layout (thinking indicator, rich UI expansion). Hiding would cause
+        // the avatar to flash off-screen via shouldShowConversationTailAvatar.
         let nowVisible = anchorY.isFinite
             && ConversationAvatarFollower.shouldShow(anchorY: anchorY, viewportHeight: scrollViewportHeight)
         if isAvatarVisible != nowVisible {
-            isAvatarVisible = nowVisible
+            if nowVisible || !isSending {
+                isAvatarVisible = nowVisible
+            }
         }
 
         // Update non-reactive tracking position (no body re-evaluation).


### PR DESCRIPTION
## Summary
- Guard `isAvatarVisible` from going false during `isSending` on transient non-finite anchors
- The previous fix (#20993) only guarded `avatarDisplayY`, but the avatar overlay visibility is controlled by `isAvatarVisible` via `shouldShowConversationTailAvatar`
- Both paths now consistently hold the avatar visible during active sends

Closes #20992
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
