### PR TITLE
fix: restore WORKSPACE_DIR fallback until platform K8s templates are updated

### DIFF
--- a/assistant/docker-entrypoint.sh
+++ b/assistant/docker-entrypoint.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env sh
 set -eu
 
-if [ "$(id -u)" = "0" ] && [ "${VELLUM_WORKSPACE_DIR:-}" = "/workspace" ] && [ -d /workspace ]; then
+# WORKSPACE_DIR fallback: remove after vellum-assistant-platform switches to VELLUM_WORKSPACE_DIR
+if [ "$(id -u)" = "0" ] && [ "${VELLUM_WORKSPACE_DIR:-${WORKSPACE_DIR:-}}" = "/workspace" ] && [ -d /workspace ]; then
   git config --global --add safe.directory /workspace >/dev/null 2>&1 || true
   git config --global --add safe.directory '/workspace/*' >/dev/null 2>&1 || true
 fi

--- a/assistant/src/config/env-registry.ts
+++ b/assistant/src/config/env-registry.ts
@@ -60,7 +60,8 @@ export function getIsContainerized(): boolean {
  * Used in containerized deployments where the workspace is a separate volume.
  */
 export function getWorkspaceDirOverride(): string | undefined {
-  return str("VELLUM_WORKSPACE_DIR");
+  // WORKSPACE_DIR fallback: remove after vellum-assistant-platform switches to VELLUM_WORKSPACE_DIR
+  return str("VELLUM_WORKSPACE_DIR") ?? str("WORKSPACE_DIR");
 }
 
 // ── Known env var names ──────────────────────────────────────────────────────

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -132,7 +132,8 @@ function buildHandlers(sessionIdRef: SessionIdRef, apiKeyRef: ApiKeyRef, secureK
   // -- Workspace root for command execution cwd ------------------------------
   // Use VELLUM_WORKSPACE_DIR when set, otherwise fall back to the legacy
   // path derived from the assistant data mount.
-  const defaultWorkspaceDir = process.env["VELLUM_WORKSPACE_DIR"] ?? (() => {
+  // WORKSPACE_DIR fallback: remove after vellum-assistant-platform switches to VELLUM_WORKSPACE_DIR
+  const defaultWorkspaceDir = process.env["VELLUM_WORKSPACE_DIR"] ?? process.env["WORKSPACE_DIR"] ?? (() => {
     const assistantDataMount =
       process.env["CES_ASSISTANT_DATA_MOUNT"] ?? "/assistant-data-ro";
     return join(join(assistantDataMount, ".vellum"), "workspace");

--- a/gateway/src/credential-reader.ts
+++ b/gateway/src/credential-reader.ts
@@ -147,7 +147,8 @@ export function getRootDir(): string {
  * to ~/.vellum/workspace.
  */
 export function getWorkspaceDir(): string {
-  const override = process.env.VELLUM_WORKSPACE_DIR?.trim();
+  // WORKSPACE_DIR fallback: remove after vellum-assistant-platform switches to VELLUM_WORKSPACE_DIR
+  const override = (process.env.VELLUM_WORKSPACE_DIR ?? process.env.WORKSPACE_DIR)?.trim();
   if (override) return override;
   return join(getRootDir(), "workspace");
 }


### PR DESCRIPTION
## Summary
- Restore WORKSPACE_DIR as a fallback in env-registry, gateway, CES, and docker-entrypoint
- Needed because vellum-assistant-platform K8s templates still set WORKSPACE_DIR
- Each fallback has a removal comment for when the platform switches to VELLUM_WORKSPACE_DIR

Fixes gap identified during plan review for consolidate-workspace-dir-env.md