### PR TITLE
fix: preserve explicit trusted_auto_approve: false in tool manifest

### DIFF
--- a/assistant/src/skills/tool-manifest.ts
+++ b/assistant/src/skills/tool-manifest.ts
@@ -156,7 +156,7 @@ function parseToolEntry(raw: unknown, prefix: string): SkillToolEntry {
     input_schema,
     executor,
     execution_target,
-    ...(trusted_auto_approve ? { trusted_auto_approve } : {}),
+    ...(trusted_auto_approve !== undefined ? { trusted_auto_approve } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary
Fixes gap: tool-manifest parser dropped explicit false values for trusted_auto_approve due to falsy check.

Part of JARVIS-334
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
