### PR TITLE
Style remove buttons as ghost danger, inline with card titles

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -269,6 +269,7 @@ struct SkillItemRow: View {
                             label: "Delete",
                             iconOnly: VIcon.trash.rawValue,
                             style: .dangerGhost,
+                            size: .compact,
                             action: onDelete
                         )
                         .accessibilityLabel("Uninstall skill")

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -282,6 +282,7 @@ struct SkillItemRow: View {
                     .foregroundStyle(VColor.contentSecondary)
                     .lineLimit(1)
                     .multilineTextAlignment(.leading)
+                    .padding(.top, VSpacing.xs)
             }
         }
         .contextMenu {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -242,46 +242,44 @@ struct SkillItemRow: View {
 
     var body: some View {
         VCard(padding: VSpacing.lg, action: onSelect) {
-            HStack(alignment: .center, spacing: VSpacing.lg) {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    HStack(alignment: .center, spacing: VSpacing.sm) {
-                        if let emoji = skill.emoji, !emoji.isEmpty {
-                            Text(emoji)
-                                .font(.system(size: 16))
-                        }
-
-                        Text(skill.name)
-                            .font(VFont.headline)
-                            .foregroundStyle(VColor.contentEmphasized)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-
-                        VTag(
-                            category.displayName,
-                            color: category.color
-                        )
-
-                        VSkillTypePill(source: skill.source)
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                HStack(alignment: .center, spacing: VSpacing.sm) {
+                    if let emoji = skill.emoji, !emoji.isEmpty {
+                        Text(emoji)
+                            .font(.system(size: 16))
                     }
 
-                    Text(skill.description)
-                        .font(VFont.bodySmall)
-                        .foregroundStyle(VColor.contentSecondary)
+                    Text(skill.name)
+                        .font(VFont.headline)
+                        .foregroundStyle(VColor.contentEmphasized)
                         .lineLimit(1)
-                        .multilineTextAlignment(.leading)
-                }
+                        .truncationMode(.tail)
 
-                Spacer()
-
-                if isRemovable {
-                    VButton(
-                        label: "Delete",
-                        iconOnly: VIcon.trash.rawValue,
-                        style: .dangerOutline,
-                        action: onDelete
+                    VTag(
+                        category.displayName,
+                        color: category.color
                     )
-                    .accessibilityLabel("Uninstall skill")
+
+                    VSkillTypePill(source: skill.source)
+
+                    Spacer()
+
+                    if isRemovable {
+                        VButton(
+                            label: "Delete",
+                            iconOnly: VIcon.trash.rawValue,
+                            style: .dangerGhost,
+                            action: onDelete
+                        )
+                        .accessibilityLabel("Uninstall skill")
+                    }
                 }
+
+                Text(skill.description)
+                    .font(VFont.bodySmall)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .lineLimit(1)
+                    .multilineTextAlignment(.leading)
             }
         }
         .contextMenu {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -263,7 +263,8 @@ struct SkillItemRow: View {
                     VSkillTypePill(source: skill.source)
 
                     Spacer()
-
+                }
+                .overlay(alignment: .trailing) {
                     if isRemovable {
                         VButton(
                             label: "Delete",

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -13,7 +13,7 @@ struct MemoryItemRow: View {
     var body: some View {
         VCard(padding: VSpacing.lg, action: onSelect) {
             VStack(alignment: .leading, spacing: VSpacing.sm) {
-                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                VStack(alignment: .leading, spacing: 0) {
                     HStack(alignment: .center, spacing: VSpacing.sm) {
                         Text(item.subject)
                             .font(VFont.headline)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -12,7 +12,7 @@ struct MemoryItemRow: View {
 
     var body: some View {
         VCard(padding: VSpacing.lg, action: onSelect) {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
                 HStack(alignment: .center, spacing: VSpacing.sm) {
                     Text(item.subject)
                         .font(VFont.headline)
@@ -26,7 +26,8 @@ struct MemoryItemRow: View {
                     )
 
                     Spacer()
-
+                }
+                .overlay(alignment: .trailing) {
                     VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerGhost, size: .compact, action: onDelete)
                         .accessibilityLabel("Delete memory")
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -12,28 +12,30 @@ struct MemoryItemRow: View {
 
     var body: some View {
         VCard(padding: VSpacing.lg, action: onSelect) {
-            VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                HStack(alignment: .center, spacing: VSpacing.sm) {
-                    Text(item.subject)
-                        .font(VFont.headline)
-                        .foregroundStyle(VColor.contentEmphasized)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    HStack(alignment: .center, spacing: VSpacing.sm) {
+                        Text(item.subject)
+                            .font(VFont.headline)
+                            .foregroundStyle(VColor.contentEmphasized)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
 
-                    VTag(
-                        memoryKind?.label ?? item.kind.capitalized,
-                        color: memoryKind?.color ?? VColor.contentTertiary
-                    )
+                        VTag(
+                            memoryKind?.label ?? item.kind.capitalized,
+                            color: memoryKind?.color ?? VColor.contentTertiary
+                        )
 
-                    Spacer()
+                        Spacer()
 
-                    VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerGhost, action: onDelete)
-                        .accessibilityLabel("Delete memory")
+                        VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerGhost, action: onDelete)
+                            .accessibilityLabel("Delete memory")
+                    }
+
+                    Text(item.relativeLastSeen)
+                        .font(VFont.caption)
+                        .foregroundStyle(VColor.contentTertiary)
                 }
-
-                Text(item.relativeLastSeen)
-                    .font(VFont.caption)
-                    .foregroundStyle(VColor.contentTertiary)
 
                 Text(item.statement)
                     .font(VFont.bodySmall)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -13,29 +13,27 @@ struct MemoryItemRow: View {
     var body: some View {
         VCard(padding: VSpacing.lg, action: onSelect) {
             VStack(alignment: .leading, spacing: VSpacing.sm) {
-                VStack(alignment: .leading, spacing: 0) {
-                    HStack(alignment: .center, spacing: VSpacing.sm) {
-                        Text(item.subject)
-                            .font(VFont.headline)
-                            .foregroundStyle(VColor.contentEmphasized)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
+                HStack(alignment: .center, spacing: VSpacing.sm) {
+                    Text(item.subject)
+                        .font(VFont.headline)
+                        .foregroundStyle(VColor.contentEmphasized)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
 
-                        VTag(
-                            memoryKind?.label ?? item.kind.capitalized,
-                            color: memoryKind?.color ?? VColor.contentTertiary
-                        )
+                    VTag(
+                        memoryKind?.label ?? item.kind.capitalized,
+                        color: memoryKind?.color ?? VColor.contentTertiary
+                    )
 
-                        Spacer()
+                    Spacer()
 
-                        VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerGhost, action: onDelete)
-                            .accessibilityLabel("Delete memory")
-                    }
-
-                    Text(item.relativeLastSeen)
-                        .font(VFont.caption)
-                        .foregroundStyle(VColor.contentTertiary)
+                    VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerGhost, size: .compact, action: onDelete)
+                        .accessibilityLabel("Delete memory")
                 }
+
+                Text(item.relativeLastSeen)
+                    .font(VFont.caption)
+                    .foregroundStyle(VColor.contentTertiary)
 
                 Text(item.statement)
                     .font(VFont.bodySmall)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -12,7 +12,7 @@ struct MemoryItemRow: View {
 
     var body: some View {
         VCard(padding: VSpacing.lg, action: onSelect) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
+            VStack(alignment: .leading, spacing: 0) {
                 HStack(alignment: .center, spacing: VSpacing.sm) {
                     Text(item.subject)
                         .font(VFont.headline)
@@ -35,10 +35,12 @@ struct MemoryItemRow: View {
                 Text(item.relativeLastSeen)
                     .font(VFont.caption)
                     .foregroundStyle(VColor.contentTertiary)
+                    .padding(.top, VSpacing.xxs)
 
                 Text(item.statement)
                     .font(VFont.bodySmall)
                     .foregroundStyle(VColor.contentSecondary)
+                    .padding(.top, VSpacing.sm)
                     .lineLimit(1)
                     .multilineTextAlignment(.leading)
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -12,36 +12,34 @@ struct MemoryItemRow: View {
 
     var body: some View {
         VCard(padding: VSpacing.lg, action: onSelect) {
-            HStack(alignment: .center, spacing: VSpacing.lg) {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    HStack(alignment: .center, spacing: VSpacing.sm) {
-                        Text(item.subject)
-                            .font(VFont.headline)
-                            .foregroundStyle(VColor.contentEmphasized)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-
-                        VTag(
-                            memoryKind?.label ?? item.kind.capitalized,
-                            color: memoryKind?.color ?? VColor.contentTertiary
-                        )
-                    }
-
-                    Text(item.statement)
-                        .font(VFont.bodySmall)
-                        .foregroundStyle(VColor.contentSecondary)
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                HStack(alignment: .center, spacing: VSpacing.sm) {
+                    Text(item.subject)
+                        .font(VFont.headline)
+                        .foregroundStyle(VColor.contentEmphasized)
                         .lineLimit(1)
-                        .multilineTextAlignment(.leading)
-                }
+                        .truncationMode(.tail)
 
-                Spacer()
+                    VTag(
+                        memoryKind?.label ?? item.kind.capitalized,
+                        color: memoryKind?.color ?? VColor.contentTertiary
+                    )
+
+                    Spacer()
+
+                    VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerGhost, action: onDelete)
+                        .accessibilityLabel("Delete memory")
+                }
 
                 Text(item.relativeLastSeen)
                     .font(VFont.caption)
                     .foregroundStyle(VColor.contentTertiary)
 
-                VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerOutline, action: onDelete)
-                    .accessibilityLabel("Delete memory")
+                Text(item.statement)
+                    .font(VFont.bodySmall)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .lineLimit(1)
+                    .multilineTextAlignment(.leading)
             }
         }
         .contextMenu {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -12,7 +12,7 @@ struct MemoryItemRow: View {
 
     var body: some View {
         VCard(padding: VSpacing.lg, action: onSelect) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
                 HStack(alignment: .center, spacing: VSpacing.sm) {
                     Text(item.subject)
                         .font(VFont.headline)


### PR DESCRIPTION
## Summary
- Change remove/delete buttons on memory and skill cards from `dangerOutline` to `dangerGhost` style and move them inline with the card title row
- Move the timestamp on memory cards to sit below the title (above the statement)
- Simplify card layout from nested HStack+VStack to a single VStack with the title HStack containing the Spacer and delete button

## Original prompt
--safe make remove button ghost danger and move it in the same line with title of the memories skills cards; move timestamp under memory card title
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
