### PR TITLE
feat: add real-time social auto-like skill for Slack channels

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -464,6 +464,21 @@
       "compatibility": "Designed for Vellum personal assistants"
     },
     {
+      "id": "social-auto-like",
+      "name": "social-auto-like",
+      "description": "Automatically like Twitter/X posts shared in Slack channels in real-time",
+      "metadata": {
+        "emoji": "❤️",
+        "vellum": {
+          "display-name": "Social Auto-Like",
+          "includes": [
+            "twitter"
+          ]
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants"
+    },
+    {
       "id": "spotify-oauth-setup",
       "name": "spotify-oauth-setup",
       "description": "Set up Spotify OAuth credentials using a collaborative guided flow",

--- a/skills/social-auto-like/SKILL.md
+++ b/skills/social-auto-like/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: social-auto-like
+description: Automatically like Twitter/X posts shared in Slack channels in real-time
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "❤️"
+  vellum:
+    display-name: "Social Auto-Like"
+    includes:
+      - "twitter"
+---
+
+## Purpose
+
+When a message arrives in a Slack channel containing a Twitter/X link, automatically like that tweet and leave a reaction emoji on the Slack message as visual confirmation.
+
+## Channel Scoping
+
+Auto-liking applies to all Slack channels the bot is a member of. To restrict which channels are auto-liked, control which channels the Slack bot is added to.
+
+## Behavior
+
+When you receive an inbound Slack message:
+
+1. If the message contains any `twitter.com` or `x.com` status URLs, call `twitter_auto_like_scan` with the full message text
+2. The tool handles everything: extracting URLs, liking each tweet, and adding a reaction emoji to the original Slack message
+3. Do not call any other tools for the reaction — the scan tool handles it internally
+
+## Trust Requirements
+
+- **Guardian**: Full auto-approve
+- **Trusted contacts**: Auto-approve via `trusted_auto_approve` flag (all tools are low-risk). People who post in the channel should be added as trusted contacts.
+- **Unknown actors**: Tool execution blocked. Message silently not processed.
+
+## Prerequisites
+
+- Twitter/X OAuth connected (see `twitter-oauth-setup`)
+- Slack connected (see `slack-app-setup`)
+- Bot must be a member of the target channel
+- Posters should be trusted contacts


### PR DESCRIPTION
## Summary
- Add `social-auto-like` portable skill that teaches the assistant to auto-like tweets posted in Slack channels
- When an inbound Slack message contains Twitter/X URLs, the assistant calls `twitter_auto_like_scan` which handles the full flow: extract URLs, like tweets, add Slack reaction
- Documents trust requirements: guardian auto-approves, trusted contacts auto-approve via `trusted_auto_approve` flag, unknown actors silently blocked

Closes JARVIS-334
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21031" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
