### PR TITLE
M4: Memoize ChatBubble interleaved content computation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -108,32 +108,52 @@ struct ChatBubble: View {
 
         // Eagerly compute interleaved content cache so the first body
         // evaluation uses the correct layout path (no flash).
-        let interleaved = Self.computeHasInterleavedContent(message.contentOrder)
-        _cachedHasInterleavedContent = State(initialValue: interleaved)
-
-        if interleaved {
-            let groups = Self.computeContentGroupsStatic(
-                contentOrder: message.contentOrder,
-                hasInterleavedContent: interleaved
-            )
-            _cachedContentGroups = State(initialValue: groups)
-
-            var trailingTextIds = Set<String>()
-            for group in groups {
-                guard case .toolCalls(let indices) = group else { continue }
-                if Self.computeHasTextAfterToolGroupStatic(
-                    toolIndices: indices,
-                    contentOrder: message.contentOrder,
-                    textSegments: message.textSegments,
-                    hasText: !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                ) {
-                    trailingTextIds.insert(group.stableId)
-                }
-            }
-            _cachedToolGroupsWithTrailingText = State(initialValue: trailingTextIds)
+        // Check the static cache first to avoid redundant O(k²) computation
+        // for completed messages in old conversations during scroll.
+        if let cached = Self.cachedInterleavedResult(for: message) {
+            _cachedHasInterleavedContent = State(initialValue: cached.hasInterleaved)
+            _cachedContentGroups = State(initialValue: cached.groups)
+            _cachedToolGroupsWithTrailingText = State(initialValue: cached.trailingTextIds)
         } else {
-            _cachedContentGroups = State(initialValue: [])
-            _cachedToolGroupsWithTrailingText = State(initialValue: [])
+            let interleaved = Self.computeHasInterleavedContent(message.contentOrder)
+            _cachedHasInterleavedContent = State(initialValue: interleaved)
+
+            if interleaved {
+                let groups = Self.computeContentGroupsStatic(
+                    contentOrder: message.contentOrder,
+                    hasInterleavedContent: interleaved
+                )
+                _cachedContentGroups = State(initialValue: groups)
+
+                var trailingTextIds = Set<String>()
+                for group in groups {
+                    guard case .toolCalls(let indices) = group else { continue }
+                    if Self.computeHasTextAfterToolGroupStatic(
+                        toolIndices: indices,
+                        contentOrder: message.contentOrder,
+                        textSegments: message.textSegments,
+                        hasText: !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    ) {
+                        trailingTextIds.insert(group.stableId)
+                    }
+                }
+                _cachedToolGroupsWithTrailingText = State(initialValue: trailingTextIds)
+
+                // Store in static cache for future init() calls
+                Self.storeInterleavedResult(
+                    InterleavedCacheValue(hasInterleaved: interleaved, groups: groups, trailingTextIds: trailingTextIds),
+                    for: message
+                )
+            } else {
+                _cachedContentGroups = State(initialValue: [])
+                _cachedToolGroupsWithTrailingText = State(initialValue: [])
+
+                // Store non-interleaved result in static cache
+                Self.storeInterleavedResult(
+                    InterleavedCacheValue(hasInterleaved: false, groups: [], trailingTextIds: []),
+                    for: message
+                )
+            }
         }
     }
     /// Injected from the parent instead of observing the shared singleton directly.

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -37,6 +37,62 @@ extension ChatBubble {
         }
     }
 
+    // MARK: - Static Interleaved Content Cache
+
+    /// Cache key for memoized interleaved content computation results.
+    /// Keyed by (messageId, contentOrderHash) to invalidate when content changes.
+    private struct InterleavedCacheKey: Hashable {
+        let messageId: UUID
+        let contentOrderHash: Int
+    }
+
+    /// Cached result of interleaved content computation.
+    private struct InterleavedCacheValue {
+        let hasInterleaved: Bool
+        let groups: [ContentGroup]
+        let trailingTextIds: Set<String>
+    }
+
+    /// Static cache of interleaved content computation results. For completed
+    /// messages in old conversations, `contentOrder` is stable so these results
+    /// can be reused across ChatBubble.init() calls during scroll.
+    @MainActor private static var interleavedContentCache: [InterleavedCacheKey: InterleavedCacheValue] = [:]
+
+    /// Maximum number of entries in the interleaved content cache before
+    /// clearing. This is a performance cache, not a correctness cache, so
+    /// full clear on overflow is safe and simple.
+    private static let interleavedCacheMaxEntries = 500
+
+    /// Builds a cache key from message identity + content structure.
+    static func interleavedCacheKey(for message: ChatMessage) -> InterleavedCacheKey {
+        var orderHasher = Hasher()
+        for ref in message.contentOrder { orderHasher.combine(ref) }
+        // Also hash textSegments count since trailingText depends on it
+        orderHasher.combine(message.textSegments.count)
+        orderHasher.combine(message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        return InterleavedCacheKey(
+            messageId: message.id,
+            contentOrderHash: orderHasher.finalize()
+        )
+    }
+
+    /// Looks up a cached interleaved content result for the given message.
+    @MainActor
+    static func cachedInterleavedResult(for message: ChatMessage) -> InterleavedCacheValue? {
+        let key = interleavedCacheKey(for: message)
+        return interleavedContentCache[key]
+    }
+
+    /// Stores an interleaved content computation result in the static cache.
+    @MainActor
+    static func storeInterleavedResult(_ value: InterleavedCacheValue, for message: ChatMessage) {
+        if interleavedContentCache.count > interleavedCacheMaxEntries {
+            interleavedContentCache.removeAll(keepingCapacity: true)
+        }
+        let key = interleavedCacheKey(for: message)
+        interleavedContentCache[key] = value
+    }
+
     // MARK: - Cache Recomputation
 
     /// Recomputes all cached interleaved content state. Called from `.onAppear`
@@ -48,6 +104,11 @@ extension ChatBubble {
         guard interleaved else {
             cachedContentGroups = []
             cachedToolGroupsWithTrailingText = []
+            // Update static cache with non-interleaved result
+            Self.storeInterleavedResult(
+                InterleavedCacheValue(hasInterleaved: false, groups: [], trailingTextIds: []),
+                for: message
+            )
             return
         }
 
@@ -73,6 +134,12 @@ extension ChatBubble {
             }
         }
         cachedToolGroupsWithTrailingText = trailingTextIds
+
+        // Update static cache so the next init() for this message uses fresh values
+        Self.storeInterleavedResult(
+            InterleavedCacheValue(hasInterleaved: interleaved, groups: groups, trailingTextIds: trailingTextIds),
+            for: message
+        )
     }
 
     /// Whether this message has meaningful interleaved content (multiple block types).

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -67,8 +67,11 @@ extension ChatBubble {
     static func interleavedCacheKey(for message: ChatMessage) -> InterleavedCacheKey {
         var orderHasher = Hasher()
         for ref in message.contentOrder { orderHasher.combine(ref) }
-        // Also hash textSegments count since trailingText depends on it
-        orderHasher.combine(message.textSegments.count)
+        // Hash per-segment emptiness since trailingText computation checks
+        // each segment's trimmed content, not just the count.
+        for segment in message.textSegments {
+            orderHasher.combine(segment.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
         orderHasher.combine(message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         return InterleavedCacheKey(
             messageId: message.id,

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1545,7 +1545,7 @@ public struct SkillInvocationData: Equatable {
 }
 
 /// Identifies a content block within a ChatMessage for interleaving order.
-public enum ContentBlockRef: Equatable {
+public enum ContentBlockRef: Hashable {
     case text(Int)
     case toolCall(Int)
     case surface(Int)


### PR DESCRIPTION
## Summary
Memoize the eager interleaved content computation in ChatBubble.init() so completed messages in old conversations return cached results instead of recomputing on every scroll-triggered init.

## Changes
- Added InterleavedCacheKey/Value types and static interleavedContentCache
- ChatBubble.init() checks cache before running computation
- recomputeInterleavedContentCache() updates the static cache after recomputation
- Cache capped at 500 entries with full clear on overflow
- Made ContentBlockRef conform to Hashable (was only Equatable) for cache key hashing

Closes #20998
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
