### PR TITLE
fix: clear stale panel on conversation navigation so restart lands on chat LUM-389

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -41,6 +41,9 @@ public final class MainWindowState: ObservableObject {
             if case .conversation(let id) = selection {
                 persistentConversationId = id
             }
+            // Clear persisted panel so app restart lands on the latest chat, not a stale panel.
+            if case .conversation = selection { lastActivePanelString = nil }
+            else if selection == nil { lastActivePanelString = nil }
             // Chat dock is only relevant inside app views. Clear it when
             // navigating away so other pages never show a stale split layout.
             switch selection {

--- a/clients/macos/vellum-assistantTests/MainWindowStateNavigationHistoryTests.swift
+++ b/clients/macos/vellum-assistantTests/MainWindowStateNavigationHistoryTests.swift
@@ -78,6 +78,17 @@ final class MainWindowStateNavigationHistoryTests: XCTestCase {
         XCTAssertNil(state.selection)
     }
 
+    func testNavigatingToConversationClearsLastActivePanel() {
+        let state = MainWindowState()
+        // Show a panel so lastActivePanelString is set
+        state.showPanel(.settings)
+        // Navigate to a conversation
+        let convId = UUID()
+        state.selection = .conversation(convId)
+        // The persisted panel should be cleared so restart lands on chat
+        XCTAssertNil(UserDefaults.standard.string(forKey: "lastActivePanel"))
+    }
+
     func testCloseDynamicPanelClearsState() {
         let state = MainWindowState()
         state.selection = .app("myapp")


### PR DESCRIPTION
## Summary
- **Bug (LUM-389):** App restart lands on Library (or whatever panel was last visited) instead of the latest chat, because `@AppStorage("lastActivePanel")` is never cleared when navigating back to a conversation.
- **Fix:** Clear `lastActivePanelString` in the `selection` property's `didSet` when navigating to `.conversation` or `nil` (chat default), so `restoreLastActivePanel()` has nothing stale to restore on next launch.
- **Test:** Added `testNavigatingToConversationClearsLastActivePanel` verifying that the persisted panel is cleared when navigating from a panel to a conversation.

## Original prompt
Implement the fix for LUM-389: App restart should land on latest chat, not Library page. Clear lastActivePanelString when the selection changes to .conversation or nil (chat default) in the existing didSet block. Add a test verifying the behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
