### PR TITLE
Remove getCurrentAssistant in favor of idempotent hatch

### DIFF
--- a/clients/ARCHITECTURE.md
+++ b/clients/ARCHITECTURE.md
@@ -457,7 +457,7 @@ The avatar uses a simple image-based approach: a custom user-uploaded profile pi
 
 ## Managed Sign-In (macOS)
 
-Managed sign-in allows macOS users to connect to a platform-hosted assistant during first-run onboarding instead of running a local daemon. When a user clicks "Sign in" on the onboarding screen, the app authenticates via WorkOS through the platform, discovers or creates a managed assistant, and connects to it through platform proxy endpoints.
+Managed sign-in allows macOS users to connect to a platform-hosted assistant during first-run onboarding instead of running a local daemon. When a user clicks "Sign in" on the onboarding screen, the app authenticates via WorkOS through the platform, ensures a managed assistant exists (via the idempotent hatch endpoint), and connects to it through platform proxy endpoints.
 
 ### Sign-In Flow
 
@@ -465,8 +465,8 @@ Managed sign-in allows macOS users to connect to a platform-hosted assistant dur
 User clicks "Sign in"
   --> WorkOS authentication (via AuthManager)
   --> ManagedAssistantBootstrapService.ensureManagedAssistant()
-      --> GET /v1/assistants/current/  (discover existing)
-      --> If 404: POST /v1/assistants/hatch/  (create new)
+      --> If connectedAssistantId stored: GET /v1/assistants/{id}/  (retrieve by ID)
+      --> Otherwise: POST /v1/assistants/hatch/  (idempotent — returns existing or creates new)
   --> Upsert lockfile entry (cloud: "vellum")
   --> Set connectedAssistantId in UserDefaults
   --> Configure managed HTTP transport
@@ -511,7 +511,7 @@ When a managed-mode HTTP request receives a 401, the `HTTPDaemonClient` does not
 | File | Purpose |
 |------|---------|
 | `clients/shared/App/Auth/ManagedAssistantBootstrapService.swift` | Discover-or-create orchestrator for managed assistants |
-| `clients/shared/App/Auth/AuthService.swift` | Platform API methods (`getCurrentAssistant`, `hatchAssistant`) |
+| `clients/shared/App/Auth/AuthService.swift` | Platform API methods (`getAssistant`, `hatchAssistant`) |
 | `clients/shared/App/Auth/SessionTokenManager.swift` | Session token storage (Keychain + `~/.vellum/platform-token` file bridge) |
 | `clients/shared/Network/DaemonConfig.swift` | `RouteMode`, `AuthMode`, `TransportMetadata` types |
 | `clients/shared/Network/HTTPDaemonClient.swift` | Endpoint builder and auth application for both route modes |

--- a/clients/macos/vellum-assistant/App/ManagedAssistantConnectionCoordinator.swift
+++ b/clients/macos/vellum-assistant/App/ManagedAssistantConnectionCoordinator.swift
@@ -8,8 +8,6 @@ protocol ManagedAssistantBootstrapProviding {
         description: String?,
         anthropicApiKey: String?
     ) async throws -> ManagedBootstrapOutcome
-
-    func discoverManagedAssistant() async throws -> PlatformAssistant?
 }
 
 extension ManagedAssistantBootstrapService: ManagedAssistantBootstrapProviding {}
@@ -93,14 +91,6 @@ final class ManagedAssistantConnectionCoordinator {
     func activateManagedAssistantAfterReauth() async throws -> ManagedAssistantConnectionResult {
         userDefaults.removeObject(forKey: "connectedOrganizationId")
         return try await activateManagedAssistant()
-    }
-
-    func activateAssociatedManagedAssistantIfPresent() async throws -> ManagedAssistantConnectionResult? {
-        guard let assistant = try await bootstrapService.discoverManagedAssistant() else {
-            return nil
-        }
-
-        return try persistManagedAssistant(assistant, reusedExisting: true)
     }
 
     private func persistManagedAssistant(

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -266,16 +266,11 @@ struct OnboardingFlowView: View {
         defer { isResolvingAssociatedManagedAssistant = false }
 
         do {
-            if let activation = try await ManagedAssistantConnectionCoordinator().activateAssociatedManagedAssistantIfPresent() {
-                log.info("Authenticated with associated managed assistant \(activation.assistant.id, privacy: .public); proceeding to app")
-                onComplete()
-                return
-            }
-
-            log.info("Authenticated account has no associated managed assistant — advancing to hosting selector")
-            state.advance()
+            let activation = try await ManagedAssistantConnectionCoordinator().activateManagedAssistant()
+            log.info("Authenticated with managed assistant \(activation.assistant.id, privacy: .public); proceeding to app")
+            onComplete()
         } catch {
-            log.error("Failed to discover associated managed assistant after authentication: \(error.localizedDescription, privacy: .public)")
+            log.error("Failed to activate managed assistant after authentication: \(error.localizedDescription, privacy: .public)")
             state.advance()
         }
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -267,8 +267,19 @@ struct OnboardingFlowView: View {
 
         do {
             let activation = try await ManagedAssistantConnectionCoordinator().activateManagedAssistant()
-            log.info("Authenticated with managed assistant \(activation.assistant.id, privacy: .public); proceeding to app")
-            onComplete()
+
+            if activation.reusedExisting {
+                // Assistant is already provisioned and running — safe to proceed.
+                log.info("Authenticated with existing managed assistant \(activation.assistant.id, privacy: .public); proceeding to app")
+                onComplete()
+            } else {
+                // Newly created — enter hatching UI and wait for readiness.
+                log.info("Authenticated and created new managed assistant \(activation.assistant.id, privacy: .public); entering hatching flow")
+                state.hasExistingManagedAssistant = false
+                state.isManagedHatch = true
+                state.isHatching = true
+                await awaitManagedAssistantReady(assistantId: activation.assistant.id)
+            }
         } catch {
             log.error("Failed to activate managed assistant after authentication: \(error.localizedDescription, privacy: .public)")
             state.advance()

--- a/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorTests.swift
@@ -115,64 +115,18 @@ final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
         XCTAssertNil(defaults.string(forKey: "connectedOrganizationId"))
     }
 
-    func testActivateAssociatedManagedAssistantIfPresentPersistsManagedSelection() async throws {
-        let assistant = PlatformAssistant(id: "managed-existing", name: "Existing")
-        let coordinator = ManagedAssistantConnectionCoordinator(
-            bootstrapService: MockManagedAssistantBootstrapService(
-                discoveredAssistant: assistant
-            ),
-            userDefaults: defaults,
-            runtimeURLProvider: { "https://platform.example.com" },
-            updateAssistantTag: { _ in },
-            lockfilePath: lockfilePath
-        )
-
-        let result = try await coordinator.activateAssociatedManagedAssistantIfPresent()
-
-        XCTAssertEqual(result?.assistant.id, assistant.id)
-        XCTAssertEqual(result?.reusedExisting, true)
-        XCTAssertEqual(defaults.string(forKey: "connectedAssistantId"), assistant.id)
-
-        let data = try Data(contentsOf: URL(fileURLWithPath: lockfilePath))
-        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        let assistants = json?["assistants"] as? [[String: Any]]
-        XCTAssertEqual(assistants?.count, 1)
-        XCTAssertEqual(assistants?.first?["assistantId"] as? String, assistant.id)
-        XCTAssertEqual(assistants?.first?["cloud"] as? String, "vellum")
-    }
-
-    func testActivateAssociatedManagedAssistantIfPresentReturnsNilWhenAccountHasNoManagedAssistant() async throws {
-        let coordinator = ManagedAssistantConnectionCoordinator(
-            bootstrapService: MockManagedAssistantBootstrapService(
-                discoveredAssistant: nil
-            ),
-            userDefaults: defaults,
-            runtimeURLProvider: { "https://platform.example.com" },
-            updateAssistantTag: { _ in },
-            lockfilePath: lockfilePath
-        )
-
-        let result = try await coordinator.activateAssociatedManagedAssistantIfPresent()
-
-        XCTAssertNil(result)
-        XCTAssertNil(defaults.string(forKey: "connectedAssistantId"))
-        XCTAssertFalse(FileManager.default.fileExists(atPath: lockfilePath))
-    }
 }
 
 @MainActor
 private final class MockManagedAssistantBootstrapService: ManagedAssistantBootstrapProviding {
     private let outcome: ManagedBootstrapOutcome?
-    private let discoveredAssistant: PlatformAssistant?
     private let onEnsureManagedAssistant: (() -> Void)?
 
     init(
         outcome: ManagedBootstrapOutcome? = nil,
-        discoveredAssistant: PlatformAssistant? = nil,
         onEnsureManagedAssistant: (() -> Void)? = nil
     ) {
         self.outcome = outcome
-        self.discoveredAssistant = discoveredAssistant
         self.onEnsureManagedAssistant = onEnsureManagedAssistant
     }
 
@@ -186,9 +140,5 @@ private final class MockManagedAssistantBootstrapService: ManagedAssistantBootst
             fatalError("ensureManagedAssistant called without a configured outcome")
         }
         return outcome
-    }
-
-    func discoverManagedAssistant() async throws -> PlatformAssistant? {
-        discoveredAssistant
     }
 }

--- a/clients/shared/App/Auth/AuthModels.swift
+++ b/clients/shared/App/Auth/AuthModels.swift
@@ -158,6 +158,12 @@ public enum PlatformAssistantResult: Sendable {
     case accessDenied
 }
 
+/// Result type for the idempotent hatch endpoint (200 = existing, 201 = created).
+public enum HatchAssistantResult: Sendable {
+    case reusedExisting(PlatformAssistant)
+    case createdNew(PlatformAssistant)
+}
+
 /// Errors specific to platform API calls (non-allauth endpoints).
 public enum PlatformAPIError: LocalizedError, Sendable {
     case invalidURL

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -275,13 +275,14 @@ public final class AuthService {
         }
     }
 
-    /// Create a new managed assistant via the platform hatch endpoint.
+    /// Create or retrieve a managed assistant via the idempotent hatch endpoint.
+    /// Returns `.reusedExisting` on 200 (assistant already exists) or `.createdNew` on 201.
     public func hatchAssistant(
         organizationId: String,
         name: String? = nil,
         description: String? = nil,
         anthropicApiKey: String? = nil
-    ) async throws -> PlatformAssistant {
+    ) async throws -> HatchAssistantResult {
         let urlString = "\(baseURL)/v1/assistants/hatch/"
         guard let url = URL(string: urlString) else {
             throw PlatformAPIError.invalidURL
@@ -329,10 +330,17 @@ public final class AuthService {
             throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
         }
 
+        let assistant: PlatformAssistant
         do {
-            return try JSONDecoder().decode(PlatformAssistant.self, from: data)
+            assistant = try JSONDecoder().decode(PlatformAssistant.self, from: data)
         } catch {
             throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+
+        if statusCode == 200 {
+            return .reusedExisting(assistant)
+        } else {
+            return .createdNew(assistant)
         }
     }
 

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -219,59 +219,6 @@ public final class AuthService {
 
     // MARK: - Platform Assistant API
 
-    /// Fetch the current user's managed assistant.
-    /// Returns `.found` with the assistant on 200, `.notFound` on 404.
-    public func getCurrentAssistant(organizationId: String) async throws -> PlatformAssistantResult {
-        let urlString = "\(baseURL)/v1/assistants/current/"
-        guard let url = URL(string: urlString) else {
-            throw PlatformAPIError.invalidURL
-        }
-
-        var urlRequest = URLRequest(url: url)
-        urlRequest.httpMethod = "GET"
-        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
-        urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
-
-        if let token = await SessionTokenManager.getTokenAsync() {
-            urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
-        } else {
-            throw PlatformAPIError.authenticationRequired
-        }
-
-        let data: Data
-        let response: URLResponse
-        do {
-            (data, response) = try await URLSession.shared.data(for: urlRequest)
-        } catch {
-            throw PlatformAPIError.networkError(error.localizedDescription)
-        }
-
-        let httpResponse = response as? HTTPURLResponse
-        let statusCode = httpResponse?.statusCode ?? 0
-
-        log.debug("Platform request GET assistants/current/ -> \(statusCode)")
-
-        if statusCode == 404 {
-            return .notFound
-        }
-
-        if statusCode == 401 || statusCode == 403 {
-            throw PlatformAPIError.authenticationRequired
-        }
-
-        guard (200..<300).contains(statusCode) else {
-            let detail = String(data: data, encoding: .utf8)
-            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
-        }
-
-        do {
-            let assistant = try JSONDecoder().decode(PlatformAssistant.self, from: data)
-            return .found(assistant)
-        } catch {
-            throw PlatformAPIError.decodingError(error.localizedDescription)
-        }
-    }
-
     /// Retrieve a specific managed assistant by ID.
     public func getAssistant(id: String, organizationId: String) async throws -> PlatformAssistantResult {
         let urlString = "\(baseURL)/v1/assistants/\(id)/"

--- a/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
@@ -45,9 +45,8 @@ public enum ManagedBootstrapError: LocalizedError, Sendable {
 /// 1. If a `connectedAssistantId` exists, fetch that specific assistant via GET /assistants/{id}/.
 ///    - 404 (deleted): clear the stale ID and fall through to step 2.
 ///    - 403 (access revoked): surface an `accessRevoked` error so the user knows.
-/// 2. Fall back to GET /assistants/current/ to discover the user's assistant.
-/// 3. If none exists (404), create one via hatch and return `.createdNew`.
-/// 4. Any other error is surfaced as a typed `ManagedBootstrapError`.
+/// 2. Call POST /assistants/hatch/ (idempotent — returns existing or creates new).
+/// 3. Any other error is surfaced as a typed `ManagedBootstrapError`.
 @MainActor
 public final class ManagedAssistantBootstrapService {
     public static let shared = ManagedAssistantBootstrapService()
@@ -80,9 +79,8 @@ public final class ManagedAssistantBootstrapService {
                 log.info("Retrieved connected assistant: \(assistant.id, privacy: .public)")
                 return .reusedExisting(assistant)
             case .notFound:
-                // Clear the stale ID and fall through to current/ + hatch
-                // so the user doesn't have to manually retry.
-                log.warning("Connected assistant \(connectedId, privacy: .public) not found — clearing stale ID and falling through to discovery")
+                // Clear the stale ID and fall through to idempotent hatch.
+                log.warning("Connected assistant \(connectedId, privacy: .public) not found — clearing stale ID and falling through to hatch")
                 UserDefaults.standard.removeObject(forKey: "connectedAssistantId")
             case .accessDenied:
                 log.error("Access to connected assistant \(connectedId, privacy: .public) has been revoked")
@@ -91,64 +89,22 @@ public final class ManagedAssistantBootstrapService {
             }
         }
 
-        // No selected assistant (or stale one was cleared) — discover via current/ or hatch a new one.
-        log.info("Falling back to current/ discovery")
-        let currentResult: PlatformAssistantResult
+        // No selected assistant (or stale one was cleared) — hatch is idempotent
+        // and will return the existing assistant if one exists.
+        log.info("No stored assistant ID — calling idempotent hatch")
+        let newAssistant: PlatformAssistant
         do {
-            currentResult = try await authService.getCurrentAssistant(organizationId: organizationId)
+            newAssistant = try await authService.hatchAssistant(
+                organizationId: organizationId,
+                name: name,
+                description: description,
+                anthropicApiKey: anthropicApiKey
+            )
         } catch let error as PlatformAPIError {
             throw mapPlatformError(error)
         }
-
-        switch currentResult {
-        case .found(let assistant):
-            log.info("Found existing managed assistant: \(assistant.id, privacy: .public)")
-            return .reusedExisting(assistant)
-
-        case .accessDenied:
-            throw ManagedBootstrapError.authenticationRequired
-
-        case .notFound:
-            log.info("No managed assistant found, hatching a new one")
-            let newAssistant: PlatformAssistant
-            do {
-                newAssistant = try await authService.hatchAssistant(
-                    organizationId: organizationId,
-                    name: name,
-                    description: description,
-                    anthropicApiKey: anthropicApiKey
-                )
-            } catch let error as PlatformAPIError {
-                throw mapPlatformError(error)
-            }
-            log.info("Created new managed assistant: \(newAssistant.id, privacy: .public)")
-            return .createdNew(newAssistant)
-        }
-    }
-
-    /// Discovers an already-associated managed assistant for the signed-in
-    /// account without creating a new one when none exists.
-    public func discoverManagedAssistant() async throws -> PlatformAssistant? {
-        let organizationId = try await resolveOrganizationId()
-
-        log.info("Checking for an existing managed assistant via current/ discovery")
-        let currentResult: PlatformAssistantResult
-        do {
-            currentResult = try await authService.getCurrentAssistant(organizationId: organizationId)
-        } catch let error as PlatformAPIError {
-            throw mapPlatformError(error)
-        }
-
-        switch currentResult {
-        case .found(let assistant):
-            log.info("Discovered existing managed assistant: \(assistant.id, privacy: .public)")
-            return assistant
-        case .notFound:
-            log.info("No existing managed assistant found for the signed-in account")
-            return nil
-        case .accessDenied:
-            throw ManagedBootstrapError.authenticationRequired
-        }
+        log.info("Hatch returned assistant: \(newAssistant.id, privacy: .public)")
+        return .createdNew(newAssistant)
     }
 
     /// Resolve the organization ID, preferring the persisted value.

--- a/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
@@ -92,9 +92,9 @@ public final class ManagedAssistantBootstrapService {
         // No selected assistant (or stale one was cleared) — hatch is idempotent
         // and will return the existing assistant if one exists.
         log.info("No stored assistant ID — calling idempotent hatch")
-        let newAssistant: PlatformAssistant
+        let hatchResult: HatchAssistantResult
         do {
-            newAssistant = try await authService.hatchAssistant(
+            hatchResult = try await authService.hatchAssistant(
                 organizationId: organizationId,
                 name: name,
                 description: description,
@@ -103,8 +103,15 @@ public final class ManagedAssistantBootstrapService {
         } catch let error as PlatformAPIError {
             throw mapPlatformError(error)
         }
-        log.info("Hatch returned assistant: \(newAssistant.id, privacy: .public)")
-        return .createdNew(newAssistant)
+
+        switch hatchResult {
+        case .reusedExisting(let assistant):
+            log.info("Hatch returned existing assistant: \(assistant.id, privacy: .public)")
+            return .reusedExisting(assistant)
+        case .createdNew(let assistant):
+            log.info("Hatch created new assistant: \(assistant.id, privacy: .public)")
+            return .createdNew(assistant)
+        }
     }
 
     /// Resolve the organization ID, preferring the persisted value.


### PR DESCRIPTION
## Summary
- Remove `GET /v1/assistants/current/` client (`AuthService.getCurrentAssistant`) — no longer needed since `POST /v1/assistants/hatch/` is idempotent
- Remove `discoverManagedAssistant()` and `activateAssociatedManagedAssistantIfPresent()` which only existed for the `current/` discovery path
- Simplify `ensureManagedAssistant()` to: stored ID → `getAssistant(id:)`, else → `hatchAssistant()`
- Update `continueManagedOnboardingAfterAuthentication()` to use `activateManagedAssistant()` directly

## Test plan
- [ ] Verify fresh onboarding with Vellum Cloud creates a managed assistant via hatch
- [ ] Verify re-opening app with existing `connectedAssistantId` retrieves by ID
- [ ] Verify deleted server-side assistant falls through to hatch and recovers
- [ ] Verify existing unit tests pass (2 discover-related tests removed, 3 remaining tests unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
