### PR TITLE
fix: remove duplicate workspace commits and starting broadcast from managed rollback

### DIFF
--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -173,21 +173,7 @@ async function rollbackPlatformViaEndpoint(
     }
   }
 
-  // Step 2 — Workspace commit (starting)
-  await commitWorkspaceViaGateway(
-    entry.runtimeUrl,
-    entry.assistantId,
-    buildUpgradeCommitMessage({
-      action: "rollback",
-      phase: "starting",
-      from: currentVersion ?? "unknown",
-      to: version ?? "previous",
-      topology: "managed",
-      assistantId: entry.assistantId,
-    }),
-  );
-
-  // Step 3 — Authenticate
+  // Step 2 — Authenticate
   const token = readPlatformToken();
   if (!token) {
     const msg =
@@ -211,15 +197,7 @@ async function rollbackPlatformViaEndpoint(
     process.exit(1);
   }
 
-  // Step 4 — Broadcast starting event
-  console.log("📢 Notifying connected clients...");
-  await broadcastUpgradeEvent(
-    entry.runtimeUrl,
-    entry.assistantId,
-    buildStartingEvent(version ?? "previous", 90),
-  );
-
-  // Step 5 — Call rollback endpoint
+  // Step 3 — Call rollback endpoint
   if (version) {
     console.log(`Rolling back to ${version}...`);
   } else {
@@ -270,22 +248,7 @@ async function rollbackPlatformViaEndpoint(
 
   const rolledBackVersion = result.version ?? version ?? "unknown";
 
-  // Step 6 — Workspace commit (complete)
-  await commitWorkspaceViaGateway(
-    entry.runtimeUrl,
-    entry.assistantId,
-    buildUpgradeCommitMessage({
-      action: "rollback",
-      phase: "complete",
-      from: currentVersion ?? "unknown",
-      to: rolledBackVersion,
-      topology: "managed",
-      assistantId: entry.assistantId,
-      result: "success",
-    }),
-  );
-
-  // Step 7 — Print success
+  // Step 4 — Print success
   console.log(`Rolled back to version ${rolledBackVersion}.`);
   if (!version) {
     console.log("Tip: Run 'vellum rollback' again to undo.");


### PR DESCRIPTION
## Summary
- Remove pre-rollback and post-rollback workspace commit calls from rollbackPlatformViaEndpoint() since the platform API now handles these
- Remove pre-rollback starting broadcast from rollbackPlatformViaEndpoint() since the platform broadcasts starting in Phase 1
- Keep failure broadcast for error cases where the platform API call itself fails
- Update step numbering in remaining comments

Part of plan: upgrade-parity-gaps.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
