### PR TITLE
fix: trust-gate NOW.md scratchpad injection to guardian-only

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -683,8 +683,14 @@ export async function runAgentLoopImpl(
     }
 
     // Read NOW.md scratchpad fresh each turn so mid-conversation edits are
-    // picked up without caching or conversation eviction.
-    const nowScratchpad = readNowScratchpad();
+    // picked up without caching or conversation eviction.  Only inject for
+    // guardian conversations — the scratchpad may contain private context
+    // (mood, relationship state, personal details) that should not be
+    // exposed to trusted contacts or unknown actors.
+    const nowScratchpad =
+      resolveTrustClass(ctx.trustContext) === "guardian"
+        ? readNowScratchpad()
+        : null;
 
     const isInteractiveResolved =
       options?.isInteractive ?? (!ctx.hasNoClient && !ctx.headlessLock);


### PR DESCRIPTION
## Summary
- Gate NOW.md scratchpad injection on guardian trust class to prevent private content (mood, relationship state, personal details) from being exposed in trusted-contact or unknown-actor conversations
- Local mode (HTTP auth disabled) continues to inject normally since `resolveTrustClass` returns `"guardian"`
- No injection infrastructure changes needed — null scratchpad is already handled correctly by the injection chain

## Original prompt
Trust-gate NOW.md injection to guardian-only conversations to prevent leaking private scratchpad content on public channels
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
