### PR TITLE
fix: make SurfaceClient public for cross-module access

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -72,16 +72,16 @@ public struct SurfaceContentResponse: Sendable {
 }
 
 @MainActor
-protocol SurfaceClientProtocol {
+public protocol SurfaceClientProtocol {
     func fetchSurfaceData(surfaceId: String, conversationId: String) async -> SurfaceData?
     func fetchSurfaceContent(surfaceId: String, conversationId: String) async -> SurfaceContentResponse?
 }
 
 @MainActor
-struct SurfaceClient: SurfaceClientProtocol {
-    nonisolated init() {}
+public struct SurfaceClient: SurfaceClientProtocol {
+    nonisolated public init() {}
 
-    func fetchSurfaceData(surfaceId: String, conversationId: String) async -> SurfaceData? {
+    public func fetchSurfaceData(surfaceId: String, conversationId: String) async -> SurfaceData? {
         let response = try? await GatewayHTTPClient.get(
             path: "assistants/{assistantId}/surfaces/\(surfaceId)", params: ["conversationId": conversationId], timeout: 10
         )
@@ -95,7 +95,7 @@ struct SurfaceClient: SurfaceClientProtocol {
 
     /// Fetch surface content returning the raw response dict, suitable for
     /// reconstructing a `UiSurfaceShowMessage` to re-open ephemeral surfaces.
-    func fetchSurfaceContent(surfaceId: String, conversationId: String) async -> SurfaceContentResponse? {
+    public func fetchSurfaceContent(surfaceId: String, conversationId: String) async -> SurfaceContentResponse? {
         let response = try? await GatewayHTTPClient.get(
             path: "assistants/{assistantId}/surfaces/\(surfaceId)", params: ["conversationId": conversationId], timeout: 10
         )


### PR DESCRIPTION
## Summary
- `SurfaceClient`, `SurfaceClientProtocol`, and their members were `internal` (default) in the `VellumAssistantShared` module
- `MainWindowView.swift` (in `VellumAssistantLib`) references `SurfaceClient()` directly, causing a "cannot find 'SurfaceClient' in scope" build error
- Added `public` access modifiers to the protocol, struct, init, and both methods

## Original prompt
Fix Swift build error: `cannot find 'SurfaceClient' in scope` in MainWindowView.swift:953

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
