### PR TITLE
fix: ensure OAuth presentation anchor is always a valid window [LUM-401]

### DIFF
--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -238,7 +238,13 @@ public final class WebAuthPresentationContext: NSObject, ASWebAuthenticationPres
 
     public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         #if os(macOS)
-        NSApp.keyWindow ?? NSApp.windows.first ?? ASPresentationAnchor()
+        if let window = NSApp.keyWindow ?? NSApp.windows.first(where: { $0.isVisible }) ?? NSApp.windows.first {
+            return window
+        }
+        // Last resort: create a temporary window so the auth sheet has a valid anchor.
+        let fallback = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 1, height: 1), styleMask: [], backing: .buffered, defer: true)
+        fallback.center()
+        return fallback
         #elseif os(iOS)
         UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }


### PR DESCRIPTION
## Summary
- `WebAuthPresentationContext.presentationAnchor()` fell back to an empty `ASPresentationAnchor()` (zero-frame, off-screen window) when no windows were available, causing the OAuth browser sheet to be unclickable and crashing the app
- Now prefers a visible window, then any window, and as a last resort creates a temporary centered window so the auth sheet always has a valid anchor

## Test plan
- [ ] Initiate Gmail OAuth from Settings → managed mode → "Connect Gmail Account"
- [ ] Complete the OAuth flow and verify credentials are saved
- [ ] Verify the flow works when pop-out thread windows are open (previous crash scenario)

Closes LUM-401

🤖 Generated with [Claude Code](https://claude.com/claude-code)