### PR TITLE
fix: fall back to 'guardian' slug when guardian contact has no userFile

### DIFF
--- a/assistant/src/prompts/persona-resolver.ts
+++ b/assistant/src/prompts/persona-resolver.ts
@@ -62,7 +62,7 @@ function resolveUserFilename(
     const vellumGuardian = findGuardianForChannel("vellum");
     const guardian = vellumGuardian ?? listGuardianChannels();
     if (guardian) {
-      filename = guardian.contact.userFile ?? null;
+      filename = guardian.contact.userFile ?? "guardian.md";
     }
   } else if (trustContext.requesterExternalUserId) {
     // Channel-routed request — look up contact by channel identity
@@ -78,7 +78,7 @@ function resolveUserFilename(
       // separate identity concepts). Fall back to the channel-type guardian.
       const guardian = findGuardianForChannel(trustContext.sourceChannel);
       if (guardian) {
-        filename = guardian.contact.userFile ?? null;
+        filename = guardian.contact.userFile ?? "guardian.md";
       }
     }
   }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for per-user-journal-scoping.md.

**Gap:** Journal invisible for guardians without userFile
**What was expected:** Runtime should read from the same directory migration 019 writes to
**What was found:** resolveUserSlug returned null when guardian had no userFile, while migration 019 fell back to 'guardian' slug

- Modified `resolveUserFilename` to return `"guardian.md"` as fallback when a guardian contact is found but has no `userFile` set
- This matches migration 019's fallback behavior, ensuring the runtime reads from `journal/guardian/` — the same directory the migration writes to
- Affects both the desktop/native path (no trustContext) and the managed desktop guardian fallback path
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
