### PR TITLE
fix: remove counterproductive no-null-comparison lint rule

### DIFF
--- a/assistant/eslint.config.mjs
+++ b/assistant/eslint.config.mjs
@@ -29,37 +29,6 @@ const eslintConfig = defineConfig([
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
       "@typescript-eslint/no-explicit-any": "error",
-
-      // Standardize on `undefined` only — avoid `null` in new code.
-      // Prefer `=== undefined`, `?? fallback`, or `?.` optional chaining
-      // instead of `=== null`.
-      "no-restricted-syntax": [
-        "error",
-        {
-          selector:
-            "BinaryExpression[operator='==='][right.type='Literal'][right.raw='null']",
-          message:
-            "Avoid `=== null`. Prefer `=== undefined`, `?? fallback`, or optional chaining `?.` instead.",
-        },
-        {
-          selector:
-            "BinaryExpression[operator='==='][left.type='Literal'][left.raw='null']",
-          message:
-            "Avoid `null ===`. Prefer `=== undefined`, `?? fallback`, or optional chaining `?.` instead.",
-        },
-        {
-          selector:
-            "BinaryExpression[operator='!=='][right.type='Literal'][right.raw='null']",
-          message:
-            "Avoid `!== null`. Prefer `!== undefined`, nullish coalescing `??`, or optional chaining `?.` instead.",
-        },
-        {
-          selector:
-            "BinaryExpression[operator='!=='][left.type='Literal'][left.raw='null']",
-          message:
-            "Avoid `null !==`. Prefer `!== undefined`, nullish coalescing `??`, or optional chaining `?.` instead.",
-        },
-      ],
     },
   },
   {

--- a/assistant/src/prompts/update-bulletin-format.ts
+++ b/assistant/src/prompts/update-bulletin-format.ts
@@ -50,7 +50,6 @@ export function extractContentMarkers(body: string): string[] {
   const ids: string[] = [];
   const regex = /<!-- vellum-update-release:(.+?) -->/g;
   let match: RegExpExecArray | null;
-  // eslint-disable-next-line no-restricted-syntax -- RegExp.exec returns null
   while ((match = regex.exec(body)) !== null) {
     ids.push(match[1]);
   }
@@ -62,7 +61,6 @@ export function extractReleaseIds(content: string): string[] {
   const ids: string[] = [];
   MARKER_REGEX.lastIndex = 0;
   let match: RegExpExecArray | null;
-  // eslint-disable-next-line no-restricted-syntax -- RegExp.exec returns null
   while ((match = MARKER_REGEX.exec(content)) !== null) {
     ids.push(match[1]);
   }

--- a/assistant/src/skills/inline-command-expansions.ts
+++ b/assistant/src/skills/inline-command-expansions.ts
@@ -61,8 +61,8 @@ function buildFencedCodeRanges(body: string): Array<[number, number]> {
   const fenceRe = /^(`{3,}|~{3,})(.*)?$/gm;
   let openFence: { index: number; delimiter: string } | undefined;
 
-  let match: RegExpExecArray | undefined;
-  while ((match = fenceRe.exec(body) ?? undefined) !== undefined) {
+  let match: RegExpExecArray | null;
+  while ((match = fenceRe.exec(body)) !== null) {
     const delimiter = match[1];
     if (openFence === undefined) {
       // Opening fence
@@ -125,10 +125,10 @@ export function parseInlineCommandExpansions(
   // We use a non-greedy match to find the first closing backtick.
   const tokenRe = /!\`([^`]*)\`/g;
 
-  let match: RegExpExecArray | undefined;
+  let match: RegExpExecArray | null;
   let placeholderCounter = 0;
 
-  while ((match = tokenRe.exec(body) ?? undefined) !== undefined) {
+  while ((match = tokenRe.exec(body)) !== null) {
     const startOffset = match.index;
     const endOffset = startOffset + match[0].length;
     const rawCommand = match[1];
@@ -172,12 +172,12 @@ export function parseInlineCommandExpansions(
   const matchedStarts = new Set<number>();
   // Re-run the token regex to collect all matched positions
   tokenRe.lastIndex = 0;
-  while ((match = tokenRe.exec(body) ?? undefined) !== undefined) {
+  while ((match = tokenRe.exec(body)) !== null) {
     matchedStarts.add(match.index);
   }
 
-  let unmatchedMatch: RegExpExecArray | undefined;
-  while ((unmatchedMatch = unmatchedRe.exec(body) ?? undefined) !== undefined) {
+  let unmatchedMatch: RegExpExecArray | null;
+  while ((unmatchedMatch = unmatchedRe.exec(body)) !== null) {
     const offset = unmatchedMatch.index;
 
     // Skip if this was already matched as a complete token

--- a/assistant/src/tools/sensitive-output-placeholders.ts
+++ b/assistant/src/tools/sensitive-output-placeholders.ts
@@ -85,8 +85,8 @@ export function extractAndSanitize(content: string): SanitizeResult {
   // Step 1: parse directives
   // Reset lastIndex for safety since the regex is global
   DIRECTIVE_RE.lastIndex = 0;
-  let match: RegExpExecArray | undefined;
-  while ((match = DIRECTIVE_RE.exec(content) ?? undefined) !== undefined) {
+  let match: RegExpExecArray | null;
+  while ((match = DIRECTIVE_RE.exec(content)) !== null) {
     const kind = match[1];
     const value = match[2];
 


### PR DESCRIPTION
## Summary

- Remove 4 `no-restricted-syntax` ESLint entries that banned `=== null` / `!== null` comparisons
- Clean up 2 `eslint-disable-next-line` comments that existed solely to work around the rule
- Revert 5 `?? undefined) !== undefined` workarounds in `inline-command-expansions.ts` and `sensitive-output-placeholders.ts` back to idiomatic `!== null` checks

The rule was counterproductive: `=== undefined` is not a semantic replacement for `=== null` (they check different values), null is unavoidable from RegExp.exec/SQL/JSON/external APIs, the codebase already had 352 `== null` loose-equality checks bypassing it, and it forced less-readable workarounds where followed.

## Original prompt

Remove the counterproductive no-null-comparison ESLint lint rule and clean up workarounds
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
