### PR TITLE
fix: address review gaps in platform backup/restore/rollback CLI

### DIFF
--- a/cli/src/commands/restore.ts
+++ b/cli/src/commands/restore.ts
@@ -377,6 +377,11 @@ async function restorePlatform(
     process.exit(1);
   }
 
+  if (importResult.statusCode < 200 || importResult.statusCode >= 300) {
+    console.error(`Error: Import failed (${importResult.statusCode})`);
+    process.exit(1);
+  }
+
   const result = importResult.body as unknown as ImportResponse;
 
   if (!result.success) {
@@ -397,7 +402,7 @@ async function restorePlatform(
     files_skipped: 0,
     backups_created: 0,
   };
-  console.log("Restore complete.");
+  console.log("✅ Restore complete.");
   console.log(`  Files created:     ${summary.files_created}`);
   console.log(`  Files overwritten: ${summary.files_overwritten}`);
   console.log(`  Files skipped:     ${summary.files_skipped}`);
@@ -470,6 +475,13 @@ export async function restore(): Promise<void> {
   if (cloud === "vellum") {
     await restorePlatform(entry, name, bundleData, { version, dryRun });
     return;
+  }
+
+  if (version && cloud !== "docker") {
+    console.error(
+      "Restore with --version is only supported for Docker and managed assistants.",
+    );
+    process.exit(1);
   }
 
   // Obtain auth token (acquired before dry-run or before data import;

--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -230,7 +230,11 @@ async function rollbackPlatformViaEndpoint(
         `Target version is not older than the current version. Use 'vellum upgrade --version' instead.`,
       );
     } else if (detail.includes("not found")) {
-      console.error(`Version ${version} not found.`);
+      console.error(
+        version
+          ? `Version ${version} not found.`
+          : `Rollback target not found.`,
+      );
     } else if (
       err instanceof TypeError ||
       detail.includes("fetch failed") ||

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -132,11 +132,6 @@ export async function fetchCurrentUser(token: string): Promise<PlatformUser> {
 // Rollback
 // ---------------------------------------------------------------------------
 
-interface RollbackResponse {
-  detail: string;
-  version: string | null;
-}
-
 export async function rollbackPlatformAssistant(
   token: string,
   orgId: string,
@@ -153,8 +148,9 @@ export async function rollbackPlatformAssistant(
     body: JSON.stringify(version ? { version } : {}),
   });
 
-  const body = (await response.json()) as RollbackResponse & {
+  const body = (await response.json().catch(() => ({}))) as {
     detail?: string;
+    version?: string | null;
   };
 
   if (response.status === 200) {

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -154,7 +154,7 @@ export async function rollbackPlatformAssistant(
   };
 
   if (response.status === 200) {
-    return { detail: body.detail, version: body.version };
+    return { detail: body.detail ?? "", version: body.version ?? null };
   }
 
   if (response.status === 400) {


### PR DESCRIPTION
## Summary
Fixes 5 gaps found during self-review of platform-backup-restore plan:

1. **Restore topology guard**: Re-add guard preventing GCP/custom/local from hitting Docker rollback path with --version
2. **JSON parse safety**: Wrap rollbackPlatformAssistant response.json() with .catch() for non-JSON 502 responses
3. **Import catch-all**: Add catch-all status code check in restore import path (matching preflight pattern)
4. **Emoji parity**: Add missing emoji to platform restore success message
5. **Undefined interpolation**: Handle version-less 404 error message in rollback

Part of plan: platform-backup-restore.md (review fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
