### PR TITLE
feat: start/stop RemoteFeatureFlagSync in gateway lifecycle

### DIFF
--- a/gateway/knip.json
+++ b/gateway/knip.json
@@ -1,9 +1,4 @@
 {
-  "entry": [
-    "src/**/*.test.ts",
-    "src/**/__tests__/**/*.ts",
-    "src/feature-flag-remote-store.ts",
-    "src/remote-feature-flag-sync.ts"
-  ],
+  "entry": ["src/**/*.test.ts", "src/**/__tests__/**/*.ts"],
   "project": ["src/**/*.ts"]
 }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -14,6 +14,7 @@ import {
 import { ConfigFileCache } from "./config-file-cache.js";
 import { ConfigFileWatcher } from "./config-file-watcher.js";
 import { FeatureFlagWatcher } from "./feature-flag-watcher.js";
+import { RemoteFeatureFlagSync } from "./remote-feature-flag-sync.js";
 import { loadConfig } from "./config.js";
 import { CredentialCache } from "./credential-cache.js";
 import { credentialKey } from "./credential-key.js";
@@ -1276,6 +1277,9 @@ async function main() {
   const featureFlagWatcher = new FeatureFlagWatcher();
   featureFlagWatcher.start();
 
+  const remoteFeatureFlagSync = new RemoteFeatureFlagSync();
+  remoteFeatureFlagSync.start();
+
   // ── Sleep/wake detection ──
   // Detect system sleep/wake transitions and force-reconnect channels
   // that may have stale connections after the OS suspended the process.
@@ -1307,6 +1311,7 @@ async function main() {
     credentialWatcher.stop();
     configFileWatcher.stop();
     featureFlagWatcher.stop();
+    remoteFeatureFlagSync.stop();
     telegramDedupCache.stopCleanup();
     whatsappDedupCache.stopCleanup();
     if (slackSocketClient) {


### PR DESCRIPTION
## Summary
- Wire `RemoteFeatureFlagSync` into gateway startup (start) and SIGTERM shutdown (stop)
- Remote flags are fetched and cached on startup without blocking the server
- Clean up knip entry points now that the modules are imported transitively

Part of plan: remote-feature-flag-layer.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
