### PR TITLE
fix: add accessibility label to MissingApiKeyBanner dismiss button

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -255,6 +255,7 @@ struct MissingApiKeyBanner: View {
                         .foregroundStyle(VColor.contentSecondary)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Dismiss")
             }
 
             VStack(spacing: VSpacing.xs) {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for inline-api-key-error.md.

**Gap:** Missing accessibility label on MissingApiKeyBanner dismiss button
**What was expected:** Icon-only buttons require .accessibilityLabel() per AGENTS.md
**What was found:** No accessibility label on the dismiss button
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
