### PR TITLE
chore: raise minimum macOS deployment target to 15 (Sequoia)

### DIFF
--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -42,7 +42,7 @@ APIs that still compile without warning but are deprecated by Apple. Do not intr
 
 ### State Management: @Observable vs ObservableObject
 
-For new view models and state objects targeting macOS 14+ / iOS 17+, prefer the `@Observable` macro (Observation framework) over `ObservableObject`.
+For new view models and state objects targeting macOS 15+ / iOS 17+, prefer the `@Observable` macro (Observation framework) over `ObservableObject`.
 
 <details>
 <summary><strong>Migration reference table</strong></summary>
@@ -217,7 +217,7 @@ Swift's type checker has quadratic complexity with chained view modifiers. Compl
 - If you have 3+ `.onKeyPress()` handlers on a single view, extract the view + handlers into its own `@ViewBuilder`.
 - Use computed properties (`private var foo: some View`) for complex sub-hierarchies.
 
-**`.onKeyPress()` API signatures (macOS 14+):**
+**`.onKeyPress()` API signatures (macOS 15+):**
 - `.onKeyPress(.key) { return .handled }` — no-argument closure `() -> KeyPress.Result`
 - `.onKeyPress(.key, phases: .down) { press in return .handled }` — use this when you need `press.modifiers`
 - These are different overloads; using the wrong signature causes confusing build errors.

--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -6,7 +6,7 @@ let appVersion = "0.5.10"
 let package = Package(
     name: "vellum-assistant",
     platforms: [
-        .macOS(.v14),
+        .macOS("15.0"),
         .iOS(.v17)
     ],
     products: [

--- a/clients/README.md
+++ b/clients/README.md
@@ -51,7 +51,7 @@ clients/
 ## Targets
 
 ### VellumAssistantShared (Library)
-**Platforms**: macOS 14+, iOS 17+
+**Platforms**: macOS 15+, iOS 17+
 **Purpose**: Platform-agnostic code shared between macOS and iOS apps
 
 **Contains**:
@@ -70,7 +70,7 @@ clients/
 **Dependencies**: None (only system frameworks: AuthenticationServices, Network, Security)
 
 ### VellumAssistantLib (Library)
-**Platforms**: macOS 14+ only
+**Platforms**: macOS 15+ only
 **Purpose**: macOS application logic
 
 **Contains**:
@@ -84,7 +84,7 @@ clients/
 **⚠️ iOS apps should NOT depend on this target** - it links macOS-only frameworks.
 
 ### vellum-assistant (Executable)
-**Platforms**: macOS 14+
+**Platforms**: macOS 15+
 **Purpose**: Thin entry point for macOS app
 
 **Contains**: Just `@main` app delegate setup

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -69,13 +69,13 @@ All releases are available at [github.com/vellum-ai/velly/releases](https://gith
 ## Requirements
 
 ### Local Mode
-- macOS 14.0 (Sonoma) or later
+- macOS 15.0 (Sequoia) or later
 - Xcode 15+ (for building from source)
 - Anthropic API key
 - Local daemon running (`vellum wake`)
 
 ### Managed Mode
-- macOS 14.0 (Sonoma) or later
+- macOS 15.0 (Sequoia) or later
 - Xcode 15+ (for building from source)
 - Internet connection (assistant runs on the Vellum platform)
 - No API key or local daemon required

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -307,19 +307,17 @@ struct RecordingSourcePickerView: View {
             }
             .padding(.horizontal, VSpacing.xl)
 
-            if #available(macOS 14, *) {
-                HStack(spacing: VSpacing.sm) {
-                    VToggle(isOn: $viewModel.includeMicrophone)
-                        .accessibilityLabel("Microphone")
-                    VIconView(.mic, size: 14)
-                        .foregroundColor(VColor.contentSecondary)
-                        .frame(width: 20)
-                    Text("Microphone")
-                        .font(VFont.bodyMediumLighter)
-                        .foregroundColor(VColor.contentDefault)
-                }
-                .padding(.horizontal, VSpacing.xl)
+            HStack(spacing: VSpacing.sm) {
+                VToggle(isOn: $viewModel.includeMicrophone)
+                    .accessibilityLabel("Microphone")
+                VIconView(.mic, size: 14)
+                    .foregroundColor(VColor.contentSecondary)
+                    .frame(width: 20)
+                Text("Microphone")
+                    .font(VFont.bodyMediumLighter)
+                    .foregroundColor(VColor.contentDefault)
             }
+            .padding(.horizontal, VSpacing.xl)
 
             // Buttons
             HStack(spacing: VSpacing.md) {

--- a/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
+++ b/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
@@ -569,7 +569,7 @@ final class ScreenRecorder: NSObject {
     ///   - displayId: CGDirectDisplayID as UInt32. Required when captureScope is `display`.
     ///   - windowId: CGWindowID. Required when captureScope is `window`.
     ///   - includeAudio: Whether to capture system audio (default: false).
-    ///   - includeMicrophone: Whether to capture microphone audio (default: false). Requires macOS 14+.
+    ///   - includeMicrophone: Whether to capture microphone audio (default: false).
     func start(
         captureScope: String = "display",
         displayId: String? = nil,

--- a/clients/macos/vellum-assistant/Recording/ThumbnailProvider.swift
+++ b/clients/macos/vellum-assistant/Recording/ThumbnailProvider.swift
@@ -14,7 +14,7 @@ struct ThumbnailResult {
 
 /// Captures, normalizes, and caches source preview thumbnails.
 ///
-/// Uses `SCScreenshotManager` (macOS 14+) to capture display and window
+/// Uses `SCScreenshotManager` to capture display and window
 /// screenshots, scales them to a max of 320x200pt for picker row thumbnails,
 /// and maintains an in-memory cache with a 30-second TTL.
 ///
@@ -105,10 +105,6 @@ actor ThumbnailProvider {
             return ThumbnailResult(image: nil, status: .failed(.sourceGone), fromCache: false)
         }
 
-        guard #available(macOS 14, *) else {
-            return ThumbnailResult(image: nil, status: .failed(.captureFailed), fromCache: false)
-        }
-
         await acquireSlot()
         guard !Task.isCancelled else {
             releaseSlot()
@@ -180,10 +176,6 @@ actor ThumbnailProvider {
         guard let scWindow = window.scWindow else {
             log.warning("No SCWindow reference for window \(window.id)")
             return ThumbnailResult(image: nil, status: .failed(.sourceGone), fromCache: false)
-        }
-
-        guard #available(macOS 14, *) else {
-            return ThumbnailResult(image: nil, status: .failed(.captureFailed), fromCache: false)
         }
 
         await acquireSlot()

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -116,7 +116,7 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
         case .modifiers:
             return [
                 GalleryComponent("vCardMod", ".vCard()", keywords: ["card modifier"], description: "Apply card styling (background, corner radius, border) to any view with configurable radius and background color."),
-                GalleryComponent("pointerCursor", ".pointerCursor()", keywords: ["pointer", "cursor", "hand"], description: "Show pointing-hand cursor on hover. Uses native .pointerStyle(.link) on macOS 15+, falls back to NSCursor on macOS 14."),
+                GalleryComponent("pointerCursor", ".pointerCursor()", keywords: ["pointer", "cursor", "hand"], description: "Show pointing-hand cursor on hover. Uses native .pointerStyle(.link)."),
                 GalleryComponent("nativeTooltip", ".nativeTooltip()", keywords: ["native tooltip", "help"], description: "Attaches a native macOS tooltip via AppKit. Use instead of .help() where gesture recognizers block tooltip display."),
                 GalleryComponent("vTooltip", ".vTooltip()", keywords: ["tooltip", "popover"], description: "Fast 200ms floating tooltip using NSPanel. Escapes clipping bounds, never steals clicks. Use for quick hints on any view."),
                 GalleryComponent("vPanelBackground", ".vPanelBackground()", keywords: ["panel background"], description: "Fills the view with the subtle background color used for side panels and drawers."),

--- a/clients/shared/DesignSystem/Gallery/Sections/ModifiersGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ModifiersGallerySection.swift
@@ -74,7 +74,7 @@ struct ModifiersGallerySection: View {
                 // MARK: - .pointerCursor()
                 GallerySectionHeader(
                     title: ".pointerCursor()",
-                    description: "Shows a pointing-hand cursor on hover. Uses native .pointerStyle(.link) on macOS 15+, falls back to NSCursor on macOS 14."
+                    description: "Shows a pointing-hand cursor on hover. Uses native .pointerStyle(.link)."
                 )
 
                 VCard {

--- a/clients/shared/DesignSystem/Modifiers/PointerCursorModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/PointerCursorModifier.swift
@@ -1,13 +1,8 @@
 import SwiftUI
 
-#if os(macOS)
-import AppKit
-#endif
-
 /// A view modifier that shows a pointing-hand (link) cursor on hover.
 ///
-/// On macOS 15+ this uses the native `.pointerStyle(.link)` SwiftUI modifier.
-/// On macOS 14 it falls back to `NSCursor.pointingHand.push()` / `NSCursor.pop()`.
+/// Uses the native `.pointerStyle(.link)` SwiftUI modifier on macOS.
 ///
 /// Respects the SwiftUI disabled state: when the view is disabled via `.disabled(true)`,
 /// the pointer cursor is suppressed.
@@ -18,43 +13,13 @@ struct PointerCursorModifier: ViewModifier {
     @Environment(\.isEnabled) private var isEnabled
     var onHover: ((Bool) -> Void)?
 
-    #if os(macOS)
-    @State private var didPushCursor = false
-    #endif
-
     func body(content: Content) -> some View {
         #if os(macOS)
-        if #available(macOS 15.0, *) {
-            content
-                .pointerStyle(isEnabled ? .link : nil)
-                .onHover { hovering in
-                    onHover?(hovering)
-                }
-        } else {
-            content
-                .onHover { hovering in
-                    onHover?(hovering)
-                    if hovering && isEnabled {
-                        NSCursor.pointingHand.push()
-                        didPushCursor = true
-                    } else if didPushCursor {
-                        NSCursor.pop()
-                        didPushCursor = false
-                    }
-                }
-                .onChange(of: isEnabled) { _, enabled in
-                    if !enabled && didPushCursor {
-                        NSCursor.pop()
-                        didPushCursor = false
-                    }
-                }
-                .onDisappear {
-                    if didPushCursor {
-                        NSCursor.pop()
-                        didPushCursor = false
-                    }
-                }
-        }
+        content
+            .pointerStyle(isEnabled ? .link : nil)
+            .onHover { hovering in
+                onHover?(hovering)
+            }
         #else
         content
             .onHover { hovering in


### PR DESCRIPTION
## Summary
- Raises the macOS deployment floor from 14 (Sonoma) to 15 (Sequoia) in Package.swift
- Updates README.md and any other docs that reference macOS 14 as the minimum
- Removes now-redundant `#available(macOS 14, *)` guards

Part of plan: scroll-audit-cleanup.md (PR 0 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
