### PR TITLE
fix: silence NSString Sendable warnings in AnimatedImageView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
@@ -146,13 +146,14 @@ struct AnimatedImageView: View {
         // Move file I/O (mtime check + data read) off main thread via detached task.
         if let fileURL = localFileURL {
             // Phase 1: resolve mtime-aware cache key off main thread.
-            let effectiveKey = await Task.detached(priority: .userInitiated) { () -> NSString in
-                if let attrs = try? FileManager.default.attributesOfItem(atPath: cacheKey as String),
+            let cacheKeyString = cacheKey as String
+            let effectiveKey = await Task.detached(priority: .userInitiated) { () -> String in
+                if let attrs = try? FileManager.default.attributesOfItem(atPath: cacheKeyString),
                    let mtime = attrs[.modificationDate] as? Date {
-                    return "\(cacheKey)?\(mtime.timeIntervalSince1970)" as NSString
+                    return "\(cacheKeyString)?\(mtime.timeIntervalSince1970)"
                 }
-                return cacheKey
-            }.value
+                return cacheKeyString
+            }.value as NSString
             guard !Task.isCancelled else { return }
 
             // Check in-memory cache before reading file bytes.


### PR DESCRIPTION
## Summary
- Changed `Task.detached` closure in `AnimatedImageView.loadImage()` to return `String` instead of `NSString`, converting to `NSString` after `.value`
- `String` is `Sendable`; `NSString` is not — this eliminates all Swift 6 concurrency warnings from this file

## Original prompt
Fix NSString Sendable warnings in AnimatedImageView.swift

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
