### PR TITLE
fix: register avatar skill tools in bundled-tool-registry

### DIFF
--- a/assistant/src/config/bundled-skills/settings/SKILL.md
+++ b/assistant/src/config/bundled-skills/settings/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: settings
-description: Manage assistant voice and system settings
+description: Manage assistant voice, avatar, and system settings
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "\u2699\uFE0F"
@@ -8,4 +8,13 @@ metadata:
     display-name: "Settings"
 ---
 
-Tools for managing assistant settings: voice configuration (TTS voice, PTT activation key, conversation timeout), system settings navigation, and in-app settings tab navigation.
+Tools for managing assistant settings: voice configuration (TTS voice, PTT activation key, conversation timeout), avatar management, system settings navigation, and in-app settings tab navigation.
+
+## Avatar
+
+When the user asks to set, change, or update your avatar to an image they provide:
+
+1. Find the uploaded image in the conversation attachments directory
+2. Use the `set_avatar` tool with the `image_path` parameter set to the workspace-relative path (e.g. `conversations/<id>/attachments/Dropped Image.png`)
+
+The tool copies the image to the canonical location (`data/avatar/avatar-image.png`), removes any native character files, and notifies the app to refresh automatically. **Do NOT use `bash` or `cp` to set the avatar** — always use the `set_avatar` tool so the app is properly notified.

--- a/assistant/src/config/bundled-skills/settings/SKILL.md
+++ b/assistant/src/config/bundled-skills/settings/SKILL.md
@@ -17,4 +17,8 @@ When the user asks to set, change, or update your avatar to an image they provid
 1. Find the uploaded image in the conversation attachments directory
 2. Use the `set_avatar` tool with the `image_path` parameter set to the workspace-relative path (e.g. `conversations/<id>/attachments/Dropped Image.png`)
 
-The tool copies the image to the canonical location (`data/avatar/avatar-image.png`), removes any native character files, and notifies the app to refresh automatically. **Do NOT use `bash` or `cp` to set the avatar** — always use the `set_avatar` tool so the app is properly notified.
+The tool copies the image to the canonical location (`data/avatar/avatar-image.png`) and notifies the app to refresh automatically.
+
+When the user asks to remove, clear, or reset their avatar, use the `remove_avatar` tool. It deletes only the custom image and preserves the native character traits so the character avatar is restored automatically.
+
+**Do NOT use `bash`, `cp`, or `rm` for avatar operations** — always use `set_avatar` / `remove_avatar` so the app is properly notified and character traits are preserved.

--- a/assistant/src/config/bundled-skills/settings/TOOLS.json
+++ b/assistant/src/config/bundled-skills/settings/TOOLS.json
@@ -11,7 +11,13 @@
         "properties": {
           "setting": {
             "type": "string",
-            "enum": ["activation_key", "conversation_timeout", "fish_audio_reference_id", "tts_provider", "tts_voice_id"],
+            "enum": [
+              "activation_key",
+              "conversation_timeout",
+              "fish_audio_reference_id",
+              "tts_provider",
+              "tts_voice_id"
+            ],
             "description": "The voice setting to change"
           },
           "value": {
@@ -79,6 +85,28 @@
       },
       "executor": "tools/navigate-settings-tab.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "set_avatar",
+      "description": "Set the assistant's avatar to an image file. Copies the source image to the canonical avatar location (data/avatar/avatar-image.png), removes any native character avatar files, and notifies the app to refresh. Use this when the user asks to set, change, or update the avatar to a specific image (e.g. from a conversation attachment).",
+      "category": "system",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "image_path": {
+            "type": "string",
+            "description": "Path to the image file. Can be absolute or relative to the workspace directory (e.g. 'conversations/<id>/attachments/Dropped Image.png')."
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of what you are doing, shown to the user as a status update."
+          }
+        },
+        "required": ["image_path"]
+      },
+      "executor": "tools/avatar-update.ts",
+      "execution_target": "sandbox"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/settings/TOOLS.json
+++ b/assistant/src/config/bundled-skills/settings/TOOLS.json
@@ -107,6 +107,23 @@
       },
       "executor": "tools/avatar-update.ts",
       "execution_target": "sandbox"
+    },
+    {
+      "name": "remove_avatar",
+      "description": "Remove the custom avatar image and restore the native character avatar. Only deletes the custom image — preserves character traits so the character avatar is automatically restored. Use this when the user asks to remove, clear, or reset their avatar.",
+      "category": "system",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of what you are doing, shown to the user as a status update."
+          }
+        }
+      },
+      "executor": "tools/avatar-remove.ts",
+      "execution_target": "sandbox"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/settings/tools/avatar-remove.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/avatar-remove.ts
@@ -1,0 +1,59 @@
+import { existsSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+
+import { buildAssistantEvent } from "../../../../runtime/assistant-event.js";
+import { assistantEventHub } from "../../../../runtime/assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../../../runtime/assistant-scope.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { getLogger } from "../../../../util/logger.js";
+import { getWorkspaceDir } from "../../../../util/platform.js";
+
+const log = getLogger("avatar-remove");
+
+export async function run(
+  _input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const avatarDir = join(getWorkspaceDir(), "data", "avatar");
+  const avatarPath = join(avatarDir, "avatar-image.png");
+
+  if (!existsSync(avatarPath)) {
+    return {
+      content: "No custom avatar to remove — already using the default.",
+      isError: false,
+    };
+  }
+
+  try {
+    unlinkSync(avatarPath);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ error: message }, "Failed to remove avatar image");
+    return { content: `Error removing avatar: ${message}`, isError: true };
+  }
+
+  // character-traits.json is intentionally preserved so the native
+  // character avatar is restored automatically.
+
+  // Notify connected clients so the avatar refreshes immediately.
+  assistantEventHub
+    .publish(
+      buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, {
+        type: "avatar_updated",
+        avatarPath,
+      }),
+    )
+    .catch((err) => {
+      log.warn({ err }, "Failed to publish avatar_updated event");
+    });
+
+  log.info("Custom avatar removed, reverting to character avatar");
+
+  return {
+    content: "Custom avatar removed. The character avatar has been restored.",
+    isError: false,
+  };
+}

--- a/assistant/src/config/bundled-skills/settings/tools/avatar-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/avatar-update.ts
@@ -1,0 +1,87 @@
+import { copyFileSync, existsSync, mkdirSync, unlinkSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { buildAssistantEvent } from "../../../../runtime/assistant-event.js";
+import { assistantEventHub } from "../../../../runtime/assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../../../runtime/assistant-scope.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { getLogger } from "../../../../util/logger.js";
+import { getWorkspaceDir } from "../../../../util/platform.js";
+
+const log = getLogger("avatar-update");
+
+/** Canonical path where the custom avatar PNG is stored. */
+function getAvatarPath(): string {
+  return join(getWorkspaceDir(), "data", "avatar", "avatar-image.png");
+}
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const sourcePath = input.image_path as string | undefined;
+
+  if (!sourcePath || typeof sourcePath !== "string") {
+    return {
+      content:
+        'Error: "image_path" is required. Provide the path to the image file (absolute or relative to workspace).',
+      isError: true,
+    };
+  }
+
+  const workspaceDir = getWorkspaceDir();
+  const resolvedSource = sourcePath.startsWith("/")
+    ? sourcePath
+    : join(workspaceDir, sourcePath);
+
+  if (!existsSync(resolvedSource)) {
+    return {
+      content: `Error: source file not found: ${resolvedSource}`,
+      isError: true,
+    };
+  }
+
+  const avatarPath = getAvatarPath();
+  const avatarDir = dirname(avatarPath);
+
+  try {
+    mkdirSync(avatarDir, { recursive: true });
+    copyFileSync(resolvedSource, avatarPath);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ error: message }, "Failed to copy avatar image");
+    return { content: `Error copying avatar: ${message}`, isError: true };
+  }
+
+  // Remove native character files since custom image takes precedence.
+  const traitsPath = join(avatarDir, "character-traits.json");
+  const asciiPath = join(avatarDir, "character-ascii.txt");
+  try {
+    if (existsSync(traitsPath)) unlinkSync(traitsPath);
+    if (existsSync(asciiPath)) unlinkSync(asciiPath);
+  } catch {
+    // Best-effort cleanup
+  }
+
+  // Notify connected clients so the avatar refreshes immediately.
+  assistantEventHub
+    .publish(
+      buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, {
+        type: "avatar_updated",
+        avatarPath,
+      }),
+    )
+    .catch((err) => {
+      log.warn({ err }, "Failed to publish avatar_updated event");
+    });
+
+  log.info({ avatarPath, source: resolvedSource }, "Avatar updated");
+
+  return {
+    content: `Avatar updated from ${sourcePath}. The app will refresh automatically.`,
+    isError: false,
+  };
+}

--- a/assistant/src/config/bundled-skills/settings/tools/avatar-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/avatar-update.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync, mkdirSync, unlinkSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import { buildAssistantEvent } from "../../../../runtime/assistant-event.js";
@@ -56,15 +56,8 @@ export async function run(
     return { content: `Error copying avatar: ${message}`, isError: true };
   }
 
-  // Remove native character files since custom image takes precedence.
-  const traitsPath = join(avatarDir, "character-traits.json");
-  const asciiPath = join(avatarDir, "character-ascii.txt");
-  try {
-    if (existsSync(traitsPath)) unlinkSync(traitsPath);
-    if (existsSync(asciiPath)) unlinkSync(asciiPath);
-  } catch {
-    // Best-effort cleanup
-  }
+  // Keep character-traits.json and character-ascii.txt so the character
+  // avatar can be restored if the custom image is later removed.
 
   // Notify connected clients so the avatar refreshes immediately.
   assistantEventHub

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -132,6 +132,8 @@ import * as sequenceImport from "./bundled-skills/sequences/tools/sequence-impor
 import * as sequenceList from "./bundled-skills/sequences/tools/sequence-list.js";
 import * as sequenceUpdate from "./bundled-skills/sequences/tools/sequence-update.js";
 // ── settings ───────────────────────────────────────────────────────────────────
+import * as avatarRemove from "./bundled-skills/settings/tools/avatar-remove.js";
+import * as avatarUpdate from "./bundled-skills/settings/tools/avatar-update.js";
 import * as navigateSettingsTab from "./bundled-skills/settings/tools/navigate-settings-tab.js";
 import * as openSystemSettings from "./bundled-skills/settings/tools/open-system-settings.js";
 import * as voiceConfigUpdate from "./bundled-skills/settings/tools/voice-config-update.js";
@@ -323,6 +325,8 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["sequences:tools/sequence-analytics.ts", sequenceAnalytics],
 
   // settings
+  ["settings:tools/avatar-update.ts", avatarUpdate],
+  ["settings:tools/avatar-remove.ts", avatarRemove],
   ["settings:tools/voice-config-update.ts", voiceConfigUpdate],
   ["settings:tools/open-system-settings.ts", openSystemSettings],
   ["settings:tools/navigate-settings-tab.ts", navigateSettingsTab],

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -99,6 +99,11 @@ final class AvatarAppearanceManager {
 
     private var identityObserver: NSObjectProtocol?
 
+    /// File-system watcher for the avatar image so external changes (e.g. CLI writes) trigger a reload.
+    @ObservationIgnored private var avatarFileWatcher: DispatchSourceFileSystemObject?
+    /// Directory watcher to detect avatar file creation/deletion.
+    @ObservationIgnored private var avatarDirWatcher: DispatchSourceFileSystemObject?
+
     /// Workspace path for custom avatar -- canonical storage location.
     nonisolated static func workspaceCustomAvatarURL(homeDirectory: String = NSHomeDirectory()) -> URL {
         URL(fileURLWithPath: homeDirectory)
@@ -139,6 +144,8 @@ final class AvatarAppearanceManager {
         // bundled Vellum logo.
         updateDockLabel()
 
+        startAvatarFileWatcher()
+
         // Refresh assistantName and invalidate cached fallback avatars when
         // the user renames their assistant so the initial-letter avatar
         // reflects the new name.
@@ -160,6 +167,105 @@ final class AvatarAppearanceManager {
                 self.updateDockLabel()
             }
         }
+    }
+
+    // MARK: - Avatar File Watcher
+
+    /// Sets up watchers so that external writes to avatar-image.png
+    /// (e.g. the CLI) are picked up automatically.
+    ///
+    /// Strategy:
+    /// - Watch the **file** for `.write` to catch in-place overwrites (cp).
+    /// - Watch the **directory** for `.write` to catch file creation/deletion
+    ///   (atomic rename pattern, or first-time creation). When the directory
+    ///   changes, re-establish the file watcher in case the fd went stale.
+    private func startAvatarFileWatcher() {
+        avatarFileWatcher?.cancel()
+        avatarFileWatcher = nil
+        avatarDirWatcher?.cancel()
+        avatarDirWatcher = nil
+
+        let avatarPath = customAvatarURL.path
+        let avatarDir = customAvatarURL.deletingLastPathComponent().path
+
+        // Ensure the directory exists.
+        try? FileManager.default.createDirectory(
+            atPath: avatarDir,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+
+        // Watch the file itself for in-place overwrites.
+        watchAvatarFile(at: avatarPath)
+
+        // Watch the directory for file creation/deletion/rename.
+        let dirFd = open(avatarDir, O_EVTONLY)
+        guard dirFd >= 0 else { return }
+
+        let dirSource = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: dirFd,
+            eventMask: [.write],
+            queue: .global(qos: .utility)
+        )
+        dirSource.setEventHandler { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                log.info("Avatar directory changed — re-establishing file watcher")
+                self.watchAvatarFile(at: avatarPath)
+                self.reloadAvatarFromDisk()
+            }
+        }
+        dirSource.setCancelHandler {
+            close(dirFd)
+        }
+        dirSource.resume()
+        avatarDirWatcher = dirSource
+    }
+
+    /// Watch a specific file path for `.write` events.
+    private func watchAvatarFile(at path: String) {
+        avatarFileWatcher?.cancel()
+        avatarFileWatcher = nil
+
+        let fd = open(path, O_EVTONLY)
+        guard fd >= 0 else { return }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .delete, .rename],
+            queue: .global(qos: .utility)
+        )
+        source.setEventHandler { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                log.info("Avatar file changed on disk — reloading")
+                self.reloadAvatarFromDisk()
+            }
+        }
+        source.setCancelHandler {
+            close(fd)
+        }
+        source.resume()
+        avatarFileWatcher = source
+    }
+
+    /// Reloads the avatar directly from disk without an HTTP round-trip.
+    /// Used by the file watcher so that local changes are picked up immediately
+    /// and not overwritten by a potentially stale gateway response.
+    private func reloadAvatarFromDisk() {
+        cachedChatAvatar = nil
+        cachedFallbackAvatar = nil
+        cachedFallbackName = nil
+        cachedFullFallbackAvatar = nil
+        cachedFullFallbackName = nil
+
+        let path = customAvatarURL.path
+        if let image = NSImage(contentsOfFile: path) {
+            customAvatarImage = image
+        } else {
+            customAvatarImage = nil
+        }
+        updateDockIcon()
     }
 
     // MARK: - Component Fetch
@@ -268,7 +374,7 @@ final class AvatarAppearanceManager {
     /// and re-reads the identity so the dock label reflects the current assistant.
     /// Fetches via HTTP through the gateway for consistency across all instance types.
     func reloadAvatar() {
-        reloadAvatar(avatarPath: nil)
+        reloadAvatar(avatarPath: customAvatarURL.path)
     }
 
     /// Reloads the avatar, optionally using a local file path for an immediate

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -264,8 +264,30 @@ final class AvatarAppearanceManager {
             customAvatarImage = image
         } else {
             customAvatarImage = nil
+            // Reload character traits from disk so the character avatar
+            // is restored when the custom image is removed.
+            loadCharacterTraitsFromDisk()
         }
         updateDockIcon()
+    }
+
+    /// Loads character-traits.json from the avatar directory on disk
+    /// and populates the character avatar properties.
+    private func loadCharacterTraitsFromDisk() {
+        let traitsURL = customAvatarURL.deletingLastPathComponent()
+            .appendingPathComponent("character-traits.json")
+        guard let data = try? Data(contentsOf: traitsURL),
+              let components = try? JSONDecoder().decode(AvatarComponents.self, from: data) else {
+            characterBodyShape = nil
+            characterEyeStyle = nil
+            characterColor = nil
+            return
+        }
+        characterBodyShape = AvatarBodyShape(rawValue: components.bodyShape)
+        characterEyeStyle = AvatarEyeStyle(rawValue: components.eyeStyle)
+        characterColor = AvatarColor(rawValue: components.color)
+        cachedFallbackAvatar = nil
+        cachedFullFallbackAvatar = nil
     }
 
     // MARK: - Component Fetch

--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -90,7 +90,9 @@ struct ChatEmptyStateView: View {
     private var heroSection: some View {
         HStack(spacing: VSpacing.md) {
             Group {
-                if let body = appearance.characterBodyShape,
+                if appearance.customAvatarImage != nil {
+                    VAvatarImage(image: appearance.chatAvatarImage, size: 32)
+                } else if let body = appearance.characterBodyShape,
                    let eyes = appearance.characterEyeStyle,
                    let color = appearance.characterColor {
                     AnimatedAvatarView(bodyShape: body, eyeStyle: eyes, color: color, size: 32)

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -515,7 +515,19 @@ struct MessageListView: View {
     @ViewBuilder
     private var conversationTailAvatar: some View {
         if shouldShowConversationTailAvatar {
-            if let body = appearance.characterBodyShape,
+            if appearance.customAvatarImage != nil {
+                HStack {
+                    VAvatarImage(image: appearance.chatAvatarImage, size: ConversationAvatarFollower.avatarSize)
+                        .modifier(AvatarGlowModifier(isActive: isSending))
+                    Spacer()
+                }
+                .padding(.horizontal, VSpacing.xl)
+                .frame(maxWidth: VSpacing.chatColumnMaxWidth)
+                .frame(maxWidth: .infinity)
+                .offset(y: avatarDisplayY)
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+            } else if let body = appearance.characterBodyShape,
                let eyes = appearance.characterEyeStyle,
                let color = appearance.characterColor {
                 AnimatedAvatarView(bodyShape: body, eyeStyle: eyes, color: color,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -771,9 +771,6 @@ struct ConstellationView: View {
     /// component is present the avatar is a built character, not a custom upload.
     private var hasCustomAvatar: Bool {
         appearance.customAvatarImage != nil
-            && appearance.characterBodyShape == nil
-            && appearance.characterEyeStyle == nil
-            && appearance.characterColor == nil
     }
 
     /// Computes tree layout synchronously and populates all state vars.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -96,7 +96,10 @@ struct IdentityPanel: View {
 
                             // Large centered avatar
                             Group {
-                                if let body = appearance.characterBodyShape,
+                                if appearance.customAvatarImage != nil {
+                                    VAvatarImage(image: appearance.fullAvatarImage, size: avatarSize, showBorder: false)
+                                        .frame(maxWidth: .infinity, alignment: .center)
+                                } else if let body = appearance.characterBodyShape,
                                    let eyes = appearance.characterEyeStyle,
                                    let color = appearance.characterColor {
                                     AnimatedAvatarView(bodyShape: body, eyeStyle: eyes, color: color, size: avatarSize,


### PR DESCRIPTION
## Summary
- Add avatar-update and avatar-remove to the static import registry in `bundled-tool-registry.ts` so knip recognizes them as used files
- Follow-up to #20945 — this commit landed after the PR was merged

## Test plan
- [ ] `cd assistant && bun run lint:unused` passes with no unused file warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
