### PR TITLE
perf: replace LRU caches with NSCache and fix main-thread blocking during scroll

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
@@ -48,10 +48,9 @@ struct AnimatedImageView: View {
     // MARK: - Cached workspace directory
 
     /// Cached workspace directory to avoid synchronous lockfile reads per image.
-    /// Invalidated when the connected assistant ID changes.
+    /// Re-resolves when the connected assistant ID changes or after a transient miss.
     @MainActor private static var cachedWorkspaceDir: String?
     @MainActor private static var cachedAssistantId: String?
-    @MainActor private static var workspaceDirResolved = false
 
     /// Maximum display dimension in points (matches text bubble maxWidth).
     private let maxDimension: CGFloat = VSpacing.chatBubbleMaxWidth
@@ -118,7 +117,7 @@ struct AnimatedImageView: View {
         // Relative workspace paths — resolve to absolute to avoid cross-assistant collisions.
         if !urlString.contains("://") {
             let currentAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId")
-            if !Self.workspaceDirResolved || currentAssistantId != Self.cachedAssistantId {
+            if Self.cachedWorkspaceDir == nil || currentAssistantId != Self.cachedAssistantId {
                 Self.cachedAssistantId = currentAssistantId
                 Self.cachedWorkspaceDir = nil
                 if let assistantId = currentAssistantId,
@@ -126,7 +125,6 @@ struct AnimatedImageView: View {
                    let resolved = assistant.workspaceDir {
                     Self.cachedWorkspaceDir = resolved
                 }
-                Self.workspaceDirResolved = true
             }
             let workspaceDir = Self.cachedWorkspaceDir ?? (NSHomeDirectory() + "/.vellum/workspace")
             let absolutePath = workspaceDir + "/" + urlString

--- a/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
@@ -45,6 +45,14 @@ struct AnimatedImageView: View {
         return cache
     }()
 
+    // MARK: - Cached workspace directory
+
+    /// Cached workspace directory to avoid synchronous lockfile reads per image.
+    /// Invalidated when the connected assistant ID changes.
+    @MainActor private static var cachedWorkspaceDir: String?
+    @MainActor private static var cachedAssistantId: String?
+    @MainActor private static var workspaceDirResolved = false
+
     /// Maximum display dimension in points (matches text bubble maxWidth).
     private let maxDimension: CGFloat = VSpacing.chatBubbleMaxWidth
 
@@ -109,14 +117,18 @@ struct AnimatedImageView: View {
 
         // Relative workspace paths — resolve to absolute to avoid cross-assistant collisions.
         if !urlString.contains("://") {
-            let workspaceDir: String
-            if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
-               let assistant = LockfileAssistant.loadByName(assistantId),
-               let resolved = assistant.workspaceDir {
-                workspaceDir = resolved
-            } else {
-                workspaceDir = NSHomeDirectory() + "/.vellum/workspace"
+            let currentAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+            if !Self.workspaceDirResolved || currentAssistantId != Self.cachedAssistantId {
+                Self.cachedAssistantId = currentAssistantId
+                Self.cachedWorkspaceDir = nil
+                if let assistantId = currentAssistantId,
+                   let assistant = LockfileAssistant.loadByName(assistantId),
+                   let resolved = assistant.workspaceDir {
+                    Self.cachedWorkspaceDir = resolved
+                }
+                Self.workspaceDirResolved = true
             }
+            let workspaceDir = Self.cachedWorkspaceDir ?? (NSHomeDirectory() + "/.vellum/workspace")
             let absolutePath = workspaceDir + "/" + urlString
             let fileURL = URL(fileURLWithPath: absolutePath)
             return (absolutePath as NSString, fileURL)
@@ -126,28 +138,50 @@ struct AnimatedImageView: View {
         return (urlString as NSString, nil)
     }
 
-    /// Returns a cache key that incorporates the file's modification date so
-    /// overwritten local images (e.g. regenerated avatars) are not served stale.
-    private func localCacheKey(path: String) -> NSString {
-        if let attrs = try? FileManager.default.attributesOfItem(atPath: path),
-           let mtime = attrs[.modificationDate] as? Date {
-            return "\(path)?\(mtime.timeIntervalSince1970)" as NSString
-        }
-        return path as NSString
-    }
-
     private func loadImage() async {
         isLoading = true
         defer { isLoading = false }
 
         let (cacheKey, localFileURL) = resolveCacheKey()
 
-        // For local files, incorporate mtime so overwritten files bust the cache.
-        let effectiveKey: NSString = localFileURL != nil
-            ? localCacheKey(path: cacheKey as String)
-            : cacheKey
+        // Local file paths (absolute or workspace-relative, already resolved).
+        // Move file I/O (mtime check + data read) off main thread via detached task.
+        if let fileURL = localFileURL {
+            // Phase 1: resolve mtime-aware cache key off main thread.
+            let effectiveKey = await Task.detached(priority: .userInitiated) { () -> NSString in
+                if let attrs = try? FileManager.default.attributesOfItem(atPath: cacheKey as String),
+                   let mtime = attrs[.modificationDate] as? Date {
+                    return "\(cacheKey)?\(mtime.timeIntervalSince1970)" as NSString
+                }
+                return cacheKey
+            }.value
+            guard !Task.isCancelled else { return }
 
-        // Check in-memory cache first to avoid redundant disk reads / decoding.
+            // Check in-memory cache before reading file bytes.
+            if let entry = Self.cache.object(forKey: effectiveKey) {
+                self.loadedImage = entry.image
+                self.imageData = entry.gifData
+                self.isGIF = entry.gifData != nil
+                return
+            }
+
+            // Phase 2: cache miss — read file data off main thread.
+            let fileData = await Task.detached(priority: .userInitiated) {
+                try? Data(contentsOf: fileURL)
+            }.value
+            guard !Task.isCancelled else { return }
+
+            imageData = fileData
+            loadedImage = fileData.flatMap { NSImage(data: $0) }
+            if let data = fileData { isGIF = isAnimatedGIF(data) }
+            cacheLoadedImage(forKey: effectiveKey)
+            return
+        }
+
+        // Remote URLs — use URL string as cache key (no mtime).
+        let effectiveKey = cacheKey
+
+        // Check in-memory cache first to avoid redundant downloads.
         if let entry = Self.cache.object(forKey: effectiveKey) {
             self.loadedImage = entry.image
             self.imageData = entry.gifData
@@ -155,16 +189,6 @@ struct AnimatedImageView: View {
             return
         }
 
-        // Local file paths (absolute or workspace-relative, already resolved).
-        if let fileURL = localFileURL {
-            imageData = try? Data(contentsOf: fileURL)
-            loadedImage = imageData.flatMap { NSImage(data: $0) }
-            if let data = imageData { isGIF = isAnimatedGIF(data) }
-            cacheLoadedImage(forKey: effectiveKey)
-            return
-        }
-
-        // Remote URL.
         guard let url = URL(string: urlString) else { return }
 
         do {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -108,32 +108,52 @@ struct ChatBubble: View {
 
         // Eagerly compute interleaved content cache so the first body
         // evaluation uses the correct layout path (no flash).
-        let interleaved = Self.computeHasInterleavedContent(message.contentOrder)
-        _cachedHasInterleavedContent = State(initialValue: interleaved)
-
-        if interleaved {
-            let groups = Self.computeContentGroupsStatic(
-                contentOrder: message.contentOrder,
-                hasInterleavedContent: interleaved
-            )
-            _cachedContentGroups = State(initialValue: groups)
-
-            var trailingTextIds = Set<String>()
-            for group in groups {
-                guard case .toolCalls(let indices) = group else { continue }
-                if Self.computeHasTextAfterToolGroupStatic(
-                    toolIndices: indices,
-                    contentOrder: message.contentOrder,
-                    textSegments: message.textSegments,
-                    hasText: !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                ) {
-                    trailingTextIds.insert(group.stableId)
-                }
-            }
-            _cachedToolGroupsWithTrailingText = State(initialValue: trailingTextIds)
+        // Check the static cache first to avoid redundant O(k²) computation
+        // for completed messages in old conversations during scroll.
+        if let cached = Self.cachedInterleavedResult(for: message) {
+            _cachedHasInterleavedContent = State(initialValue: cached.hasInterleaved)
+            _cachedContentGroups = State(initialValue: cached.groups)
+            _cachedToolGroupsWithTrailingText = State(initialValue: cached.trailingTextIds)
         } else {
-            _cachedContentGroups = State(initialValue: [])
-            _cachedToolGroupsWithTrailingText = State(initialValue: [])
+            let interleaved = Self.computeHasInterleavedContent(message.contentOrder)
+            _cachedHasInterleavedContent = State(initialValue: interleaved)
+
+            if interleaved {
+                let groups = Self.computeContentGroupsStatic(
+                    contentOrder: message.contentOrder,
+                    hasInterleavedContent: interleaved
+                )
+                _cachedContentGroups = State(initialValue: groups)
+
+                var trailingTextIds = Set<String>()
+                for group in groups {
+                    guard case .toolCalls(let indices) = group else { continue }
+                    if Self.computeHasTextAfterToolGroupStatic(
+                        toolIndices: indices,
+                        contentOrder: message.contentOrder,
+                        textSegments: message.textSegments,
+                        hasText: !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    ) {
+                        trailingTextIds.insert(group.stableId)
+                    }
+                }
+                _cachedToolGroupsWithTrailingText = State(initialValue: trailingTextIds)
+
+                // Store in static cache for future init() calls
+                Self.storeInterleavedResult(
+                    InterleavedCacheValue(hasInterleaved: interleaved, groups: groups, trailingTextIds: trailingTextIds),
+                    for: message
+                )
+            } else {
+                _cachedContentGroups = State(initialValue: [])
+                _cachedToolGroupsWithTrailingText = State(initialValue: [])
+
+                // Store non-interleaved result in static cache
+                Self.storeInterleavedResult(
+                    InterleavedCacheValue(hasInterleaved: false, groups: [], trailingTextIds: []),
+                    for: message
+                )
+            }
         }
     }
     /// Injected from the parent instead of observing the shared singleton directly.

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -583,28 +583,21 @@ struct ChatBubble: View {
             let text = message.text
             guard !message.isStreaming,
                   text.count > Self.asyncParseThreshold,
-                  Self.segmentCache[text] == nil,
+                  Self.segmentCache.object(forKey: text as NSString) == nil,
                   asyncSegments[text] == nil else { return }
             let result = await MarkdownParseActor.shared.parse(text)
             guard !Task.isCancelled else { return }
             asyncSegments[text] = result
-            // Backfill synchronous cache with guardrails (size limit, byte
-            // tracking, eviction) — mirrors the logic in cachedSegments.
-            // Re-check cache after await to avoid double-counting bytes when
+            // Backfill synchronous cache with cost tracking.
+            // Re-check cache after await to avoid double-inserting when
             // multiple bubbles parse the same text concurrently.
             if text.count <= Self.maxCacheableTextLength,
-               Self.segmentCache[text] == nil {
-                if Self.segmentCache.count >= Self.maxCacheSize {
-                    if let lruKey = Self.segmentCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
-                        Self.estimatedCacheBytes -= Self.estimatedBytes(for: lruKey)
-                        Self.segmentCache.removeValue(forKey: lruKey)
-                    }
-                }
-                Self.lruCounter += 1
-                let cost = Self.estimatedBytes(for: text)
-                Self.segmentCache[text] = (result, Self.lruCounter)
-                Self.estimatedCacheBytes += cost
-                Self.evictIfOverBudget()
+               Self.segmentCache.object(forKey: text as NSString) == nil {
+                Self.segmentCache.setObject(
+                    SegmentCacheEntry(result),
+                    forKey: text as NSString,
+                    cost: text.utf8.count * 10
+                )
             }
         }
     }
@@ -639,58 +632,41 @@ struct ChatBubble: View {
     /// miss, reducing scroll jank from synchronous markdown parsing.
     static let asyncParseThreshold = 500
 
-    // MARK: - LRU Caches
+    // MARK: - Segment Cache
     //
-    // Each cache entry stores (value, accessTime) where accessTime is a
-    // monotonically increasing counter. On eviction the entry with the
-    // lowest accessTime is removed (least-recently-used).
+    // NSCache handles eviction automatically based on countLimit and
+    // totalCostLimit, eliminating the O(n) min(by:) scans of the old
+    // hand-rolled LRU dictionary.
 
-    // UInt64 to avoid silent overflow after billions of cache accesses in long-running sessions.
-    @MainActor static var lruCounter: UInt64 = 0
-
-    @MainActor static var segmentCache = [String: (value: [MarkdownSegment], accessTime: UInt64)]()
-    static let maxCacheSize = 100
+    @MainActor static var segmentCache: NSCache<NSString, SegmentCacheEntry> = {
+        let cache = NSCache<NSString, SegmentCacheEntry>()
+        cache.countLimit = 500
+        cache.totalCostLimit = 5_000_000
+        return cache
+    }()
 
     // MARK: - Cache Guardrails
     //
     // Prevents a single huge message from consuming disproportionate cache
     // space.  Text over `maxCacheableTextLength` is parsed but never stored.
-    // `estimatedCacheBytes` tracks a rough byte budget across the segment
-    // cache; when it exceeds `maxCacheBytes` the oldest entries are evicted.
 
     static let maxCacheableTextLength = 10_000
-    static let maxCacheBytes = 5_000_000
-    /// Rough byte estimate of all entries in segmentCache.  Updated on insert/evict.
-    @MainActor static var estimatedCacheBytes: Int = 0
-
-    /// Estimate the in-memory cost of caching the given text's parsed result.
-    /// Uses `utf8.count * 10` as a conservative multiplier: parsed MarkdownSegment
-    /// arrays carry overhead beyond raw bytes (segment structs, string copies,
-    /// enum metadata), so 3x was too low and allowed the budget to be exceeded.
-    static func estimatedBytes(for text: String) -> Int {
-        text.utf8.count * 10
-    }
-
-    /// Evicts the oldest entries from segmentCache until
-    /// `estimatedCacheBytes` drops below `maxCacheBytes`.
-    @MainActor static func evictIfOverBudget() {
-        while estimatedCacheBytes > maxCacheBytes {
-            guard let lruKey = segmentCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key else { break }
-            let cost = estimatedBytes(for: lruKey)
-            segmentCache.removeValue(forKey: lruKey)
-            estimatedCacheBytes -= cost
-        }
-    }
 
     // MARK: - Streaming Dedup Caches
     //
-    // During streaming, the LRU caches above skip storing results to avoid
+    // During streaming, the segment cache skips storing results to avoid
     // filling up with intermediate text states. However SwiftUI reevaluates
     // view bodies multiple times per token, often with identical text.
     // These single-entry caches hold the last-parsed streaming result so
     // redundant reevaluations return instantly without re-parsing.
 
     @MainActor static var lastStreamingSegments: (text: String, value: [MarkdownSegment])?
+}
+
+/// NSObject wrapper for `[MarkdownSegment]` to satisfy NSCache's NSObject value requirement.
+final class SegmentCacheEntry: NSObject {
+    let segments: [MarkdownSegment]
+    init(_ segments: [MarkdownSegment]) { self.segments = segments }
 }
 
 /// Applies `.compositingGroup()` only when active, to avoid re-compositing during streaming.

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -41,13 +41,13 @@ extension ChatBubble {
 
     /// Cache key for memoized interleaved content computation results.
     /// Keyed by (messageId, contentOrderHash) to invalidate when content changes.
-    private struct InterleavedCacheKey: Hashable {
+    struct InterleavedCacheKey: Hashable {
         let messageId: UUID
         let contentOrderHash: Int
     }
 
     /// Cached result of interleaved content computation.
-    private struct InterleavedCacheValue {
+    struct InterleavedCacheValue {
         let hasInterleaved: Bool
         let groups: [ContentGroup]
         let trailingTextIds: Set<String>
@@ -56,12 +56,12 @@ extension ChatBubble {
     /// Static cache of interleaved content computation results. For completed
     /// messages in old conversations, `contentOrder` is stable so these results
     /// can be reused across ChatBubble.init() calls during scroll.
-    @MainActor private static var interleavedContentCache: [InterleavedCacheKey: InterleavedCacheValue] = [:]
+    @MainActor static var interleavedContentCache: [InterleavedCacheKey: InterleavedCacheValue] = [:]
 
     /// Maximum number of entries in the interleaved content cache before
     /// clearing. This is a performance cache, not a correctness cache, so
     /// full clear on overflow is safe and simple.
-    private static let interleavedCacheMaxEntries = 500
+    static let interleavedCacheMaxEntries = 500
 
     /// Builds a cache key from message identity + content structure.
     static func interleavedCacheKey(for message: ChatMessage) -> InterleavedCacheKey {
@@ -70,7 +70,7 @@ extension ChatBubble {
         // Hash per-segment emptiness since trailingText computation checks
         // each segment's trimmed content, not just the count.
         for segment in message.textSegments {
-            orderHasher.combine(segment.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            orderHasher.combine(segment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         }
         orderHasher.combine(message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         return InterleavedCacheKey(

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -37,6 +37,65 @@ extension ChatBubble {
         }
     }
 
+    // MARK: - Static Interleaved Content Cache
+
+    /// Cache key for memoized interleaved content computation results.
+    /// Keyed by (messageId, contentOrderHash) to invalidate when content changes.
+    private struct InterleavedCacheKey: Hashable {
+        let messageId: UUID
+        let contentOrderHash: Int
+    }
+
+    /// Cached result of interleaved content computation.
+    private struct InterleavedCacheValue {
+        let hasInterleaved: Bool
+        let groups: [ContentGroup]
+        let trailingTextIds: Set<String>
+    }
+
+    /// Static cache of interleaved content computation results. For completed
+    /// messages in old conversations, `contentOrder` is stable so these results
+    /// can be reused across ChatBubble.init() calls during scroll.
+    @MainActor private static var interleavedContentCache: [InterleavedCacheKey: InterleavedCacheValue] = [:]
+
+    /// Maximum number of entries in the interleaved content cache before
+    /// clearing. This is a performance cache, not a correctness cache, so
+    /// full clear on overflow is safe and simple.
+    private static let interleavedCacheMaxEntries = 500
+
+    /// Builds a cache key from message identity + content structure.
+    static func interleavedCacheKey(for message: ChatMessage) -> InterleavedCacheKey {
+        var orderHasher = Hasher()
+        for ref in message.contentOrder { orderHasher.combine(ref) }
+        // Hash per-segment emptiness since trailingText computation checks
+        // each segment's trimmed content, not just the count.
+        for segment in message.textSegments {
+            orderHasher.combine(segment.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+        orderHasher.combine(message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        return InterleavedCacheKey(
+            messageId: message.id,
+            contentOrderHash: orderHasher.finalize()
+        )
+    }
+
+    /// Looks up a cached interleaved content result for the given message.
+    @MainActor
+    static func cachedInterleavedResult(for message: ChatMessage) -> InterleavedCacheValue? {
+        let key = interleavedCacheKey(for: message)
+        return interleavedContentCache[key]
+    }
+
+    /// Stores an interleaved content computation result in the static cache.
+    @MainActor
+    static func storeInterleavedResult(_ value: InterleavedCacheValue, for message: ChatMessage) {
+        if interleavedContentCache.count > interleavedCacheMaxEntries {
+            interleavedContentCache.removeAll(keepingCapacity: true)
+        }
+        let key = interleavedCacheKey(for: message)
+        interleavedContentCache[key] = value
+    }
+
     // MARK: - Cache Recomputation
 
     /// Recomputes all cached interleaved content state. Called from `.onAppear`
@@ -48,6 +107,11 @@ extension ChatBubble {
         guard interleaved else {
             cachedContentGroups = []
             cachedToolGroupsWithTrailingText = []
+            // Update static cache with non-interleaved result
+            Self.storeInterleavedResult(
+                InterleavedCacheValue(hasInterleaved: false, groups: [], trailingTextIds: []),
+                for: message
+            )
             return
         }
 
@@ -73,6 +137,12 @@ extension ChatBubble {
             }
         }
         cachedToolGroupsWithTrailingText = trailingTextIds
+
+        // Update static cache so the next init() for this message uses fresh values
+        Self.storeInterleavedResult(
+            InterleavedCacheValue(hasInterleaved: interleaved, groups: groups, trailingTextIds: trailingTextIds),
+            for: message
+        )
     }
 
     /// Whether this message has meaningful interleaved content (multiple block types).

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -25,28 +25,21 @@ extension ChatBubble {
             // Only run async parsing for large, non-streaming text with a cache miss
             guard !streaming,
                   segmentText.count > Self.asyncParseThreshold,
-                  Self.segmentCache[segmentText] == nil,
+                  Self.segmentCache.object(forKey: segmentText as NSString) == nil,
                   asyncSegments[segmentText] == nil else { return }
             let result = await MarkdownParseActor.shared.parse(segmentText)
             guard !Task.isCancelled else { return }
             asyncSegments[segmentText] = result
-            // Backfill the synchronous cache with guardrails (size limit,
-            // byte tracking, eviction) — mirrors the logic in cachedSegments.
-            // Re-check cache after await to avoid double-counting bytes when
+            // Backfill the synchronous cache with cost tracking.
+            // Re-check cache after await to avoid double-inserting when
             // multiple bubbles parse the same text concurrently.
             if segmentText.count <= Self.maxCacheableTextLength,
-               Self.segmentCache[segmentText] == nil {
-                if Self.segmentCache.count >= Self.maxCacheSize {
-                    if let lruKey = Self.segmentCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
-                        Self.estimatedCacheBytes -= Self.estimatedBytes(for: lruKey)
-                        Self.segmentCache.removeValue(forKey: lruKey)
-                    }
-                }
-                Self.lruCounter += 1
-                let cost = Self.estimatedBytes(for: segmentText)
-                Self.segmentCache[segmentText] = (result, Self.lruCounter)
-                Self.estimatedCacheBytes += cost
-                Self.evictIfOverBudget()
+               Self.segmentCache.object(forKey: segmentText as NSString) == nil {
+                Self.segmentCache.setObject(
+                    SegmentCacheEntry(result),
+                    forKey: segmentText as NSString,
+                    cost: segmentText.utf8.count * 10
+                )
             }
         }
     }
@@ -55,10 +48,8 @@ extension ChatBubble {
     /// large messages that haven't been synchronously cached yet.
     func resolveSegments(for text: String, isStreaming: Bool) -> [MarkdownSegment] {
         // Check the synchronous cache first (fast path for all sizes)
-        if let cached = Self.segmentCache[text] {
-            Self.lruCounter += 1
-            Self.segmentCache[text] = (cached.value, Self.lruCounter)
-            return cached.value
+        if let cached = Self.segmentCache.object(forKey: text as NSString) {
+            return cached.segments
         }
         // For large text with a cache miss, return async result or plain placeholder
         if !isStreaming, text.count > Self.asyncParseThreshold {
@@ -73,15 +64,13 @@ extension ChatBubble {
     }
 
     /// Cached markdown segment parser to avoid re-parsing on every render.
-    /// When `isStreaming` is true the result is not stored in the main LRU
+    /// When `isStreaming` is true the result is not stored in the main
     /// cache (to avoid filling it with intermediate text states), but a
     /// single-entry dedup cache returns the previous result when the text
     /// hasn't changed between SwiftUI reevaluations.
     static func cachedSegments(for text: String, isStreaming: Bool = false) -> [MarkdownSegment] {
-        if let cached = segmentCache[text] {
-            lruCounter += 1
-            segmentCache[text] = (cached.value, lruCounter)
-            return cached.value
+        if let cached = segmentCache.object(forKey: text as NSString) {
+            return cached.segments
         }
         // Streaming dedup: return the last-parsed result when text is unchanged.
         if isStreaming, let last = lastStreamingSegments, last.text == text {
@@ -95,18 +84,11 @@ extension ChatBubble {
         // Skip caching for very long text to avoid a single huge entry
         // evicting many smaller, more frequently accessed entries.
         if text.count > maxCacheableTextLength { return result }
-        if segmentCache.count >= maxCacheSize {
-            // Evict the least-recently-used entry (lowest accessTime).
-            if let lruKey = segmentCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
-                estimatedCacheBytes -= estimatedBytes(for: lruKey)
-                segmentCache.removeValue(forKey: lruKey)
-            }
-        }
-        lruCounter += 1
-        let cost = estimatedBytes(for: text)
-        segmentCache[text] = (result, lruCounter)
-        estimatedCacheBytes += cost
-        evictIfOverBudget()
+        segmentCache.setObject(
+            SegmentCacheEntry(result),
+            forKey: text as NSString,
+            cost: text.utf8.count * 10
+        )
         return result
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -3,6 +3,11 @@ import os
 import SwiftUI
 import VellumAssistantShared
 
+private final class AttributedStringCacheEntry: NSObject {
+    let attributedString: AttributedString
+    init(_ attributedString: AttributedString) { self.attributedString = attributedString }
+}
+
 /// Reusable view that renders parsed `MarkdownSegment` arrays.
 /// Groups consecutive text-selectable segments (text, headings, lists) into
 /// unified Text views so that text selection can span across paragraphs.
@@ -188,23 +193,25 @@ struct MarkdownSegmentView: View, Equatable {
     /// Keyed by a combined hash of the segment values and style colors so
     /// identical segment arrays return the cached value instead of re-parsing
     /// markdown and re-creating `AttributedString` on every SwiftUI body
-    /// evaluation. Each entry stores (value, accessTime, estimatedBytes) for
-    /// LRU eviction and byte-budget enforcement.
-    @MainActor private static var attributedStringCache: [Int: (value: AttributedString, accessTime: Int, estimatedBytes: Int)] = [:]
-    @MainActor private static var lruCounter: Int = 0
-    private static let attributedStringCacheLimit = 200
+    /// evaluation. NSCache handles eviction automatically under memory pressure.
+    @MainActor private static var attributedStringCache: NSCache<NSNumber, AttributedStringCacheEntry> = {
+        let cache = NSCache<NSNumber, AttributedStringCacheEntry>()
+        cache.countLimit = 500
+        cache.totalCostLimit = 5_000_000
+        return cache
+    }()
 
     // MARK: - Cache Guardrails
 
     private static let maxCacheableTextLength = 10_000
-    private static let maxCacheBytes = 5_000_000
-    @MainActor static var estimatedCacheBytes: Int = 0
+    /// Cache for prefix width measurements to avoid repeated Core Text layout calls.
+    @MainActor private static var prefixWidthCache: [String: CGFloat] = [:]
 
     /// Clears the attributed string cache.  Called when switching conversations
     /// or archiving a conversation to reclaim memory.
     static func clearAttributedStringCache() {
-        attributedStringCache.removeAll()
-        estimatedCacheBytes = 0
+        attributedStringCache.removeAllObjects()
+        prefixWidthCache.removeAll()
         groupedSegmentsCache.removeAll()
         MarkdownTableView.clearCellAttributedStringCache()
     }
@@ -220,16 +227,6 @@ struct MarkdownSegmentView: View, Equatable {
             case .table(let h, let r): return total + h.joined().count + r.flatMap { $0 }.joined().count
             case .image, .horizontalRule: return total
             }
-        }
-    }
-
-    /// Evicts the oldest entries until `estimatedCacheBytes` drops below
-    /// `maxCacheBytes`.
-    @MainActor private static func evictIfOverBudget() {
-        while estimatedCacheBytes > maxCacheBytes {
-            guard let lruKey = attributedStringCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key else { break }
-            let entry = attributedStringCache.removeValue(forKey: lruKey)
-            estimatedCacheBytes -= entry?.estimatedBytes ?? 0
         }
     }
 
@@ -251,10 +248,9 @@ struct MarkdownSegmentView: View, Equatable {
         hasher.combine(codeBackgroundColor.description)
         let cacheKey = hasher.finalize()
 
-        if let cached = Self.attributedStringCache[cacheKey] {
-            Self.lruCounter += 1
-            Self.attributedStringCache[cacheKey] = (cached.value, Self.lruCounter, cached.estimatedBytes)
-            return cached.value
+        let cacheKeyNS = cacheKey as NSNumber
+        if let cached = Self.attributedStringCache.object(forKey: cacheKeyNS)?.attributedString {
+            return cached
         }
 
         let result = Self.buildAttributedStringUncached(from: segments, secondaryTextColor: secondaryTextColor, codeTextColor: codeTextColor, codeBackgroundColor: codeBackgroundColor)
@@ -264,22 +260,9 @@ struct MarkdownSegmentView: View, Equatable {
         let textLen = Self.segmentTextLength(segments)
         if textLen > Self.maxCacheableTextLength { return result }
 
-        // Evict the least-recently-used entry when the cache is full.
-        if Self.attributedStringCache.count >= Self.attributedStringCacheLimit {
-            if let lruKey = Self.attributedStringCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
-                let evicted = Self.attributedStringCache.removeValue(forKey: lruKey)
-                Self.estimatedCacheBytes -= evicted?.estimatedBytes ?? 0
-            }
-        }
-        Self.lruCounter += 1
-        // Use 10 bytes per character to match the M3 fix in ChatBubble.swift (PR #11825);
-        // AttributedString carries font, color, and paragraph metadata on top of raw text,
-        // so a 3x multiplier underestimates real cost by ~3.3x and lets the cache silently
-        // exceed its 5 MB budget.
-        let cost = textLen * 10
-        Self.attributedStringCache[cacheKey] = (result, Self.lruCounter, cost)
-        Self.estimatedCacheBytes += cost
-        Self.evictIfOverBudget()
+        // Use 10 bytes per character to estimate cost; AttributedString carries
+        // font, color, and paragraph metadata on top of raw text.
+        Self.attributedStringCache.setObject(AttributedStringCacheEntry(result), forKey: cacheKeyNS, cost: textLen * 10)
         return result
     }
 
@@ -323,10 +306,18 @@ struct MarkdownSegmentView: View, Equatable {
 
                     // Apply hanging indent so wrapped lines align with item text
                     let prefixText = indentString + prefix
-                    // Measure actual prefix width using the font
-                    let font = NSFont.systemFont(ofSize: 14)
-                    let prefixNS = NSString(string: prefixText)
-                    let prefixWidth = prefixNS.size(withAttributes: [.font: font]).width
+                    // Measure actual prefix width using the font (cached to avoid repeated Core Text calls)
+                    let prefixWidth: CGFloat
+                    if let cached = prefixWidthCache[prefixText] {
+                        prefixWidth = cached
+                    } else {
+                        let font = NSFont.systemFont(ofSize: 14)
+                        let prefixNS = NSString(string: prefixText)
+                        prefixWidth = prefixNS.size(withAttributes: [.font: font]).width
+                        if prefixWidthCache.count < 200 {
+                            prefixWidthCache[prefixText] = prefixWidth
+                        }
+                    }
                     let paragraphStyle = NSMutableParagraphStyle()
                     paragraphStyle.headIndent = prefixWidth
                     paragraphStyle.firstLineHeadIndent = 0

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -1082,8 +1082,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     /// Called on conversation close, archive, and switch to prevent unbounded
     /// growth of cached `AttributedString` / segment data across conversations.
     private static func clearRenderCaches() {
-        ChatBubble.segmentCache.removeAll()
-        ChatBubble.estimatedCacheBytes = 0
+        ChatBubble.segmentCache.removeAllObjects()
         ChatBubble.lastStreamingSegments = nil
         MarkdownSegmentView.clearAttributedStringCache()
     }

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1545,7 +1545,7 @@ public struct SkillInvocationData: Equatable {
 }
 
 /// Identifies a content block within a ChatMessage for interleaving order.
-public enum ContentBlockRef: Equatable {
+public enum ContentBlockRef: Hashable {
     case text(Int)
     case toolCall(Int)
     case surface(Int)


### PR DESCRIPTION
## Summary
Replace hand-rolled LRU caches with NSCache and fix main-thread blocking during scroll in old conversations. The primary causes of the rainbow spinner were: O(n) cache eviction scans during cold-scroll bursts, synchronous file I/O on the main actor in image loading, and redundant interleaved content computation on every ChatBubble init.

## Changes
- **M1:** Replaced segmentCache dictionary with NSCache<NSString, SegmentCacheEntry> (countLimit=500, totalCostLimit=5MB), eliminating O(n) min(by:) eviction scans and manual byte tracking
- **M2:** Replaced attributedStringCache with NSCache<NSNumber, AttributedStringCacheEntry>, added prefixWidthCache for NSString.size(withAttributes:) results (capped at 200 entries)
- **M3:** Moved Data(contentsOf:) and FileManager.attributesOfItem into Task.detached so disk I/O doesn't block the main thread; cached workspace directory to eliminate per-image LockfileAssistant calls
- **M4:** Memoized ChatBubble.init() interleaved content computation by (messageId, contentOrder hash, per-segment emptiness), capped at 500 entries

## Milestone PRs (merged into feature branch)
- #20999: M1: Replace segmentCache with NSCache in ChatBubbleTextContent
- #21003: M2: Replace attributedStringCache with NSCache + cache prefix widths
- #21004: M3: Move AnimatedImageView file I/O off main thread
- #21006: M4: Memoize ChatBubble interleaved content computation

## Project issue
Closes #20994

## Test plan
- [ ] Scroll up in a long old conversation — verify no rainbow spinner / significantly reduced jank
- [ ] Switch conversations, then scroll up — caches invalidate correctly
- [ ] Conversations with images — images still load, GIFs animate
- [ ] Search in chat — search results still highlight correctly
- [ ] Switch assistants — workspace-relative image paths resolve correctly
- [ ] Streaming responses with tool calls — interleaved layout renders correctly
- [ ] Messages with numbered/bulleted lists — hanging indent alignment unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
