### PR TITLE
feat: expose notConfigured state from MessageAudioPlayer for setup popover

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageAudioPlayer.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageAudioPlayer.swift
@@ -11,6 +11,8 @@ final class MessageAudioPlayer: NSObject, ObservableObject, AVAudioPlayerDelegat
     @Published var isLoading: Bool = false
     @Published var isPlaying: Bool = false
     @Published var error: String? = nil
+    @Published var isNotConfigured: Bool = false
+    @Published var isFeatureDisabled: Bool = false
 
     private var audioPlayer: AVAudioPlayer?
     private let ttsClient: any TTSClientProtocol
@@ -23,6 +25,8 @@ final class MessageAudioPlayer: NSObject, ObservableObject, AVAudioPlayerDelegat
     func playMessage(messageId: String, conversationId: String?) async {
         isLoading = true
         error = nil
+        isNotConfigured = false
+        isFeatureDisabled = false
 
         let result = await ttsClient.synthesize(messageId: messageId, conversationId: conversationId)
 
@@ -39,9 +43,11 @@ final class MessageAudioPlayer: NSObject, ObservableObject, AVAudioPlayerDelegat
             }
 
         case .featureDisabled:
+            isFeatureDisabled = true
             error = "Text-to-speech is not enabled"
 
         case .notConfigured:
+            isNotConfigured = true
             error = "Text-to-speech is not configured"
 
         case .notFound:


### PR DESCRIPTION
## Summary
- Add `isNotConfigured` and `isFeatureDisabled` published properties to MessageAudioPlayer
- These typed boolean signals let ChatBubble distinguish between configuration errors and other failures
- Enables PR 3 to show a setup popover instead of a dead-end tooltip

Part of plan: tts-setup-ux.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
