### PR TITLE
fix: make update button reliable for local topology and fix restart-to-update relaunch

### DIFF
--- a/clients/macos/vellum-assistant/App/UpdateManager.swift
+++ b/clients/macos/vellum-assistant/App/UpdateManager.swift
@@ -292,8 +292,12 @@ public final class UpdateManager: NSObject, ObservableObject, SPUUpdaterDelegate
 
     /// Called when no valid update is found.  Clears the flag in case a
     /// previously-advertised update was pulled from the appcast.
+    /// Preserves `isUpdateAvailable` when a deferred update is already
+    /// staged — a subsequent "not found" check shouldn't hide the toolbar
+    /// button while an update is downloaded and ready to install.
     nonisolated public func updaterDidNotFindUpdate(_ updater: SPUUpdater) {
         Task { @MainActor in
+            guard !self.isDeferredUpdateReady else { return }
             self.isUpdateAvailable = false
             self.availableUpdateVersion = nil
             self.pendingUpdateVersion = nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -433,7 +433,7 @@ struct MainWindowView: View {
             }
             WindowDragArea()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-            if updateManager.isUpdateAvailable || updateManager.isServiceGroupUpdateAvailable {
+            if updateManager.isUpdateAvailable || updateManager.isServiceGroupUpdateAvailable || updateManager.isDeferredUpdateReady {
                 VButton(
                     label: updateManager.isDeferredUpdateReady
                         ? "Restart to update"
@@ -447,7 +447,11 @@ struct MainWindowView: View {
                             : "A new version is available")
                 ) {
                     if updateManager.isDeferredUpdateReady {
-                        NSApp.terminate(nil)
+                        // Trigger Sparkle's installer directly — it handles
+                        // termination and relaunch.  Calling NSApp.terminate
+                        // first creates a race where the installer starts
+                        // mid-teardown and can't coordinate the relaunch.
+                        updateManager.installDeferredUpdateIfAvailable()
                     } else if updateManager.isServiceGroupUpdateAvailable && !updateManager.isUpdateAvailable {
                         // Service group update only — navigate to Settings where the upgrade controls live
                         settingsStore.pendingSettingsTab = .general
@@ -459,6 +463,7 @@ struct MainWindowView: View {
                 .transition(.opacity.combined(with: .scale(scale: 0.9)))
                 .animation(VAnimation.fast, value: updateManager.isUpdateAvailable)
                 .animation(VAnimation.fast, value: updateManager.isServiceGroupUpdateAvailable)
+                .animation(VAnimation.fast, value: updateManager.isDeferredUpdateReady)
             }
             if windowState.isConversationVisible {
                 // Temporary chat toggle — always visible on private conversations (so users can exit temp chat),


### PR DESCRIPTION
## Summary
- Fix toolbar "Update available" button disappearing for local topology by adding `isDeferredUpdateReady` to the visibility condition and preventing `updaterDidNotFindUpdate` from clearing flags when a deferred update is staged
- Fix "Restart to update" not relaunching by calling Sparkle's deferred handler directly instead of `NSApp.terminate(nil)` — avoids race where installer starts mid-teardown

## Original prompt
implement these fixes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
