### PR TITLE
feat: add NOW.md scratchpad template and auto-seed on startup

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -84,6 +84,28 @@ export function ensurePromptFiles(): void {
     }
   }
 
+  // Seed NOW.md scratchpad — always created if missing, regardless of whether
+  // this is a fresh install or not.  Kept out of PROMPT_FILES because NOW.md is
+  // ephemeral state, not identity context.
+  const nowDest = getWorkspacePromptPath("NOW.md");
+  if (!existsSync(nowDest)) {
+    const nowSrc = join(templatesDir, "NOW.md");
+    try {
+      if (existsSync(nowSrc)) {
+        copyFileSync(nowSrc, nowDest);
+        log.info(
+          { file: "NOW.md", dest: nowDest },
+          "Created NOW.md scratchpad from template",
+        );
+      }
+    } catch (err) {
+      log.warn(
+        { err, file: "NOW.md" },
+        "Failed to create NOW.md from template",
+      );
+    }
+  }
+
   // Seed users/default.md persona template
   try {
     const usersDir = join(getWorkspaceDir(), "users");

--- a/assistant/src/prompts/templates/NOW.md
+++ b/assistant/src/prompts/templates/NOW.md
@@ -1,0 +1,26 @@
+_ Lines starting with _ are comments - they won't appear in the system prompt
+_ This is your scratchpad for present-tense state. Overwrite it freely between
+_ turns to capture what's happening right now. Unlike the journal (retrospective,
+_ append-only), this file is ephemeral — a snapshot of your current working state.
+
+# NOW.md
+
+## Focus
+
+_ What you're currently working on or paying attention to.
+
+## Active Threads
+
+_ Open loops, in-progress tasks, things you're tracking across turns.
+
+## Context
+
+_ Key facts, constraints, or situational details relevant to the current session.
+
+## Upcoming
+
+_ Near-term things on the horizon — scheduled events, pending actions, deadlines.
+
+## State
+
+_ Current priorities, energy, or operational notes. What matters most right now.


### PR DESCRIPTION
## Summary
- Add NOW.md template with generic scratchpad structure (focus, active threads, context, upcoming, state)
- Auto-seed NOW.md from template on daemon startup if it doesn't exist
- Handled separately from PROMPT_FILES to avoid injection into identity/memory contexts

Part of plan: now-scratchpad.md (PR 1 of 4)