### PR TITLE
docs: add AGENTS.md for bundled skills tool registration

### DIFF
--- a/assistant/src/config/bundled-skills/AGENTS.md
+++ b/assistant/src/config/bundled-skills/AGENTS.md
@@ -1,0 +1,34 @@
+# Bundled Skills — Agent Instructions
+
+## Registering Tool Executors
+
+When you add a new tool executor to a bundled skill's `TOOLS.json`, you **must** also register it in `assistant/src/config/bundled-tool-registry.ts`. Each new executor needs two things:
+
+1. **A static import** at the top of the file, grouped under the skill's section comment.
+2. **A registry entry** in the `bundledToolRegistry` map.
+
+### Example (settings skill)
+
+```ts
+// ── settings ───────────────────────────────────────────────────────────────────
+import * as avatarUpdate from "./bundled-skills/settings/tools/avatar-update.js";
+// ... other imports ...
+
+export const bundledToolRegistry = new Map<string, SkillToolScript>([
+  // settings
+  ["settings:tools/avatar-update.ts", avatarUpdate],
+  // ... other entries ...
+]);
+```
+
+The map key format is `skillDirBasename:executorPath` (e.g. `settings:tools/avatar-update.ts`).
+
+### Why this is required
+
+`knip` (`lint:unused`) flags dynamically-loaded executor files as unused exports unless they have a static import somewhere in the dependency graph. The registry provides that static import while also enabling the compiled Bun binary to bundle the scripts (since dynamic imports from the filesystem don't work inside `/$bunfs/`).
+
+You can regenerate the full registry with:
+
+```sh
+bun run scripts/generate-bundled-tool-registry.ts
+```


### PR DESCRIPTION
## Summary
- Adds `assistant/src/config/bundled-skills/AGENTS.md` documenting that new tool executors in bundled skills must be registered in `bundled-tool-registry.ts`
- Explains the two required steps (static import + registry entry) with an example
- Notes why this matters: knip flags unregistered executors as unused, and the Bun binary needs static imports

## Test plan
- [ ] Verify the file renders correctly on GitHub
- [ ] Confirm no other changes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21012" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
