### PR TITLE
fix: prevent reloadAvatar HTTP fetch from clobbering disk-loaded avatar

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -304,7 +304,7 @@ final class AvatarAppearanceManager {
     // MARK: - Remote Avatar Fetch (Docker/remote instances)
 
     /// Fetches the avatar image via HTTP through the gateway for Docker/remote instances.
-    private func fetchAvatarViaHTTP() async {
+    private func fetchAvatarViaHTTP(skipClearOnFailure: Bool = false) async {
         do {
             let response = try await GatewayHTTPClient.get(
                 path: "assistants/{assistantId}/workspace/file/content",
@@ -312,9 +312,11 @@ final class AvatarAppearanceManager {
                 timeout: 10
             )
             guard response.isSuccess, !response.data.isEmpty else {
-                if customAvatarImage != nil { customAvatarImage = nil }
-                cachedChatAvatar = nil
-                updateDockIcon()
+                if !skipClearOnFailure {
+                    if customAvatarImage != nil { customAvatarImage = nil }
+                    cachedChatAvatar = nil
+                    updateDockIcon()
+                }
                 return
             }
             cachedChatAvatar = nil
@@ -322,9 +324,11 @@ final class AvatarAppearanceManager {
             updateDockIcon()
         } catch {
             log.warning("Failed to fetch avatar via HTTP: \(error.localizedDescription)")
-            if customAvatarImage != nil { customAvatarImage = nil }
-            cachedChatAvatar = nil
-            updateDockIcon()
+            if !skipClearOnFailure {
+                if customAvatarImage != nil { customAvatarImage = nil }
+                cachedChatAvatar = nil
+                updateDockIcon()
+            }
         }
     }
 
@@ -424,9 +428,11 @@ final class AvatarAppearanceManager {
             updateDockIcon()
         }
 
+        let diskLoadSucceeded = customAvatarImage != nil
+
         Task { [weak self] in
             await self?.fetchComponents()
-            await self?.fetchAvatarViaHTTP()
+            await self?.fetchAvatarViaHTTP(skipClearOnFailure: diskLoadSucceeded)
             await self?.fetchTraitsViaHTTP()
         }
         updateDockLabel()


### PR DESCRIPTION
## Summary
- Add skipClearOnFailure parameter to fetchAvatarViaHTTP to prevent nil-ing customAvatarImage when a disk-loaded avatar exists
- Track disk load success in reloadAvatar and pass it through to HTTP fetch
- Successful HTTP responses still overwrite (daemon is authoritative when reachable)

Part of plan: avatar-onboard-persist.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
