### PR TITLE
refactor: remove deprecated WORKSPACE_DIR fallback from all readers

### DIFF
--- a/assistant/docker-entrypoint.sh
+++ b/assistant/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-if [ "$(id -u)" = "0" ] && [ "${VELLUM_WORKSPACE_DIR:-${WORKSPACE_DIR:-}}" = "/workspace" ] && [ -d /workspace ]; then
+if [ "$(id -u)" = "0" ] && [ "${VELLUM_WORKSPACE_DIR:-}" = "/workspace" ] && [ -d /workspace ]; then
   git config --global --add safe.directory /workspace >/dev/null 2>&1 || true
   git config --global --add safe.directory '/workspace/*' >/dev/null 2>&1 || true
 fi

--- a/assistant/src/config/env-registry.ts
+++ b/assistant/src/config/env-registry.ts
@@ -58,12 +58,9 @@ export function getIsContainerized(): boolean {
  * VELLUM_WORKSPACE_DIR — string, default: undefined
  * Canonical env var that overrides the default workspace directory.
  * Used in containerized deployments where the workspace is a separate volume.
- *
- * WORKSPACE_DIR is a deprecated alias kept for backwards compatibility
- * during migration. It will be removed in a future release.
  */
 export function getWorkspaceDirOverride(): string | undefined {
-  return str("VELLUM_WORKSPACE_DIR") ?? str("WORKSPACE_DIR");
+  return str("VELLUM_WORKSPACE_DIR");
 }
 
 // ── Known env var names ──────────────────────────────────────────────────────

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -324,7 +324,7 @@ export function getSignalsDir(): string {
 /**
  * Returns the workspace root for user-facing state.
  *
- * When the WORKSPACE_DIR env var is set, returns that value (used in
+ * When the VELLUM_WORKSPACE_DIR env var is set, returns that value (used in
  * containerized deployments where the workspace is a separate volume).
  * Otherwise falls back to ~/.vellum/workspace.
  *

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -130,10 +130,9 @@ function buildHandlers(sessionIdRef: SessionIdRef, apiKeyRef: ApiKeyRef, secureK
   }
 
   // -- Workspace root for command execution cwd ------------------------------
-  // Prefer VELLUM_WORKSPACE_DIR (canonical name) when set, fall back to
-  // WORKSPACE_DIR for backwards compatibility. Final fallback is the legacy
+  // Use VELLUM_WORKSPACE_DIR when set, otherwise fall back to the legacy
   // path derived from the assistant data mount.
-  const defaultWorkspaceDir = process.env["VELLUM_WORKSPACE_DIR"] ?? process.env["WORKSPACE_DIR"] ?? (() => {
+  const defaultWorkspaceDir = process.env["VELLUM_WORKSPACE_DIR"] ?? (() => {
     const assistantDataMount =
       process.env["CES_ASSISTANT_DATA_MOUNT"] ?? "/assistant-data-ro";
     return join(join(assistantDataMount, ".vellum"), "workspace");

--- a/gateway/src/credential-reader.ts
+++ b/gateway/src/credential-reader.ts
@@ -142,12 +142,12 @@ export function getRootDir(): string {
 /**
  * Returns the workspace root for user-facing state.
  *
- * When the VELLUM_WORKSPACE_DIR (or legacy WORKSPACE_DIR) env var is set,
- * returns that value (used in containerized deployments where the workspace
- * is a separate volume). Otherwise falls back to ~/.vellum/workspace.
+ * When VELLUM_WORKSPACE_DIR is set, returns that value (used in containerized
+ * deployments where the workspace is a separate volume). Otherwise falls back
+ * to ~/.vellum/workspace.
  */
 export function getWorkspaceDir(): string {
-  const override = (process.env.VELLUM_WORKSPACE_DIR ?? process.env.WORKSPACE_DIR)?.trim();
+  const override = process.env.VELLUM_WORKSPACE_DIR?.trim();
   if (override) return override;
   return join(getRootDir(), "workspace");
 }


### PR DESCRIPTION
## Summary
- Remove WORKSPACE_DIR backwards-compat fallbacks from env-registry, gateway, CES, and docker-entrypoint
- All readers now use only VELLUM_WORKSPACE_DIR (canonical name)
- CES_ASSISTANT_DATA_MOUNT legacy fallback retained (separate concern)
- Fixed stale comment in platform.ts that still referenced bare WORKSPACE_DIR

Part of plan: consolidate-workspace-dir-env.md (PR 9 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
