### PR TITLE
feat: merge remote flag values into gateway GET response

### DIFF
--- a/gateway/src/__tests__/feature-flags-route.test.ts
+++ b/gateway/src/__tests__/feature-flags-route.test.ts
@@ -18,6 +18,10 @@ const testDir = join(
 const vellumRoot = join(testDir, ".vellum");
 const protectedDir = join(vellumRoot, "protected");
 const featureFlagStorePath = join(protectedDir, "feature-flags.json");
+const remoteFeatureFlagStorePath = join(
+  protectedDir,
+  "feature-flags-remote.json",
+);
 
 // Write the test registry to an isolated temp path so we never touch
 // the committed gateway/src/feature-flag-registry.json file.
@@ -63,6 +67,7 @@ beforeEach(() => {
   _setRegistryCandidateOverrides([defaultsPath]);
   resetFeatureFlagDefaultsCache();
   clearFeatureFlagStoreCache();
+  clearRemoteFeatureFlagStoreCache();
 });
 
 afterEach(() => {
@@ -80,6 +85,7 @@ afterEach(() => {
   _setRegistryCandidateOverrides(null);
   resetFeatureFlagDefaultsCache();
   clearFeatureFlagStoreCache();
+  clearRemoteFeatureFlagStoreCache();
 });
 
 const { createFeatureFlagsGetHandler, createFeatureFlagsPatchHandler } =
@@ -91,6 +97,8 @@ const {
 } = await import("../feature-flag-defaults.js");
 const { clearFeatureFlagStoreCache, readPersistedFeatureFlags } =
   await import("../feature-flag-store.js");
+const { clearRemoteFeatureFlagStoreCache } =
+  await import("../feature-flag-remote-store.js");
 
 describe("GET /v1/feature-flags handler", () => {
   test("returns all declared assistant-scope flags with defaults when no persisted file exists", async () => {
@@ -247,6 +255,120 @@ describe("GET /v1/feature-flags handler", () => {
     // readPersistedFeatureFlags filters out non-boolean values, so the
     // invalid "no" string is dropped and the flag falls back to its
     // registry default (true).
+    const browserFlag = body.flags.find(
+      (f: { key: string }) => f.key === "feature_flags.browser.enabled",
+    );
+    expect(browserFlag).toBeDefined();
+    expect(browserFlag.enabled).toBe(true);
+    expect(browserFlag.defaultEnabled).toBe(true);
+  });
+
+  test("remote values fill in when no local override exists", async () => {
+    // Write a remote store with contacts enabled (overriding registry default of false)
+    writeFileSync(
+      remoteFeatureFlagStorePath,
+      JSON.stringify({
+        version: 1,
+        values: {
+          "feature_flags.contacts.enabled": true,
+        },
+      }),
+    );
+    clearRemoteFeatureFlagStoreCache();
+
+    // No local override for contacts
+    if (existsSync(featureFlagStorePath)) {
+      rmSync(featureFlagStorePath);
+    }
+    clearFeatureFlagStoreCache();
+
+    const handler = createFeatureFlagsGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const contactsFlag = body.flags.find(
+      (f: { key: string }) => f.key === "feature_flags.contacts.enabled",
+    );
+    expect(contactsFlag).toBeDefined();
+    // Remote value (true) overrides registry default (false)
+    expect(contactsFlag.enabled).toBe(true);
+  });
+
+  test("local overrides take precedence over remote values", async () => {
+    // Set remote value to true
+    writeFileSync(
+      remoteFeatureFlagStorePath,
+      JSON.stringify({
+        version: 1,
+        values: {
+          "feature_flags.contacts.enabled": true,
+        },
+      }),
+    );
+    clearRemoteFeatureFlagStoreCache();
+
+    // Set local override to false
+    writeFileSync(
+      featureFlagStorePath,
+      JSON.stringify({
+        version: 1,
+        values: {
+          "feature_flags.contacts.enabled": false,
+        },
+      }),
+    );
+    clearFeatureFlagStoreCache();
+
+    const handler = createFeatureFlagsGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const contactsFlag = body.flags.find(
+      (f: { key: string }) => f.key === "feature_flags.contacts.enabled",
+    );
+    expect(contactsFlag).toBeDefined();
+    // Local override (false) takes precedence over remote (true)
+    expect(contactsFlag.enabled).toBe(false);
+  });
+
+  test("registry default used when neither local nor remote is set", async () => {
+    // No local override
+    if (existsSync(featureFlagStorePath)) {
+      rmSync(featureFlagStorePath);
+    }
+    clearFeatureFlagStoreCache();
+
+    // No remote value (empty remote store)
+    if (existsSync(remoteFeatureFlagStorePath)) {
+      rmSync(remoteFeatureFlagStorePath);
+    }
+    clearRemoteFeatureFlagStoreCache();
+
+    const handler = createFeatureFlagsGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // contacts has defaultEnabled: false in registry
+    const contactsFlag = body.flags.find(
+      (f: { key: string }) => f.key === "feature_flags.contacts.enabled",
+    );
+    expect(contactsFlag).toBeDefined();
+    expect(contactsFlag.enabled).toBe(false);
+    expect(contactsFlag.defaultEnabled).toBe(false);
+
+    // browser has defaultEnabled: true in registry
     const browserFlag = body.flags.find(
       (f: { key: string }) => f.key === "feature_flags.browser.enabled",
     );

--- a/gateway/src/http/routes/feature-flags.ts
+++ b/gateway/src/http/routes/feature-flags.ts
@@ -2,6 +2,7 @@ import {
   loadFeatureFlagDefaults,
   isFlagDeclared,
 } from "../../feature-flag-defaults.js";
+import { readRemoteFeatureFlags } from "../../feature-flag-remote-store.js";
 import {
   readPersistedFeatureFlags,
   writeFeatureFlag,
@@ -30,6 +31,7 @@ export function createFeatureFlagsGetHandler() {
     try {
       const defaults = loadFeatureFlagDefaults();
       const persisted = readPersistedFeatureFlags();
+      const remote = readRemoteFeatureFlags();
 
       // Build entries for ALL declared flags, merging persisted values
       const entries: FeatureFlagEntry[] = [];
@@ -39,7 +41,11 @@ export function createFeatureFlagsGetHandler() {
           key,
           label: def.label,
           enabled:
-            persistedValue !== undefined ? persistedValue : def.defaultEnabled,
+            persistedValue !== undefined
+              ? persistedValue
+              : remote[key] !== undefined
+                ? remote[key]
+                : def.defaultEnabled,
           defaultEnabled: def.defaultEnabled,
           description: def.description,
         });


### PR DESCRIPTION
## Summary
- Update gateway GET `/v1/feature-flags` to include remote flag values in resolution
- Resolution priority: local override > remote value > registry default
- Add tests for three-way resolution priority

Part of plan: remote-feature-flag-layer.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
