### PR TITLE
fix: harden platform backup/restore/rollback against non-JSON responses and network errors

### DIFF
--- a/cli/src/commands/backup.ts
+++ b/cli/src/commands/backup.ts
@@ -233,7 +233,19 @@ async function backupPlatform(name: string, outputArg?: string): Promise<void> {
   let downloadUrl: string | undefined;
 
   while (Date.now() < deadline) {
-    const status = await platformPollExportStatus(jobId, token, orgId);
+    let status: { status: string; downloadUrl?: string; error?: string };
+    try {
+      status = await platformPollExportStatus(jobId, token, orgId);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // Let non-transient errors (e.g. 404 "job not found") propagate immediately
+      if (msg.includes("not found")) {
+        throw err;
+      }
+      console.warn(`Polling failed, retrying... (${msg})`);
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+      continue;
+    }
 
     if (status.status === "complete") {
       downloadUrl = status.downloadUrl;

--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -197,7 +197,19 @@ async function rollbackPlatformViaEndpoint(
     process.exit(1);
   }
 
-  const orgId = await fetchOrganizationId(token);
+  let orgId: string;
+  try {
+    orgId = await fetchOrganizationId(token);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("401") || msg.includes("403")) {
+      console.error("Authentication failed. Run 'vellum login' to refresh.");
+    } else {
+      console.error(`Error: ${msg}`);
+    }
+    emitCliError("AUTH_FAILED", "Failed to authenticate with platform", msg);
+    process.exit(1);
+  }
 
   // Step 4 — Broadcast starting event
   console.log("📢 Notifying connected clients...");

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -283,7 +283,10 @@ export async function platformImportPreflight(
     },
   );
 
-  const body = (await response.json()) as Record<string, unknown>;
+  const body = (await response.json().catch(() => ({}))) as Record<
+    string,
+    unknown
+  >;
   return { statusCode: response.status, body };
 }
 
@@ -304,6 +307,9 @@ export async function platformImportBundle(
     signal: AbortSignal.timeout(120_000),
   });
 
-  const body = (await response.json()) as Record<string, unknown>;
+  const body = (await response.json().catch(() => ({}))) as Record<
+    string,
+    unknown
+  >;
   return { statusCode: response.status, body };
 }


### PR DESCRIPTION
## Summary
Fixes 3 gaps from review round 2 of platform-backup-restore plan:

1. **JSON parse safety for import functions**: Wrap response.json() with .catch() in platformImportPreflight and platformImportBundle to handle non-JSON 502 responses (matching rollbackPlatformAssistant pattern)
2. **Rollback auth error handling**: Wrap fetchOrganizationId in try/catch in rollbackPlatformViaEndpoint to broadcast failure event and show actionable error (matching backup/restore pattern)
3. **Backup polling resilience**: Add try/catch inside polling loop to survive transient network errors during 5-minute export poll

Part of plan: platform-backup-restore.md (review fix round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
