### PR TITLE
fix: update stale Keychain references after credential backend removal

### DIFF
--- a/clients/macos/AGENTS.md
+++ b/clients/macos/AGENTS.md
@@ -274,7 +274,7 @@ All design system types use the `V` prefix (VButton, VColor, VFont, etc.). Alway
 
 ## Permissions
 
-Requires Accessibility, Screen Recording, and Microphone permissions (System Settings > Privacy & Security). `PermissionManager` handles checking/prompting. API key stored in Keychain via `APIKeyManager`.
+Requires Accessibility, Screen Recording, and Microphone permissions (System Settings > Privacy & Security). `PermissionManager` handles checking/prompting. API key stored via `APIKeyManager`.
 
 ---
 

--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -20,8 +20,8 @@ extension Notification.Name {
     static let localBootstrapCompleted = Notification.Name("localBootstrapCompleted")
 }
 
-/// Manages API keys using CredentialStorage (Keychain in Release, file-based
-/// in DEBUG). The daemon owns the canonical encrypted store; the app syncs
+/// Manages API keys using file-based CredentialStorage. The daemon owns the
+/// canonical encrypted store; the app syncs
 /// keys to the daemon via HTTP on save/clear/reconnect.
 enum APIKeyManager {
     private static let udPrefix = "vellum_provider_"
@@ -70,7 +70,7 @@ enum APIKeyManager {
            !udValue.isEmpty,
            storage.get(account: udKey) == nil {
             // Only remove from UserDefaults if the credential store
-            // write succeeds. A transient Keychain/file failure should
+            // write succeeds. A transient credential storage failure should
             // not destroy the user's only copy of the key.
             guard storage.set(account: udKey, value: udValue) else { return }
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -323,7 +323,7 @@ extension AppDelegate {
     /// Safe to call at any time — exits early if the assistant is managed/remote
     /// or the user isn't authenticated. Always calls through to
     /// `LocalAssistantBootstrapService.bootstrap()` so existing-key re-injection
-    /// and stale-key reprovisioning are handled (not just Keychain presence).
+    /// and stale-key reprovisioning are handled (not just credential storage presence).
     ///
     /// Waits up to 60s for the actor token to become available, retrying every
     /// 10s, so that assistant switches (which clear then re-bootstrap actor

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -114,7 +114,7 @@ extension AppDelegate {
 
         Task {
             // Import guardian token from CLI file before connecting, so the
-            // health check has valid credentials in the Keychain.
+            // health check has valid credentials in the credential store.
             if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
                !ActorTokenManager.hasToken {
                 _ = GuardianTokenFileReader.importIfAvailable(assistantId: assistantId)

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -392,7 +392,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         UserDefaults.standard.removeObject(forKey: "conversationTextZoomLevel")
 
         // Migrate API keys from plaintext UserDefaults to credential storage
-        // (Keychain in Release, file-based in DEBUG). Safe to call on every
+        // (file-based credential storage). Safe to call on every
         // launch — skips providers already present in credential storage.
         APIKeyManager.migrateFromUserDefaults()
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -377,7 +377,7 @@ public final class SettingsStore: ObservableObject {
         self.verificationStatusPollInterval = max(0.05, verificationStatusPollInterval)
         self.verificationStatusPollWindow = max(self.verificationStatusPollInterval, verificationStatusPollWindow)
 
-        // Seed from UserDefaults / Keychain
+        // Seed from UserDefaults / credential storage
         let anthropicKey = APIKeyManager.getKey(for: "anthropic")
         self.hasKey = anthropicKey != nil
         self.maskedKey = Self.maskKey(anthropicKey)
@@ -453,7 +453,7 @@ public final class SettingsStore: ObservableObject {
         // the first daemon fetch completes.
         providerCatalog = ProviderCatalogEntry.defaultCatalog
 
-        // React to Keychain changes from other surfaces
+        // React to credential storage changes from other surfaces
         NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in self?.refreshAPIKeyState() }
@@ -982,7 +982,7 @@ public final class SettingsStore: ObservableObject {
 
     func saveEmbeddingAPIKey(_ raw: String, provider: String) {
         embeddingKeySaveError = nil
-        // Delegate to saveInferenceAPIKey — same keychain store, same daemon validation
+        // Delegate to saveInferenceAPIKey — same credential store, same daemon validation
         saveInferenceAPIKey(raw, provider: provider, onSuccess: {
             self.refreshEmbeddingConfig()
         }, onError: { error in
@@ -1176,7 +1176,7 @@ public final class SettingsStore: ObservableObject {
     }
 
     /// Re-sync locally-known keys to daemon on reconnect.
-    /// Pushes keys present in the macOS keychain, and replays any pending
+    /// Pushes keys present in the credential store, and replays any pending
     /// deletion tombstones so user-initiated clears are eventually consistent.
     /// Waits for the JWT to become available before syncing, because reconnect
     /// can fire before async credential bootstrap completes.
@@ -2224,7 +2224,7 @@ public final class SettingsStore: ObservableObject {
             return resolved
         }
 
-        // For self-hosted assistants, the keychain mapping may not exist yet
+        // For self-hosted assistants, the credential storage mapping may not exist yet
         // (bootstrap is async and may not have completed). Trigger bootstrap
         // lazily and retry the resolve.
         guard !assistant.isManaged else {
@@ -2241,7 +2241,7 @@ public final class SettingsStore: ObservableObject {
                 assistantVersion: connectionManager?.assistantVersion
             )
         } catch {
-            // Bootstrap can persist the keychain mapping during ensure-registration
+            // Bootstrap can persist the credential storage mapping during ensure-registration
             // but then throw on daemon injection (e.g. gateway not reachable yet).
             // Always retry the resolve — the mapping may already be cached.
             log.warning("Lazy bootstrap threw (mapping may still be cached): \(error.localizedDescription)")

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -299,7 +299,7 @@ struct VoiceSettingsView: View {
                     HStack(spacing: VSpacing.xs) {
                         VIconView(.lock, size: 10)
                             .foregroundColor(VColor.contentTertiary)
-                        Text("Your API key is stored securely in the macOS Keychain.")
+                        Text("Your API key is stored securely on this device.")
                             .font(VFont.caption)
                             .foregroundColor(VColor.contentTertiary)
                     }

--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -144,7 +144,7 @@ final class SecretPromptManager {
             // Cancel: dismiss immediately
             dismissPrompt(requestId: requestId)
         } else if success {
-            // Save: delay dismiss so "Saved to Keychain" confirmation is visible
+            // Save: delay dismiss so "Saved" confirmation is visible
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
                 self?.dismissPrompt(requestId: requestId)
             }

--- a/clients/macos/vellum-assistant/Security/FileCredentialStorage.swift
+++ b/clients/macos/vellum-assistant/Security/FileCredentialStorage.swift
@@ -8,15 +8,10 @@ private let log = Logger(
     category: "FileCredentialStorage"
 )
 
-/// File-based CredentialStorage for DEBUG builds.
+/// File-based CredentialStorage implementation.
 ///
 /// Stores each credential as an individual file under
 /// `~/.vellum/protected/credentials/` with 0600 permissions.
-/// This avoids macOS Keychain authorization prompts that fire on
-/// every rebuild because the binary's cdhash changes.
-///
-/// Mirrors the approach used by `SigningIdentityManager` which stores
-/// the Ed25519 signing key on disk for the same reason.
 struct FileCredentialStorage: CredentialStorage {
 
     private static let credentialsDir: URL = {

--- a/clients/shared/App/Auth/ActorCredentialRefresher.swift
+++ b/clients/shared/App/Auth/ActorCredentialRefresher.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Shared credential refresher. Calls POST /v1/guardian/refresh
-/// through the gateway via `GatewayHTTPClient`, updates Keychain via
+/// through the gateway via `GatewayHTTPClient`, updates credential storage via
 /// ActorTokenManager, and handles terminal errors that require re-pairing.
 public class ActorCredentialRefresher {
 

--- a/clients/shared/App/Auth/ActorTokenManager.swift
+++ b/clients/shared/App/Auth/ActorTokenManager.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-/// Cross-platform JWT access token storage using Keychain via APIKeyManager.
+/// Cross-platform JWT access token storage using credential storage via APIKeyManager.
 /// The access token (JWT) serves as both authentication and identity for
 /// HTTP requests to the runtime, transmitted as `Authorization: Bearer <jwt>`.
 ///
-/// Note: Keychain storage keys are intentionally unchanged from the original
+/// Note: Storage keys are intentionally unchanged from the original
 /// "actor-token" naming to avoid orphaning existing credentials on upgrade.
 ///
-/// Follows the same Keychain persistence pattern as SessionTokenManager.
+/// Follows the same credential storage pattern as SessionTokenManager.
 public enum ActorTokenManager {
     private static let provider = "actor-token"
     private static let guardianPrincipalIdProvider = "actor-token-guardian-principal-id"

--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -4,7 +4,7 @@ import os
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "LocalAssistantBootstrap")
 
 /// Platform-agnostic credential storage abstraction.
-/// On macOS, callers should supply a Keychain-backed implementation.
+/// On macOS, callers supply a file-based implementation (FileCredentialStorage).
 public protocol CredentialStorage: Sendable {
     func get(account: String) -> String?
     func set(account: String, value: String) -> Bool

--- a/clients/shared/App/Auth/PlatformAssistantIdResolver.swift
+++ b/clients/shared/App/Auth/PlatformAssistantIdResolver.swift
@@ -12,7 +12,7 @@ public enum PlatformAssistantIdResolver {
 
     // MARK: - Key format
 
-    /// Keychain account name for the persisted platform assistant ID mapping.
+    /// Credential storage account name for the persisted platform assistant ID mapping.
     static func keychainAccount(
         runtimeAssistantId: String,
         organizationId: String,

--- a/clients/shared/App/Auth/SessionTokenManager.swift
+++ b/clients/shared/App/Auth/SessionTokenManager.swift
@@ -4,9 +4,9 @@ public extension Notification.Name {
     static let sessionTokenDidChange = Notification.Name("SessionTokenManager.didChange")
 }
 
-/// Cross-platform session token storage using Keychain via APIKeyManager.
+/// Cross-platform session token storage using credential storage via APIKeyManager.
 /// Replaces the macOS-only `/usr/bin/security` CLI approach.
-/// Uses provider "session-token" to match the old keychain account name
+/// Uses provider "session-token" to match the old credential storage account name
 /// so existing macOS users' stored sessions are preserved after upgrade.
 ///
 /// Also writes the token to `~/.config/vellum/platform-token` (XDG path)

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -287,7 +287,7 @@ public enum GatewayHTTPClient {
             ])
         }
 
-        // Rebuild with fresh credentials from the Keychain.
+        // Rebuild with fresh credentials from the credential store.
         let freshConnection = try resolveConnection()
         var retryRequest = try buildRequest(path: path, params: nil, method: "POST", timeout: timeout, connection: freshConnection)
         retryRequest.setValue("text/event-stream", forHTTPHeaderField: "Accept")
@@ -326,7 +326,7 @@ public enum GatewayHTTPClient {
     ///   (managed, remote, and local assistants).
     /// - iOS: Uses UserDefaults for managed assistants (`managed_assistant_id` +
     ///   `managed_platform_base_url`) and QR-paired assistants (`gateway_base_url`),
-    ///   with tokens from the Keychain via `SessionTokenManager` / `ActorTokenManager`.
+    ///   with tokens from credential storage via `SessionTokenManager` / `ActorTokenManager`.
     private static func resolveConnection() throws -> ConnectionInfo {
         #if os(macOS)
         guard let assistant = resolveConnectedAssistant() else {
@@ -547,7 +547,7 @@ public enum GatewayHTTPClient {
             return response
         }
 
-        // Rebuild with fresh credentials from the Keychain.
+        // Rebuild with fresh credentials from the credential store.
         let freshConnection = try resolveConnection()
         var retryRequest = try buildRequest(path: path, params: params, method: method, timeout: timeout, connection: freshConnection)
         configure?(&retryRequest)

--- a/clients/shared/Network/GuardianClient.swift
+++ b/clients/shared/Network/GuardianClient.swift
@@ -75,7 +75,7 @@ public struct GuardianClient: GuardianClientProtocol {
     // MARK: - Actor Token Bootstrap
 
     /// Calls `POST /v1/guardian/init` to obtain a JWT access token bound to
-    /// (assistantId, platform, deviceId). Stores credentials in Keychain via
+    /// (assistantId, platform, deviceId). Stores credentials in credential storage via
     /// `ActorTokenManager`.
     ///
     /// - Returns: `true` on success, `false` on failure.


### PR DESCRIPTION
## Summary
- Fix user-facing string in VoiceSettingsView that falsely claimed Keychain storage
- Update stale doc comments and code comments across macOS Swift source
- Update AGENTS.md and FileCredentialStorage description

Part of plan: remove-keychain-backend.md (review fix round 1)