### PR TITLE
docs: replace WORKSPACE_DIR references with VELLUM_WORKSPACE_DIR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ CES tools are the only approved exception — see `assistant/src/tools/AGENTS.md
 
 When the daemon runs with `BASE_DATA_DIR` set to an instance directory (e.g. `~/.vellum/instances/alice/`), `getRootDir()` resolves to `join(BASE_DATA_DIR, ".vellum")`. All CLI and daemon code that references instance-scoped files must use `join(instanceDir, ".vellum", ...)` — never assume the root is `~/.vellum/` directly. This ensures PID files, tokens, and config are correctly scoped per instance.
 
-In Docker mode, `WORKSPACE_DIR` overrides the workspace location (e.g. `/workspace`). Code that needs the workspace path must use the resolved workspace directory rather than assuming it lives under `getRootDir()`. The workspace volume is shared between the assistant and gateway containers.
+In Docker mode, `VELLUM_WORKSPACE_DIR` overrides the workspace location (e.g. `/workspace`). Code that needs the workspace path must use the resolved workspace directory rather than assuming it lives under `getRootDir()`. The workspace volume is shared between the assistant and gateway containers.
 
 ## Qdrant Port Override
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -147,7 +147,7 @@ Docker instances use dedicated volumes with per-service access boundaries instea
 <instance-name>-socket          →  /run/ces-bootstrap   (assistant + CES)
 ```
 
-- **Workspace volume** (`/workspace`): Shared state — config, conversations, apps, skills, database, logs. Set via `WORKSPACE_DIR=/workspace`. The assistant and gateway have read-write access; the CES mounts it read-only (for config reading).
+- **Workspace volume** (`/workspace`): Shared state — config, conversations, apps, skills, database, logs. Set via `VELLUM_WORKSPACE_DIR=/workspace`. The assistant and gateway have read-write access; the CES mounts it read-only (for config reading).
 - **Gateway security volume** (`/gateway-security`): Trust rules (`trust.json`), actor token signing key, and guardian init lock. Only the gateway container mounts this volume. Set via `GATEWAY_SECURITY_DIR=/gateway-security`.
 - **CES security volume** (`/ces-security`): Credential encryption keys (`keys.enc`, `store.key`). Only the CES container mounts this volume. Set via `CREDENTIAL_SECURITY_DIR=/ces-security`.
 - **Socket volume** (`/run/ces-bootstrap`): CES bootstrap socket for initial service handshake between the assistant and CES containers.


### PR DESCRIPTION
## Summary
- Update AGENTS.md and ARCHITECTURE.md to reference VELLUM_WORKSPACE_DIR as the canonical env var
- Remove all documentation references to bare WORKSPACE_DIR
- CLAUDE.md does not exist in this repo; the AGENTS.md file serves as the project instructions

Part of plan: consolidate-workspace-dir-env.md (PR 10 of 10)