### PR TITLE
refactor: use existing config infrastructure for platform URL resolution

### DIFF
--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -13,16 +13,9 @@
  * imported from platform/logger without circular imports.
  */
 
-import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
-
 import { getLogger } from "../util/logger.js";
-import {
-  checkUnrecognizedEnvVars,
-  getBaseDataDir,
-  getWorkspaceDirOverride,
-} from "./env-registry.js";
+import { checkUnrecognizedEnvVars } from "./env-registry.js";
+import { getConfig } from "./loader.js";
 
 const log = getLogger("env");
 
@@ -145,34 +138,6 @@ export function getOllamaBaseUrlEnv(): string | undefined {
 
 // ── Platform ─────────────────────────────────────────────────────────────────
 
-/**
- * Read the platform base URL from the workspace config file
- * (~/.vellum/workspace/config.json → platform.baseUrl).
- *
- * Resolves the workspace directory inline (same logic as platform.ts) to
- * avoid importing from util/platform.js, which many tests mock without
- * providing every export.
- */
-function getConfigPlatformUrl(): string | undefined {
-  try {
-    const wsDir =
-      getWorkspaceDirOverride() ||
-      join(getBaseDataDir() || homedir(), ".vellum", "workspace");
-    const configPath = join(wsDir, "config.json");
-    if (!existsSync(configPath)) return undefined;
-    const raw = JSON.parse(readFileSync(configPath, "utf-8")) as Record<
-      string,
-      unknown
-    >;
-    const platform = raw.platform as Record<string, unknown> | undefined;
-    const baseUrl = platform?.baseUrl;
-    if (typeof baseUrl === "string" && baseUrl.trim()) return baseUrl.trim();
-  } catch {
-    // ignore
-  }
-  return undefined;
-}
-
 let _platformBaseUrlOverride: string | undefined;
 
 export function setPlatformBaseUrl(value: string | undefined): void {
@@ -180,8 +145,15 @@ export function setPlatformBaseUrl(value: string | undefined): void {
 }
 
 export function getPlatformBaseUrl(): string {
+  let configUrl: string | undefined;
+  try {
+    const val = getConfig().platform.baseUrl;
+    if (val) configUrl = val;
+  } catch {
+    // Config not yet available (early bootstrap) — fall through
+  }
   return (
-    getConfigPlatformUrl() ||
+    configUrl ||
     str("VELLUM_PLATFORM_URL") ||
     _platformBaseUrlOverride ||
     "https://platform.vellum.ai"

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -17,32 +17,25 @@ function getPlatformTokenPath(): string {
   return join(getXdgConfigHome(), "vellum", "platform-token");
 }
 
-/**
- * Read the platform base URL from the workspace config file
- * (~/.vellum/workspace/config.json → platform.baseUrl).
- */
-function getConfigPlatformUrl(): string | undefined {
-  try {
-    const configPath = join(homedir(), ".vellum", "workspace", "config.json");
-    if (!existsSync(configPath)) return undefined;
-    const raw = JSON.parse(readFileSync(configPath, "utf-8")) as Record<
-      string,
-      unknown
-    >;
-    const platform = raw.platform as Record<string, unknown> | undefined;
-    const baseUrl = platform?.baseUrl;
-    if (typeof baseUrl === "string" && baseUrl.trim()) return baseUrl.trim();
-  } catch {
-    // ignore
-  }
-  return undefined;
-}
-
 export function getPlatformUrl(): string {
+  let configUrl: string | undefined;
+  try {
+    const base = process.env.BASE_DATA_DIR?.trim() || homedir();
+    const configPath = join(base, ".vellum", "workspace", "config.json");
+    if (existsSync(configPath)) {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8")) as Record<
+        string,
+        unknown
+      >;
+      const val = (raw.platform as Record<string, unknown> | undefined)
+        ?.baseUrl;
+      if (typeof val === "string" && val.trim()) configUrl = val.trim();
+    }
+  } catch {
+    // Config not available — fall through
+  }
   return (
-    getConfigPlatformUrl() ||
-    process.env.VELLUM_PLATFORM_URL ||
-    "https://platform.vellum.ai"
+    configUrl || process.env.VELLUM_PLATFORM_URL || "https://platform.vellum.ai"
   );
 }
 


### PR DESCRIPTION
## Summary
- Replace raw `getConfigPlatformUrl()` in `env.ts` with `getConfig().platform.baseUrl` from the existing Zod-validated config loader (with try/catch for early bootstrap)
- Remove duplicated JSON parsing, file reading, and path resolution that duplicated the config infrastructure
- Fix CLI `platform-client.ts` to respect `BASE_DATA_DIR` when reading the workspace config (consistent with the rest of the CLI)

## Original prompt
Fix the platform URL resolution that was just merged in PR #21020. The current implementation added raw `getConfigPlatformUrl()` functions that manually read and parse `config.json` — duplicating the existing config infrastructure. Use `getConfig().platform.baseUrl` in the assistant and `BASE_DATA_DIR`-aware path resolution in the CLI instead.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
