### PR TITLE
Copy memories layout for skills page

### DIFF
--- a/clients/ios/Views/Intelligence/InstalledSkillsView.swift
+++ b/clients/ios/Views/Intelligence/InstalledSkillsView.swift
@@ -142,7 +142,7 @@ struct InstalledSkillsView: View {
                 if !skill.description.isEmpty {
                     Text(skill.description)
                         .font(VFont.caption)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                         .lineLimit(2)
                 }
             }
@@ -200,16 +200,16 @@ struct InstalledSkillsView: View {
     private var noMatchesState: some View {
         VStack(spacing: VSpacing.lg) {
             VIconView(.search, size: 48)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
                 .accessibilityHidden(true)
 
             Text("No Matching Skills")
                 .font(VFont.title)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
 
             Text("Try adjusting your search or filters.")
                 .font(VFont.body)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, VSpacing.xl)
         }

--- a/clients/ios/Views/Intelligence/InstalledSkillsView.swift
+++ b/clients/ios/Views/Intelligence/InstalledSkillsView.swift
@@ -2,53 +2,21 @@
 import SwiftUI
 import VellumAssistantShared
 
-private enum SkillStateFilter: String, CaseIterable {
-    case all = "All"
-    case enabled = "Enabled"
-    case disabled = "Disabled"
-
-    func matches(_ state: String) -> Bool {
-        switch self {
-        case .all: return true
-        case .enabled: return state == "enabled"
-        case .disabled: return state == "disabled"
-        }
-    }
-}
-
 struct InstalledSkillsView: View {
     @ObservedObject var skillsStore: SkillsStore
     @State private var skillToUninstall: SkillInfo?
     @State private var showUninstallConfirmation = false
-    @State private var searchText = ""
-    @State private var stateFilter: SkillStateFilter = .all
-
-    private var filteredSkills: [SkillInfo] {
-        skillsStore.skills.filter { skill in
-            guard stateFilter.matches(skill.state) else { return false }
-            guard !searchText.isEmpty else { return true }
-            let query = searchText.lowercased()
-            return skill.name.lowercased().contains(query)
-                || skill.description.lowercased().contains(query)
-        }
-    }
 
     var body: some View {
-        VStack(spacing: 0) {
-            filterBar
-            Group {
-                if skillsStore.isLoading && skillsStore.skills.isEmpty {
-                    loadingState
-                } else if filteredSkills.isEmpty && !skillsStore.skills.isEmpty {
-                    noMatchesState
-                } else if skillsStore.skills.isEmpty {
-                    emptyState
-                } else {
-                    skillsList
-                }
+        Group {
+            if skillsStore.isLoading && skillsStore.skills.isEmpty {
+                loadingState
+            } else if skillsStore.skills.isEmpty {
+                emptyState
+            } else {
+                skillsList
             }
         }
-        .searchable(text: $searchText, prompt: "Search skills...")
         .navigationTitle("Skills")
         .refreshable {
             skillsStore.fetchSkills(force: true)
@@ -67,54 +35,39 @@ struct InstalledSkillsView: View {
         }
     }
 
-    // MARK: - Filter Bar
-
-    private var filterBar: some View {
-        Picker("State", selection: $stateFilter) {
-            ForEach(SkillStateFilter.allCases, id: \.self) { filter in
-                Text(filter.rawValue).tag(filter)
-            }
-        }
-        .pickerStyle(.segmented)
-        .padding(.horizontal)
-        .padding(.vertical, VSpacing.sm)
-    }
-
     // MARK: - Skills List
 
     private var skillsList: some View {
         List {
-            Section {
-                ForEach(filteredSkills) { skill in
-                    NavigationLink {
-                        SkillDetailView(skill: skill, skillsStore: skillsStore)
-                    } label: {
-                        skillRow(skill)
-                    }
-                    .swipeActions(edge: .leading) {
-                        if skill.state == "enabled" {
-                            Button {
-                                skillsStore.disableSkill(name: skill.name)
-                            } label: {
-                                Label { Text("Disable") } icon: { VIconView(.circlePlay, size: 12) }
-                            }
-                            .tint(.orange)
-                        } else {
-                            Button {
-                                skillsStore.enableSkill(name: skill.name)
-                            } label: {
-                                Label { Text("Enable") } icon: { VIconView(.circlePlay, size: 12) }
-                            }
-                            .tint(.green)
-                        }
-                    }
-                    .swipeActions(edge: .trailing) {
-                        Button(role: .destructive) {
-                            skillToUninstall = skill
-                            showUninstallConfirmation = true
+            ForEach(skillsStore.skills) { skill in
+                NavigationLink {
+                    SkillDetailView(skill: skill, skillsStore: skillsStore)
+                } label: {
+                    skillRow(skill)
+                }
+                .swipeActions(edge: .leading) {
+                    if skill.state == "enabled" {
+                        Button {
+                            skillsStore.disableSkill(name: skill.name)
                         } label: {
-                            Label { Text("Uninstall") } icon: { VIconView(.trash, size: 12) }
+                            Label { Text("Disable") } icon: { VIconView(.circlePlay, size: 12) }
                         }
+                        .tint(.orange)
+                    } else {
+                        Button {
+                            skillsStore.enableSkill(name: skill.name)
+                        } label: {
+                            Label { Text("Enable") } icon: { VIconView(.circlePlay, size: 12) }
+                        }
+                        .tint(.green)
+                    }
+                }
+                .swipeActions(edge: .trailing) {
+                    Button(role: .destructive) {
+                        skillToUninstall = skill
+                        showUninstallConfirmation = true
+                    } label: {
+                        Label { Text("Uninstall") } icon: { VIconView(.trash, size: 12) }
                     }
                 }
             }
@@ -133,7 +86,7 @@ struct InstalledSkillsView: View {
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 4) {
                     Text(skill.name)
-                        .font(VFont.bodyMedium)
+                        .font(VFont.body)
                         .foregroundColor(VColor.contentDefault)
 
                     stateBadge(skill.state)
@@ -142,12 +95,13 @@ struct InstalledSkillsView: View {
                 if !skill.description.isEmpty {
                     Text(skill.description)
                         .font(VFont.caption)
-                        .foregroundStyle(VColor.contentSecondary)
+                        .foregroundColor(VColor.contentTertiary)
                         .lineLimit(2)
                 }
             }
 
             Spacer()
+
         }
         .padding(.vertical, 2)
         .accessibilityElement(children: .combine)
@@ -195,27 +149,6 @@ struct InstalledSkillsView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("No skills installed. Ask your assistant in chat to search for and install new skills.")
-    }
-
-    private var noMatchesState: some View {
-        VStack(spacing: VSpacing.lg) {
-            VIconView(.search, size: 48)
-                .foregroundStyle(VColor.contentTertiary)
-                .accessibilityHidden(true)
-
-            Text("No Matching Skills")
-                .font(VFont.title)
-                .foregroundStyle(VColor.contentDefault)
-
-            Text("Try adjusting your search or filters.")
-                .font(VFont.body)
-                .foregroundStyle(VColor.contentSecondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, VSpacing.xl)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("No matching skills. Try adjusting your search or filters.")
     }
 
     private var loadingState: some View {

--- a/clients/ios/Views/Intelligence/InstalledSkillsView.swift
+++ b/clients/ios/Views/Intelligence/InstalledSkillsView.swift
@@ -2,21 +2,53 @@
 import SwiftUI
 import VellumAssistantShared
 
+private enum SkillStateFilter: String, CaseIterable {
+    case all = "All"
+    case enabled = "Enabled"
+    case disabled = "Disabled"
+
+    func matches(_ state: String) -> Bool {
+        switch self {
+        case .all: return true
+        case .enabled: return state == "enabled"
+        case .disabled: return state == "disabled"
+        }
+    }
+}
+
 struct InstalledSkillsView: View {
     @ObservedObject var skillsStore: SkillsStore
     @State private var skillToUninstall: SkillInfo?
     @State private var showUninstallConfirmation = false
+    @State private var searchText = ""
+    @State private var stateFilter: SkillStateFilter = .all
+
+    private var filteredSkills: [SkillInfo] {
+        skillsStore.skills.filter { skill in
+            guard stateFilter.matches(skill.state) else { return false }
+            guard !searchText.isEmpty else { return true }
+            let query = searchText.lowercased()
+            return skill.name.lowercased().contains(query)
+                || skill.description.lowercased().contains(query)
+        }
+    }
 
     var body: some View {
-        Group {
-            if skillsStore.isLoading && skillsStore.skills.isEmpty {
-                loadingState
-            } else if skillsStore.skills.isEmpty {
-                emptyState
-            } else {
-                skillsList
+        VStack(spacing: 0) {
+            filterBar
+            Group {
+                if skillsStore.isLoading && skillsStore.skills.isEmpty {
+                    loadingState
+                } else if filteredSkills.isEmpty && !skillsStore.skills.isEmpty {
+                    noMatchesState
+                } else if skillsStore.skills.isEmpty {
+                    emptyState
+                } else {
+                    skillsList
+                }
             }
         }
+        .searchable(text: $searchText, prompt: "Search skills...")
         .navigationTitle("Skills")
         .refreshable {
             skillsStore.fetchSkills(force: true)
@@ -35,39 +67,54 @@ struct InstalledSkillsView: View {
         }
     }
 
+    // MARK: - Filter Bar
+
+    private var filterBar: some View {
+        Picker("State", selection: $stateFilter) {
+            ForEach(SkillStateFilter.allCases, id: \.self) { filter in
+                Text(filter.rawValue).tag(filter)
+            }
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal)
+        .padding(.vertical, VSpacing.sm)
+    }
+
     // MARK: - Skills List
 
     private var skillsList: some View {
         List {
-            ForEach(skillsStore.skills) { skill in
-                NavigationLink {
-                    SkillDetailView(skill: skill, skillsStore: skillsStore)
-                } label: {
-                    skillRow(skill)
-                }
-                .swipeActions(edge: .leading) {
-                    if skill.state == "enabled" {
-                        Button {
-                            skillsStore.disableSkill(name: skill.name)
-                        } label: {
-                            Label { Text("Disable") } icon: { VIconView(.circlePlay, size: 12) }
-                        }
-                        .tint(.orange)
-                    } else {
-                        Button {
-                            skillsStore.enableSkill(name: skill.name)
-                        } label: {
-                            Label { Text("Enable") } icon: { VIconView(.circlePlay, size: 12) }
-                        }
-                        .tint(.green)
-                    }
-                }
-                .swipeActions(edge: .trailing) {
-                    Button(role: .destructive) {
-                        skillToUninstall = skill
-                        showUninstallConfirmation = true
+            Section {
+                ForEach(filteredSkills) { skill in
+                    NavigationLink {
+                        SkillDetailView(skill: skill, skillsStore: skillsStore)
                     } label: {
-                        Label { Text("Uninstall") } icon: { VIconView(.trash, size: 12) }
+                        skillRow(skill)
+                    }
+                    .swipeActions(edge: .leading) {
+                        if skill.state == "enabled" {
+                            Button {
+                                skillsStore.disableSkill(name: skill.name)
+                            } label: {
+                                Label { Text("Disable") } icon: { VIconView(.circlePlay, size: 12) }
+                            }
+                            .tint(.orange)
+                        } else {
+                            Button {
+                                skillsStore.enableSkill(name: skill.name)
+                            } label: {
+                                Label { Text("Enable") } icon: { VIconView(.circlePlay, size: 12) }
+                            }
+                            .tint(.green)
+                        }
+                    }
+                    .swipeActions(edge: .trailing) {
+                        Button(role: .destructive) {
+                            skillToUninstall = skill
+                            showUninstallConfirmation = true
+                        } label: {
+                            Label { Text("Uninstall") } icon: { VIconView(.trash, size: 12) }
+                        }
                     }
                 }
             }
@@ -86,7 +133,7 @@ struct InstalledSkillsView: View {
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 4) {
                     Text(skill.name)
-                        .font(VFont.body)
+                        .font(VFont.bodyMedium)
                         .foregroundColor(VColor.contentDefault)
 
                     stateBadge(skill.state)
@@ -95,13 +142,12 @@ struct InstalledSkillsView: View {
                 if !skill.description.isEmpty {
                     Text(skill.description)
                         .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundColor(VColor.contentSecondary)
                         .lineLimit(2)
                 }
             }
 
             Spacer()
-
         }
         .padding(.vertical, 2)
         .accessibilityElement(children: .combine)
@@ -149,6 +195,27 @@ struct InstalledSkillsView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("No skills installed. Ask your assistant in chat to search for and install new skills.")
+    }
+
+    private var noMatchesState: some View {
+        VStack(spacing: VSpacing.lg) {
+            VIconView(.search, size: 48)
+                .foregroundColor(VColor.contentTertiary)
+                .accessibilityHidden(true)
+
+            Text("No Matching Skills")
+                .font(VFont.title)
+                .foregroundColor(VColor.contentDefault)
+
+            Text("Try adjusting your search or filters.")
+                .font(VFont.body)
+                .foregroundColor(VColor.contentSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, VSpacing.xl)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("No matching skills. Try adjusting your search or filters.")
     }
 
     private var loadingState: some View {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -1,6 +1,30 @@
 import SwiftUI
 import VellumAssistantShared
 
+// MARK: - Skill State Filter
+
+private enum SkillStateFilter: String, CaseIterable {
+    case all = "All"
+    case enabled = "Enabled"
+    case disabled = "Disabled"
+
+    func matches(_ state: String) -> Bool {
+        switch self {
+        case .all: return true
+        case .enabled: return state == "enabled"
+        case .disabled: return state == "disabled"
+        }
+    }
+
+    var icon: VIcon {
+        switch self {
+        case .all: return .circle
+        case .enabled: return .circleCheck
+        case .disabled: return .circleDashed
+        }
+    }
+}
+
 // MARK: - Agent Panel Content (embeddable)
 
 /// The installed skills management content, usable standalone
@@ -16,6 +40,8 @@ struct AgentPanelContent: View {
     @State private var selectedCategories: Set<SkillCategory> = []
     @State private var globalSkillSearchQuery = ""
     @State private var showFilterPopover = false
+    @State private var stateFilter: SkillStateFilter = .all
+    @State private var showStateFilterPopover = false
 
     init(onInvokeSkill: ((SkillInfo) -> Void)? = nil, onSkillsChanged: (() -> Void)? = nil, connectionManager: GatewayConnectionManager) {
         self.onInvokeSkill = onInvokeSkill
@@ -71,6 +97,12 @@ struct AgentPanelContent: View {
                 selectedInstalledSkillId = nil
             }
         }
+        .onChange(of: stateFilter) {
+            if let selectedId = selectedInstalledSkillId,
+               !categoryFilteredSkills.contains(where: { $0.id == selectedId }) {
+                selectedInstalledSkillId = nil
+            }
+        }
         .sheet(item: $skillToDelete) { skill in
             SkillDeleteConfirmView(
                 skillName: skill.name,
@@ -92,9 +124,10 @@ struct AgentPanelContent: View {
     }
 
     private var filteredUserSkills: [SkillInfo] {
-        guard hasActiveSearch else { return userSkills }
+        var result = userSkills.filter { stateFilter.matches($0.state) }
+        guard hasActiveSearch else { return result }
         let query = normalizedSkillQuery
-        return userSkills.filter {
+        return result.filter {
             $0.name.lowercased().contains(query) ||
             $0.description.lowercased().contains(query) ||
             $0.id.lowercased().contains(query) ||
@@ -117,6 +150,64 @@ struct AgentPanelContent: View {
             let bInstalled = (b.source == "managed" || b.source == "clawhub")
             if aInstalled != bInstalled { return aInstalled }
             return a.name.localizedCaseInsensitiveCompare(b.name) == .orderedAscending
+        }
+    }
+
+    // MARK: - State Filter Dropdown
+
+    private var stateFilterDropdown: some View {
+        Button {
+            showStateFilterPopover.toggle()
+        } label: {
+            HStack(spacing: VSpacing.md) {
+                Text(stateFilter.rawValue)
+                    .foregroundStyle(VColor.contentDefault)
+                    .font(VFont.body)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                VIconView(.chevronDown, size: 13)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .accessibilityHidden(true)
+            }
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
+            .frame(height: 32)
+            .vInputChrome()
+        }
+        .buttonStyle(.plain)
+        .frame(width: 158)
+        .accessibilityLabel("State filter: \(stateFilter.rawValue)")
+        .popover(isPresented: $showStateFilterPopover, arrowEdge: .bottom) {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(SkillStateFilter.allCases, id: \.self) { state in
+                    Button {
+                        stateFilter = state
+                        showStateFilterPopover = false
+                    } label: {
+                        HStack(spacing: VSpacing.sm) {
+                            VIconView(state.icon, size: 14)
+                                .foregroundStyle(VColor.contentDefault)
+                                .frame(width: 20)
+                            Text(state.rawValue)
+                                .font(VFont.body)
+                                .foregroundStyle(VColor.contentDefault)
+                            Spacer()
+                            if stateFilter == state {
+                                VIconView(.check, size: 12)
+                                    .foregroundStyle(VColor.primaryBase)
+                            }
+                        }
+                        .padding(.horizontal, VSpacing.md)
+                        .padding(.vertical, VSpacing.sm)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(state.rawValue) state")
+                    .accessibilityAddTraits(stateFilter == state ? .isSelected : [])
+                }
+            }
+            .padding(.vertical, VSpacing.sm)
+            .frame(width: 180)
         }
     }
 
@@ -284,6 +375,7 @@ struct AgentPanelContent: View {
             VStack(spacing: VSpacing.md) {
                 HStack(spacing: VSpacing.sm) {
                     VSearchBar(placeholder: "Search skills", text: $globalSkillSearchQuery)
+                    stateFilterDropdown
                     categoryFilterDropdown
                 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -1,30 +1,6 @@
 import SwiftUI
 import VellumAssistantShared
 
-// MARK: - Skill State Filter
-
-private enum SkillStateFilter: String, CaseIterable {
-    case all = "All"
-    case enabled = "Enabled"
-    case disabled = "Disabled"
-
-    func matches(_ state: String) -> Bool {
-        switch self {
-        case .all: return true
-        case .enabled: return state == "enabled"
-        case .disabled: return state == "disabled"
-        }
-    }
-
-    var icon: VIcon {
-        switch self {
-        case .all: return .circle
-        case .enabled: return .circleCheck
-        case .disabled: return .circleDashed
-        }
-    }
-}
-
 // MARK: - Agent Panel Content (embeddable)
 
 /// The installed skills management content, usable standalone
@@ -37,11 +13,8 @@ struct AgentPanelContent: View {
     @StateObject private var skillsManager: SkillsManager
     @State private var selectedInstalledSkillId: String?
     @State private var skillToDelete: SkillInfo?
-    @State private var selectedCategories: Set<SkillCategory> = []
+    @State private var selectedCategory: SkillCategory?
     @State private var globalSkillSearchQuery = ""
-    @State private var showFilterPopover = false
-    @State private var stateFilter: SkillStateFilter = .all
-    @State private var showStateFilterPopover = false
 
     init(onInvokeSkill: ((SkillInfo) -> Void)? = nil, onSkillsChanged: (() -> Void)? = nil, connectionManager: GatewayConnectionManager) {
         self.onInvokeSkill = onInvokeSkill
@@ -56,24 +29,15 @@ struct AgentPanelContent: View {
 
     private var hasActiveSearch: Bool { !normalizedSkillQuery.isEmpty }
 
-    private var allCategoriesSelected: Bool {
-        selectedCategories.isEmpty || selectedCategories.count == SkillCategory.allCases.count
-    }
-
-    /// Dynamic subtitle for the category-filtered empty state.
-    private var categoryEmptySubtitle: String {
-        let sorted = selectedCategories.sorted { $0.displayName < $1.displayName }
-        if sorted.count <= 2 {
-            let names = sorted.map(\.displayName).joined(separator: " or ")
-            return "No installed skills match \(names)"
-        } else {
-            return "No installed skills in \(sorted.count) selected categories"
-        }
-    }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            skillsContent
+            filterBar
+            HStack(alignment: .top, spacing: VSpacing.xxl) {
+                categorySidebar
+                    .frame(width: 220)
+                contentView
+            }
+            .padding(.top, VSpacing.lg)
         }
         .onAppear {
             skillsManager.fetchSkills()
@@ -87,19 +51,13 @@ struct AgentPanelContent: View {
         }
         .onChange(of: globalSkillSearchQuery) {
             if let selectedId = selectedInstalledSkillId,
-               !categoryFilteredSkills.contains(where: { $0.id == selectedId }) {
+               !filteredSkills.contains(where: { $0.id == selectedId }) {
                 selectedInstalledSkillId = nil
             }
         }
-        .onChange(of: selectedCategories) {
+        .onChange(of: selectedCategory) {
             if let selectedId = selectedInstalledSkillId,
-               !categoryFilteredSkills.contains(where: { $0.id == selectedId }) {
-                selectedInstalledSkillId = nil
-            }
-        }
-        .onChange(of: stateFilter) {
-            if let selectedId = selectedInstalledSkillId,
-               !categoryFilteredSkills.contains(where: { $0.id == selectedId }) {
+               !filteredSkills.contains(where: { $0.id == selectedId }) {
                 selectedInstalledSkillId = nil
             }
         }
@@ -117,17 +75,60 @@ struct AgentPanelContent: View {
         }
     }
 
-    // MARK: - Skills Tab
+    // MARK: - Filter Bar
+
+    @ViewBuilder
+    private var filterBar: some View {
+        HStack(spacing: VSpacing.sm) {
+            VSearchBar(placeholder: "Search Skills", text: $globalSkillSearchQuery)
+        }
+    }
+
+    // MARK: - Category Sidebar
+
+    private var categorySidebar: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            categorySidebarRow(icon: VIcon.layoutGrid.rawValue, label: "All", category: nil)
+            ForEach(SkillCategory.allCases.sorted { $0.displayName < $1.displayName }, id: \.rawValue) { category in
+                categorySidebarRow(icon: category.icon.rawValue, label: category.displayName, category: category)
+            }
+        }
+    }
+
+    private func categorySidebarRow(icon: String, label: String, category: SkillCategory?) -> some View {
+        VSidebarRow(
+            icon: icon,
+            label: label,
+            isActive: selectedCategory == category,
+            action: {
+                withAnimation(VAnimation.fast) { selectedCategory = category }
+            }
+        ) {
+            Text("\(categoryCount(for: category))")
+                .font(VFont.caption)
+                .foregroundStyle(VColor.contentTertiary)
+        }
+        .accessibilityLabel("\(label) filter")
+        .accessibilityAddTraits(selectedCategory == category ? .isSelected : [])
+    }
+
+    private func categoryCount(for category: SkillCategory?) -> Int {
+        let base = searchFilteredSkills
+        guard let category else { return base.count }
+        return base.filter { inferCategory($0) == category }.count
+    }
+
+    // MARK: - Filtering
 
     private var userSkills: [SkillInfo] {
         skillsManager.skills
     }
 
-    private var filteredUserSkills: [SkillInfo] {
-        var result = userSkills.filter { stateFilter.matches($0.state) }
-        guard hasActiveSearch else { return result }
+    /// Skills filtered by search query only.
+    private var searchFilteredSkills: [SkillInfo] {
+        guard hasActiveSearch else { return userSkills }
         let query = normalizedSkillQuery
-        return result.filter {
+        return userSkills.filter {
             $0.name.lowercased().contains(query) ||
             $0.description.lowercased().contains(query) ||
             $0.id.lowercased().contains(query) ||
@@ -135,15 +136,14 @@ struct AgentPanelContent: View {
         }
     }
 
-    /// Installed skills further filtered by selected categories, sorted with installed first then alphabetically.
-    private var categoryFilteredSkills: [SkillInfo] {
+    /// Skills filtered by both search and selected category, installed first then alphabetical.
+    private var filteredSkills: [SkillInfo] {
+        let base = searchFilteredSkills
         let filtered: [SkillInfo]
-        if allCategoriesSelected {
-            filtered = filteredUserSkills
+        if let category = selectedCategory {
+            filtered = base.filter { inferCategory($0) == category }
         } else {
-            filtered = filteredUserSkills.filter { skill in
-                selectedCategories.contains(inferCategory(skill))
-            }
+            filtered = base
         }
         return filtered.sorted { a, b in
             let aInstalled = (a.source == "managed" || a.source == "clawhub")
@@ -153,185 +153,12 @@ struct AgentPanelContent: View {
         }
     }
 
-    // MARK: - State Filter Dropdown
-
-    private var stateFilterDropdown: some View {
-        Button {
-            showStateFilterPopover.toggle()
-        } label: {
-            HStack(spacing: VSpacing.md) {
-                Text(stateFilter.rawValue)
-                    .foregroundStyle(VColor.contentDefault)
-                    .font(VFont.body)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                VIconView(.chevronDown, size: 13)
-                    .foregroundStyle(VColor.contentTertiary)
-                    .accessibilityHidden(true)
-            }
-            .padding(.horizontal, VSpacing.sm)
-            .padding(.vertical, VSpacing.xs)
-            .frame(height: 32)
-            .vInputChrome()
-        }
-        .buttonStyle(.plain)
-        .frame(width: 158)
-        .accessibilityLabel("State filter: \(stateFilter.rawValue)")
-        .popover(isPresented: $showStateFilterPopover, arrowEdge: .bottom) {
-            VStack(alignment: .leading, spacing: 0) {
-                ForEach(SkillStateFilter.allCases, id: \.self) { state in
-                    Button {
-                        stateFilter = state
-                        showStateFilterPopover = false
-                    } label: {
-                        HStack(spacing: VSpacing.sm) {
-                            VIconView(state.icon, size: 14)
-                                .foregroundStyle(VColor.contentDefault)
-                                .frame(width: 20)
-                            Text(state.rawValue)
-                                .font(VFont.body)
-                                .foregroundStyle(VColor.contentDefault)
-                            Spacer()
-                            if stateFilter == state {
-                                VIconView(.check, size: 12)
-                                    .foregroundStyle(VColor.primaryBase)
-                            }
-                        }
-                        .padding(.horizontal, VSpacing.md)
-                        .padding(.vertical, VSpacing.sm)
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("\(state.rawValue) state")
-                    .accessibilityAddTraits(stateFilter == state ? .isSelected : [])
-                }
-            }
-            .padding(.vertical, VSpacing.sm)
-            .frame(width: 180)
-        }
-    }
-
-    // MARK: - Category Filter Dropdown
-
-    /// Categories sorted alphabetically by display name.
-    private var sortedCategories: [SkillCategory] {
-        SkillCategory.allCases.sorted { $0.displayName < $1.displayName }
-    }
-
-    private func categoryBinding(for category: SkillCategory) -> Binding<Bool> {
-        Binding(
-            get: { selectedCategories.contains(category) },
-            set: { isOn in
-                withAnimation(VAnimation.fast) {
-                    if isOn { selectedCategories.insert(category) }
-                    else { selectedCategories.remove(category) }
-                }
-            }
-        )
-    }
-
-    private var filterLabel: String {
-        if allCategoriesSelected {
-            return "All"
-        }
-        let sorted = selectedCategories.sorted { $0.displayName < $1.displayName }
-        if sorted.count <= 2 {
-            return sorted.map(\.displayName).joined(separator: ", ")
-        }
-        return "\(sorted.count) categories"
-    }
+    // MARK: - Content View
 
     @ViewBuilder
-    private var categoryFilterDropdown: some View {
-        Button {
-            showFilterPopover.toggle()
-        } label: {
-            HStack(spacing: VSpacing.md) {
-                HStack(spacing: VSpacing.sm) {
-                    VIconView(.filter, size: 13)
-                        .foregroundColor(VColor.contentTertiary)
-                    Text(filterLabel)
-                        .foregroundColor(VColor.contentDefault)
-                }
-                .font(VFont.body)
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-                VIconView(.chevronDown, size: 13)
-                    .foregroundColor(VColor.contentTertiary)
-                    .accessibilityHidden(true)
-            }
-            .padding(.horizontal, VSpacing.md)
-            .padding(.vertical, VSpacing.xs)
-            .frame(height: 32)
-            .vInputChrome()
-        }
-        .buttonStyle(.plain)
-        .frame(width: 200)
-        .popover(isPresented: $showFilterPopover, arrowEdge: .bottom) {
-            VStack(alignment: .leading, spacing: 0) {
-                Button {
-                    withAnimation(VAnimation.fast) {
-                        selectedCategories.removeAll()
-                    }
-                } label: {
-                    HStack(spacing: VSpacing.sm) {
-                        VIconView(.layoutGrid, size: 14)
-                            .foregroundColor(VColor.contentDefault)
-                            .frame(width: 20)
-                        Text("All")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.contentDefault)
-                        Spacer()
-                    }
-                    .padding(.horizontal, VSpacing.md)
-                    .padding(.vertical, VSpacing.sm)
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-
-                Divider().padding(.horizontal, VSpacing.sm)
-
-                ForEach(sortedCategories, id: \.rawValue) { category in
-                    Button {
-                        withAnimation(VAnimation.fast) {
-                            if selectedCategories.contains(category) {
-                                selectedCategories.remove(category)
-                            } else {
-                                selectedCategories.insert(category)
-                            }
-                        }
-                    } label: {
-                        HStack(spacing: VSpacing.sm) {
-                            VIconView(category.icon, size: 14)
-                                .foregroundColor(VColor.contentDefault)
-                                .frame(width: 20)
-                            Text(category.displayName)
-                                .font(VFont.body)
-                                .foregroundColor(VColor.contentDefault)
-                            Spacer()
-                            if selectedCategories.contains(category) {
-                                VIconView(.check, size: 12)
-                                    .foregroundColor(VColor.primaryBase)
-                            }
-                        }
-                        .padding(.horizontal, VSpacing.md)
-                        .padding(.vertical, VSpacing.sm)
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-            .padding(.vertical, VSpacing.sm)
-            .frame(width: 220)
-        }
-    }
-
-    // MARK: - Skills Content
-
-    @ViewBuilder
-    private var skillsContent: some View {
+    private var contentView: some View {
         if let selectedId = selectedInstalledSkillId,
-           let skill = filteredUserSkills.first(where: { $0.id == selectedId }) {
+           let skill = filteredSkills.first(where: { $0.id == selectedId }) {
             SkillDetailView(
                 skill: skill,
                 skillsManager: skillsManager,
@@ -344,141 +171,41 @@ struct AgentPanelContent: View {
                     skillToDelete = skill
                 }
             )
-        } else if skillsManager.isLoading {
-            HStack {
+        } else if skillsManager.isLoading && userSkills.isEmpty {
+            VStack {
                 Spacer()
-                ProgressView()
-                    .controlSize(.small)
+                VLoadingIndicator()
                 Spacer()
             }
-            .frame(height: 60)
-        } else if userSkills.isEmpty {
-            VStack(spacing: VSpacing.md) {
-                Text("No skills installed")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.contentTertiary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                Button(action: { skillsManager.fetchSkills() }) {
-                    HStack(spacing: VSpacing.xs) {
-                        VIconView(.refreshCw, size: 11)
-                        Text("Refresh")
-                            .font(VFont.caption)
-                    }
-                    .foregroundColor(VColor.primaryBase)
-                }
-                .buttonStyle(.plain)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .padding(.vertical, VSpacing.sm)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if filteredSkills.isEmpty {
+            VEmptyState(
+                title: selectedCategory == nil ? "No Skills Installed" : "No \(selectedCategory!.displayName) Skills",
+                subtitle: selectedCategory == nil
+                    ? "Ask your assistant in chat to search for and install new skills."
+                    : "Try selecting a different category or clearing the filter.",
+                icon: VIcon.zap.rawValue
+            )
         } else {
-            VStack(spacing: VSpacing.md) {
-                HStack(spacing: VSpacing.sm) {
-                    VSearchBar(placeholder: "Search skills", text: $globalSkillSearchQuery)
-                    stateFilterDropdown
-                    categoryFilterDropdown
-                }
-
-                if categoryFilteredSkills.isEmpty {
-                    VEmptyState(
-                        title: "No skills in selected categories",
-                        subtitle: categoryEmptySubtitle,
-                        icon: "tray"
-                    )
-                    .frame(minHeight: 100)
-                } else {
-                    ScrollView {
-                        LazyVGrid(
-                            columns: [
-                                GridItem(.flexible(), spacing: VSpacing.md),
-                                GridItem(.flexible(), spacing: VSpacing.md)
-                            ],
-                            spacing: VSpacing.md
-                        ) {
-                            ForEach(categoryFilteredSkills) { skill in
-                                skillCard(skill)
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private func skillCard(_ skill: SkillInfo) -> some View {
-        SkillCardButton(skill: skill) {
-            withAnimation(VAnimation.fast) {
-                selectedInstalledSkillId = skill.id
-            }
-        } onDelete: {
-            skillToDelete = skill
-        }
-    }
-
-    // MARK: - Skill Card
-
-    private struct SkillCardButton: View {
-        let skill: SkillInfo
-        let onSelect: () -> Void
-        let onDelete: () -> Void
-
-        private var isRemovable: Bool {
-            skill.source == "managed" || skill.source == "clawhub"
-        }
-
-        var body: some View {
-            VInteractiveCard(action: onSelect) {
-                HStack(alignment: .center, spacing: VSpacing.lg) {
-                    skillIcon(skill.emoji)
-
-                    VStack(alignment: .leading, spacing: VSpacing.sm) {
-                        HStack(spacing: VSpacing.sm) {
-                            Text(skill.name)
-                                .font(VFont.bodyBold)
-                                .foregroundColor(VColor.contentDefault)
-                                .lineLimit(1)
-                                .truncationMode(.tail)
-
-                            Spacer()
-
-                            VSkillTypePill(source: skill.source)
-
-                            if isRemovable {
-                                VButton(
-                                    label: "Delete",
-                                    iconOnly: VIcon.trash.rawValue,
-                                    style: .dangerGhost,
-                                    tooltip: "Uninstall skill"
-                                ) {
-                                    onDelete()
+            ScrollView {
+                LazyVStack(spacing: VSpacing.sm) {
+                    ForEach(filteredSkills) { skill in
+                        SkillItemRow(
+                            skill: skill,
+                            onSelect: {
+                                withAnimation(VAnimation.fast) {
+                                    selectedInstalledSkillId = skill.id
                                 }
+                            },
+                            onDelete: {
+                                skillToDelete = skill
                             }
-                        }
-
-                        Text(skill.description)
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.contentSecondary)
-                            .lineLimit(2)
-                            .frame(maxWidth: .infinity, minHeight: 28, alignment: .topLeading)
+                        )
                     }
                 }
+                .background { OverlayScrollerStyle() }
             }
-            .contextMenu {
-                Button("Remove", role: .destructive, action: onDelete)
-            }
-        }
-
-        @ViewBuilder
-        private func skillIcon(_ emoji: String?) -> some View {
-            if let emoji, !emoji.isEmpty {
-                Text(emoji)
-                    .font(.system(size: 32))
-                    .frame(width: 40, height: 40)
-            } else {
-                VIconView(.zap, size: 20)
-                    .foregroundColor(VColor.contentTertiary)
-                    .frame(width: 40, height: 40)
-            }
+            .scrollContentBackground(.hidden)
         }
     }
 
@@ -495,5 +222,71 @@ struct AgentPanelContent: View {
         default:
             return source.replacingOccurrences(of: "-", with: " ").capitalized
         }
+    }
+}
+
+// MARK: - Skill Item Row
+
+struct SkillItemRow: View {
+    let skill: SkillInfo
+    let onSelect: () -> Void
+    let onDelete: () -> Void
+
+    private var isRemovable: Bool {
+        skill.source == "managed" || skill.source == "clawhub"
+    }
+
+    private var category: SkillCategory {
+        inferCategory(skill)
+    }
+
+    var body: some View {
+        VCard(padding: VSpacing.lg, action: onSelect) {
+            HStack(alignment: .center, spacing: VSpacing.lg) {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    HStack(alignment: .center, spacing: VSpacing.sm) {
+                        if let emoji = skill.emoji, !emoji.isEmpty {
+                            Text(emoji)
+                                .font(.system(size: 16))
+                        }
+
+                        Text(skill.name)
+                            .font(VFont.headline)
+                            .foregroundStyle(VColor.contentEmphasized)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+
+                        VTag(
+                            category.displayName,
+                            color: category.color
+                        )
+
+                        VSkillTypePill(source: skill.source)
+                    }
+
+                    Text(skill.description)
+                        .font(VFont.bodySmall)
+                        .foregroundStyle(VColor.contentSecondary)
+                        .lineLimit(1)
+                        .multilineTextAlignment(.leading)
+                }
+
+                Spacer()
+
+                if isRemovable {
+                    VButton(
+                        label: "Delete",
+                        iconOnly: VIcon.trash.rawValue,
+                        style: .dangerOutline,
+                        action: onDelete
+                    )
+                    .accessibilityLabel("Uninstall skill")
+                }
+            }
+        }
+        .contextMenu {
+            Button("Remove", role: .destructive, action: onDelete)
+        }
+        .accessibilityElement(children: .combine)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -188,6 +188,7 @@ struct IntelligencePanel: View {
                 isEmailEnabled: isEmailEnabled,
                 showToast: showToast
             )
+            .padding(.top, VSpacing.sm)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
 
         case .memories:

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -83,7 +83,7 @@ struct MemoriesPanel: View {
 
     /// Kinds to show in the sidebar filter. Excludes system-managed kinds.
     private static let filterableKinds: [MemoryKind] = [
-        .identity, .preference, .project, .decision, .constraint, .event, .journal
+        .constraint, .decision, .event, .identity, .journal, .preference, .project
     ]
 
     var body: some View {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -28,8 +28,8 @@ struct MemoryItemRow: View {
                     }
 
                     Text(item.statement)
-                        .font(VFont.caption)
-                        .foregroundStyle(VColor.contentTertiary)
+                        .font(VFont.bodySmall)
+                        .foregroundStyle(VColor.contentSecondary)
                         .lineLimit(1)
                         .multilineTextAlignment(.leading)
                 }


### PR DESCRIPTION
## Summary
- Add segmented state filter (All/Enabled/Disabled) and search bar to the iOS skills list, mirroring the memories page layout pattern
- Client-side filtering via computed `filteredSkills` property with combined state + text search
- Add "No Matching Skills" empty state when filters produce no results
- Align row typography: `bodyMedium` for skill name, `contentSecondary` for description (matching memories rows)

## Original prompt
--safe copy memories layout for skills page
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
