### PR TITLE
feat: add legend to approval prompts explaining button scopes

### DIFF
--- a/assistant/src/runtime/guardian-decision-types.ts
+++ b/assistant/src/runtime/guardian-decision-types.ts
@@ -38,6 +38,8 @@ export interface GuardianDecisionAction {
   action: string;
   /** Human-readable label for the action. */
   label: string;
+  /** Short explanation shown in rich-UI legends (Telegram, Slack). */
+  description?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -46,14 +48,27 @@ export interface GuardianDecisionAction {
 
 /** Canonical set of all guardian decision actions with their labels. */
 export const GUARDIAN_DECISION_ACTIONS = {
-  approve_once: { action: "approve_once", label: "Approve once" },
-  approve_10m: { action: "approve_10m", label: "Allow 10 min" },
+  approve_once: {
+    action: "approve_once",
+    label: "Approve once",
+    description: "This tool, this call only",
+  },
+  approve_10m: {
+    action: "approve_10m",
+    label: "Allow 10 min",
+    description: "All tools for 10 minutes",
+  },
   approve_conversation: {
     action: "approve_conversation",
     label: "Allow conversation",
+    description: "All tools for this conversation",
   },
-  approve_always: { action: "approve_always", label: "Approve always" },
-  reject: { action: "reject", label: "Reject" },
+  approve_always: {
+    action: "approve_always",
+    label: "Approve always",
+    description: "This tool, permanently",
+  },
+  reject: { action: "reject", label: "Reject", description: "Deny this call" },
 } as const satisfies Record<string, GuardianDecisionAction>;
 
 /**
@@ -87,6 +102,32 @@ export function buildDecisionActions(opts?: {
     ...(showAlways ? [GUARDIAN_DECISION_ACTIONS.approve_always] : []),
     GUARDIAN_DECISION_ACTIONS.reject,
   ];
+}
+
+/**
+ * Build a compact legend string explaining each action, for rich-UI channels
+ * (Telegram, Slack) where buttons are shown but their scope isn't obvious.
+ *
+ * Accepts either `GuardianDecisionAction[]` or action ID strings and looks up
+ * descriptions from the canonical constants.
+ */
+export function buildActionLegend(
+  actionIds: readonly (string | { action?: string; id?: string })[],
+): string {
+  const lookup = GUARDIAN_DECISION_ACTIONS as Record<
+    string,
+    GuardianDecisionAction | undefined
+  >;
+  const lines = actionIds
+    .map((a) => {
+      const id = typeof a === "string" ? a : (a.action ?? a.id ?? "");
+      const canonical = lookup[id];
+      return canonical?.description
+        ? `• *${canonical.label}* — ${canonical.description}`
+        : null;
+    })
+    .filter(Boolean);
+  return lines.length > 0 ? lines.join("\n") : "";
 }
 
 /**

--- a/assistant/src/runtime/routes/guardian-approval-prompt.ts
+++ b/assistant/src/runtime/routes/guardian-approval-prompt.ts
@@ -14,6 +14,7 @@ import {
   deliverApprovalPrompt,
   deliverChannelReply,
 } from "../gateway-client.js";
+import { buildActionLegend } from "../guardian-decision-types.js";
 import type { ApprovalCopyGenerator } from "../http-types.js";
 import { requiredDecisionKeywords } from "./channel-route-shared.js";
 
@@ -60,11 +61,15 @@ export async function deliverGeneratedApprovalPrompt(
       approvalCopyGenerator,
     );
 
+    // Append a legend explaining what each button does
+    const legend = buildActionLegend(uiMetadata.actions);
+    const richTextWithLegend = legend ? `${richText}\n\n${legend}` : richText;
+
     try {
       await deliverApprovalPrompt(
         replyCallbackUrl,
         chatId,
-        richText,
+        richTextWithLegend,
         uiMetadata,
         assistantId,
         bearerToken,


### PR DESCRIPTION
## Summary
- Add descriptions to each approval action (Approve once, Allow 10 min, etc.) explaining their scope
- Append a compact legend to the message text in rich-UI channels (Telegram, Slack, WhatsApp) so users understand what each button does before tapping
- Legend shows e.g. "• **Approve once** — This tool, this call only" / "• **Allow 10 min** — All tools for 10 minutes"

Closes JARVIS-323

## Test plan
- [ ] Trigger a tool approval in Telegram and verify the legend appears above the buttons
- [ ] Verify plain-text fallback channels are unaffected
- [ ] Verify macOS app approval prompts are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21063" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
