### PR TITLE
revert: "Open in New Window" UI (#21141) — needs manual testing first

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -429,8 +429,6 @@ extension AppDelegate {
         connectionManager.disconnect()
         // Reset dock icon to default before loading the new assistant's avatar
         AvatarAppearanceManager.shared.resetForDisconnect()
-        // Close pop-out thread windows before tearing down the main window
-        threadWindowManager?.closeAll()
         // Close and recreate the main window to reset conversation state
         mainWindow?.close()
         mainWindow = nil
@@ -607,7 +605,6 @@ extension AppDelegate {
         actorTokenBootstrapTask = nil
         ActorTokenManager.deleteToken()
 
-        threadWindowManager?.closeAll()
         mainWindow?.close()
         mainWindow = nil
         conversationBadgeCancellable?.cancel()

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -688,10 +688,6 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             sendReorderConversations()
         }
 
-        // Close any pop-out window for this conversation before releasing the VM.
-        AppDelegate.shared?.threadWindowManager?.closeThread(conversationLocalId: id)
-        pinnedViewModelIds.remove(id)
-
         if let conversationId = conversations[index].conversationId {
             chatViewModels[id]?.stopGenerating()
             var archived = archivedConversationIds

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
@@ -56,7 +56,6 @@ struct ConversationActionsDrawer: View {
     let onUnpin: () -> Void
     let onArchive: () -> Void
     let onRename: () -> Void
-    var onOpenInNewWindow: (() -> Void)? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -66,10 +65,6 @@ struct ConversationActionsDrawer: View {
 
             if presentation.showsForkConversationAction {
                 SidebarPrimaryRow(icon: VIcon.gitBranch.rawValue, label: "Fork conversation", action: onForkConversation)
-            }
-
-            if let onOpenInNewWindow {
-                SidebarPrimaryRow(icon: VIcon.externalLink.rawValue, label: "Open in new window", action: onOpenInNewWindow)
             }
 
             SidebarPrimaryRow(

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -193,12 +193,6 @@ extension MainWindowView {
                 sidebar.draggingConversationId = conversation.id
                 sidebar.isHoveredConversation = nil
             },
-            onOpenInNewWindow: conversation.conversationId != nil ? {
-                AppDelegate.shared?.threadWindowManager?.openThread(
-                    conversationLocalId: conversation.id,
-                    conversationManager: conversationManager
-                )
-            } : nil,
             onShowFeedback: conversation.conversationId != nil && !LogExporter.isManagedAssistant ? {
                 AppDelegate.shared?.showLogReportWindow(scope: .conversation(conversationId: conversation.conversationId!, conversationTitle: conversation.title))
             } : nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1176,15 +1176,7 @@ struct MainWindowView: View {
                     conversationManager.archiveConversation(id: id)
                     dismissConversationDrawer()
                 },
-                onRename: { startRenameActiveConversation(); dismissConversationDrawer() },
-                onOpenInNewWindow: conversationManager.activeConversation?.conversationId != nil ? {
-                    guard let id = conversationManager.activeConversationId else { return }
-                    AppDelegate.shared?.threadWindowManager?.openThread(
-                        conversationLocalId: id,
-                        conversationManager: conversationManager
-                    )
-                    dismissConversationDrawer()
-                } : nil
+                onRename: { startRenameActiveConversation(); dismissConversationDrawer() }
             )
             .offset(x: conversationTitleFrame.minX, y: conversationTitleFrame.maxY)
             .zIndex(10)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -24,7 +24,6 @@ struct SidebarConversationItem: View, Equatable {
     var onMarkUnread: () -> Void
     var onHoverChange: (Bool) -> Void
     var onDragStart: () -> Void
-    var onOpenInNewWindow: (() -> Void)?
     var onShowFeedback: (() -> Void)?
 
     static func == (lhs: SidebarConversationItem, rhs: SidebarConversationItem) -> Bool {
@@ -194,14 +193,6 @@ struct SidebarConversationItem: View, Equatable {
                 Label { Text("Mark as unread") } icon: { VIconView(.circle, size: 14) }
             }
             .disabled(!canMarkUnread)
-
-            if let onOpenInNewWindow {
-                Button {
-                    onOpenInNewWindow()
-                } label: {
-                    Label { Text("Open in New Window") } icon: { VIconView(.externalLink, size: 14) }
-                }
-            }
 
             Divider()
 


### PR DESCRIPTION
Reverts #21141 so the feature can be tested locally before merging to main.

The original PR will be re-opened for review after local testing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
