### PR TITLE
feat: add polling infrastructure to RemoteFeatureFlagSync

### DIFF
--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -5,19 +5,33 @@ import { getLogger } from "./logger.js";
 const log = getLogger("remote-feature-flag-sync");
 
 /**
+ * Default polling interval: 5 minutes.
+ *
+ * Configurable via `REMOTE_FF_POLL_INTERVAL_MS` env var for testing or
+ * deployment tuning.
+ */
+const DEFAULT_POLL_INTERVAL_MS = 5 * 60 * 1000;
+
+function getPollIntervalMs(): number {
+  const envVal = process.env.REMOTE_FF_POLL_INTERVAL_MS;
+  if (envVal) {
+    const parsed = parseInt(envVal, 10);
+    if (!isNaN(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_POLL_INTERVAL_MS;
+}
+
+/**
  * Manages the lifecycle of syncing remote feature flags from the platform.
  *
  * On start, fetches the current flag state and persists it to disk via the
- * remote feature flag store. Errors are caught and logged — the system falls
- * through to registry defaults if this fails.
+ * remote feature flag store, then polls on a configurable interval. Errors
+ * are caught and logged — the system falls through to registry defaults if
+ * this fails.
  */
 export class RemoteFeatureFlagSync {
   private started = false;
-
-  // TODO: Replace fetchRemoteFeatureFlags with an SSE EventSource connection
-  // to the platform. On initial connection, the platform sends the full flag
-  // state. On subsequent events, call fetchAndCache() again with the updated
-  // values.
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
 
   async start(): Promise<void> {
     this.started = true;
@@ -25,13 +39,29 @@ export class RemoteFeatureFlagSync {
     try {
       await this.fetchAndCache();
     } catch (err) {
-      log.warn({ err }, "Failed to sync remote feature flags");
+      log.warn({ err }, "Failed to sync remote feature flags on startup");
     }
+
+    // TODO: Replace stub fetch with real platform API call to
+    // GET ${VELLUM_PLATFORM_URL}/v1/feature-flags (or similar).
+    // The poll interval ensures the gateway picks up flag changes
+    // without requiring a restart.
+    const intervalMs = getPollIntervalMs();
+    this.pollTimer = setInterval(() => {
+      this.fetchAndCache().catch((err) => {
+        log.warn({ err }, "Failed to sync remote feature flags during poll");
+      });
+    }, intervalMs);
+
+    log.info({ intervalMs }, "Remote feature flag polling started");
   }
 
   stop(): void {
     this.started = false;
-    // TODO: Close SSE EventSource connection here
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
   }
 
   private async fetchAndCache(): Promise<void> {
@@ -45,7 +75,7 @@ export class RemoteFeatureFlagSync {
 
   /**
    * Stub: returns the same values the registry provides so the net effect on
-   * resolution is zero until the real platform SSE replaces this.
+   * resolution is zero until the real platform API replaces this.
    */
   private async fetchRemoteFeatureFlags(): Promise<Record<string, boolean>> {
     log.debug("Fetching remote feature flags (stub)");


### PR DESCRIPTION
## Summary
- Replace SSE-oriented TODOs with polling-based infrastructure
- Add configurable poll interval (default 5min, override via `REMOTE_FF_POLL_INTERVAL_MS`)
- `start()` fetches immediately then polls on interval; `stop()` clears the timer
- Stub fetch still returns registry defaults — ready for real platform API

## Test plan
- [ ] Verify gateway starts and logs polling interval
- [ ] Verify `stop()` cleans up the interval on SIGTERM
- [ ] Verify `REMOTE_FF_POLL_INTERVAL_MS` override works
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
