### PR TITLE
feat: add file-backed remote feature flag store

### DIFF
--- a/gateway/knip.json
+++ b/gateway/knip.json
@@ -1,4 +1,8 @@
 {
-  "entry": ["src/**/*.test.ts", "src/**/__tests__/**/*.ts"],
+  "entry": [
+    "src/**/*.test.ts",
+    "src/**/__tests__/**/*.ts",
+    "src/feature-flag-remote-store.ts"
+  ],
   "project": ["src/**/*.ts"]
 }

--- a/gateway/src/feature-flag-remote-store.ts
+++ b/gateway/src/feature-flag-remote-store.ts
@@ -1,0 +1,119 @@
+/**
+ * Gateway-side remote feature flag store — file-backed persistence of
+ * feature flag values pushed from the platform.
+ *
+ * Mirrors the feature-flag-store.ts pattern: file path resolution via
+ * GATEWAY_SECURITY_DIR (Docker) or ~/.vellum/protected/ (local), atomic
+ * writes (temp file + rename), 0o600 permissions, and module-level caching
+ * with manual invalidation.
+ *
+ * Unlike the local override store, writes replace the *entire* value map at
+ * once (the platform pushes a complete snapshot) and immediately update the
+ * in-memory cache so no file watcher is needed.
+ */
+
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+import { getLogger } from "./logger.js";
+import { getRootDir } from "./credential-reader.js";
+
+const log = getLogger("feature-flag-remote-store");
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface FeatureFlagFileData {
+  version: 1;
+  values: Record<string, boolean>;
+}
+
+// ---------------------------------------------------------------------------
+// File path
+// ---------------------------------------------------------------------------
+
+export function getRemoteFeatureFlagStorePath(): string {
+  const securityDir = process.env.GATEWAY_SECURITY_DIR;
+  if (securityDir) {
+    return join(securityDir, "feature-flags-remote.json");
+  }
+  return join(getRootDir(), "protected", "feature-flags-remote.json");
+}
+
+// ---------------------------------------------------------------------------
+// Disk I/O with caching
+// ---------------------------------------------------------------------------
+
+let cachedRemoteValues: Record<string, boolean> | null = null;
+
+export function readRemoteFeatureFlags(): Record<string, boolean> {
+  if (cachedRemoteValues != null) return cachedRemoteValues;
+
+  const path = getRemoteFeatureFlagStorePath();
+  if (!existsSync(path)) {
+    cachedRemoteValues = {};
+    return cachedRemoteValues;
+  }
+
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const data = JSON.parse(raw) as FeatureFlagFileData;
+
+    if (data.version !== 1) {
+      log.warn(
+        { version: data.version },
+        "Unknown remote feature flag store version, returning empty values",
+      );
+      cachedRemoteValues = {};
+      return cachedRemoteValues;
+    }
+
+    if (
+      data.values &&
+      typeof data.values === "object" &&
+      !Array.isArray(data.values)
+    ) {
+      const filtered: Record<string, boolean> = {};
+      for (const [k, v] of Object.entries(data.values)) {
+        if (typeof v === "boolean") filtered[k] = v;
+      }
+      cachedRemoteValues = filtered;
+    } else {
+      cachedRemoteValues = {};
+    }
+    return cachedRemoteValues;
+  } catch (err) {
+    log.error({ err }, "Failed to load remote feature flag store");
+    cachedRemoteValues = {};
+    return cachedRemoteValues;
+  }
+}
+
+export function writeRemoteFeatureFlags(values: Record<string, boolean>): void {
+  const path = getRemoteFeatureFlagStorePath();
+  const dir = dirname(path);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  const data: FeatureFlagFileData = { version: 1, values };
+  const tmpPath = path + ".tmp." + process.pid;
+  writeFileSync(tmpPath, JSON.stringify(data, null, 2), { mode: 0o600 });
+  renameSync(tmpPath, path);
+  chmodSync(path, 0o600);
+
+  cachedRemoteValues = values;
+  log.info({ count: Object.keys(values).length }, "Wrote remote feature flags");
+}
+
+export function clearRemoteFeatureFlagStoreCache(): void {
+  cachedRemoteValues = null;
+}


### PR DESCRIPTION
## Summary
- Add `gateway/src/feature-flag-remote-store.ts` — a file-backed store for caching remote (platform-pushed) feature flag values
- Mirrors the existing `feature-flag-store.ts` pattern (atomic writes, 0o600 permissions, module-level caching)
- Stores values in `feature-flags-remote.json` separate from local overrides

Part of plan: remote-feature-flag-layer.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
