### PR TITLE
Unify platform URL resolution across assistant and CLI

### DIFF
--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -13,7 +13,10 @@
  * imported from platform/logger without circular imports.
  */
 
+import { existsSync, readFileSync } from "node:fs";
+
 import { getLogger } from "../util/logger.js";
+import { getWorkspaceConfigPath } from "../util/platform.js";
 import { checkUnrecognizedEnvVars } from "./env-registry.js";
 
 const log = getLogger("env");
@@ -137,6 +140,27 @@ export function getOllamaBaseUrlEnv(): string | undefined {
 
 // ── Platform ─────────────────────────────────────────────────────────────────
 
+/**
+ * Read the platform base URL from the workspace config file
+ * (~/.vellum/workspace/config.json → platform.baseUrl).
+ */
+function getConfigPlatformUrl(): string | undefined {
+  try {
+    const configPath = getWorkspaceConfigPath();
+    if (!existsSync(configPath)) return undefined;
+    const raw = JSON.parse(readFileSync(configPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    const platform = raw.platform as Record<string, unknown> | undefined;
+    const baseUrl = platform?.baseUrl;
+    if (typeof baseUrl === "string" && baseUrl.trim()) return baseUrl.trim();
+  } catch {
+    // ignore
+  }
+  return undefined;
+}
+
 let _platformBaseUrlOverride: string | undefined;
 
 export function setPlatformBaseUrl(value: string | undefined): void {
@@ -144,7 +168,12 @@ export function setPlatformBaseUrl(value: string | undefined): void {
 }
 
 export function getPlatformBaseUrl(): string {
-  return str("VELLUM_PLATFORM_URL") ?? _platformBaseUrlOverride ?? "";
+  return (
+    getConfigPlatformUrl() ||
+    str("VELLUM_PLATFORM_URL") ||
+    _platformBaseUrlOverride ||
+    "https://platform.vellum.ai"
+  );
 }
 
 let _platformAssistantIdOverride: string | undefined;

--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -14,10 +14,15 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
-import { getWorkspaceConfigPath } from "../util/platform.js";
-import { checkUnrecognizedEnvVars } from "./env-registry.js";
+import {
+  checkUnrecognizedEnvVars,
+  getBaseDataDir,
+  getWorkspaceDirOverride,
+} from "./env-registry.js";
 
 const log = getLogger("env");
 
@@ -143,10 +148,17 @@ export function getOllamaBaseUrlEnv(): string | undefined {
 /**
  * Read the platform base URL from the workspace config file
  * (~/.vellum/workspace/config.json → platform.baseUrl).
+ *
+ * Resolves the workspace directory inline (same logic as platform.ts) to
+ * avoid importing from util/platform.js, which many tests mock without
+ * providing every export.
  */
 function getConfigPlatformUrl(): string | undefined {
   try {
-    const configPath = getWorkspaceConfigPath();
+    const wsDir =
+      getWorkspaceDirOverride() ||
+      join(getBaseDataDir() || homedir(), ".vellum", "workspace");
+    const configPath = join(wsDir, "config.json");
     if (!existsSync(configPath)) return undefined;
     const raw = JSON.parse(readFileSync(configPath, "utf-8")) as Record<
       string,

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -13,12 +13,9 @@ import { homedir } from "node:os";
 import { dirname, join, posix, resolve, sep } from "node:path";
 import { gunzipSync } from "node:zlib";
 
+import { getPlatformBaseUrl } from "../config/env.js";
 import { getLogger } from "../util/logger.js";
-import {
-  getWorkspaceConfigPath,
-  getWorkspaceSkillsDir,
-  readPlatformToken,
-} from "../util/platform.js";
+import { getWorkspaceSkillsDir, readPlatformToken } from "../util/platform.js";
 import { deleteSkillCapabilityMemory } from "./skill-memory.js";
 
 const log = getLogger("catalog-install");
@@ -70,27 +67,6 @@ export function getRepoSkillsDir(): string | undefined {
 
 // ─── Platform API ────────────────────────────────────────────────────────────
 
-function getConfigPlatformUrl(): string | undefined {
-  try {
-    const configPath = getWorkspaceConfigPath();
-    if (!existsSync(configPath)) return undefined;
-    const raw = JSON.parse(readFileSync(configPath, "utf-8")) as Record<
-      string,
-      unknown
-    >;
-    const platform = raw.platform as Record<string, unknown> | undefined;
-    const baseUrl = platform?.baseUrl;
-    if (typeof baseUrl === "string" && baseUrl.trim()) return baseUrl.trim();
-  } catch {
-    // ignore
-  }
-  return undefined;
-}
-
-function getPlatformUrl(): string {
-  return process.env.VELLUM_PLATFORM_URL ?? getConfigPlatformUrl() ?? "";
-}
-
 function buildHeaders(): Record<string, string> {
   const headers: Record<string, string> = {};
   const token = readPlatformToken();
@@ -103,10 +79,7 @@ function buildHeaders(): Record<string, string> {
 // ─── Catalog operations ──────────────────────────────────────────────────────
 
 export async function fetchCatalog(): Promise<CatalogSkill[]> {
-  const platformUrl = getPlatformUrl();
-  if (!platformUrl) {
-    return [];
-  }
+  const platformUrl = getPlatformBaseUrl();
   const url = `${platformUrl}/v1/skills/`;
   const response = await fetch(url, {
     headers: buildHeaders(),
@@ -214,12 +187,7 @@ export async function fetchAndExtractSkill(
   skillId: string,
   destDir: string,
 ): Promise<void> {
-  const platformUrl = getPlatformUrl();
-  if (!platformUrl) {
-    throw new Error(
-      `Cannot fetch skill "${skillId}": VELLUM_PLATFORM_URL is not configured.`,
-    );
-  }
+  const platformUrl = getPlatformBaseUrl();
   const url = `${platformUrl}/v1/skills/${encodeURIComponent(skillId)}/`;
   const response = await fetch(url, {
     headers: buildHeaders(),

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -9,8 +9,6 @@ import {
 import { homedir } from "os";
 import { join, dirname } from "path";
 
-const DEFAULT_PLATFORM_URL = "";
-
 function getXdgConfigHome(): string {
   return process.env.XDG_CONFIG_HOME?.trim() || join(homedir(), ".config");
 }
@@ -19,22 +17,33 @@ function getPlatformTokenPath(): string {
   return join(getXdgConfigHome(), "vellum", "platform-token");
 }
 
-export function getPlatformUrl(): string {
-  return process.env.VELLUM_PLATFORM_URL ?? DEFAULT_PLATFORM_URL;
+/**
+ * Read the platform base URL from the workspace config file
+ * (~/.vellum/workspace/config.json → platform.baseUrl).
+ */
+function getConfigPlatformUrl(): string | undefined {
+  try {
+    const configPath = join(homedir(), ".vellum", "workspace", "config.json");
+    if (!existsSync(configPath)) return undefined;
+    const raw = JSON.parse(readFileSync(configPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    const platform = raw.platform as Record<string, unknown> | undefined;
+    const baseUrl = platform?.baseUrl;
+    if (typeof baseUrl === "string" && baseUrl.trim()) return baseUrl.trim();
+  } catch {
+    // ignore
+  }
+  return undefined;
 }
 
-/**
- * Returns the platform URL, throwing a clear error if it is not configured.
- * Use this in functions that need a valid URL to make HTTP requests.
- */
-function requirePlatformUrl(): string {
-  const url = getPlatformUrl();
-  if (!url) {
-    throw new Error(
-      "VELLUM_PLATFORM_URL is not configured. Set it in your environment or .env file.",
-    );
-  }
-  return url;
+export function getPlatformUrl(): string {
+  return (
+    getConfigPlatformUrl() ||
+    process.env.VELLUM_PLATFORM_URL ||
+    "https://platform.vellum.ai"
+  );
 }
 
 export function readPlatformToken(): string | null {
@@ -74,7 +83,7 @@ interface OrganizationListResponse {
 }
 
 export async function fetchOrganizationId(token: string): Promise<string> {
-  const platformUrl = requirePlatformUrl();
+  const platformUrl = getPlatformUrl();
   const url = `${platformUrl}/v1/organizations/`;
   const response = await fetch(url, {
     headers: { "X-Session-Token": token },
@@ -106,7 +115,7 @@ interface AllauthSessionResponse {
 }
 
 export async function fetchCurrentUser(token: string): Promise<PlatformUser> {
-  const url = `${requirePlatformUrl()}/_allauth/app/v1/auth/session`;
+  const url = `${getPlatformUrl()}/_allauth/app/v1/auth/session`;
   const response = await fetch(url, {
     headers: { "X-Session-Token": token },
   });
@@ -137,7 +146,7 @@ export async function rollbackPlatformAssistant(
   orgId: string,
   version?: string,
 ): Promise<{ detail: string; version: string | null }> {
-  const platformUrl = requirePlatformUrl();
+  const platformUrl = getPlatformUrl();
   const response = await fetch(`${platformUrl}/v1/assistants/rollback/`, {
     method: "POST",
     headers: {
@@ -181,7 +190,7 @@ export async function platformInitiateExport(
   orgId: string,
   description?: string,
 ): Promise<{ jobId: string; status: string }> {
-  const platformUrl = requirePlatformUrl();
+  const platformUrl = getPlatformUrl();
   const response = await fetch(`${platformUrl}/v1/migrations/export/`, {
     method: "POST",
     headers: {
@@ -214,7 +223,7 @@ export async function platformPollExportStatus(
   token: string,
   orgId: string,
 ): Promise<{ status: string; downloadUrl?: string; error?: string }> {
-  const platformUrl = requirePlatformUrl();
+  const platformUrl = getPlatformUrl();
   const response = await fetch(
     `${platformUrl}/v1/migrations/export/${jobId}/status/`,
     {
@@ -268,7 +277,7 @@ export async function platformImportPreflight(
   token: string,
   orgId: string,
 ): Promise<{ statusCode: number; body: Record<string, unknown> }> {
-  const platformUrl = requirePlatformUrl();
+  const platformUrl = getPlatformUrl();
   const response = await fetch(
     `${platformUrl}/v1/migrations/import-preflight/`,
     {
@@ -295,7 +304,7 @@ export async function platformImportBundle(
   token: string,
   orgId: string,
 ): Promise<{ statusCode: number; body: Record<string, unknown> }> {
-  const platformUrl = requirePlatformUrl();
+  const platformUrl = getPlatformUrl();
   const response = await fetch(`${platformUrl}/v1/migrations/import/`, {
     method: "POST",
     headers: {


### PR DESCRIPTION
## Summary
- Consolidate three separate platform URL helpers into a consistent pattern: config file → env var → runtime override → https://platform.vellum.ai
- Move getConfigPlatformUrl() from catalog-install.ts into env.ts, add fallback to getPlatformBaseUrl()
- Add config file reading to CLI platform-client.ts, remove dead requirePlatformUrl() and DEFAULT_PLATFORM_URL

Part of plan: concurrent-bouncing-eclipse.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
