### PR TITLE
fix: expand collapsed multi-turn assistant messages to prevent thinking block API errors

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -198,6 +198,137 @@ function hasOrderedToolResultPrefix(
  * regular content — they are self-paired within the assistant message and must
  * not be separated by the cross-message pairing logic.
  */
+
+/**
+ * Expand collapsed multi-turn assistant messages. During agentic tool use, the
+ * daemon stores multiple thinking→tool_use→tool_result cycles in a single
+ * assistant message. The Anthropic API rejects thinking blocks between
+ * tool_use blocks ("tool_use without tool_result immediately after") and
+ * requires thinking blocks in the latest assistant message to remain exactly
+ * as generated.
+ *
+ * This function splits collapsed messages at each "thinking/redacted_thinking
+ * after tool_use" boundary, recreating the original multi-turn structure.
+ * It also distributes tool_result blocks from the following user message to
+ * match each segment's tool_use blocks, creating proper assistant→user pairs.
+ */
+function expandCollapsedAssistantTurns(
+  messages: Anthropic.MessageParam[],
+): Anthropic.MessageParam[] {
+  const result: Anthropic.MessageParam[] = [];
+
+  for (let mi = 0; mi < messages.length; mi++) {
+    const msg = messages[mi];
+    if (msg.role !== "assistant") {
+      result.push(msg);
+      continue;
+    }
+
+    const content = Array.isArray(msg.content) ? msg.content : [];
+
+    // Check if this message has thinking blocks between tool_use blocks
+    let hasThinkingAfterToolUse = false;
+    let seenToolUse = false;
+    for (const block of content) {
+      if (isToolUseBlock(block)) {
+        seenToolUse = true;
+      } else if (seenToolUse) {
+        const type = (block as { type: string }).type;
+        if (type === "thinking" || type === "redacted_thinking") {
+          hasThinkingAfterToolUse = true;
+          break;
+        }
+      }
+    }
+
+    if (!hasThinkingAfterToolUse) {
+      result.push(msg);
+      continue;
+    }
+
+    // Split at each "thinking after tool_use" boundary into separate segments
+    const segments: Anthropic.ContentBlockParam[][] = [];
+    let current: Anthropic.ContentBlockParam[] = [];
+    let segmentHasToolUse = false;
+
+    for (const block of content) {
+      const type = (block as { type: string }).type;
+      const isThinking =
+        type === "thinking" || type === "redacted_thinking";
+
+      if (isThinking && segmentHasToolUse) {
+        segments.push(current);
+        current = [block];
+        segmentHasToolUse = false;
+      } else {
+        current.push(block);
+        if (isToolUseBlock(block)) {
+          segmentHasToolUse = true;
+        }
+      }
+    }
+    if (current.length > 0) {
+      segments.push(current);
+    }
+
+    // Build a map of tool_results from the following user message (if any)
+    const nextMsg = messages[mi + 1];
+    const nextIsUser = nextMsg && nextMsg.role === "user";
+    const nextContent =
+      nextIsUser && Array.isArray(nextMsg.content) ? nextMsg.content : [];
+    const toolResultMap = new Map<string, Anthropic.ContentBlockParam>();
+    const nonToolResultContent: Anthropic.ContentBlockParam[] = [];
+    for (const block of nextContent) {
+      if (isToolResultBlock(block)) {
+        toolResultMap.set(block.tool_use_id, block);
+      } else {
+        nonToolResultContent.push(block);
+      }
+    }
+
+    // Emit each segment as assistant→user pairs, distributing tool_results
+    for (let si = 0; si < segments.length; si++) {
+      const segment = segments[si];
+      const segToolUseIds = getOrderedToolUseIds(segment);
+      const isLastSegment = si === segments.length - 1;
+
+      result.push({ role: "assistant" as const, content: segment });
+
+      if (segToolUseIds.length > 0 && !isLastSegment) {
+        // Intermediate segment: pair with matching tool_results
+        const segResults = segToolUseIds.map(
+          (id) => toolResultMap.get(id) ?? buildSyntheticToolResult(id),
+        );
+        // Remove matched results from the map
+        for (const id of segToolUseIds) toolResultMap.delete(id);
+        result.push({ role: "user" as const, content: segResults });
+      }
+    }
+
+    // For the last segment, let ensureToolPairing handle pairing with the
+    // (now reduced) user message. Rebuild the user message without the
+    // tool_results that were already distributed to intermediate segments.
+    if (nextIsUser) {
+      const remainingResults = Array.from(toolResultMap.values());
+      const rebuiltUserContent = [
+        ...remainingResults,
+        ...nonToolResultContent,
+      ];
+      // Replace the original user message with the rebuilt one
+      result.push({
+        role: "user" as const,
+        content:
+          rebuiltUserContent.length > 0
+            ? rebuiltUserContent
+            : [{ type: "text" as const, text: "(continue)" }],
+      });
+      mi++; // skip the original user message
+    }
+  }
+
+  return result;
+}
+
 function splitAssistantForToolPairing(content: Anthropic.ContentBlockParam[]): {
   pairedContent: Anthropic.ContentBlockParam[];
   carryoverContent: Anthropic.ContentBlockParam[];
@@ -386,6 +517,7 @@ function ensureToolPairing(
     }
 
     const content = Array.isArray(msg.content) ? msg.content : [];
+
     const { pairedContent, carryoverContent, toolUseIds } =
       splitAssistantForToolPairing(content);
 
@@ -663,7 +795,17 @@ export class AnthropicProvider implements Provider {
         }
       }
 
-      sentMessages = ensureToolPairing(repairOrphanedServerToolUse(formatted));
+      // Expand collapsed multi-turn assistant messages. When agentic tool use
+      // produces multiple thinking→tool_use cycles in a single stored message,
+      // the API rejects thinking blocks between tool_use blocks. Split such
+      // messages at each "thinking after tool_use" boundary to recreate the
+      // original multi-turn structure. This also resolves the constraint that
+      // thinking blocks in the latest assistant message must remain unmodified —
+      // after expansion, each segment's thinking blocks are at the start (their
+      // natural position), and only the final segment is the "latest."
+      const expanded = expandCollapsedAssistantTurns(formatted);
+
+      sentMessages = ensureToolPairing(repairOrphanedServerToolUse(expanded));
       const { effort, output_config, ...restConfig } = (config ?? {}) as Record<
         string,
         unknown


### PR DESCRIPTION
## Summary

- When extended thinking + tool use produces multiple thinking→tool_use cycles in a single stored assistant message, the Anthropic API rejects it because thinking blocks between tool_use blocks are invalid
- Added `expandCollapsedAssistantTurns()` in the Anthropic provider that splits these collapsed messages at each "thinking after tool_use" boundary, recreating the original multi-turn assistant→user structure
- Tool_result blocks from the following user message are distributed to match each segment's tool_use IDs, so intermediate segments get real results (not synthetic placeholders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
