### PR TITLE
feat: add providerNotConfigured conversation error category in shared Swift code

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -159,6 +159,8 @@ struct ChatConversationErrorToast: View {
             return .refreshCw
         case .authenticationRequired:
             return .lock
+        case .providerNotConfigured:
+            return .keyRound
         case .unknown:
             return .circleAlert
         }

--- a/clients/shared/Features/Chat/ChatConversationError.swift
+++ b/clients/shared/Features/Chat/ChatConversationError.swift
@@ -13,6 +13,7 @@ public enum ConversationErrorCategory: Equatable, Sendable {
     case processingFailed
     case regenerateFailed
     case authenticationRequired
+    case providerNotConfigured
     case unknown
 
     public init(from code: ConversationErrorCode) {
@@ -39,6 +40,8 @@ public enum ConversationErrorCategory: Equatable, Sendable {
             self = .regenerateFailed
         case .authenticationRequired:
             self = .authenticationRequired
+        case .providerNotConfigured:
+            self = .providerNotConfigured
         case .unknown:
             self = .unknown
         }
@@ -69,6 +72,8 @@ public enum ConversationErrorCategory: Equatable, Sendable {
             return "Click Retry to regenerate, or send a new message instead."
         case .authenticationRequired:
             return "Sign in or check your credentials in Settings to continue."
+        case .providerNotConfigured:
+            return "Add your API key in Settings to continue."
         case .unknown:
             return "Click Retry or send a new message. Copy debug info if the problem repeats."
         }

--- a/clients/shared/Features/Chat/InlineChatErrorAlert.swift
+++ b/clients/shared/Features/Chat/InlineChatErrorAlert.swift
@@ -45,6 +45,7 @@ public struct InlineChatErrorAlert: View {
         case .conversationAborted: return .circleStop
         case .processingFailed, .regenerateFailed: return .refreshCw
         case .authenticationRequired: return .lock
+        case .providerNotConfigured: return .keyRound
         case .unknown: return .circleAlert
         }
     }
@@ -62,6 +63,7 @@ public struct InlineChatErrorAlert: View {
         case .processingFailed: return "Processing Failed"
         case .regenerateFailed: return "Regeneration Failed"
         case .authenticationRequired: return "Authentication Required"
+        case .providerNotConfigured: return "API Key Required"
         case .unknown: return "Error"
         }
     }

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1245,6 +1245,7 @@ public enum ConversationErrorCode: String, CaseIterable, Codable, Sendable {
     case conversationProcessingFailed = "CONVERSATION_PROCESSING_FAILED"
     case regenerateFailed = "REGENERATE_FAILED"
     case authenticationRequired = "AUTHENTICATION_REQUIRED"
+    case providerNotConfigured = "PROVIDER_NOT_CONFIGURED"
     case unknown = "UNKNOWN"
 
     /// Fall back to `.unknown` for unrecognized codes so that version skew


### PR DESCRIPTION
## Summary
- Add providerNotConfigured case to ConversationErrorCategory enum
- Wire PROVIDER_NOT_CONFIGURED code string to the new category
- Add recovery suggestion and category title for the new error type

Part of plan: inline-api-key-error.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
