### PR TITLE
feat: remove hasAPIKey gating from composer so users can send and get inline error

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -8,7 +8,6 @@ import VellumAssistantShared
 /// a `ComposerView` so the user can immediately start typing.
 struct ChatEmptyStateView: View {
     @Binding var inputText: String
-    let hasAPIKey: Bool
     let isSending: Bool
     let isRecording: Bool
     let suggestion: String?
@@ -121,7 +120,6 @@ struct ChatEmptyStateView: View {
     private var composerSection: some View {
         ComposerView(
             inputText: $inputText,
-            hasAPIKey: hasAPIKey,
             isSending: isSending,
             hasPendingConfirmation: false,
             isRecording: isRecording,
@@ -324,7 +322,6 @@ struct FlowLayout: Layout {
 /// Variant shown for temporary (non-persistent) chats.
 struct ChatTemporaryChatEmptyStateView: View {
     @Binding var inputText: String
-    let hasAPIKey: Bool
     let isSending: Bool
     let isRecording: Bool
     let suggestion: String?
@@ -367,7 +364,6 @@ struct ChatTemporaryChatEmptyStateView: View {
 
             ComposerView(
                 inputText: $inputText,
-                hasAPIKey: hasAPIKey,
                 isSending: isSending,
                 hasPendingConfirmation: false,
                 isRecording: isRecording,

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -8,7 +8,6 @@ private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "Ch
 struct ChatView: View {
     let messages: [ChatMessage]
     @Binding var inputText: String
-    let hasAPIKey: Bool
     let isThinking: Bool
     let isCompacting: Bool
     let isSending: Bool
@@ -178,7 +177,6 @@ struct ChatView: View {
                     if isTemporaryChat {
                         ChatTemporaryChatEmptyStateView(
                             inputText: $inputText,
-                            hasAPIKey: hasAPIKey,
                             isSending: isSending,
                             isRecording: isRecording,
                             suggestion: suggestion,
@@ -199,7 +197,6 @@ struct ChatView: View {
                     } else {
                         ChatEmptyStateView(
                             inputText: $inputText,
-                            hasAPIKey: hasAPIKey,
                             isSending: isSending,
                             isRecording: isRecording,
                             suggestion: suggestion,
@@ -296,7 +293,6 @@ struct ChatView: View {
 
                         ComposerSection(
                             inputText: $inputText,
-                            hasAPIKey: hasAPIKey,
                             isSending: isSending,
                             hasPendingConfirmation: PendingConfirmationFocusSelector.activeRequestId(from: composerMessages) != nil,
                             onAllowPendingConfirmation: {

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
@@ -3,7 +3,6 @@ import VellumAssistantShared
 
 struct ComposerSection: View {
     @Binding var inputText: String
-    let hasAPIKey: Bool
     let isSending: Bool
     let hasPendingConfirmation: Bool
     var onAllowPendingConfirmation: (() -> Void)? = nil
@@ -40,7 +39,6 @@ struct ComposerSection: View {
 
             ComposerView(
                 inputText: $inputText,
-                hasAPIKey: hasAPIKey,
                 isSending: isSending,
                 hasPendingConfirmation: hasPendingConfirmation,
                 onAllowPendingConfirmation: onAllowPendingConfirmation,

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -37,7 +37,6 @@ struct ComposerView: View {
     }
 
     @Binding var inputText: String
-    let hasAPIKey: Bool
     let isSending: Bool
     let hasPendingConfirmation: Bool
     var onAllowPendingConfirmation: (() -> Void)? = nil
@@ -123,7 +122,7 @@ struct ComposerView: View {
         .padding(.top, VSpacing.sm)
         .frame(maxWidth: VSpacing.chatColumnMaxWidth)
         .frame(maxWidth: .infinity)
-        .disabled(!hasAPIKey || !isInteractionEnabled)
+        .disabled(!isInteractionEnabled)
         .animation(VAnimation.fast, value: isComposerFocused)
         .onAppear {
             // Delay focus slightly so the NSTextView field editor is fully
@@ -397,7 +396,7 @@ struct ComposerView: View {
                     iconSize: composerActionButtonSize,
                     action: { onAttach() }
                 )
-                .disabled(!hasAPIKey)
+
                 .vTooltip("Attach file")
 
                 Spacer()
@@ -421,7 +420,7 @@ struct ComposerView: View {
                     iconSize: composerActionButtonSize,
                     action: { onVoiceModeToggle?() }
                 )
-                .disabled(!hasAPIKey)
+
                 .vTooltip("Live voice conversation")
 
                 // Dictate button
@@ -432,7 +431,7 @@ struct ComposerView: View {
                     iconSize: composerActionButtonSize,
                     action: { (onDictateToggle ?? onMicrophoneToggle)() }
                 )
-                .disabled(!hasAPIKey)
+
                 .vTooltip(micTooltipText)
 
                 // Send button (always visible, disabled when empty)
@@ -456,7 +455,7 @@ struct ComposerView: View {
                     iconSize: composerActionButtonSize,
                     action: { (onDictateToggle ?? onMicrophoneToggle)() }
                 )
-                .disabled(!hasAPIKey)
+
                 .vTooltip(micTooltipText)
 
                 // Send button
@@ -480,7 +479,7 @@ struct ComposerView: View {
                     iconSize: composerActionButtonSize,
                     action: { onVoiceModeToggle?() }
                 )
-                .disabled(!hasAPIKey)
+
 
                 VButton(
                     label: isRecording ? "Stop recording" : "Dictate",
@@ -489,7 +488,7 @@ struct ComposerView: View {
                     iconSize: composerActionButtonSize,
                     action: { (onDictateToggle ?? onMicrophoneToggle)() }
                 )
-                .disabled(!hasAPIKey)
+
 
                 VButton(
                     label: "Send message",
@@ -651,8 +650,7 @@ VStreamingWaveform(
     var canSend: Bool {
         // Block send while an attachment is still loading: the user tapping Send
         // before the async load completes would drop the attachment from the message.
-        hasAPIKey
-            && !isLoadingAttachment
+        !isLoadingAttachment
             && (!inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !pendingAttachments.isEmpty)
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -63,7 +63,6 @@ public final class MainWindowState: ObservableObject {
     @Published var pendingMemoryId: String?
     @Published var activeDynamicSurface: UiSurfaceShowMessage?
     @Published var activeDynamicParsedSurface: Surface?
-    @Published var hasAPIKey: Bool
     @Published var workspaceComposerExpanded = false
     @Published var layoutConfig: LayoutConfig
     @Published var toastInfo: ToastInfo?
@@ -132,8 +131,7 @@ public final class MainWindowState: ObservableObject {
         }
     }
 
-    init(hasAPIKey: Bool = APIKeyManager.hasAnyKey()) {
-        self.hasAPIKey = hasAPIKey
+    init() {
         self.layoutConfig = LayoutConfigStore.load()
         self.navigationHistoryCancellable = navigationHistory.objectWillChange
             .sink { [weak self] _ in self?.objectWillChange.send() }
@@ -229,10 +227,6 @@ public final class MainWindowState: ObservableObject {
     func showMemory(id: String) {
         pendingMemoryId = id
         showPanel(.intelligence)
-    }
-
-    func refreshAPIKeyStatus(isConnected: Bool, isAuthenticated: Bool) {
-        hasAPIKey = APIKeyManager.hasAnyKey() || isConnected || isAuthenticated
     }
 
     func applyLayoutConfig(_ wire: UiLayoutConfigMessage) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -579,7 +579,6 @@ struct MainWindowView: View {
             if let viewModel = conversationManager.activeViewModel {
                 ErrorToastOverlay(
                     errorManager: viewModel.errorManager,
-                    hasAPIKey: windowState.hasAPIKey,
                     onOpenModelsAndServices: {
                         settingsStore.pendingSettingsTab = .modelsAndServices
                         windowState.selection = .panel(.settings)
@@ -689,9 +688,6 @@ struct MainWindowView: View {
             .onReceive(NotificationCenter.default.publisher(for: .identityFileDidChange)) { _ in
                 cachedAssistantName = AssistantDisplayName.resolve(IdentityInfo.load()?.name, fallback: "Your Assistant")
             }
-            .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
-                refreshWindowAPIStatus(isConnected: connectionManager.isConnected, isAuthenticated: authManager.isAuthenticated)
-            }
             .onReceive(connectionManager.$isConnected) { connected in
                 handleDaemonConnectionChange(connected)
             }
@@ -699,9 +695,6 @@ struct MainWindowView: View {
                 guard let outcome else { return }
                 handleUpdateOutcome(outcome)
                 connectionManager.clearLastUpdateOutcome()
-            }
-            .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
-                refreshWindowAPIStatus(isConnected: connectionManager.isConnected, isAuthenticated: isAuthenticated)
             }
             .onChange(of: conversationManager.conversations.isEmpty) { _, isEmpty in
                 if !isEmpty && showDaemonLoading {
@@ -781,7 +774,6 @@ struct MainWindowView: View {
         isAppChatOpen = false
         cachedAssistantName = AssistantDisplayName.resolve(IdentityInfo.load()?.name, fallback: "Your Assistant")
         startIdentityFileWatcher()
-        refreshWindowAPIStatus(isConnected: connectionManager.isConnected, isAuthenticated: authManager.isAuthenticated)
         selectedConversationId = conversationManager.activeConversationId
         if let activeId = conversationManager.activeConversationId {
             windowState.persistentConversationId = activeId
@@ -845,13 +837,7 @@ struct MainWindowView: View {
         identityFileWatcher = source
     }
 
-    private func refreshWindowAPIStatus(isConnected: Bool, isAuthenticated: Bool) {
-        windowState.refreshAPIKeyStatus(isConnected: isConnected, isAuthenticated: isAuthenticated)
-    }
-
     private func handleDaemonConnectionChange(_ connected: Bool) {
-        refreshWindowAPIStatus(isConnected: connected, isAuthenticated: authManager.isAuthenticated)
-
         // Fallback for fresh users with 0 conversations: dismiss skeleton after a
         // short delay once the daemon is connected. Only applies during initial load.
         guard connected, showDaemonLoading else { return }
@@ -1242,7 +1228,6 @@ struct MainWindowView: View {
 /// toast is visible.
 private struct ErrorToastOverlay: View {
     @ObservedObject var errorManager: ChatErrorManager
-    let hasAPIKey: Bool
     let onOpenModelsAndServices: () -> Void
     let onRetryConversationError: () -> Void
     let onCopyDebugInfo: () -> Void

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -641,7 +641,6 @@ struct ActiveChatViewWrapper: View {
                 get: { viewModel.inputText },
                 set: { viewModel.inputText = $0 }
             ),
-            hasAPIKey: windowState.hasAPIKey,
             isThinking: viewModel.isThinking,
             isCompacting: viewModel.isCompacting,
             isSending: viewModel.isSending,

--- a/clients/macos/vellum-assistantTests/DocumentEditorConversationVisibilityTests.swift
+++ b/clients/macos/vellum-assistantTests/DocumentEditorConversationVisibilityTests.swift
@@ -9,7 +9,7 @@ final class DocumentEditorConversationVisibilityTests: XCTestCase {
 
     /// Creates a `MainWindowState` pre-configured with the given selection.
     private func makeState(_ selection: ViewSelection?) -> MainWindowState {
-        let state = MainWindowState(hasAPIKey: false)
+        let state = MainWindowState()
         state.selection = selection
         return state
     }

--- a/clients/macos/vellum-assistantTests/MainWindowAppsNavigationTests.swift
+++ b/clients/macos/vellum-assistantTests/MainWindowAppsNavigationTests.swift
@@ -7,7 +7,7 @@ final class MainWindowAppsNavigationTests: XCTestCase {
     // MARK: - showPanel(.apps)
 
     func testShowAppsPanelSetsSelectionToApps() {
-        let state = MainWindowState(hasAPIKey: false)
+        let state = MainWindowState()
         state.selection = .conversation(UUID())
 
         state.showPanel(.apps)
@@ -16,7 +16,7 @@ final class MainWindowAppsNavigationTests: XCTestCase {
     }
 
     func testShowAppsPanelIsIdempotent() {
-        let state = MainWindowState(hasAPIKey: false)
+        let state = MainWindowState()
         state.showPanel(.apps)
         XCTAssertEqual(state.selection, .panel(.apps))
 
@@ -26,7 +26,7 @@ final class MainWindowAppsNavigationTests: XCTestCase {
     }
 
     func testShowAppsPanelClearsConversationVisible() {
-        let state = MainWindowState(hasAPIKey: false)
+        let state = MainWindowState()
         // Simulate a prior app-edit flow that left isAppChatOpen = true
         // by toggling the chat dock while in an app editing state.
         let conversationId = UUID()
@@ -43,7 +43,7 @@ final class MainWindowAppsNavigationTests: XCTestCase {
     // MARK: - dismissOverlay() clears sticky state
 
     func testDismissOverlayClearsAppChatState() {
-        let state = MainWindowState(hasAPIKey: false)
+        let state = MainWindowState()
         let conversationId = UUID()
         state.selection = .conversation(conversationId)
         // Navigate to app editing then dismiss.
@@ -61,7 +61,7 @@ final class MainWindowAppsNavigationTests: XCTestCase {
     /// panel and transition to the conversation, not keep the app open.
     func testSelectingConversationFromAppEditingDismissesApp() {
         // GIVEN the user is editing an app alongside a conversation
-        let state = MainWindowState(hasAPIKey: false)
+        let state = MainWindowState()
         let originalConversationId = UUID()
         state.selection = .appEditing(appId: "test-app", conversationId: originalConversationId)
 
@@ -78,7 +78,7 @@ final class MainWindowAppsNavigationTests: XCTestCase {
     // MARK: - closeDynamicPanel() clears sticky state
 
     func testCloseDynamicPanelClearsAppChatState() {
-        let state = MainWindowState(hasAPIKey: false)
+        let state = MainWindowState()
         state.selection = .app("test-app")
         state.closeDynamicPanel()
 

--- a/clients/macos/vellum-assistantTests/MainWindowAvatarRoutingTests.swift
+++ b/clients/macos/vellum-assistantTests/MainWindowAvatarRoutingTests.swift
@@ -9,7 +9,7 @@ final class MainWindowAvatarRoutingTests: XCTestCase {
 
     /// Constructs an IdentityPanel and verifies the onClose callback clears selection.
     func testIdentityPanelOnCloseCallback() {
-        let state = MainWindowState(hasAPIKey: false)
+        let state = MainWindowState()
         state.selection = .panel(.intelligence)
         let connectionManager = GatewayConnectionManager()
 

--- a/clients/macos/vellum-assistantTests/MainWindowStateNavigationHistoryTests.swift
+++ b/clients/macos/vellum-assistantTests/MainWindowStateNavigationHistoryTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class MainWindowStateNavigationHistoryTests: XCTestCase {
 
     func testBackForwardAcrossConversationPanelApp() {
-        let state = MainWindowState(hasAPIKey: false)
+        let state = MainWindowState()
         let id1 = UUID()
         state.selection = .conversation(id1)
         state.selection = .panel(.settings)
@@ -25,7 +25,7 @@ final class MainWindowStateNavigationHistoryTests: XCTestCase {
     }
 
     func testRepeatedShowAppsPanelNoDuplicates() {
-        let state = MainWindowState(hasAPIKey: false)
+        let state = MainWindowState()
         state.showPanel(.apps)
         state.showPanel(.apps)
 
@@ -34,13 +34,13 @@ final class MainWindowStateNavigationHistoryTests: XCTestCase {
     }
 
     func testBackOnEmptyStackIsNoOp() {
-        let state = MainWindowState(hasAPIKey: false)
+        let state = MainWindowState()
         state.navigateBack()
         XCTAssertNil(state.selection)
     }
 
     func testBackToChatDefaultRestoresConversation() {
-        let state = MainWindowState(hasAPIKey: false)
+        let state = MainWindowState()
         let someId = UUID()
         state.persistentConversationId = someId
         // selection is nil (chat default), persistentConversationId is someId
@@ -51,7 +51,7 @@ final class MainWindowStateNavigationHistoryTests: XCTestCase {
     }
 
     func testNavigateBackDoesNotReRecord() {
-        let state = MainWindowState(hasAPIKey: false)
+        let state = MainWindowState()
         let idA = UUID()
         let idB = UUID()
         state.selection = .conversation(idA)
@@ -63,7 +63,7 @@ final class MainWindowStateNavigationHistoryTests: XCTestCase {
     }
 
     func testRestoreLastActivePanelDoesNotSeedHistory() {
-        let freshState = MainWindowState(hasAPIKey: false)
+        let freshState = MainWindowState()
         // restoreLastActivePanel reads from @AppStorage which we can't easily mock
         // So just verify the method doesn't crash and check suppression behavior
         freshState.restoreLastActivePanel()
@@ -71,7 +71,7 @@ final class MainWindowStateNavigationHistoryTests: XCTestCase {
     }
 
     func testBackToChatDefaultNilResolvesToNilSelection() {
-        let state = MainWindowState(hasAPIKey: false)
+        let state = MainWindowState()
         // selection is nil, persistentConversationId is nil
         state.selection = .panel(.settings)
         state.navigateBack()
@@ -79,7 +79,7 @@ final class MainWindowStateNavigationHistoryTests: XCTestCase {
     }
 
     func testCloseDynamicPanelClearsState() {
-        let state = MainWindowState(hasAPIKey: false)
+        let state = MainWindowState()
         state.selection = .app("myapp")
 
         state.closeDynamicPanel()


### PR DESCRIPTION
## Summary
- Remove hasAPIKey property from ComposerView, ComposerSection, ChatView, ChatEmptyStateView, ChatTemporaryChatEmptyStateView, and ErrorToastOverlay
- Remove all .disabled(!hasAPIKey) modifiers from composer buttons
- Remove hasAPIKey condition from canSend computed property
- Clean up hasAPIKey from PanelCoordinator, MainWindowState (property, init param, refreshAPIKeyStatus method), and MainWindowView (refreshWindowAPIStatus, apiKeyManagerDidChange subscriber, authManager onChange)
- Update test files to use parameterless MainWindowState() initializer

Part of plan: inline-api-key-error.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
