### PR TITLE
fix: remove dead inferenceConfigDidChange notification definition and post sites

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -18,7 +18,6 @@ extension Notification.Name {
     static let requestAppPreview = Notification.Name("MainWindow.requestAppPreview")
     static let assistantFeatureFlagDidChange = Notification.Name("assistantFeatureFlagDidChange")
     static let localBootstrapCompleted = Notification.Name("localBootstrapCompleted")
-    static let inferenceConfigDidChange = Notification.Name("SettingsStore.inferenceConfigDidChange")
 }
 
 /// Manages API keys using CredentialStorage (Keychain in Release, file-based

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2149,7 +2149,6 @@ public final class SettingsStore: ObservableObject {
             }
         }
         scheduleRoutingSourceRefresh()
-        NotificationCenter.default.post(name: .inferenceConfigDidChange, object: nil)
     }
 
     func setImageGenMode(_ mode: String) {
@@ -2631,7 +2630,6 @@ public final class SettingsStore: ObservableObject {
             }
         }
         scheduleRoutingSourceRefresh()
-        NotificationCenter.default.post(name: .inferenceConfigDidChange, object: nil)
     }
 
     /// Schedules a delayed refresh of provider routing sources, giving the


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for inline-api-key-error.md.

**Gap:** Dead code: inferenceConfigDidChange notification has no remaining subscribers
**What was expected:** Notification definition and post sites cleaned up after removing sole observer
**What was found:** Notification still defined in APIKeyManager.swift and posted in two SettingsStore.swift locations with no subscribers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
