### PR TITLE
docs: update workspace volume migration to reference VELLUM_WORKSPACE_DIR

### DIFF
--- a/assistant/src/workspace/migrations/migrate-to-workspace-volume.ts
+++ b/assistant/src/workspace/migrations/migrate-to-workspace-volume.ts
@@ -2,13 +2,13 @@
  * Workspace migration: Migrate workspace data from /data to /workspace volume.
  *
  * In the old Docker volume layout, workspace data lived at
- * `$BASE_DATA_DIR/.vellum/workspace`. In the new layout, WORKSPACE_DIR points
+ * `$BASE_DATA_DIR/.vellum/workspace`. In the new layout, VELLUM_WORKSPACE_DIR points
  * to a dedicated volume (e.g. `/workspace`). On first boot with the new layout,
  * this migration copies existing workspace data from the old location to the
  * new volume so nothing is lost.
  *
  * Idempotent:
- * - Skips if WORKSPACE_DIR is not set (non-Docker or old layout).
+ * - Skips if VELLUM_WORKSPACE_DIR is not set (non-Docker or old layout).
  * - Skips if the workspace volume already has data (config.json exists).
  * - Skips if the sentinel file exists (already migrated).
  * - Skips if the old workspace directory doesn't exist or is empty.
@@ -34,7 +34,7 @@ const SENTINEL_FILENAME = ".workspace-volume-migrated";
 export const migrateToWorkspaceVolumeMigration: WorkspaceMigration = {
   id: "014-migrate-to-workspace-volume",
   description:
-    "Copy workspace data from old /data/.vellum/workspace to new WORKSPACE_DIR volume on first boot",
+    "Copy workspace data from old /data/.vellum/workspace to new VELLUM_WORKSPACE_DIR volume on first boot",
 
   down(workspaceDir: string): void {
     // This migration copies data between volumes. Actually reversing the copy
@@ -55,7 +55,7 @@ export const migrateToWorkspaceVolumeMigration: WorkspaceMigration = {
   run(workspaceDir: string): void {
     const workspaceDirOverride = getWorkspaceDirOverride();
 
-    // Only relevant when WORKSPACE_DIR is explicitly set (Docker with separate volume)
+    // Only relevant when VELLUM_WORKSPACE_DIR is explicitly set (Docker with separate volume)
     if (!workspaceDirOverride) return;
 
     const sentinelPath = join(workspaceDir, SENTINEL_FILENAME);


### PR DESCRIPTION
## Summary
- Update comments in migrate-to-workspace-volume.ts to reference VELLUM_WORKSPACE_DIR instead of WORKSPACE_DIR
- No logic changes — migration behavior is unchanged

Part of plan: consolidate-workspace-dir-env.md (PR 8 of 10)