### PR TITLE
feat: pass userSlug through BuildSystemPromptOptions to buildJournalContext

### DIFF
--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -374,6 +374,7 @@ export class Conversation {
                 hasNoClient: this.hasNoClient,
                 userPersona: persona.userPersona,
                 channelPersona: persona.channelPersona,
+                userSlug: persona.userSlug,
               });
             })(),
         maxTokens: configuredMaxTokens,

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -120,6 +120,7 @@ export interface BuildSystemPromptOptions {
   excludeBootstrap?: boolean;
   userPersona?: string | null;
   channelPersona?: string | null;
+  userSlug?: string | null;
 }
 
 /**
@@ -222,6 +223,7 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
 
   const journalContext = buildJournalContext(
     getConfig().journal?.contextWindowSize ?? 10,
+    options?.userSlug,
   );
   if (journalContext) dynamicParts.push(journalContext);
 


### PR DESCRIPTION
## Summary
- Add userSlug to BuildSystemPromptOptions interface
- Pass options.userSlug to buildJournalContext() call
- Wire persona.userSlug through in conversation.ts resolveSystemPromptCallback

Part of plan: per-user-journal-scoping.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
