### PR TITLE
feat: guardian channel 'Set up' button opens conversation with assistant

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -11,6 +11,7 @@ struct ContactDetailView: View {
     var store: SettingsStore?
     var onDelete: (() -> Void)?
     var onSelectAssistant: (() -> Void)?
+    var conversationManager: ConversationManager?
     var showToast: ((String, ToastInfo.Style) -> Void)?
     var guardianName: String?
 
@@ -39,6 +40,7 @@ struct ContactDetailView: View {
                     contact: displayContact,
                     connectionManager: connectionManager,
                     store: store,
+                    conversationManager: conversationManager,
                     onSelectAssistant: onSelectAssistant,
                     showCardBorders: false
                 )

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -128,6 +128,7 @@ struct ContactsContainerView: View {
                                     viewModel.loadContacts()
                                 },
                                 onSelectAssistant: { selection = .assistant },
+                                conversationManager: conversationManager,
                                 showToast: showToast,
                                 guardianName: viewModel.guardianContact?.displayName
                             )
@@ -241,6 +242,7 @@ struct ContactsContainerView: View {
                     contact: contact,
                     connectionManager: connectionManager,
                     store: store,
+                    conversationManager: conversationManager,
                     onSelectAssistant: { selection = .assistant },
                     showCardBorders: false
                 )

--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -15,6 +15,7 @@ struct GuardianChannelsDetailView: View {
     var contactClient: ContactClientProtocol = ContactClient()
     var channelClient: ChannelClientProtocol = ChannelClient()
     var store: SettingsStore?
+    var conversationManager: ConversationManager?
     var onSelectAssistant: (() -> Void)?
     var showCardBorders: Bool = true
 
@@ -210,8 +211,15 @@ struct GuardianChannelsDetailView: View {
                         }
                     } else if needsSetup {
                         VButton(label: "Set up", style: .outlined) {
-                            dismissedChannels.remove(type)
-                            setupExpanded.insert(type)
+                            if let conversationManager {
+                                conversationManager.openConversation(
+                                    message: channelSetupMessage(for: type),
+                                    forceNew: true
+                                )
+                            } else {
+                                dismissedChannels.remove(type)
+                                setupExpanded.insert(type)
+                            }
                         }
                     }
                 }
@@ -232,6 +240,18 @@ struct GuardianChannelsDetailView: View {
             || (!existingChannels.isEmpty && !dismissedChannels.contains(type))
             || setupExpanded.contains(type) {
             verificationFlowContent(for: type)
+        } else {
+            VButton(label: "Set up", style: .outlined) {
+                if let conversationManager {
+                    conversationManager.openConversation(
+                        message: channelSetupMessage(for: type),
+                        forceNew: true
+                    )
+                } else {
+                    dismissedChannels.remove(type)
+                    setupExpanded.insert(type)
+                }
+            }
         }
 
         if errorChannelType == type, let errorMessage {
@@ -479,6 +499,15 @@ struct GuardianChannelsDetailView: View {
         case "phone": return "Phone Calling"
         case "slack": return "Slack"
         default: return type.capitalized
+        }
+    }
+
+    private func channelSetupMessage(for type: String) -> String {
+        switch type {
+        case "telegram": return "I'd like to verify my identity as your guardian on Telegram. Can you help me set that up?"
+        case "slack": return "I'd like to verify my identity as your guardian on Slack. Can you help me set that up?"
+        case "phone": return "I'd like to verify my identity as your guardian for phone calls. Can you help me set that up?"
+        default: return "I'd like to verify my identity as your guardian on \(type.capitalized). Can you help me set that up?"
         }
     }
 


### PR DESCRIPTION
## Summary
- Changed the guardian contact card's "Set up" button to open a new conversation with the assistant (like the assistant card does) instead of expanding the inline verification form
- Each channel sends a tailored message: Telegram, Slack, and Phone each have specific copy asking the assistant for help verifying guardian identity
- Falls back to the old inline-expand behavior if no `conversationManager` is available

## Original prompt
Make the guardian "Set up" button more like the assistant button — it should open a conversation with a message like "I'd like to verify my identity as your guardian on Telegram. Can you help me set that up?"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
