### PR TITLE
fix: sort imports in conversation-runtime-assembly test

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -18,8 +18,8 @@ import {
   resolveChannelCapabilities,
   stripChannelCapabilityContext,
   stripChannelTurnContext,
-  stripInjectedContext,
   stripInboundActorContext,
+  stripInjectedContext,
   stripNowScratchpad,
   stripTemporalContext,
 } from "../daemon/conversation-runtime-assembly.js";


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `conversation-runtime-assembly.test.ts` by sorting `stripInboundActorContext` before `stripInjectedContext`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23471498589/job/68295076905
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
