### PR TITLE
fix: add providerNotConfigured case to iOS exhaustive switch in ChatContentView

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -656,6 +656,7 @@ struct ChatContentView: View {
         case .contextTooLarge: return .fileText
         case .providerBilling: return .creditCard
         case .authenticationRequired: return .lock
+        case .providerNotConfigured: return .keyRound
         case .unknown: return .triangleAlert
         }
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for inline-api-key-error.md.

**Gap:** iOS compilation failure — exhaustive switch missing providerNotConfigured case
**What was expected:** All exhaustive switches on ConversationErrorCategory handle the new case
**What was found:** ChatContentView.swift conversationErrorIcon switch was missing the case
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
