### PR TITLE
fix: register avatar skill tools in bundled-tool-registry

### DIFF
--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -132,6 +132,8 @@ import * as sequenceImport from "./bundled-skills/sequences/tools/sequence-impor
 import * as sequenceList from "./bundled-skills/sequences/tools/sequence-list.js";
 import * as sequenceUpdate from "./bundled-skills/sequences/tools/sequence-update.js";
 // ── settings ───────────────────────────────────────────────────────────────────
+import * as avatarRemove from "./bundled-skills/settings/tools/avatar-remove.js";
+import * as avatarUpdate from "./bundled-skills/settings/tools/avatar-update.js";
 import * as navigateSettingsTab from "./bundled-skills/settings/tools/navigate-settings-tab.js";
 import * as openSystemSettings from "./bundled-skills/settings/tools/open-system-settings.js";
 import * as voiceConfigUpdate from "./bundled-skills/settings/tools/voice-config-update.js";
@@ -323,6 +325,8 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["sequences:tools/sequence-analytics.ts", sequenceAnalytics],
 
   // settings
+  ["settings:tools/avatar-update.ts", avatarUpdate],
+  ["settings:tools/avatar-remove.ts", avatarRemove],
   ["settings:tools/voice-config-update.ts", voiceConfigUpdate],
   ["settings:tools/open-system-settings.ts", openSystemSettings],
   ["settings:tools/navigate-settings-tab.ts", navigateSettingsTab],


### PR DESCRIPTION
## Summary
- Register `avatar-update` and `avatar-remove` tool executors in `bundled-tool-registry.ts` so knip's `lint:unused` check no longer flags them as unused files.

## Test plan
- [x] `bun run lint:unused` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
