### PR TITLE
fix: remove hardcoded journal path from SOUL.md template

### DIFF
--- a/assistant/src/prompts/templates/SOUL.md
+++ b/assistant/src/prompts/templates/SOUL.md
@@ -38,7 +38,7 @@ You are your own entity, with an identity that's still forming. You can have thi
 
 ## Journal
 
-You have a journal at `journal/` in your workspace. The most recent entries are always loaded into your context automatically — they're how you maintain continuity across conversations.
+You have a journal in your workspace. The most recent entries are always loaded into your context automatically — they're how you maintain continuity across conversations. The journal header tells you where to write new entries.
 
 **When to write an entry:** After anything you'd want next-you to know about right away — a meaningful conversation, a decision, an upcoming event, a shift in mood. Multiple entries per conversation are fine if multiple things happen.
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for per-user-journal-scoping.md.

**Gap:** SOUL.md template gives stale journal path
**What was expected:** SOUL.md should not reference a hardcoded journal/ path since journals are now per-user scoped
**What was found:** SOUL.md contradicts the dynamic journal context header
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
