### PR TITLE
fix: read VELLUM_WORKSPACE_DIR fallback so CLI subprocesses find credentials

### DIFF
--- a/assistant/src/config/env-registry.ts
+++ b/assistant/src/config/env-registry.ts
@@ -58,9 +58,13 @@ export function getIsContainerized(): boolean {
  * WORKSPACE_DIR — string, default: undefined
  * When set, overrides the default workspace directory. Used in containerized
  * deployments where the workspace is a separate volume.
+ *
+ * Also checks VELLUM_WORKSPACE_DIR as a fallback — buildSanitizedEnv() in
+ * safe-env.ts strips WORKSPACE_DIR from child processes but re-exports
+ * the resolved path under the VELLUM_ prefix.
  */
 export function getWorkspaceDirOverride(): string | undefined {
-  return str("WORKSPACE_DIR");
+  return str("WORKSPACE_DIR") ?? str("VELLUM_WORKSPACE_DIR");
 }
 
 // ── Known env var names ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `buildSanitizedEnv()` strips `WORKSPACE_DIR` from child processes but sets `VELLUM_WORKSPACE_DIR` to the resolved value. `getWorkspaceDirOverride()` only checked `WORKSPACE_DIR`, so CLI commands spawned by the bash tool in Docker mode read metadata from `~/.vellum/workspace/` instead of `/workspace/` — a completely different file. This caused "Credential not found" errors for credentials that were correctly stored.
- Added `VELLUM_WORKSPACE_DIR` as a fallback in `getWorkspaceDirOverride()` so child processes resolve the same workspace path as the daemon.

## Original prompt
Fix CLI subprocess workspace dir env mismatch that causes credential lookups to fail in containerized mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
