### PR TITLE
feat: add RemoteFeatureFlagSync lifecycle class

### DIFF
--- a/gateway/knip.json
+++ b/gateway/knip.json
@@ -2,7 +2,8 @@
   "entry": [
     "src/**/*.test.ts",
     "src/**/__tests__/**/*.ts",
-    "src/feature-flag-remote-store.ts"
+    "src/feature-flag-remote-store.ts",
+    "src/remote-feature-flag-sync.ts"
   ],
   "project": ["src/**/*.ts"]
 }

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -1,0 +1,60 @@
+import { loadFeatureFlagDefaults } from "./feature-flag-defaults.js";
+import { writeRemoteFeatureFlags } from "./feature-flag-remote-store.js";
+import { getLogger } from "./logger.js";
+
+const log = getLogger("remote-feature-flag-sync");
+
+/**
+ * Manages the lifecycle of syncing remote feature flags from the platform.
+ *
+ * On start, fetches the current flag state and persists it to disk via the
+ * remote feature flag store. Errors are caught and logged — the system falls
+ * through to registry defaults if this fails.
+ */
+export class RemoteFeatureFlagSync {
+  private started = false;
+
+  // TODO: Replace fetchRemoteFeatureFlags with an SSE EventSource connection
+  // to the platform. On initial connection, the platform sends the full flag
+  // state. On subsequent events, call fetchAndCache() again with the updated
+  // values.
+
+  async start(): Promise<void> {
+    this.started = true;
+
+    try {
+      await this.fetchAndCache();
+    } catch (err) {
+      log.warn({ err }, "Failed to sync remote feature flags");
+    }
+  }
+
+  stop(): void {
+    this.started = false;
+    // TODO: Close SSE EventSource connection here
+  }
+
+  private async fetchAndCache(): Promise<void> {
+    const values = await this.fetchRemoteFeatureFlags();
+    writeRemoteFeatureFlags(values);
+    log.info(
+      { count: Object.keys(values).length },
+      "Synced remote feature flags",
+    );
+  }
+
+  /**
+   * Stub: returns the same values the registry provides so the net effect on
+   * resolution is zero until the real platform SSE replaces this.
+   */
+  private async fetchRemoteFeatureFlags(): Promise<Record<string, boolean>> {
+    log.debug("Fetching remote feature flags (stub)");
+
+    const defaults = loadFeatureFlagDefaults();
+    const result: Record<string, boolean> = {};
+    for (const [key, entry] of Object.entries(defaults)) {
+      result[key] = entry.defaultEnabled;
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `gateway/src/remote-feature-flag-sync.ts` — lifecycle class for syncing remote feature flags from the platform
- Stubbed fetch returns registry defaults for now; TODO comments mark where SSE EventSource will plug in
- Follows the same start/stop pattern as SleepWakeDetector, FeatureFlagWatcher, etc.

Part of plan: remote-feature-flag-layer.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
