### PR TITLE
fix: only add Slack reaction when at least one tweet was liked

### DIFF
--- a/assistant/src/config/bundled-skills/twitter/tools/twitter-auto-like-scan.ts
+++ b/assistant/src/config/bundled-skills/twitter/tools/twitter-auto-like-scan.ts
@@ -114,8 +114,8 @@ export async function run(
   }
   const resultSummary = parts.join(". ") + ".";
 
-  // 5. Add Slack reaction if we have an inbound event
-  if (context.inboundEventId) {
+  // 5. Add Slack reaction if we have an inbound event and at least one tweet was liked
+  if (context.inboundEventId && liked.length > 0) {
     try {
       const event = getDb()
         .select({


### PR DESCRIPTION
## Summary
Fixes gap: Slack reaction was added even when all tweet likes failed. Now gates on at least one successful like.

Part of JARVIS-334
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
