### PR TITLE
docs: add AGENTS.md for workspace migrations with self-containment conventions

### DIFF
--- a/assistant/AGENTS.md
+++ b/assistant/AGENTS.md
@@ -2,4 +2,4 @@
 
 For error handling conventions (throw vs result objects vs null), see [docs/error-handling.md](docs/error-handling.md).
 
-Subdirectory-scoped rules live in local AGENTS.md files: `src/cli/`, `src/runtime/`, `src/approvals/`, `src/notifications/`.
+Subdirectory-scoped rules live in local AGENTS.md files: `src/cli/`, `src/runtime/`, `src/approvals/`, `src/notifications/`, `src/workspace/migrations/`.

--- a/assistant/src/workspace/migrations/AGENTS.md
+++ b/assistant/src/workspace/migrations/AGENTS.md
@@ -1,0 +1,11 @@
+# Workspace Migrations — Agent Instructions
+
+## Self-Containment
+
+Each migration file must be **fully self-contained**. All helper functions, constants, and utilities that a migration needs must be defined inline within the migration file itself — not imported from shared modules outside of `./types.js` and the logger.
+
+- **No external exports.** Migration files must not export anything other than the single `WorkspaceMigration` object. Other code must never import from a migration file.
+- **Duplicate rather than share.** If two migrations need the same helper, duplicate it in both files. Migrations are write-once code — they run once per assistant and are never modified after release. Duplication is preferable to coupling.
+- **Allowed imports:** `./types.js` (for the `WorkspaceMigration` interface), `../../util/logger.js` (for structured logging), and `../../security/encrypted-store.js` (for credential store access). All other dependencies should be inlined.
+- **Graceful on all platforms.** Migrations run on macOS, Linux, and in Docker. Platform-specific operations (e.g. macOS Keychain access) must no-op gracefully on unsupported platforms — never throw.
+- **Idempotent.** Migrations must be safe to re-run if interrupted. The runner checkpoints state as `"started"` before execution and `"completed"` after, so a crash mid-migration triggers a re-run on next startup.


### PR DESCRIPTION
## Summary
- Add AGENTS.md to workspace migrations directory with self-containment rules
- Update assistant/AGENTS.md to reference the new subdirectory conventions file

Part of plan: inline-keychain-security-cli.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
