### PR TITLE
Fix scroll loop beach ball on normal conversations (LUM-392)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -782,6 +782,26 @@ struct ScrollWheelDetector: NSViewRepresentable {
             let locationInView = view.convert(event.locationInWindow, from: nil)
             guard view.bounds.width > 0, view.bounds.contains(locationInView) else { return event }
 
+            // Skip this event if a duplicate detector exists and this one isn't the most recent.
+            let convId = coordinator.conversationId?.uuidString ?? "none"
+            let winId = window.windowNumber
+            let winIdStr = String(winId)
+            if let registry = coordinator.registry,
+               registry.hasDuplicates(conversationId: convId, windowId: winIdStr) {
+                let entries = registry.entries(conversationId: convId, windowId: winIdStr)
+                // lastUpdatedAt tracks which detector SwiftUI is actively managing.
+                // Per-frame races are transient; leaked detectors are caught by purgeStale().
+                let mostRecent = entries.max(by: { $0.lastUpdatedAt < $1.lastUpdatedAt })
+                if mostRecent?.detectorId != coordinator.detectorId {
+                    // This detector is stale — the most recent one is active for the same conversation/window.
+                    // Suppress callbacks to prevent competing scroll-state fights.
+                    if coordinator.shouldRecordDiagnostic(kind: .detectorUpdate) {
+                        log.debug("ScrollWheelDetector: suppressing event for stale detector \(coordinator.detectorId) (most recent: \(mostRecent?.detectorId ?? "nil"))")
+                    }
+                    return event
+                }
+            }
+
             if event.scrollingDeltaY > 3 && event.momentumPhase.isEmpty {
                 // Direct user scroll up (toward older content) — untether immediately.
                 // Momentum events are excluded so a flick doesn't accidentally untether.

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -520,6 +520,10 @@ struct MessageListView: View {
     }
 
     private func applyAvatarDisplayY(forAnchorY anchorY: CGFloat) {
+        // Circuit breaker: suppress @State mutations when a scroll loop is detected.
+        let convIdString = conversationId?.uuidString ?? "unknown"
+        if scrollLoopGuard.isTripped(conversationId: convIdString) { return }
+
         let y = anchorY + ConversationAvatarFollower.verticalOffset
         // Dead-zone: skip @State update when position hasn't moved meaningfully.
         // Each avatarDisplayY change triggers a MessageListView body re-evaluation;
@@ -548,11 +552,18 @@ struct MessageListView: View {
 
     private func updateAvatarFollower(anchorY: CGFloat) {
         recordScrollLoopEvent(.avatarFollowerUpdate)
-        // Compute visibility once and update @State only on boundary crossings.
+
+        // Compute visibility
         let nowVisible = anchorY.isFinite
             && ConversationAvatarFollower.shouldShow(anchorY: anchorY, viewportHeight: scrollViewportHeight)
+        let convIdString = conversationId?.uuidString ?? "unknown"
+        let isTripped = scrollLoopGuard.isTripped(conversationId: convIdString)
         if isAvatarVisible != nowVisible {
-            isAvatarVisible = nowVisible
+            // When tripped, only allow hiding (removing UI is safe and prevents stale state).
+            // Showing (false→true) adds layout that could feed the loop — suppress it.
+            if !isTripped || !nowVisible {
+                isAvatarVisible = nowVisible
+            }
         }
 
         // Update non-reactive tracking position (no body re-evaluation).
@@ -569,7 +580,8 @@ struct MessageListView: View {
             avatarSmoothingTask = nil
             scrollTracking.pendingAvatarY = nil
             scrollTracking.avatarLastAppliedAt = nil
-            if avatarDisplayY != .infinity { avatarDisplayY = .infinity }
+            // Only mutate @State avatarDisplayY when circuit breaker isn't tripped
+            if !isTripped && avatarDisplayY != .infinity { avatarDisplayY = .infinity }
             return
         }
 
@@ -596,7 +608,10 @@ struct MessageListView: View {
             avatarSmoothingTask?.cancel()
             avatarSmoothingTask = nil
             scrollTracking.pendingAvatarY = nil
-            applyAvatarDisplayY(forAnchorY: anchorY)
+            // Only apply @State avatar position when circuit breaker isn't tripped
+            if !isTripped {
+                applyAvatarDisplayY(forAnchorY: anchorY)
+            }
             return
         }
 
@@ -615,7 +630,10 @@ struct MessageListView: View {
                 return
             }
             scrollTracking.pendingAvatarY = nil
-            applyAvatarDisplayY(forAnchorY: pending)
+            // Only apply @State avatar position when circuit breaker isn't tripped
+            if !scrollLoopGuard.isTripped(conversationId: conversationId?.uuidString ?? "unknown") {
+                applyAvatarDisplayY(forAnchorY: pending)
+            }
             avatarSmoothingTask = nil
         }
     }


### PR DESCRIPTION
## Summary
Fixes the spinning beach ball caused by scroll loop feedback cycles in normal chat conversations. The circuit breaker (ChatScrollLoopGuard) detected the loop but failed to suppress the avatar follower feedback path, and duplicate scroll detectors competed over scroll state without automatic resolution.

## Changes
- **Extend circuit breaker to avatar follower path**: `scrollLoopGuard.isTripped()` checks in `applyAvatarDisplayY()` and `updateAvatarFollower()` suppress @State mutations during detected scroll loops while keeping non-reactive tracking active for recovery
- **Skip scroll callbacks for duplicate detectors**: When multiple ScrollWheelDetector instances exist for the same conversation/window pair, only the most recently updated detector processes scroll events — stale detectors skip all callbacks

## Milestone PRs (merged into feature branch)
- #20985: M1 — Extend circuit breaker to suppress avatar follower feedback loop
- #20988: M2 — Skip scroll callbacks for duplicate detectors

## Project issue
Closes #20980

## Test plan
- [ ] Open a normal conversation with 20+ messages
- [ ] Scroll up and down rapidly — no beach ball or UI freeze
- [ ] Toggle sidebar while scrolling — no freeze
- [ ] Switch conversations during active scroll — no freeze
- [ ] Send a message while scrolled up, then scroll to bottom — avatar follows correctly
- [ ] During streaming, verify avatar tracks growing content without freeze
- [ ] After a detected scroll loop trips the circuit breaker, verify avatar hides correctly when scrolled past it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21002" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
