### PR TITLE
feat: auto-like Twitter/X posts shared in Slack channels

### DIFF
--- a/assistant/src/__tests__/trusted-auto-approve.test.ts
+++ b/assistant/src/__tests__/trusted-auto-approve.test.ts
@@ -1,0 +1,590 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "trusted-auto-approve-test-"));
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  getRootDir: () => testDir,
+  getWorkspaceDir: () => join(testDir, "workspace"),
+  getWorkspaceDirDisplay: () => join(testDir, "workspace"),
+  getWorkspaceSkillsDir: () => join(testDir, "workspace", "skills"),
+  getWorkspaceConfigPath: () => join(testDir, "workspace", "config.json"),
+  getWorkspaceHooksDir: () => join(testDir, "workspace", "hooks"),
+  getWorkspacePromptPath: (file: string) =>
+    join(testDir, "workspace", "prompts", file),
+  getConversationsDir: () => join(testDir, "conversations"),
+  getHooksDir: () => join(testDir, "hooks"),
+  getSignalsDir: () => join(testDir, "signals"),
+  getHistoryPath: () => join(testDir, "history"),
+  getInterfacesDir: () => join(testDir, "interfaces"),
+  getSandboxRootDir: () => join(testDir, "sandbox"),
+  getSandboxWorkingDir: () => join(testDir, "sandbox", "work"),
+  getSoundsDir: () => join(testDir, "sounds"),
+  getEmbeddingModelsDir: () => join(testDir, "embedding-models"),
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPlatformName: () => "test",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+  getTCPPort: () => 0,
+  isTCPEnabled: () => false,
+  getTCPHost: () => "127.0.0.1",
+  isIOSPairingEnabled: () => false,
+  getPlatformTokenPath: () => join(testDir, "token"),
+  readPlatformToken: () => null,
+  getClipboardCommand: () => null,
+  resolveInstanceDataDir: () => undefined,
+  normalizeAssistantId: (id: string) => id,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  truncateForLog: (value: string) => value,
+}));
+
+mock.module("../tools/verification-control-plane-policy.js", () => ({
+  enforceVerificationControlPlanePolicy: () => ({ denied: false }),
+}));
+
+mock.module("../tasks/ephemeral-permissions.js", () => ({
+  getTaskRunRules: () => [],
+}));
+
+// Mock config
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    permissions: { dangerouslySkipPermissions: false },
+    sandbox: { enabled: false },
+    timeouts: { permissionTimeoutSec: 30 },
+    secretDetection: { allowOneTimeSend: false },
+  }),
+}));
+
+// Mock hooks
+mock.module("../hooks/manager.js", () => ({
+  getHookManager: () => ({
+    trigger: async () => {},
+  }),
+}));
+
+// Mock conversation approval overrides
+mock.module("../runtime/conversation-approval-overrides.js", () => ({
+  getEffectiveMode: () => undefined,
+  setTimedMode: () => {},
+  setConversationMode: () => {},
+}));
+
+// Mock permission checker
+mock.module("../permissions/checker.js", () => ({
+  check: async () => ({ decision: "prompt", reason: "needs approval" }),
+  classifyRisk: async () => "low",
+  generateAllowlistOptions: async () => [],
+  generateScopeOptions: () => [],
+  normalizeWebFetchUrl: (url: string) => url,
+}));
+
+// Mock policy context
+mock.module("../tools/policy-context.js", () => ({
+  buildPolicyContext: () => null,
+}));
+
+// Mock side effects
+mock.module("../tools/side-effects.js", () => ({
+  isSideEffectTool: (name: string) => name !== "read_only_tool",
+}));
+
+// Mock sandbox
+mock.module("../tools/terminal/sandbox.js", () => ({
+  wrapCommand: () => ({ sandboxed: false }),
+}));
+
+// Mock channel permission profiles
+mock.module("../channels/permission-profiles.js", () => ({
+  isToolAllowedInChannel: () => true,
+}));
+
+import { initializeDb, resetDb } from "../memory/db.js";
+import { RiskLevel } from "../permissions/types.js";
+import type { Tool, ToolContext, ToolLifecycleEvent } from "../tools/types.js";
+
+// Initialize the DB so ToolApprovalHandler tests can use grant tables
+initializeDb();
+
+// ── Helper factories ─────────────────────────────────────────────────
+
+function makeTool(overrides: Partial<Tool> = {}): Tool {
+  return {
+    name: overrides.name ?? "test_tool",
+    description: "Test tool",
+    category: "test",
+    defaultRiskLevel: overrides.defaultRiskLevel ?? RiskLevel.Low,
+    trustedAutoApprove: overrides.trustedAutoApprove ?? false,
+    getDefinition: () => ({
+      name: overrides.name ?? "test_tool",
+      description: "Test tool",
+      input_schema: { type: "object" as const, properties: {} },
+    }),
+    execute: async () => ({ content: "ok", isError: false }),
+    ...overrides,
+  };
+}
+
+function makeToolContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: testDir,
+    conversationId: "test-conv",
+    trustClass: overrides.trustClass ?? "trusted_contact",
+    isInteractive: overrides.isInteractive ?? false,
+    requireFreshApproval: overrides.requireFreshApproval ?? false,
+    ...overrides,
+  };
+}
+
+const noopEmit = (_event: ToolLifecycleEvent): void => {};
+const noopSanitize = (_name: string, input: Record<string, unknown>) => input;
+const noopDiff = () => undefined;
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("trusted_auto_approve", () => {
+  // ─── Permission Checker tests ────────────────────────────────────
+
+  describe("PermissionChecker", () => {
+    // We need to dynamically import after mocks are set up
+    let PermissionChecker: typeof import("../tools/permission-checker.js").PermissionChecker;
+
+    beforeEach(async () => {
+      const mod = await import("../tools/permission-checker.js");
+      PermissionChecker = mod.PermissionChecker;
+    });
+
+    const mockPrompter = {
+      prompt: async () => ({ decision: "allow" as const }),
+      dispose: () => {},
+    };
+
+    test("trustedAutoApprove: true + low risk + trusted_contact + non-interactive → auto-approved", async () => {
+      const checker = new PermissionChecker(mockPrompter as any);
+      const tool = makeTool({
+        trustedAutoApprove: true,
+        defaultRiskLevel: RiskLevel.Low,
+      });
+      const context = makeToolContext({
+        trustClass: "trusted_contact",
+        isInteractive: false,
+      });
+
+      const result = await checker.checkPermission(
+        "test_tool",
+        {},
+        tool,
+        context,
+        "host",
+        noopEmit,
+        noopSanitize,
+        Date.now(),
+        noopDiff,
+      );
+
+      expect(result.allowed).toBe(true);
+      expect(result.decision).toBe("trusted_auto_approve");
+    });
+
+    test("trustedAutoApprove: true + low risk + trusted_contact + interactive → auto-approved", async () => {
+      const checker = new PermissionChecker(mockPrompter as any);
+      const tool = makeTool({
+        trustedAutoApprove: true,
+        defaultRiskLevel: RiskLevel.Low,
+      });
+      const context = makeToolContext({
+        trustClass: "trusted_contact",
+        isInteractive: true,
+      });
+
+      const result = await checker.checkPermission(
+        "test_tool",
+        {},
+        tool,
+        context,
+        "host",
+        noopEmit,
+        noopSanitize,
+        Date.now(),
+        noopDiff,
+      );
+
+      expect(result.allowed).toBe(true);
+      expect(result.decision).toBe("trusted_auto_approve");
+    });
+
+    test("trustedAutoApprove: true + medium risk + trusted_contact + non-interactive → denied (risk cap)", async () => {
+      const checker = new PermissionChecker(mockPrompter as any);
+      const tool = makeTool({
+        trustedAutoApprove: true,
+        defaultRiskLevel: RiskLevel.Medium,
+      });
+      const context = makeToolContext({
+        trustClass: "trusted_contact",
+        isInteractive: false,
+      });
+
+      const result = await checker.checkPermission(
+        "test_tool",
+        {},
+        tool,
+        context,
+        "host",
+        noopEmit,
+        noopSanitize,
+        Date.now(),
+        noopDiff,
+      );
+
+      // Should NOT be trusted_auto_approve because risk is medium
+      expect(result.decision).not.toBe("trusted_auto_approve");
+    });
+
+    test("trustedAutoApprove: true + medium risk + trusted_contact + interactive → denied (risk cap)", async () => {
+      const checker = new PermissionChecker(mockPrompter as any);
+      const tool = makeTool({
+        trustedAutoApprove: true,
+        defaultRiskLevel: RiskLevel.Medium,
+      });
+      const context = makeToolContext({
+        trustClass: "trusted_contact",
+        isInteractive: true,
+      });
+
+      const result = await checker.checkPermission(
+        "test_tool",
+        {},
+        tool,
+        context,
+        "host",
+        noopEmit,
+        noopSanitize,
+        Date.now(),
+        noopDiff,
+      );
+
+      expect(result.decision).not.toBe("trusted_auto_approve");
+    });
+
+    test("trustedAutoApprove: true + low risk + unknown + non-interactive → denied", async () => {
+      const checker = new PermissionChecker(mockPrompter as any);
+      const tool = makeTool({
+        trustedAutoApprove: true,
+        defaultRiskLevel: RiskLevel.Low,
+      });
+      const context = makeToolContext({
+        trustClass: "unknown",
+        isInteractive: false,
+      });
+
+      const result = await checker.checkPermission(
+        "test_tool",
+        {},
+        tool,
+        context,
+        "host",
+        noopEmit,
+        noopSanitize,
+        Date.now(),
+        noopDiff,
+      );
+
+      expect(result.decision).not.toBe("trusted_auto_approve");
+      expect(result.allowed).toBe(false);
+    });
+
+    test("trustedAutoApprove: true + low risk + unknown + interactive → denied", async () => {
+      const checker = new PermissionChecker(mockPrompter as any);
+      const tool = makeTool({
+        trustedAutoApprove: true,
+        defaultRiskLevel: RiskLevel.Low,
+      });
+      const context = makeToolContext({
+        trustClass: "unknown",
+        isInteractive: true,
+      });
+
+      const result = await checker.checkPermission(
+        "test_tool",
+        {},
+        tool,
+        context,
+        "host",
+        noopEmit,
+        noopSanitize,
+        Date.now(),
+        noopDiff,
+      );
+
+      expect(result.decision).not.toBe("trusted_auto_approve");
+    });
+
+    test("trustedAutoApprove: false + low risk + trusted_contact + non-interactive → denied (flag required)", async () => {
+      const checker = new PermissionChecker(mockPrompter as any);
+      const tool = makeTool({
+        trustedAutoApprove: false,
+        defaultRiskLevel: RiskLevel.Low,
+      });
+      const context = makeToolContext({
+        trustClass: "trusted_contact",
+        isInteractive: false,
+      });
+
+      const result = await checker.checkPermission(
+        "test_tool",
+        {},
+        tool,
+        context,
+        "host",
+        noopEmit,
+        noopSanitize,
+        Date.now(),
+        noopDiff,
+      );
+
+      expect(result.decision).not.toBe("trusted_auto_approve");
+      expect(result.allowed).toBe(false);
+    });
+
+    test("trustedAutoApprove: true + low risk + guardian + non-interactive → guardian_auto_approve (unchanged)", async () => {
+      const checker = new PermissionChecker(mockPrompter as any);
+      const tool = makeTool({
+        trustedAutoApprove: true,
+        defaultRiskLevel: RiskLevel.Low,
+      });
+      const context = makeToolContext({
+        trustClass: "guardian",
+        isInteractive: false,
+      });
+
+      const result = await checker.checkPermission(
+        "test_tool",
+        {},
+        tool,
+        context,
+        "host",
+        noopEmit,
+        noopSanitize,
+        Date.now(),
+        noopDiff,
+      );
+
+      expect(result.allowed).toBe(true);
+      expect(result.decision).toBe("guardian_auto_approve");
+    });
+
+    test("trustedAutoApprove: true + low risk + trusted_contact + requireFreshApproval → denied", async () => {
+      const checker = new PermissionChecker(mockPrompter as any);
+      const tool = makeTool({
+        trustedAutoApprove: true,
+        defaultRiskLevel: RiskLevel.Low,
+      });
+      const context = makeToolContext({
+        trustClass: "trusted_contact",
+        isInteractive: false,
+        requireFreshApproval: true,
+      });
+
+      const result = await checker.checkPermission(
+        "test_tool",
+        {},
+        tool,
+        context,
+        "host",
+        noopEmit,
+        noopSanitize,
+        Date.now(),
+        noopDiff,
+      );
+
+      expect(result.decision).not.toBe("trusted_auto_approve");
+      expect(result.allowed).toBe(false);
+    });
+
+    test("trustedAutoApprove: true + low risk + trusted_contact + dynamic skill load → denied", async () => {
+      // Override the check mock to return a matched rule with skill_load_dynamic pattern
+      mock.module("../permissions/checker.js", () => ({
+        check: async () => ({
+          decision: "prompt",
+          reason: "needs approval",
+          matchedRule: { pattern: "skill_load_dynamic:test" },
+        }),
+        classifyRisk: async () => "low",
+        generateAllowlistOptions: async () => [],
+        generateScopeOptions: () => [],
+        normalizeWebFetchUrl: (url: string) => url,
+      }));
+
+      // Re-import to get the new mock
+      const { PermissionChecker: FreshChecker } =
+        await import("../tools/permission-checker.js");
+      const checker = new FreshChecker(mockPrompter as any);
+      const tool = makeTool({
+        trustedAutoApprove: true,
+        defaultRiskLevel: RiskLevel.Low,
+      });
+      const context = makeToolContext({
+        trustClass: "trusted_contact",
+        isInteractive: false,
+      });
+
+      const result = await checker.checkPermission(
+        "test_tool",
+        {},
+        tool,
+        context,
+        "host",
+        noopEmit,
+        noopSanitize,
+        Date.now(),
+        noopDiff,
+      );
+
+      expect(result.decision).not.toBe("trusted_auto_approve");
+      expect(result.allowed).toBe(false);
+
+      // Restore original mock
+      mock.module("../permissions/checker.js", () => ({
+        check: async () => ({ decision: "prompt", reason: "needs approval" }),
+        classifyRisk: async () => "low",
+        generateAllowlistOptions: async () => [],
+        generateScopeOptions: () => [],
+        normalizeWebFetchUrl: (url: string) => url,
+      }));
+    });
+  });
+
+  // ─── Tool Approval Handler (pre-exec gate) tests ────────────────
+
+  describe("ToolApprovalHandler pre-exec gate", () => {
+    let registeredTools: Map<string, Tool>;
+
+    beforeEach(() => {
+      registeredTools = new Map();
+    });
+
+    // Override tool registry mock with tools that have trustedAutoApprove
+    function setupToolRegistry(tools: Tool[]) {
+      registeredTools.clear();
+      for (const t of tools) registeredTools.set(t.name, t);
+      mock.module("../tools/registry.js", () => ({
+        getTool: (name: string) => registeredTools.get(name),
+        getAllTools: () => Array.from(registeredTools.values()),
+      }));
+    }
+
+    test("trusted_contact + trustedAutoApprove + low risk → skips grant consumption", async () => {
+      const tool = makeTool({
+        name: "auto_like",
+        trustedAutoApprove: true,
+        defaultRiskLevel: RiskLevel.Low,
+      });
+      setupToolRegistry([tool]);
+
+      const { ToolApprovalHandler } =
+        await import("../tools/tool-approval-handler.js");
+      const handler = new ToolApprovalHandler();
+      const context = makeToolContext({
+        trustClass: "trusted_contact",
+        isInteractive: true,
+      });
+
+      const result = await handler.checkPreExecutionGates(
+        "auto_like",
+        {},
+        context,
+        "host",
+        "low",
+        Date.now(),
+        noopEmit,
+      );
+
+      expect(result.allowed).toBe(true);
+      if (result.allowed) {
+        // No grant should have been consumed
+        expect(result.grantConsumed).toBeUndefined();
+      }
+    });
+
+    test("trusted_contact + trustedAutoApprove + medium risk → still requires grant", async () => {
+      const tool = makeTool({
+        name: "risky_tool",
+        trustedAutoApprove: true,
+        defaultRiskLevel: RiskLevel.Medium,
+      });
+      setupToolRegistry([tool]);
+
+      const { ToolApprovalHandler } =
+        await import("../tools/tool-approval-handler.js");
+      const handler = new ToolApprovalHandler();
+      const context = makeToolContext({
+        trustClass: "trusted_contact",
+        isInteractive: false,
+      });
+
+      const result = await handler.checkPreExecutionGates(
+        "risky_tool",
+        {},
+        context,
+        "host",
+        "medium",
+        Date.now(),
+        noopEmit,
+      );
+
+      // Without a grant, should be denied
+      expect(result.allowed).toBe(false);
+    });
+
+    test("unknown + trustedAutoApprove + low risk → denied (unknown actors fully blocked)", async () => {
+      const tool = makeTool({
+        name: "auto_like",
+        trustedAutoApprove: true,
+        defaultRiskLevel: RiskLevel.Low,
+      });
+      setupToolRegistry([tool]);
+
+      const { ToolApprovalHandler } =
+        await import("../tools/tool-approval-handler.js");
+      const handler = new ToolApprovalHandler();
+      const context = makeToolContext({
+        trustClass: "unknown",
+        isInteractive: false,
+      });
+
+      const result = await handler.checkPreExecutionGates(
+        "auto_like",
+        {},
+        context,
+        "host",
+        "low",
+        Date.now(),
+        noopEmit,
+      );
+
+      expect(result.allowed).toBe(false);
+    });
+  });
+});
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});

--- a/assistant/src/__tests__/trusted-auto-approve.test.ts
+++ b/assistant/src/__tests__/trusted-auto-approve.test.ts
@@ -176,6 +176,7 @@ describe("trusted_auto_approve", () => {
       const checker = new PermissionChecker(mockPrompter as any);
       const tool = makeTool({
         trustedAutoApprove: true,
+        ownerSkillBundled: true,
         defaultRiskLevel: RiskLevel.Low,
       });
       const context = makeToolContext({
@@ -203,6 +204,7 @@ describe("trusted_auto_approve", () => {
       const checker = new PermissionChecker(mockPrompter as any);
       const tool = makeTool({
         trustedAutoApprove: true,
+        ownerSkillBundled: true,
         defaultRiskLevel: RiskLevel.Low,
       });
       const context = makeToolContext({
@@ -390,12 +392,41 @@ describe("trusted_auto_approve", () => {
       const checker = new PermissionChecker(mockPrompter as any);
       const tool = makeTool({
         trustedAutoApprove: true,
+        ownerSkillBundled: true,
         defaultRiskLevel: RiskLevel.Low,
       });
       const context = makeToolContext({
         trustClass: "trusted_contact",
         isInteractive: false,
         requireFreshApproval: true,
+      });
+
+      const result = await checker.checkPermission(
+        "test_tool",
+        {},
+        tool,
+        context,
+        "host",
+        noopEmit,
+        noopSanitize,
+        Date.now(),
+        noopDiff,
+      );
+
+      expect(result.decision).not.toBe("trusted_auto_approve");
+      expect(result.allowed).toBe(false);
+    });
+
+    test("trustedAutoApprove: true + low risk + trusted_contact + non-bundled skill → denied (bundled-only guard)", async () => {
+      const checker = new PermissionChecker(mockPrompter as any);
+      const tool = makeTool({
+        trustedAutoApprove: true,
+        defaultRiskLevel: RiskLevel.Low,
+        ownerSkillBundled: false,
+      });
+      const context = makeToolContext({
+        trustClass: "trusted_contact",
+        isInteractive: false,
       });
 
       const result = await checker.checkPermission(
@@ -434,6 +465,7 @@ describe("trusted_auto_approve", () => {
       const checker = new FreshChecker(mockPrompter as any);
       const tool = makeTool({
         trustedAutoApprove: true,
+        ownerSkillBundled: true,
         defaultRiskLevel: RiskLevel.Low,
       });
       const context = makeToolContext({
@@ -486,10 +518,11 @@ describe("trusted_auto_approve", () => {
       }));
     }
 
-    test("trusted_contact + trustedAutoApprove + low risk → skips grant consumption", async () => {
+    test("trusted_contact + trustedAutoApprove + low risk + bundled → skips grant consumption", async () => {
       const tool = makeTool({
         name: "auto_like",
         trustedAutoApprove: true,
+        ownerSkillBundled: true,
         defaultRiskLevel: RiskLevel.Low,
       });
       setupToolRegistry([tool]);
@@ -546,6 +579,37 @@ describe("trusted_auto_approve", () => {
       );
 
       // Without a grant, should be denied
+      expect(result.allowed).toBe(false);
+    });
+
+    test("trusted_contact + trustedAutoApprove + low risk + non-bundled → requires grant (bundled-only guard)", async () => {
+      const tool = makeTool({
+        name: "auto_like",
+        trustedAutoApprove: true,
+        ownerSkillBundled: false,
+        defaultRiskLevel: RiskLevel.Low,
+      });
+      setupToolRegistry([tool]);
+
+      const { ToolApprovalHandler } =
+        await import("../tools/tool-approval-handler.js");
+      const handler = new ToolApprovalHandler();
+      const context = makeToolContext({
+        trustClass: "trusted_contact",
+        isInteractive: true,
+      });
+
+      const result = await handler.checkPreExecutionGates(
+        "auto_like",
+        {},
+        context,
+        "host",
+        "low",
+        Date.now(),
+        noopEmit,
+      );
+
+      // Non-bundled skill should NOT get the bypass — denied without grant
       expect(result.allowed).toBe(false);
     });
 

--- a/assistant/src/__tests__/twitter-tools.test.ts
+++ b/assistant/src/__tests__/twitter-tools.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  _resetUserIdCache,
+  extractAllTweetUrls,
+  extractTweetId,
+} from "../config/bundled-skills/twitter/tools/shared.js";
+import { TokenExpiredError } from "../security/token-manager.js";
+
+describe("extractTweetId", () => {
+  test("extracts from twitter.com URL", () => {
+    expect(
+      extractTweetId("https://twitter.com/elonmusk/status/1234567890"),
+    ).toBe("1234567890");
+  });
+
+  test("extracts from x.com URL", () => {
+    expect(extractTweetId("https://x.com/user/status/9876543210")).toBe(
+      "9876543210",
+    );
+  });
+
+  test("strips query parameters", () => {
+    expect(
+      extractTweetId("https://x.com/user/status/1234567890?s=20&t=abc"),
+    ).toBe("1234567890");
+  });
+
+  test("handles Slack <url|label> format", () => {
+    expect(
+      extractTweetId("<https://x.com/user/status/1234567890|Check this tweet>"),
+    ).toBe("1234567890");
+  });
+
+  test("handles Slack <url> format without label", () => {
+    expect(extractTweetId("<https://twitter.com/user/status/555>")).toBe("555");
+  });
+
+  test("handles raw numeric ID", () => {
+    expect(extractTweetId("1234567890")).toBe("1234567890");
+  });
+
+  test("returns null for non-matching input", () => {
+    expect(extractTweetId("not a tweet")).toBeNull();
+    expect(extractTweetId("https://google.com/something")).toBeNull();
+    expect(extractTweetId("")).toBeNull();
+  });
+});
+
+describe("extractAllTweetUrls", () => {
+  test("extracts multiple URLs from one message", () => {
+    const text =
+      "Check out https://x.com/user1/status/111 and https://twitter.com/user2/status/222";
+    const results = extractAllTweetUrls(text);
+    expect(results).toHaveLength(2);
+    expect(results[0].tweetId).toBe("111");
+    expect(results[1].tweetId).toBe("222");
+  });
+
+  test("handles mixed content with non-tweet URLs", () => {
+    const text =
+      "Visit https://google.com and https://x.com/user/status/333 for more info";
+    const results = extractAllTweetUrls(text);
+    expect(results).toHaveLength(1);
+    expect(results[0].tweetId).toBe("333");
+  });
+
+  test("handles Slack-formatted URLs", () => {
+    const text =
+      "Look at <https://x.com/user/status/444|tweet1> and <https://twitter.com/user/status/555|tweet2>";
+    const results = extractAllTweetUrls(text);
+    expect(results).toHaveLength(2);
+    expect(results[0].tweetId).toBe("444");
+    expect(results[1].tweetId).toBe("555");
+  });
+
+  test("deduplicates same tweet ID", () => {
+    const text =
+      "https://x.com/user/status/111 and https://twitter.com/other/status/111";
+    const results = extractAllTweetUrls(text);
+    expect(results).toHaveLength(1);
+    expect(results[0].tweetId).toBe("111");
+  });
+
+  test("returns empty array for no tweet URLs", () => {
+    const results = extractAllTweetUrls("No tweets here, just text.");
+    expect(results).toHaveLength(0);
+  });
+});
+
+describe("twitter_like_post response handling", () => {
+  test("success response returns liked message", async () => {
+    // This test validates the response handling logic inline
+    // since the actual tool requires OAuth connections
+    const mockResponse = {
+      status: 200,
+      body: { data: { liked: true } },
+    };
+    expect(mockResponse.status).toBe(200);
+    expect(
+      (mockResponse.body as { data?: { liked?: boolean } }).data?.liked,
+    ).toBe(true);
+  });
+
+  test("already-liked response detected", () => {
+    const mockResponse = {
+      status: 200,
+      body: { data: { liked: false } },
+    };
+    expect(
+      (mockResponse.body as { data?: { liked?: boolean } }).data?.liked,
+    ).toBe(false);
+  });
+
+  test("TokenExpiredError is caught correctly", () => {
+    // Verify the error class is constructable and has expected properties
+    const error = new TokenExpiredError("integration:twitter");
+    expect(error).toBeInstanceOf(TokenExpiredError);
+    expect(error.name).toBe("TokenExpiredError");
+  });
+
+  test("429 response returns rate limit error", () => {
+    const mockResponse = { status: 429, body: {} };
+    expect(mockResponse.status).toBe(429);
+  });
+
+  test("generic error status returns API error", () => {
+    const mockResponse = {
+      status: 403,
+      body: { detail: "Forbidden" },
+    };
+    expect(mockResponse.status).toBe(403);
+  });
+});
+
+describe("getAuthenticatedUserId cache", () => {
+  test("composite key isolates different connections", () => {
+    // Verify the cache is keyed by connection ID + account info
+    _resetUserIdCache();
+    // The cache is internal, but we can verify the reset works without error
+    expect(true).toBe(true);
+  });
+});
+
+describe("twitter_auto_like_scan", () => {
+  test("extracts URLs and builds results summary shape", () => {
+    const text =
+      "Check https://x.com/user/status/111 and https://x.com/other/status/222";
+    const urls = extractAllTweetUrls(text);
+    expect(urls).toHaveLength(2);
+
+    // Verify the summary-building logic shape
+    const liked = ["111"];
+    const alreadyLiked = ["222"];
+    const failed: Array<{ tweetId: string; reason: string }> = [];
+
+    const parts: string[] = [];
+    if (liked.length > 0) {
+      parts.push(`Liked ${liked.length} tweet(s): ${liked.join(", ")}`);
+    }
+    if (alreadyLiked.length > 0) {
+      parts.push(
+        `Already liked ${alreadyLiked.length} tweet(s): ${alreadyLiked.join(", ")}`,
+      );
+    }
+    if (failed.length > 0) {
+      parts.push(
+        `Failed ${failed.length} tweet(s): ${failed.map((f) => `${f.tweetId} (${f.reason})`).join(", ")}`,
+      );
+    }
+    const summary = parts.join(". ") + ".";
+
+    expect(summary).toContain("Liked 1 tweet(s)");
+    expect(summary).toContain("Already liked 1 tweet(s)");
+  });
+
+  test("handles no-URLs-found case", () => {
+    const urls = extractAllTweetUrls("Just a normal message with no links.");
+    expect(urls).toHaveLength(0);
+  });
+});

--- a/assistant/src/__tests__/twitter-tools.test.ts
+++ b/assistant/src/__tests__/twitter-tools.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-  _resetUserIdCache,
   extractAllTweetUrls,
   extractTweetId,
 } from "../config/bundled-skills/twitter/tools/shared.js";
@@ -89,28 +88,15 @@ describe("extractAllTweetUrls", () => {
 });
 
 describe("twitter_like_post response handling", () => {
-  test("success response returns liked message", async () => {
-    // This test validates the response handling logic inline
-    // since the actual tool requires OAuth connections
-    const mockResponse = {
-      status: 200,
-      body: { data: { liked: true } },
-    };
-    expect(mockResponse.status).toBe(200);
-    expect(
-      (mockResponse.body as { data?: { liked?: boolean } }).data?.liked,
-    ).toBe(true);
-  });
+  test.todo(
+    "success response returns liked message when run() is called with a valid tweet ID",
+    () => {},
+  );
 
-  test("already-liked response detected", () => {
-    const mockResponse = {
-      status: 200,
-      body: { data: { liked: false } },
-    };
-    expect(
-      (mockResponse.body as { data?: { liked?: boolean } }).data?.liked,
-    ).toBe(false);
-  });
+  test.todo(
+    "already-liked response is detected and reported when run() encounters a previously liked tweet",
+    () => {},
+  );
 
   test("TokenExpiredError is caught correctly", () => {
     // Verify the error class is constructable and has expected properties
@@ -119,63 +105,37 @@ describe("twitter_like_post response handling", () => {
     expect(error.name).toBe("TokenExpiredError");
   });
 
-  test("429 response returns rate limit error", () => {
-    const mockResponse = { status: 429, body: {} };
-    expect(mockResponse.status).toBe(429);
-  });
+  test.todo(
+    "429 response returns rate limit error when run() hits Twitter API rate limits",
+    () => {},
+  );
 
-  test("generic error status returns API error", () => {
-    const mockResponse = {
-      status: 403,
-      body: { detail: "Forbidden" },
-    };
-    expect(mockResponse.status).toBe(403);
-  });
+  test.todo(
+    "generic error status returns API error when run() receives a non-200 response",
+    () => {},
+  );
 });
 
 describe("getAuthenticatedUserId cache", () => {
-  test("composite key isolates different connections", () => {
-    // Verify the cache is keyed by connection ID + account info
-    _resetUserIdCache();
-    // The cache is internal, but we can verify the reset works without error
-    expect(true).toBe(true);
-  });
+  test.todo(
+    "composite key isolates different connections — cache returns distinct user IDs for different connection IDs",
+    () => {},
+  );
 });
 
 describe("twitter_auto_like_scan", () => {
-  test("extracts URLs and builds results summary shape", () => {
-    const text =
-      "Check https://x.com/user/status/111 and https://x.com/other/status/222";
-    const urls = extractAllTweetUrls(text);
-    expect(urls).toHaveLength(2);
+  test.todo(
+    "run() extracts tweet URLs from messages and likes each one via the Twitter API",
+    () => {},
+  );
 
-    // Verify the summary-building logic shape
-    const liked = ["111"];
-    const alreadyLiked = ["222"];
-    const failed: Array<{ tweetId: string; reason: string }> = [];
+  test.todo(
+    "run() returns a summary with liked, already-liked, and failed counts",
+    () => {},
+  );
 
-    const parts: string[] = [];
-    if (liked.length > 0) {
-      parts.push(`Liked ${liked.length} tweet(s): ${liked.join(", ")}`);
-    }
-    if (alreadyLiked.length > 0) {
-      parts.push(
-        `Already liked ${alreadyLiked.length} tweet(s): ${alreadyLiked.join(", ")}`,
-      );
-    }
-    if (failed.length > 0) {
-      parts.push(
-        `Failed ${failed.length} tweet(s): ${failed.map((f) => `${f.tweetId} (${f.reason})`).join(", ")}`,
-      );
-    }
-    const summary = parts.join(". ") + ".";
-
-    expect(summary).toContain("Liked 1 tweet(s)");
-    expect(summary).toContain("Already liked 1 tweet(s)");
-  });
-
-  test("handles no-URLs-found case", () => {
-    const urls = extractAllTweetUrls("Just a normal message with no links.");
-    expect(urls).toHaveLength(0);
-  });
+  test.todo(
+    "run() handles no-URLs-found case by returning an appropriate message",
+    () => {},
+  );
 });

--- a/assistant/src/config/bundled-skills/twitter/SKILL.md
+++ b/assistant/src/config/bundled-skills/twitter/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: twitter
+description: Twitter/X engagement tools
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🐦"
+  vellum:
+    display-name: "Twitter / X"
+    feature-flag: "integration-twitter"
+---
+
+You are a Twitter/X assistant that helps users engage with tweets. Use the twitter tools for liking, unliking, and auto-liking tweets.
+
+## Tools
+
+### twitter_like_post
+
+Like a tweet by URL or tweet ID. Accepts:
+- Full twitter.com or x.com URLs (e.g. `https://x.com/user/status/123`)
+- Slack-formatted URLs (e.g. `<https://x.com/user/status/123|tweet>`)
+- Raw numeric tweet IDs
+
+### twitter_unlike_post
+
+Unlike a previously liked tweet. Accepts the same URL/ID formats as `twitter_like_post`.
+
+### twitter_auto_like_scan
+
+Scan a message for tweet URLs, like each one, and optionally add a Slack reaction to the source message as visual confirmation. This is the primary tool for automated tweet engagement workflows.
+
+Input:
+- `message_text`: The raw message text to scan for tweet URLs.
+- `reaction_emoji` (optional): The Slack emoji to add as a reaction (default: `heart`).
+
+## Connection
+
+Before using any Twitter tool, verify that Twitter/X is connected. If not connected, load the **twitter-oauth-setup** skill (`skill_load` with `skill: "twitter-oauth-setup"`) and follow its guided flow.

--- a/assistant/src/config/bundled-skills/twitter/TOOLS.json
+++ b/assistant/src/config/bundled-skills/twitter/TOOLS.json
@@ -1,0 +1,78 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "twitter_like_post",
+      "description": "Like a tweet on Twitter/X by URL or tweet ID.",
+      "category": "twitter",
+      "risk": "low",
+      "trusted_auto_approve": true,
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "url_or_id": {
+            "type": "string",
+            "description": "Tweet URL (twitter.com or x.com) or numeric tweet ID"
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["url_or_id"]
+      },
+      "executor": "tools/twitter-like-post.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "twitter_unlike_post",
+      "description": "Unlike a previously liked tweet on Twitter/X by URL or tweet ID.",
+      "category": "twitter",
+      "risk": "low",
+      "trusted_auto_approve": true,
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "url_or_id": {
+            "type": "string",
+            "description": "Tweet URL (twitter.com or x.com) or numeric tweet ID"
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["url_or_id"]
+      },
+      "executor": "tools/twitter-unlike-post.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "twitter_auto_like_scan",
+      "description": "Scan a message for tweet URLs, like each one via the Twitter API, and add a Slack reaction emoji to the source message as visual confirmation.",
+      "category": "twitter",
+      "risk": "low",
+      "trusted_auto_approve": true,
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_text": {
+            "type": "string",
+            "description": "The raw message text to scan for tweet URLs"
+          },
+          "reaction_emoji": {
+            "type": "string",
+            "description": "Slack emoji name to react with (default: heart)"
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["message_text"]
+      },
+      "executor": "tools/twitter-auto-like-scan.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/twitter/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/twitter/tools/shared.ts
@@ -1,0 +1,131 @@
+/**
+ * Shared utilities for twitter skill tools.
+ */
+
+import type { OAuthConnection } from "../../../../oauth/connection.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
+import type { ToolExecutionResult } from "../../../../tools/types.js";
+
+export function ok(content: string): ToolExecutionResult {
+  return { content, isError: false };
+}
+
+export function err(message: string): ToolExecutionResult {
+  return { content: message, isError: true };
+}
+
+/**
+ * Resolve the Twitter OAuth connection.
+ */
+export async function getTwitterConnection(): Promise<OAuthConnection> {
+  return resolveOAuthConnection("integration:twitter");
+}
+
+/**
+ * Cache for authenticated user IDs, keyed by `${connectionId}:${accountInfo}`.
+ */
+const userIdCache = new Map<string, string>();
+
+/**
+ * Get the authenticated Twitter user ID for a connection.
+ * Results are cached per connection+account to avoid redundant API calls.
+ */
+export async function getAuthenticatedUserId(
+  conn: OAuthConnection,
+): Promise<string> {
+  const cacheKey = `${conn.id}:${conn.accountInfo ?? "default"}`;
+  const cached = userIdCache.get(cacheKey);
+  if (cached) return cached;
+
+  const resp = await conn.request({
+    method: "GET",
+    path: "/2/users/me",
+  });
+
+  const body = resp.body as { data?: { id?: string } };
+  const userId = body?.data?.id;
+  if (!userId) {
+    throw new Error(
+      "Failed to resolve authenticated Twitter user ID. Check your connection.",
+    );
+  }
+
+  userIdCache.set(cacheKey, userId);
+  return userId;
+}
+
+/**
+ * Extract a tweet ID from a URL or raw numeric string.
+ *
+ * Handles:
+ * - https://twitter.com/user/status/123
+ * - https://x.com/user/status/123
+ * - URLs with query parameters
+ * - Slack `<url|label>` format
+ * - Raw numeric strings
+ */
+export function extractTweetId(input: string): string | null {
+  if (!input) return null;
+
+  let url = input.trim();
+
+  // Handle Slack <url|label> format: extract URL before pipe, strip angle brackets
+  if (url.startsWith("<") && url.includes("|")) {
+    url = url.slice(1, url.indexOf("|"));
+  } else if (url.startsWith("<") && url.endsWith(">")) {
+    url = url.slice(1, -1);
+  }
+
+  // Try to parse as a tweet URL
+  const urlMatch = url.match(
+    /(?:https?:\/\/)?(?:(?:twitter|x)\.com)\/[^/]+\/status\/(\d+)/,
+  );
+  if (urlMatch) return urlMatch[1];
+
+  // Try raw numeric ID
+  if (/^\d+$/.test(url)) return url;
+
+  return null;
+}
+
+/**
+ * Extract all tweet URLs from a block of text.
+ *
+ * Scans for twitter.com and x.com status URLs, including Slack-formatted links.
+ * Returns an array of `{ url, tweetId }` objects.
+ */
+export function extractAllTweetUrls(
+  text: string,
+): Array<{ url: string; tweetId: string }> {
+  const results: Array<{ url: string; tweetId: string }> = [];
+  const seen = new Set<string>();
+
+  // Match Slack-formatted URLs: <https://x.com/user/status/123|label>
+  const slackPattern =
+    /<(https?:\/\/(?:twitter|x)\.com\/[^/]+\/status\/(\d+))[^>]*>/g;
+  let match: RegExpExecArray | undefined;
+  while ((match = slackPattern.exec(text) ?? undefined) !== undefined) {
+    const tweetId = match[2];
+    if (!seen.has(tweetId)) {
+      seen.add(tweetId);
+      results.push({ url: match[1], tweetId });
+    }
+  }
+
+  // Match plain URLs: https://x.com/user/status/123
+  const plainPattern = /https?:\/\/(?:twitter|x)\.com\/[^/]+\/status\/(\d+)/g;
+  while ((match = plainPattern.exec(text) ?? undefined) !== undefined) {
+    const tweetId = match[1];
+    if (!seen.has(tweetId)) {
+      seen.add(tweetId);
+      results.push({ url: match[0], tweetId });
+    }
+  }
+
+  return results;
+}
+
+/** Reset the user ID cache (for testing). */
+export function _resetUserIdCache(): void {
+  userIdCache.clear();
+}

--- a/assistant/src/config/bundled-skills/twitter/tools/twitter-auto-like-scan.ts
+++ b/assistant/src/config/bundled-skills/twitter/tools/twitter-auto-like-scan.ts
@@ -1,0 +1,160 @@
+import { eq } from "drizzle-orm";
+
+import { getDb } from "../../../../memory/db.js";
+import { channelInboundEvents } from "../../../../memory/schema.js";
+import { addReaction } from "../../../../messaging/providers/slack/client.js";
+import { TokenExpiredError } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { getLogger } from "../../../../util/logger.js";
+import { getSlackConnection } from "../../slack/tools/shared.js";
+import {
+  err,
+  extractAllTweetUrls,
+  getAuthenticatedUserId,
+  getTwitterConnection,
+  ok,
+} from "./shared.js";
+
+const log = getLogger("twitter-auto-like-scan");
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const messageText = input.message_text as string;
+  if (!messageText) {
+    return err("message_text is required.");
+  }
+
+  const reactionEmoji = (input.reaction_emoji as string) || "heart";
+
+  // 1. Extract tweet URLs from message text
+  const tweetUrls = extractAllTweetUrls(messageText);
+  if (tweetUrls.length === 0) {
+    return ok("No tweet URLs found.");
+  }
+
+  // 2. Get Twitter connection and authenticated user ID
+  let conn;
+  try {
+    conn = await getTwitterConnection();
+  } catch (e) {
+    return err(
+      `Twitter not connected. Load the twitter-oauth-setup skill to connect: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+
+  let userId: string;
+  try {
+    userId = await getAuthenticatedUserId(conn);
+  } catch (e) {
+    return err(
+      `Failed to get authenticated Twitter user: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+
+  // 3. Like each tweet, collecting results
+  const liked: string[] = [];
+  const alreadyLiked: string[] = [];
+  const failed: Array<{ tweetId: string; reason: string }> = [];
+
+  for (const { tweetId } of tweetUrls) {
+    try {
+      const resp = await conn.request({
+        method: "POST",
+        path: `/2/users/${userId}/likes`,
+        body: { tweet_id: tweetId },
+      });
+
+      const body = resp.body as { data?: { liked?: boolean } };
+
+      if (resp.status === 200) {
+        if (body.data?.liked === false) {
+          alreadyLiked.push(tweetId);
+        } else {
+          liked.push(tweetId);
+        }
+      } else if (resp.status === 429) {
+        failed.push({ tweetId, reason: "rate limited" });
+      } else {
+        failed.push({
+          tweetId,
+          reason: `HTTP ${resp.status}: ${JSON.stringify(body)}`,
+        });
+      }
+    } catch (e: unknown) {
+      if (e instanceof TokenExpiredError) {
+        failed.push({ tweetId, reason: "auth expired" });
+      } else {
+        failed.push({
+          tweetId,
+          reason: e instanceof Error ? e.message : String(e),
+        });
+      }
+    }
+  }
+
+  // 4. Build result summary
+  const parts: string[] = [];
+  if (liked.length > 0) {
+    parts.push(`Liked ${liked.length} tweet(s): ${liked.join(", ")}`);
+  }
+  if (alreadyLiked.length > 0) {
+    parts.push(
+      `Already liked ${alreadyLiked.length} tweet(s): ${alreadyLiked.join(", ")}`,
+    );
+  }
+  if (failed.length > 0) {
+    parts.push(
+      `Failed ${failed.length} tweet(s): ${failed.map((f) => `${f.tweetId} (${f.reason})`).join(", ")}`,
+    );
+  }
+  const resultSummary = parts.join(". ") + ".";
+
+  // 5. Add Slack reaction if we have an inbound event
+  if (context.inboundEventId) {
+    try {
+      const event = getDb()
+        .select({
+          sourceChannel: channelInboundEvents.sourceChannel,
+          externalChatId: channelInboundEvents.externalChatId,
+          sourceMessageId: channelInboundEvents.sourceMessageId,
+        })
+        .from(channelInboundEvents)
+        .where(eq(channelInboundEvents.id, context.inboundEventId))
+        .get();
+
+      if (
+        event &&
+        event.sourceChannel === "slack" &&
+        event.externalChatId &&
+        event.sourceMessageId
+      ) {
+        try {
+          const slackConn = await getSlackConnection();
+          await addReaction(
+            slackConn,
+            event.externalChatId,
+            event.sourceMessageId,
+            reactionEmoji,
+          );
+        } catch (slackErr) {
+          log.warn(
+            { err: slackErr, channel: event.externalChatId },
+            "Failed to add Slack reaction after auto-like",
+          );
+        }
+      }
+    } catch (dbErr) {
+      log.warn(
+        { err: dbErr, inboundEventId: context.inboundEventId },
+        "Failed to query inbound event for Slack reaction",
+      );
+    }
+  }
+
+  return ok(resultSummary);
+}

--- a/assistant/src/config/bundled-skills/twitter/tools/twitter-auto-like-scan.ts
+++ b/assistant/src/config/bundled-skills/twitter/tools/twitter-auto-like-scan.ts
@@ -114,8 +114,8 @@ export async function run(
   }
   const resultSummary = parts.join(". ") + ".";
 
-  // 5. Add Slack reaction if we have an inbound event
-  if (context.inboundEventId) {
+  // 5. Add Slack reaction if we have an inbound event and at least one tweet was liked
+  if (context.inboundEventId && liked.length > 0) {
     try {
       const event = getDb()
         .select({

--- a/assistant/src/config/bundled-skills/twitter/tools/twitter-like-post.ts
+++ b/assistant/src/config/bundled-skills/twitter/tools/twitter-like-post.ts
@@ -1,0 +1,64 @@
+import { TokenExpiredError } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import {
+  err,
+  extractTweetId,
+  getAuthenticatedUserId,
+  getTwitterConnection,
+  ok,
+} from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const urlOrId = input.url_or_id as string;
+  if (!urlOrId) {
+    return err("url_or_id is required.");
+  }
+
+  const tweetId = extractTweetId(urlOrId);
+  if (!tweetId) {
+    return err(
+      `Could not extract a tweet ID from "${urlOrId}". Provide a twitter.com/x.com URL or a numeric tweet ID.`,
+    );
+  }
+
+  let conn;
+  try {
+    conn = await getTwitterConnection();
+  } catch (e) {
+    return err(
+      `Twitter not connected. Load the twitter-oauth-setup skill to connect: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+
+  const userId = await getAuthenticatedUserId(conn);
+
+  try {
+    const resp = await conn.request({
+      method: "POST",
+      path: `/2/users/${userId}/likes`,
+      body: { tweet_id: tweetId },
+    });
+
+    const body = resp.body as { data?: { liked?: boolean } };
+
+    if (resp.status === 200) {
+      if (body.data?.liked === false) return ok("Tweet was already liked.");
+      return ok(`Liked tweet ${tweetId}.`);
+    }
+
+    if (resp.status === 429) return err("Rate limited. Try again later.");
+
+    return err(`Twitter API error (${resp.status}): ${JSON.stringify(body)}`);
+  } catch (e: unknown) {
+    if (e instanceof TokenExpiredError) {
+      return err("Twitter auth expired. Re-run twitter-oauth-setup.");
+    }
+    throw e;
+  }
+}

--- a/assistant/src/config/bundled-skills/twitter/tools/twitter-unlike-post.ts
+++ b/assistant/src/config/bundled-skills/twitter/tools/twitter-unlike-post.ts
@@ -47,7 +47,8 @@ export async function run(
     const body = resp.body as { data?: { liked?: boolean } };
 
     if (resp.status === 200) {
-      if (body.data?.liked === true) return ok("Tweet was not liked.");
+      if (body.data?.liked === true)
+        return ok("Tweet was not previously liked — nothing to unlike.");
       return ok(`Unliked tweet ${tweetId}.`);
     }
 

--- a/assistant/src/config/bundled-skills/twitter/tools/twitter-unlike-post.ts
+++ b/assistant/src/config/bundled-skills/twitter/tools/twitter-unlike-post.ts
@@ -1,0 +1,63 @@
+import { TokenExpiredError } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import {
+  err,
+  extractTweetId,
+  getAuthenticatedUserId,
+  getTwitterConnection,
+  ok,
+} from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const urlOrId = input.url_or_id as string;
+  if (!urlOrId) {
+    return err("url_or_id is required.");
+  }
+
+  const tweetId = extractTweetId(urlOrId);
+  if (!tweetId) {
+    return err(
+      `Could not extract a tweet ID from "${urlOrId}". Provide a twitter.com/x.com URL or a numeric tweet ID.`,
+    );
+  }
+
+  let conn;
+  try {
+    conn = await getTwitterConnection();
+  } catch (e) {
+    return err(
+      `Twitter not connected. Load the twitter-oauth-setup skill to connect: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+
+  const userId = await getAuthenticatedUserId(conn);
+
+  try {
+    const resp = await conn.request({
+      method: "DELETE",
+      path: `/2/users/${userId}/likes/${tweetId}`,
+    });
+
+    const body = resp.body as { data?: { liked?: boolean } };
+
+    if (resp.status === 200) {
+      if (body.data?.liked === true) return ok("Tweet was not liked.");
+      return ok(`Unliked tweet ${tweetId}.`);
+    }
+
+    if (resp.status === 429) return err("Rate limited. Try again later.");
+
+    return err(`Twitter API error (${resp.status}): ${JSON.stringify(body)}`);
+  } catch (e: unknown) {
+    if (e instanceof TokenExpiredError) {
+      return err("Twitter auth expired. Re-run twitter-oauth-setup.");
+    }
+    throw e;
+  }
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -167,6 +167,10 @@ import * as taskRun from "./bundled-skills/tasks/tools/task-run.js";
 import * as taskSave from "./bundled-skills/tasks/tools/task-save.js";
 // ── transcribe ─────────────────────────────────────────────────────────────────
 import * as transcribeMedia from "./bundled-skills/transcribe/tools/transcribe-media.js";
+// ── twitter ────────────────────────────────────────────────────────────────────
+import * as twitterAutoLikeScan from "./bundled-skills/twitter/tools/twitter-auto-like-scan.js";
+import * as twitterLikePost from "./bundled-skills/twitter/tools/twitter-like-post.js";
+import * as twitterUnlikePost from "./bundled-skills/twitter/tools/twitter-unlike-post.js";
 // ── watcher ────────────────────────────────────────────────────────────────────
 import * as watcherCreate from "./bundled-skills/watcher/tools/watcher-create.js";
 import * as watcherDelete from "./bundled-skills/watcher/tools/watcher-delete.js";
@@ -325,11 +329,11 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["sequences:tools/sequence-analytics.ts", sequenceAnalytics],
 
   // settings
-  ["settings:tools/avatar-update.ts", avatarUpdate],
-  ["settings:tools/avatar-remove.ts", avatarRemove],
   ["settings:tools/voice-config-update.ts", voiceConfigUpdate],
   ["settings:tools/open-system-settings.ts", openSystemSettings],
   ["settings:tools/navigate-settings-tab.ts", navigateSettingsTab],
+  ["settings:tools/avatar-update.ts", avatarUpdate],
+  ["settings:tools/avatar-remove.ts", avatarRemove],
 
   // skill-management
   ["skill-management:tools/scaffold-managed.ts", scaffoldManaged],
@@ -365,6 +369,11 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
 
   // transcribe
   ["transcribe:tools/transcribe-media.ts", transcribeMedia],
+
+  // twitter
+  ["twitter:tools/twitter-like-post.ts", twitterLikePost],
+  ["twitter:tools/twitter-unlike-post.ts", twitterUnlikePost],
+  ["twitter:tools/twitter-auto-like-scan.ts", twitterAutoLikeScan],
 
   // watcher
   ["watcher:tools/watcher-create.ts", watcherCreate],

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -141,6 +141,8 @@ export interface SkillToolEntry {
   executor: string;
   /** Where the tool script runs. */
   execution_target: "host" | "sandbox";
+  /** When true, trusted contacts can auto-approve this tool without guardian approval (low-risk only). */
+  trusted_auto_approve?: boolean;
 }
 
 /**

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -236,6 +236,7 @@ export interface AgentLoopConversationContext {
   workspaceTopLevelDirty: boolean;
   channelCapabilities?: ChannelCapabilities;
   commandIntent?: { type: string; payload?: string; languageCode?: string };
+  inboundEventId?: string;
   trustContext?: TrustContext;
   assistantId?: string;
   voiceCallControlPrompt?: string;
@@ -1777,6 +1778,8 @@ export async function runAgentLoopImpl(
     // Channel command intents (e.g. Telegram /start) are single-turn metadata.
     // Clear at turn end so they never leak into subsequent unrelated messages.
     ctx.commandIntent = undefined;
+    // Inbound event IDs are single-turn metadata — clear at turn end.
+    ctx.inboundEventId = undefined;
 
     if (userMessageId) {
       const didMutateHistory = consolidateAssistantMessages(

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -110,6 +110,8 @@ export interface ToolSetupContext extends SurfaceConversationContext {
   hostFileProxy?: import("./host-file-proxy.js").HostFileProxy;
   /** CES RPC client for credential execution operations. Injected when CES tools are enabled and the CES process is available. */
   cesClient?: CesClient;
+  /** Inbound event ID from channelInboundEvents. Set for channel-originating turns. */
+  inboundEventId?: string;
 }
 
 // ── buildToolDefinitions ─────────────────────────────────────────────
@@ -191,6 +193,7 @@ export function createToolExecutor(
       hostBashProxy: ctx.hostBashProxy,
       hostFileProxy: ctx.hostFileProxy,
       cesClient: ctx.cesClient,
+      inboundEventId: ctx.inboundEventId,
       onToolLifecycleEvent: handleToolLifecycleEvent,
       sendToClient: (msg) => {
         // Tool context's sendToClient uses a loose { type: string; [key: string]: unknown }

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -193,6 +193,7 @@ export class Conversation {
     payload?: string;
     languageCode?: string;
   };
+  /** @internal */ inboundEventId?: string;
   /** @internal */ surfaceActionRequestIds = new Set<string>();
   /** @internal */ pendingSurfaceActions = new Map<
     string,
@@ -899,6 +900,10 @@ export class Conversation {
     intent: { type: string; payload?: string; languageCode?: string } | null,
   ): void {
     this.commandIntent = intent ?? undefined;
+  }
+
+  setInboundEventId(id: string | null): void {
+    this.inboundEventId = id ?? undefined;
   }
 
   setPreactivatedSkillIds(ids: string[] | undefined): void {

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -132,6 +132,8 @@ export interface ConversationCreateOptions {
   strictPrivateSideEffects?: boolean;
   /** Channel command intent metadata (e.g. Telegram /start). */
   commandIntent?: { type: string; payload?: string; languageCode?: string };
+  /** Channel inbound event ID for correlating tools to the originating message. */
+  inboundEventId?: string;
   /** Optional callback to receive real-time agent loop events (text deltas, tool starts, etc.). */
   onEvent?: (msg: ServerMessage) => void;
 }

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -40,10 +40,7 @@ import { updateMetaFile } from "../memory/conversation-disk-view.js";
 import { getOrCreateConversation } from "../memory/conversation-key-store.js";
 import { buildSystemPrompt } from "../prompts/system-prompt.js";
 import { RateLimitProvider } from "../providers/ratelimit.js";
-import {
-  getProvider,
-  initializeProviders,
-} from "../providers/registry.js";
+import { getProvider, initializeProviders } from "../providers/registry.js";
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
@@ -702,9 +699,7 @@ export class DaemonServer {
 
       const createPromise = (async () => {
         const config = getConfig();
-        let provider = getProvider(
-          config.services.inference.provider,
-        );
+        let provider = getProvider(config.services.inference.provider);
         const { rateLimit } = config;
         if (rateLimit.maxRequestsPerMinute > 0) {
           provider = new RateLimitProvider(
@@ -891,6 +886,7 @@ export class DaemonServer {
       conversation.setHostCuProxy(undefined);
     }
     conversation.setCommandIntent(options?.commandIntent ?? null);
+    conversation.setInboundEventId(options?.inboundEventId ?? null);
     conversation.setTurnChannelContext({
       userMessageChannel: resolvedChannel,
       assistantMessageChannel: resolvedChannel,

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -192,6 +192,7 @@ export async function sweepFailedEvents(
           trustContext,
           isInteractive:
             resolveRoutingStateFromRuntime(trustContext).promptWaitingAllowed,
+          inboundEventId: event.id,
         },
         sourceChannel,
         sourceInterface,

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -129,6 +129,8 @@ export interface RuntimeMessageConversationOptions {
   isInteractive?: boolean;
   /** Channel command intent metadata (e.g. Telegram /start). */
   commandIntent?: { type: string; payload?: string; languageCode?: string };
+  /** Channel inbound event ID for correlating tools to the originating message. */
+  inboundEventId?: string;
   /** Optional callback to receive real-time agent loop events (text deltas, tool starts, etc.). */
   onEvent?: (msg: ServerMessage) => void;
 }

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -199,6 +199,7 @@ export function processChannelMessageInBackground(
           trustContext: trustCtx,
           isInteractive: resolveRoutingState(trustCtx).promptWaitingAllowed,
           ...(cmdIntent ? { commandIntent: cmdIntent } : {}),
+          inboundEventId: eventId,
         },
         sourceChannel,
         sourceInterface,

--- a/assistant/src/skills/tool-manifest.ts
+++ b/assistant/src/skills/tool-manifest.ts
@@ -156,7 +156,7 @@ function parseToolEntry(raw: unknown, prefix: string): SkillToolEntry {
     input_schema,
     executor,
     execution_target,
-    ...(trusted_auto_approve ? { trusted_auto_approve } : {}),
+    ...(trusted_auto_approve !== undefined ? { trusted_auto_approve } : {}),
   };
 }
 

--- a/assistant/src/skills/tool-manifest.ts
+++ b/assistant/src/skills/tool-manifest.ts
@@ -137,6 +137,17 @@ function parseToolEntry(raw: unknown, prefix: string): SkillToolEntry {
   const execution_target =
     entry.execution_target as SkillToolEntry["execution_target"];
 
+  // trusted_auto_approve (optional boolean, defaults to false)
+  let trusted_auto_approve: boolean | undefined;
+  if ("trusted_auto_approve" in entry) {
+    if (typeof entry.trusted_auto_approve !== "boolean") {
+      throw new Error(
+        `${prefix}: "trusted_auto_approve" must be a boolean if provided`,
+      );
+    }
+    trusted_auto_approve = entry.trusted_auto_approve;
+  }
+
   return {
     name,
     description,
@@ -145,6 +156,7 @@ function parseToolEntry(raw: unknown, prefix: string): SkillToolEntry {
     input_schema,
     executor,
     execution_target,
+    ...(trusted_auto_approve ? { trusted_auto_approve } : {}),
   };
 }
 

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -8,6 +8,7 @@ import {
 } from "../permissions/checker.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import { addRule } from "../permissions/trust-store.js";
+import { RiskLevel } from "../permissions/types.js";
 import {
   getEffectiveMode,
   setConversationMode,
@@ -152,7 +153,11 @@ export class PermissionChecker {
             { toolName: name, riskLevel },
             "dangerouslySkipPermissions active — auto-approving without prompt",
           );
-          return { allowed: true, decision: "dangerously_skip_permissions", riskLevel };
+          return {
+            allowed: true,
+            decision: "dangerously_skip_permissions",
+            riskLevel,
+          };
         }
 
         // Guardian-trust sessions (e.g. scheduled jobs, reminders) should be
@@ -179,6 +184,29 @@ export class PermissionChecker {
           return {
             allowed: true,
             decision: "guardian_auto_approve",
+            riskLevel,
+          };
+        }
+
+        // Trusted contacts with trustedAutoApprove + low-risk tools can
+        // auto-approve without guardian involvement. This works for both
+        // interactive and non-interactive sessions — Slack trusted contacts
+        // are interactive when a guardian binding exists, so restricting to
+        // non-interactive only would prevent the feature from working.
+        if (
+          context.trustClass === "trusted_contact" &&
+          tool.trustedAutoApprove === true &&
+          tool.defaultRiskLevel === RiskLevel.Low &&
+          !context.requireFreshApproval &&
+          !isDynamicSkillLoad
+        ) {
+          log.info(
+            { toolName: name, riskLevel },
+            "Auto-approving for trusted contact with trustedAutoApprove flag",
+          );
+          return {
+            allowed: true,
+            decision: "trusted_auto_approve",
             riskLevel,
           };
         }

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -196,6 +196,7 @@ export class PermissionChecker {
         if (
           context.trustClass === "trusted_contact" &&
           tool.trustedAutoApprove === true &&
+          tool.ownerSkillBundled === true &&
           tool.defaultRiskLevel === RiskLevel.Low &&
           !context.requireFreshApproval &&
           !isDynamicSkillLoad

--- a/assistant/src/tools/skills/skill-tool-factory.ts
+++ b/assistant/src/tools/skills/skill-tool-factory.ts
@@ -37,6 +37,7 @@ export function createSkillTool(
     executionTarget: entry.execution_target as ExecutionTarget,
     ownerSkillVersionHash: versionHash,
     ownerSkillBundled: bundled,
+    trustedAutoApprove: entry.trusted_auto_approve ?? false,
 
     getDefinition(): ToolDefinition {
       return {

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -4,6 +4,7 @@ import {
   getCanonicalGuardianRequest,
   updateCanonicalGuardianRequest,
 } from "../memory/canonical-guardian-store.js";
+import { RiskLevel } from "../permissions/types.js";
 import { isUntrustedTrustClass } from "../runtime/actor-trust-resolver.js";
 import { createOrReuseToolGrantRequest } from "../runtime/tool-grant-request-helper.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
@@ -268,9 +269,15 @@ export class ToolApprovalHandler {
       | Parameters<typeof consumeGrantForInvocation>[0]
       | null = null;
 
+    const toolForGrant = getTool(name);
     if (
       isUntrustedTrustClass(context.trustClass) &&
-      requiresGuardianApprovalForActor(name, input, executionTarget)
+      requiresGuardianApprovalForActor(name, input, executionTarget) &&
+      !(
+        context.trustClass === "trusted_contact" &&
+        toolForGrant?.trustedAutoApprove === true &&
+        toolForGrant?.defaultRiskLevel === RiskLevel.Low
+      )
     ) {
       const inputDigest = computeToolApprovalDigest(name, input);
       needsGrantConsumption = true;

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -276,6 +276,7 @@ export class ToolApprovalHandler {
       !(
         context.trustClass === "trusted_contact" &&
         toolForGrant?.trustedAutoApprove === true &&
+        toolForGrant?.ownerSkillBundled === true &&
         toolForGrant?.defaultRiskLevel === RiskLevel.Low
       )
     ) {

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -179,6 +179,8 @@ export interface ToolContext {
   hostFileProxy?: import("../daemon/host-file-proxy.js").HostFileProxy;
   /** CES RPC client for credential execution operations. When present, the executor can bridge CES approval flows. */
   cesClient?: CesClient;
+  /** Inbound event ID from channelInboundEvents. Set for channel-originating turns. Used to correlate tool execution to the exact inbound Slack/Telegram/etc message. */
+  inboundEventId?: string;
 }
 
 export interface DiffInfo {
@@ -278,6 +280,8 @@ export interface Tool {
   /** Declared execution target from the skill manifest. Used by resolveExecutionTarget
    * to accurately label lifecycle events for skill-provided tools. */
   executionTarget?: ExecutionTarget;
+  /** When true, trusted contacts can auto-approve this tool without guardian approval (low-risk only). */
+  trustedAutoApprove?: boolean;
   getDefinition(): ToolDefinition;
   execute(
     input: Record<string, unknown>,

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -464,6 +464,21 @@
       "compatibility": "Designed for Vellum personal assistants"
     },
     {
+      "id": "social-auto-like",
+      "name": "social-auto-like",
+      "description": "Automatically like Twitter/X posts shared in Slack channels in real-time",
+      "metadata": {
+        "emoji": "❤️",
+        "vellum": {
+          "display-name": "Social Auto-Like",
+          "includes": [
+            "twitter"
+          ]
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants"
+    },
+    {
       "id": "spotify-oauth-setup",
       "name": "spotify-oauth-setup",
       "description": "Set up Spotify OAuth credentials using a collaborative guided flow",

--- a/skills/social-auto-like/SKILL.md
+++ b/skills/social-auto-like/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: social-auto-like
+description: Automatically like Twitter/X posts shared in Slack channels in real-time
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "❤️"
+  vellum:
+    display-name: "Social Auto-Like"
+    includes:
+      - "twitter"
+---
+
+## Purpose
+
+When a message arrives in a Slack channel containing a Twitter/X link, automatically like that tweet and leave a reaction emoji on the Slack message as visual confirmation.
+
+## Channel Scoping
+
+Auto-liking applies to all Slack channels the bot is a member of. To restrict which channels are auto-liked, control which channels the Slack bot is added to.
+
+## Behavior
+
+When you receive an inbound Slack message:
+
+1. If the message contains any `twitter.com` or `x.com` status URLs, call `twitter_auto_like_scan` with the full message text
+2. The tool handles everything: extracting URLs, liking each tweet, and adding a reaction emoji to the original Slack message
+3. Do not call any other tools for the reaction — the scan tool handles it internally
+
+## Trust Requirements
+
+- **Guardian**: Full auto-approve
+- **Trusted contacts**: Auto-approve via `trusted_auto_approve` flag (all tools are low-risk). People who post in the channel should be added as trusted contacts.
+- **Unknown actors**: Tool execution blocked. Message silently not processed.
+
+## Prerequisites
+
+- Twitter/X OAuth connected (see `twitter-oauth-setup`)
+- Slack connected (see `slack-app-setup`)
+- Bot must be a member of the target channel
+- Posters should be trusted contacts


### PR DESCRIPTION
## Summary
When someone posts a Twitter/X link in a Slack channel, the assistant automatically likes that tweet and adds a reaction emoji to the Slack message as visual confirmation. Works for the guardian and trusted contacts.

## PRs merged into feature branch
- #21021: feat: add `trusted_auto_approve` tool flag and `inboundEventId` to ToolContext
- #21025: feat: add Twitter/X like tools and auto-like-scan tool
- #21031: feat: add real-time social auto-like skill for Slack channels

## Self-review result
PASS after 1 remediation round (5 fix PRs)

## Fix PRs
- #21037: fix: restrict trusted_auto_approve to bundled skills only
- #21033: fix: preserve explicit trusted_auto_approve: false in tool manifest
- #21034: fix: only add Slack reaction when at least one tweet was liked
- #21035: fix: clarify unlike response message for non-liked tweets
- #21036: fix: convert superficial twitter tool tests to test.todo

Closes JARVIS-334

Part of plan: social-auto-like.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
