### PR TITLE
refactor: make VELLUM_WORKSPACE_DIR the primary workspace dir env var

### DIFF
--- a/assistant/src/config/env-registry.ts
+++ b/assistant/src/config/env-registry.ts
@@ -55,16 +55,15 @@ export function getIsContainerized(): boolean {
 }
 
 /**
- * WORKSPACE_DIR — string, default: undefined
- * When set, overrides the default workspace directory. Used in containerized
- * deployments where the workspace is a separate volume.
+ * VELLUM_WORKSPACE_DIR — string, default: undefined
+ * Canonical env var that overrides the default workspace directory.
+ * Used in containerized deployments where the workspace is a separate volume.
  *
- * Also checks VELLUM_WORKSPACE_DIR as a fallback — buildSanitizedEnv() in
- * safe-env.ts strips WORKSPACE_DIR from child processes but re-exports
- * the resolved path under the VELLUM_ prefix.
+ * WORKSPACE_DIR is a deprecated alias kept for backwards compatibility
+ * during migration. It will be removed in a future release.
  */
 export function getWorkspaceDirOverride(): string | undefined {
-  return str("WORKSPACE_DIR") ?? str("VELLUM_WORKSPACE_DIR");
+  return str("VELLUM_WORKSPACE_DIR") ?? str("WORKSPACE_DIR");
 }
 
 // ── Known env var names ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Flip priority in getWorkspaceDirOverride() to check VELLUM_WORKSPACE_DIR first, fall back to WORKSPACE_DIR
- Update JSDoc to document VELLUM_WORKSPACE_DIR as canonical, WORKSPACE_DIR as deprecated alias

Part of plan: consolidate-workspace-dir-env.md (PR 1 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
