### PR TITLE
fix: restore "About <name>" header in Intelligence panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -48,7 +48,7 @@ struct IntelligencePanel: View {
         VStack(alignment: .leading, spacing: 0) {
             // Header
             HStack(alignment: .center) {
-                Text("Intelligence")
+                Text("About \(cachedAssistantName)")
                     .font(VFont.titleLarge)
                     .foregroundColor(VColor.contentEmphasized)
                 Spacer()


### PR DESCRIPTION
## Summary
- The font audit (0776d9bed) accidentally reverted the Intelligence panel header from "About <assistantName>" back to "Intelligence" while updating font tokens
- Restores the `"About \(cachedAssistantName)"` header text — the state property was still wired up, just unused

## Test plan
- [ ] Open the Intelligence panel (brain icon in sidebar)
- [ ] Verify header reads "About Pax" (or whatever the assistant name is)
- [ ] Verify it shows "About Your Assistant" when no name is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
