### PR TITLE
fix: replace keychain broker with inline security CLI helpers in migration 016

### DIFF
--- a/assistant/src/__tests__/workspace-migration-016-migrate-credentials-from-keychain.test.ts
+++ b/assistant/src/__tests__/workspace-migration-016-migrate-credentials-from-keychain.test.ts
@@ -1,37 +1,30 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ---------------------------------------------------------------------------
 // Mock state
 // ---------------------------------------------------------------------------
 
-const isAvailableFn = mock((): boolean => true);
-const brokerGetFn = mock(
-  async (
-    _account: string,
-  ): Promise<{ found: boolean; value?: string } | null> => ({
-    found: true,
-    value: "secret",
-  }),
+const execFileSyncFn = mock(
+  (
+    _file: string,
+    _args?: readonly string[],
+    _options?: object,
+  ): string | Buffer => "",
 );
-const brokerDelFn = mock(async (_account: string): Promise<boolean> => true);
-const brokerListFn = mock(async (): Promise<string[]> => []);
-const createBrokerClientFn = mock(() => ({
-  isAvailable: isAvailableFn,
-  get: brokerGetFn,
-  del: brokerDelFn,
-  list: brokerListFn,
-}));
 
-const setKeyFn = mock(
-  (_account: string, _value: string): boolean => true,
+const setKeyFn = mock((_account: string, _value: string): boolean => true);
+
+const listKeysFn = mock((): string[] => []);
+const getKeyFn = mock((_account: string): string | undefined => undefined);
+const deleteKeyFn = mock(
+  (_account: string): "deleted" | "not-found" | "error" => "deleted",
 );
 
 // ---------------------------------------------------------------------------
 // Mock modules — before importing module under test
 //
 // The logger is mocked with a silent Proxy to suppress pino output in tests.
-// The broker client and encrypted store are mocked to control migration
-// behavior without touching real keychain or filesystem state.
+// node:child_process is mocked to control security CLI behavior.
 // ---------------------------------------------------------------------------
 
 mock.module("../util/logger.js", () => ({
@@ -41,12 +34,15 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-mock.module("../security/keychain-broker-client.js", () => ({
-  createBrokerClient: createBrokerClientFn,
+mock.module("node:child_process", () => ({
+  execFileSync: execFileSyncFn,
 }));
 
 mock.module("../security/encrypted-store.js", () => ({
   setKey: setKeyFn,
+  listKeys: listKeysFn,
+  getKey: getKeyFn,
+  deleteKey: deleteKeyFn,
 }));
 
 // Import after mocking
@@ -58,28 +54,48 @@ import { migrateCredentialsFromKeychainMigration } from "../workspace/migrations
 
 const WORKSPACE_DIR = "/mock-home/.vellum/workspace";
 
+/**
+ * Build a dump-keychain output block for the given accounts.
+ */
+function buildDumpKeychainOutput(accounts: string[]): string {
+  return accounts
+    .map(
+      (acct) =>
+        `class: "genp"\n    0x00000007 <blob>="vellum-assistant"\n    "svce"<blob>="vellum-assistant"\n    "acct"<blob>="${acct}"`,
+    )
+    .join("\n");
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 describe("016-migrate-credentials-from-keychain migration", () => {
+  const originalPlatform = process.platform;
+
   beforeEach(() => {
-    isAvailableFn.mockClear();
-    brokerGetFn.mockClear();
-    brokerDelFn.mockClear();
-    brokerListFn.mockClear();
-    createBrokerClientFn.mockClear();
+    execFileSyncFn.mockClear();
     setKeyFn.mockClear();
+    listKeysFn.mockClear();
+    getKeyFn.mockClear();
+    deleteKeyFn.mockClear();
 
     // Defaults: mac production build
     process.env.VELLUM_DESKTOP_APP = "1";
     delete process.env.VELLUM_DEV;
 
-    isAvailableFn.mockReturnValue(true);
-    brokerGetFn.mockResolvedValue({ found: true, value: "secret" });
-    brokerDelFn.mockResolvedValue(true);
-    brokerListFn.mockResolvedValue([]);
+    // Ensure platform is darwin for keychain availability
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
     setKeyFn.mockReturnValue(true);
+    listKeysFn.mockReturnValue([]);
+    getKeyFn.mockReturnValue(undefined);
+    deleteKeyFn.mockReturnValue("deleted");
+  });
+
+  // Restore platform after all tests
+  afterAll(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
   });
 
   test("has correct migration id", () => {
@@ -93,8 +109,8 @@ describe("016-migrate-credentials-from-keychain migration", () => {
 
     await migrateCredentialsFromKeychainMigration.run(WORKSPACE_DIR);
 
-    expect(createBrokerClientFn).not.toHaveBeenCalled();
-    expect(brokerListFn).not.toHaveBeenCalled();
+    expect(execFileSyncFn).not.toHaveBeenCalled();
+    expect(setKeyFn).not.toHaveBeenCalled();
   });
 
   test("skips when VELLUM_DESKTOP_APP is not '1'", async () => {
@@ -102,7 +118,7 @@ describe("016-migrate-credentials-from-keychain migration", () => {
 
     await migrateCredentialsFromKeychainMigration.run(WORKSPACE_DIR);
 
-    expect(createBrokerClientFn).not.toHaveBeenCalled();
+    expect(execFileSyncFn).not.toHaveBeenCalled();
   });
 
   test("skips when VELLUM_DEV=1", async () => {
@@ -110,43 +126,55 @@ describe("016-migrate-credentials-from-keychain migration", () => {
 
     await migrateCredentialsFromKeychainMigration.run(WORKSPACE_DIR);
 
-    expect(createBrokerClientFn).not.toHaveBeenCalled();
-    expect(brokerListFn).not.toHaveBeenCalled();
+    expect(execFileSyncFn).not.toHaveBeenCalled();
+    expect(setKeyFn).not.toHaveBeenCalled();
   });
 
-  test(
-    "throws when broker is not available (skips checkpoint for retry)",
-    async () => {
-      isAvailableFn.mockReturnValue(false);
+  test("no-ops when not on macOS", async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
 
-      // Throwing skips the checkpoint so the migration retries on next startup
-      await expect(
-        migrateCredentialsFromKeychainMigration.run(WORKSPACE_DIR),
-      ).rejects.toThrow("Keychain broker not available after waiting");
+    await migrateCredentialsFromKeychainMigration.run(WORKSPACE_DIR);
 
-      // Should not proceed to list or migrate keys
-      expect(brokerListFn).not.toHaveBeenCalled();
-      expect(setKeyFn).not.toHaveBeenCalled();
-    },
-    { timeout: 10_000 },
-  );
+    expect(execFileSyncFn).not.toHaveBeenCalled();
+    expect(setKeyFn).not.toHaveBeenCalled();
+  });
 
   test("no-ops when keychain has no accounts", async () => {
-    brokerListFn.mockResolvedValue([]);
+    // dump-keychain returns empty output (no vellum-assistant entries)
+    execFileSyncFn.mockReturnValue("");
 
     await migrateCredentialsFromKeychainMigration.run(WORKSPACE_DIR);
 
     expect(setKeyFn).not.toHaveBeenCalled();
-    expect(brokerDelFn).not.toHaveBeenCalled();
   });
 
   test("copies credentials from keychain to encrypted store and deletes from keychain", async () => {
-    brokerListFn.mockResolvedValue(["account-a", "account-b"]);
-    brokerGetFn.mockImplementation(async (account: string) => {
-      if (account === "account-a") return { found: true, value: "secret-a" };
-      if (account === "account-b") return { found: true, value: "secret-b" };
-      return null;
-    });
+    execFileSyncFn.mockImplementation(
+      (file: string, args?: readonly string[]) => {
+        const cmd = args?.[0];
+
+        if (cmd === "dump-keychain") {
+          return buildDumpKeychainOutput(["account-a", "account-b"]);
+        }
+
+        if (cmd === "find-generic-password") {
+          const accountIdx = args?.indexOf("-a");
+          const account =
+            accountIdx !== undefined && accountIdx >= 0
+              ? args?.[accountIdx + 1]
+              : undefined;
+          if (account === "account-a") return "secret-a\n";
+          if (account === "account-b") return "secret-b\n";
+          throw new Error("not found");
+        }
+
+        if (cmd === "delete-generic-password") {
+          return "";
+        }
+
+        return "";
+      },
+    );
     setKeyFn.mockReturnValue(true);
 
     await migrateCredentialsFromKeychainMigration.run(WORKSPACE_DIR);
@@ -156,52 +184,77 @@ describe("016-migrate-credentials-from-keychain migration", () => {
     expect(setKeyFn).toHaveBeenCalledWith("account-a", "secret-a");
     expect(setKeyFn).toHaveBeenCalledWith("account-b", "secret-b");
 
-    // Should have deleted each key from keychain after successful migration
-    expect(brokerDelFn).toHaveBeenCalledTimes(2);
-    expect(brokerDelFn).toHaveBeenCalledWith("account-a");
-    expect(brokerDelFn).toHaveBeenCalledWith("account-b");
+    // Should have called delete-generic-password for each key
+    const deleteCalls = execFileSyncFn.mock.calls.filter(
+      (call) => (call[1] as string[])?.[0] === "delete-generic-password",
+    );
+    expect(deleteCalls).toHaveLength(2);
   });
 
-  test("skips key when broker.get returns null", async () => {
-    brokerListFn.mockResolvedValue(["ghost-key", "real-key"]);
-    brokerGetFn.mockImplementation(async (account: string) => {
-      if (account === "ghost-key") return null;
-      if (account === "real-key") return { found: true, value: "real-secret" };
-      return null;
-    });
+  test("skips key when security CLI returns nothing", async () => {
+    execFileSyncFn.mockImplementation(
+      (file: string, args?: readonly string[]) => {
+        const cmd = args?.[0];
+
+        if (cmd === "dump-keychain") {
+          return buildDumpKeychainOutput(["ghost-key", "real-key"]);
+        }
+
+        if (cmd === "find-generic-password") {
+          const accountIdx = args?.indexOf("-a");
+          const account =
+            accountIdx !== undefined && accountIdx >= 0
+              ? args?.[accountIdx + 1]
+              : undefined;
+          if (account === "ghost-key") throw new Error("not found");
+          if (account === "real-key") return "real-secret\n";
+          throw new Error("not found");
+        }
+
+        if (cmd === "delete-generic-password") {
+          return "";
+        }
+
+        return "";
+      },
+    );
 
     await migrateCredentialsFromKeychainMigration.run(WORKSPACE_DIR);
 
-    // ghost-key should not be written or deleted
-    expect(setKeyFn).not.toHaveBeenCalledWith(
-      "ghost-key",
-      expect.anything(),
-    );
-    expect(brokerDelFn).not.toHaveBeenCalledWith("ghost-key");
+    // ghost-key should not be written
+    expect(setKeyFn).not.toHaveBeenCalledWith("ghost-key", expect.anything());
 
     // real-key should be migrated
     expect(setKeyFn).toHaveBeenCalledWith("real-key", "real-secret");
-    expect(brokerDelFn).toHaveBeenCalledWith("real-key");
-  });
-
-  test("skips key when broker.get returns not found", async () => {
-    brokerListFn.mockResolvedValue(["missing-key"]);
-    brokerGetFn.mockResolvedValue({ found: false });
-
-    await migrateCredentialsFromKeychainMigration.run(WORKSPACE_DIR);
-
-    expect(setKeyFn).not.toHaveBeenCalled();
-    expect(brokerDelFn).not.toHaveBeenCalled();
   });
 
   test("skips key when setKey fails and does not delete from keychain", async () => {
-    brokerListFn.mockResolvedValue(["fail-key", "ok-key"]);
-    brokerGetFn.mockImplementation(async (account: string) => {
-      if (account === "fail-key")
-        return { found: true, value: "fail-secret" };
-      if (account === "ok-key") return { found: true, value: "ok-secret" };
-      return null;
-    });
+    execFileSyncFn.mockImplementation(
+      (file: string, args?: readonly string[]) => {
+        const cmd = args?.[0];
+
+        if (cmd === "dump-keychain") {
+          return buildDumpKeychainOutput(["fail-key", "ok-key"]);
+        }
+
+        if (cmd === "find-generic-password") {
+          const accountIdx = args?.indexOf("-a");
+          const account =
+            accountIdx !== undefined && accountIdx >= 0
+              ? args?.[accountIdx + 1]
+              : undefined;
+          if (account === "fail-key") return "fail-secret\n";
+          if (account === "ok-key") return "ok-secret\n";
+          throw new Error("not found");
+        }
+
+        if (cmd === "delete-generic-password") {
+          return "";
+        }
+
+        return "";
+      },
+    );
     setKeyFn.mockImplementation((account: string) => {
       if (account === "fail-key") return false;
       return true;
@@ -209,12 +262,134 @@ describe("016-migrate-credentials-from-keychain migration", () => {
 
     await migrateCredentialsFromKeychainMigration.run(WORKSPACE_DIR);
 
-    // fail-key should NOT have been deleted from keychain (setKey failed)
-    expect(brokerDelFn).not.toHaveBeenCalledWith("fail-key");
+    // fail-key should NOT have triggered delete (setKey failed)
+    const deleteCalls = execFileSyncFn.mock.calls.filter((call) => {
+      const args = call[1] as string[] | undefined;
+      return (
+        args?.[0] === "delete-generic-password" && args?.includes("fail-key")
+      );
+    });
+    expect(deleteCalls).toHaveLength(0);
 
     // ok-key should have been migrated and deleted
     expect(setKeyFn).toHaveBeenCalledWith("ok-key", "ok-secret");
-    expect(brokerDelFn).toHaveBeenCalledWith("ok-key");
-    expect(brokerDelFn).toHaveBeenCalledTimes(1);
+    const okDeleteCalls = execFileSyncFn.mock.calls.filter((call) => {
+      const args = call[1] as string[] | undefined;
+      return (
+        args?.[0] === "delete-generic-password" && args?.includes("ok-key")
+      );
+    });
+    expect(okDeleteCalls).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // down() path — encrypted store -> keychain rollback
+  // -------------------------------------------------------------------------
+
+  describe("down()", () => {
+    test("skips when VELLUM_DESKTOP_APP is not set", async () => {
+      delete process.env.VELLUM_DESKTOP_APP;
+
+      await migrateCredentialsFromKeychainMigration.down!(WORKSPACE_DIR);
+
+      expect(execFileSyncFn).not.toHaveBeenCalled();
+    });
+
+    test("skips when VELLUM_DEV=1", async () => {
+      process.env.VELLUM_DEV = "1";
+
+      await migrateCredentialsFromKeychainMigration.down!(WORKSPACE_DIR);
+
+      expect(execFileSyncFn).not.toHaveBeenCalled();
+    });
+
+    test("no-ops when not on macOS", async () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+
+      await migrateCredentialsFromKeychainMigration.down!(WORKSPACE_DIR);
+
+      expect(execFileSyncFn).not.toHaveBeenCalled();
+    });
+
+    test("rolls back credentials from encrypted store to keychain", async () => {
+      listKeysFn.mockReturnValue(["key-a", "key-b"]);
+      getKeyFn.mockImplementation((account: string) => {
+        if (account === "key-a") return "secret-a";
+        if (account === "key-b") return "secret-b";
+        return undefined;
+      });
+
+      // Mock keychainSet (add-generic-password) to succeed
+      execFileSyncFn.mockReturnValue("");
+
+      await migrateCredentialsFromKeychainMigration.down!(WORKSPACE_DIR);
+
+      // Should have called add-generic-password for each key
+      const setCalls = execFileSyncFn.mock.calls.filter(
+        (call) => (call[1] as string[])?.[0] === "add-generic-password",
+      );
+      expect(setCalls).toHaveLength(2);
+
+      // Should have deleted each key from encrypted store
+      expect(deleteKeyFn).toHaveBeenCalledTimes(2);
+      expect(deleteKeyFn).toHaveBeenCalledWith("key-a");
+      expect(deleteKeyFn).toHaveBeenCalledWith("key-b");
+    });
+
+    test("skips key when getKey returns undefined during rollback", async () => {
+      listKeysFn.mockReturnValue(["missing-key", "good-key"]);
+      getKeyFn.mockImplementation((account: string) => {
+        if (account === "missing-key") return undefined;
+        if (account === "good-key") return "good-secret";
+        return undefined;
+      });
+      execFileSyncFn.mockReturnValue("");
+
+      await migrateCredentialsFromKeychainMigration.down!(WORKSPACE_DIR);
+
+      // missing-key should not trigger add-generic-password
+      // good-key should be rolled back
+      const setCalls = execFileSyncFn.mock.calls.filter(
+        (call) => (call[1] as string[])?.[0] === "add-generic-password",
+      );
+      expect(setCalls).toHaveLength(1);
+      expect(deleteKeyFn).toHaveBeenCalledWith("good-key");
+      expect(deleteKeyFn).not.toHaveBeenCalledWith("missing-key");
+    });
+
+    test("skips key when keychainSet fails during rollback", async () => {
+      listKeysFn.mockReturnValue(["fail-key", "ok-key"]);
+      getKeyFn.mockImplementation((account: string) => {
+        if (account === "fail-key") return "fail-secret";
+        if (account === "ok-key") return "ok-secret";
+        return undefined;
+      });
+
+      execFileSyncFn.mockImplementation(
+        (file: string, args?: readonly string[]) => {
+          const cmd = args?.[0];
+          if (cmd === "add-generic-password") {
+            const accountIdx = args?.indexOf("-a");
+            const account =
+              accountIdx !== undefined && accountIdx >= 0
+                ? args?.[accountIdx + 1]
+                : undefined;
+            if (account === "fail-key")
+              throw new Error("keychain write failed");
+            return "";
+          }
+          return "";
+        },
+      );
+
+      await migrateCredentialsFromKeychainMigration.down!(WORKSPACE_DIR);
+
+      // fail-key should NOT have been deleted from encrypted store
+      expect(deleteKeyFn).not.toHaveBeenCalledWith("fail-key");
+
+      // ok-key should have been rolled back
+      expect(deleteKeyFn).toHaveBeenCalledWith("ok-key");
+      expect(deleteKeyFn).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/assistant/src/workspace/migrations/016-migrate-credentials-from-keychain.ts
+++ b/assistant/src/workspace/migrations/016-migrate-credentials-from-keychain.ts
@@ -1,10 +1,108 @@
+import { execFileSync } from "node:child_process";
+
 import { getLogger } from "../../util/logger.js";
 import type { WorkspaceMigration } from "./types.js";
 
 const log = getLogger("workspace-migrations");
 
-const BROKER_WAIT_INTERVAL_MS = 500;
-const BROKER_WAIT_MAX_ATTEMPTS = 10; // 5 seconds total
+// ---------------------------------------------------------------------------
+// Inline macOS Keychain helpers (security CLI)
+//
+// Intentionally duplicated from 015 — each migration must be fully
+// self-contained so it can run independently even if surrounding code changes.
+// ---------------------------------------------------------------------------
+
+const SERVICE_NAME = "vellum-assistant";
+
+function keychainIsAvailable(): boolean {
+  return process.platform === "darwin";
+}
+
+function keychainGet(account: string): string | undefined {
+  try {
+    const stdout = execFileSync(
+      "/usr/bin/security",
+      ["find-generic-password", "-s", SERVICE_NAME, "-a", account, "-w"],
+      { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    return stdout.trim();
+  } catch {
+    return undefined;
+  }
+}
+
+function keychainSet(account: string, value: string): boolean {
+  try {
+    execFileSync(
+      "/usr/bin/security",
+      [
+        "add-generic-password",
+        "-s",
+        SERVICE_NAME,
+        "-a",
+        account,
+        "-w",
+        value,
+        "-U",
+      ],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function keychainDelete(account: string): boolean {
+  try {
+    execFileSync(
+      "/usr/bin/security",
+      ["delete-generic-password", "-s", SERVICE_NAME, "-a", account],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    return true;
+  } catch (err: unknown) {
+    // Item-not-found is acceptable (already deleted)
+    if (
+      err instanceof Error &&
+      "stderr" in err &&
+      typeof (err as { stderr: unknown }).stderr === "string" &&
+      (err as { stderr: string }).stderr.includes("could not be found")
+    ) {
+      return true;
+    }
+    return false;
+  }
+}
+
+function keychainList(): string[] {
+  try {
+    const stdout = execFileSync("/usr/bin/security", ["dump-keychain"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+      maxBuffer: 10 * 1024 * 1024,
+    });
+
+    const blocks = stdout.split('class: "genp"');
+    const accounts: string[] = [];
+
+    for (const block of blocks) {
+      if (!block.includes(`"svce"<blob>="${SERVICE_NAME}"`)) continue;
+      const match = block.match(/"acct"<blob>="([^"]+)"/);
+      if (match) {
+        accounts.push(match[1]);
+      }
+    }
+
+    return accounts;
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Migration
+// ---------------------------------------------------------------------------
 
 export const migrateCredentialsFromKeychainMigration: WorkspaceMigration = {
   id: "016-migrate-credentials-from-keychain",
@@ -21,24 +119,8 @@ export const migrateCredentialsFromKeychainMigration: WorkspaceMigration = {
       return;
     }
 
-    const { createBrokerClient } =
-      await import("../../security/keychain-broker-client.js");
-    const client = createBrokerClient();
-
-    let brokerAvailable = false;
-    for (let i = 0; i < BROKER_WAIT_MAX_ATTEMPTS; i++) {
-      if (client.isAvailable()) {
-        brokerAvailable = true;
-        break;
-      }
-      await new Promise((r) => setTimeout(r, BROKER_WAIT_INTERVAL_MS));
-    }
-
-    if (!brokerAvailable) {
-      throw new Error(
-        "Keychain broker not available after waiting — credential rollback " +
-          "will be retried on next startup",
-      );
+    if (!keychainIsAvailable()) {
+      return;
     }
 
     const { listKeys, getKey, deleteKey } =
@@ -61,13 +143,12 @@ export const migrateCredentialsFromKeychainMigration: WorkspaceMigration = {
         continue;
       }
 
-      const result = await client.set(account, value);
-      if (result.status === "ok") {
+      if (keychainSet(account, value)) {
         deleteKey(account);
         rolledBackCount++;
       } else {
         log.warn(
-          { account, status: result.status },
+          { account },
           "Failed to write key to keychain during rollback — skipping",
         );
         failedCount++;
@@ -89,31 +170,13 @@ export const migrateCredentialsFromKeychainMigration: WorkspaceMigration = {
       return;
     }
 
-    const { createBrokerClient } =
-      await import("../../security/keychain-broker-client.js");
-    const client = createBrokerClient();
-
-    // Wait for the broker to become available (up to 5 seconds), matching
-    // the retry strategy in secure-keys.ts waitForBrokerAvailability().
-    let brokerAvailable = false;
-    for (let i = 0; i < BROKER_WAIT_MAX_ATTEMPTS; i++) {
-      if (client.isAvailable()) {
-        brokerAvailable = true;
-        break;
-      }
-      await new Promise((r) => setTimeout(r, BROKER_WAIT_INTERVAL_MS));
-    }
-
-    if (!brokerAvailable) {
-      throw new Error(
-        "Keychain broker not available after waiting — credential migration " +
-          "will be retried on next startup",
-      );
+    if (!keychainIsAvailable()) {
+      return;
     }
 
     const { setKey } = await import("../../security/encrypted-store.js");
 
-    const accounts = await client.list();
+    const accounts = keychainList();
     if (accounts.length === 0) {
       return;
     }
@@ -122,16 +185,16 @@ export const migrateCredentialsFromKeychainMigration: WorkspaceMigration = {
     let failedCount = 0;
 
     for (const account of accounts) {
-      const result = await client.get(account);
-      if (!result || !result.found || result.value === undefined) {
+      const value = keychainGet(account);
+      if (value === undefined) {
         log.warn({ account }, "Failed to read key from keychain — skipping");
         failedCount++;
         continue;
       }
 
-      const written = setKey(account, result.value);
+      const written = setKey(account, value);
       if (written) {
-        await client.del(account);
+        keychainDelete(account);
         migratedCount++;
       } else {
         log.warn(


### PR DESCRIPTION
## Summary
- Replace keychain broker client dependency in migration 016 with inline helper functions that shell out to macOS security CLI
- Migrations gracefully no-op on non-macOS platforms instead of throwing fatal errors
- Update tests to mock node:child_process instead of the deleted broker client

Part of plan: inline-keychain-security-cli.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
