### PR TITLE
feat: scan journal subdirectories for memory indexing

### DIFF
--- a/assistant/src/memory/journal-memory.ts
+++ b/assistant/src/memory/journal-memory.ts
@@ -6,7 +6,7 @@ import { v4 as uuid } from "uuid";
 
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
-import { getDb } from "./db.js";
+import { type DrizzleDb, getDb } from "./db.js";
 import { computeMemoryFingerprint } from "./fingerprint.js";
 import { enqueueMemoryJob } from "./jobs-store.js";
 import { memoryItems, memoryItemSources } from "./schema.js";
@@ -14,9 +14,111 @@ import { memoryItems, memoryItemSources } from "./schema.js";
 const log = getLogger("memory-journal");
 
 /**
+ * Process a single journal `.md` file: read content, derive subject, compute
+ * fingerprint, upsert to DB, and enqueue an embed job.
+ *
+ * Returns `true` if a new memory item was inserted, `false` if it already
+ * existed (or was skipped).
+ */
+function upsertSingleJournalFile(
+  filepath: string,
+  filename: string,
+  messageCreatedAt: number,
+  scopeId: string,
+  messageId: string,
+  db: DrizzleDb,
+): boolean {
+  const content = readFileSync(filepath, "utf-8");
+
+  // Derive subject from filename:
+  // strip .md extension, strip leading date prefix, replace hyphens with spaces, capitalize first letter
+  const basename = filename.replace(/\.md$/, "");
+  const withoutDate = basename.replace(/^\d{4}-\d{2}-\d{2}-?/, "");
+  const withSpaces = withoutDate.replace(/-/g, " ");
+  const subject =
+    withSpaces.length > 0
+      ? withSpaces.charAt(0).toUpperCase() + withSpaces.slice(1)
+      : basename;
+
+  const fingerprint = computeMemoryFingerprint(
+    scopeId,
+    "journal",
+    subject,
+    content,
+  );
+
+  const existing = db
+    .select()
+    .from(memoryItems)
+    .where(
+      and(
+        eq(memoryItems.fingerprint, fingerprint),
+        eq(memoryItems.scopeId, scopeId),
+      ),
+    )
+    .get();
+
+  let memoryItemId: string;
+  let inserted = false;
+
+  if (existing) {
+    memoryItemId = existing.id;
+    db.update(memoryItems)
+      .set({
+        lastSeenAt: messageCreatedAt,
+        status: "active",
+      })
+      .where(eq(memoryItems.id, existing.id))
+      .run();
+  } else {
+    memoryItemId = uuid();
+    db.insert(memoryItems)
+      .values({
+        id: memoryItemId,
+        kind: "journal",
+        subject,
+        statement: content,
+        status: "active",
+        confidence: 0.95,
+        importance: 0.8,
+        fingerprint,
+        sourceType: "extraction",
+        sourceMessageRole: "assistant",
+        verificationState: "assistant_inferred",
+        scopeId,
+        firstSeenAt: messageCreatedAt,
+        lastSeenAt: messageCreatedAt,
+        lastUsedAt: null,
+        supersedes: null,
+        overrideConfidence: null,
+      })
+      .run();
+    inserted = true;
+  }
+
+  db.insert(memoryItemSources)
+    .values({
+      memoryItemId,
+      messageId,
+      evidence: content,
+      createdAt: Date.now(),
+    })
+    .onConflictDoNothing()
+    .run();
+
+  enqueueMemoryJob("embed_item", { itemId: memoryItemId });
+
+  return inserted;
+}
+
+/**
  * Scan the journal directory for `.md` files created during (or after) the
  * given message timestamp and upsert them as journal memory items with the
  * raw, unedited file content as the `statement`.
+ *
+ * Also scans immediate subdirectories (e.g. per-user folders like
+ * `journal/sidd/`) so that user-scoped journal entries are indexed alongside
+ * root-level files.
  *
  * This bypasses the LLM extraction layer entirely — journal memories are
  * stored verbatim so they are never summarised or rewritten.
@@ -56,89 +158,48 @@ export function upsertJournalMemoriesFromDisk(
         // Only process files created during or after this message
         if (stat.birthtimeMs < messageCreatedAt) continue;
 
-        const content = readFileSync(filepath, "utf-8");
-
-        // Derive subject from filename:
-        // strip .md extension, strip leading date prefix, replace hyphens with spaces, capitalize first letter
-        const basename = filename.replace(/\.md$/, "");
-        const withoutDate = basename.replace(/^\d{4}-\d{2}-\d{2}-?/, "");
-        const withSpaces = withoutDate.replace(/-/g, " ");
-        const subject =
-          withSpaces.length > 0
-            ? withSpaces.charAt(0).toUpperCase() + withSpaces.slice(1)
-            : basename;
-
-        const fingerprint = computeMemoryFingerprint(
-          scopeId,
-          "journal",
-          subject,
-          content,
-        );
-
-        const existing = db
-          .select()
-          .from(memoryItems)
-          .where(
-            and(
-              eq(memoryItems.fingerprint, fingerprint),
-              eq(memoryItems.scopeId, scopeId),
-            ),
-          )
-          .get();
-
-        let memoryItemId: string;
-
-        if (existing) {
-          memoryItemId = existing.id;
-          db.update(memoryItems)
-            .set({
-              lastSeenAt: messageCreatedAt,
-              status: "active",
-            })
-            .where(eq(memoryItems.id, existing.id))
-            .run();
-        } else {
-          memoryItemId = uuid();
-          db.insert(memoryItems)
-            .values({
-              id: memoryItemId,
-              kind: "journal",
-              subject,
-              statement: content,
-              status: "active",
-              confidence: 0.95,
-              importance: 0.8,
-              fingerprint,
-              sourceType: "extraction",
-              sourceMessageRole: "assistant",
-              verificationState: "assistant_inferred",
-              scopeId,
-              firstSeenAt: messageCreatedAt,
-              lastSeenAt: messageCreatedAt,
-              lastUsedAt: null,
-              supersedes: null,
-              overrideConfidence: null,
-            })
-            .run();
+        if (upsertSingleJournalFile(filepath, filename, messageCreatedAt, scopeId, messageId, db)) {
           upserted += 1;
         }
-
-        db.insert(memoryItemSources)
-          .values({
-            memoryItemId,
-            messageId,
-            evidence: content,
-            createdAt: Date.now(),
-          })
-          .onConflictDoNothing()
-          .run();
-
-        enqueueMemoryJob("embed_item", { itemId: memoryItemId });
       } catch (err) {
         log.warn(
           { filename, err: err instanceof Error ? err.message : String(err) },
           "Failed to process journal file for memory — skipping",
         );
+      }
+    }
+
+    // Scan per-user journal subdirectories
+    for (const entry of files) {
+      try {
+        const subdirPath = join(journalDir, entry);
+        if (!statSync(subdirPath).isDirectory()) continue;
+
+        const subFiles = readdirSync(subdirPath).filter(
+          (f) => f.endsWith(".md") && f.toLowerCase() !== "readme.md",
+        );
+
+        for (const filename of subFiles) {
+          try {
+            const filepath = join(subdirPath, filename);
+            const stat = statSync(filepath);
+            if (!stat.isFile()) continue;
+
+            // Only process files created during or after this message
+            if (stat.birthtimeMs < messageCreatedAt) continue;
+
+            if (upsertSingleJournalFile(filepath, filename, messageCreatedAt, scopeId, messageId, db)) {
+              upserted += 1;
+            }
+          } catch (err) {
+            log.warn(
+              { filename, err: err instanceof Error ? err.message : String(err) },
+              "Failed to process journal file for memory — skipping",
+            );
+          }
+        }
+      } catch {
+        // Skip unreadable subdirectories
       }
     }
 


### PR DESCRIPTION
## Summary
- Extract per-file upsert logic into `upsertSingleJournalFile` helper
- Add second pass scanning immediate subdirectories of `journal/`
- Root-level scanning unchanged; subdirs skipped by existing `isFile()` check

Part of plan: per-user-journal-scoping.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
