### PR TITLE
feat: add heartbeat HTTP routes for desktop app settings card

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -840,6 +840,7 @@ export async function runDaemon(): Promise<void> {
         getHandlerContext: () => server.getHandlerContext(),
       }),
       getCesClient: () => server.getCesClient(),
+      getHeartbeatService: () => server.getHeartbeatService(),
     });
 
     // Inject voice bridge deps BEFORE attempting to start the HTTP server.

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -304,6 +304,10 @@ export class DaemonServer {
     this._heartbeatService = service;
   }
 
+  getHeartbeatService(): HeartbeatService | undefined {
+    return this._heartbeatService;
+  }
+
   private deriveMemoryPolicy(conversationId: string): ConversationMemoryPolicy {
     const conversationType = getConversationType(conversationId);
     if (conversationType === "private") {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -171,6 +171,7 @@ import {
   pairingRouteDefinitions,
 } from "./routes/pairing-routes.js";
 import { recordingRouteDefinitions } from "./routes/recording-routes.js";
+import { heartbeatRouteDefinitions } from "./routes/heartbeat-routes.js";
 import { scheduleRouteDefinitions } from "./routes/schedule-routes.js";
 import { secretRouteDefinitions } from "./routes/secret-routes.js";
 import { settingsRouteDefinitions } from "./routes/settings-routes.js";
@@ -250,6 +251,7 @@ export class RuntimeHttpServer {
   private getWatchDeps?: RuntimeHttpServerOptions["getWatchDeps"];
   private getRecordingDeps?: RuntimeHttpServerOptions["getRecordingDeps"];
   private getCesClient?: RuntimeHttpServerOptions["getCesClient"];
+  private getHeartbeatService?: RuntimeHttpServerOptions["getHeartbeatService"];
   private router: HttpRouter;
 
   constructor(options: RuntimeHttpServerOptions = {}) {
@@ -272,6 +274,7 @@ export class RuntimeHttpServer {
     this.getWatchDeps = options.getWatchDeps;
     this.getRecordingDeps = options.getRecordingDeps;
     this.getCesClient = options.getCesClient;
+    this.getHeartbeatService = options.getHeartbeatService;
     this.router = new HttpRouter(this.buildRouteTable());
   }
 
@@ -956,6 +959,9 @@ export class RuntimeHttpServer {
       ...avatarRouteDefinitions(),
       ...scheduleRouteDefinitions({
         sendMessageDeps: this.sendMessageDeps,
+      }),
+      ...heartbeatRouteDefinitions({
+        getHeartbeatService: this.getHeartbeatService,
       }),
       ...notificationRouteDefinitions(),
       ...diagnosticsRouteDefinitions(),

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -228,6 +228,8 @@ export interface RuntimeHttpServerOptions {
   getRecordingDeps?: () => import("./routes/recording-routes.js").RecordingDeps;
   /** Accessor for the CES client, used to push API key updates to CES after hatch. */
   getCesClient?: () => CesClient | undefined;
+  /** Accessor for the heartbeat service (for run-now and config routes). */
+  getHeartbeatService?: () => import("../heartbeat/heartbeat-service.js").HeartbeatService | undefined;
 }
 
 export interface RuntimeAttachmentMetadata {

--- a/assistant/src/runtime/routes/heartbeat-routes.ts
+++ b/assistant/src/runtime/routes/heartbeat-routes.ts
@@ -1,0 +1,202 @@
+/**
+ * HTTP route handlers for heartbeat management.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+import { desc, eq } from "drizzle-orm";
+
+import { getConfig, saveConfig } from "../../config/loader.js";
+import type { HeartbeatService } from "../../heartbeat/heartbeat-service.js";
+import { getDb } from "../../memory/db.js";
+import { conversations } from "../../memory/schema/conversations.js";
+import { readTextFileSync } from "../../util/fs.js";
+import { getLogger } from "../../util/logger.js";
+import { getWorkspacePromptPath } from "../../util/platform.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+const log = getLogger("heartbeat-routes");
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+function handleGetConfig(): Response {
+  const config = getConfig().heartbeat;
+  return Response.json({
+    enabled: config.enabled,
+    intervalMs: config.intervalMs,
+    activeHoursStart: config.activeHoursStart ?? null,
+    activeHoursEnd: config.activeHoursEnd ?? null,
+    nextRunAt: null, // TODO: track next run time in HeartbeatService
+    success: true,
+  });
+}
+
+function handleUpdateConfig(body: Record<string, unknown>): Response {
+  const config = getConfig();
+  const heartbeat = { ...config.heartbeat };
+
+  if (typeof body.enabled === "boolean") heartbeat.enabled = body.enabled;
+  if (typeof body.intervalMs === "number") heartbeat.intervalMs = body.intervalMs;
+  if ("activeHoursStart" in body) {
+    heartbeat.activeHoursStart =
+      typeof body.activeHoursStart === "number" ? body.activeHoursStart : undefined;
+  }
+  if ("activeHoursEnd" in body) {
+    heartbeat.activeHoursEnd =
+      typeof body.activeHoursEnd === "number" ? body.activeHoursEnd : undefined;
+  }
+
+  try {
+    saveConfig({ ...config, heartbeat });
+    log.info({ heartbeat }, "Heartbeat config updated via HTTP");
+  } catch (err) {
+    log.error({ err }, "Failed to save heartbeat config");
+    return httpError("INTERNAL_ERROR", "Failed to save config", 500);
+  }
+
+  return Response.json({
+    enabled: heartbeat.enabled,
+    intervalMs: heartbeat.intervalMs,
+    activeHoursStart: heartbeat.activeHoursStart ?? null,
+    activeHoursEnd: heartbeat.activeHoursEnd ?? null,
+    nextRunAt: null,
+    success: true,
+  });
+}
+
+function handleListRuns(limit: number): Response {
+  const db = getDb();
+  const rows = db
+    .select({
+      id: conversations.id,
+      title: conversations.title,
+      createdAt: conversations.createdAt,
+    })
+    .from(conversations)
+    .where(eq(conversations.source, "heartbeat"))
+    .orderBy(desc(conversations.createdAt))
+    .limit(limit)
+    .all();
+
+  return Response.json({
+    runs: rows.map((r) => ({
+      id: r.id,
+      title: r.title ?? "Heartbeat",
+      createdAt: r.createdAt,
+      result: "ok",
+    })),
+  });
+}
+
+async function handleRunNow(
+  heartbeatService?: HeartbeatService,
+): Promise<Response> {
+  if (!heartbeatService) {
+    return httpError(
+      "SERVICE_UNAVAILABLE",
+      "Heartbeat service not available",
+      503,
+    );
+  }
+
+  try {
+    const ran = await heartbeatService.runOnce({ force: true });
+    return Response.json({ success: true, ran });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, "Heartbeat run-now failed");
+    return Response.json({ success: false, error: message });
+  }
+}
+
+function handleGetChecklist(): Response {
+  const path = getWorkspacePromptPath("HEARTBEAT.md");
+  const content = readTextFileSync(path);
+  return Response.json({
+    content: content ?? "",
+    isDefault: content == null,
+  });
+}
+
+function handleWriteChecklist(content: string): Response {
+  const path = getWorkspacePromptPath("HEARTBEAT.md");
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, content, "utf-8");
+    log.info("Heartbeat checklist updated via HTTP");
+    return Response.json({ success: true });
+  } catch (err) {
+    log.error({ err }, "Failed to write heartbeat checklist");
+    return httpError("INTERNAL_ERROR", "Failed to write checklist", 500);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function heartbeatRouteDefinitions(deps: {
+  getHeartbeatService?: () => HeartbeatService | undefined;
+}): RouteDefinition[] {
+  return [
+    {
+      endpoint: "heartbeat/config",
+      method: "GET",
+      policyKey: "heartbeat",
+      handler: () => handleGetConfig(),
+    },
+    {
+      endpoint: "heartbeat/config",
+      method: "PUT",
+      policyKey: "heartbeat",
+      handler: async ({ req }) => {
+        const body: unknown = await req.json();
+        if (typeof body !== "object" || !body || Array.isArray(body)) {
+          return httpError(
+            "BAD_REQUEST",
+            "Request body must be a JSON object",
+            400,
+          );
+        }
+        return handleUpdateConfig(body as Record<string, unknown>);
+      },
+    },
+    {
+      endpoint: "heartbeat/runs",
+      method: "GET",
+      policyKey: "heartbeat",
+      handler: ({ url }) => {
+        const limit = Number(url.searchParams.get("limit") ?? 20);
+        return handleListRuns(limit);
+      },
+    },
+    {
+      endpoint: "heartbeat/run-now",
+      method: "POST",
+      policyKey: "heartbeat",
+      handler: () => handleRunNow(deps.getHeartbeatService?.()),
+    },
+    {
+      endpoint: "heartbeat/checklist",
+      method: "GET",
+      policyKey: "heartbeat",
+      handler: () => handleGetChecklist(),
+    },
+    {
+      endpoint: "heartbeat/checklist",
+      method: "PUT",
+      policyKey: "heartbeat",
+      handler: async ({ req }) => {
+        const body = (await req.json()) as { content?: string };
+        if (typeof body.content !== "string") {
+          return httpError("BAD_REQUEST", "content is required", 400);
+        }
+        return handleWriteChecklist(body.content);
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

- Creates `heartbeat-routes.ts` with six HTTP route handlers (GET/PUT config, GET runs, POST run-now, GET/PUT checklist) matching the endpoints the macOS `HeartbeatClient` already calls
- Wires routes into `RuntimeHttpServer` via lazy `getHeartbeatService` getter (service is created after the HTTP server, so eager access would be undefined)
- Adds `getHeartbeatService()` accessor to `DaemonServer` and passes it through `RuntimeHttpServerOptions`

## Original prompt
Add heartbeat HTTP routes so the Schedules settings tab heartbeat card can fetch data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
