### PR TITLE
fix: remove Developer Settings button from connection timeout view

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantConnectionTimeoutView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantConnectionTimeoutView.swift
@@ -2,11 +2,9 @@ import SwiftUI
 import VellumAssistantShared
 
 /// Shown when the assistant loading skeleton times out without connecting.
-/// Displays an "unreachable" message with actions to start over, navigate to
-/// the developer settings tab, or report to Vellum.
+/// Displays an "unreachable" message with actions to retry or report to Vellum.
 struct AssistantConnectionTimeoutView: View {
     let onRetry: () -> Void
-    let onGoToDeveloper: () -> Void
     let onSendLogs: () -> Void
 
     @State private var visible = false
@@ -23,20 +21,15 @@ struct AssistantConnectionTimeoutView: View {
                     .font(.system(size: 24, weight: .regular, design: .serif))
                     .foregroundColor(VColor.contentDefault)
 
-                Text("We couldn\u{2019}t connect to your assistant. Check your connection settings in the Developer tab or try again.")
+                Text("We couldn\u{2019}t connect to your assistant. Please try again.")
                     .font(.system(size: 14))
                     .foregroundColor(VColor.contentSecondary)
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: 380)
             }
 
-            HStack(spacing: VSpacing.md) {
-                VButton(label: "Retry", leftIcon: VIcon.refreshCw.rawValue, style: .outlined) {
-                    onRetry()
-                }
-                VButton(label: "Developer Settings", leftIcon: VIcon.settings.rawValue, style: .primary) {
-                    onGoToDeveloper()
-                }
+            VButton(label: "Retry", leftIcon: VIcon.refreshCw.rawValue, style: .outlined) {
+                onRetry()
             }
 
             VButton(label: "Report to Vellum", leftIcon: VIcon.send.rawValue, style: .ghost) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -397,11 +397,7 @@ struct MainWindowView: View {
         if showDaemonLoading && !isSettingsOpen {
             AssistantLoadingOverlayContent(
                 onRetry: { rewakeAssistant() },
-                onSendLogs: { AppDelegate.shared?.showLogReportWindow(reason: .appCrash) },
-                onGoToDeveloper: {
-                    settingsStore.pendingSettingsTab = .developer
-                    windowState.selection = .panel(.settings)
-                }
+                onSendLogs: { AppDelegate.shared?.showLogReportWindow(reason: .appCrash) }
             )
             .transition(.opacity)
         }
@@ -1326,7 +1322,6 @@ private struct ErrorToastOverlay: View {
 private struct AssistantLoadingOverlayContent: View {
     let onRetry: () -> Void
     let onSendLogs: () -> Void
-    let onGoToDeveloper: () -> Void
 
     /// How long to wait before showing the timeout error state.
     private static let timeoutSeconds: UInt64 = 15
@@ -1343,7 +1338,6 @@ private struct AssistantLoadingOverlayContent: View {
                         timedOut = false
                         onRetry()
                     },
-                    onGoToDeveloper: onGoToDeveloper,
                     onSendLogs: onSendLogs
                 )
             }


### PR DESCRIPTION
## Summary

- Removed the "Developer Settings" button from `AssistantConnectionTimeoutView` and its callback plumbing through `AssistantLoadingOverlayContent` and `MainWindowView`
- Simplified the error message from "Check your connection settings in the Developer tab or try again" to "Please try again"

## Original prompt

remove the "Developer Settings" button.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
