### PR TITLE
fix: sync avatar traits to daemon from all onboarding paths and clean up state

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -547,20 +547,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                     // reflects the user's saved image instead of the
                     // bundled Vellum logo.
                     AvatarAppearanceManager.shared.reloadAvatar()
-
-                    // Sync the onboarding avatar traits to the daemon so it persists
-                    // the rendered avatar in its workspace. Critical for managed/remote
-                    // assistants where the client filesystem is not shared with the daemon.
-                    if let body = self.onboardingState?.hatchAvatarBodyShape,
-                       let eyes = self.onboardingState?.hatchAvatarEyeStyle,
-                       let color = self.onboardingState?.hatchAvatarColor {
-                        Task {
-                            await AvatarAppearanceManager.shared.syncTraitsToDaemon(
-                                bodyShape: body, eyeStyle: eyes, color: color
-                            )
-                        }
-                    }
-                    self.onboardingState = nil
+                    self.syncOnboardingAvatarIfNeeded()
 
                     // Record lifecycle telemetry events (fire-and-forget).
                     Task { await self.telemetryClient.recordLifecycleEvent("hatch") }
@@ -587,6 +574,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                     // Assistant not ready — show the main window with a
                     // timeout screen so the user knows something went wrong.
                     log.warning("Assistant not ready after timeout — showing timeout screen")
+                    // Can't sync traits (no daemon), but still clean up onboarding state.
                     self.onboardingState = nil
                     transitionBootstrap(to: .timedOut)
                     showMainWindow(isFirstLaunch: true)
@@ -602,7 +590,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                     // Gateway is healthy — reload the avatar so
                     // logout→re-login cycles repopulate the dock icon.
                     AvatarAppearanceManager.shared.reloadAvatar()
+                    self.syncOnboardingAvatarIfNeeded()
                     await self.telemetryClient.recordLifecycleEvent("app_open")
+                } else {
+                    // Can't sync traits (no daemon), but still clean up onboarding state.
+                    self.onboardingState = nil
                 }
             }
             showMainWindow()
@@ -670,6 +662,24 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         showMainWindow()
         mainWindow?.conversationManager.createConversation()
         SoundManager.shared.play(.newConversation)
+    }
+
+    /// If onboarding generated avatar traits, sync them to the daemon and clear the state.
+    /// Called from both the first-launch and non-first-launch paths in `proceedToApp`
+    /// so that auth-gate onboarding flows also persist avatar traits on the daemon.
+    private func syncOnboardingAvatarIfNeeded() {
+        guard let body = onboardingState?.hatchAvatarBodyShape,
+              let eyes = onboardingState?.hatchAvatarEyeStyle,
+              let color = onboardingState?.hatchAvatarColor else {
+            onboardingState = nil
+            return
+        }
+        Task {
+            await AvatarAppearanceManager.shared.syncTraitsToDaemon(
+                bodyShape: body, eyeStyle: eyes, color: color
+            )
+        }
+        onboardingState = nil
     }
 
 }


### PR DESCRIPTION
## Summary
Fixes two gaps: (1) avatar traits were only synced to daemon in the isFirstLaunch path, missing the auth-gate onboarding flow; (2) onboardingState was never cleared in the auth-gate path.

**Gap 1:** Auth-gate path doesn't sync traits to daemon
**Gap 2:** onboardingState never cleared in auth-gate path

Extracts sync + cleanup into syncOnboardingAvatarIfNeeded() and calls it from both first-launch and non-first-launch paths in proceedToApp.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21094" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
