### PR TITLE
fix: replace deprecated .foregroundColor() with .foregroundStyle() in TTS setup popover

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -541,10 +541,10 @@ struct ChatBubble: View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
             Text("Read aloud isn't set up yet")
                 .font(VFont.titleSmall)
-                .foregroundColor(VColor.contentEmphasized)
+                .foregroundStyle(VColor.contentEmphasized)
             Text("Connect a Fish Audio voice to hear messages spoken aloud.")
                 .font(VFont.bodyMediumDefault)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
             HStack(spacing: VSpacing.md) {
                 VButton(label: "Set Up", style: .primary) {
                     showTTSSetupPopover = false


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for tts-setup-ux.md.

**Gap:** Two uses of deprecated .foregroundColor() in the new ttsSetupPopoverContent view in ChatBubble.swift. Replaced with .foregroundStyle() per clients/AGENTS.md Deprecated API Watchlist.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
