### PR TITLE
feat: add feature flag to show background conversations in sidebar

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -60,6 +60,8 @@ import {
   consumeCallback,
   consumeCallbackError,
 } from "../security/oauth-callback-registry.js";
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig } from "../config/loader.js";
 import { UserError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import { buildAssistantEvent } from "./assistant-event.js";
@@ -828,8 +830,7 @@ export class RuntimeHttpServer {
       title: conversation.title ?? "Untitled",
       createdAt: conversation.createdAt,
       updatedAt: conversation.updatedAt,
-      conversationType:
-        conversation.conversationType === "private" ? "private" : "standard",
+      conversationType: conversation.conversationType ?? "standard",
       source: conversation.source ?? "user",
       ...(conversation.scheduleJobId
         ? { scheduleJobId: conversation.scheduleJobId }
@@ -1021,8 +1022,16 @@ export class RuntimeHttpServer {
         handler: ({ url }) => {
           const limit = Number(url.searchParams.get("limit") ?? 50);
           const offset = Number(url.searchParams.get("offset") ?? 0);
-          const conversations = listConversations(limit, false, offset);
-          const totalCount = countConversations();
+          const includeBackground = isAssistantFeatureFlagEnabled(
+            "feature_flags.show-background-conversations.enabled",
+            getConfig(),
+          );
+          const conversations = listConversations(
+            limit,
+            includeBackground,
+            offset,
+          );
+          const totalCount = countConversations(includeBackground);
           const conversationIds = conversations.map((c) => c.id);
           const displayMeta = getDisplayMetaForConversations(conversationIds);
           const bindings =

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -328,6 +328,14 @@
       "label": "Backward Releases",
       "description": "Show older versions in the version picker, allowing rollback to previous releases",
       "defaultEnabled": true
+    },
+    {
+      "id": "show-background-conversations",
+      "scope": "assistant",
+      "key": "feature_flags.show-background-conversations.enabled",
+      "label": "Show Background Conversations",
+      "description": "Include background conversations (heartbeat, tasks) in the sidebar conversation list",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Registers a new `show-background-conversations` feature flag (default: disabled) that controls whether background conversations (heartbeat, tasks) appear in the sidebar
- Wires the flag into the GET `/v1/conversations` endpoint so `listConversations` and `countConversations` respect it
- Fixes `serializeConversationSummary` to pass through the actual `conversationType` (e.g. `"background"`) instead of collapsing everything non-private to `"standard"`

## Original prompt
Show background (heartbeat) conversations in the sidebar via a feature flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)