### PR TITLE
fix: move avatar trait init from computed getters to onAppear

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -16,28 +16,13 @@ struct HatchingStepView: View {
     @State private var hatchStarted = false
     @State private var failureReason: String?
     private var hatchBody: AvatarBodyShape {
-        get {
-            if state.hatchAvatarBodyShape == nil {
-                state.hatchAvatarBodyShape = .allCases.randomElement()!
-            }
-            return state.hatchAvatarBodyShape!
-        }
+        state.hatchAvatarBodyShape ?? .allCases[0]
     }
     private var hatchEyes: AvatarEyeStyle {
-        get {
-            if state.hatchAvatarEyeStyle == nil {
-                state.hatchAvatarEyeStyle = .allCases.randomElement()!
-            }
-            return state.hatchAvatarEyeStyle!
-        }
+        state.hatchAvatarEyeStyle ?? .allCases[0]
     }
     private var hatchColor: AvatarColor {
-        get {
-            if state.hatchAvatarColor == nil {
-                state.hatchAvatarColor = .allCases.randomElement()!
-            }
-            return state.hatchAvatarColor!
-        }
+        state.hatchAvatarColor ?? .allCases[0]
     }
     @State private var completionTask: Task<Void, Never>?
 
@@ -59,6 +44,18 @@ struct HatchingStepView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .opacity(showContent ? 1 : 0)
         .onAppear {
+            // Eagerly initialize avatar traits so computed getters don't
+            // mutate @Observable state during body evaluation.
+            if state.hatchAvatarBodyShape == nil {
+                state.hatchAvatarBodyShape = .allCases.randomElement()!
+            }
+            if state.hatchAvatarEyeStyle == nil {
+                state.hatchAvatarEyeStyle = .allCases.randomElement()!
+            }
+            if state.hatchAvatarColor == nil {
+                state.hatchAvatarColor = .allCases.randomElement()!
+            }
+
             withAnimation(.easeOut(duration: 0.5)) {
                 showContent = true
             }


### PR DESCRIPTION
## Summary
Fixes gap where computed property getters in HatchingStepView mutated @Observable state during SwiftUI body evaluation, causing an unnecessary extra render cycle.

**Gap:** Computed property getters mutate @Observable during body evaluation
**What was expected:** Avatar traits initialized without triggering re-render loops
**What was found:** Lazy init in getters fired observation changes during render
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
