### PR TITLE
feat: read and inject NOW.md scratchpad each conversation turn

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -106,6 +106,7 @@ import {
   applyRuntimeInjections,
   inboundActorContextFromTrust,
   inboundActorContextFromTrustContext,
+  readNowScratchpad,
   stripInjectedContext,
 } from "./conversation-runtime-assembly.js";
 import type { SkillProjectionCache } from "./conversation-skill-tools.js";
@@ -681,6 +682,10 @@ export async function runAgentLoopImpl(
       }
     }
 
+    // Read NOW.md scratchpad fresh each turn so mid-conversation edits are
+    // picked up without caching or conversation eviction.
+    const nowScratchpad = readNowScratchpad();
+
     const isInteractiveResolved =
       options?.isInteractive ?? (!ctx.hasNoClient && !ctx.headlessLock);
 
@@ -694,6 +699,7 @@ export async function runAgentLoopImpl(
       interfaceTurnContext,
       inboundActorContext: resolvedInboundActorContext,
       temporalContext,
+      nowScratchpad,
       voiceCallControlPrompt: ctx.voiceCallControlPrompt ?? null,
       isNonInteractive: !isInteractiveResolved,
     } as const;


### PR DESCRIPTION
## Summary
- Import readNowScratchpad from conversation-runtime-assembly
- Read NOW.md from disk each turn (no caching, picks up changes immediately)
- Pass scratchpad content to applyRuntimeInjections via injectionOpts
- No new fields on Conversation or AgentLoopConversationContext

Part of plan: now-scratchpad.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
