### PR TITLE
fix: replace keychain broker with inline security CLI helpers in migration 015

### DIFF
--- a/assistant/src/__tests__/workspace-migration-015-migrate-credentials-to-keychain.test.ts
+++ b/assistant/src/__tests__/workspace-migration-015-migrate-credentials-to-keychain.test.ts
@@ -1,25 +1,20 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ---------------------------------------------------------------------------
 // Mock state
 // ---------------------------------------------------------------------------
 
-const isAvailableFn = mock((): boolean => true);
-const brokerSetFn = mock(
-  async (
-    _account: string,
-    _value: string,
-  ): Promise<{ status: string; code?: string; message?: string }> => ({
-    status: "ok",
-  }),
+const execFileSyncFn = mock(
+  (
+    _file: string,
+    _args?: readonly string[],
+    _options?: object,
+  ): string | Buffer => "",
 );
-const createBrokerClientFn = mock(() => ({
-  isAvailable: isAvailableFn,
-  set: brokerSetFn,
-}));
 
 const listKeysFn = mock((): string[] => []);
 const getKeyFn = mock((_account: string): string | undefined => undefined);
+const setKeyFn = mock((_account: string, _value: string): boolean => true);
 const deleteKeyFn = mock(
   (_account: string): "deleted" | "not-found" | "error" => "deleted",
 );
@@ -28,8 +23,8 @@ const deleteKeyFn = mock(
 // Mock modules — before importing module under test
 //
 // The logger is mocked with a silent Proxy to suppress pino output in tests.
-// The broker client and encrypted store are mocked to control migration
-// behavior without touching real keychain or filesystem state.
+// node:child_process is mocked to control security CLI calls without touching
+// the real keychain. The encrypted store is mocked to avoid filesystem state.
 // ---------------------------------------------------------------------------
 
 mock.module("../util/logger.js", () => ({
@@ -39,13 +34,14 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-mock.module("../security/keychain-broker-client.js", () => ({
-  createBrokerClient: createBrokerClientFn,
+mock.module("node:child_process", () => ({
+  execFileSync: execFileSyncFn,
 }));
 
 mock.module("../security/encrypted-store.js", () => ({
   listKeys: listKeysFn,
   getKey: getKeyFn,
+  setKey: setKeyFn,
   deleteKey: deleteKeyFn,
 }));
 
@@ -58,28 +54,49 @@ import { migrateCredentialsToKeychainMigration } from "../workspace/migrations/0
 
 const WORKSPACE_DIR = "/mock-home/.vellum/workspace";
 
+const originalPlatform = process.platform;
+
+function setPlatform(value: string): void {
+  Object.defineProperty(process, "platform", {
+    value,
+    writable: true,
+    configurable: true,
+  });
+}
+
+function restorePlatform(): void {
+  Object.defineProperty(process, "platform", {
+    value: originalPlatform,
+    writable: true,
+    configurable: true,
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 describe("015-migrate-credentials-to-keychain migration", () => {
   beforeEach(() => {
-    isAvailableFn.mockClear();
-    brokerSetFn.mockClear();
-    createBrokerClientFn.mockClear();
+    execFileSyncFn.mockClear();
     listKeysFn.mockClear();
     getKeyFn.mockClear();
+    setKeyFn.mockClear();
     deleteKeyFn.mockClear();
 
     // Defaults: mac production build
     process.env.VELLUM_DESKTOP_APP = "1";
     delete process.env.VELLUM_DEV;
 
-    isAvailableFn.mockReturnValue(true);
-    brokerSetFn.mockResolvedValue({ status: "ok" });
+    restorePlatform();
     listKeysFn.mockReturnValue([]);
     getKeyFn.mockReturnValue(undefined);
+    setKeyFn.mockReturnValue(true);
     deleteKeyFn.mockReturnValue("deleted");
+  });
+
+  afterEach(() => {
+    restorePlatform();
   });
 
   test("has correct migration id", () => {
@@ -93,7 +110,7 @@ describe("015-migrate-credentials-to-keychain migration", () => {
 
     await migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR);
 
-    expect(createBrokerClientFn).not.toHaveBeenCalled();
+    expect(execFileSyncFn).not.toHaveBeenCalled();
     expect(listKeysFn).not.toHaveBeenCalled();
   });
 
@@ -102,7 +119,7 @@ describe("015-migrate-credentials-to-keychain migration", () => {
 
     await migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR);
 
-    expect(createBrokerClientFn).not.toHaveBeenCalled();
+    expect(execFileSyncFn).not.toHaveBeenCalled();
   });
 
   test("skips when VELLUM_DEV=1", async () => {
@@ -110,50 +127,18 @@ describe("015-migrate-credentials-to-keychain migration", () => {
 
     await migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR);
 
-    expect(createBrokerClientFn).not.toHaveBeenCalled();
+    expect(execFileSyncFn).not.toHaveBeenCalled();
     expect(listKeysFn).not.toHaveBeenCalled();
   });
 
-  test(
-    "throws when broker is not available after max retry attempts",
-    async () => {
-      isAvailableFn.mockReturnValue(false);
-
-      await expect(
-        migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR),
-      ).rejects.toThrow(
-        "Keychain broker not available after waiting — credential migration will be retried on next startup",
-      );
-
-      // Should have retried isAvailable multiple times
-      expect(isAvailableFn.mock.calls.length).toBeGreaterThan(1);
-
-      // Should not proceed to list or migrate keys
-      expect(listKeysFn).not.toHaveBeenCalled();
-      expect(brokerSetFn).not.toHaveBeenCalled();
-    },
-    { timeout: 10_000 },
-  );
-
-  test("succeeds when broker becomes available after retry", async () => {
-    // Broker unavailable for first 3 calls, then available
-    let callCount = 0;
-    isAvailableFn.mockImplementation(() => {
-      callCount++;
-      return callCount > 3;
-    });
-    listKeysFn.mockReturnValue(["retry-key"]);
-    getKeyFn.mockReturnValue("retry-secret");
-    brokerSetFn.mockResolvedValue({ status: "ok" });
+  test("no-ops when not on macOS", async () => {
+    setPlatform("linux");
 
     await migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR);
 
-    // Should have called isAvailable 4 times (3 false + 1 true)
-    expect(isAvailableFn).toHaveBeenCalledTimes(4);
-
-    // Should have proceeded with migration
-    expect(brokerSetFn).toHaveBeenCalledWith("retry-key", "retry-secret");
-    expect(deleteKeyFn).toHaveBeenCalledWith("retry-key");
+    // Should not invoke the security CLI or touch encrypted store
+    expect(execFileSyncFn).not.toHaveBeenCalled();
+    expect(listKeysFn).not.toHaveBeenCalled();
   });
 
   test("no-ops when encrypted store has no keys", async () => {
@@ -161,7 +146,7 @@ describe("015-migrate-credentials-to-keychain migration", () => {
 
     await migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR);
 
-    expect(brokerSetFn).not.toHaveBeenCalled();
+    expect(execFileSyncFn).not.toHaveBeenCalled();
     expect(deleteKeyFn).not.toHaveBeenCalled();
   });
 
@@ -172,14 +157,41 @@ describe("015-migrate-credentials-to-keychain migration", () => {
       if (account === "account-b") return "secret-b";
       return undefined;
     });
-    brokerSetFn.mockResolvedValue({ status: "ok" });
+    // execFileSync succeeds (no throw) for add-generic-password
+    execFileSyncFn.mockReturnValue("");
 
     await migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR);
 
-    // Should have called broker.set for each key
-    expect(brokerSetFn).toHaveBeenCalledTimes(2);
-    expect(brokerSetFn).toHaveBeenCalledWith("account-a", "secret-a");
-    expect(brokerSetFn).toHaveBeenCalledWith("account-b", "secret-b");
+    // Should have called security CLI add-generic-password for each key
+    expect(execFileSyncFn).toHaveBeenCalledTimes(2);
+    expect(execFileSyncFn).toHaveBeenCalledWith(
+      "/usr/bin/security",
+      [
+        "add-generic-password",
+        "-s",
+        "vellum-assistant",
+        "-a",
+        "account-a",
+        "-w",
+        "secret-a",
+        "-U",
+      ],
+      expect.objectContaining({ stdio: ["ignore", "pipe", "pipe"] }),
+    );
+    expect(execFileSyncFn).toHaveBeenCalledWith(
+      "/usr/bin/security",
+      [
+        "add-generic-password",
+        "-s",
+        "vellum-assistant",
+        "-a",
+        "account-b",
+        "-w",
+        "secret-b",
+        "-U",
+      ],
+      expect.objectContaining({ stdio: ["ignore", "pipe", "pipe"] }),
+    );
 
     // Should have deleted each key from encrypted store after successful migration
     expect(deleteKeyFn).toHaveBeenCalledTimes(2);
@@ -194,24 +206,21 @@ describe("015-migrate-credentials-to-keychain migration", () => {
       if (account === "ok-key") return "ok-secret";
       return undefined;
     });
-    brokerSetFn.mockImplementation(async (account: string) => {
-      if (account === "fail-key") {
-        return {
-          status: "rejected" as const,
-          code: "UNKNOWN",
-          message: "broker rejected",
-        };
-      }
-      return { status: "ok" as const };
-    });
+    execFileSyncFn.mockImplementation(
+      (_file: string, args?: readonly string[]) => {
+        if (args && args.includes("fail-key")) {
+          throw new Error("security CLI error");
+        }
+        return "";
+      },
+    );
 
     await migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR);
 
-    // fail-key should NOT have been deleted (broker rejected it)
+    // fail-key should NOT have been deleted (security CLI failed)
     expect(deleteKeyFn).not.toHaveBeenCalledWith("fail-key");
 
     // ok-key should have been migrated and deleted
-    expect(brokerSetFn).toHaveBeenCalledWith("ok-key", "ok-secret");
     expect(deleteKeyFn).toHaveBeenCalledWith("ok-key");
     expect(deleteKeyFn).toHaveBeenCalledTimes(1);
   });
@@ -223,30 +232,130 @@ describe("015-migrate-credentials-to-keychain migration", () => {
       if (account === "real-key") return "real-secret";
       return undefined;
     });
-    brokerSetFn.mockResolvedValue({ status: "ok" });
+    execFileSyncFn.mockReturnValue("");
 
     await migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR);
 
-    // ghost-key should not be sent to broker or deleted
-    expect(brokerSetFn).not.toHaveBeenCalledWith(
-      "ghost-key",
-      expect.anything(),
-    );
+    // ghost-key should not trigger security CLI or be deleted
     expect(deleteKeyFn).not.toHaveBeenCalledWith("ghost-key");
 
     // real-key should be migrated
-    expect(brokerSetFn).toHaveBeenCalledWith("real-key", "real-secret");
     expect(deleteKeyFn).toHaveBeenCalledWith("real-key");
   });
 
-  test("handles broker unreachable status for individual keys", async () => {
+  test("handles security CLI failure for individual keys", async () => {
     listKeysFn.mockReturnValue(["key-1"]);
     getKeyFn.mockReturnValue("secret-1");
-    brokerSetFn.mockResolvedValue({ status: "unreachable" });
+    execFileSyncFn.mockImplementation(() => {
+      throw new Error("security: SecKeychainItemCopyAccess: error");
+    });
 
     await migrateCredentialsToKeychainMigration.run(WORKSPACE_DIR);
 
-    // Should not delete when broker is unreachable
+    // Should not delete when security CLI fails
     expect(deleteKeyFn).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // down() tests
+  // ---------------------------------------------------------------------------
+
+  describe("down()", () => {
+    test("no-ops when not on macOS", async () => {
+      setPlatform("linux");
+
+      await migrateCredentialsToKeychainMigration.down!(WORKSPACE_DIR);
+
+      expect(execFileSyncFn).not.toHaveBeenCalled();
+      expect(setKeyFn).not.toHaveBeenCalled();
+    });
+
+    test("rolls back keychain credentials to encrypted store", async () => {
+      // Mock dump-keychain to list accounts
+      const dumpOutput = [
+        'keychain: "/Users/test/Library/Keychains/login.keychain-db"',
+        'class: "genp"',
+        '    "svce"<blob>="vellum-assistant"',
+        '    "acct"<blob>="cred-x"',
+        'class: "genp"',
+        '    "svce"<blob>="vellum-assistant"',
+        '    "acct"<blob>="cred-y"',
+        'class: "genp"',
+        '    "svce"<blob>="other-service"',
+        '    "acct"<blob>="unrelated"',
+      ].join("\n");
+
+      execFileSyncFn.mockImplementation(
+        (_file: string, args?: readonly string[]) => {
+          if (args && args[0] === "dump-keychain") {
+            return dumpOutput;
+          }
+          if (args && args[0] === "find-generic-password") {
+            const accountIdx = args.indexOf("-a");
+            const account = accountIdx >= 0 ? args[accountIdx + 1] : "";
+            if (account === "cred-x") return "value-x\n";
+            if (account === "cred-y") return "value-y\n";
+            throw new Error("not found");
+          }
+          // delete-generic-password succeeds
+          return "";
+        },
+      );
+
+      setKeyFn.mockReturnValue(true);
+
+      await migrateCredentialsToKeychainMigration.down!(WORKSPACE_DIR);
+
+      // Should have written both credentials to encrypted store
+      expect(setKeyFn).toHaveBeenCalledTimes(2);
+      expect(setKeyFn).toHaveBeenCalledWith("cred-x", "value-x");
+      expect(setKeyFn).toHaveBeenCalledWith("cred-y", "value-y");
+
+      // Should have called delete-generic-password for both
+      const deleteCalls = execFileSyncFn.mock.calls.filter(
+        (call) =>
+          Array.isArray(call[1]) && call[1][0] === "delete-generic-password",
+      );
+      expect(deleteCalls.length).toBe(2);
+    });
+
+    test("continues on individual key failure during rollback", async () => {
+      const dumpOutput = [
+        'class: "genp"',
+        '    "svce"<blob>="vellum-assistant"',
+        '    "acct"<blob>="fail-cred"',
+        'class: "genp"',
+        '    "svce"<blob>="vellum-assistant"',
+        '    "acct"<blob>="ok-cred"',
+      ].join("\n");
+
+      execFileSyncFn.mockImplementation(
+        (_file: string, args?: readonly string[]) => {
+          if (args && args[0] === "dump-keychain") {
+            return dumpOutput;
+          }
+          if (args && args[0] === "find-generic-password") {
+            const accountIdx = args.indexOf("-a");
+            const account = accountIdx >= 0 ? args[accountIdx + 1] : "";
+            if (account === "fail-cred") {
+              throw new Error("keychain item not found");
+            }
+            if (account === "ok-cred") return "ok-value\n";
+            throw new Error("not found");
+          }
+          return "";
+        },
+      );
+
+      setKeyFn.mockReturnValue(true);
+
+      await migrateCredentialsToKeychainMigration.down!(WORKSPACE_DIR);
+
+      // fail-cred should NOT have been written to encrypted store
+      expect(setKeyFn).not.toHaveBeenCalledWith("fail-cred", expect.anything());
+
+      // ok-cred should have been rolled back
+      expect(setKeyFn).toHaveBeenCalledWith("ok-cred", "ok-value");
+    });
   });
 });

--- a/assistant/src/__tests__/workspace-migration-015-migrate-credentials-to-keychain.test.ts
+++ b/assistant/src/__tests__/workspace-migration-015-migrate-credentials-to-keychain.test.ts
@@ -88,7 +88,8 @@ describe("015-migrate-credentials-to-keychain migration", () => {
     process.env.VELLUM_DESKTOP_APP = "1";
     delete process.env.VELLUM_DEV;
 
-    restorePlatform();
+    // Ensure tests run as if on macOS, even when CI is Linux
+    setPlatform("darwin");
     listKeysFn.mockReturnValue([]);
     getKeyFn.mockReturnValue(undefined);
     setKeyFn.mockReturnValue(true);

--- a/assistant/src/workspace/migrations/015-migrate-credentials-to-keychain.ts
+++ b/assistant/src/workspace/migrations/015-migrate-credentials-to-keychain.ts
@@ -1,10 +1,99 @@
+import { execFileSync } from "node:child_process";
+
 import { getLogger } from "../../util/logger.js";
 import type { WorkspaceMigration } from "./types.js";
 
 const log = getLogger("workspace-migrations");
 
-const BROKER_WAIT_INTERVAL_MS = 500;
-const BROKER_WAIT_MAX_ATTEMPTS = 10; // 5 seconds total
+// ---------------------------------------------------------------------------
+// Inline macOS Keychain helpers (private to this migration)
+//
+// These shell out to /usr/bin/security directly, replacing the former
+// keychain broker (UDS server) that was deleted in PR #21099.
+// ---------------------------------------------------------------------------
+
+const SERVICE_NAME = "vellum-assistant";
+
+function keychainIsAvailable(): boolean {
+  return process.platform === "darwin";
+}
+
+function keychainGet(account: string): string | undefined {
+  try {
+    const stdout = execFileSync(
+      "/usr/bin/security",
+      ["find-generic-password", "-s", SERVICE_NAME, "-a", account, "-w"],
+      { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    return stdout.trim();
+  } catch {
+    return undefined;
+  }
+}
+
+function keychainSet(account: string, value: string): boolean {
+  try {
+    execFileSync(
+      "/usr/bin/security",
+      [
+        "add-generic-password",
+        "-s",
+        SERVICE_NAME,
+        "-a",
+        account,
+        "-w",
+        value,
+        "-U",
+      ],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function keychainDelete(account: string): boolean {
+  try {
+    execFileSync(
+      "/usr/bin/security",
+      ["delete-generic-password", "-s", SERVICE_NAME, "-a", account],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    return true;
+  } catch (err: unknown) {
+    // Item not found is acceptable — treat as success
+    if (err instanceof Error && err.message.includes("could not be found")) {
+      return true;
+    }
+    return false;
+  }
+}
+
+function keychainList(): string[] {
+  try {
+    const stdout = execFileSync("/usr/bin/security", ["dump-keychain"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+      maxBuffer: 10 * 1024 * 1024,
+    });
+
+    const blocks = stdout.split(/class: "genp"/);
+    const accounts: string[] = [];
+
+    for (const block of blocks) {
+      if (!block.includes(`"svce"<blob>="${SERVICE_NAME}"`)) continue;
+      const match = block.match(/"acct"<blob>="([^"]+)"/);
+      if (match) {
+        accounts.push(match[1]);
+      }
+    }
+
+    return accounts;
+  } catch {
+    return [];
+  }
+}
 
 export const migrateCredentialsToKeychainMigration: WorkspaceMigration = {
   id: "015-migrate-credentials-to-keychain",
@@ -21,37 +110,21 @@ export const migrateCredentialsToKeychainMigration: WorkspaceMigration = {
       return;
     }
 
-    const { createBrokerClient } =
-      await import("../../security/keychain-broker-client.js");
-    const client = createBrokerClient();
-
-    let brokerAvailable = false;
-    for (let i = 0; i < BROKER_WAIT_MAX_ATTEMPTS; i++) {
-      if (client.isAvailable()) {
-        brokerAvailable = true;
-        break;
-      }
-      await new Promise((r) => setTimeout(r, BROKER_WAIT_INTERVAL_MS));
-    }
-
-    if (!brokerAvailable) {
-      throw new Error(
-        "Keychain broker not available after waiting — credential rollback " +
-          "will be retried on next startup",
-      );
+    if (!keychainIsAvailable()) {
+      return;
     }
 
     const { setKey } = await import("../../security/encrypted-store.js");
 
-    const accounts = await client.list();
+    const accounts = keychainList();
     if (accounts.length === 0) return;
 
     let rolledBackCount = 0;
     let failedCount = 0;
 
     for (const account of accounts) {
-      const result = await client.get(account);
-      if (!result || !result.found || result.value === undefined) {
+      const value = keychainGet(account);
+      if (value === undefined) {
         log.warn(
           { account },
           "Failed to read key from keychain during rollback — skipping",
@@ -60,9 +133,9 @@ export const migrateCredentialsToKeychainMigration: WorkspaceMigration = {
         continue;
       }
 
-      const written = setKey(account, result.value);
+      const written = setKey(account, value);
       if (written) {
-        await client.del(account);
+        keychainDelete(account);
         rolledBackCount++;
       } else {
         log.warn(
@@ -88,26 +161,8 @@ export const migrateCredentialsToKeychainMigration: WorkspaceMigration = {
       return;
     }
 
-    const { createBrokerClient } =
-      await import("../../security/keychain-broker-client.js");
-    const client = createBrokerClient();
-
-    // Wait for the broker to become available (up to 5 seconds), matching
-    // the retry strategy in secure-keys.ts waitForBrokerAvailability().
-    let brokerAvailable = false;
-    for (let i = 0; i < BROKER_WAIT_MAX_ATTEMPTS; i++) {
-      if (client.isAvailable()) {
-        brokerAvailable = true;
-        break;
-      }
-      await new Promise((r) => setTimeout(r, BROKER_WAIT_INTERVAL_MS));
-    }
-
-    if (!brokerAvailable) {
-      throw new Error(
-        "Keychain broker not available after waiting — credential migration " +
-          "will be retried on next startup",
-      );
+    if (!keychainIsAvailable()) {
+      return;
     }
 
     const { listKeys, getKey, deleteKey } =
@@ -132,15 +187,12 @@ export const migrateCredentialsToKeychainMigration: WorkspaceMigration = {
         continue;
       }
 
-      const result = await client.set(account, value);
-      if (result.status === "ok") {
+      const result = keychainSet(account, value);
+      if (result) {
         deleteKey(account);
         migratedCount++;
       } else {
-        log.warn(
-          { account, status: result.status },
-          "Failed to write key to keychain — skipping",
-        );
+        log.warn({ account }, "Failed to write key to keychain — skipping");
         failedCount++;
       }
     }


### PR DESCRIPTION
## Summary
- Replace keychain broker client dependency in migration 015 with inline helper functions that shell out to macOS security CLI
- Migrations gracefully no-op on non-macOS platforms instead of throwing fatal errors
- Update tests to mock node:child_process instead of the deleted broker client

Part of plan: inline-keychain-security-cli.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
