### PR TITLE
docs(assistant): remind agents to update safe-env.ts when adding new env vars

### DIFF
--- a/assistant/AGENTS.md
+++ b/assistant/AGENTS.md
@@ -3,3 +3,11 @@
 For error handling conventions (throw vs result objects vs null), see [docs/error-handling.md](docs/error-handling.md).
 
 Subdirectory-scoped rules live in local AGENTS.md files: `src/cli/`, `src/runtime/`, `src/approvals/`, `src/notifications/`, `src/workspace/migrations/`.
+
+## Adding new environment variables
+
+When you introduce a new env var that the assistant process needs to read at runtime, **update `src/tools/terminal/safe-env.ts`** as well.
+
+`safe-env.ts` maintains the allowlist of env vars that are forwarded to agent-spawned child processes (bash tool, skill sandbox, etc.). Anything not on the list is stripped to prevent credential leakage. If your new var is needed by commands the agent runs, it must be added.
+
+**Default to including it.** If the var doesn't contain secrets (e.g. a URL, a feature flag, a path, a mode string), add it. Only omit it if it carries credential material (tokens, passwords, private keys) — those must stay isolated to CES.


### PR DESCRIPTION
## Summary
- Adds a section to `assistant/AGENTS.md` explaining that `safe-env.ts` must be updated when introducing new env vars the assistant process needs
- Instructs agents to err on the side of including vars unless they carry credential material (tokens, passwords, keys)

## Original prompt
update agents.md to include something about remembering to update safe-env.ts if necessary when adding new env vars and should error on side of caution and add it if its not a security issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
