### PR TITLE
refactor: docker-entrypoint.sh checks VELLUM_WORKSPACE_DIR

### DIFF
--- a/assistant/docker-entrypoint.sh
+++ b/assistant/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-if [ "$(id -u)" = "0" ] && [ "${WORKSPACE_DIR:-}" = "/workspace" ] && [ -d /workspace ]; then
+if [ "$(id -u)" = "0" ] && [ "${VELLUM_WORKSPACE_DIR:-${WORKSPACE_DIR:-}}" = "/workspace" ] && [ -d /workspace ]; then
   git config --global --add safe.directory /workspace >/dev/null 2>&1 || true
   git config --global --add safe.directory '/workspace/*' >/dev/null 2>&1 || true
 fi


### PR DESCRIPTION
## Summary
- Update docker-entrypoint.sh guard to check VELLUM_WORKSPACE_DIR first, fall back to WORKSPACE_DIR
- Git safe.directory config is applied when either variable is set to /workspace

Part of plan: consolidate-workspace-dir-env.md (PR 5 of 10)