### PR TITLE
fix: remove duplicate workspace commits and starting broadcast from managed upgrade

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -716,20 +716,6 @@ async function upgradePlatform(
     }
   }
 
-  // Record version transition start in workspace git history
-  await commitWorkspaceViaGateway(
-    entry.runtimeUrl,
-    entry.assistantId,
-    buildUpgradeCommitMessage({
-      action: "upgrade",
-      phase: "starting",
-      from: entry.serviceGroupVersion ?? "unknown",
-      to: version ?? "latest",
-      topology: "managed",
-      assistantId: entry.assistantId,
-    }),
-  );
-
   console.log(
     `🔄 Upgrading platform-hosted assistant '${entry.assistantId}'...\n`,
   );
@@ -752,15 +738,6 @@ async function upgradePlatform(
   if (version) {
     body.version = version;
   }
-
-  // Notify connected clients that an upgrade is about to begin.
-  const targetVersion = version ?? `v${cliPkg.version}`;
-  console.log("📢 Notifying connected clients...");
-  await broadcastUpgradeEvent(
-    entry.runtimeUrl,
-    entry.assistantId,
-    buildStartingEvent(targetVersion, 90),
-  );
 
   const response = await fetch(url, {
     method: "POST",
@@ -798,21 +775,6 @@ async function upgradePlatform(
   // completion signal will come from the client's health-check
   // version-change detection (DaemonConnection.swift) once the new
   // version actually appears after the platform restarts the service group.
-
-  // Record successful upgrade in workspace git history
-  await commitWorkspaceViaGateway(
-    entry.runtimeUrl,
-    entry.assistantId,
-    buildUpgradeCommitMessage({
-      action: "upgrade",
-      phase: "complete",
-      from: entry.serviceGroupVersion ?? "unknown",
-      to: version ?? "latest",
-      topology: "managed",
-      assistantId: entry.assistantId,
-      result: "success",
-    }),
-  );
 
   console.log(`✅ ${result.detail}`);
   if (result.version) {


### PR DESCRIPTION
## Summary
- Remove pre-upgrade and post-upgrade workspace commit calls from upgradePlatform() since the platform API now handles these
- Remove pre-upgrade starting broadcast from upgradePlatform() since the platform broadcasts starting in Phase 5
- Keep failure broadcast for error cases where the platform API call itself fails

Part of plan: upgrade-parity-gaps.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
