### PR TITLE
fix: remove keychain broker fallback from gateway credential reader

### DIFF
--- a/gateway/src/__tests__/credential-reader.test.ts
+++ b/gateway/src/__tests__/credential-reader.test.ts
@@ -1,6 +1,5 @@
 import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, writeFileSync, rmSync, unlinkSync } from "node:fs";
-import { createServer, type Server } from "node:net";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { hostname, tmpdir, userInfo } from "node:os";
 import { createCipheriv, pbkdf2Sync, randomBytes } from "node:crypto";
@@ -145,88 +144,6 @@ function writeEncryptedStoreV2(entries: Record<string, string>): void {
 }
 
 // ---------------------------------------------------------------------------
-// Broker test helpers — mock UDS server
-// ---------------------------------------------------------------------------
-
-const TEST_TOKEN = "test-auth-token-abc123";
-
-function writeBrokerToken(token: string): void {
-  const tokenDir = join(testDir, ".vellum", "protected");
-  mkdirSync(tokenDir, { recursive: true });
-  writeFileSync(join(tokenDir, "keychain-broker.token"), token);
-}
-
-/**
- * Create a mock keychain broker UDS server that responds to key.get requests.
- * Listens on the derived socket path (getRootDir() + keychain-broker.sock).
- * Returns the socket path and a handle to close the server.
- */
-function createMockBroker(credentials: Record<string, string>): {
-  socketPath: string;
-  server: Server;
-  close: () => void;
-} {
-  const socketPath = join(testDir, ".vellum", "keychain-broker.sock");
-  mkdirSync(join(testDir, ".vellum"), { recursive: true });
-
-  const server = createServer((conn) => {
-    let buf = "";
-    conn.on("data", (chunk) => {
-      buf += chunk.toString();
-      const idx = buf.indexOf("\n");
-      if (idx !== -1) {
-        const line = buf.slice(0, idx);
-        buf = buf.slice(idx + 1);
-        try {
-          const req = JSON.parse(line);
-          if (req.token !== TEST_TOKEN) {
-            conn.write(
-              JSON.stringify({
-                id: req.id,
-                ok: false,
-                error: { code: "UNAUTHORIZED", message: "bad token" },
-              }) + "\n",
-            );
-            return;
-          }
-          if (req.method === "key.get") {
-            const account = req.params?.account;
-            const value = credentials[account];
-            conn.write(
-              JSON.stringify({
-                id: req.id,
-                ok: true,
-                result:
-                  value !== undefined
-                    ? { found: true, value }
-                    : { found: false },
-              }) + "\n",
-            );
-          }
-        } catch {
-          // ignore malformed requests
-        }
-      }
-    });
-  });
-
-  server.listen(socketPath);
-
-  return {
-    socketPath,
-    server,
-    close: () => {
-      server.close();
-      try {
-        unlinkSync(socketPath);
-      } catch {
-        // best-effort
-      }
-    },
-  };
-}
-
-// ---------------------------------------------------------------------------
 // Setup / teardown
 // ---------------------------------------------------------------------------
 
@@ -358,88 +275,6 @@ describe("v1 encrypted store backward compatibility", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: broker credential reading
-// ---------------------------------------------------------------------------
-
-describe("readCredential broker integration", () => {
-  test("returns undefined when socket file does not exist", async () => {
-    const result = await readCredential(credentialKey("test", "key"));
-    expect(result).toBeUndefined();
-  });
-
-  test("falls back to encrypted store when socket file does not exist", async () => {
-    writeEncryptedStore({
-      [credentialKey("test", "key")]: "encrypted-value",
-    });
-
-    const result = await readCredential(credentialKey("test", "key"));
-    expect(result).toBe("encrypted-value");
-  });
-
-  test("falls back to encrypted store when broker token file is missing", async () => {
-    // Create socket file but no token file
-    mkdirSync(join(testDir, ".vellum"), { recursive: true });
-    writeFileSync(join(testDir, ".vellum", "keychain-broker.sock"), "");
-
-    writeEncryptedStore({
-      [credentialKey("test", "key")]: "encrypted-value",
-    });
-
-    const result = await readCredential(credentialKey("test", "key"));
-    expect(result).toBe("encrypted-value");
-  });
-
-  test("reads credential from broker when available", async () => {
-    const broker = createMockBroker({
-      [credentialKey("test", "key")]: "broker-secret-value",
-    });
-    try {
-      writeBrokerToken(TEST_TOKEN);
-
-      const result = await readCredential(credentialKey("test", "key"));
-      expect(result).toBe("broker-secret-value");
-    } finally {
-      broker.close();
-    }
-  });
-
-  test("broker result takes priority over encrypted store", async () => {
-    const broker = createMockBroker({
-      [credentialKey("test", "key")]: "broker-value",
-    });
-    try {
-      writeBrokerToken(TEST_TOKEN);
-
-      writeEncryptedStore({
-        [credentialKey("test", "key")]: "encrypted-value",
-      });
-
-      const result = await readCredential(credentialKey("test", "key"));
-      expect(result).toBe("broker-value");
-    } finally {
-      broker.close();
-    }
-  });
-
-  test("falls back to encrypted store when broker returns not found", async () => {
-    // Broker has no entry for the test credential key
-    const broker = createMockBroker({});
-    try {
-      writeBrokerToken(TEST_TOKEN);
-
-      writeEncryptedStore({
-        [credentialKey("test", "key")]: "encrypted-value",
-      });
-
-      const result = await readCredential(credentialKey("test", "key"));
-      expect(result).toBe("encrypted-value");
-    } finally {
-      broker.close();
-    }
-  });
-});
-
-// ---------------------------------------------------------------------------
 // Tests: secret values must not leak into log output
 // ---------------------------------------------------------------------------
 
@@ -447,26 +282,6 @@ describe("secret leak prevention", () => {
   function allLogStrings(): string {
     return JSON.stringify(logCalls);
   }
-
-  test("broker read does not leak secret values into logs", async () => {
-    const secretValue = "super-secret-broker-credential-value";
-    const broker = createMockBroker({
-      [credentialKey("leak-test", "key")]: secretValue,
-    });
-    try {
-      writeBrokerToken(TEST_TOKEN);
-
-      const result = await readCredential(credentialKey("leak-test", "key"));
-      expect(result).toBe(secretValue);
-
-      const serialized = allLogStrings();
-      expect(serialized).not.toContain(secretValue);
-      // The auth token used for broker handshake should also stay out of logs
-      expect(serialized).not.toContain(TEST_TOKEN);
-    } finally {
-      broker.close();
-    }
-  });
 
   test("encrypted store read does not leak secret values into logs", async () => {
     const secretValue = "super-secret-encrypted-credential-value";

--- a/gateway/src/credential-reader.ts
+++ b/gateway/src/credential-reader.ts
@@ -2,14 +2,12 @@
  * Read-only reader for the assistant's credential stores.
  *
  * Resolution order:
- * 1. CES HTTP API (when CES_CREDENTIAL_URL is set — containerized mode)
- * 2. Keychain broker (UDS — native macOS/Linux)
- * 3. Encrypted-at-rest file (~/.vellum/protected/keys.enc)
+ * 1. CES HTTP API (when CES_CREDENTIAL_URL is set)
+ * 2. Encrypted-at-rest file (~/.vellum/protected/keys.enc)
  */
 
-import { createDecipheriv, pbkdf2Sync, randomUUID } from "node:crypto";
+import { createDecipheriv, pbkdf2Sync } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
-import { createConnection } from "node:net";
 import { hostname, userInfo } from "node:os";
 import { join } from "node:path";
 import { credentialKey } from "./credential-key.js";
@@ -197,126 +195,6 @@ function readEncryptedCredential(account: string): string | undefined {
 }
 
 // ---------------------------------------------------------------------------
-// Keychain broker reader (UDS) — native async implementation
-// ---------------------------------------------------------------------------
-
-const BROKER_TIMEOUT_MS = 5_000;
-
-function getBrokerTokenPath(): string {
-  return join(getRootDir(), "protected", "keychain-broker.token");
-}
-
-/**
- * Try to read a credential from the keychain broker over its Unix domain socket.
- * Uses a native UDS connection (no external process spawn).
- * Returns `undefined` if the broker is unavailable, the socket file doesn't exist,
- * the token file is missing, or the broker doesn't have the requested key.
- */
-async function readBrokerCredential(
-  account: string,
-): Promise<string | undefined> {
-  const socketPath = join(getRootDir(), "keychain-broker.sock");
-
-  // Check socket file exists before attempting connection — createConnection
-  // can throw synchronously in some runtimes (e.g. Bun) for ENOENT.
-  if (!existsSync(socketPath)) return undefined;
-
-  const tokenPath = getBrokerTokenPath();
-  let token: string;
-  try {
-    if (!existsSync(tokenPath)) return undefined;
-    token = readFileSync(tokenPath, "utf-8").trim();
-    if (!token) return undefined;
-  } catch {
-    return undefined;
-  }
-
-  const reqId = randomUUID();
-  const request = JSON.stringify({
-    v: 1,
-    id: reqId,
-    method: "key.get",
-    token,
-    params: { account },
-  });
-
-  try {
-    return await new Promise<string | undefined>((resolve) => {
-      let buf = "";
-      let settled = false;
-
-      // Declare socket before the timer so the timeout closure never
-      // hits a TDZ if createConnection throws synchronously.
-      let socket: ReturnType<typeof createConnection> | undefined;
-
-      const timer = setTimeout(() => {
-        if (!settled) {
-          settled = true;
-          try {
-            socket?.destroy();
-          } catch {
-            /* already destroyed or never created */
-          }
-          log.debug({ account }, "Broker read timed out");
-          resolve(undefined);
-        }
-      }, BROKER_TIMEOUT_MS);
-
-      try {
-        socket = createConnection({ path: socketPath });
-      } catch (err) {
-        clearTimeout(timer);
-        settled = true;
-        log.debug({ err, account }, "Failed to connect to keychain broker");
-        resolve(undefined);
-        return;
-      }
-
-      socket.on("connect", () => {
-        socket!.write(request + "\n");
-      });
-
-      socket.on("data", (chunk) => {
-        buf += chunk.toString();
-        const idx = buf.indexOf("\n");
-        if (idx !== -1) {
-          clearTimeout(timer);
-          if (settled) return;
-          settled = true;
-          try {
-            const resp = JSON.parse(buf.slice(0, idx));
-            if (
-              resp.ok &&
-              resp.result?.found &&
-              typeof resp.result.value === "string"
-            ) {
-              resolve(resp.result.value);
-            } else {
-              resolve(undefined);
-            }
-          } catch {
-            resolve(undefined);
-          }
-          socket!.destroy();
-        }
-      });
-
-      socket.on("error", (err) => {
-        clearTimeout(timer);
-        if (!settled) {
-          settled = true;
-          log.debug({ err, account }, "Failed to read from keychain broker");
-          resolve(undefined);
-        }
-      });
-    });
-  } catch (err) {
-    log.debug({ err, account }, "Failed to read from keychain broker");
-    return undefined;
-  }
-}
-
-// ---------------------------------------------------------------------------
 // CES HTTP credential reader (containerized mode)
 // ---------------------------------------------------------------------------
 
@@ -382,7 +260,7 @@ async function readCesCredential(
 }
 
 // ---------------------------------------------------------------------------
-// Public credential reader — tries CES, broker, then encrypted store
+// Public credential reader — tries CES, then encrypted store
 // ---------------------------------------------------------------------------
 
 /**
@@ -390,8 +268,7 @@ async function readCesCredential(
  *
  * Resolution order:
  * 1. CES HTTP API (when CES_CREDENTIAL_URL is set)
- * 2. Keychain broker (UDS)
- * 3. Encrypted-at-rest store (keys.enc)
+ * 2. Encrypted-at-rest store (keys.enc)
  */
 export async function readCredential(
   account: string,
@@ -399,10 +276,6 @@ export async function readCredential(
   // CES HTTP backend (containerized mode)
   const cesValue = await readCesCredential(account);
   if (cesValue !== undefined) return cesValue;
-
-  // Keychain broker (native mode)
-  const brokerValue = await readBrokerCredential(account);
-  if (brokerValue !== undefined) return brokerValue;
 
   // Encrypted file fallback
   return readEncryptedCredential(account);


### PR DESCRIPTION
## Summary
- Remove dead keychain broker UDS fallback from gateway credential reader
- Gateway now resolves credentials via CES HTTP → encrypted file store only
- Delete broker-related test helpers and test cases

Part of plan: remove-keychain-backend.md (PR 1 of 4)