### PR TITLE
fix: suppress Sendable warning on SurfaceContentResponse

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -58,7 +58,7 @@ struct ConversationStarterClient: ConversationStarterClientProtocol {
 
 /// Raw surface content from the daemon, preserving the untyped data dict
 /// so callers can construct a `UiSurfaceShowMessage` without lossy roundtrips.
-public struct SurfaceContentResponse: Sendable {
+public struct SurfaceContentResponse: @unchecked Sendable {
     public let surfaceType: String
     public let title: String?
     public let rawData: [String: Any]


### PR DESCRIPTION
## Summary
- Mark `SurfaceContentResponse` as `@unchecked Sendable` to suppress the Swift compiler warning about `[String: Any]` not conforming to `Sendable`
- The struct is immutable (all `let` properties) with JSON-derived data, so this is safe

## Original prompt
Fix: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
Building (debug)...
[1/1] Planning build
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/shared/Features/Chat/ChatViewModel.swift:64:16: warning: stored property 'rawData' of 'Sendable'-conforming struct 'SurfaceContentResponse' contains non-Sendable type 'Any'; this is an error in the Swift 6 language mode