### PR TITLE
fix: address review gaps in remote feature flag layer

### DIFF
--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -339,6 +339,7 @@ export function _setOverridesForTesting(
   overrides: Record<string, boolean>,
 ): void {
   cachedOverrides = { ...overrides };
+  cachedRemoteValues = null;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -158,6 +158,10 @@ export class ConfigWatcher {
         clearFeatureFlagOverridesCache();
         onConversationEvict();
       },
+      "feature-flags-remote.json": () => {
+        clearFeatureFlagOverridesCache();
+        onConversationEvict();
+      },
       "secret-allowlist.json": () => {
         resetAllowlist();
         try {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1278,7 +1278,9 @@ async function main() {
   featureFlagWatcher.start();
 
   const remoteFeatureFlagSync = new RemoteFeatureFlagSync();
-  remoteFeatureFlagSync.start();
+  // Intentionally fire-and-forget: remote flag fetch is best-effort;
+  // the gateway continues with registry defaults if it fails.
+  void remoteFeatureFlagSync.start();
 
   // ── Sleep/wake detection ──
   // Detect system sleep/wake transitions and force-reconnect channels


### PR DESCRIPTION
## Summary
- Add `feature-flags-remote.json` handler to daemon config watcher for cache invalidation
- Clear `cachedRemoteValues` in `_setOverridesForTesting()` for clean test isolation
- Mark `remoteFeatureFlagSync.start()` as explicitly fire-and-forget with `void` prefix

Fixes review gaps from plan: remote-feature-flag-layer.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
