### PR TITLE
fix: use AppDelegate.showSettingsTab for TTS setup navigation and remove sticky isNotConfigured short-circuit

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -512,17 +512,13 @@ struct ChatBubble: View {
             iconSize: 24,
             iconColor: audioPlayer.error != nil ? VColor.systemNegativeStrong : VColor.contentTertiary
         ) {
-            if audioPlayer.isNotConfigured {
-                showTTSSetupPopover = true
-            } else {
-                Task {
-                    await audioPlayer.playMessage(
-                        messageId: daemonMessageId,
-                        conversationId: nil
-                    )
-                    if audioPlayer.isNotConfigured {
-                        showTTSSetupPopover = true
-                    }
+            Task {
+                await audioPlayer.playMessage(
+                    messageId: daemonMessageId,
+                    conversationId: nil
+                )
+                if audioPlayer.isNotConfigured {
+                    showTTSSetupPopover = true
                 }
             }
         }
@@ -552,10 +548,7 @@ struct ChatBubble: View {
             HStack(spacing: VSpacing.md) {
                 VButton(label: "Set Up", style: .primary) {
                     showTTSSetupPopover = false
-                    NotificationCenter.default.post(
-                        name: .navigateToSettingsTab,
-                        object: SettingsTab.voice
-                    )
+                    AppDelegate.shared?.showSettingsTab("Voice")
                 }
                 Button {
                     if let url = URL(string: "https://fish.audio") {


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for tts-setup-ux.md.

**Gap 1:** The TTS setup popover's 'Set Up' button posted a notification that was only received by SettingsPanel when already visible. Replaced with AppDelegate.shared?.showSettingsTab("Voice") which correctly opens Settings and navigates to the Voice tab from any context.

**Gap 2:** The button action short-circuited when isNotConfigured was true, preventing playback after the user configures Fish Audio. Removed the short-circuit so playMessage() is always called, allowing the state to refresh.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
