### PR TITLE
feat: "Open in New Window" UI + lifecycle cleanup [JARVIS-340]

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -429,6 +429,8 @@ extension AppDelegate {
         connectionManager.disconnect()
         // Reset dock icon to default before loading the new assistant's avatar
         AvatarAppearanceManager.shared.resetForDisconnect()
+        // Close pop-out thread windows before tearing down the main window
+        threadWindowManager?.closeAll()
         // Close and recreate the main window to reset conversation state
         mainWindow?.close()
         mainWindow = nil
@@ -605,6 +607,7 @@ extension AppDelegate {
         actorTokenBootstrapTask = nil
         ActorTokenManager.deleteToken()
 
+        threadWindowManager?.closeAll()
         mainWindow?.close()
         mainWindow = nil
         conversationBadgeCancellable?.cancel()

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -688,6 +688,10 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             sendReorderConversations()
         }
 
+        // Close any pop-out window for this conversation before releasing the VM.
+        AppDelegate.shared?.threadWindowManager?.closeThread(conversationLocalId: id)
+        pinnedViewModelIds.remove(id)
+
         if let conversationId = conversations[index].conversationId {
             chatViewModels[id]?.stopGenerating()
             var archived = archivedConversationIds

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
@@ -56,6 +56,7 @@ struct ConversationActionsDrawer: View {
     let onUnpin: () -> Void
     let onArchive: () -> Void
     let onRename: () -> Void
+    var onOpenInNewWindow: (() -> Void)? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -65,6 +66,10 @@ struct ConversationActionsDrawer: View {
 
             if presentation.showsForkConversationAction {
                 SidebarPrimaryRow(icon: VIcon.gitBranch.rawValue, label: "Fork conversation", action: onForkConversation)
+            }
+
+            if let onOpenInNewWindow {
+                SidebarPrimaryRow(icon: VIcon.externalLink.rawValue, label: "Open in new window", action: onOpenInNewWindow)
             }
 
             SidebarPrimaryRow(

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -193,6 +193,12 @@ extension MainWindowView {
                 sidebar.draggingConversationId = conversation.id
                 sidebar.isHoveredConversation = nil
             },
+            onOpenInNewWindow: conversation.conversationId != nil ? {
+                AppDelegate.shared?.threadWindowManager?.openThread(
+                    conversationLocalId: conversation.id,
+                    conversationManager: conversationManager
+                )
+            } : nil,
             onShowFeedback: conversation.conversationId != nil && !LogExporter.isManagedAssistant ? {
                 AppDelegate.shared?.showLogReportWindow(scope: .conversation(conversationId: conversation.conversationId!, conversationTitle: conversation.title))
             } : nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1176,7 +1176,15 @@ struct MainWindowView: View {
                     conversationManager.archiveConversation(id: id)
                     dismissConversationDrawer()
                 },
-                onRename: { startRenameActiveConversation(); dismissConversationDrawer() }
+                onRename: { startRenameActiveConversation(); dismissConversationDrawer() },
+                onOpenInNewWindow: conversationManager.activeConversation?.conversationId != nil ? {
+                    guard let id = conversationManager.activeConversationId else { return }
+                    AppDelegate.shared?.threadWindowManager?.openThread(
+                        conversationLocalId: id,
+                        conversationManager: conversationManager
+                    )
+                    dismissConversationDrawer()
+                } : nil
             )
             .offset(x: conversationTitleFrame.minX, y: conversationTitleFrame.maxY)
             .zIndex(10)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -24,6 +24,7 @@ struct SidebarConversationItem: View, Equatable {
     var onMarkUnread: () -> Void
     var onHoverChange: (Bool) -> Void
     var onDragStart: () -> Void
+    var onOpenInNewWindow: (() -> Void)?
     var onShowFeedback: (() -> Void)?
 
     static func == (lhs: SidebarConversationItem, rhs: SidebarConversationItem) -> Bool {
@@ -193,6 +194,14 @@ struct SidebarConversationItem: View, Equatable {
                 Label { Text("Mark as unread") } icon: { VIconView(.circle, size: 14) }
             }
             .disabled(!canMarkUnread)
+
+            if let onOpenInNewWindow {
+                Button {
+                    onOpenInNewWindow()
+                } label: {
+                    Label { Text("Open in New Window") } icon: { VIconView(.externalLink, size: 14) }
+                }
+            }
 
             Divider()
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -186,10 +186,26 @@ private struct ThreadWindowContentView: View {
         conversationManager.conversations.first(where: { $0.id == conversationLocalId })?.title ?? "Thread"
     }
 
+    @State private var showTitleActions = false
+
     var body: some View {
-        VStack(spacing: 0) {
-            threadTitleBar
-            chatContent
+        ZStack(alignment: .top) {
+            VStack(spacing: 0) {
+                threadTitleBar
+                chatContent
+                    .padding(.bottom, VSpacing.md)
+            }
+
+            // Actions drawer rendered above all content
+            if showTitleActions {
+                // Dismiss backdrop
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onTapGesture { withAnimation { showTitleActions = false } }
+
+                threadTitleActionsDrawer
+                    .offset(y: 48)
+            }
         }
         .frame(minWidth: 480, maxWidth: .infinity, minHeight: 400, maxHeight: .infinity)
         .background(VColor.surfaceBase)
@@ -200,16 +216,54 @@ private struct ThreadWindowContentView: View {
             // Left padding to avoid traffic light buttons
             Spacer().frame(width: 72)
             Spacer()
-            Text(title)
-                .font(VFont.bodyMediumDefault)
-                .foregroundStyle(VColor.contentDefault)
-                .lineLimit(1)
+            VButton(
+                label: title,
+                rightIcon: VIcon.chevronDown.rawValue,
+                style: .ghost
+            ) {
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
+                    showTitleActions.toggle()
+                }
+            }
+            .lineLimit(1)
             Spacer()
             // Right padding to balance
             Spacer().frame(width: 72)
         }
         .frame(height: 48)
         .background(VColor.surfaceBase)
+    }
+
+    private var conversation: ConversationModel? {
+        conversationManager.conversations.first(where: { $0.id == conversationLocalId })
+    }
+
+    private var threadTitleActionsDrawer: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            SidebarPrimaryRow(
+                icon: (conversation?.isPinned ?? false) ? VIcon.pinOff.rawValue : VIcon.pin.rawValue,
+                label: (conversation?.isPinned ?? false) ? "Unpin" : "Pin",
+                action: {
+                    if conversation?.isPinned ?? false {
+                        conversationManager.unpinConversation(id: conversationLocalId)
+                    } else {
+                        conversationManager.pinConversation(id: conversationLocalId)
+                    }
+                    showTitleActions = false
+                }
+            )
+            SidebarPrimaryRow(icon: VIcon.archive.rawValue, label: "Archive", action: {
+                conversationManager.archiveConversation(id: conversationLocalId)
+                showTitleActions = false
+            })
+        }
+        .padding(VSpacing.sm)
+        .background(VColor.surfaceLift)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .shadow(color: VColor.auxBlack.opacity(0.1), radius: 1.5, x: 0, y: 1)
+        .shadow(color: VColor.auxBlack.opacity(0.1), radius: 6, x: 0, y: 4)
+        .frame(width: 200)
+        .transition(.opacity.combined(with: .scale(scale: 0.95, anchor: .top)))
     }
 
     private var chatContent: some View {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -82,6 +82,7 @@ final class ThreadWindow: NSObject, NSWindowDelegate {
         nsWindow.backgroundColor = NSColor(VColor.surfaceBase)
         nsWindow.isReleasedWhenClosed = false
         nsWindow.contentMinSize = NSSize(width: 480, height: 400)
+        nsWindow.setFrame(windowRect, display: false)
         nsWindow.title = title
         nsWindow.delegate = self
 
@@ -190,6 +191,7 @@ private struct ThreadWindowContentView: View {
             threadTitleBar
             chatContent
         }
+        .frame(minWidth: 480, maxWidth: .infinity, minHeight: 400, maxHeight: .infinity)
         .background(VColor.surfaceBase)
     }
 


### PR DESCRIPTION
## Summary
Re-opens #21141 (which was reverted in #21143 for manual testing).

- Adds **"Open in New Window"** to the sidebar conversation context menu (right-click)
- Adds **"Open in new window"** to the conversation title actions drawer (top-left dropdown)
- Closes pop-out windows on **conversation archive**, **logout**, and **assistant switch**
- Menu item only appears for conversations with a daemon-assigned conversation ID

## Test plan
- [ ] Right-click a conversation in sidebar → "Open in New Window" → opens pop-out
- [ ] Click conversation title dropdown → "Open in new window" → opens pop-out
- [ ] Archive a conversation with an open pop-out → pop-out closes
- [ ] New conversations (no messages sent yet) don't show the menu item

Closes JARVIS-340

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
