### PR TITLE
fix: forward VELLUM_DEV env var to compiled daemon binary

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -948,6 +948,7 @@ export async function startLocalDaemon(
         "USER",
         "LANG",
         "VELLUM_DEBUG",
+        "VELLUM_DEV",
         "VELLUM_DESKTOP_APP",
       ]) {
         if (process.env[key]) {


### PR DESCRIPTION
## Summary

- Added `VELLUM_DEV` to the forwarded env vars whitelist in `cli/src/lib/local.ts` when spawning the compiled daemon binary
- The macOS app sets `VELLUM_DEV=1` for `#if DEBUG` builds, but the CLI stripped it when constructing the daemon's minimal environment — causing migration 015 to try connecting to the keychain broker (which is compiled out in debug builds), time out, and crash the daemon on every fresh hatch

## Original prompt

Ship the one-line fix in cli/src/lib/local.ts that adds "VELLUM_DEV" to the forwarded env vars whitelist when spawning the compiled daemon binary. This fixes a bug where the daemon crashes on fresh hatch in debug builds because migration 015-migrate-credentials-to-keychain tries to connect to the keychain broker (which is compiled out in DEBUG builds via #if !DEBUG), since VELLUM_DEV=1 was not being forwarded from the CLI's minimal environment.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
