### PR TITLE
fix: increase CI timeout for ChatBottomPinCoordinator transient geometry test

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
@@ -611,7 +611,9 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
         coordinator.requestPin(reason: .initialRestore, conversationId: convId)
 
         // Wait long enough for the session to exhaust or timeout.
-        try await Task.sleep(nanoseconds: 700_000_000)
+        // Use a generous timeout because @MainActor Task scheduling on CI
+        // runners can be much slower than the 50ms retry interval would suggest.
+        try await Task.sleep(nanoseconds: 2_000_000_000)
 
         // The session must have terminated on its own (bounded retries or timeout).
         XCTAssertNil(coordinator.activeSession,


### PR DESCRIPTION
## Summary
- The `testTransientMissingGeometryDoesNotCauseEndlessRetries` test in `ChatBottomPinCoordinatorTests` fails on CI because the 700ms `Task.sleep` isn't enough margin for slow GitHub Actions runners where `@MainActor` task scheduling overhead accumulates across retry intervals
- Increased the sleep from 700ms to 2s, matching the existing pattern in the companion test `testGeometryBecomingAvailableMidSessionCompletesPin` which already uses a generous timeout with a comment explaining the CI scheduling issue

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23474427574/job/68304118173