### PR TITLE
feat: display MissingApiKeyBanner inline in chat when provider is not configured

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -102,6 +102,15 @@ struct ChatView: View {
     /// Dismisses the credits-exhausted banner.
     var onDismissCreditsExhausted: (() -> Void)? = nil
 
+    // MARK: - Provider Not Configured (inline banner)
+
+    /// Non-nil when the conversation ended because no provider is configured.
+    var providerNotConfiguredError: ConversationError? = nil
+    /// Opens the Models & Services settings tab.
+    var onOpenModelsAndServices: (() -> Void)? = nil
+    /// Dismisses the provider-not-configured banner.
+    var onDismissProviderNotConfigured: (() -> Void)? = nil
+
     // MARK: - Pagination
 
     var displayedMessageCount: Int = .max
@@ -264,6 +273,16 @@ struct ChatView: View {
                         if let exhaustedError = creditsExhaustedError, exhaustedError.isCreditsExhausted {
                             CreditsExhaustedBanner(
                                 onAddFunds: { onAddFunds?() }
+                            )
+                            .frame(maxWidth: VSpacing.chatColumnMaxWidth - 2 * VSpacing.xl)
+                            .frame(maxWidth: .infinity)
+                            .padding(.bottom, -VSpacing.sm)
+                        }
+
+                        if let _ = providerNotConfiguredError {
+                            MissingApiKeyBanner(
+                                onOpenSettings: { onOpenModelsAndServices?() },
+                                onDismiss: { onDismissProviderNotConfigured?() }
                             )
                             .frame(maxWidth: VSpacing.chatColumnMaxWidth - 2 * VSpacing.xl)
                             .frame(maxWidth: .infinity)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -1411,9 +1411,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             return self.isLatestToolUseRecipient(viewModel)
         }
         viewModel.shouldCreateInlineErrorMessage = { error in
-            // Credits-exhausted errors use the dedicated CreditsExhaustedBanner
-            // instead of the generic InlineChatErrorAlert
-            !error.isCreditsExhausted
+            // Credits-exhausted and provider-not-configured errors use dedicated
+            // inline banners instead of the generic InlineChatErrorAlert
+            !error.isCreditsExhausted && !error.isProviderNotConfigured
         }
         viewModel.onInlineConfirmationResponse = { [weak self] requestId, decision in
             // The decision was already sent to the daemon by ChatViewModel.

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -755,6 +755,12 @@ struct ActiveChatViewWrapper: View {
                 windowState.selection = .panel(.settings)
             },
             onDismissCreditsExhausted: { viewModel.dismissConversationError() },
+            providerNotConfiguredError: viewModel.errorManager.conversationError?.isProviderNotConfigured == true ? viewModel.errorManager.conversationError : nil,
+            onOpenModelsAndServices: {
+                settingsStore.pendingSettingsTab = .modelsAndServices
+                windowState.selection = .panel(.settings)
+            },
+            onDismissProviderNotConfigured: { viewModel.dismissConversationError() },
             displayedMessageCount: viewModel.displayedMessageCount,
             hasMoreMessages: viewModel.hasMoreMessages,
             isLoadingMoreMessages: viewModel.isLoadingMoreMessages,

--- a/clients/shared/Features/Chat/ChatConversationError.swift
+++ b/clients/shared/Features/Chat/ChatConversationError.swift
@@ -116,4 +116,9 @@ public struct ConversationError: Equatable {
     public var isCreditsExhausted: Bool {
         errorCategory?.hasSuffix("credits_exhausted") == true
     }
+
+    /// Whether this error indicates that no provider is configured for inference.
+    public var isProviderNotConfigured: Bool {
+        category == .providerNotConfigured
+    }
 }


### PR DESCRIPTION
## Summary
- Add isProviderNotConfigured computed property on ConversationError
- Wire MissingApiKeyBanner into ChatView with Open Settings CTA and dismiss action
- Filter providerNotConfigured errors from generic InlineChatErrorAlert rendering
- Connect through PanelCoordinator to navigate to Models & Services settings

Part of plan: inline-api-key-error.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
