### PR TITLE
fix: clean up completed ACP sessions to free concurrency slots

### DIFF
--- a/assistant/src/__tests__/acp-session.test.ts
+++ b/assistant/src/__tests__/acp-session.test.ts
@@ -350,6 +350,129 @@ describe("AcpSessionManager", () => {
     });
   });
 
+  describe("session cleanup after prompt", () => {
+    test("completed session is removed from the session map", async () => {
+      let resolvePrompt: (v: { stopReason: string }) => void;
+      const promptPromise = new Promise<{ stopReason: string }>((r) => {
+        resolvePrompt = r;
+      });
+
+      const manager = new AcpSessionManager(1);
+      const sendToVellum = mock(() => {});
+
+      // Inject a fake session directly into the manager to avoid needing
+      // a real child process.
+      const fakeProcess = {
+        prompt: () => promptPromise,
+        kill: mock(() => {}),
+        spawn: mock(() => {}),
+        initialize: mock(() => Promise.resolve()),
+        createSession: mock(() => Promise.resolve("proto-session")),
+        cancel: mock(() => Promise.resolve()),
+      };
+      const fakeHandler = new VellumAcpClientHandler(
+        "test-session",
+        sendToVellum,
+        "conv-1",
+      );
+
+      // Access private sessions map via any cast
+      const sessions = (manager as any).sessions as Map<string, any>;
+      const entry = {
+        process: fakeProcess,
+        state: {
+          id: "test-session",
+          agentId: "agent-1",
+          acpSessionId: "proto-session",
+          status: "running",
+          startedAt: Date.now(),
+        },
+        clientHandler: fakeHandler,
+        sendToVellum,
+        currentPrompt: null as any,
+        parentConversationId: "conv-1",
+        cwd: "/tmp",
+      };
+      sessions.set("test-session", entry);
+
+      // Fire the prompt in the background via the private method
+      const bgPromise = (manager as any).firePromptInBackground(
+        "test-session",
+        entry,
+        "proto-session",
+        "do something",
+      );
+      entry.currentPrompt = bgPromise;
+
+      // Session exists before completion
+      expect((manager.getStatus() as any[]).length).toBe(1);
+
+      // Complete the prompt
+      resolvePrompt!({ stopReason: "end_turn" });
+      await bgPromise;
+
+      // Session should be cleaned up
+      expect((manager.getStatus() as any[]).length).toBe(0);
+      expect(fakeProcess.kill).toHaveBeenCalled();
+    });
+
+    test("failed session is removed from the session map", async () => {
+      const manager = new AcpSessionManager(1);
+      const sendToVellum = mock(() => {});
+
+      let rejectPrompt: (e: Error) => void;
+      const promptPromise = new Promise<{ stopReason: string }>((_r, rej) => {
+        rejectPrompt = rej;
+      });
+
+      const fakeProcess = {
+        prompt: () => promptPromise,
+        kill: mock(() => {}),
+      };
+      const fakeHandler = new VellumAcpClientHandler(
+        "test-session-2",
+        sendToVellum,
+        "conv-2",
+      );
+
+      const sessions = (manager as any).sessions as Map<string, any>;
+      const entry = {
+        process: fakeProcess,
+        state: {
+          id: "test-session-2",
+          agentId: "agent-1",
+          acpSessionId: "proto-session-2",
+          status: "running",
+          startedAt: Date.now(),
+        },
+        clientHandler: fakeHandler,
+        sendToVellum,
+        currentPrompt: null as any,
+        parentConversationId: "conv-2",
+        cwd: "/tmp",
+      };
+      sessions.set("test-session-2", entry);
+
+      const bgPromise = (manager as any).firePromptInBackground(
+        "test-session-2",
+        entry,
+        "proto-session-2",
+        "do something",
+      );
+      entry.currentPrompt = bgPromise;
+
+      expect((manager.getStatus() as any[]).length).toBe(1);
+
+      // Fail the prompt
+      rejectPrompt!(new Error("agent crashed"));
+      await bgPromise;
+
+      // Session should be cleaned up even on failure
+      expect((manager.getStatus() as any[]).length).toBe(0);
+      expect(fakeProcess.kill).toHaveBeenCalled();
+    });
+  });
+
   describe("closeAll / dispose", () => {
     test("closeAll on empty manager does not throw", () => {
       const manager = new AcpSessionManager(5);

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -212,8 +212,13 @@ export class AcpSessionManager {
     if (!entry) {
       throw new Error(`ACP session "${acpSessionId}" not found`);
     }
-    // Auto-deny pending ACP permission requests for THIS session only,
-    // so other sessions on the same parent conversation are unaffected.
+    this.teardownSession(acpSessionId, entry);
+  }
+
+  /**
+   * Denies pending ACP permissions, kills the process, and removes the session.
+   */
+  private teardownSession(acpSessionId: string, entry: SessionEntry): void {
     for (const requestId of entry.clientHandler.pendingRequestIds) {
       const interaction = pendingInteractions.resolve(requestId);
       if (interaction?.directResolve) {
@@ -283,10 +288,9 @@ export class AcpSessionManager {
             stopReason: response.stopReason,
           });
 
-          // Free the session slot so it doesn't count against the
-          // concurrency limit. Kill the agent process first.
-          current.process.kill();
-          this.sessions.delete(acpSessionId);
+          // Free the session slot, deny any pending permissions, and
+          // kill the agent process.
+          this.teardownSession(acpSessionId, current);
 
           // Notify parent session so the LLM sees the agent's output
           if (this.onAcpSessionFinished) {
@@ -327,9 +331,8 @@ export class AcpSessionManager {
             error: err.message,
           });
 
-          // Free the session slot.
-          current.process.kill();
-          this.sessions.delete(acpSessionId);
+          // Free the session slot and deny any pending permissions.
+          this.teardownSession(acpSessionId, current);
         }
       });
 

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -169,8 +169,11 @@ export class AcpSessionManager {
       );
     }
 
-    // Cancel any in-flight prompt before starting a new one
+    // Cancel any in-flight prompt before starting a new one.
+    // Clear currentPrompt BEFORE awaiting cancel so the old prompt's
+    // catch handler sees currentPrompt !== promptPromise and skips teardown.
     if (entry.currentPrompt) {
+      entry.currentPrompt = null;
       try {
         await entry.process.cancel(entry.state.acpSessionId);
       } catch (err) {
@@ -179,7 +182,6 @@ export class AcpSessionManager {
           "Failed to cancel in-flight prompt before steer",
         );
       }
-      entry.currentPrompt = null;
     }
 
     // Fire new prompt in the background with event handlers

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -283,6 +283,11 @@ export class AcpSessionManager {
             stopReason: response.stopReason,
           });
 
+          // Free the session slot so it doesn't count against the
+          // concurrency limit. Kill the agent process first.
+          current.process.kill();
+          this.sessions.delete(acpSessionId);
+
           // Notify parent session so the LLM sees the agent's output
           if (this.onAcpSessionFinished) {
             const agentLabel = current.state.agentId;
@@ -321,6 +326,10 @@ export class AcpSessionManager {
             acpSessionId,
             error: err.message,
           });
+
+          // Free the session slot.
+          current.process.kill();
+          this.sessions.delete(acpSessionId);
         }
       });
 


### PR DESCRIPTION
## Summary
- Completed and failed ACP sessions were never removed from the session map, causing them to count against `maxConcurrentSessions` (default 4). After 4 sessions, no new ACP agents could be spawned.
- Now kills the process and removes the session from the map after prompt completion or failure.
- Added tests verifying cleanup on both success and failure paths.

## Test plan
- [x] Added test: completed session is removed from session map
- [x] Added test: failed session is removed from session map
- [x] All 21 tests pass
- [x] Manual testing: can spawn multiple ACP sessions sequentially without hitting the limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
