### PR TITLE
refactor: CES reads VELLUM_WORKSPACE_DIR for workspace path

### DIFF
--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -130,10 +130,10 @@ function buildHandlers(sessionIdRef: SessionIdRef, apiKeyRef: ApiKeyRef, secureK
   }
 
   // -- Workspace root for command execution cwd ------------------------------
-  // Prefer WORKSPACE_DIR when set (new Docker layout mounts workspace at
-  // /workspace). Fall back to the legacy path derived from the assistant
-  // data mount for backwards compatibility.
-  const defaultWorkspaceDir = process.env["WORKSPACE_DIR"] ?? (() => {
+  // Prefer VELLUM_WORKSPACE_DIR (canonical name) when set, fall back to
+  // WORKSPACE_DIR for backwards compatibility. Final fallback is the legacy
+  // path derived from the assistant data mount.
+  const defaultWorkspaceDir = process.env["VELLUM_WORKSPACE_DIR"] ?? process.env["WORKSPACE_DIR"] ?? (() => {
     const assistantDataMount =
       process.env["CES_ASSISTANT_DATA_MOUNT"] ?? "/assistant-data-ro";
     return join(join(assistantDataMount, ".vellum"), "workspace");


### PR DESCRIPTION
## Summary
- Change CES workspace root resolution to check VELLUM_WORKSPACE_DIR first, fall back to WORKSPACE_DIR
- Maintains backwards compatibility with CES_ASSISTANT_DATA_MOUNT legacy path

Part of plan: consolidate-workspace-dir-env.md (PR 4 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
