### PR TITLE
feat: sync onboarding avatar to daemon on hatch completion for all flows

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -63,6 +63,7 @@ extension AppDelegate {
             OnboardingState.clearPersistedState()
             let state = OnboardingState()
             state.shouldPersist = false
+            self.onboardingState = state
             authView = AnyView(OnboardingFlowView(
                 state: state,
                 connectionManager: connectionManager,

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -434,6 +434,10 @@ extension AppDelegate {
             // Clear any stale panel state so the user lands on chat, not settings
             UserDefaults.standard.removeObject(forKey: "lastActivePanel")
 
+            // Retain the onboarding state so the first-launch bootstrap can
+            // read the randomly-generated avatar traits and sync them to the daemon.
+            self?.onboardingState = state
+
             // By this point the user has either entered an API key (steps 0→1→2)
             // or authenticated via Vellum Account (WorkOS). Proceed directly —
             // don't re-check auth, which would show the auth gate again.
@@ -441,6 +445,7 @@ extension AppDelegate {
         }
         onboarding.onDismiss = { [weak self] in
             self?.onboardingWindow = nil
+            self?.onboardingState = nil
         }
         onboarding.show()
         onboardingWindow = onboarding

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -158,6 +158,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     /// finished before the observer was registered.
     var localBootstrapDidComplete = false
 
+    /// Onboarding state retained during first-launch so post-hatch logic
+    /// can access the randomly-generated avatar traits.
+    var onboardingState: OnboardingState?
+
     /// Guards `.appOpen` sound so it fires only once per app session,
     /// even if `proceedToApp()` is called again after assistant switches
     /// or re-authentication flows.
@@ -544,6 +548,20 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                     // bundled Vellum logo.
                     AvatarAppearanceManager.shared.reloadAvatar()
 
+                    // Sync the onboarding avatar traits to the daemon so it persists
+                    // the rendered avatar in its workspace. Critical for managed/remote
+                    // assistants where the client filesystem is not shared with the daemon.
+                    if let body = self.onboardingState?.hatchAvatarBodyShape,
+                       let eyes = self.onboardingState?.hatchAvatarEyeStyle,
+                       let color = self.onboardingState?.hatchAvatarColor {
+                        Task {
+                            await AvatarAppearanceManager.shared.syncTraitsToDaemon(
+                                bodyShape: body, eyeStyle: eyes, color: color
+                            )
+                        }
+                    }
+                    self.onboardingState = nil
+
                     // Record lifecycle telemetry events (fire-and-forget).
                     Task { await self.telemetryClient.recordLifecycleEvent("hatch") }
                     Task { await self.telemetryClient.recordLifecycleEvent("app_open") }
@@ -569,6 +587,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                     // Assistant not ready — show the main window with a
                     // timeout screen so the user knows something went wrong.
                     log.warning("Assistant not ready after timeout — showing timeout screen")
+                    self.onboardingState = nil
                     transitionBootstrap(to: .timedOut)
                     showMainWindow(isFirstLaunch: true)
                     debugStateWriter.start(appDelegate: self)


### PR DESCRIPTION
## Summary
- Store OnboardingState reference on AppDelegate so post-hatch logic can access avatar traits
- After daemon is ready on first launch, post avatar traits to daemon via syncTraitsToDaemon
- Works for both managed (Vellum Cloud) and local flows
- Clean up onboardingState reference after use

Part of plan: avatar-onboard-persist.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
