### PR TITLE
feat: add remote feature flag layer with platform sync stub

### DIFF
--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -7,8 +7,11 @@
  * (in priority order):
  *   1. Override values from `~/.vellum/protected/feature-flags.json` (local)
  *      or via the gateway HTTP API (Docker/containerized)
- *   2. defaults registry `defaultEnabled`         (for declared keys)
- *   3. `true`                                     (for undeclared keys)
+ *   2. Remote values from `feature-flags-remote.json` (platform-pushed,
+ *      cached locally; only used in local mode — containerized mode gets
+ *      remote values via the gateway)
+ *   3. defaults registry `defaultEnabled`         (for declared keys)
+ *   4. `true`                                     (for undeclared keys)
  *
  * Key format:
  *   Canonical:  `feature_flags.<id>.enabled`
@@ -260,14 +263,68 @@ function loadOverrides(): Record<string, boolean> {
   return cachedOverrides;
 }
 
+// ---------------------------------------------------------------------------
+// Remote values — platform-pushed flags cached in a local JSON file
+// ---------------------------------------------------------------------------
+
 /**
- * Invalidate the cached override values so the next call to
+ * Module-level cache of remote feature flag values. Populated lazily on
+ * first access, invalidated by `clearFeatureFlagOverridesCache()`.
+ */
+let cachedRemoteValues: Record<string, boolean> | null = null;
+
+/**
+ * Load remote flag values from the `feature-flags-remote.json` file that
+ * lives alongside the local overrides file. Returns an empty record if the
+ * file doesn't exist or is malformed.
+ *
+ * In containerized mode, this file won't exist — the gateway already merges
+ * remote values into its response — so we'll harmlessly return `{}`.
+ */
+function loadRemoteValuesFromFile(): Record<string, boolean> {
+  const overridesPath = getFeatureFlagOverridesPath();
+  const remotePath = join(dirname(overridesPath), "feature-flags-remote.json");
+  if (!existsSync(remotePath)) return {};
+
+  try {
+    const raw = readFileSync(remotePath, "utf-8");
+    const data = JSON.parse(raw) as FeatureFlagFileData;
+    if (data.version !== 1) return {};
+    if (
+      data.values &&
+      typeof data.values === "object" &&
+      !Array.isArray(data.values)
+    ) {
+      const filtered: Record<string, boolean> = {};
+      for (const [k, v] of Object.entries(data.values)) {
+        if (typeof v === "boolean") filtered[k] = v;
+      }
+      return filtered;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Load remote values with module-level caching.
+ */
+function loadRemoteValues(): Record<string, boolean> {
+  if (cachedRemoteValues != null) return cachedRemoteValues;
+  cachedRemoteValues = loadRemoteValuesFromFile();
+  return cachedRemoteValues;
+}
+
+/**
+ * Invalidate the cached override and remote values so the next call to
  * `isAssistantFeatureFlagEnabled` re-reads from the source.
  *
  * Called by the config watcher when the feature-flags file changes.
  */
 export function clearFeatureFlagOverridesCache(): void {
   cachedOverrides = null;
+  cachedRemoteValues = null;
 }
 
 /**
@@ -294,8 +351,10 @@ export function _setOverridesForTesting(
  * Resolution order:
  *   1. Override from `~/.vellum/protected/feature-flags.json` (local) or
  *      gateway HTTP (Docker/containerized)
- *   2. defaults registry `defaultEnabled`         (for declared assistant-scope keys)
- *   3. `true`                                     (for undeclared keys with no override)
+ *   2. Remote value from `feature-flags-remote.json` (platform-pushed,
+ *      cached locally)
+ *   3. defaults registry `defaultEnabled`         (for declared assistant-scope keys)
+ *   4. `true`                                     (for undeclared keys with no override)
  */
 export function isAssistantFeatureFlagEnabled(
   key: string,
@@ -309,12 +368,15 @@ export function isAssistantFeatureFlagEnabled(
   const explicit = overrides[key];
   if (typeof explicit === "boolean") return explicit;
 
-  // 2. For declared keys, use the registry default
-  if (declared) {
-    return declared.defaultEnabled;
-  }
+  // 2. Check remote values (platform-pushed, cached locally)
+  const remote = loadRemoteValues();
+  const remoteValue = remote[key];
+  if (typeof remoteValue === "boolean") return remoteValue;
 
-  // 3. Undeclared keys with no persisted override default to enabled
+  // 3. For declared keys, use the registry default
+  if (declared) return declared.defaultEnabled;
+
+  // 4. Undeclared keys with no persisted override default to enabled
   return true;
 }
 

--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -339,6 +339,7 @@ export function _setOverridesForTesting(
   overrides: Record<string, boolean>,
 ): void {
   cachedOverrides = { ...overrides };
+  cachedRemoteValues = null;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -158,6 +158,10 @@ export class ConfigWatcher {
         clearFeatureFlagOverridesCache();
         onConversationEvict();
       },
+      "feature-flags-remote.json": () => {
+        clearFeatureFlagOverridesCache();
+        onConversationEvict();
+      },
       "secret-allowlist.json": () => {
         resetAllowlist();
         try {

--- a/clients/macos/vellum-assistant/Services/AssistantFeatureFlagResolver.swift
+++ b/clients/macos/vellum-assistant/Services/AssistantFeatureFlagResolver.swift
@@ -30,6 +30,18 @@ enum AssistantFeatureFlagResolver {
         return "\(home)/.vellum/protected/feature-flags.json"
     }()
 
+    // MARK: - Remote feature-flags file path
+
+    /// Resolves the path to the remote feature-flags cache file, stored alongside
+    /// the local overrides file as `feature-flags-remote.json`.
+    static func resolvedRemoteFlagsPath() -> String {
+        let localPath = resolvedFeatureFlagsPath()
+        return URL(fileURLWithPath: localPath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("feature-flags-remote.json")
+            .path
+    }
+
     // MARK: - Protected file I/O
 
     /// Reads persisted feature-flag overrides from the protected file.
@@ -38,6 +50,29 @@ enum AssistantFeatureFlagResolver {
     /// malformed JSON, or lacks a `values` object.
     static func readPersistedFlags(from path: String? = nil) -> [String: Bool] {
         let filePath = path ?? resolvedFeatureFlagsPath()
+
+        guard FileManager.default.fileExists(atPath: filePath),
+              let data = FileManager.default.contents(atPath: filePath),
+              !data.isEmpty else {
+            return [:]
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data, options: []),
+              let dict = json as? [String: Any],
+              dict["version"] as? Int == 1,
+              let values = dict["values"] as? [String: Bool] else {
+            return [:]
+        }
+
+        return values
+    }
+
+    /// Reads remote feature-flag values from the cached remote file.
+    ///
+    /// Returns an empty dictionary when the file is missing, empty, contains
+    /// malformed JSON, or lacks a `values` object.
+    static func readRemoteFlags(from path: String? = nil) -> [String: Bool] {
+        let filePath = path ?? resolvedRemoteFlagsPath()
 
         guard FileManager.default.fileExists(atPath: filePath),
               let data = FileManager.default.contents(atPath: filePath),
@@ -75,8 +110,12 @@ enum AssistantFeatureFlagResolver {
     static func resolvedFlags(
         registryDefaults: [String: Bool]
     ) -> [String: Bool] {
+        let remote = readRemoteFlags()
         let persistedFlags = readPersistedFlags()
-        return resolvedFlags(persistedFlags: persistedFlags, registryDefaults: registryDefaults)
+        // Priority: persisted > remote > defaults
+        return registryDefaults
+            .merging(remote) { _, remote in remote }
+            .merging(persistedFlags) { _, persisted in persisted }
     }
 
     static func resolvedFlags(

--- a/gateway/knip.json
+++ b/gateway/knip.json
@@ -1,9 +1,4 @@
 {
-  "entry": [
-    "src/**/*.test.ts",
-    "src/**/__tests__/**/*.ts",
-    "src/feature-flag-remote-store.ts",
-    "src/remote-feature-flag-sync.ts"
-  ],
+  "entry": ["src/**/*.test.ts", "src/**/__tests__/**/*.ts"],
   "project": ["src/**/*.ts"]
 }

--- a/gateway/knip.json
+++ b/gateway/knip.json
@@ -2,7 +2,8 @@
   "entry": [
     "src/**/*.test.ts",
     "src/**/__tests__/**/*.ts",
-    "src/feature-flag-remote-store.ts"
+    "src/feature-flag-remote-store.ts",
+    "src/remote-feature-flag-sync.ts"
   ],
   "project": ["src/**/*.ts"]
 }

--- a/gateway/knip.json
+++ b/gateway/knip.json
@@ -1,4 +1,8 @@
 {
-  "entry": ["src/**/*.test.ts", "src/**/__tests__/**/*.ts"],
+  "entry": [
+    "src/**/*.test.ts",
+    "src/**/__tests__/**/*.ts",
+    "src/feature-flag-remote-store.ts"
+  ],
   "project": ["src/**/*.ts"]
 }

--- a/gateway/src/__tests__/feature-flags-route.test.ts
+++ b/gateway/src/__tests__/feature-flags-route.test.ts
@@ -18,6 +18,10 @@ const testDir = join(
 const vellumRoot = join(testDir, ".vellum");
 const protectedDir = join(vellumRoot, "protected");
 const featureFlagStorePath = join(protectedDir, "feature-flags.json");
+const remoteFeatureFlagStorePath = join(
+  protectedDir,
+  "feature-flags-remote.json",
+);
 
 // Write the test registry to an isolated temp path so we never touch
 // the committed gateway/src/feature-flag-registry.json file.
@@ -63,6 +67,7 @@ beforeEach(() => {
   _setRegistryCandidateOverrides([defaultsPath]);
   resetFeatureFlagDefaultsCache();
   clearFeatureFlagStoreCache();
+  clearRemoteFeatureFlagStoreCache();
 });
 
 afterEach(() => {
@@ -80,6 +85,7 @@ afterEach(() => {
   _setRegistryCandidateOverrides(null);
   resetFeatureFlagDefaultsCache();
   clearFeatureFlagStoreCache();
+  clearRemoteFeatureFlagStoreCache();
 });
 
 const { createFeatureFlagsGetHandler, createFeatureFlagsPatchHandler } =
@@ -91,6 +97,8 @@ const {
 } = await import("../feature-flag-defaults.js");
 const { clearFeatureFlagStoreCache, readPersistedFeatureFlags } =
   await import("../feature-flag-store.js");
+const { clearRemoteFeatureFlagStoreCache } =
+  await import("../feature-flag-remote-store.js");
 
 describe("GET /v1/feature-flags handler", () => {
   test("returns all declared assistant-scope flags with defaults when no persisted file exists", async () => {
@@ -247,6 +255,120 @@ describe("GET /v1/feature-flags handler", () => {
     // readPersistedFeatureFlags filters out non-boolean values, so the
     // invalid "no" string is dropped and the flag falls back to its
     // registry default (true).
+    const browserFlag = body.flags.find(
+      (f: { key: string }) => f.key === "feature_flags.browser.enabled",
+    );
+    expect(browserFlag).toBeDefined();
+    expect(browserFlag.enabled).toBe(true);
+    expect(browserFlag.defaultEnabled).toBe(true);
+  });
+
+  test("remote values fill in when no local override exists", async () => {
+    // Write a remote store with contacts enabled (overriding registry default of false)
+    writeFileSync(
+      remoteFeatureFlagStorePath,
+      JSON.stringify({
+        version: 1,
+        values: {
+          "feature_flags.contacts.enabled": true,
+        },
+      }),
+    );
+    clearRemoteFeatureFlagStoreCache();
+
+    // No local override for contacts
+    if (existsSync(featureFlagStorePath)) {
+      rmSync(featureFlagStorePath);
+    }
+    clearFeatureFlagStoreCache();
+
+    const handler = createFeatureFlagsGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const contactsFlag = body.flags.find(
+      (f: { key: string }) => f.key === "feature_flags.contacts.enabled",
+    );
+    expect(contactsFlag).toBeDefined();
+    // Remote value (true) overrides registry default (false)
+    expect(contactsFlag.enabled).toBe(true);
+  });
+
+  test("local overrides take precedence over remote values", async () => {
+    // Set remote value to true
+    writeFileSync(
+      remoteFeatureFlagStorePath,
+      JSON.stringify({
+        version: 1,
+        values: {
+          "feature_flags.contacts.enabled": true,
+        },
+      }),
+    );
+    clearRemoteFeatureFlagStoreCache();
+
+    // Set local override to false
+    writeFileSync(
+      featureFlagStorePath,
+      JSON.stringify({
+        version: 1,
+        values: {
+          "feature_flags.contacts.enabled": false,
+        },
+      }),
+    );
+    clearFeatureFlagStoreCache();
+
+    const handler = createFeatureFlagsGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const contactsFlag = body.flags.find(
+      (f: { key: string }) => f.key === "feature_flags.contacts.enabled",
+    );
+    expect(contactsFlag).toBeDefined();
+    // Local override (false) takes precedence over remote (true)
+    expect(contactsFlag.enabled).toBe(false);
+  });
+
+  test("registry default used when neither local nor remote is set", async () => {
+    // No local override
+    if (existsSync(featureFlagStorePath)) {
+      rmSync(featureFlagStorePath);
+    }
+    clearFeatureFlagStoreCache();
+
+    // No remote value (empty remote store)
+    if (existsSync(remoteFeatureFlagStorePath)) {
+      rmSync(remoteFeatureFlagStorePath);
+    }
+    clearRemoteFeatureFlagStoreCache();
+
+    const handler = createFeatureFlagsGetHandler();
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // contacts has defaultEnabled: false in registry
+    const contactsFlag = body.flags.find(
+      (f: { key: string }) => f.key === "feature_flags.contacts.enabled",
+    );
+    expect(contactsFlag).toBeDefined();
+    expect(contactsFlag.enabled).toBe(false);
+    expect(contactsFlag.defaultEnabled).toBe(false);
+
+    // browser has defaultEnabled: true in registry
     const browserFlag = body.flags.find(
       (f: { key: string }) => f.key === "feature_flags.browser.enabled",
     );

--- a/gateway/src/feature-flag-remote-store.ts
+++ b/gateway/src/feature-flag-remote-store.ts
@@ -1,0 +1,119 @@
+/**
+ * Gateway-side remote feature flag store — file-backed persistence of
+ * feature flag values pushed from the platform.
+ *
+ * Mirrors the feature-flag-store.ts pattern: file path resolution via
+ * GATEWAY_SECURITY_DIR (Docker) or ~/.vellum/protected/ (local), atomic
+ * writes (temp file + rename), 0o600 permissions, and module-level caching
+ * with manual invalidation.
+ *
+ * Unlike the local override store, writes replace the *entire* value map at
+ * once (the platform pushes a complete snapshot) and immediately update the
+ * in-memory cache so no file watcher is needed.
+ */
+
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+import { getLogger } from "./logger.js";
+import { getRootDir } from "./credential-reader.js";
+
+const log = getLogger("feature-flag-remote-store");
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface FeatureFlagFileData {
+  version: 1;
+  values: Record<string, boolean>;
+}
+
+// ---------------------------------------------------------------------------
+// File path
+// ---------------------------------------------------------------------------
+
+export function getRemoteFeatureFlagStorePath(): string {
+  const securityDir = process.env.GATEWAY_SECURITY_DIR;
+  if (securityDir) {
+    return join(securityDir, "feature-flags-remote.json");
+  }
+  return join(getRootDir(), "protected", "feature-flags-remote.json");
+}
+
+// ---------------------------------------------------------------------------
+// Disk I/O with caching
+// ---------------------------------------------------------------------------
+
+let cachedRemoteValues: Record<string, boolean> | null = null;
+
+export function readRemoteFeatureFlags(): Record<string, boolean> {
+  if (cachedRemoteValues != null) return cachedRemoteValues;
+
+  const path = getRemoteFeatureFlagStorePath();
+  if (!existsSync(path)) {
+    cachedRemoteValues = {};
+    return cachedRemoteValues;
+  }
+
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const data = JSON.parse(raw) as FeatureFlagFileData;
+
+    if (data.version !== 1) {
+      log.warn(
+        { version: data.version },
+        "Unknown remote feature flag store version, returning empty values",
+      );
+      cachedRemoteValues = {};
+      return cachedRemoteValues;
+    }
+
+    if (
+      data.values &&
+      typeof data.values === "object" &&
+      !Array.isArray(data.values)
+    ) {
+      const filtered: Record<string, boolean> = {};
+      for (const [k, v] of Object.entries(data.values)) {
+        if (typeof v === "boolean") filtered[k] = v;
+      }
+      cachedRemoteValues = filtered;
+    } else {
+      cachedRemoteValues = {};
+    }
+    return cachedRemoteValues;
+  } catch (err) {
+    log.error({ err }, "Failed to load remote feature flag store");
+    cachedRemoteValues = {};
+    return cachedRemoteValues;
+  }
+}
+
+export function writeRemoteFeatureFlags(values: Record<string, boolean>): void {
+  const path = getRemoteFeatureFlagStorePath();
+  const dir = dirname(path);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  const data: FeatureFlagFileData = { version: 1, values };
+  const tmpPath = path + ".tmp." + process.pid;
+  writeFileSync(tmpPath, JSON.stringify(data, null, 2), { mode: 0o600 });
+  renameSync(tmpPath, path);
+  chmodSync(path, 0o600);
+
+  cachedRemoteValues = values;
+  log.info({ count: Object.keys(values).length }, "Wrote remote feature flags");
+}
+
+export function clearRemoteFeatureFlagStoreCache(): void {
+  cachedRemoteValues = null;
+}

--- a/gateway/src/http/routes/feature-flags.ts
+++ b/gateway/src/http/routes/feature-flags.ts
@@ -2,6 +2,7 @@ import {
   loadFeatureFlagDefaults,
   isFlagDeclared,
 } from "../../feature-flag-defaults.js";
+import { readRemoteFeatureFlags } from "../../feature-flag-remote-store.js";
 import {
   readPersistedFeatureFlags,
   writeFeatureFlag,
@@ -30,6 +31,7 @@ export function createFeatureFlagsGetHandler() {
     try {
       const defaults = loadFeatureFlagDefaults();
       const persisted = readPersistedFeatureFlags();
+      const remote = readRemoteFeatureFlags();
 
       // Build entries for ALL declared flags, merging persisted values
       const entries: FeatureFlagEntry[] = [];
@@ -39,7 +41,11 @@ export function createFeatureFlagsGetHandler() {
           key,
           label: def.label,
           enabled:
-            persistedValue !== undefined ? persistedValue : def.defaultEnabled,
+            persistedValue !== undefined
+              ? persistedValue
+              : remote[key] !== undefined
+                ? remote[key]
+                : def.defaultEnabled,
           defaultEnabled: def.defaultEnabled,
           description: def.description,
         });

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -14,6 +14,7 @@ import {
 import { ConfigFileCache } from "./config-file-cache.js";
 import { ConfigFileWatcher } from "./config-file-watcher.js";
 import { FeatureFlagWatcher } from "./feature-flag-watcher.js";
+import { RemoteFeatureFlagSync } from "./remote-feature-flag-sync.js";
 import { loadConfig } from "./config.js";
 import { CredentialCache } from "./credential-cache.js";
 import { credentialKey } from "./credential-key.js";
@@ -1276,6 +1277,9 @@ async function main() {
   const featureFlagWatcher = new FeatureFlagWatcher();
   featureFlagWatcher.start();
 
+  const remoteFeatureFlagSync = new RemoteFeatureFlagSync();
+  remoteFeatureFlagSync.start();
+
   // ── Sleep/wake detection ──
   // Detect system sleep/wake transitions and force-reconnect channels
   // that may have stale connections after the OS suspended the process.
@@ -1307,6 +1311,7 @@ async function main() {
     credentialWatcher.stop();
     configFileWatcher.stop();
     featureFlagWatcher.stop();
+    remoteFeatureFlagSync.stop();
     telegramDedupCache.stopCleanup();
     whatsappDedupCache.stopCleanup();
     if (slackSocketClient) {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1278,7 +1278,9 @@ async function main() {
   featureFlagWatcher.start();
 
   const remoteFeatureFlagSync = new RemoteFeatureFlagSync();
-  remoteFeatureFlagSync.start();
+  // Intentionally fire-and-forget: remote flag fetch is best-effort;
+  // the gateway continues with registry defaults if it fails.
+  void remoteFeatureFlagSync.start();
 
   // ── Sleep/wake detection ──
   // Detect system sleep/wake transitions and force-reconnect channels

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -1,0 +1,60 @@
+import { loadFeatureFlagDefaults } from "./feature-flag-defaults.js";
+import { writeRemoteFeatureFlags } from "./feature-flag-remote-store.js";
+import { getLogger } from "./logger.js";
+
+const log = getLogger("remote-feature-flag-sync");
+
+/**
+ * Manages the lifecycle of syncing remote feature flags from the platform.
+ *
+ * On start, fetches the current flag state and persists it to disk via the
+ * remote feature flag store. Errors are caught and logged — the system falls
+ * through to registry defaults if this fails.
+ */
+export class RemoteFeatureFlagSync {
+  private started = false;
+
+  // TODO: Replace fetchRemoteFeatureFlags with an SSE EventSource connection
+  // to the platform. On initial connection, the platform sends the full flag
+  // state. On subsequent events, call fetchAndCache() again with the updated
+  // values.
+
+  async start(): Promise<void> {
+    this.started = true;
+
+    try {
+      await this.fetchAndCache();
+    } catch (err) {
+      log.warn({ err }, "Failed to sync remote feature flags");
+    }
+  }
+
+  stop(): void {
+    this.started = false;
+    // TODO: Close SSE EventSource connection here
+  }
+
+  private async fetchAndCache(): Promise<void> {
+    const values = await this.fetchRemoteFeatureFlags();
+    writeRemoteFeatureFlags(values);
+    log.info(
+      { count: Object.keys(values).length },
+      "Synced remote feature flags",
+    );
+  }
+
+  /**
+   * Stub: returns the same values the registry provides so the net effect on
+   * resolution is zero until the real platform SSE replaces this.
+   */
+  private async fetchRemoteFeatureFlags(): Promise<Record<string, boolean>> {
+    log.debug("Fetching remote feature flags (stub)");
+
+    const defaults = loadFeatureFlagDefaults();
+    const result: Record<string, boolean> = {};
+    for (const [key, entry] of Object.entries(defaults)) {
+      result[key] = entry.defaultEnabled;
+    }
+    return result;
+  }
+}

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -5,19 +5,33 @@ import { getLogger } from "./logger.js";
 const log = getLogger("remote-feature-flag-sync");
 
 /**
+ * Default polling interval: 5 minutes.
+ *
+ * Configurable via `REMOTE_FF_POLL_INTERVAL_MS` env var for testing or
+ * deployment tuning.
+ */
+const DEFAULT_POLL_INTERVAL_MS = 5 * 60 * 1000;
+
+function getPollIntervalMs(): number {
+  const envVal = process.env.REMOTE_FF_POLL_INTERVAL_MS;
+  if (envVal) {
+    const parsed = parseInt(envVal, 10);
+    if (!isNaN(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_POLL_INTERVAL_MS;
+}
+
+/**
  * Manages the lifecycle of syncing remote feature flags from the platform.
  *
  * On start, fetches the current flag state and persists it to disk via the
- * remote feature flag store. Errors are caught and logged — the system falls
- * through to registry defaults if this fails.
+ * remote feature flag store, then polls on a configurable interval. Errors
+ * are caught and logged — the system falls through to registry defaults if
+ * this fails.
  */
 export class RemoteFeatureFlagSync {
   private started = false;
-
-  // TODO: Replace fetchRemoteFeatureFlags with an SSE EventSource connection
-  // to the platform. On initial connection, the platform sends the full flag
-  // state. On subsequent events, call fetchAndCache() again with the updated
-  // values.
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
 
   async start(): Promise<void> {
     this.started = true;
@@ -25,13 +39,29 @@ export class RemoteFeatureFlagSync {
     try {
       await this.fetchAndCache();
     } catch (err) {
-      log.warn({ err }, "Failed to sync remote feature flags");
+      log.warn({ err }, "Failed to sync remote feature flags on startup");
     }
+
+    // TODO: Replace stub fetch with real platform API call to
+    // GET ${VELLUM_PLATFORM_URL}/v1/feature-flags (or similar).
+    // The poll interval ensures the gateway picks up flag changes
+    // without requiring a restart.
+    const intervalMs = getPollIntervalMs();
+    this.pollTimer = setInterval(() => {
+      this.fetchAndCache().catch((err) => {
+        log.warn({ err }, "Failed to sync remote feature flags during poll");
+      });
+    }, intervalMs);
+
+    log.info({ intervalMs }, "Remote feature flag polling started");
   }
 
   stop(): void {
     this.started = false;
-    // TODO: Close SSE EventSource connection here
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
   }
 
   private async fetchAndCache(): Promise<void> {
@@ -45,7 +75,7 @@ export class RemoteFeatureFlagSync {
 
   /**
    * Stub: returns the same values the registry provides so the net effect on
-   * resolution is zero until the real platform SSE replaces this.
+   * resolution is zero until the real platform API replaces this.
    */
   private async fetchRemoteFeatureFlags(): Promise<Record<string, boolean>> {
     log.debug("Fetching remote feature flags (stub)");


### PR DESCRIPTION
## Summary
Add a "remote" feature flag layer to the gateway that syncs flag values from the platform, caches them in a separate file (`feature-flags-remote.json`), and integrates them into the existing resolution chain between local overrides and registry defaults. A `RemoteFeatureFlagSync` lifecycle class manages the connection — on startup it fetches the initial state and writes it to disk; the real platform SSE push will replace the stub later.

Resolution priority everywhere: **local override > remote value > registry default**

## PRs merged into feature branch
- #21134: feat: add file-backed remote feature flag store
- #21135: feat: add RemoteFeatureFlagSync lifecycle class
- #21137: feat: include remote flag values in daemon local-mode resolution
- #21138: feat: merge remote flag values into gateway GET response
- #21139: feat: include remote flag values in Swift assistant flag resolution
- #21140: feat: start/stop RemoteFeatureFlagSync in gateway lifecycle
- #21142: fix: address review gaps in remote feature flag layer

## Self-review result
PASS — all 3 integration gaps found and fixed in #21142

## Fix PRs
- #21142: fix: address review gaps (config watcher handler, test cache clearing, void prefix)

Part of plan: remote-feature-flag-layer.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
