### PR TITLE
refactor: pass VELLUM_WORKSPACE_DIR through sanitized env instead of re-exporting

### DIFF
--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -28,6 +28,7 @@ const SAFE_ENV_VARS = [
   "GPG_TTY",
   "GNUPGHOME",
   "VELLUM_DEV",
+  "VELLUM_WORKSPACE_DIR",
 ] as const;
 
 export function buildSanitizedEnv(): Record<string, string> {


### PR DESCRIPTION
## Summary
- Add VELLUM_WORKSPACE_DIR to SAFE_ENV_VARS allowlist so it passes through naturally
- Keep explicit assignment to ensure it's always set even in local (non-Docker) mode

Part of plan: consolidate-workspace-dir-env.md (PR 2 of 10)