### PR TITLE
fix: make NOW.md template all-comments to prevent empty scaffolding injection

### DIFF
--- a/assistant/src/prompts/templates/NOW.md
+++ b/assistant/src/prompts/templates/NOW.md
@@ -2,25 +2,25 @@ _ Lines starting with _ are comments - they won't appear in the system prompt
 _ This is your scratchpad for present-tense state. Overwrite it freely between
 _ turns to capture what's happening right now. Unlike the journal (retrospective,
 _ append-only), this file is ephemeral — a snapshot of your current working state.
-
-# NOW.md
-
-## Focus
-
+_
+_ # NOW.md
+_
+_ ## Focus
+_
 _ What you're currently working on or paying attention to.
-
-## Active Threads
-
+_
+_ ## Active Threads
+_
 _ Open loops, in-progress tasks, things you're tracking across turns.
-
-## Context
-
+_
+_ ## Context
+_
 _ Key facts, constraints, or situational details relevant to the current session.
-
-## Upcoming
-
+_
+_ ## Upcoming
+_
 _ Near-term things on the horizon — scheduled events, pending actions, deadlines.
-
-## State
-
+_
+_ ## State
+_
 _ Current priorities, energy, or operational notes. What matters most right now.


### PR DESCRIPTION
## Summary
- Convert all section headers in NOW.md template to comment lines
- Unedited NOW.md now produces empty string after stripping, returning null (no injection)