### PR TITLE
fix: replace deprecated .foregroundColor() with .foregroundStyle() in Read Aloud card

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -333,21 +333,21 @@ struct VoiceSettingsView: View {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     Text("1. Create a Fish Audio account at fish.audio")
                         .font(VFont.bodyMediumDefault)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                     Text("2. Generate an API key from your Fish Audio dashboard")
                         .font(VFont.bodyMediumDefault)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                     Text("3. Choose or create a voice and copy its reference ID")
                         .font(VFont.bodyMediumDefault)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                     Text("4. Run the setup commands in your terminal:")
                         .font(VFont.bodyMediumDefault)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                 }
 
                 Text("assistant credentials set --service fish-audio --field api_key YOUR_KEY\nassistant config set fishAudio.referenceId YOUR_VOICE_ID")
                     .font(.system(size: 12, design: .monospaced))
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
                     .padding(VSpacing.md)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(


### PR DESCRIPTION
## Summary
Fixes style compliance gaps identified during plan review for tts-setup-ux.md.

**Gap 1:** Replaced 5 uses of deprecated `.foregroundColor()` with `.foregroundStyle()` in the new `readAloudCard`, per clients/AGENTS.md Deprecated API Watchlist.
**Gap 2:** Confirmed the raw `.font(.system(size: 12, design: .monospaced))` is acceptable — no monospaced SwiftUI font token exists in the design system (`VFont.mono`/`VFont.monoSmall` were deliberately removed), and all other monospaced SwiftUI text in the codebase uses the same raw literal pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
