### PR TITLE
fix: don't auto-create managed assistant during onboarding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -262,28 +262,19 @@ struct OnboardingFlowView: View {
         }
 
         isResolvingAssociatedManagedAssistant = true
-        managedBootstrapError = nil
         defer { isResolvingAssociatedManagedAssistant = false }
 
-        do {
-            let activation = try await ManagedAssistantConnectionCoordinator().activateManagedAssistant()
-
-            if activation.reusedExisting {
-                // Assistant is already provisioned and running — safe to proceed.
-                log.info("Authenticated with existing managed assistant \(activation.assistant.id, privacy: .public); proceeding to app")
-                onComplete()
-            } else {
-                // Newly created — enter hatching UI and wait for readiness.
-                log.info("Authenticated and created new managed assistant \(activation.assistant.id, privacy: .public); entering hatching flow")
-                state.hasExistingManagedAssistant = false
-                state.isManagedHatch = true
-                state.isHatching = true
-                await awaitManagedAssistantReady(assistantId: activation.assistant.id)
-            }
-        } catch {
-            log.error("Failed to activate managed assistant after authentication: \(error.localizedDescription, privacy: .public)")
-            state.advance()
+        // Only auto-proceed if there's already a managed assistant in the lockfile.
+        // Do NOT create a new managed assistant here — that should only happen if
+        // the user explicitly selects Vellum Cloud on the hosting selector.
+        if let existing = LockfileAssistant.loadLatest(), existing.isManaged {
+            log.info("Authenticated with existing managed assistant \(existing.assistantId, privacy: .public); proceeding to app")
+            onComplete()
+            return
         }
+
+        log.info("Authenticated account has no existing managed assistant — advancing to hosting selector")
+        state.advance()
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- `continueManagedOnboardingAfterAuthentication()` was calling `activateManagedAssistant()` which unconditionally creates a managed assistant on the platform if one doesn't exist — bypassing the hosting selector
- Replace with a lockfile check: if an existing managed assistant is found, reconnect to it; otherwise advance to the hosting selector so `platform_hosted_enabled` is respected
- This restores the pre-#21001 behavior where fresh authenticated users always see the hosting options

## Original prompt
Fix the onboarding flow so that authenticated users without an existing managed assistant are shown the hosting selector instead of being auto-hatched on Vellum Cloud. PR #21001 introduced a regression by replacing `activateAssociatedManagedAssistantIfPresent()` with `activateManagedAssistant()`, which always creates a managed assistant.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
