### PR TITLE
feat: add avatar trait properties to OnboardingState

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -15,9 +15,30 @@ struct HatchingStepView: View {
     @State private var showCharacter = true
     @State private var hatchStarted = false
     @State private var failureReason: String?
-    @State private var hatchBody = AvatarBodyShape.allCases.randomElement()!
-    @State private var hatchEyes = AvatarEyeStyle.allCases.randomElement()!
-    @State private var hatchColor = AvatarColor.allCases.randomElement()! // color-literal-ok
+    private var hatchBody: AvatarBodyShape {
+        get {
+            if state.hatchAvatarBodyShape == nil {
+                state.hatchAvatarBodyShape = .allCases.randomElement()!
+            }
+            return state.hatchAvatarBodyShape!
+        }
+    }
+    private var hatchEyes: AvatarEyeStyle {
+        get {
+            if state.hatchAvatarEyeStyle == nil {
+                state.hatchAvatarEyeStyle = .allCases.randomElement()!
+            }
+            return state.hatchAvatarEyeStyle!
+        }
+    }
+    private var hatchColor: AvatarColor {
+        get {
+            if state.hatchAvatarColor == nil {
+                state.hatchAvatarColor = .allCases.randomElement()!
+            }
+            return state.hatchAvatarColor!
+        }
+    }
     @State private var completionTask: Task<Void, Never>?
 
     var body: some View {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -95,6 +95,13 @@ final class OnboardingState {
     var hatchCompleted: Bool = false
     var hatchFailed: Bool = false
 
+    /// Avatar traits generated during the hatching animation. Stored here
+    /// (rather than as @State in HatchingStepView) so they survive view
+    /// disappearance and are available to the post-hatch sync logic.
+    var hatchAvatarBodyShape: AvatarBodyShape?
+    var hatchAvatarEyeStyle: AvatarEyeStyle?
+    var hatchAvatarColor: AvatarColor?
+
     /// Restore onboarding progress from a previous session (e.g. after macOS
     /// kills the app when toggling screen-recording permission).
     init() {
@@ -168,6 +175,9 @@ final class OnboardingState {
         hatchFailed = false
         hatchCompleted = false
         hatchLogLines = []
+        hatchAvatarBodyShape = nil
+        hatchAvatarEyeStyle = nil
+        hatchAvatarColor = nil
         hasHatched = false
         skippedAuth = false
         skippedAPIKeyEntry = false


### PR DESCRIPTION
## Summary
- Move avatar traits (bodyShape, eyeStyle, color) from ephemeral @State in HatchingStepView to OnboardingState so they survive view disappearance
- Add lazy-init computed properties in HatchingStepView backed by the state object
- Clear traits in resetForRetry() for fresh random generation on retry

Part of plan: avatar-onboard-persist.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
