### PR TITLE
fix: use VIconView instead of Image(systemName:) in MissingApiKeyBanner dismiss button

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -250,8 +250,7 @@ struct MissingApiKeyBanner: View {
             HStack {
                 Spacer()
                 Button { onDismiss?() } label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 12, weight: .medium))
+                    VIconView(.x, size: 12)
                         .foregroundStyle(VColor.contentSecondary)
                 }
                 .buttonStyle(.plain)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for inline-api-key-error.md.

**Gap:** MissingApiKeyBanner dismiss button uses Image(systemName:) instead of VIconView
**What was expected:** All new UI icons use VIconView per AGENTS.md
**What was found:** Image(systemName: "xmark") used instead of VIconView(.x, size: 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
