### PR TITLE
fix: update stale keychain references in assistant TypeScript and docs

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -321,7 +321,7 @@ The WhatsApp channel enables inbound and outbound messaging via the Meta WhatsAp
 - `WHATSAPP_APP_SECRET` — App secret for webhook signature verification
 - `WHATSAPP_WEBHOOK_VERIFY_TOKEN` — Token for the Meta webhook subscription handshake
 
-These can be set via environment variables or stored in the credential vault (keychain / encrypted store) under the `whatsapp` service prefix.
+These can be set via environment variables or stored in the credential vault (CES / encrypted store) under the `whatsapp` service prefix.
 
 **Limitations (v1)**: Rich approval UI (inline buttons) is not supported. Contacts and location message types are acknowledged but not forwarded.
 
@@ -343,7 +343,7 @@ All endpoints are JWT-authenticated via `Authorization: Bearer <jwt>`.
 
 **Credential storage pattern:**
 
-Both tokens are stored in the secure key store (macOS Keychain with encrypted file fallback):
+Both tokens are stored in the secure key store (CES credential store with encrypted file fallback):
 
 | Secure key                           | Content                                                                    |
 | ------------------------------------ | -------------------------------------------------------------------------- |
@@ -667,9 +667,9 @@ All six enforcement points derive the flag key via `skillFlagKey(skill)` — whi
 
 ```mermaid
 graph LR
-    subgraph "macOS Keychain"
-        K1["API Key<br/>service: vellum-assistant<br/>account: anthropic<br/>stored via /usr/bin/security CLI"]
-        K2["Credential Secrets<br/>key: credential/{service}/{field}<br/>stored via secure-keys.ts<br/>(encrypted file fallback if Keychain unavailable)"]
+    subgraph "Credential Store"
+        K1["API Key<br/>service: vellum-assistant<br/>account: anthropic<br/>stored via CES"]
+        K2["Credential Secrets<br/>key: credential/{service}/{field}<br/>stored via secure-keys.ts<br/>(encrypted file fallback)"]
     end
 
     subgraph "UserDefaults (plist)"
@@ -1937,10 +1937,10 @@ Connected channels are resolved at signal emission time: vellum is always includ
 
 | What                                     | Where                                                             | Format                              | ORM/Driver                         | Retention                                               |
 | ---------------------------------------- | ----------------------------------------------------------------- | ----------------------------------- | ---------------------------------- | ------------------------------------------------------- |
-| API key                                  | macOS Keychain                                                    | Encrypted binary                    | `/usr/bin/security` CLI            | Permanent                                               |
-| Credential secrets                       | macOS Keychain (or encrypted file fallback)                       | Encrypted binary                    | `secure-keys.ts` wrapper           | Permanent (until deleted via tool)                      |
+| API key                                  | CES / encrypted file store                                        | Encrypted binary                    | CES API / `secure-keys.ts`         | Permanent                                               |
+| Credential secrets                       | CES / encrypted file store                                        | Encrypted binary                    | `secure-keys.ts` wrapper           | Permanent (until deleted via tool)                      |
 | Credential metadata                      | `~/.vellum/workspace/data/credentials/metadata.json`              | JSON                                | Atomic file write                  | Permanent (until deleted via tool)                      |
-| Integration OAuth tokens                 | macOS Keychain (or encrypted file fallback, via `secure-keys.ts`) | Encrypted binary                    | `TokenManager` auto-refresh        | Until disconnected or revoked                           |
+| Integration OAuth tokens                 | CES / encrypted file store (via `secure-keys.ts`)                 | Encrypted binary                    | `TokenManager` auto-refresh        | Until disconnected or revoked                           |
 | User preferences                         | UserDefaults                                                      | plist                               | Foundation                         | Permanent                                               |
 | Session logs                             | `~/Library/.../logs/session-*.json`                               | JSON per session                    | Swift Codable                      | Unbounded                                               |
 | Conversations & messages                 | `~/.vellum/workspace/data/db/assistant.db`                        | SQLite + WAL                        | Drizzle ORM (Bun)                  | Permanent                                               |

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -204,7 +204,7 @@ The runtime exposes a RESTful HTTP API for Twilio configuration, credential mana
 | Method | Path                                        | Description                                                                                                                                 |
 | ------ | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | GET    | `/v1/integrations/twilio/config`            | Returns current state: `hasCredentials` (boolean) and `phoneNumber` (if assigned)                                                           |
-| POST   | `/v1/integrations/twilio/credentials`       | Validates and stores Account SID and Auth Token in secure storage (Keychain / encrypted file)                                               |
+| POST   | `/v1/integrations/twilio/credentials`       | Validates and stores Account SID and Auth Token in secure storage (CES / encrypted file store)                                               |
 | DELETE | `/v1/integrations/twilio/credentials`       | Removes stored credentials. Preserves the phone number in config so re-entering credentials resumes working without reassigning the number. |
 | GET    | `/v1/integrations/twilio/numbers`           | Lists all incoming phone numbers on the Twilio account with their capabilities                                                              |
 | POST   | `/v1/integrations/twilio/numbers/provision` | Purchases a new phone number. Accepts optional `areaCode` and `country`. Auto-assigns and configures webhooks when ingress is available.    |

--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -122,7 +122,7 @@ sequenceDiagram
     participant Browser as System Browser
     participant Google as Google OAuth Server
     participant Store as SQLite OAuth Store
-    participant Vault as Secure Keychain
+    participant Vault as Credential Store
     participant TokenMgr as TokenManager
     participant Tool as Gmail Tool Executor
     participant API as Gmail REST API
@@ -173,7 +173,7 @@ sequenceDiagram
 
 | Decision                                   | Rationale                                                                                                                                                                                                                                        |
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| PKCE by default, optional client_secret    | Desktop apps prefer PKCE; some providers (Slack) require a secret, which is stored in the secure keychain (`oauth_app/{id}/client_secret`) for autonomous refresh                                                                                |
+| PKCE by default, optional client_secret    | Desktop apps prefer PKCE; some providers (Slack) require a secret, which is stored in the credential store (`oauth_app/{id}/client_secret`) for autonomous refresh                                                                                |
 | Shared connect orchestrator                | All OAuth providers route through `orchestrateOAuthConnect()`, which resolves profiles, enforces scope policy, runs the flow, stores tokens, and verifies identity. Adding a provider is a declarative profile entry, not new orchestration code |
 | Canonical credential naming                | All reads and writes use `client_id`/`client_secret` as canonical field names                                                                                                                                                                    |
 | Gateway callback transport                 | OAuth callbacks are now routed through the gateway at `${ingress.publicBaseUrl}/webhooks/oauth/callback` instead of a loopback redirect URI. This enables OAuth flows to work in remote and tunneled deployments.                                |
@@ -261,7 +261,7 @@ Result is a discriminated union: `{ success, deferred, grantedScopes, accountInf
 
 `assistant/src/daemon/handlers/oauth-connect.ts` handles `oauth_connect_start` messages. The handler:
 
-1. Resolves client credentials from the keychain using canonical names (`client_id`, `client_secret`).
+1. Resolves client credentials from the credential store using canonical names (`client_id`, `client_secret`).
 2. Validates that required credentials exist (including `client_secret` when the provider requires it).
 3. Delegates to `orchestrateOAuthConnect()`.
 4. Sends `oauth_connect_result` back to the client.
@@ -286,7 +286,7 @@ This replaces provider-specific handlers — any provider in the registry can be
 | `assistant/src/oauth/scope-policy.ts`            | Scope resolution and policy enforcement (pure, no I/O)                           |
 | `assistant/src/oauth/connect-orchestrator.ts`    | Shared connect orchestrator (profile → scopes → flow → tokens)                   |
 | `assistant/src/oauth/connect-types.ts`           | Shared types (`OAuthProviderBehavior`, `OAuthScopePolicy`, `OAuthConnectResult`) |
-| `assistant/src/oauth/token-persistence.ts`       | Token storage: keychain writes, metadata upsert, post-connect hooks              |
+| `assistant/src/oauth/token-persistence.ts`       | Token storage: credential store writes, metadata upsert, post-connect hooks      |
 | `assistant/src/daemon/handlers/oauth-connect.ts` | Generic `oauth_connect_start` / `oauth_connect_result` handler                   |
 
 ---

--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -895,7 +895,7 @@ describe("assistant credentials CLI", () => {
       expect(result.exitCode).toBe(0);
       const parsed = JSON.parse(result.stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.scrubbedValue).toBe("(broker unreachable)");
+      expect(parsed.scrubbedValue).toBe("(credential store unreachable)");
       expect(parsed.brokerUnreachable).toBe(true);
     });
 
@@ -913,7 +913,7 @@ describe("assistant credentials CLI", () => {
       expect(result.exitCode).toBe(1);
       const parsed = JSON.parse(result.stdout);
       expect(parsed.ok).toBe(false);
-      expect(parsed.error).toContain("Keychain broker is unreachable");
+      expect(parsed.error).toContain("Credential store is unreachable");
     });
   });
 
@@ -1029,7 +1029,7 @@ describe("assistant credentials CLI", () => {
       expect(result.exitCode).toBe(1);
       const parsed = JSON.parse(result.stdout);
       expect(parsed.ok).toBe(false);
-      expect(parsed.error).toContain("Keychain broker is unreachable");
+      expect(parsed.error).toContain("Credential store is unreachable");
     });
 
     test("returns credential-not-found when broker is up", async () => {

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -635,7 +635,7 @@ Examples:
             if (unreachable) {
               writeError(
                 cmd,
-                "Keychain broker is unreachable — restart the Vellum app and accept the macOS Keychain prompt",
+                "Credential store is unreachable — ensure the assistant is running",
               );
             } else {
               writeError(cmd, "Credential not found");
@@ -676,7 +676,7 @@ Examples:
           const output = buildCredentialOutput(metadata, secret, connection);
 
           if (unreachable && (secret == null || secret.length === 0)) {
-            output.scrubbedValue = "(broker unreachable)";
+            output.scrubbedValue = "(credential store unreachable)";
             output.brokerUnreachable = true;
           }
 
@@ -686,7 +686,7 @@ Examples:
             printCredentialHuman(output);
             if (unreachable && (secret == null || secret.length === 0)) {
               log.info(
-                "    \u26A0 Keychain broker unreachable — restart the Vellum app and accept the macOS Keychain prompt to access credentials",
+                "    \u26A0 Credential store is unreachable — ensure the assistant is running",
               );
             }
           }
@@ -770,7 +770,7 @@ Examples:
             if (unreachable) {
               writeError(
                 cmd,
-                "Keychain broker is unreachable — restart the Vellum app and accept the macOS Keychain prompt",
+                "Credential store is unreachable — ensure the assistant is running",
               );
             } else {
               writeError(cmd, "Credential not found");

--- a/assistant/src/cli/commands/oauth/apps.ts
+++ b/assistant/src/cli/commands/oauth/apps.ts
@@ -168,7 +168,7 @@ At least --id or --provider must be specified.`,
     .requiredOption("--client-id <id>", "OAuth client ID")
     .option(
       "--client-secret <secret>",
-      "OAuth client secret (stored in secure keychain)",
+      "OAuth client secret (stored in credential store)",
     )
     .option(
       "--client-secret-credential-path <path>",
@@ -179,7 +179,7 @@ At least --id or --provider must be specified.`,
       `
 Creates a new app registration or returns the existing one if an app with the
 same provider and client ID already exists. The client secret, if provided, is
-stored in the secure system keychain — not in the database.
+stored in the secure credential store — not in the database.
 
 When an existing app is matched and a --client-secret is provided, the stored
 secret is updated. The app row itself is returned as-is.
@@ -277,7 +277,7 @@ Arguments:
   id   The app UUID to delete (as returned by "apps list" or "apps get")
 
 Permanently removes the app registration and its stored client secret from
-the keychain. Any OAuth connections that reference this app will no longer be
+the credential store. Any OAuth connections that reference this app will no longer be
 able to refresh tokens.
 
 Exits with code 1 if the app ID is not found.

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -213,7 +213,7 @@ async function handleOAuthConnectStart(body: {
   if (requiresSecret && !clientSecret) {
     return httpError(
       "BAD_REQUEST",
-      `client_secret is required for "${body.service}" but not found in the keychain. Store it first via the credential vault.`,
+      `client_secret is required for "${body.service}" but not found in the credential store. Store it first via the credential vault.`,
       400,
     );
   }


### PR DESCRIPTION
## Summary
- Fix user-facing CLI error messages that referenced removed Keychain broker
- Update API error message and CLI help text to use 'credential store' terminology
- Update assistant ARCHITECTURE.md, README.md, and integrations.md docs

Part of plan: remove-keychain-backend.md (review fix round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
