### PR TITLE
fix: clarify unlike response message for non-liked tweets

### DIFF
--- a/assistant/src/config/bundled-skills/twitter/tools/twitter-unlike-post.ts
+++ b/assistant/src/config/bundled-skills/twitter/tools/twitter-unlike-post.ts
@@ -47,7 +47,8 @@ export async function run(
     const body = resp.body as { data?: { liked?: boolean } };
 
     if (resp.status === 200) {
-      if (body.data?.liked === true) return ok("Tweet was not liked.");
+      if (body.data?.liked === true)
+        return ok("Tweet was not previously liked — nothing to unlike.");
       return ok(`Unliked tweet ${tweetId}.`);
     }
 


### PR DESCRIPTION
## Summary
Fixes misleading response message in twitter-unlike-post when the tweet wasn't previously liked.

Part of JARVIS-334
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
