### PR TITLE
feat: add MissingApiKeyBanner inline card for chat conversation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -236,3 +236,51 @@ struct CreditsExhaustedBanner: View {
         .transition(.move(edge: .bottom).combined(with: .opacity))
     }
 }
+
+// MARK: - Missing API Key Banner
+
+/// Inline banner shown when the user attempts to chat without a configured API key.
+/// Presents a dismiss button, title, subtitle, and a full-width CTA to open settings.
+struct MissingApiKeyBanner: View {
+    let onOpenSettings: () -> Void
+    let onDismiss: (() -> Void)?
+
+    var body: some View {
+        VStack(spacing: VSpacing.md) {
+            HStack {
+                Spacer()
+                Button { onDismiss?() } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(VColor.contentSecondary)
+                }
+                .buttonStyle(.plain)
+            }
+
+            VStack(spacing: VSpacing.xs) {
+                Text("API key required")
+                    .font(VFont.headline)
+                    .foregroundStyle(VColor.contentEmphasized)
+                Text("Add an API key in Settings to start chatting.")
+                    .font(VFont.bodyMedium)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
+
+            VButton(label: "Open Settings", style: .primary) {
+                onOpenSettings()
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .padding(VSpacing.lg)
+        .background(VColor.surfaceActive)
+        .clipShape(
+            UnevenRoundedRectangle(
+                topLeadingRadius: VRadius.lg,
+                bottomLeadingRadius: 0,
+                bottomTrailingRadius: 0,
+                topTrailingRadius: VRadius.lg
+            )
+        )
+        .transition(.move(edge: .bottom).combined(with: .opacity))
+    }
+}


### PR DESCRIPTION
## Summary
- Add MissingApiKeyBanner view struct in ChatErrorToastView.swift
- Follows the same pattern as CreditsExhaustedBanner with dismiss X, title, subtitle, and full-width CTA
- Matches existing visual style (background, corner radii, transitions)

Part of plan: inline-api-key-error.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
