### PR TITLE
feat: "Open in New Window" UI + lifecycle cleanup [JARVIS-340]

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -429,6 +429,8 @@ extension AppDelegate {
         connectionManager.disconnect()
         // Reset dock icon to default before loading the new assistant's avatar
         AvatarAppearanceManager.shared.resetForDisconnect()
+        // Close pop-out thread windows before tearing down the main window
+        threadWindowManager?.closeAll()
         // Close and recreate the main window to reset conversation state
         mainWindow?.close()
         mainWindow = nil
@@ -605,6 +607,7 @@ extension AppDelegate {
         actorTokenBootstrapTask = nil
         ActorTokenManager.deleteToken()
 
+        threadWindowManager?.closeAll()
         mainWindow?.close()
         mainWindow = nil
         conversationBadgeCancellable?.cancel()

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -688,6 +688,10 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             sendReorderConversations()
         }
 
+        // Close any pop-out window for this conversation before releasing the VM.
+        AppDelegate.shared?.threadWindowManager?.closeThread(conversationLocalId: id)
+        pinnedViewModelIds.remove(id)
+
         if let conversationId = conversations[index].conversationId {
             chatViewModels[id]?.stopGenerating()
             var archived = archivedConversationIds

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
@@ -56,6 +56,7 @@ struct ConversationActionsDrawer: View {
     let onUnpin: () -> Void
     let onArchive: () -> Void
     let onRename: () -> Void
+    var onOpenInNewWindow: (() -> Void)? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -65,6 +66,10 @@ struct ConversationActionsDrawer: View {
 
             if presentation.showsForkConversationAction {
                 SidebarPrimaryRow(icon: VIcon.gitBranch.rawValue, label: "Fork conversation", action: onForkConversation)
+            }
+
+            if let onOpenInNewWindow {
+                SidebarPrimaryRow(icon: VIcon.externalLink.rawValue, label: "Open in new window", action: onOpenInNewWindow)
             }
 
             SidebarPrimaryRow(

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -193,6 +193,12 @@ extension MainWindowView {
                 sidebar.draggingConversationId = conversation.id
                 sidebar.isHoveredConversation = nil
             },
+            onOpenInNewWindow: conversation.conversationId != nil ? {
+                AppDelegate.shared?.threadWindowManager?.openThread(
+                    conversationLocalId: conversation.id,
+                    conversationManager: conversationManager
+                )
+            } : nil,
             onShowFeedback: conversation.conversationId != nil && !LogExporter.isManagedAssistant ? {
                 AppDelegate.shared?.showLogReportWindow(scope: .conversation(conversationId: conversation.conversationId!, conversationTitle: conversation.title))
             } : nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1176,7 +1176,15 @@ struct MainWindowView: View {
                     conversationManager.archiveConversation(id: id)
                     dismissConversationDrawer()
                 },
-                onRename: { startRenameActiveConversation(); dismissConversationDrawer() }
+                onRename: { startRenameActiveConversation(); dismissConversationDrawer() },
+                onOpenInNewWindow: conversationManager.activeConversation?.conversationId != nil ? {
+                    guard let id = conversationManager.activeConversationId else { return }
+                    AppDelegate.shared?.threadWindowManager?.openThread(
+                        conversationLocalId: id,
+                        conversationManager: conversationManager
+                    )
+                    dismissConversationDrawer()
+                } : nil
             )
             .offset(x: conversationTitleFrame.minX, y: conversationTitleFrame.maxY)
             .zIndex(10)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -24,6 +24,7 @@ struct SidebarConversationItem: View, Equatable {
     var onMarkUnread: () -> Void
     var onHoverChange: (Bool) -> Void
     var onDragStart: () -> Void
+    var onOpenInNewWindow: (() -> Void)?
     var onShowFeedback: (() -> Void)?
 
     static func == (lhs: SidebarConversationItem, rhs: SidebarConversationItem) -> Bool {
@@ -193,6 +194,14 @@ struct SidebarConversationItem: View, Equatable {
                 Label { Text("Mark as unread") } icon: { VIconView(.circle, size: 14) }
             }
             .disabled(!canMarkUnread)
+
+            if let onOpenInNewWindow {
+                Button {
+                    onOpenInNewWindow()
+                } label: {
+                    Label { Text("Open in New Window") } icon: { VIconView(.externalLink, size: 14) }
+                }
+            }
 
             Divider()
 


### PR DESCRIPTION
## Summary
- Adds **"Open in New Window"** to the sidebar conversation context menu (right-click)
- Adds **"Open in new window"** to the conversation title actions drawer (top-left dropdown)
- Closes pop-out windows on **conversation archive**, **logout**, and **assistant switch**
- Menu item only appears for conversations with a daemon-assigned conversation ID (new/unsaved conversations can't be popped out)

This completes the thread pop-out feature started in #21129 and refined in #21131.

## Test plan
- [x] macOS build passes
- [x] All 148 tests pass
- [ ] Manual: right-click a conversation in sidebar → "Open in New Window" → opens pop-out
- [ ] Manual: click conversation title dropdown → "Open in new window" → opens pop-out
- [ ] Manual: archive a conversation with an open pop-out → pop-out closes
- [ ] Manual: logout → all pop-outs close
- [ ] Manual: new conversations (no messages sent yet) don't show the menu item

Closes JARVIS-340

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
