### PR TITLE
fix: use FileCredentialStorage in release builds instead of keychain

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -26,13 +26,7 @@ extension Notification.Name {
 enum APIKeyManager {
     private static let udPrefix = "vellum_provider_"
 
-    private static let storage: CredentialStorage = {
-        #if DEBUG
-        return FileCredentialStorage()
-        #else
-        return KeychainCredentialStorage()
-        #endif
-    }()
+    private static let storage: CredentialStorage = FileCredentialStorage()
 
     /// Provider identifiers whose API keys are synced to the daemon as
     /// `type: "api_key"`.

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -199,11 +199,7 @@ extension AppDelegate {
             }
 
             // Clear locally-cached credentials for all local assistants
-            #if DEBUG
             let credStorage = FileCredentialStorage()
-            #else
-            let credStorage = KeychainCredentialStorage()
-            #endif
             for assistant in LockfileAssistant.loadAll() where !assistant.isRemote && !assistant.isManaged {
                 let credentialAccount = LocalAssistantBootstrapService.credentialAccount(for: assistant.assistantId)
                 _ = credStorage.delete(account: credentialAccount)
@@ -381,11 +377,7 @@ extension AppDelegate {
             }
 
             do {
-                #if DEBUG
                 let credentialStorage = FileCredentialStorage()
-                #else
-                let credentialStorage = KeychainCredentialStorage()
-                #endif
                 let bootstrapService = LocalAssistantBootstrapService(credentialStorage: credentialStorage)
                 let outcome = try await bootstrapService.bootstrap(
                     runtimeAssistantId: assistantId,

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -527,13 +527,7 @@ struct SettingsDeveloperTab: View {
             isManaged: assistant.isManaged,
             organizationId: orgId,
             userId: userId,
-            credentialStorage: {
-                #if DEBUG
-                return FileCredentialStorage()
-                #else
-                return KeychainCredentialStorage()
-                #endif
-            }()
+            credentialStorage: FileCredentialStorage()
         )
     }
 
@@ -778,11 +772,7 @@ struct SettingsDeveloperTab: View {
             if response.isSuccess || response.statusCode == 404 {
                 // Clear the locally-cached credential so the key is not
                 // re-injected on the next daemon restart or bootstrap.
-                #if DEBUG
                 let credStorage = FileCredentialStorage()
-                #else
-                let credStorage = KeychainCredentialStorage()
-                #endif
                 let credentialAccount = LocalAssistantBootstrapService.credentialAccount(for: targetAssistantId)
                 _ = credStorage.delete(account: credentialAccount)
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2208,11 +2208,7 @@ public final class SettingsStore: ObservableObject {
             return nil
         }
 
-        #if DEBUG
         let credentialStorage = FileCredentialStorage()
-        #else
-        let credentialStorage = KeychainCredentialStorage()
-        #endif
 
         let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
 


### PR DESCRIPTION
## Summary
- Switch all 6 credential storage call sites from `#if DEBUG` keychain/file conditionals to always use `FileCredentialStorage`
- Release builds now use file-based credential storage under `~/.vellum/protected/credentials/` instead of macOS keychain
- No migration needed — credentials are auto-reprovisioned from the platform on next launch

Part of plan: remove-keychain-backend.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21097" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
