### PR TITLE
feat: remove pre-send "Add an API key" banner and allow sending without API key

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -64,7 +64,6 @@ public final class MainWindowState: ObservableObject {
     @Published var activeDynamicSurface: UiSurfaceShowMessage?
     @Published var activeDynamicParsedSurface: Surface?
     @Published var hasAPIKey: Bool
-    @Published var needsInferenceApiKey: Bool = false
     @Published var workspaceComposerExpanded = false
     @Published var layoutConfig: LayoutConfig
     @Published var toastInfo: ToastInfo?
@@ -138,7 +137,6 @@ public final class MainWindowState: ObservableObject {
         self.layoutConfig = LayoutConfigStore.load()
         self.navigationHistoryCancellable = navigationHistory.objectWillChange
             .sink { [weak self] _ in self?.objectWillChange.send() }
-        refreshInferenceApiKeyStatus()
     }
 
     // MARK: - Selection Helpers
@@ -235,49 +233,6 @@ public final class MainWindowState: ObservableObject {
 
     func refreshAPIKeyStatus(isConnected: Bool, isAuthenticated: Bool) {
         hasAPIKey = APIKeyManager.hasAnyKey() || isConnected || isAuthenticated
-    }
-
-    /// Re-evaluates whether the "API key not set" toast should appear based on
-    /// authentication state, the workspace config's inference service mode, and
-    /// the selected provider's API key presence in the daemon's credential store.
-    ///
-    /// `needsInferenceApiKey` is `true` only when:
-    /// - The user is **not** authenticated, AND
-    /// - `services.inference.mode` is `"your-own"`, AND
-    /// - the configured provider (defaulting to `"anthropic"`) has no API key
-    ///   in the daemon's credential store.
-    ///
-    /// Authenticated users always have access to managed inference through the
-    /// platform, so the banner is never shown for them.
-    func refreshInferenceApiKeyStatus(isAuthenticated: Bool = false) {
-        if isAuthenticated {
-            needsInferenceApiKey = false
-            return
-        }
-        Task {
-            let client = SettingsClient()
-            let config = await client.fetchConfig() ?? [:]
-            let result = await resolveInferenceApiKeyNeeded(config: config, client: client)
-            await MainActor.run { needsInferenceApiKey = result }
-        }
-    }
-
-    /// Determines whether the inference API key banner should be shown by
-    /// checking the daemon's credential store rather than the macOS app's
-    /// local keychain.
-    private func resolveInferenceApiKeyNeeded(
-        config: [String: Any],
-        client: SettingsClientProtocol
-    ) async -> Bool {
-        guard let services = config["services"] as? [String: Any],
-              let inference = services["inference"] as? [String: Any],
-              let mode = inference["mode"] as? String,
-              mode == "your-own" else {
-            return false
-        }
-        let provider = (inference["provider"] as? String) ?? "anthropic"
-        let exists = await client.checkApiKeyExists(provider: provider)
-        return !exists
     }
 
     func applyLayoutConfig(_ wire: UiLayoutConfigMessage) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -580,7 +580,6 @@ struct MainWindowView: View {
                 ErrorToastOverlay(
                     errorManager: viewModel.errorManager,
                     hasAPIKey: windowState.hasAPIKey,
-                    needsInferenceApiKey: windowState.needsInferenceApiKey,
                     onOpenModelsAndServices: {
                         settingsStore.pendingSettingsTab = .modelsAndServices
                         windowState.selection = .panel(.settings)
@@ -592,20 +591,6 @@ struct MainWindowView: View {
                     onRetryLastMessage: { viewModel.retryLastMessage() },
                     onDismissError: { viewModel.dismissError() }
                 )
-            } else if windowState.needsInferenceApiKey {
-                ChatConversationErrorToast(
-                    message: "Add an API key to start chatting.",
-                    icon: .keyRound,
-                    accentColor: VColor.systemMidStrong,
-                    actionLabel: "Open Settings",
-                    onAction: {
-                        settingsStore.pendingSettingsTab = .modelsAndServices
-                        windowState.selection = .panel(.settings)
-                    }
-                )
-                .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
-                .padding(.top, VSpacing.sm)
-                .animation(VAnimation.fast, value: windowState.needsInferenceApiKey)
             }
         }
         .frame(maxWidth: .infinity, alignment: .center)
@@ -706,9 +691,6 @@ struct MainWindowView: View {
             }
             .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
                 refreshWindowAPIStatus(isConnected: connectionManager.isConnected, isAuthenticated: authManager.isAuthenticated)
-            }
-            .onReceive(NotificationCenter.default.publisher(for: .inferenceConfigDidChange)) { _ in
-                windowState.refreshInferenceApiKeyStatus(isAuthenticated: authManager.isAuthenticated)
             }
             .onReceive(connectionManager.$isConnected) { connected in
                 handleDaemonConnectionChange(connected)
@@ -865,7 +847,6 @@ struct MainWindowView: View {
 
     private func refreshWindowAPIStatus(isConnected: Bool, isAuthenticated: Bool) {
         windowState.refreshAPIKeyStatus(isConnected: isConnected, isAuthenticated: isAuthenticated)
-        windowState.refreshInferenceApiKeyStatus(isAuthenticated: isAuthenticated)
     }
 
     private func handleDaemonConnectionChange(_ connected: Bool) {
@@ -1262,7 +1243,6 @@ struct MainWindowView: View {
 private struct ErrorToastOverlay: View {
     @ObservedObject var errorManager: ChatErrorManager
     let hasAPIKey: Bool
-    let needsInferenceApiKey: Bool
     let onOpenModelsAndServices: () -> Void
     let onRetryConversationError: () -> Void
     let onCopyDebugInfo: () -> Void
@@ -1273,17 +1253,6 @@ private struct ErrorToastOverlay: View {
 
     var body: some View {
         VStack(alignment: .center, spacing: VSpacing.xs) {
-            if needsInferenceApiKey {
-                ChatConversationErrorToast(
-                    message: "Add an API key to start chatting.",
-                    icon: .keyRound,
-                    accentColor: VColor.systemMidStrong,
-                    actionLabel: "Open Settings",
-                    onAction: onOpenModelsAndServices
-                )
-                .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
-            }
-
             if let conversationError = errorManager.conversationError, !conversationError.isCreditsExhausted, !errorManager.isConversationErrorDisplayedInline {
                 ChatConversationErrorToast(
                     error: conversationError,
@@ -1306,7 +1275,6 @@ private struct ErrorToastOverlay: View {
             }
         }
         .padding(.top, VSpacing.sm)
-        .animation(VAnimation.fast, value: needsInferenceApiKey)
         .animation(VAnimation.fast, value: errorManager.conversationError != nil)
         .animation(VAnimation.fast, value: errorManager.errorText != nil)
     }


### PR DESCRIPTION
## Summary
- Remove the yellow 'Add an API key to start chatting' banner from MainWindowView
- Remove needsInferenceApiKey published property and its refresh logic from MainWindowState
- Remove all call sites of refreshInferenceApiKeyStatus throughout the codebase
- ErrorToastOverlay no longer references needsInferenceApiKey

Part of plan: inline-api-key-error.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
