### PR TITLE
fix: persist onboarding avatar to daemon workspace

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -63,6 +63,7 @@ extension AppDelegate {
             OnboardingState.clearPersistedState()
             let state = OnboardingState()
             state.shouldPersist = false
+            self.onboardingState = state
             authView = AnyView(OnboardingFlowView(
                 state: state,
                 connectionManager: connectionManager,

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -434,6 +434,10 @@ extension AppDelegate {
             // Clear any stale panel state so the user lands on chat, not settings
             UserDefaults.standard.removeObject(forKey: "lastActivePanel")
 
+            // Retain the onboarding state so the first-launch bootstrap can
+            // read the randomly-generated avatar traits and sync them to the daemon.
+            self?.onboardingState = state
+
             // By this point the user has either entered an API key (steps 0→1→2)
             // or authenticated via Vellum Account (WorkOS). Proceed directly —
             // don't re-check auth, which would show the auth gate again.
@@ -441,6 +445,7 @@ extension AppDelegate {
         }
         onboarding.onDismiss = { [weak self] in
             self?.onboardingWindow = nil
+            self?.onboardingState = nil
         }
         onboarding.show()
         onboardingWindow = onboarding

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -547,20 +547,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                     // reflects the user's saved image instead of the
                     // bundled Vellum logo.
                     AvatarAppearanceManager.shared.reloadAvatar()
-
-                    // Sync the onboarding avatar traits to the daemon so it persists
-                    // the rendered avatar in its workspace. Critical for managed/remote
-                    // assistants where the client filesystem is not shared with the daemon.
-                    if let body = self.onboardingState?.hatchAvatarBodyShape,
-                       let eyes = self.onboardingState?.hatchAvatarEyeStyle,
-                       let color = self.onboardingState?.hatchAvatarColor {
-                        Task {
-                            await AvatarAppearanceManager.shared.syncTraitsToDaemon(
-                                bodyShape: body, eyeStyle: eyes, color: color
-                            )
-                        }
-                    }
-                    self.onboardingState = nil
+                    self.syncOnboardingAvatarIfNeeded()
 
                     // Record lifecycle telemetry events (fire-and-forget).
                     Task { await self.telemetryClient.recordLifecycleEvent("hatch") }
@@ -587,6 +574,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                     // Assistant not ready — show the main window with a
                     // timeout screen so the user knows something went wrong.
                     log.warning("Assistant not ready after timeout — showing timeout screen")
+                    // Can't sync traits (no daemon), but still clean up onboarding state.
                     self.onboardingState = nil
                     transitionBootstrap(to: .timedOut)
                     showMainWindow(isFirstLaunch: true)
@@ -602,7 +590,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                     // Gateway is healthy — reload the avatar so
                     // logout→re-login cycles repopulate the dock icon.
                     AvatarAppearanceManager.shared.reloadAvatar()
+                    self.syncOnboardingAvatarIfNeeded()
                     await self.telemetryClient.recordLifecycleEvent("app_open")
+                } else {
+                    // Can't sync traits (no daemon), but still clean up onboarding state.
+                    self.onboardingState = nil
                 }
             }
             showMainWindow()
@@ -670,6 +662,24 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         showMainWindow()
         mainWindow?.conversationManager.createConversation()
         SoundManager.shared.play(.newConversation)
+    }
+
+    /// If onboarding generated avatar traits, sync them to the daemon and clear the state.
+    /// Called from both the first-launch and non-first-launch paths in `proceedToApp`
+    /// so that auth-gate onboarding flows also persist avatar traits on the daemon.
+    private func syncOnboardingAvatarIfNeeded() {
+        guard let body = onboardingState?.hatchAvatarBodyShape,
+              let eyes = onboardingState?.hatchAvatarEyeStyle,
+              let color = onboardingState?.hatchAvatarColor else {
+            onboardingState = nil
+            return
+        }
+        Task {
+            await AvatarAppearanceManager.shared.syncTraitsToDaemon(
+                bodyShape: body, eyeStyle: eyes, color: color
+            )
+        }
+        onboardingState = nil
     }
 
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -158,6 +158,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     /// finished before the observer was registered.
     var localBootstrapDidComplete = false
 
+    /// Onboarding state retained during first-launch so post-hatch logic
+    /// can access the randomly-generated avatar traits.
+    var onboardingState: OnboardingState?
+
     /// Guards `.appOpen` sound so it fires only once per app session,
     /// even if `proceedToApp()` is called again after assistant switches
     /// or re-authentication flows.
@@ -544,6 +548,20 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                     // bundled Vellum logo.
                     AvatarAppearanceManager.shared.reloadAvatar()
 
+                    // Sync the onboarding avatar traits to the daemon so it persists
+                    // the rendered avatar in its workspace. Critical for managed/remote
+                    // assistants where the client filesystem is not shared with the daemon.
+                    if let body = self.onboardingState?.hatchAvatarBodyShape,
+                       let eyes = self.onboardingState?.hatchAvatarEyeStyle,
+                       let color = self.onboardingState?.hatchAvatarColor {
+                        Task {
+                            await AvatarAppearanceManager.shared.syncTraitsToDaemon(
+                                bodyShape: body, eyeStyle: eyes, color: color
+                            )
+                        }
+                    }
+                    self.onboardingState = nil
+
                     // Record lifecycle telemetry events (fire-and-forget).
                     Task { await self.telemetryClient.recordLifecycleEvent("hatch") }
                     Task { await self.telemetryClient.recordLifecycleEvent("app_open") }
@@ -569,6 +587,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                     // Assistant not ready — show the main window with a
                     // timeout screen so the user knows something went wrong.
                     log.warning("Assistant not ready after timeout — showing timeout screen")
+                    self.onboardingState = nil
                     transitionBootstrap(to: .timedOut)
                     showMainWindow(isFirstLaunch: true)
                     debugStateWriter.start(appDelegate: self)

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -432,6 +432,35 @@ final class AvatarAppearanceManager {
         updateDockLabel()
     }
 
+    /// Posts character traits to the daemon via the gateway so the daemon
+    /// renders and persists the avatar in its workspace. Used after onboarding
+    /// to sync the randomly-generated avatar to the daemon (especially
+    /// important for managed/remote assistants where the filesystem is not shared).
+    /// Fires `reloadAvatar()` on success so cached state picks up the daemon's
+    /// rendered image.
+    func syncTraitsToDaemon(bodyShape: AvatarBodyShape, eyeStyle: AvatarEyeStyle, color: AvatarColor) async {
+        let json: [String: Any] = [
+            "bodyShape": bodyShape.rawValue,
+            "eyeStyle": eyeStyle.rawValue,
+            "color": color.rawValue,
+        ]
+        do {
+            let response = try await GatewayHTTPClient.post(
+                path: "assistants/{assistantId}/avatar/render-from-traits",
+                json: json,
+                timeout: 15
+            )
+            if response.isSuccess {
+                log.info("Synced avatar traits to daemon: \(bodyShape.rawValue)/\(eyeStyle.rawValue)/\(color.rawValue)")
+                reloadAvatar()
+            } else {
+                log.warning("Failed to sync avatar traits to daemon: HTTP \(response.statusCode)")
+            }
+        } catch {
+            log.warning("Failed to sync avatar traits to daemon: \(error.localizedDescription)")
+        }
+    }
+
     /// Clears all cached avatar state and resets the dock icon to the default
     /// bundle icon without deleting any files on disk.
     /// Called during logout, retire, and switch-assistant flows.

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -304,7 +304,7 @@ final class AvatarAppearanceManager {
     // MARK: - Remote Avatar Fetch (Docker/remote instances)
 
     /// Fetches the avatar image via HTTP through the gateway for Docker/remote instances.
-    private func fetchAvatarViaHTTP() async {
+    private func fetchAvatarViaHTTP(skipClearOnFailure: Bool = false) async {
         do {
             let response = try await GatewayHTTPClient.get(
                 path: "assistants/{assistantId}/workspace/file/content",
@@ -312,9 +312,11 @@ final class AvatarAppearanceManager {
                 timeout: 10
             )
             guard response.isSuccess, !response.data.isEmpty else {
-                if customAvatarImage != nil { customAvatarImage = nil }
-                cachedChatAvatar = nil
-                updateDockIcon()
+                if !skipClearOnFailure {
+                    if customAvatarImage != nil { customAvatarImage = nil }
+                    cachedChatAvatar = nil
+                    updateDockIcon()
+                }
                 return
             }
             cachedChatAvatar = nil
@@ -322,9 +324,11 @@ final class AvatarAppearanceManager {
             updateDockIcon()
         } catch {
             log.warning("Failed to fetch avatar via HTTP: \(error.localizedDescription)")
-            if customAvatarImage != nil { customAvatarImage = nil }
-            cachedChatAvatar = nil
-            updateDockIcon()
+            if !skipClearOnFailure {
+                if customAvatarImage != nil { customAvatarImage = nil }
+                cachedChatAvatar = nil
+                updateDockIcon()
+            }
         }
     }
 
@@ -424,9 +428,11 @@ final class AvatarAppearanceManager {
             updateDockIcon()
         }
 
+        let diskLoadSucceeded = customAvatarImage != nil
+
         Task { [weak self] in
             await self?.fetchComponents()
-            await self?.fetchAvatarViaHTTP()
+            await self?.fetchAvatarViaHTTP(skipClearOnFailure: diskLoadSucceeded)
             await self?.fetchTraitsViaHTTP()
         }
         updateDockLabel()

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -15,9 +15,30 @@ struct HatchingStepView: View {
     @State private var showCharacter = true
     @State private var hatchStarted = false
     @State private var failureReason: String?
-    @State private var hatchBody = AvatarBodyShape.allCases.randomElement()!
-    @State private var hatchEyes = AvatarEyeStyle.allCases.randomElement()!
-    @State private var hatchColor = AvatarColor.allCases.randomElement()! // color-literal-ok
+    private var hatchBody: AvatarBodyShape {
+        get {
+            if state.hatchAvatarBodyShape == nil {
+                state.hatchAvatarBodyShape = .allCases.randomElement()!
+            }
+            return state.hatchAvatarBodyShape!
+        }
+    }
+    private var hatchEyes: AvatarEyeStyle {
+        get {
+            if state.hatchAvatarEyeStyle == nil {
+                state.hatchAvatarEyeStyle = .allCases.randomElement()!
+            }
+            return state.hatchAvatarEyeStyle!
+        }
+    }
+    private var hatchColor: AvatarColor {
+        get {
+            if state.hatchAvatarColor == nil {
+                state.hatchAvatarColor = .allCases.randomElement()!
+            }
+            return state.hatchAvatarColor!
+        }
+    }
     @State private var completionTask: Task<Void, Never>?
 
     var body: some View {

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -16,28 +16,13 @@ struct HatchingStepView: View {
     @State private var hatchStarted = false
     @State private var failureReason: String?
     private var hatchBody: AvatarBodyShape {
-        get {
-            if state.hatchAvatarBodyShape == nil {
-                state.hatchAvatarBodyShape = .allCases.randomElement()!
-            }
-            return state.hatchAvatarBodyShape!
-        }
+        state.hatchAvatarBodyShape ?? .allCases[0]
     }
     private var hatchEyes: AvatarEyeStyle {
-        get {
-            if state.hatchAvatarEyeStyle == nil {
-                state.hatchAvatarEyeStyle = .allCases.randomElement()!
-            }
-            return state.hatchAvatarEyeStyle!
-        }
+        state.hatchAvatarEyeStyle ?? .allCases[0]
     }
     private var hatchColor: AvatarColor {
-        get {
-            if state.hatchAvatarColor == nil {
-                state.hatchAvatarColor = .allCases.randomElement()!
-            }
-            return state.hatchAvatarColor!
-        }
+        state.hatchAvatarColor ?? .allCases[0]
     }
     @State private var completionTask: Task<Void, Never>?
 
@@ -59,6 +44,18 @@ struct HatchingStepView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .opacity(showContent ? 1 : 0)
         .onAppear {
+            // Eagerly initialize avatar traits so computed getters don't
+            // mutate @Observable state during body evaluation.
+            if state.hatchAvatarBodyShape == nil {
+                state.hatchAvatarBodyShape = .allCases.randomElement()!
+            }
+            if state.hatchAvatarEyeStyle == nil {
+                state.hatchAvatarEyeStyle = .allCases.randomElement()!
+            }
+            if state.hatchAvatarColor == nil {
+                state.hatchAvatarColor = .allCases.randomElement()!
+            }
+
             withAnimation(.easeOut(duration: 0.5)) {
                 showContent = true
             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -95,6 +95,13 @@ final class OnboardingState {
     var hatchCompleted: Bool = false
     var hatchFailed: Bool = false
 
+    /// Avatar traits generated during the hatching animation. Stored here
+    /// (rather than as @State in HatchingStepView) so they survive view
+    /// disappearance and are available to the post-hatch sync logic.
+    var hatchAvatarBodyShape: AvatarBodyShape?
+    var hatchAvatarEyeStyle: AvatarEyeStyle?
+    var hatchAvatarColor: AvatarColor?
+
     /// Restore onboarding progress from a previous session (e.g. after macOS
     /// kills the app when toggling screen-recording permission).
     init() {
@@ -168,6 +175,9 @@ final class OnboardingState {
         hatchFailed = false
         hatchCompleted = false
         hatchLogLines = []
+        hatchAvatarBodyShape = nil
+        hatchAvatarEyeStyle = nil
+        hatchAvatarColor = nil
         hasHatched = false
         skippedAuth = false
         skippedAPIKeyEntry = false


### PR DESCRIPTION
## Summary
Fixes avatar persistence during Mac onboarding — the avatar character shown during "Waking up..." now persists to the assistant's workspace after the daemon starts, for both managed (Vellum Cloud) and local flows.

**Root cause:** Two bugs: (1) managed flow never called `handleHatchSuccess()`, so random avatar traits were ephemeral `@State` lost on view disappearance; (2) `reloadAvatar()`'s async HTTP fetch could overwrite a successfully disk-loaded avatar to `nil` on failure.

**Fix:** Move traits to `OnboardingState`, sync them to the daemon via `POST /v1/avatar/render-from-traits` after hatch, and harden `reloadAvatar` against HTTP clobber.

## PRs merged into feature branch
- #21087: feat: add avatar trait properties to OnboardingState
- #21088: feat: add syncTraitsToDaemon method to push avatar traits via gateway
- #21089: fix: prevent reloadAvatar HTTP fetch from clobbering disk-loaded avatar
- #21092: feat: sync onboarding avatar to daemon on hatch completion for all flows
- #21093: fix: move avatar trait init from computed getters to onAppear
- #21094: fix: sync avatar traits to daemon from all onboarding paths and clean up state

## Self-review result
3 gaps found and fixed in round 1:
1. Computed property getters mutated @Observable during body eval → moved to onAppear
2. Auth-gate path didn't sync traits to daemon → extracted helper, called from all paths
3. onboardingState never cleared in auth-gate path → cleaned up in helper

## Test plan
- [ ] Fresh onboarding (local): avatar shown during "Waking up..." persists after daemon starts
- [ ] Fresh onboarding (Vellum Cloud/managed): same — avatar persists on remote daemon
- [ ] Retry hatch: new random avatar generated on retry
- [ ] Non-first-launch app reopen: existing avatar loads from disk, not clobbered by HTTP failure

Part of plan: avatar-onboard-persist.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
