### PR TITLE
refactor: remove WORKSPACE_DIR fallbacks now that platform uses VELLUM_WORKSPACE_DIR

### DIFF
--- a/assistant/docker-entrypoint.sh
+++ b/assistant/docker-entrypoint.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-# WORKSPACE_DIR fallback: remove after vellum-assistant-platform switches to VELLUM_WORKSPACE_DIR
-if [ "$(id -u)" = "0" ] && [ "${VELLUM_WORKSPACE_DIR:-${WORKSPACE_DIR:-}}" = "/workspace" ] && [ -d /workspace ]; then
+if [ "$(id -u)" = "0" ] && [ "${VELLUM_WORKSPACE_DIR:-}" = "/workspace" ] && [ -d /workspace ]; then
   git config --global --add safe.directory /workspace >/dev/null 2>&1 || true
   git config --global --add safe.directory '/workspace/*' >/dev/null 2>&1 || true
 fi

--- a/assistant/src/config/env-registry.ts
+++ b/assistant/src/config/env-registry.ts
@@ -56,12 +56,11 @@ export function getIsContainerized(): boolean {
 
 /**
  * VELLUM_WORKSPACE_DIR — string, default: undefined
- * Canonical env var that overrides the default workspace directory.
+ * Overrides the default workspace directory.
  * Used in containerized deployments where the workspace is a separate volume.
  */
 export function getWorkspaceDirOverride(): string | undefined {
-  // WORKSPACE_DIR fallback: remove after vellum-assistant-platform switches to VELLUM_WORKSPACE_DIR
-  return str("VELLUM_WORKSPACE_DIR") ?? str("WORKSPACE_DIR");
+  return str("VELLUM_WORKSPACE_DIR");
 }
 
 // ── Known env var names ──────────────────────────────────────────────────────

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -132,8 +132,7 @@ function buildHandlers(sessionIdRef: SessionIdRef, apiKeyRef: ApiKeyRef, secureK
   // -- Workspace root for command execution cwd ------------------------------
   // Use VELLUM_WORKSPACE_DIR when set, otherwise fall back to the legacy
   // path derived from the assistant data mount.
-  // WORKSPACE_DIR fallback: remove after vellum-assistant-platform switches to VELLUM_WORKSPACE_DIR
-  const defaultWorkspaceDir = process.env["VELLUM_WORKSPACE_DIR"] ?? process.env["WORKSPACE_DIR"] ?? (() => {
+  const defaultWorkspaceDir = process.env["VELLUM_WORKSPACE_DIR"] ?? (() => {
     const assistantDataMount =
       process.env["CES_ASSISTANT_DATA_MOUNT"] ?? "/assistant-data-ro";
     return join(join(assistantDataMount, ".vellum"), "workspace");

--- a/gateway/src/credential-reader.ts
+++ b/gateway/src/credential-reader.ts
@@ -147,8 +147,7 @@ export function getRootDir(): string {
  * to ~/.vellum/workspace.
  */
 export function getWorkspaceDir(): string {
-  // WORKSPACE_DIR fallback: remove after vellum-assistant-platform switches to VELLUM_WORKSPACE_DIR
-  const override = (process.env.VELLUM_WORKSPACE_DIR ?? process.env.WORKSPACE_DIR)?.trim();
+  const override = process.env.VELLUM_WORKSPACE_DIR?.trim();
   if (override) return override;
   return join(getRootDir(), "workspace");
 }


### PR DESCRIPTION
## Summary
- Remove temporary WORKSPACE_DIR fallbacks from env-registry, gateway, CES, and docker-entrypoint
- Platform K8s templates already switched to VELLUM_WORKSPACE_DIR (vellum-ai/vellum-assistant-platform#3009)

Part of plan: consolidate-workspace-dir-env.md (cleanup)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
