### PR TITLE
fix: hide category sidebar when skill detail is open

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -29,12 +29,20 @@ struct AgentPanelContent: View {
 
     private var hasActiveSearch: Bool { !normalizedSkillQuery.isEmpty }
 
+    private var isShowingDetail: Bool {
+        selectedInstalledSkillId != nil
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            filterBar
+            if !isShowingDetail {
+                filterBar
+            }
             HStack(alignment: .top, spacing: VSpacing.xxl) {
-                categorySidebar
-                    .frame(width: 220)
+                if !isShowingDetail {
+                    categorySidebar
+                        .frame(width: 220)
+                }
                 contentView
             }
             .padding(.top, VSpacing.lg)


### PR DESCRIPTION
## Summary
- Hide the category sidebar and search bar when viewing a skill's detail view in the skill store
- The sidebar reappears when navigating back from the detail view

## Original prompt
category list has to be hidden when detailed view for skill is opened
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21086" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
