### PR TITLE
fix: grant heartbeat conversations guardian trust level

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -1093,7 +1093,12 @@ export async function runDaemon(): Promise<void> {
     const heartbeatConfig = config.heartbeat;
     const heartbeat = new HeartbeatService({
       processMessage: (conversationId, content) =>
-        server.processMessage(conversationId, content),
+        server.processMessage(conversationId, content, undefined, {
+          trustContext: {
+            sourceChannel: "vellum",
+            trustClass: "guardian",
+          },
+        }),
       alerter: (alert) => server.broadcast(alert),
     });
     heartbeat.start();


### PR DESCRIPTION
## Summary

- Heartbeat conversations were blocked from all write actions because they had no `trustContext`, resolving to `trustClass: "unknown"` (fail-closed with no escalation)
- Pass `{ sourceChannel: "vellum", trustClass: "guardian" }` in the heartbeat's `processMessage` call so heartbeat runs have full write access (file_write, file_edit, bash, send_notification)
- Same trust level as local desktop app conversations — appropriate since the heartbeat is an internal process the user explicitly enabled

## Original prompt
Grant heartbeat conversations guardian trust so they can perform write actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
