### PR TITLE
feat: add syncTraitsToDaemon method to push avatar traits via gateway

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -432,6 +432,35 @@ final class AvatarAppearanceManager {
         updateDockLabel()
     }
 
+    /// Posts character traits to the daemon via the gateway so the daemon
+    /// renders and persists the avatar in its workspace. Used after onboarding
+    /// to sync the randomly-generated avatar to the daemon (especially
+    /// important for managed/remote assistants where the filesystem is not shared).
+    /// Fires `reloadAvatar()` on success so cached state picks up the daemon's
+    /// rendered image.
+    func syncTraitsToDaemon(bodyShape: AvatarBodyShape, eyeStyle: AvatarEyeStyle, color: AvatarColor) async {
+        let json: [String: Any] = [
+            "bodyShape": bodyShape.rawValue,
+            "eyeStyle": eyeStyle.rawValue,
+            "color": color.rawValue,
+        ]
+        do {
+            let response = try await GatewayHTTPClient.post(
+                path: "assistants/{assistantId}/avatar/render-from-traits",
+                json: json,
+                timeout: 15
+            )
+            if response.isSuccess {
+                log.info("Synced avatar traits to daemon: \(bodyShape.rawValue)/\(eyeStyle.rawValue)/\(color.rawValue)")
+                reloadAvatar()
+            } else {
+                log.warning("Failed to sync avatar traits to daemon: HTTP \(response.statusCode)")
+            }
+        } catch {
+            log.warning("Failed to sync avatar traits to daemon: \(error.localizedDescription)")
+        }
+    }
+
     /// Clears all cached avatar state and resets the dock icon to the default
     /// bundle icon without deleting any files on disk.
     /// Called during logout, retire, and switch-assistant flows.


### PR DESCRIPTION
## Summary
- Add syncTraitsToDaemon(bodyShape:eyeStyle:color:) method to AvatarAppearanceManager
- Posts traits to daemon via gateway's POST /v1/avatar/render-from-traits endpoint
- Calls reloadAvatar() on success to refresh cached state, logs warnings on failure

Part of plan: avatar-onboard-persist.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
