### PR TITLE
fix: default inference mode to managed for signed-in users

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -154,11 +154,14 @@ struct InferenceServiceCard: View {
             }
 
             // Symmetric case: if the user is authenticated and the mode is
-            // still the default "your-own" and they have no BYO key saved,
-            // switch to "managed" so signed-in users get managed inference
-            // out of the box. Users who have explicitly configured a BYO key
-            // keep their preference.
-            if isLoggedIn && draftMode == "your-own" && !store.hasKeyForProvider(draftProvider) {
+            // still the default "your-own", switch to "managed" so signed-in
+            // users get managed inference out of the box — but only when the
+            // provider requires an API key and the user hasn't configured one.
+            // Providers like Ollama that don't use keys (apiKeyPlaceholder is
+            // nil) are left alone since the user intentionally set up a local
+            // provider.
+            let providerRequiresKey = store.dynamicProviderApiKeyPlaceholder(draftProvider) != nil
+            if isLoggedIn && draftMode == "your-own" && providerRequiresKey && !store.hasKeyForProvider(draftProvider) {
                 draftMode = "managed"
                 store.setInferenceMode("managed")
             }
@@ -184,10 +187,15 @@ struct InferenceServiceCard: View {
                 // loading to authenticated), restore the persisted managed
                 // mode that onAppear may have temporarily overridden.
                 draftMode = "managed"
-            } else if isAuthenticated && store.inferenceMode == "your-own" && !store.hasKeyForProvider(draftProvider) {
-                // When a user signs in and has no BYO key, default to managed.
-                draftMode = "managed"
-                store.setInferenceMode("managed")
+            } else if isAuthenticated && store.inferenceMode == "your-own" {
+                // When a user signs in and has no BYO key for a key-based
+                // provider, default to managed. Keyless providers (e.g. Ollama)
+                // are left in your-own mode.
+                let requiresKey = store.dynamicProviderApiKeyPlaceholder(draftProvider) != nil
+                if requiresKey && !store.hasKeyForProvider(draftProvider) {
+                    draftMode = "managed"
+                    store.setInferenceMode("managed")
+                }
             }
         }
         .onChange(of: authManager.isLoading) { _, isLoading in

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -154,9 +154,11 @@ struct InferenceServiceCard: View {
             }
 
             // Symmetric case: if the user is authenticated and the mode is
-            // still the default "your-own", switch to "managed" so signed-in
-            // users get managed inference out of the box.
-            if isLoggedIn && draftMode == "your-own" {
+            // still the default "your-own" and they have no BYO key saved,
+            // switch to "managed" so signed-in users get managed inference
+            // out of the box. Users who have explicitly configured a BYO key
+            // keep their preference.
+            if isLoggedIn && draftMode == "your-own" && !store.hasKeyForProvider(draftProvider) {
                 draftMode = "managed"
                 store.setInferenceMode("managed")
             }
@@ -177,15 +179,15 @@ struct InferenceServiceCard: View {
                 // attempt managed-proxy routing while unauthenticated.
                 draftMode = "your-own"
                 store.setInferenceMode("your-own")
-            } else if isAuthenticated {
-                // When auth becomes available, default to managed mode.
-                // This covers both restoring a persisted managed mode that
-                // onAppear may have temporarily overridden, and switching
-                // new sign-ins from the "your-own" default to managed.
+            } else if isAuthenticated && store.inferenceMode == "managed" {
+                // When auth becomes available (e.g. startup transition from
+                // loading to authenticated), restore the persisted managed
+                // mode that onAppear may have temporarily overridden.
                 draftMode = "managed"
-                if store.inferenceMode != "managed" {
-                    store.setInferenceMode("managed")
-                }
+            } else if isAuthenticated && store.inferenceMode == "your-own" && !store.hasKeyForProvider(draftProvider) {
+                // When a user signs in and has no BYO key, default to managed.
+                draftMode = "managed"
+                store.setInferenceMode("managed")
             }
         }
         .onChange(of: authManager.isLoading) { _, isLoading in

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -152,6 +152,14 @@ struct InferenceServiceCard: View {
                     store.setInferenceMode("your-own")
                 }
             }
+
+            // Symmetric case: if the user is authenticated and the mode is
+            // still the default "your-own", switch to "managed" so signed-in
+            // users get managed inference out of the box.
+            if isLoggedIn && draftMode == "your-own" {
+                draftMode = "managed"
+                store.setInferenceMode("managed")
+            }
         }
         .onChange(of: store.inferenceMode) { _, newValue in
             // Sync draft when external changes arrive (e.g. daemon reload),
@@ -169,11 +177,15 @@ struct InferenceServiceCard: View {
                 // attempt managed-proxy routing while unauthenticated.
                 draftMode = "your-own"
                 store.setInferenceMode("your-own")
-            } else if isAuthenticated && store.inferenceMode == "managed" {
-                // When auth becomes available (e.g. startup transition from
-                // loading to authenticated), restore the persisted managed
-                // mode that onAppear may have temporarily overridden.
+            } else if isAuthenticated {
+                // When auth becomes available, default to managed mode.
+                // This covers both restoring a persisted managed mode that
+                // onAppear may have temporarily overridden, and switching
+                // new sign-ins from the "your-own" default to managed.
                 draftMode = "managed"
+                if store.inferenceMode != "managed" {
+                    store.setInferenceMode("managed")
+                }
             }
         }
         .onChange(of: authManager.isLoading) { _, isLoading in


### PR DESCRIPTION
## Summary
- When a user is signed in, the inference service card now defaults to "managed" mode instead of "your-own" (BYO)
- Symmetric with the existing behavior that resets to "your-own" when unauthenticated
- Applies on card appear, and dynamically when auth state changes (sign in/out)

## Test plan
- [ ] Sign in → open settings → verify inference mode shows "Managed"
- [ ] Sign out → verify inference mode resets to "Your Own"
- [ ] Fresh install + sign in during onboarding → verify settings show "Managed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
