### PR TITLE
feat: unify ACP permission requests with confirmation_request flow

### DIFF
--- a/assistant/src/__tests__/acp-session.test.ts
+++ b/assistant/src/__tests__/acp-session.test.ts
@@ -17,7 +17,11 @@ describe("VellumAcpClientHandler", () => {
   beforeEach(() => {
     sent = [];
     sendToVellum = (msg) => sent.push(msg);
-    handler = new VellumAcpClientHandler("session-1", sendToVellum);
+    handler = new VellumAcpClientHandler(
+      "session-1",
+      sendToVellum,
+      "conv-parent",
+    );
     pendingInteractions.clear();
   });
 
@@ -254,6 +258,7 @@ describe("VellumAcpClientHandler", () => {
       const racyHandler = new VellumAcpClientHandler(
         "session-racy",
         overwritingSend,
+        "conv-racy",
       );
 
       const resultPromise = racyHandler.requestPermission({

--- a/assistant/src/__tests__/acp-session.test.ts
+++ b/assistant/src/__tests__/acp-session.test.ts
@@ -1,11 +1,9 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import {
-  resolvePermission,
-  VellumAcpClientHandler,
-} from "../acp/client-handler.js";
+import { VellumAcpClientHandler } from "../acp/client-handler.js";
 import { AcpSessionManager } from "../acp/session-manager.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
+import * as pendingInteractions from "../runtime/pending-interactions.js";
 
 // ---------------------------------------------------------------------------
 // VellumAcpClientHandler tests
@@ -14,18 +12,13 @@ import type { ServerMessage } from "../daemon/message-protocol.js";
 describe("VellumAcpClientHandler", () => {
   let sent: ServerMessage[];
   let sendToVellum: (msg: ServerMessage) => void;
-  let pendingPermissions: Map<string, { resolve: (optionId: string) => void }>;
   let handler: VellumAcpClientHandler;
 
   beforeEach(() => {
     sent = [];
     sendToVellum = (msg) => sent.push(msg);
-    pendingPermissions = new Map();
-    handler = new VellumAcpClientHandler(
-      "session-1",
-      sendToVellum,
-      pendingPermissions,
-    );
+    handler = new VellumAcpClientHandler("session-1", sendToVellum);
+    pendingInteractions.clear();
   });
 
   describe("sessionUpdate", () => {
@@ -152,7 +145,7 @@ describe("VellumAcpClientHandler", () => {
   });
 
   describe("requestPermission", () => {
-    test("sends permission request and resolves when permission is granted", async () => {
+    test("sends confirmation_request and resolves when permission is granted", async () => {
       const resultPromise = handler.requestPermission({
         toolCall: {
           title: "Run command",
@@ -165,52 +158,134 @@ describe("VellumAcpClientHandler", () => {
         ],
       } as any);
 
-      // Should have sent a permission request
+      // Should have sent a standard confirmation_request with ACP context
       expect(sent).toHaveLength(1);
       const msg = sent[0] as any;
-      expect(msg.type).toBe("acp_permission_request");
-      expect(msg.acpSessionId).toBe("session-1");
-      expect(msg.toolTitle).toBe("Run command");
-      expect(msg.toolKind).toBe("execute");
-      expect(msg.options).toHaveLength(2);
+      expect(msg.type).toBe("confirmation_request");
+      expect(msg.toolName).toBe("ACP Agent: Run command");
+      expect(msg.riskLevel).toBe("high"); // "execute" maps to high
+      expect(msg.persistentDecisionsAllowed).toBe(false);
+      expect(msg.allowlistOptions).toEqual([]);
+      // ACP-specific fields passed through for client rendering
+      expect(msg.acpToolKind).toBe("execute");
+      expect(msg.acpOptions).toEqual([
+        { optionId: "allow", name: "Allow", kind: "allow_once" },
+        { optionId: "deny", name: "Deny", kind: "reject_once" },
+      ]);
 
-      // A pending permission should exist
-      expect(pendingPermissions.size).toBe(1);
       const requestId = msg.requestId;
 
-      // Resolve the permission
-      resolvePermission(pendingPermissions, requestId, "allow");
+      // Resolve via the pendingInteractions tracker (same as POST /v1/confirm)
+      const interaction = pendingInteractions.resolve(requestId);
+      expect(interaction).toBeDefined();
+      expect(interaction!.kind).toBe("acp_confirmation");
+      interaction!.directResolve!("allow");
 
       const result = await resultPromise;
       expect(result).toEqual({
         outcome: { outcome: "selected", optionId: "allow" },
       });
-      expect(pendingPermissions.size).toBe(0);
     });
-  });
-});
 
-// ---------------------------------------------------------------------------
-// resolvePermission standalone tests
-// ---------------------------------------------------------------------------
+    test("maps deny decision to reject_once option", async () => {
+      const resultPromise = handler.requestPermission({
+        toolCall: {
+          title: "Write file",
+          kind: "edit",
+          rawInput: { path: "/tmp/test.txt" },
+        },
+        options: [
+          { optionId: "opt-allow", name: "Allow", kind: "allow_once" },
+          { optionId: "opt-deny", name: "Deny", kind: "reject_once" },
+        ],
+      } as any);
 
-describe("resolvePermission", () => {
-  test("resolves and removes the pending entry", () => {
-    let resolved = "";
-    const pending = new Map<string, { resolve: (id: string) => void }>();
-    pending.set("req-1", { resolve: (id) => (resolved = id) });
+      const msg = sent[0] as any;
+      expect(msg.riskLevel).toBe("medium"); // "edit" maps to medium
 
-    resolvePermission(pending, "req-1", "allow");
+      const interaction = pendingInteractions.resolve(msg.requestId);
+      interaction!.directResolve!("deny");
 
-    expect(resolved).toBe("allow");
-    expect(pending.size).toBe(0);
-  });
+      const result = await resultPromise;
+      expect(result).toEqual({
+        outcome: { outcome: "selected", optionId: "opt-deny" },
+      });
+    });
 
-  test("is a no-op when request ID is not found", () => {
-    const pending = new Map<string, { resolve: (id: string) => void }>();
-    // Should not throw
-    resolvePermission(pending, "nonexistent", "allow");
-    expect(pending.size).toBe(0);
+    test("maps read toolKind to low risk", async () => {
+      handler.requestPermission({
+        toolCall: {
+          title: "Read file",
+          kind: "read",
+        },
+        options: [{ optionId: "allow", name: "Allow", kind: "allow_once" }],
+      } as any);
+
+      const msg = sent[0] as any;
+      expect(msg.riskLevel).toBe("low");
+    });
+
+    test("ACP registration survives sendToVellum overwrite (makeEventSender race)", async () => {
+      // Simulate makeEventSender: when sendToVellum is called with a
+      // confirmation_request, it overwrites the pendingInteractions entry
+      // with a normal "confirmation" (no directResolve). This is what
+      // happens in production because sendToVellum goes through the
+      // conversation's event sender.
+      const overwritingSend = (msg: ServerMessage) => {
+        sent.push(msg);
+        if ((msg as any).type === "confirmation_request") {
+          pendingInteractions.register((msg as any).requestId, {
+            conversation: {} as any, // fake conversation
+            conversationId: "conv-123",
+            kind: "confirmation",
+            confirmationDetails: {
+              toolName: (msg as any).toolName,
+              input: (msg as any).input,
+              riskLevel: (msg as any).riskLevel,
+              allowlistOptions: [],
+              scopeOptions: [],
+            },
+            // NO directResolve — this is the bug scenario
+          });
+        }
+      };
+
+      // Create handler with the overwriting sender
+      const racyHandler = new VellumAcpClientHandler(
+        "session-racy",
+        overwritingSend,
+      );
+
+      const resultPromise = racyHandler.requestPermission({
+        toolCall: {
+          title: "Write file",
+          kind: "edit",
+          rawInput: "test",
+        },
+        options: [
+          { optionId: "yes", name: "Allow", kind: "allow_once" },
+          { optionId: "no", name: "Deny", kind: "reject_once" },
+        ],
+      } as any);
+
+      const requestId = (sent[sent.length - 1] as any).requestId;
+
+      // The critical assertion: after requestPermission completes setup,
+      // the pendingInteractions entry must be the ACP one with directResolve,
+      // NOT the overwritten "confirmation" without it.
+      const interaction = pendingInteractions.resolve(requestId);
+      expect(interaction).toBeDefined();
+      expect(interaction!.kind).toBe("acp_confirmation");
+      expect(interaction!.directResolve).toBeDefined();
+
+      // Resolve it — this would fail silently if the overwrite won
+      interaction!.directResolve!("allow");
+
+      const result = await resultPromise;
+      expect(result).toEqual({
+        outcome: { outcome: "selected", optionId: "yes" },
+      });
+    });
   });
 });
 
@@ -267,14 +342,6 @@ describe("AcpSessionManager", () => {
       await expect(manager.steer("nonexistent", "go left")).rejects.toThrow(
         /not found/,
       );
-    });
-  });
-
-  describe("resolvePermission", () => {
-    test("logs warning for unknown request ID (no throw)", () => {
-      const manager = new AcpSessionManager(5);
-      // Should not throw — just logs a warning
-      manager.resolvePermission("unknown-req", "allow");
     });
   });
 

--- a/assistant/src/__tests__/acp-session.test.ts
+++ b/assistant/src/__tests__/acp-session.test.ts
@@ -163,7 +163,7 @@ describe("VellumAcpClientHandler", () => {
       const msg = sent[0] as any;
       expect(msg.type).toBe("confirmation_request");
       expect(msg.toolName).toBe("ACP Agent: Run command");
-      expect(msg.riskLevel).toBe("high"); // "execute" maps to high
+      expect(msg.riskLevel).toBe("execute"); // passes through toolKind directly
       expect(msg.persistentDecisionsAllowed).toBe(false);
       expect(msg.allowlistOptions).toEqual([]);
       // ACP-specific fields passed through for client rendering
@@ -201,7 +201,7 @@ describe("VellumAcpClientHandler", () => {
       } as any);
 
       const msg = sent[0] as any;
-      expect(msg.riskLevel).toBe("medium"); // "edit" maps to medium
+      expect(msg.riskLevel).toBe("edit"); // passes through toolKind directly
 
       const interaction = pendingInteractions.resolve(msg.requestId);
       interaction!.directResolve!("deny");
@@ -212,7 +212,7 @@ describe("VellumAcpClientHandler", () => {
       });
     });
 
-    test("maps read toolKind to low risk", async () => {
+    test("passes toolKind through as riskLevel", async () => {
       handler.requestPermission({
         toolCall: {
           title: "Read file",
@@ -222,7 +222,7 @@ describe("VellumAcpClientHandler", () => {
       } as any);
 
       const msg = sent[0] as any;
-      expect(msg.riskLevel).toBe("low");
+      expect(msg.riskLevel).toBe("read");
     });
 
     test("ACP registration survives sendToVellum overwrite (makeEventSender race)", async () => {

--- a/assistant/src/__tests__/acp-session.test.ts
+++ b/assistant/src/__tests__/acp-session.test.ts
@@ -163,7 +163,7 @@ describe("VellumAcpClientHandler", () => {
       const msg = sent[0] as any;
       expect(msg.type).toBe("confirmation_request");
       expect(msg.toolName).toBe("ACP Agent: Run command");
-      expect(msg.riskLevel).toBe("execute"); // passes through toolKind directly
+      expect(msg.riskLevel).toBe("medium"); // ACP defaults to medium
       expect(msg.persistentDecisionsAllowed).toBe(false);
       expect(msg.allowlistOptions).toEqual([]);
       // ACP-specific fields passed through for client rendering
@@ -201,7 +201,7 @@ describe("VellumAcpClientHandler", () => {
       } as any);
 
       const msg = sent[0] as any;
-      expect(msg.riskLevel).toBe("edit"); // passes through toolKind directly
+      expect(msg.riskLevel).toBe("medium"); // ACP defaults to medium
 
       const interaction = pendingInteractions.resolve(msg.requestId);
       interaction!.directResolve!("deny");
@@ -212,7 +212,7 @@ describe("VellumAcpClientHandler", () => {
       });
     });
 
-    test("passes toolKind through as riskLevel", async () => {
+    test("defaults riskLevel to medium for all ACP permissions", async () => {
       handler.requestPermission({
         toolCall: {
           title: "Read file",
@@ -222,7 +222,7 @@ describe("VellumAcpClientHandler", () => {
       } as any);
 
       const msg = sent[0] as any;
-      expect(msg.riskLevel).toBe("read");
+      expect(msg.riskLevel).toBe("medium");
     });
 
     test("ACP registration survives sendToVellum overwrite (makeEventSender race)", async () => {

--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -304,7 +304,7 @@ describe("handleChannelDecision", () => {
     expect(result.applied).toBe(true);
     expect(result.requestId).toBe("req-1");
     expect(
-      interaction!.conversation.handleConfirmationResponse,
+      interaction!.conversation!.handleConfirmationResponse,
     ).toHaveBeenCalledWith("req-1", "allow");
   });
 
@@ -320,7 +320,7 @@ describe("handleChannelDecision", () => {
     expect(result.applied).toBe(true);
     expect(result.requestId).toBe("req-1");
     expect(
-      interaction!.conversation.handleConfirmationResponse,
+      interaction!.conversation!.handleConfirmationResponse,
     ).toHaveBeenCalledWith("req-1", "deny");
   });
 
@@ -339,10 +339,10 @@ describe("handleChannelDecision", () => {
     expect(result.applied).toBe(true);
     expect(result.requestId).toBe("req-newer");
     expect(
-      newerInteraction!.conversation.handleConfirmationResponse,
+      newerInteraction!.conversation!.handleConfirmationResponse,
     ).toHaveBeenCalledWith("req-newer", "allow");
     expect(
-      olderInteraction!.conversation.handleConfirmationResponse,
+      olderInteraction!.conversation!.handleConfirmationResponse,
     ).not.toHaveBeenCalled();
   });
 
@@ -393,7 +393,7 @@ describe("handleChannelDecision", () => {
 
     // The session is approved with "allow"
     expect(
-      interaction!.conversation.handleConfirmationResponse,
+      interaction!.conversation!.handleConfirmationResponse,
     ).toHaveBeenCalledWith("req-1", "allow");
 
     addRuleSpy.mockRestore();
@@ -420,7 +420,7 @@ describe("handleChannelDecision", () => {
     // The decision should still be applied as a one-time approval
     expect(result.applied).toBe(true);
     expect(
-      interaction!.conversation.handleConfirmationResponse,
+      interaction!.conversation!.handleConfirmationResponse,
     ).toHaveBeenCalledWith("req-1", "allow");
 
     addRuleSpy.mockRestore();
@@ -446,7 +446,7 @@ describe("handleChannelDecision", () => {
     // The current invocation should still be approved (one-time allow)
     expect(result.applied).toBe(true);
     expect(
-      interaction!.conversation.handleConfirmationResponse,
+      interaction!.conversation!.handleConfirmationResponse,
     ).toHaveBeenCalledWith("req-1", "allow");
 
     addRuleSpy.mockRestore();

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -174,7 +174,6 @@ export class VellumAcpClientHandler implements Client {
         ? (rawInput as Record<string, unknown>)
         : { command: rawInput };
 
-    const riskLevel = mapToolKindToRiskLevel(toolKind);
     const toolName = `ACP Agent: ${toolTitle}`;
     const acpOptions = options.map((opt) => ({
       optionId: opt.optionId,
@@ -189,7 +188,7 @@ export class VellumAcpClientHandler implements Client {
       requestId,
       toolName,
       input,
-      riskLevel,
+      riskLevel: toolKind,
       allowlistOptions: [],
       scopeOptions: [],
       persistentDecisionsAllowed: false,
@@ -216,7 +215,7 @@ export class VellumAcpClientHandler implements Client {
         confirmationDetails: {
           toolName,
           input,
-          riskLevel,
+          riskLevel: toolKind,
           allowlistOptions: [],
           scopeOptions: [],
           persistentDecisionsAllowed: false,
@@ -382,26 +381,6 @@ export class VellumAcpClientHandler implements Client {
       this.terminals.delete(params.terminalId);
     }
     return {};
-  }
-}
-
-/**
- * Maps an ACP ToolKind to a risk level for the confirmation_request.
- *
- * ACP ToolKind values: "read" | "edit" | "delete" | "move" | "search" |
- * "execute" | "think" | "fetch" | "switch_mode" | "other"
- */
-function mapToolKindToRiskLevel(toolKind: string): string {
-  switch (toolKind) {
-    case "execute":
-      return "high";
-    case "edit":
-    case "delete":
-    case "move":
-      return "medium";
-    default:
-      // read, search, think, fetch, switch_mode, other
-      return "low";
   }
 }
 

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -53,6 +53,8 @@ interface TerminalState {
 export class VellumAcpClientHandler implements Client {
   private terminals = new Map<string, TerminalState>();
   private accumulatedText = "";
+  /** Tracks pending ACP permission requestIds for cleanup on session close. */
+  readonly pendingRequestIds = new Set<string>();
 
   /** Returns the full agent response text accumulated from agent_message_chunk events. */
   get responseText(): string {
@@ -210,6 +212,7 @@ export class VellumAcpClientHandler implements Client {
         }
       }, timeoutMs);
 
+      this.pendingRequestIds.add(requestId);
       pendingInteractions.register(requestId, {
         conversation: null,
         conversationId: this.parentConversationId,
@@ -226,6 +229,7 @@ export class VellumAcpClientHandler implements Client {
         },
         directResolve: (decision: UserDecision) => {
           clearTimeout(timer);
+          this.pendingRequestIds.delete(requestId);
           const optionId = mapDecisionToOptionId(decision, options);
           resolve(optionId);
         },

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -62,6 +62,7 @@ export class VellumAcpClientHandler implements Client {
   constructor(
     private readonly acpSessionId: string,
     private readonly sendToVellum: (msg: ServerMessage) => void,
+    private readonly parentConversationId: string,
   ) {}
 
   async sessionUpdate(params: SessionNotification): Promise<void> {
@@ -194,6 +195,7 @@ export class VellumAcpClientHandler implements Client {
       persistentDecisionsAllowed: false,
       acpToolKind: toolKind,
       acpOptions,
+      conversationId: this.parentConversationId,
     });
 
     // Now overwrite with our ACP registration that has directResolve.
@@ -210,7 +212,7 @@ export class VellumAcpClientHandler implements Client {
 
       pendingInteractions.register(requestId, {
         conversation: null,
-        conversationId: `acp:${this.acpSessionId}`,
+        conversationId: this.parentConversationId,
         kind: "acp_confirmation",
         confirmationDetails: {
           toolName,

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -188,7 +188,7 @@ export class VellumAcpClientHandler implements Client {
       requestId,
       toolName,
       input,
-      riskLevel: toolKind,
+      riskLevel: "medium",
       allowlistOptions: [],
       scopeOptions: [],
       persistentDecisionsAllowed: false,
@@ -215,7 +215,7 @@ export class VellumAcpClientHandler implements Client {
         confirmationDetails: {
           toolName,
           input,
-          riskLevel: toolKind,
+          riskLevel: "medium",
           allowlistOptions: [],
           scopeOptions: [],
           persistentDecisionsAllowed: false,

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -31,6 +31,8 @@ import type {
 } from "@agentclientprotocol/sdk";
 
 import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { UserDecision } from "../permissions/types.js";
+import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("acp:client-handler");
@@ -60,10 +62,6 @@ export class VellumAcpClientHandler implements Client {
   constructor(
     private readonly acpSessionId: string,
     private readonly sendToVellum: (msg: ServerMessage) => void,
-    private readonly pendingPermissions: Map<
-      string,
-      { resolve: (optionId: string) => void }
-    >,
   ) {}
 
   async sessionUpdate(params: SessionNotification): Promise<void> {
@@ -152,33 +150,85 @@ export class VellumAcpClientHandler implements Client {
     params: RequestPermissionRequest,
   ): Promise<RequestPermissionResponse> {
     const requestId = randomUUID();
+    const toolTitle = params.toolCall.title ?? "Unknown tool";
+    const toolKind = params.toolCall.kind ?? "other";
+    const options = params.options;
+
     log.info(
       {
         acpSessionId: this.acpSessionId,
         requestId,
-        toolTitle: params.toolCall.title,
-        toolKind: params.toolCall.kind,
-        optionCount: params.options.length,
+        toolTitle,
+        toolKind,
+        optionCount: options.length,
       },
       "ACP permission requested",
     );
 
-    const optionIdPromise = new Promise<string>((resolve) => {
-      this.pendingPermissions.set(requestId, { resolve });
+    // Normalize rawInput into a Record for the confirmation_request shape
+    const rawInput = params.toolCall.rawInput;
+    const input: Record<string, unknown> =
+      rawInput != null &&
+      typeof rawInput === "object" &&
+      !Array.isArray(rawInput)
+        ? (rawInput as Record<string, unknown>)
+        : { command: rawInput };
+
+    const riskLevel = mapToolKindToRiskLevel(toolKind);
+    const toolName = `ACP Agent: ${toolTitle}`;
+    const acpOptions = options.map((opt) => ({
+      optionId: opt.optionId,
+      name: opt.name,
+      kind: opt.kind,
+    }));
+
+    // Send the confirmation_request first — this triggers makeEventSender
+    // which registers a normal "confirmation" entry in pendingInteractions.
+    this.sendToVellum({
+      type: "confirmation_request",
+      requestId,
+      toolName,
+      input,
+      riskLevel,
+      allowlistOptions: [],
+      scopeOptions: [],
+      persistentDecisionsAllowed: false,
+      acpToolKind: toolKind,
+      acpOptions,
     });
 
-    this.sendToVellum({
-      type: "acp_permission_request",
-      acpSessionId: this.acpSessionId,
-      requestId,
-      toolTitle: params.toolCall.title ?? "Unknown tool",
-      toolKind: params.toolCall.kind ?? "other",
-      rawInput: params.toolCall.rawInput,
-      options: params.options.map((opt) => ({
-        optionId: opt.optionId,
-        name: opt.name,
-        kind: opt.kind,
-      })),
+    // Now overwrite with our ACP registration that has directResolve.
+    // This must come AFTER sendToVellum so it wins over makeEventSender's
+    // registration.
+    const optionIdPromise = new Promise<string>((resolve) => {
+      const timeoutMs = 5 * 60 * 1000; // 5 minutes
+      const timer = setTimeout(() => {
+        const pending = pendingInteractions.resolve(requestId);
+        if (pending?.directResolve) {
+          pending.directResolve("deny");
+        }
+      }, timeoutMs);
+
+      pendingInteractions.register(requestId, {
+        conversation: null,
+        conversationId: `acp:${this.acpSessionId}`,
+        kind: "acp_confirmation",
+        confirmationDetails: {
+          toolName,
+          input,
+          riskLevel,
+          allowlistOptions: [],
+          scopeOptions: [],
+          persistentDecisionsAllowed: false,
+          acpToolKind: toolKind,
+          acpOptions,
+        },
+        directResolve: (decision: UserDecision) => {
+          clearTimeout(timer);
+          const optionId = mapDecisionToOptionId(decision, options);
+          resolve(optionId);
+        },
+      });
     });
 
     const optionId = await optionIdPromise;
@@ -336,18 +386,65 @@ export class VellumAcpClientHandler implements Client {
 }
 
 /**
- * Resolves a pending permission request by its request ID.
+ * Maps an ACP ToolKind to a risk level for the confirmation_request.
+ *
+ * ACP ToolKind values: "read" | "edit" | "delete" | "move" | "search" |
+ * "execute" | "think" | "fetch" | "switch_mode" | "other"
  */
-export function resolvePermission(
-  pendingPermissions: Map<string, { resolve: (optionId: string) => void }>,
-  requestId: string,
-  optionId: string,
-): void {
-  const pending = pendingPermissions.get(requestId);
-  if (pending) {
-    pending.resolve(optionId);
-    pendingPermissions.delete(requestId);
+function mapToolKindToRiskLevel(toolKind: string): string {
+  switch (toolKind) {
+    case "execute":
+      return "high";
+    case "edit":
+    case "delete":
+    case "move":
+      return "medium";
+    default:
+      // read, search, think, fetch, switch_mode, other
+      return "low";
   }
+}
+
+/**
+ * Maps a UserDecision to the best-matching ACP option ID.
+ */
+function mapDecisionToOptionId(
+  decision: UserDecision,
+  options: Array<{ optionId: string; kind: string }>,
+): string {
+  const isAllow =
+    decision === "allow" ||
+    decision === "allow_10m" ||
+    decision === "allow_conversation" ||
+    decision === "always_allow" ||
+    decision === "always_allow_high_risk" ||
+    decision === "temporary_override" ||
+    decision === "dangerously_skip_permissions";
+
+  if (isAllow) {
+    // Prefer allow_always for persistent decisions, fallback to allow_once
+    if (decision === "always_allow" || decision === "always_allow_high_risk") {
+      const alwaysOpt = options.find((o) => o.kind === "allow_always");
+      if (alwaysOpt) return alwaysOpt.optionId;
+    }
+    const allowOpt =
+      options.find((o) => o.kind === "allow_once") ??
+      options.find((o) => o.kind === "allow_always");
+    if (allowOpt) return allowOpt.optionId;
+  }
+
+  // Deny: prefer reject_always for persistent deny, fallback to reject_once
+  if (decision === "always_deny") {
+    const alwaysDeny = options.find((o) => o.kind === "reject_always");
+    if (alwaysDeny) return alwaysDeny.optionId;
+  }
+  const denyOpt =
+    options.find((o) => o.kind === "reject_once") ??
+    options.find((o) => o.kind === "reject_always");
+  if (denyOpt) return denyOpt.optionId;
+
+  // Fallback: return first option
+  return options[0]?.optionId ?? "deny";
 }
 
 /**

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -6,6 +6,7 @@
 import { randomUUID } from "node:crypto";
 
 import type { ServerMessage } from "../daemon/message-protocol.js";
+import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { getLogger } from "../util/logger.js";
 import { AcpAgentProcess } from "./agent-process.js";
 import { VellumAcpClientHandler } from "./client-handler.js";
@@ -210,6 +211,20 @@ export class AcpSessionManager {
     const entry = this.sessions.get(acpSessionId);
     if (!entry) {
       throw new Error(`ACP session "${acpSessionId}" not found`);
+    }
+    // Auto-deny any pending ACP permission requests so they don't linger
+    // until the 5-minute timeout fires.
+    const pending = pendingInteractions.getByConversation(
+      entry.parentConversationId,
+    );
+    for (const interaction of pending) {
+      if (
+        interaction.kind === "acp_confirmation" &&
+        interaction.directResolve
+      ) {
+        pendingInteractions.resolve(interaction.requestId);
+        interaction.directResolve("deny");
+      }
     }
     entry.process.kill();
     this.sessions.delete(acpSessionId);

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -212,17 +212,11 @@ export class AcpSessionManager {
     if (!entry) {
       throw new Error(`ACP session "${acpSessionId}" not found`);
     }
-    // Auto-deny any pending ACP permission requests so they don't linger
-    // until the 5-minute timeout fires.
-    const pending = pendingInteractions.getByConversation(
-      entry.parentConversationId,
-    );
-    for (const interaction of pending) {
-      if (
-        interaction.kind === "acp_confirmation" &&
-        interaction.directResolve
-      ) {
-        pendingInteractions.resolve(interaction.requestId);
+    // Auto-deny pending ACP permission requests for THIS session only,
+    // so other sessions on the same parent conversation are unaffected.
+    for (const requestId of entry.clientHandler.pendingRequestIds) {
+      const interaction = pendingInteractions.resolve(requestId);
+      if (interaction?.directResolve) {
         interaction.directResolve("deny");
       }
     }

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -8,7 +8,7 @@ import { randomUUID } from "node:crypto";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import { getLogger } from "../util/logger.js";
 import { AcpAgentProcess } from "./agent-process.js";
-import { resolvePermission, VellumAcpClientHandler } from "./client-handler.js";
+import { VellumAcpClientHandler } from "./client-handler.js";
 import type { AcpAgentConfig, AcpSessionState } from "./types.js";
 
 const log = getLogger("acp:session-manager");
@@ -17,7 +17,6 @@ interface SessionEntry {
   process: AcpAgentProcess;
   state: AcpSessionState;
   clientHandler: VellumAcpClientHandler;
-  pendingPermissions: Map<string, { resolve: (optionId: string) => void }>;
   sendToVellum: (msg: ServerMessage) => void;
   currentPrompt: Promise<unknown> | null;
   parentConversationId: string;
@@ -75,15 +74,9 @@ export class AcpSessionManager {
       "ACP spawn requested",
     );
 
-    const pendingPermissions = new Map<
-      string,
-      { resolve: (optionId: string) => void }
-    >();
-
     const clientHandler = new VellumAcpClientHandler(
       acpSessionId,
       sendToVellum,
-      pendingPermissions,
     );
 
     const agentProcess = new AcpAgentProcess(
@@ -106,7 +99,6 @@ export class AcpSessionManager {
       process: agentProcess,
       state,
       clientHandler,
-      pendingPermissions,
       sendToVellum,
       currentPrompt: null,
       parentConversationId,
@@ -245,19 +237,6 @@ export class AcpSessionManager {
       return entry.state;
     }
     return Array.from(this.sessions.values()).map((e) => e.state);
-  }
-
-  /**
-   * Resolves a pending permission request in any session that holds it.
-   */
-  resolvePermission(requestId: string, optionId: string): void {
-    for (const entry of this.sessions.values()) {
-      if (entry.pendingPermissions.has(requestId)) {
-        resolvePermission(entry.pendingPermissions, requestId, optionId);
-        return;
-      }
-    }
-    log.warn({ requestId }, "No pending permission found for request ID");
   }
 
   /**

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -77,6 +77,7 @@ export class AcpSessionManager {
     const clientHandler = new VellumAcpClientHandler(
       acpSessionId,
       sendToVellum,
+      parentConversationId,
     );
 
     const agentProcess = new AcpAgentProcess(

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -234,10 +234,9 @@ export class AcpSessionManager {
    * Kills all agent processes and clears the session map.
    */
   closeAll(): void {
-    for (const entry of this.sessions.values()) {
-      entry.process.kill();
+    for (const acpSessionId of [...this.sessions.keys()]) {
+      this.close(acpSessionId);
     }
-    this.sessions.clear();
   }
 
   /**

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -233,7 +233,7 @@ const pendingInteractionResolver: GuardianRequestResolver = {
     // Map action to the permission system's UserDecision type and notify session.
     const userDecision =
       decision.action === "reject" ? ("deny" as const) : ("allow" as const);
-    resolved.conversation.handleConfirmationResponse(
+    resolved.conversation!.handleConfirmationResponse(
       request.id,
       userDecision,
       undefined,

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -132,6 +132,8 @@ import * as sequenceImport from "./bundled-skills/sequences/tools/sequence-impor
 import * as sequenceList from "./bundled-skills/sequences/tools/sequence-list.js";
 import * as sequenceUpdate from "./bundled-skills/sequences/tools/sequence-update.js";
 // ── settings ───────────────────────────────────────────────────────────────────
+import * as avatarRemove from "./bundled-skills/settings/tools/avatar-remove.js";
+import * as avatarUpdate from "./bundled-skills/settings/tools/avatar-update.js";
 import * as navigateSettingsTab from "./bundled-skills/settings/tools/navigate-settings-tab.js";
 import * as openSystemSettings from "./bundled-skills/settings/tools/open-system-settings.js";
 import * as voiceConfigUpdate from "./bundled-skills/settings/tools/voice-config-update.js";
@@ -323,6 +325,8 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["sequences:tools/sequence-analytics.ts", sequenceAnalytics],
 
   // settings
+  ["settings:tools/avatar-update.ts", avatarUpdate],
+  ["settings:tools/avatar-remove.ts", avatarRemove],
   ["settings:tools/voice-config-update.ts", voiceConfigUpdate],
   ["settings:tools/open-system-settings.ts", openSystemSettings],
   ["settings:tools/navigate-settings-tab.ts", navigateSettingsTab],

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -59,41 +59,49 @@ export function makeEventSender(params: {
 
   return (event: ServerMessage) => {
     if (event.type === "confirmation_request") {
-      pendingInteractions.register(event.requestId, {
-        conversation,
-        conversationId,
-        kind: "confirmation",
-        confirmationDetails: {
-          toolName: event.toolName,
-          input: event.input,
-          riskLevel: event.riskLevel,
-          executionTarget: event.executionTarget,
-          allowlistOptions: event.allowlistOptions,
-          scopeOptions: event.scopeOptions,
-          persistentDecisionsAllowed: event.persistentDecisionsAllowed,
-          temporaryOptionsAvailable: event.temporaryOptionsAvailable,
-        },
-      });
+      // ACP permission requests are handled by client-handler.ts — skip
+      // the normal registration and guardian request creation for them.
+      // The ACP handler registers its own entry with directResolve after
+      // this callback returns.
+      const isAcpPermission = "acpToolKind" in event && !!event.acpToolKind;
 
-      try {
-        const trustContext = conversation.trustContext;
-        createCanonicalGuardianRequest({
-          id: event.requestId,
-          kind: "tool_approval",
-          sourceType: "desktop",
-          sourceChannel,
+      if (!isAcpPermission) {
+        pendingInteractions.register(event.requestId, {
+          conversation,
           conversationId,
-          guardianPrincipalId: trustContext?.guardianPrincipalId ?? undefined,
-          toolName: event.toolName,
-          status: "pending",
-          requestCode: generateCanonicalRequestCode(),
-          expiresAt: Date.now() + 5 * 60 * 1000,
+          kind: "confirmation",
+          confirmationDetails: {
+            toolName: event.toolName,
+            input: event.input,
+            riskLevel: event.riskLevel,
+            executionTarget: event.executionTarget,
+            allowlistOptions: event.allowlistOptions,
+            scopeOptions: event.scopeOptions,
+            persistentDecisionsAllowed: event.persistentDecisionsAllowed,
+            temporaryOptionsAvailable: event.temporaryOptionsAvailable,
+          },
         });
-      } catch (err) {
-        log.debug(
-          { err, requestId: event.requestId, conversationId },
-          "Failed to create canonical request from local confirmation event",
-        );
+
+        try {
+          const trustContext = conversation.trustContext;
+          createCanonicalGuardianRequest({
+            id: event.requestId,
+            kind: "tool_approval",
+            sourceType: "desktop",
+            sourceChannel,
+            conversationId,
+            guardianPrincipalId: trustContext?.guardianPrincipalId ?? undefined,
+            toolName: event.toolName,
+            status: "pending",
+            requestCode: generateCanonicalRequestCode(),
+            expiresAt: Date.now() + 5 * 60 * 1000,
+          });
+        } catch (err) {
+          log.debug(
+            { err, requestId: event.requestId, conversationId },
+            "Failed to create canonical request from local confirmation event",
+          );
+        }
       }
     } else if (event.type === "secret_request") {
       pendingInteractions.register(event.requestId, {

--- a/assistant/src/daemon/message-types/acp.ts
+++ b/assistant/src/daemon/message-types/acp.ts
@@ -25,20 +25,6 @@ export interface AcpSessionUpdate {
   toolStatus?: string;
 }
 
-export interface AcpPermissionRequest {
-  type: "acp_permission_request";
-  acpSessionId: string;
-  requestId: string;
-  toolTitle: string;
-  toolKind: string;
-  rawInput?: unknown;
-  options: Array<{
-    optionId: string;
-    name: string;
-    kind: "allow_once" | "allow_always" | "reject_once" | "reject_always";
-  }>;
-}
-
 export interface AcpSessionCompleted {
   type: "acp_session_completed";
   acpSessionId: string;
@@ -61,6 +47,5 @@ export interface AcpSessionError {
 export type _AcpServerMessages =
   | AcpSessionSpawned
   | AcpSessionUpdate
-  | AcpPermissionRequest
   | AcpSessionCompleted
   | AcpSessionError;

--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -156,6 +156,14 @@ export interface ConfirmationRequest {
   temporaryOptionsAvailable?: Array<"allow_10m" | "allow_conversation">;
   /** The tool_use block ID for client-side correlation with specific tool calls. */
   toolUseId?: string;
+  /** ACP tool kind from the agent (e.g. "read", "edit", "execute"). Present only for ACP permission requests. */
+  acpToolKind?: string;
+  /** ACP permission options from the agent. Present only for ACP permission requests. Clients should use these to render the correct buttons. */
+  acpOptions?: Array<{
+    optionId: string;
+    name: string;
+    kind: "allow_once" | "allow_always" | "reject_once" | "reject_always";
+  }>;
 }
 
 export interface SecretRequest {

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -339,7 +339,6 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "acp/cancel", scopes: ["chat.write"] },
   { endpoint: "acp/close", scopes: ["chat.write"] },
   { endpoint: "acp", scopes: ["chat.read"] },
-  { endpoint: "acp/permission", scopes: ["approval.write"] },
 
   // Model config
   { endpoint: "model:GET", scopes: ["settings.read"] },

--- a/assistant/src/runtime/channel-approvals.ts
+++ b/assistant/src/runtime/channel-approvals.ts
@@ -221,12 +221,12 @@ export function handleChannelDecision(
   // Map channel-level action to the permission system's UserDecision type.
   const userDecision = mapApprovalActionToUserDecision(decision.action);
   if (decisionContext === undefined) {
-    resolved.conversation.handleConfirmationResponse(
+    resolved.conversation!.handleConfirmationResponse(
       info.requestId,
       userDecision,
     );
   } else {
-    resolved.conversation.handleConfirmationResponse(
+    resolved.conversation!.handleConfirmationResponse(
       info.requestId,
       userDecision,
       undefined,

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -11,6 +11,7 @@
  */
 
 import type { Conversation } from "../daemon/conversation.js";
+import type { UserDecision } from "../permissions/types.js";
 
 export interface ConfirmationDetails {
   toolName: string;
@@ -25,13 +26,29 @@ export interface ConfirmationDetails {
   scopeOptions: Array<{ label: string; scope: string }>;
   persistentDecisionsAllowed?: boolean;
   temporaryOptionsAvailable?: Array<"allow_10m" | "allow_conversation">;
+  /** ACP tool kind from the agent (e.g. "read", "edit", "execute"). */
+  acpToolKind?: string;
+  /** ACP permission options from the agent. */
+  acpOptions?: Array<{
+    optionId: string;
+    name: string;
+    kind: "allow_once" | "allow_always" | "reject_once" | "reject_always";
+  }>;
 }
 
 export interface PendingInteraction {
-  conversation: Conversation;
+  conversation: Conversation | null;
   conversationId: string;
-  kind: "confirmation" | "secret" | "host_bash" | "host_file" | "host_cu";
+  kind:
+    | "confirmation"
+    | "secret"
+    | "host_bash"
+    | "host_file"
+    | "host_cu"
+    | "acp_confirmation";
   confirmationDetails?: ConfirmationDetails;
+  /** For ACP permissions: resolves directly without a Conversation object. */
+  directResolve?: (decision: UserDecision) => void;
 }
 
 const pending = new Map<string, PendingInteraction>();
@@ -96,7 +113,8 @@ export function removeByConversation(conversation: Conversation): void {
       interaction.conversation === conversation &&
       interaction.kind !== "host_bash" &&
       interaction.kind !== "host_file" &&
-      interaction.kind !== "host_cu"
+      interaction.kind !== "host_cu" &&
+      interaction.kind !== "acp_confirmation"
     ) {
       pending.delete(requestId);
     }

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -143,28 +143,5 @@ export function acpRouteDefinitions(): RouteDefinition[] {
         return Response.json({ sessions });
       },
     },
-
-    // POST /v1/acp/permission
-    {
-      endpoint: "acp/permission",
-      method: "POST",
-      policyKey: "acp/permission",
-      handler: async ({ req }) => {
-        const body = (await req.json()) as {
-          requestId?: string;
-          optionId?: string;
-        };
-        if (!body.requestId || !body.optionId) {
-          return httpError(
-            "BAD_REQUEST",
-            "requestId and optionId are required",
-            400,
-          );
-        }
-        const manager = getAcpSessionManager();
-        manager.resolvePermission(body.requestId, body.optionId);
-        return Response.json({ resolved: true });
-      },
-    },
   ];
 }

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -129,7 +129,13 @@ export async function handleConfirm(
   // Validation passed — consume the pending interaction.
   const interaction = pendingInteractions.resolve(requestId)!;
 
-  interaction.conversation.handleConfirmationResponse(
+  // ACP permissions: resolve directly without a Conversation object.
+  if (interaction.directResolve) {
+    interaction.directResolve(decision as UserDecision);
+    return Response.json({ accepted: true });
+  }
+
+  interaction.conversation!.handleConfirmationResponse(
     requestId,
     decision as UserDecision,
     selectedPattern,
@@ -187,7 +193,7 @@ export async function handleSecret(
     );
   }
 
-  interaction.conversation.handleSecretResponse(
+  interaction.conversation!.handleSecretResponse(
     requestId,
     value,
     delivery as "store" | "transient_send" | undefined,
@@ -355,7 +361,9 @@ export function handleListPendingInteractions(
     resolvedConversationId,
   );
 
-  const confirmation = interactions.find((i) => i.kind === "confirmation");
+  const confirmation = interactions.find(
+    (i) => i.kind === "confirmation" || i.kind === "acp_confirmation",
+  );
   const secret = interactions.find((i) => i.kind === "secret");
 
   return Response.json({
@@ -377,6 +385,8 @@ export function handleListPendingInteractions(
             confirmation.confirmationDetails?.persistentDecisionsAllowed,
           temporaryOptionsAvailable:
             confirmation.confirmationDetails?.temporaryOptionsAvailable,
+          acpToolKind: confirmation.confirmationDetails?.acpToolKind,
+          acpOptions: confirmation.confirmationDetails?.acpOptions,
         }
       : null,
     pendingSecret: secret

--- a/assistant/src/runtime/routes/host-bash-routes.ts
+++ b/assistant/src/runtime/routes/host-bash-routes.ts
@@ -57,7 +57,7 @@ export async function handleHostBashResult(
   // Validation passed — consume the pending interaction.
   const interaction = pendingInteractions.resolve(requestId)!;
 
-  interaction.conversation.resolveHostBash(requestId, {
+  interaction.conversation!.resolveHostBash(requestId, {
     stdout: stdout ?? "",
     stderr: stderr ?? "",
     exitCode: exitCode ?? null,

--- a/assistant/src/runtime/routes/host-cu-routes.ts
+++ b/assistant/src/runtime/routes/host-cu-routes.ts
@@ -64,7 +64,7 @@ export async function handleHostCuResult(
   // Validation passed — consume the pending interaction.
   const interaction = pendingInteractions.resolve(requestId)!;
 
-  interaction.conversation.resolveHostCu(requestId, {
+  interaction.conversation!.resolveHostCu(requestId, {
     axTree: body.axTree,
     axDiff: body.axDiff,
     screenshot: body.screenshot,

--- a/assistant/src/runtime/routes/host-file-routes.ts
+++ b/assistant/src/runtime/routes/host-file-routes.ts
@@ -55,7 +55,7 @@ export async function handleHostFileResult(
   // Validation passed — consume the pending interaction.
   const interaction = pendingInteractions.resolve(requestId)!;
 
-  interaction.conversation.resolveHostFile(requestId, {
+  interaction.conversation!.resolveHostFile(requestId, {
     content: content ?? "",
     isError: isError ?? false,
   });

--- a/assistant/src/signals/confirm.ts
+++ b/assistant/src/signals/confirm.ts
@@ -63,7 +63,7 @@ export function handleConfirmationSignal(): void {
       return;
     }
 
-    interaction.conversation.handleConfirmationResponse(
+    interaction.conversation!.handleConfirmationResponse(
       requestId,
       decision,
       undefined,

--- a/assistant/src/signals/confirm.ts
+++ b/assistant/src/signals/confirm.ts
@@ -63,14 +63,18 @@ export function handleConfirmationSignal(): void {
       return;
     }
 
-    interaction.conversation!.handleConfirmationResponse(
-      requestId,
-      decision,
-      undefined,
-      undefined,
-      undefined,
-      { source: "button" },
-    );
+    if (interaction.directResolve) {
+      interaction.directResolve(decision);
+    } else {
+      interaction.conversation!.handleConfirmationResponse(
+        requestId,
+        decision,
+        undefined,
+        undefined,
+        undefined,
+        { source: "button" },
+      );
+    }
     log.info({ requestId, decision }, "Confirmation resolved via signal file");
   } catch (err) {
     log.error({ err }, "Failed to handle confirmation signal");


### PR DESCRIPTION
## Summary
- Route ACP agent permission requests through the standard `confirmation_request` SSE message and `POST /v1/confirm` endpoint instead of the separate `acp_permission_request` / `POST /v1/acp/permission` flow
- All clients (macOS, web, CLI) now show the same approval UI for ACP permissions without any client-side changes
- Passes through `acpToolKind` and `acpOptions` in the confirmation request so clients can render agent-specific options
- Removes old ACP permission infrastructure (message type, endpoint, route policy, per-session tracking)
- Skips guardian canonical request creation for ACP confirmations to avoid duplicate approval cards

## Test plan
- [x] Added regression test for `makeEventSender` overwrite race condition
- [x] Updated existing ACP session tests for new `confirmation_request` flow
- [x] Verified typecheck, lint, prettier all pass
- [x] Manual testing: ACP permission renders inline confirmation UI, "Allow once" resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
