### PR TITLE
fix: open ephemeral ui_show surfaces without hitting app store

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -932,12 +932,64 @@ struct MainWindowView: View {
                 windowState.selection = .app(msg.surfaceId)
             }
         } else if let ref = notification.userInfo?["surfaceRef"] as? SurfaceRef {
-            // Lightweight ref from inline surface click — the daemon will
-            // send a fresh ui_surface_show via SSE with the full payload.
-            let reopenId = ref.appId ?? ref.surfaceId
-            windowState.selection = .app(reopenId)
-            Task { await AppsClient.openAppAndDispatchSurface(id: reopenId, connectionManager: connectionManager, eventStreamClient: eventStreamClient) }
+            if let appId = ref.appId {
+                // Persistent app — re-open via the apps endpoint.
+                windowState.selection = .app(appId)
+                Task { await AppsClient.openAppAndDispatchSurface(id: appId, connectionManager: connectionManager, eventStreamClient: eventStreamClient) }
+            } else {
+                // Ephemeral surface (ui_show) — fetch from daemon or client memory.
+                windowState.selection = .app(ref.surfaceId)
+                Task { await reopenEphemeralSurface(ref) }
+            }
         }
+    }
+
+    /// Fetch surface content for an ephemeral (non-app) dynamic page surface
+    /// and set it as the active workspace surface. Tries the daemon's surface
+    /// content endpoint first, falls back to the conversation message list.
+    private func reopenEphemeralSurface(_ ref: SurfaceRef) async {
+        // Primary: fetch from daemon in-memory surface state.
+        if let conversationId = ref.conversationId {
+            if let content = await SurfaceClient().fetchSurfaceContent(surfaceId: ref.surfaceId, conversationId: conversationId) {
+                let msg = UiSurfaceShowMessage(
+                    conversationId: conversationId,
+                    surfaceId: ref.surfaceId,
+                    surfaceType: content.surfaceType,
+                    title: content.title ?? ref.title,
+                    data: AnyCodable(content.rawData),
+                    actions: nil,
+                    display: "panel",
+                    messageId: nil
+                )
+                windowState.activeDynamicSurface = msg
+                windowState.activeDynamicParsedSurface = Surface.from(msg)
+                return
+            }
+        }
+
+        // Fallback: reconstruct from inline surface data in the conversation.
+        if let inlineData = conversationManager.activeViewModel?.messages
+            .lazy.flatMap({ $0.inlineSurfaces })
+            .first(where: { $0.id == ref.surfaceId }),
+           case .dynamicPage(let dpData) = inlineData.data {
+            let msg = UiSurfaceShowMessage(
+                conversationId: ref.conversationId,
+                surfaceId: ref.surfaceId,
+                surfaceType: ref.surfaceType,
+                title: ref.title ?? inlineData.title,
+                data: AnyCodable(dpData.asDictionary),
+                actions: nil,
+                display: "panel",
+                messageId: nil
+            )
+            windowState.activeDynamicSurface = msg
+            windowState.activeDynamicParsedSurface = Surface.from(msg)
+            return
+        }
+
+        // Both paths failed — clear loading state so user isn't stuck.
+        windowState.closeDynamicPanel()
+        windowState.showToast(message: "Failed to load surface", style: .error)
     }
 
     private func handlePinAppNotification(_ notification: Notification, isPinned: Bool) {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -56,9 +56,25 @@ struct ConversationStarterClient: ConversationStarterClientProtocol {
     }
 }
 
+/// Raw surface content from the daemon, preserving the untyped data dict
+/// so callers can construct a `UiSurfaceShowMessage` without lossy roundtrips.
+public struct SurfaceContentResponse: Sendable {
+    public let surfaceType: String
+    public let title: String?
+    public let rawData: [String: Any]
+
+    // Sendable conformance — rawData is JSON-derived (all plist types).
+    nonisolated public init(surfaceType: String, title: String?, rawData: [String: Any]) {
+        self.surfaceType = surfaceType
+        self.title = title
+        self.rawData = rawData
+    }
+}
+
 @MainActor
 protocol SurfaceClientProtocol {
     func fetchSurfaceData(surfaceId: String, conversationId: String) async -> SurfaceData?
+    func fetchSurfaceContent(surfaceId: String, conversationId: String) async -> SurfaceContentResponse?
 }
 
 @MainActor
@@ -75,6 +91,25 @@ struct SurfaceClient: SurfaceClientProtocol {
         }
         guard let data = response?.data else { return nil }
         return Surface.parseSurfaceDataFromResponse(data)
+    }
+
+    /// Fetch surface content returning the raw response dict, suitable for
+    /// reconstructing a `UiSurfaceShowMessage` to re-open ephemeral surfaces.
+    func fetchSurfaceContent(surfaceId: String, conversationId: String) async -> SurfaceContentResponse? {
+        let response = try? await GatewayHTTPClient.get(
+            path: "assistants/{assistantId}/surfaces/\(surfaceId)", params: ["conversationId": conversationId], timeout: 10
+        )
+        if let statusCode = response?.statusCode, !(200..<300).contains(statusCode) {
+            log.error("Fetch surface content \(surfaceId) failed (HTTP \(statusCode))")
+            return nil
+        }
+        guard let data = response?.data,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        return SurfaceContentResponse(
+            surfaceType: json["surfaceType"] as? String ?? "",
+            title: json["title"] as? String,
+            rawData: json["data"] as? [String: Any] ?? [:]
+        )
     }
 }
 

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -332,6 +332,21 @@ public struct DynamicPageSurfaceData: Sendable, Equatable {
         self.reloadGeneration = reloadGeneration
         self.status = status
     }
+
+    /// Convert to a dictionary suitable for `AnyCodable` when reconstructing
+    /// a `UiSurfaceShowMessage` from client-side data (e.g. re-opening an
+    /// ephemeral `ui_show` surface from the conversation message list).
+    public var asDictionary: [String: Any] {
+        var dict: [String: Any] = ["html": html]
+        if let width { dict["width"] = width }
+        if let height { dict["height"] = height }
+        if let appId { dict["appId"] = appId }
+        if let dirName { dict["dirName"] = dirName }
+        if let appType { dict["appType"] = appType }
+        if let reloadGeneration { dict["reloadGeneration"] = reloadGeneration }
+        if let status { dict["status"] = status }
+        return dict
+    }
 }
 
 public struct FileUploadSurfaceData: Sendable, Equatable {


### PR DESCRIPTION
## Summary
- **Root cause**: clicking a `ui_show` dynamic_page surface in chat called `AppsClient.openAppAndDispatchSurface` with the surface UUID — but ephemeral surfaces have no app store record, so the daemon returned 404 and the loading view timed out
- **Fix**: split the `surfaceRef` path in `handleOpenDynamicWorkspace` — surfaces with `appId` use the app endpoint (unchanged), surfaces without `appId` use the existing surface content endpoint (`GET /v1/surfaces/:surfaceId`) with a fallback to reconstructing from the conversation's inline surface data
- **Added**: `SurfaceClient.fetchSurfaceContent` (returns raw response dict for `UiSurfaceShowMessage` construction) and `DynamicPageSurfaceData.asDictionary` (for client-memory fallback)

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
