### PR TITLE
refactor: extract MessageListView scroll state into ScrollCoordinator

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
@@ -1,0 +1,679 @@
+import Combine
+import Foundation
+import os
+import SwiftUI
+import VellumAssistantShared
+
+private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "MessageListScrollCoordinator")
+
+/// Holds the last-known anchor minY without triggering SwiftUI re-renders.
+/// Only `isVisible` is @Published so re-renders happen only when the
+/// visible/invisible boundary is crossed — not on every scroll tick.
+///
+/// Retained as a standalone type for testability. The coordinator delegates
+/// anchor tracking to this class internally but exposes `anchorIsVisible`
+/// and `anchorLastMinY` as top-level properties for convenience.
+@MainActor final class AnchorVisibilityTracker: ObservableObject {
+    var lastMinY: CGFloat = .infinity  // NOT @Published — no re-render on scroll
+    @Published var isVisible: Bool = true
+
+    /// Updates the tracked minY and recalculates visibility.
+    /// Only publishes `isVisible` when the boundary is actually crossed
+    /// (visible ↔ invisible), not on every scroll tick — this prevents
+    /// SwiftUI re-renders during continuous scrolling.
+    func update(minY: CGFloat, viewportHeight: CGFloat) {
+        lastMinY = minY
+        let newVisible = minY >= -20 && minY <= viewportHeight + 20
+        if isVisible != newVisible { isVisible = newVisible }
+    }
+
+    /// Returns `true` when the viewport height actually changed, so callers
+    /// can refresh any state tied to the visible geometry.
+    @discardableResult
+    func updateViewport(height: CGFloat, storedViewportHeight: inout CGFloat) -> Bool {
+        guard storedViewportHeight != height else { return false }
+        storedViewportHeight = height
+        // Don't recompute visibility before the anchor position has been
+        // measured — lastMinY starts at .infinity, and .infinity <= height + 20
+        // evaluates to false, incorrectly flipping isVisible to false and
+        // flashing the "Scroll to latest" button on short conversations.
+        guard lastMinY.isFinite else { return true }
+        let newVisible = lastMinY >= -20 && lastMinY <= height + 20
+        if isVisible != newVisible { isVisible = newVisible }
+        return true
+    }
+}
+
+/// Consolidates all scroll-related state from `MessageListView` into a single
+/// `ObservableObject` that preserves the reactive / non-reactive split.
+///
+/// **Non-reactive (plain stored properties, NOT `@Published`):**
+/// - All fields on `ScrollTrackingState` (dead-zone guards, smoothing state,
+///   precomputed cache) — updated every scroll tick, must never trigger
+///   `objectWillChange`.
+/// - `anchorLastMinY` — last-known anchor minY, updated on every scroll tick.
+/// - `hasReceivedScrollEvent`, `hasFreshAnchorMeasurement`, `wasPaginationTriggerInRange`,
+///   `hasLoggedNonFiniteGeometry` — bookkeeping flags that don't drive UI.
+/// - `ChatBottomPinCoordinator`, `ChatScrollLoopGuard` — stateful helpers that
+///   never need to trigger view re-evaluation themselves.
+/// - All in-flight `Task` references.
+///
+/// **Reactive (`@Published`):**
+/// - `anchorIsVisible` — boundary-crossing only (visible ↔ invisible), drives
+///   the "Scroll to latest" button.
+/// - `isSuppressingBottomScroll`, `isPaginationInFlight` — change
+///   infrequently and legitimately require view updates.
+@MainActor
+final class MessageListScrollCoordinator: ObservableObject {
+
+    // MARK: - Reactive State (@Published)
+
+    /// Whether the scroll-bottom-anchor is physically within the scroll view's
+    /// visible viewport. Only publishes on boundary crossings (visible ↔ invisible).
+    @Published var anchorIsVisible: Bool = true
+
+    /// Suppresses bottom auto-scroll for the ~32ms layout window after pagination
+    /// restores scroll position, preventing a jump back to the bottom.
+    @Published var isSuppressingBottomScroll: Bool = false
+
+    /// Guards the pagination sentinel against re-entry during the brief window
+    /// between Task launch and the first `await`.
+    @Published var isPaginationInFlight: Bool = false
+
+
+    // MARK: - Non-Reactive State (plain stored properties)
+
+    /// Non-reactive scroll tracking state (dead-zone guards, smoothing).
+    /// Stored on a class so mutations never trigger body re-evaluations.
+    /// Keeping this as a plain `var` (not `@Published`) ensures mutations
+    /// bypass `objectWillChange`, preserving the existing perf-critical pattern.
+    var scrollTracking = ScrollTrackingState()
+
+    /// Last-known anchor minY without triggering SwiftUI re-renders.
+    /// Only `anchorIsVisible` is @Published so re-renders happen only when
+    /// the visible/invisible boundary is crossed — not on every scroll tick.
+    var anchorLastMinY: CGFloat = .infinity
+
+    /// Coordinates bounded scroll-to-bottom retry sessions and manages the
+    /// follow/detach state machine.
+    var bottomPinCoordinator = ChatBottomPinCoordinator()
+
+    /// Detects runaway scroll-loop patterns and emits one aggregate warning
+    /// per cooldown window instead of per-frame log spam.
+    var scrollLoopGuard = ChatScrollLoopGuard()
+
+    /// Whether a physical scroll event (wheel/trackpad) has been received since
+    /// the current conversation loaded.
+    var hasReceivedScrollEvent: Bool = false
+
+    /// Whether the AnchorMinYKey preference has fired since the last scroll
+    /// restore began.
+    var hasFreshAnchorMeasurement: Bool = false
+
+    /// Tracks whether the pagination sentinel was previously inside the trigger band.
+    var wasPaginationTriggerInRange: Bool = false
+
+    /// One-shot flag: logs a warning the first time anchor, tail, or viewport
+    /// geometry is non-finite during a render pass.
+    var hasLoggedNonFiniteGeometry: Bool = false
+
+    // MARK: - Tasks
+
+    /// In-flight suppression task for off-bottom content expansion.
+    var expandSuppressionTask: Task<Void, Never>?
+
+    /// In-flight pagination load task.
+    var paginationTask: Task<Void, Never>?
+
+
+    /// In-flight staged scroll-to-bottom task used after conversation switches
+    /// and app restarts.
+    var scrollRestoreTask: Task<Void, Never>?
+
+    // MARK: - Anchor Visibility (mirrors AnchorVisibilityTracker)
+
+    /// Updates the tracked anchor minY and recalculates visibility.
+    /// Only publishes `anchorIsVisible` when the boundary is actually crossed
+    /// (visible ↔ invisible), not on every scroll tick.
+    func updateAnchor(minY: CGFloat, viewportHeight: CGFloat) {
+        anchorLastMinY = minY
+        let newVisible = minY >= -20 && minY <= viewportHeight + 20
+        if anchorIsVisible != newVisible { anchorIsVisible = newVisible }
+    }
+
+    /// Returns `true` when the viewport height actually changed, so callers
+    /// can refresh any state tied to the visible geometry.
+    @discardableResult
+    func updateAnchorViewport(height: CGFloat, storedViewportHeight: inout CGFloat) -> Bool {
+        guard storedViewportHeight != height else { return false }
+        storedViewportHeight = height
+        // Don't recompute visibility before the anchor position has been
+        // measured — anchorLastMinY starts at .infinity, and .infinity <= height + 20
+        // evaluates to false, incorrectly flipping anchorIsVisible to false and
+        // flashing the "Scroll to latest" button on short conversations.
+        guard anchorLastMinY.isFinite else { return true }
+        let newVisible = anchorLastMinY >= -20 && anchorLastMinY <= height + 20
+        if anchorIsVisible != newVisible { anchorIsVisible = newVisible }
+        return true
+    }
+
+    // MARK: - Scroll Methods
+
+    /// Sentinel UUID used for pin requests before the daemon assigns a real
+    /// conversation ID. Lets bootstrap-window requests coalesce normally.
+    static let bootstrapConversationId = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
+
+    /// Routes an automatic bottom-follow request through the coordinator.
+    func requestBottomPin(
+        reason: BottomPinRequestReason,
+        proxy: ScrollViewProxy,
+        conversationId: UUID?,
+        animated: Bool = false
+    ) {
+        let convId = conversationId ?? Self.bootstrapConversationId
+        bottomPinCoordinator.requestPin(
+            reason: reason,
+            conversationId: convId,
+            animated: animated
+        )
+    }
+
+    /// Configures the coordinator's callbacks to wire pin requests back to
+    /// the scroll view proxy and follow-state changes back to `isNearBottom`.
+    func configureBottomPinCoordinator(
+        proxy: ScrollViewProxy,
+        scrollViewportHeight: CGFloat,
+        conversationId: UUID?,
+        isNearBottom: Binding<Bool>
+    ) {
+        bottomPinCoordinator.onPinRequested = { [weak self] reason, animated in
+            guard let self else { return false }
+            guard !isSuppressingBottomScroll else { return false }
+            // Circuit breaker: suppress scroll-to when a scroll loop was detected.
+            let convIdString = conversationId?.uuidString ?? "unknown"
+            if scrollLoopGuard.isTripped(conversationId: convIdString) {
+                os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested",
+                            "target=bottomAnchor reason=circuitBreakerSuppressed")
+                return false
+            }
+            os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested",
+                        "target=bottomAnchor reason=coordinator-%{public}s", reason.rawValue)
+            recordScrollLoopEvent(.scrollToRequested, conversationId: conversationId)
+            if animated {
+                withAnimation(VAnimation.fast) {
+                    proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                }
+            } else {
+                proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+            }
+            // Check if the pin succeeded (anchor within viewport).
+            let outcome = MessageListBottomAnchorPolicy.verify(
+                anchorMinY: anchorLastMinY,
+                viewportHeight: scrollViewportHeight
+            )
+            return outcome == .anchored
+        }
+        bottomPinCoordinator.onFollowStateChanged = { isFollowing in
+            isNearBottom.wrappedValue = isFollowing
+        }
+
+        // If detach() was called before this callback was wired up, sync
+        // isNearBottom now so it isn't stuck at true permanently.
+        if !bottomPinCoordinator.isFollowingBottom {
+            isNearBottom.wrappedValue = false
+        }
+    }
+
+    /// Staged scroll-to-bottom that retries after increasing delays to handle
+    /// cases where SwiftUI hasn't committed the new content's layout yet.
+    func restoreScrollToBottom(
+        proxy: ScrollViewProxy,
+        conversationId: UUID?,
+        anchorMessageId: Binding<UUID?>,
+        scrollViewportHeight: CGFloat,
+        avatarSmoothingTask: inout Task<Void, Never>?,
+        isAvatarVisible: inout Bool,
+        avatarDisplayY: inout CGFloat
+    ) {
+        scrollRestoreTask?.cancel()
+        hasFreshAnchorMeasurement = false
+
+        // Reset avatar follower state so the avatar starts hidden and only
+        // appears once the conversation tail anchor reports a fresh position.
+        avatarSmoothingTask?.cancel()
+        avatarSmoothingTask = nil
+        scrollTracking.avatarTargetY = .infinity
+        isAvatarVisible = false
+        avatarDisplayY = .infinity
+        scrollTracking.pendingAvatarY = nil
+        scrollTracking.avatarLastAppliedAt = nil
+        scrollTracking.lastTailAnchorY = .infinity
+
+        // Route the initial restore through the coordinator for bounded retries.
+        if anchorMessageId.wrappedValue == nil {
+            requestBottomPin(reason: .initialRestore, proxy: proxy, conversationId: conversationId)
+        }
+
+        scrollRestoreTask = Task { @MainActor [weak self] in
+            guard let self, !Task.isCancelled else { return }
+            // Stage 0: immediate — the coordinator fires its first attempt above.
+            os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=0")
+            log.debug("Scroll restore: stage 0 (immediate, coordinator-driven)")
+
+            // Stage 1: ~3 frames — handles most conversation switches.
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            guard !Task.isCancelled else { return }
+            os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=1")
+            if anchorMessageId.wrappedValue == nil {
+                requestBottomPin(reason: .initialRestore, proxy: proxy, conversationId: conversationId)
+            }
+            log.debug("Scroll restore: stage 1 (50ms)")
+
+            // Stage 2: ~9 frames — catches slower layout/materialization.
+            try? await Task.sleep(nanoseconds: 150_000_000)
+            guard !Task.isCancelled else { return }
+            let restoreOutcome = MessageListBottomAnchorPolicy.verify(
+                anchorMinY: anchorLastMinY,
+                viewportHeight: scrollViewportHeight
+            )
+            if anchorMessageId.wrappedValue == nil
+                && !hasReceivedScrollEvent
+                && restoreOutcome == .needsRepin
+            {
+                os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=2 action=retry")
+                requestBottomPin(reason: .initialRestore, proxy: proxy, conversationId: conversationId)
+                log.debug("Scroll restore: stage 2 (200ms) — retrying via coordinator")
+            } else {
+                os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=2 action=skipped")
+                log.debug("Scroll restore: stage 2 skipped (anchor=\(String(describing: anchorMessageId.wrappedValue)) scrollEvent=\(self.hasReceivedScrollEvent))")
+            }
+
+            if !Task.isCancelled { scrollRestoreTask = nil }
+        }
+    }
+
+    /// Fires a single pagination load, restores the scroll anchor, and
+    /// manages the `isPaginationInFlight` / `isSuppressingBottomScroll` guards.
+    func triggerPagination(
+        proxy: ScrollViewProxy,
+        visibleMessages: [ChatMessage],
+        conversationId: UUID?,
+        loadPreviousMessagePage: (() async -> Bool)?
+    ) {
+        guard !isPaginationInFlight else { return }
+        isPaginationInFlight = true
+        // Pagination scroll-position restore is higher priority — cancel any
+        // active pin session so the coordinator doesn't fight the restore.
+        bottomPinCoordinator.cancelActiveSession(reason: .paginationRestore)
+        let anchorId = visibleMessages.first?.id
+        os_signpost(.event, log: PerfSignposts.log, name: "paginationSentinelFired")
+        log.debug("[pagination] fired — anchorId: \(String(describing: anchorId))")
+        paginationTask = Task { [weak self] in
+            guard let self else { return }
+            defer {
+                if !Task.isCancelled {
+                    isPaginationInFlight = false
+                    paginationTask = nil
+                } else if paginationTask == nil {
+                    isPaginationInFlight = false
+                }
+            }
+            let hadMore = await loadPreviousMessagePage?() ?? false
+            log.debug("[pagination] loadPreviousMessagePage returned hadMore=\(hadMore)")
+            if hadMore, let id = anchorId {
+                isSuppressingBottomScroll = true
+                os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=pagination")
+                try? await Task.sleep(nanoseconds: 100_000_000)
+                guard !Task.isCancelled else {
+                    isSuppressingBottomScroll = false
+                    return
+                }
+                os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=paginationAnchor")
+                recordScrollLoopEvent(.scrollToRequested, conversationId: conversationId)
+                proxy.scrollTo(id, anchor: .top)
+                log.debug("[pagination] scroll restored to anchor \(id)")
+                isSuppressingBottomScroll = false
+                os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "off reason=paginationDone")
+            }
+        }
+    }
+
+    /// Records a scroll-related event into the loop guard and emits a
+    /// diagnostic warning if the guard trips.
+    func recordScrollLoopEvent(
+        _ kind: ChatScrollLoopGuard.EventKind,
+        conversationId: UUID?,
+        isNearBottom: Bool = false,
+        scrollViewportHeight: CGFloat = .infinity,
+        anchorMessageId: UUID? = nil
+    ) {
+        let convId = conversationId?.uuidString ?? "unknown"
+        let timestamp = ProcessInfo.processInfo.systemUptime
+
+        if let snapshot = scrollLoopGuard.record(kind, conversationId: convId, timestamp: timestamp) {
+            let countsDescription = snapshot.counts.map { "\($0.key.rawValue)=\($0.value)" }.joined(separator: " ")
+            log.warning(
+                "Scroll loop detected — trippedBy=\(snapshot.trippedBy.rawValue) window=\(snapshot.windowDuration)s \(countsDescription) isNearBottom=\(isNearBottom) hasReceivedScrollEvent=\(self.hasReceivedScrollEvent) anchorMessageId=\(String(describing: anchorMessageId)) anchorLastMinY=\(self.anchorLastMinY) viewportHeight=\(scrollViewportHeight)"
+            )
+            var sanitizer = NumericSanitizer()
+            let safeScrollOffsetY = sanitizer.sanitize(anchorLastMinY, field: "scrollOffsetY")
+            let safeViewportHeight = sanitizer.sanitize(scrollViewportHeight, field: "viewportHeight")
+            logNonFiniteGeometryOnce(sanitizer: sanitizer)
+            ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
+                kind: .scrollLoopDetected,
+                conversationId: convId,
+                reason: "trippedBy=\(snapshot.trippedBy.rawValue) \(countsDescription)",
+                isPinnedToBottom: isNearBottom,
+                isUserScrolling: hasReceivedScrollEvent,
+                scrollOffsetY: safeScrollOffsetY,
+                viewportHeight: safeViewportHeight,
+                nonFiniteFields: sanitizer.nonFiniteFields
+            ))
+        }
+    }
+
+    /// Schedules a debounced transcript snapshot capture.
+    func scheduleTranscriptSnapshot(
+        conversationId: UUID?,
+        messages: [ChatMessage],
+        isNearBottom: Bool,
+        scrollViewportHeight: CGFloat,
+        containerWidth: CGFloat,
+        anchorMessageId: UUID?,
+        highlightedMessageId: UUID?
+    ) {
+        scrollTracking.snapshotDebounceTask?.cancel()
+        scrollTracking.snapshotDebounceTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled, let self else { return }
+            self.updateTranscriptSnapshot(
+                conversationId: conversationId,
+                messages: messages,
+                isNearBottom: isNearBottom,
+                scrollViewportHeight: scrollViewportHeight,
+                containerWidth: containerWidth,
+                anchorMessageId: anchorMessageId,
+                highlightedMessageId: highlightedMessageId
+            )
+        }
+    }
+
+    /// Captures a point-in-time transcript snapshot into `ChatDiagnosticsStore`.
+    private func updateTranscriptSnapshot(
+        conversationId: UUID?,
+        messages: [ChatMessage],
+        isNearBottom: Bool,
+        scrollViewportHeight: CGFloat,
+        containerWidth: CGFloat,
+        anchorMessageId: UUID?,
+        highlightedMessageId: UUID?
+    ) {
+        guard let convId = conversationId else { return }
+        let totalToolCalls = messages.reduce(0) { $0 + $1.toolCalls.count }
+
+        var sanitizer = NumericSanitizer()
+        let safeAnchorMinY = sanitizer.sanitize(anchorLastMinY, field: "anchorMinY")
+        let safeTailAnchorY = sanitizer.sanitize(scrollTracking.lastTailAnchorY, field: "tailAnchorY")
+        let safeViewportHeight = sanitizer.sanitize(scrollViewportHeight, field: "scrollViewportHeight")
+        let safeContainerWidth = sanitizer.sanitize(containerWidth, field: "containerWidth")
+        logNonFiniteGeometryOnce(sanitizer: sanitizer)
+
+        let guardCounts = scrollLoopGuard.currentCounts(conversationId: convId.uuidString)
+        let guardCountsStringKeyed: [String: Int]? = guardCounts.isEmpty ? nil : Dictionary(
+            uniqueKeysWithValues: guardCounts.map { ($0.key.rawValue, $0.value) }
+        )
+
+        ChatDiagnosticsStore.shared.updateSnapshot(ChatTranscriptSnapshot(
+            conversationId: convId.uuidString,
+            capturedAt: Date(),
+            messageCount: messages.count,
+            toolCallCount: totalToolCalls,
+            isPinnedToBottom: isNearBottom,
+            isUserScrolling: hasReceivedScrollEvent,
+            scrollOffsetY: safeAnchorMinY,
+            contentHeight: nil,
+            viewportHeight: safeViewportHeight,
+            isNearBottom: isNearBottom,
+            hasReceivedScrollEvent: hasReceivedScrollEvent,
+            isPaginationInFlight: isPaginationInFlight,
+            suppressionReason: isSuppressingBottomScroll ? "bottomScrollSuppressed" : nil,
+            anchorMessageId: anchorMessageId?.uuidString,
+            highlightedMessageId: highlightedMessageId?.uuidString,
+            anchorMinY: safeAnchorMinY,
+            tailAnchorY: safeTailAnchorY,
+            scrollViewportHeight: safeViewportHeight,
+            containerWidth: safeContainerWidth,
+            scrollLoopGuardCounts: guardCountsStringKeyed,
+            nonFiniteFields: sanitizer.nonFiniteFields
+        ))
+    }
+
+    /// Logs a one-time warning when scroll geometry first becomes non-finite.
+    func logNonFiniteGeometryOnce(sanitizer: NumericSanitizer) {
+        guard !hasLoggedNonFiniteGeometry, let fields = sanitizer.nonFiniteFields else { return }
+        hasLoggedNonFiniteGeometry = true
+        log.warning("Non-finite scroll geometry detected — sanitized fields: \(fields.joined(separator: ", "))")
+    }
+
+    // MARK: - Cleanup
+
+    /// Cancels all in-flight tasks. Called from `onDisappear`.
+    func cancelAllTasks() {
+        expandSuppressionTask?.cancel()
+        expandSuppressionTask = nil
+        scrollRestoreTask?.cancel()
+        scrollRestoreTask = nil
+        paginationTask?.cancel()
+        paginationTask = nil
+        isPaginationInFlight = false
+        scrollTracking.snapshotDebounceTask?.cancel()
+        scrollTracking.snapshotDebounceTask = nil
+        bottomPinCoordinator.cancelActiveSession(reason: .conversationSwitch)
+        bottomPinCoordinator.onPinRequested = nil
+    }
+
+    /// Handles physical scroll-wheel/trackpad upward movement.
+    func handleScrollUp() {
+        scrollRestoreTask?.cancel()
+        scrollRestoreTask = nil
+        expandSuppressionTask?.cancel()
+        expandSuppressionTask = nil
+        isSuppressingBottomScroll = false
+        bottomPinCoordinator.handleUserAction(.scrollUp)
+        hasReceivedScrollEvent = true
+    }
+
+    /// Handles user explicitly scrolling to the bottom.
+    func handleScrollToBottom() {
+        scrollRestoreTask?.cancel()
+        scrollRestoreTask = nil
+        isSuppressingBottomScroll = false
+        bottomPinCoordinator.handleUserAction(.scrollToBottom)
+        hasReceivedScrollEvent = true
+    }
+
+    /// Handles the suppress-auto-scroll environment action from child views.
+    func handleSuppressAutoScroll(
+        isNearBottom: Bool,
+        isResizeActive: Bool,
+        conversationId: UUID?,
+        proxy: ScrollViewProxy,
+        scrollViewportHeight: CGFloat
+    ) {
+        expandSuppressionTask?.cancel()
+        if isNearBottom {
+            if !isResizeActive {
+                isSuppressingBottomScroll = false
+            }
+            os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=expansionPinning")
+            recordScrollLoopEvent(.suppressionFlip, conversationId: conversationId, isNearBottom: isNearBottom, scrollViewportHeight: scrollViewportHeight)
+            requestBottomPin(reason: .expansion, proxy: proxy, conversationId: conversationId, animated: false)
+        } else {
+            isSuppressingBottomScroll = true
+            os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=offBottomExpansion")
+            recordScrollLoopEvent(.suppressionFlip, conversationId: conversationId, isNearBottom: isNearBottom, scrollViewportHeight: scrollViewportHeight)
+            expandSuppressionTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: 200_000_000)
+                guard !Task.isCancelled, let self else { return }
+                if !isResizeActive && !self.isPaginationInFlight {
+                    self.isSuppressingBottomScroll = false
+                    os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "off reason=expansionExpired")
+                }
+            }
+        }
+    }
+
+    /// Handles the AnchorMinYKey preference change when the value is non-finite,
+    /// marking the anchor as off-screen.
+    func handleNonFiniteAnchor() {
+        if anchorIsVisible {
+            anchorIsVisible = false
+        }
+        anchorLastMinY = .infinity
+    }
+
+    /// Creates a resize scroll stabilization task. The caller is responsible for
+    /// assigning the returned task to the view-local `resizeScrollTask` state and
+    /// cancelling any previous task before calling this.
+    func makeResizeTask(
+        proxy: ScrollViewProxy,
+        conversationId: UUID?,
+        isNearBottom: Bool,
+        anchorMessageId: UUID?,
+        scrollViewportHeight: CGFloat,
+        onComplete: @escaping @MainActor () -> Void
+    ) -> Task<Void, Never> {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.isSuppressingBottomScroll = true
+            os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=resize")
+            defer {
+                if !Task.isCancelled {
+                    self.isSuppressingBottomScroll = false
+                    os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "off reason=resizeDone")
+                    onComplete()
+                }
+            }
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            guard !Task.isCancelled else { return }
+
+            if isNearBottom && anchorMessageId == nil {
+                let resizeOutcome = MessageListBottomAnchorPolicy.verify(
+                    anchorMinY: self.anchorLastMinY,
+                    viewportHeight: scrollViewportHeight
+                )
+                if resizeOutcome == .needsRepin {
+                    self.requestBottomPin(reason: .resize, proxy: proxy, conversationId: conversationId)
+                }
+            }
+        }
+    }
+
+    /// Evaluates a pagination sentinel preference change and triggers pagination
+    /// if the sentinel entered the trigger band. Returns true if pagination was triggered.
+    @discardableResult
+    func handlePaginationSentinel(
+        sentinelMinY: CGFloat,
+        scrollViewportHeight: CGFloat,
+        hasMoreMessages: Bool,
+        isLoadingMoreMessages: Bool,
+        proxy: ScrollViewProxy,
+        visibleMessages: [ChatMessage],
+        conversationId: UUID?,
+        loadPreviousMessagePage: (() async -> Bool)?
+    ) -> Bool {
+        guard PreferenceGeometryFilter.evaluate(
+            newValue: sentinelMinY,
+            previous: .infinity,
+            deadZone: 0
+        ) != .rejectNonFinite else { return false }
+
+        let isInRange = MessageListPaginationTriggerPolicy.isInTriggerBand(
+            sentinelMinY: sentinelMinY,
+            viewportHeight: scrollViewportHeight
+        )
+        let shouldFire = MessageListPaginationTriggerPolicy.shouldTrigger(
+            sentinelMinY: sentinelMinY,
+            viewportHeight: scrollViewportHeight,
+            wasInRange: wasPaginationTriggerInRange
+        )
+        wasPaginationTriggerInRange = isInRange
+
+        guard shouldFire,
+              hasMoreMessages,
+              !isLoadingMoreMessages,
+              !isPaginationInFlight
+        else { return false }
+
+        triggerPagination(
+            proxy: proxy,
+            visibleMessages: visibleMessages,
+            conversationId: conversationId,
+            loadPreviousMessagePage: loadPreviousMessagePage
+        )
+        return true
+    }
+
+    /// Handles the AnchorMinYKey preference change when the value is accepted (finite, past dead-zone).
+    /// Returns true if a direct scroll-to-bottom was issued (first measurement after conversation switch).
+    @discardableResult
+    func handleAcceptedAnchorMinY(
+        accepted: CGFloat,
+        scrollViewportHeight: CGFloat,
+        anchorMessageId: UUID?,
+        proxy: ScrollViewProxy,
+        conversationId: UUID?,
+        messages: [ChatMessage],
+        isNearBottom: Bool,
+        containerWidth: CGFloat,
+        highlightedMessageId: UUID?
+    ) -> Bool {
+        recordScrollLoopEvent(.anchorPreferenceChange, conversationId: conversationId, isNearBottom: isNearBottom, scrollViewportHeight: scrollViewportHeight)
+        updateAnchor(minY: accepted, viewportHeight: scrollViewportHeight)
+        var didDirectScroll = false
+        if !hasFreshAnchorMeasurement {
+            hasFreshAnchorMeasurement = true
+            if !hasReceivedScrollEvent && anchorMessageId == nil {
+                proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                didDirectScroll = true
+            }
+        }
+        scheduleTranscriptSnapshot(
+            conversationId: conversationId,
+            messages: messages,
+            isNearBottom: isNearBottom,
+            scrollViewportHeight: scrollViewportHeight,
+            containerWidth: containerWidth,
+            anchorMessageId: anchorMessageId,
+            highlightedMessageId: highlightedMessageId
+        )
+        return didDirectScroll
+    }
+
+    /// Resets state for a conversation switch.
+    func resetForConversationSwitch(
+        oldConversationId: UUID?,
+        newConversationId: UUID?,
+        isSending: Bool,
+        assistantActivityPhase: String
+    ) {
+        expandSuppressionTask?.cancel()
+        expandSuppressionTask = nil
+        scrollTracking.snapshotDebounceTask?.cancel()
+        scrollTracking.snapshotDebounceTask = nil
+        paginationTask?.cancel()
+        paginationTask = nil
+        isPaginationInFlight = false
+        wasPaginationTriggerInRange = false
+        isSuppressingBottomScroll = false
+        // Reset the coordinator for the new conversation.
+        bottomPinCoordinator.reset(newConversationId: newConversationId)
+        anchorIsVisible = true
+        anchorLastMinY = .infinity
+        hasReceivedScrollEvent = false
+        // Reset the OLD conversation's scroll-loop guard state.
+        if let oldConvId = oldConversationId {
+            scrollLoopGuard.reset(conversationId: oldConvId.uuidString)
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -22,40 +22,6 @@ extension EnvironmentValues {
     }
 }
 
-/// Holds the last-known anchor minY without triggering SwiftUI re-renders.
-/// Only `isVisible` is @Published so re-renders happen only when the
-/// visible/invisible boundary is crossed — not on every scroll tick.
-@MainActor final class AnchorVisibilityTracker: ObservableObject {
-    var lastMinY: CGFloat = .infinity  // NOT @Published — no re-render on scroll
-    @Published var isVisible: Bool = true
-
-    /// Updates the tracked minY and recalculates visibility.
-    /// Only publishes `isVisible` when the boundary is actually crossed
-    /// (visible ↔ invisible), not on every scroll tick — this prevents
-    /// SwiftUI re-renders during continuous scrolling.
-    func update(minY: CGFloat, viewportHeight: CGFloat) {
-        lastMinY = minY
-        let newVisible = minY >= -20 && minY <= viewportHeight + 20
-        if isVisible != newVisible { isVisible = newVisible }
-    }
-
-    /// Returns `true` when the viewport height actually changed, so callers
-    /// can refresh any state tied to the visible geometry.
-    @discardableResult
-    func updateViewport(height: CGFloat, storedViewportHeight: inout CGFloat) -> Bool {
-        guard storedViewportHeight != height else { return false }
-        storedViewportHeight = height
-        // Don't recompute visibility before the anchor position has been
-        // measured — lastMinY starts at .infinity, and .infinity <= height + 20
-        // evaluates to false, incorrectly flipping isVisible to false and
-        // flashing the "Scroll to latest" button on short conversations.
-        guard lastMinY.isFinite else { return true }
-        let newVisible = lastMinY >= -20 && lastMinY <= height + 20
-        if isVisible != newVisible { isVisible = newVisible }
-        return true
-    }
-}
-
 /// Holds scroll-related tracking values that must persist across body
 /// evaluations but must NOT trigger SwiftUI re-renders when updated.
 /// These values serve as dead-zone guards and smoothing state — they
@@ -192,29 +158,13 @@ struct MessageListView: View {
     /// Observing the full TaskProgressOverlayManager would cause the entire
     /// message list to re-render on every frequent `data` progress tick.
     @State private var activeSurfaceId: String?
-    /// Guards the pagination sentinel against re-entry during the brief window
-    /// between Task launch and the first `await` (before isLoadingMoreMessages is set).
-    @State private var isPaginationInFlight: Bool = false
-    @State private var paginationTask: Task<Void, Never>?
-    /// Suppresses bottom auto-scroll for the ~32ms layout window after pagination
-    /// restores scroll position, preventing a jump back to the bottom.
-    @State private var isSuppressingBottomScroll: Bool = false
-    @State private var expandSuppressionTask: Task<Void, Never>?
     /// Tracks the last pending confirmation request ID that triggered an
     /// auto-focus handoff. Used to detect nil→non-nil transitions so we
     /// resign first responder exactly once per new confirmation appearance.
     @State private var lastAutoFocusedRequestId: String?
-    /// Tracks whether the scroll-bottom-anchor is physically within the scroll
-    /// view's visible viewport. Used alongside `isNearBottom` to suppress the
-    /// "Scroll to latest" button when all content fits on screen. Stored as an
-    /// ObservableObject so only boundary crossings (not every scroll tick)
-    /// trigger re-renders.
-    @StateObject private var anchorTracker = AnchorVisibilityTracker()
-    /// Whether a physical scroll event (wheel/trackpad) has been received since
-    /// the current conversation loaded. Used by `restoreScrollToBottom` to skip
-    /// retries once the user has interacted, and by the scroll-bottom-anchor's
-    /// `onAppear` to avoid premature re-tethering during LazyVStack prefetch.
-    @State private var hasReceivedScrollEvent: Bool = false
+    /// Consolidates all scroll-related state: anchor tracking, scroll loop guard,
+    /// bottom pin coordinator, suppression flags, and scroll-related tasks.
+    @StateObject private var scrollCoordinator = MessageListScrollCoordinator()
     /// The scroll view's viewport height, captured via preference key. Used by
     /// the anchor GeometryReader to determine if the anchor is within bounds.
     @State private var scrollViewportHeight: CGFloat = .infinity
@@ -232,40 +182,15 @@ struct MessageListView: View {
     @State private var resizeScrollTask: Task<Void, Never>?
     /// Task that clears the highlight flash after the animation duration.
     @State private var highlightDismissTask: Task<Void, Never>?
-    /// In-flight staged scroll-to-bottom task used after conversation switches and
-    /// app restarts to reliably anchor the viewport once layout settles.
-    @State private var scrollRestoreTask: Task<Void, Never>?
-    /// Whether the AnchorMinYKey preference has fired since the last scroll
-    /// restore began. Ensures anchorTracker.isVisible reflects real geometry
-    /// rather than the manual reset applied on conversation switch.
-    @State private var hasFreshAnchorMeasurement: Bool = false
     @State private var isAvatarVisible: Bool = false
     @State private var avatarDisplayY: CGFloat = .infinity
     @State private var avatarSmoothingTask: Task<Void, Never>?
     @State private var hasPlayedTailEntryAnimation = false
-    /// Non-reactive scroll tracking state (dead-zone guards, smoothing).
-    /// Stored on a class so mutations never trigger body re-evaluations.
-    @State private var scrollTracking = ScrollTrackingState()
-    /// Tracks whether the pagination sentinel was previously inside the
-    /// trigger band. Used by `MessageListPaginationTriggerPolicy.shouldTrigger`
-    /// to enforce one-shot edge-transition semantics.
-    @State private var wasPaginationTriggerInRange: Bool = false
-    /// Detects runaway scroll-loop patterns and emits one aggregate warning
-    /// per cooldown window instead of per-frame log spam.
-    @State private var scrollLoopGuard = ChatScrollLoopGuard()
-    /// Coordinates bounded scroll-to-bottom retry sessions and manages the
-    /// follow/detach state machine. All automatic bottom-follow requests are
-    /// routed through this coordinator instead of issuing direct scrollTo calls.
-    @State private var bottomPinCoordinator = ChatBottomPinCoordinator()
     /// Captures the `assistantActivityPhase` at the moment `isSending` goes false.
     /// Used to distinguish mid-turn tool-confirmation pauses (phase == "awaiting_confirmation")
     /// from genuine turn endings, so the `onChange(of: isSending)` handler can decide
     /// whether to reattach the scroll position on the next `isSending = true` transition.
     @State private var phaseWhenSendingStopped: String = ""
-    /// One-shot flag: logs a warning the first time anchor, tail, or viewport
-    /// geometry is non-finite during a render pass. Visible even if the JSONL
-    /// session log later fails for an unrelated reason.
-    @State private var hasLoggedNonFiniteGeometry: Bool = false
 
     /// The subset of messages actually shown, honoring the pagination window.
     /// Uses the shared `ChatVisibleMessageFilter` so hidden automated messages
@@ -278,7 +203,7 @@ struct MessageListView: View {
     }
 
     /// Checks whether observable message-level inputs have changed since the
-    /// last body evaluation and, if so, bumps `scrollTracking.messageListVersion`.
+    /// last body evaluation and, if so, bumps `scrollCoordinator.scrollTracking.messageListVersion`.
     /// This replaces the former O(n) `computeMessageFingerprint()` hash with an
     /// O(1) version counter. Over-invalidation is safe (triggers a recompute);
     /// under-invalidation is not.
@@ -305,21 +230,21 @@ struct MessageListView: View {
 
         var changed = false
 
-        if currentCount != scrollTracking.lastKnownMessageCount {
-            scrollTracking.lastKnownMessageCount = currentCount
+        if currentCount != scrollCoordinator.scrollTracking.lastKnownMessageCount {
+            scrollCoordinator.scrollTracking.lastKnownMessageCount = currentCount
             changed = true
         }
-        if currentLastStreaming != scrollTracking.lastKnownLastMessageStreaming {
-            scrollTracking.lastKnownLastMessageStreaming = currentLastStreaming
+        if currentLastStreaming != scrollCoordinator.scrollTracking.lastKnownLastMessageStreaming {
+            scrollCoordinator.scrollTracking.lastKnownLastMessageStreaming = currentLastStreaming
             changed = true
         }
-        if currentIncompleteToolCalls != scrollTracking.lastKnownIncompleteToolCallCount {
-            scrollTracking.lastKnownIncompleteToolCallCount = currentIncompleteToolCalls
+        if currentIncompleteToolCalls != scrollCoordinator.scrollTracking.lastKnownIncompleteToolCallCount {
+            scrollCoordinator.scrollTracking.lastKnownIncompleteToolCallCount = currentIncompleteToolCalls
             changed = true
         }
 
         if changed {
-            scrollTracking.messageListVersion += 1
+            scrollCoordinator.scrollTracking.messageListVersion += 1
         }
     }
 
@@ -360,7 +285,7 @@ struct MessageListView: View {
         os_signpost(.begin, log: stallLog, name: "PrecomputedState.resolve")
         refreshMessageListVersionIfNeeded()
         let key = PrecomputedCacheKey(
-            messageListVersion: scrollTracking.messageListVersion,
+            messageListVersion: scrollCoordinator.scrollTracking.messageListVersion,
             isSending: isSending,
             isThinking: isThinking,
             isCompacting: isCompacting,
@@ -369,8 +294,8 @@ struct MessageListView: View {
             displayedMessageCount: displayedMessageCount
         )
 
-        if key == scrollTracking.cachedPrecomputedKey,
-           let cached = scrollTracking.cachedPrecomputedState {
+        if key == scrollCoordinator.scrollTracking.cachedPrecomputedKey,
+           let cached = scrollCoordinator.scrollTracking.cachedPrecomputedState {
             #if DEBUG
             // Spot-check cache correctness in debug builds.
             let freshMessages = visibleMessages
@@ -383,7 +308,7 @@ struct MessageListView: View {
             return cached
         }
 
-        os_signpost(.event, log: stallLog, name: "PrecomputedState.cacheMiss", "version=%d", scrollTracking.messageListVersion)
+        os_signpost(.event, log: stallLog, name: "PrecomputedState.cacheMiss", "version=%d", scrollCoordinator.scrollTracking.messageListVersion)
 
         let displayMessages = visibleMessages
         let activePendingRequestId = PendingConfirmationFocusSelector.activeRequestId(from: displayMessages)
@@ -486,8 +411,8 @@ struct MessageListView: View {
             effectiveStatusText: effectiveStatusText
         )
 
-        scrollTracking.cachedPrecomputedKey = key
-        scrollTracking.cachedPrecomputedState = result
+        scrollCoordinator.scrollTracking.cachedPrecomputedKey = key
+        scrollCoordinator.scrollTracking.cachedPrecomputedState = result
         os_signpost(.end, log: stallLog, name: "PrecomputedState.resolve", "miss")
         return result
     }
@@ -558,7 +483,7 @@ struct MessageListView: View {
     private func applyAvatarDisplayY(forAnchorY anchorY: CGFloat) {
         // Circuit breaker: suppress @State mutations when a scroll loop is detected.
         let convIdString = conversationId?.uuidString ?? "unknown"
-        if scrollLoopGuard.isTripped(conversationId: convIdString) { return }
+        if scrollCoordinator.scrollLoopGuard.isTripped(conversationId: convIdString) { return }
 
         let y = anchorY + ConversationAvatarFollower.verticalOffset
         // Dead-zone: skip @State update when position hasn't moved meaningfully.
@@ -577,7 +502,7 @@ struct MessageListView: View {
         }
 
         recordScrollLoopEvent(.avatarDisplayYApplied)
-        scrollTracking.avatarLastAppliedAt = Date()
+        scrollCoordinator.scrollTracking.avatarLastAppliedAt = Date()
         // Set @State without withAnimation — the spring animation is applied via
         // .animation() on the avatar view's .offset() modifier instead. This avoids
         // wrapping the mutation in an animation transaction, which would cause SwiftUI
@@ -596,7 +521,7 @@ struct MessageListView: View {
         let nowVisible = anchorY.isFinite
             && ConversationAvatarFollower.shouldShow(anchorY: anchorY, viewportHeight: scrollViewportHeight)
         let convIdString = conversationId?.uuidString ?? "unknown"
-        let isTripped = scrollLoopGuard.isTripped(conversationId: convIdString)
+        let isTripped = scrollCoordinator.scrollLoopGuard.isTripped(conversationId: convIdString)
         if isAvatarVisible != nowVisible {
             // Circuit breaker: when tripped, only allow hiding (removing UI is safe).
             // Showing (false→true) adds layout that could feed the loop — suppress it.
@@ -608,18 +533,18 @@ struct MessageListView: View {
 
         // Update non-reactive tracking position (no body re-evaluation).
         if ConversationAvatarFollower.shouldUpdateTarget(
-            previousAnchorY: scrollTracking.avatarTargetY,
+            previousAnchorY: scrollCoordinator.scrollTracking.avatarTargetY,
             newAnchorY: anchorY,
             viewportHeight: scrollViewportHeight
         ) {
-            scrollTracking.avatarTargetY = anchorY
+            scrollCoordinator.scrollTracking.avatarTargetY = anchorY
         }
 
         guard anchorY.isFinite else {
             avatarSmoothingTask?.cancel()
             avatarSmoothingTask = nil
-            scrollTracking.pendingAvatarY = nil
-            scrollTracking.avatarLastAppliedAt = nil
+            scrollCoordinator.scrollTracking.pendingAvatarY = nil
+            scrollCoordinator.scrollTracking.avatarLastAppliedAt = nil
             // During an active send, the LazyVStack may transiently deallocate
             // the tail anchor view during re-layout (e.g. thinking indicator
             // insertion, rich UI expansion), producing a non-finite preference.
@@ -638,7 +563,7 @@ struct MessageListView: View {
         guard nowVisible else {
             avatarSmoothingTask?.cancel()
             avatarSmoothingTask = nil
-            scrollTracking.pendingAvatarY = nil
+            scrollCoordinator.scrollTracking.pendingAvatarY = nil
             return
         }
 
@@ -647,14 +572,14 @@ struct MessageListView: View {
             isSending: isSending,
             isThinking: isThinking,
             isLastMessageStreaming: isLastMessageStreaming,
-            lastAppliedAt: scrollTracking.avatarLastAppliedAt,
+            lastAppliedAt: scrollCoordinator.scrollTracking.avatarLastAppliedAt,
             now: now
         )
 
         if delay <= 0 {
             avatarSmoothingTask?.cancel()
             avatarSmoothingTask = nil
-            scrollTracking.pendingAvatarY = nil
+            scrollCoordinator.scrollTracking.pendingAvatarY = nil
             // Only apply @State avatar position when circuit breaker isn't tripped
             if !isTripped {
                 applyAvatarDisplayY(forAnchorY: anchorY)
@@ -662,7 +587,7 @@ struct MessageListView: View {
             return
         }
 
-        scrollTracking.pendingAvatarY = anchorY
+        scrollCoordinator.scrollTracking.pendingAvatarY = anchorY
         guard avatarSmoothingTask == nil else { return }
 
         avatarSmoothingTask = Task { @MainActor in
@@ -672,13 +597,13 @@ struct MessageListView: View {
                 return
             }
             guard !Task.isCancelled else { return }
-            guard let pending = scrollTracking.pendingAvatarY else {
+            guard let pending = scrollCoordinator.scrollTracking.pendingAvatarY else {
                 avatarSmoothingTask = nil
                 return
             }
-            scrollTracking.pendingAvatarY = nil
+            scrollCoordinator.scrollTracking.pendingAvatarY = nil
             // Only apply @State avatar position when circuit breaker isn't tripped
-            if !scrollLoopGuard.isTripped(conversationId: conversationId?.uuidString ?? "unknown") {
+            if !scrollCoordinator.scrollLoopGuard.isTripped(conversationId: conversationId?.uuidString ?? "unknown") {
                 applyAvatarDisplayY(forAnchorY: pending)
             }
             avatarSmoothingTask = nil
@@ -738,118 +663,17 @@ struct MessageListView: View {
         }
     }
 
-    /// Staged scroll-to-bottom that retries after increasing delays to handle
-    /// cases where SwiftUI hasn't committed the new content's layout yet (e.g.
-    /// after a conversation switch or app restart). Cancelled by user scroll-up,
-    /// user scroll-to-bottom, anchor message set, or view disappearance.
+    /// Delegates scroll-to-bottom restoration to the coordinator.
     private func restoreScrollToBottom(proxy: ScrollViewProxy) {
-        scrollRestoreTask?.cancel()
-        hasFreshAnchorMeasurement = false
-
-        // Reset avatar follower state so the avatar starts hidden and only
-        // appears once the conversation tail anchor reports a fresh position
-        // after the scroll settles. Without this, the avatar can flash at a
-        // stale Y from a previous layout pass (e.g. app re-launch where
-        // onAppear calls restoreScrollToBottom without resetting avatar state).
-        avatarSmoothingTask?.cancel()
-        avatarSmoothingTask = nil
-        scrollTracking.avatarTargetY = .infinity
-        isAvatarVisible = false
-        avatarDisplayY = .infinity
-        scrollTracking.pendingAvatarY = nil
-        scrollTracking.avatarLastAppliedAt = nil
-        scrollTracking.lastTailAnchorY = .infinity
-
-        // Route the initial restore through the coordinator for bounded retries.
-        if anchorMessageId == nil {
-            requestBottomPin(reason: .initialRestore, proxy: proxy)
-        }
-
-        scrollRestoreTask = Task { @MainActor in
-            guard !Task.isCancelled else { return }
-            // Stage 0: immediate — the coordinator fires its first attempt above.
-            os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=0")
-            log.debug("Scroll restore: stage 0 (immediate, coordinator-driven)")
-
-            // Stage 1: ~3 frames — handles most conversation switches.
-            try? await Task.sleep(nanoseconds: 50_000_000)
-            guard !Task.isCancelled else { return }
-            os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=1")
-            if anchorMessageId == nil {
-                requestBottomPin(reason: .initialRestore, proxy: proxy)
-            }
-            log.debug("Scroll restore: stage 1 (50ms)")
-
-            // Stage 2: ~9 frames — catches slower layout/materialization.
-            try? await Task.sleep(nanoseconds: 150_000_000)
-            guard !Task.isCancelled else { return }
-            // Only retry when the anchor genuinely drifted off-screen.
-            // `geometryUnavailable` means layout hasn't measured yet —
-            // the coordinator will pick up the next finite preference update
-            // instead of spinning retries on missing geometry.
-            let restoreOutcome = MessageListBottomAnchorPolicy.verify(
-                anchorMinY: anchorTracker.lastMinY,
-                viewportHeight: scrollViewportHeight
-            )
-            if anchorMessageId == nil
-                && !hasReceivedScrollEvent
-                && restoreOutcome == .needsRepin
-            {
-                os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=2 action=retry")
-                requestBottomPin(reason: .initialRestore, proxy: proxy)
-                log.debug("Scroll restore: stage 2 (200ms) — retrying via coordinator")
-            } else {
-                os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=2 action=skipped")
-                log.debug("Scroll restore: stage 2 skipped (anchor=\(String(describing: anchorMessageId)) scrollEvent=\(hasReceivedScrollEvent))")
-            }
-
-            if !Task.isCancelled { scrollRestoreTask = nil }
-        }
-    }
-
-    /// Fires a single pagination load, restores the scroll anchor, and
-    /// manages the `isPaginationInFlight` / `isSuppressingBottomScroll` guards.
-    private func triggerPagination(proxy: ScrollViewProxy) {
-        guard !isPaginationInFlight else { return }
-        isPaginationInFlight = true
-        // Pagination scroll-position restore is higher priority — cancel any
-        // active pin session so the coordinator doesn't fight the restore.
-        bottomPinCoordinator.cancelActiveSession(reason: .paginationRestore)
-        let anchorId = visibleMessages.first?.id
-        os_signpost(.event, log: PerfSignposts.log, name: "paginationSentinelFired")
-        log.debug("[pagination] fired — anchorId: \(String(describing: anchorId))")
-        paginationTask = Task {
-            defer {
-                if !Task.isCancelled {
-                    isPaginationInFlight = false
-                    paginationTask = nil
-                } else if paginationTask == nil {
-                    isPaginationInFlight = false
-                }
-            }
-            let hadMore = await loadPreviousMessagePage?() ?? false
-            log.debug("[pagination] loadPreviousMessagePage returned hadMore=\(hadMore)")
-            if hadMore, let id = anchorId {
-                // Suppress bottom auto-scroll for the brief layout window so the
-                // restored anchor position is not immediately overridden.
-                isSuppressingBottomScroll = true
-                os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=pagination")
-                // Wait ~6 frames for SwiftUI to complete layout before restoring position.
-                // 100ms gives video embed cards (which animate height over 0.25s) enough
-                // time to settle so the scroll restoration lands at the right position.
-                try? await Task.sleep(nanoseconds: 100_000_000)
-                guard !Task.isCancelled else {
-                    isSuppressingBottomScroll = false
-                    return
-                }
-                os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=paginationAnchor")
-                recordScrollLoopEvent(.scrollToRequested)
-                proxy.scrollTo(id, anchor: .top)
-                log.debug("[pagination] scroll restored to anchor \(id)")
-                isSuppressingBottomScroll = false
-                os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "off reason=paginationDone")
-            }
-        }
+        scrollCoordinator.restoreScrollToBottom(
+            proxy: proxy,
+            conversationId: conversationId,
+            anchorMessageId: $anchorMessageId,
+            scrollViewportHeight: scrollViewportHeight,
+            avatarSmoothingTask: &avatarSmoothingTask,
+            isAvatarVisible: &isAvatarVisible,
+            avatarDisplayY: &avatarDisplayY
+        )
     }
 
     /// Flash-highlight the given message after an anchor scroll completes.
@@ -871,170 +695,40 @@ struct MessageListView: View {
         }
     }
 
-    /// Records a scroll-related event into the loop guard and emits a
-    /// diagnostic warning if the guard trips (too many events in the window).
+    /// Delegates scroll loop event recording to the coordinator.
     private func recordScrollLoopEvent(_ kind: ChatScrollLoopGuard.EventKind) {
-        let convId = conversationId?.uuidString ?? "unknown"
-        let timestamp = ProcessInfo.processInfo.systemUptime
-
-        if let snapshot = scrollLoopGuard.record(kind, conversationId: convId, timestamp: timestamp) {
-            let countsDescription = snapshot.counts.map { "\($0.key.rawValue)=\($0.value)" }.joined(separator: " ")
-            log.warning(
-                "Scroll loop detected — trippedBy=\(snapshot.trippedBy.rawValue) window=\(snapshot.windowDuration)s \(countsDescription) isNearBottom=\(isNearBottom) hasReceivedScrollEvent=\(hasReceivedScrollEvent) anchorMessageId=\(String(describing: anchorMessageId)) anchorLastMinY=\(anchorTracker.lastMinY) viewportHeight=\(scrollViewportHeight)"
-            )
-            var sanitizer = NumericSanitizer()
-            let safeScrollOffsetY = sanitizer.sanitize(anchorTracker.lastMinY, field: "scrollOffsetY")
-            let safeViewportHeight = sanitizer.sanitize(scrollViewportHeight, field: "viewportHeight")
-            logNonFiniteGeometryOnce(sanitizer: sanitizer)
-            ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
-                kind: .scrollLoopDetected,
-                conversationId: convId,
-                reason: "trippedBy=\(snapshot.trippedBy.rawValue) \(countsDescription)",
-                isPinnedToBottom: isNearBottom,
-                isUserScrolling: hasReceivedScrollEvent,
-                scrollOffsetY: safeScrollOffsetY,
-                viewportHeight: safeViewportHeight,
-                nonFiniteFields: sanitizer.nonFiniteFields
-            ))
-        }
-    }
-
-    /// Schedules a debounced transcript snapshot capture. Coalesces rapid scroll
-    /// events into a single snapshot per 150ms window, avoiding O(n) tool-call
-    /// scans on every scroll tick.
-    private func scheduleTranscriptSnapshot() {
-        scrollTracking.snapshotDebounceTask?.cancel()
-        scrollTracking.snapshotDebounceTask = Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(150))
-            guard !Task.isCancelled else { return }
-            updateTranscriptSnapshot()
-        }
-    }
-
-    /// Captures a point-in-time transcript snapshot into `ChatDiagnosticsStore`.
-    /// Called via `scheduleTranscriptSnapshot()` so that `DebugStateWriter`
-    /// and `HangContextWriter` always have recent transcript state available.
-    private func updateTranscriptSnapshot() {
-        guard let convId = conversationId else { return }
-        let msgs = messages
-        let totalToolCalls = msgs.reduce(0) { $0 + $1.toolCalls.count }
-
-        // Route all geometry through NumericSanitizer so non-finite values
-        // (inf, -inf, NaN) are replaced with nil and tracked in nonFiniteFields.
-        // scrollViewportHeight and lastTailAnchorY start as .infinity before
-        // their preference callbacks run.
-        var sanitizer = NumericSanitizer()
-        let safeAnchorMinY = sanitizer.sanitize(anchorTracker.lastMinY, field: "anchorMinY")
-        let safeTailAnchorY = sanitizer.sanitize(scrollTracking.lastTailAnchorY, field: "tailAnchorY")
-        let safeViewportHeight = sanitizer.sanitize(scrollViewportHeight, field: "scrollViewportHeight")
-        let safeContainerWidth = sanitizer.sanitize(containerWidth, field: "containerWidth")
-        logNonFiniteGeometryOnce(sanitizer: sanitizer)
-
-        // Capture rolling scroll loop guard counts for debug-state.json.
-        let guardCounts = scrollLoopGuard.currentCounts(conversationId: convId.uuidString)
-        let guardCountsStringKeyed: [String: Int]? = guardCounts.isEmpty ? nil : Dictionary(
-            uniqueKeysWithValues: guardCounts.map { ($0.key.rawValue, $0.value) }
-        )
-
-        ChatDiagnosticsStore.shared.updateSnapshot(ChatTranscriptSnapshot(
-            conversationId: convId.uuidString,
-            capturedAt: Date(),
-            messageCount: msgs.count,
-            toolCallCount: totalToolCalls,
-            isPinnedToBottom: isNearBottom,
-            isUserScrolling: hasReceivedScrollEvent,
-            scrollOffsetY: safeAnchorMinY,
-            contentHeight: nil,
-            viewportHeight: safeViewportHeight,
+        scrollCoordinator.recordScrollLoopEvent(
+            kind,
+            conversationId: conversationId,
             isNearBottom: isNearBottom,
-            hasReceivedScrollEvent: hasReceivedScrollEvent,
-            isPaginationInFlight: isPaginationInFlight,
-            suppressionReason: isSuppressingBottomScroll ? "bottomScrollSuppressed" : nil,
-            anchorMessageId: anchorMessageId?.uuidString,
-            highlightedMessageId: highlightedMessageId?.uuidString,
-            anchorMinY: safeAnchorMinY,
-            tailAnchorY: safeTailAnchorY,
-            scrollViewportHeight: safeViewportHeight,
-            containerWidth: safeContainerWidth,
-            scrollLoopGuardCounts: guardCountsStringKeyed,
-            nonFiniteFields: sanitizer.nonFiniteFields
-        ))
+            scrollViewportHeight: scrollViewportHeight,
+            anchorMessageId: anchorMessageId
+        )
     }
 
-    /// Logs a one-time warning when scroll geometry first becomes non-finite
-    /// during a render pass. Uses the MessageListView logger so the condition
-    /// is visible even if the JSONL session log later fails for another reason.
-    private func logNonFiniteGeometryOnce(sanitizer: NumericSanitizer) {
-        guard !hasLoggedNonFiniteGeometry, let fields = sanitizer.nonFiniteFields else { return }
-        hasLoggedNonFiniteGeometry = true
-        log.warning("Non-finite scroll geometry detected — sanitized fields: \(fields.joined(separator: ", "))")
-    }
 
-    /// Routes an automatic bottom-follow request through the coordinator.
-    /// The coordinator decides whether to suppress (user is detached), coalesce
-    /// (duplicate request within an active session), or start a new bounded
-    /// retry session. Anchor-message jumps and pagination restoration bypass
-    /// this helper entirely — they are higher-priority flows.
-    /// Sentinel UUID used for pin requests before the daemon assigns a real
-    /// conversation ID. Lets bootstrap-window requests coalesce normally.
-    private static let bootstrapConversationId = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
-
+    /// Delegates bottom-pin request to the coordinator.
     private func requestBottomPin(
         reason: BottomPinRequestReason,
         proxy: ScrollViewProxy,
         animated: Bool = false
     ) {
-        let convId = conversationId ?? Self.bootstrapConversationId
-        bottomPinCoordinator.requestPin(
+        scrollCoordinator.requestBottomPin(
             reason: reason,
-            conversationId: convId,
+            proxy: proxy,
+            conversationId: conversationId,
             animated: animated
         )
     }
 
-    /// Configures the coordinator's callbacks to wire pin requests back to
-    /// the scroll view proxy and follow-state changes back to `isNearBottom`.
+    /// Delegates bottom-pin coordinator configuration to the scroll coordinator.
     private func configureBottomPinCoordinator(proxy: ScrollViewProxy) {
-        bottomPinCoordinator.onPinRequested = { [self] reason, animated in
-            guard !isSuppressingBottomScroll else { return false }
-            // Circuit breaker: suppress scroll-to when a scroll loop was detected.
-            // The guard re-arms after a quiet cooldown window elapses.
-            let convIdString = conversationId?.uuidString ?? "unknown"
-            if scrollLoopGuard.isTripped(conversationId: convIdString) {
-                os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested",
-                            "target=bottomAnchor reason=circuitBreakerSuppressed")
-                return false
-            }
-            os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested",
-                        "target=bottomAnchor reason=coordinator-%{public}s", reason.rawValue)
-            recordScrollLoopEvent(.scrollToRequested)
-            if animated {
-                withAnimation(VAnimation.fast) {
-                    proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
-                }
-            } else {
-                proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
-            }
-            // Check if the pin succeeded (anchor within viewport).
-            // Use `verify()` so that `geometryUnavailable` returns false
-            // (wait for the next finite preference update) instead of being
-            // treated as an immediate failed pin that triggers retry churn.
-            let outcome = MessageListBottomAnchorPolicy.verify(
-                anchorMinY: anchorTracker.lastMinY,
-                viewportHeight: scrollViewportHeight
-            )
-            return outcome == .anchored
-        }
-        bottomPinCoordinator.onFollowStateChanged = { isFollowing in
-            isNearBottom = isFollowing
-        }
-
-        // If detach() was called before this callback was wired up (e.g. a
-        // scroll-wheel event fired between makeNSView and onAppear), sync
-        // isNearBottom now so it isn't stuck at true permanently.
-        if !bottomPinCoordinator.isFollowingBottom {
-            isNearBottom = false
-        }
+        scrollCoordinator.configureBottomPinCoordinator(
+            proxy: proxy,
+            scrollViewportHeight: scrollViewportHeight,
+            conversationId: conversationId,
+            isNearBottom: $isNearBottom
+        )
     }
 
     private var shouldAnchorThinkingToConfirmationChip: Bool {
@@ -1226,7 +920,7 @@ struct MessageListView: View {
                             // anchorTracker preference tracking to manage isNearBottom —
                             // LazyVStack fires onAppear in the prefetch zone (several screens
                             // ahead) which would prematurely re-tether during normal scrolling.
-                            if !hasReceivedScrollEvent {
+                            if !scrollCoordinator.hasReceivedScrollEvent {
                                 isNearBottom = true
                             }
                         }
@@ -1250,64 +944,22 @@ struct MessageListView: View {
             .coordinateSpace(name: "chatScrollView")
             .scrollDisabled(messages.isEmpty && !isSending)
             .environment(\.suppressAutoScroll, { [self] in
-                expandSuppressionTask?.cancel()
-                if isNearBottom {
-                    // Clear any stale suppression left by a canceled off-bottom expansion,
-                    // but only when the resize guard isn't actively suppressing scroll.
-                    let resizeActive = resizeScrollTask != nil && !resizeScrollTask!.isCancelled
-                    if !resizeActive {
-                        isSuppressingBottomScroll = false
-                    }
-                    // Route expansion bottom-follow through the coordinator for
-                    // bounded staged retries instead of per-frame repinning.
-                    os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=expansionPinning")
-                    recordScrollLoopEvent(.suppressionFlip)
-                    requestBottomPin(reason: .expansion, proxy: proxy, animated: false)
-                } else {
-                    // When scrolled away from bottom, suppress auto-scroll so the
-                    // expansion doesn't yank the viewport to the bottom.
-                    isSuppressingBottomScroll = true
-                    os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=offBottomExpansion")
-                    recordScrollLoopEvent(.suppressionFlip)
-                    expandSuppressionTask = Task { @MainActor in
-                        try? await Task.sleep(nanoseconds: 200_000_000)
-                        guard !Task.isCancelled else { return }
-                        // Only clear if no other mechanism (resize, pagination) still needs suppression.
-                        let resizeActive = resizeScrollTask != nil && !resizeScrollTask!.isCancelled
-                        let paginationActive = isPaginationInFlight
-                        if !resizeActive && !paginationActive {
-                            isSuppressingBottomScroll = false
-                            os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "off reason=expansionExpired")
-                        }
-                    }
-                }
+                let resizeActive = resizeScrollTask != nil && !resizeScrollTask!.isCancelled
+                scrollCoordinator.handleSuppressAutoScroll(
+                    isNearBottom: isNearBottom,
+                    isResizeActive: resizeActive,
+                    conversationId: conversationId,
+                    proxy: proxy,
+                    scrollViewportHeight: scrollViewportHeight
+                )
             })
             .background {
                 GeometryReader { geo in
                     Color.clear.preference(key: ScrollViewportHeightKey.self, value: geo.size.height)
                 }
                 ScrollWheelDetector(
-                    onScrollUp: {
-
-                        scrollRestoreTask?.cancel()
-                        scrollRestoreTask = nil
-                        expandSuppressionTask?.cancel()
-                        expandSuppressionTask = nil
-                        isSuppressingBottomScroll = false
-                        // Signal the coordinator to detach — this sets isNearBottom
-                        // to false and cancels any active pin session.
-                        bottomPinCoordinator.handleUserAction(.scrollUp)
-                        hasReceivedScrollEvent = true
-                    },
-                    onScrollToBottom: {
-                        scrollRestoreTask?.cancel()
-                        scrollRestoreTask = nil
-                        isSuppressingBottomScroll = false
-                        // Signal the coordinator to reattach — this sets isNearBottom
-                        // to true and allows future pin requests.
-                        bottomPinCoordinator.handleUserAction(.scrollToBottom)
-                        hasReceivedScrollEvent = true
-                    },
+                    onScrollUp: { scrollCoordinator.handleScrollUp() },
+                    onScrollToBottom: { scrollCoordinator.handleScrollToBottom() },
                     conversationId: conversationId
                 )
             }
@@ -1324,14 +976,14 @@ struct MessageListView: View {
                 )
                 guard case .accept(let accepted) = decision else { return }
                 os_signpost(.begin, log: PerfSignposts.log, name: "viewportHeightPreferenceChange")
-                let viewportChanged = anchorTracker.updateViewport(
+                let viewportChanged = scrollCoordinator.updateAnchorViewport(
                     height: accepted,
                     storedViewportHeight: &scrollViewportHeight
                 )
-                if viewportChanged, scrollTracking.lastTailAnchorY.isFinite {
+                if viewportChanged, scrollCoordinator.scrollTracking.lastTailAnchorY.isFinite {
                     // Reconcile the avatar follower on resize so a hidden target
                     // is refreshed before a later visibility transition reveals it.
-                    updateAvatarFollower(anchorY: scrollTracking.lastTailAnchorY)
+                    updateAvatarFollower(anchorY: scrollCoordinator.scrollTracking.lastTailAnchorY)
                 }
                 os_signpost(.end, log: PerfSignposts.log, name: "viewportHeightPreferenceChange")
             }
@@ -1341,44 +993,27 @@ struct MessageListView: View {
                 // reduce layout invalidation cascades during rapid scroll.
                 let decision = PreferenceGeometryFilter.evaluate(
                     newValue: minY,
-                    previous: anchorTracker.lastMinY
+                    previous: scrollCoordinator.anchorLastMinY
                 )
                 switch decision {
                 case .rejectNonFinite:
-                    // The anchor was deallocated by the LazyVStack (no child reports
-                    // a finite value, so the preference reduces to its .infinity default).
-                    // Mark the anchor as off-screen so the "Scroll to latest" button can appear.
-                    // Also reset lastMinY to .infinity so the button condition
-                    // (!isNearBottom && !isVisible && lastMinY > viewportHeight + 20) is satisfied.
-                    // .infinity is safe: updateViewport() guards isFinite, evaluate() treats
-                    // it as a skip for the dead-zone check, and verify() returns .geometryUnavailable.
-                    if anchorTracker.isVisible {
-                        anchorTracker.isVisible = false
-                        log.debug("Anchor preference non-finite — marking anchor invisible (deallocated by LazyVStack)")
-                    }
-                    anchorTracker.lastMinY = .infinity
+                    scrollCoordinator.handleNonFiniteAnchor()
                     return
                 case .rejectDeadZone:
                     return
                 case .accept(let accepted):
                     os_signpost(.begin, log: PerfSignposts.log, name: "anchorMinYPreferenceChange")
-                    recordScrollLoopEvent(.anchorPreferenceChange)
-                    anchorTracker.update(minY: accepted, viewportHeight: scrollViewportHeight)
-                    if !hasFreshAnchorMeasurement {
-                        hasFreshAnchorMeasurement = true
-                        // First finite anchor measurement after a conversation switch.
-                        // LazyVStack may report the anchor as "within viewport" before
-                        // materializing message cells, causing the coordinator to skip
-                        // the scrollTo. Bypass the coordinator and scroll directly so
-                        // messages are visible without user interaction.
-                        if !hasReceivedScrollEvent && anchorMessageId == nil {
-                            proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
-                        }
-                    }
-                    scheduleTranscriptSnapshot()
-                    // Geometry tracking only — no per-frame scrollTo calls here.
-                    // All bottom-follow work is handled by the ChatBottomPinCoordinator
-                    // via bounded staged retries, not inline on every anchor change.
+                    scrollCoordinator.handleAcceptedAnchorMinY(
+                        accepted: accepted,
+                        scrollViewportHeight: scrollViewportHeight,
+                        anchorMessageId: anchorMessageId,
+                        proxy: proxy,
+                        conversationId: conversationId,
+                        messages: messages,
+                        isNearBottom: isNearBottom,
+                        containerWidth: containerWidth,
+                        highlightedMessageId: highlightedMessageId
+                    )
                     os_signpost(.end, log: PerfSignposts.log, name: "anchorMinYPreferenceChange")
                 }
             }
@@ -1388,11 +1023,11 @@ struct MessageListView: View {
                 // to reduce layout invalidation cascades during rapid scroll.
                 let decision = PreferenceGeometryFilter.evaluate(
                     newValue: anchorY,
-                    previous: scrollTracking.lastTailAnchorY
+                    previous: scrollCoordinator.scrollTracking.lastTailAnchorY
                 )
                 guard case .accept(let accepted) = decision else { return }
                 recordScrollLoopEvent(.tailAnchorPreferenceChange)
-                scrollTracking.lastTailAnchorY = accepted
+                scrollCoordinator.scrollTracking.lastTailAnchorY = accepted
                 // Defer to next run loop to prevent synchronous layout re-entry
                 // on macOS. This preference fires during placeSubviews; calling
                 // withAnimation (inside applyAvatarDisplayY) synchronously causes
@@ -1405,49 +1040,29 @@ struct MessageListView: View {
             }
             .transaction { $0.disablesAnimations = true }
             .onPreferenceChange(PaginationSentinelMinYKey.self) { sentinelMinY in
-                // Filter non-finite sentinel values to prevent transient layout
-                // data from corrupting pagination trigger state. No dead-zone —
-                // every finite position change matters for edge-transition detection.
-                guard PreferenceGeometryFilter.evaluate(
-                    newValue: sentinelMinY,
-                    previous: .infinity,
-                    deadZone: 0
-                ) != .rejectNonFinite else { return }
-
-                let isInRange = MessageListPaginationTriggerPolicy.isInTriggerBand(
+                scrollCoordinator.handlePaginationSentinel(
                     sentinelMinY: sentinelMinY,
-                    viewportHeight: scrollViewportHeight
+                    scrollViewportHeight: scrollViewportHeight,
+                    hasMoreMessages: hasMoreMessages,
+                    isLoadingMoreMessages: isLoadingMoreMessages,
+                    proxy: proxy,
+                    visibleMessages: visibleMessages,
+                    conversationId: conversationId,
+                    loadPreviousMessagePage: loadPreviousMessagePage
                 )
-                let shouldFire = MessageListPaginationTriggerPolicy.shouldTrigger(
-                    sentinelMinY: sentinelMinY,
-                    viewportHeight: scrollViewportHeight,
-                    wasInRange: wasPaginationTriggerInRange
-                )
-                wasPaginationTriggerInRange = isInRange
-
-                log.debug("[pagination] sentinel minY=\(sentinelMinY, privacy: .public) inRange=\(isInRange) shouldFire=\(shouldFire) hasMore=\(hasMoreMessages) loading=\(isLoadingMoreMessages) inFlight=\(isPaginationInFlight)")
-
-                guard shouldFire,
-                      hasMoreMessages,
-                      !isLoadingMoreMessages,
-                      !isPaginationInFlight
-                else { return }
-
-                log.debug("[pagination] sentinel entered range — triggering pagination")
-                triggerPagination(proxy: proxy)
             }
             .overlay(alignment: .topLeading) {
                 conversationTailAvatar
             }
             .overlay(alignment: .bottom) {
-                if !isNearBottom && !anchorTracker.isVisible
-                    && anchorTracker.lastMinY > scrollViewportHeight + 20
+                if !isNearBottom && !scrollCoordinator.anchorIsVisible
+                    && scrollCoordinator.anchorLastMinY > scrollViewportHeight + 20
                 {
                     Button(action: {
                         os_signpost(.event, log: PerfSignposts.log, name: "scrollToLatestPressed")
-                        hasReceivedScrollEvent = true
+                        scrollCoordinator.hasReceivedScrollEvent = true
                         // Signal the coordinator to reattach and scroll to bottom.
-                        bottomPinCoordinator.handleUserAction(.jumpToLatest)
+                        scrollCoordinator.bottomPinCoordinator.handleUserAction(.jumpToLatest)
                         requestBottomPin(reason: .initialRestore, proxy: proxy, animated: true)
                     }) {
                         HStack(spacing: VSpacing.xs) {
@@ -1509,7 +1124,7 @@ struct MessageListView: View {
                             anchorMessageId = nil
                             anchorSetTime = nil
                             anchorTimeoutTask = nil
-                            bottomPinCoordinator.reattach()
+                            scrollCoordinator.bottomPinCoordinator.reattach()
                             requestBottomPin(reason: .initialRestore, proxy: proxy, animated: true)
                         }
                     }
@@ -1521,32 +1136,20 @@ struct MessageListView: View {
                 // retry once history finishes loading.
             }
             .onDisappear {
+                scrollCoordinator.cancelAllTasks()
                 anchorTimeoutTask?.cancel()
                 anchorTimeoutTask = nil
                 resizeScrollTask?.cancel()
                 resizeScrollTask = nil
-                expandSuppressionTask?.cancel()
-                expandSuppressionTask = nil
-                scrollRestoreTask?.cancel()
-                scrollRestoreTask = nil
-                paginationTask?.cancel()
-                paginationTask = nil
-                isPaginationInFlight = false
                 avatarSmoothingTask?.cancel()
                 avatarSmoothingTask = nil
                 highlightDismissTask?.cancel()
                 highlightDismissTask = nil
-                scrollTracking.snapshotDebounceTask?.cancel()
-                scrollTracking.snapshotDebounceTask = nil
                 highlightedMessageId = nil
-                // Cancel any active pin session to prevent the coordinator's
-                // sessionTask from calling scrollTo on a stale ScrollViewProxy.
-                bottomPinCoordinator.cancelActiveSession(reason: .conversationSwitch)
-                bottomPinCoordinator.onPinRequested = nil
             }
             .onChange(of: isSending) {
                 if isSending {
-                    hasReceivedScrollEvent = true
+                    scrollCoordinator.hasReceivedScrollEvent = true
                     // Reattach and pin to bottom for user-initiated actions (send,
                     // regenerate, retry). Skip reattach only when the daemon resumes
                     // from a tool confirmation (not a user action during confirmation).
@@ -1559,10 +1162,10 @@ struct MessageListView: View {
                     let isDaemonConfirmationResume =
                         phaseWhenSendingStopped == "awaiting_confirmation"
                         && assistantActivityPhase != "awaiting_confirmation"
-                    if isDaemonConfirmationResume && !bottomPinCoordinator.isFollowingBottom {
+                    if isDaemonConfirmationResume && !scrollCoordinator.bottomPinCoordinator.isFollowingBottom {
                         // Daemon resumed from confirmation while user was scrolled up.
                     } else {
-                        bottomPinCoordinator.reattach()
+                        scrollCoordinator.bottomPinCoordinator.reattach()
                         requestBottomPin(reason: .messageCount, proxy: proxy, animated: true)
                     }
                 } else {
@@ -1595,7 +1198,7 @@ struct MessageListView: View {
             }
             .onChange(of: shouldCoalesceAvatarUpdates) {
                 if !shouldCoalesceAvatarUpdates {
-                    updateAvatarFollower(anchorY: scrollTracking.pendingAvatarY ?? scrollTracking.avatarTargetY)
+                    updateAvatarFollower(anchorY: scrollCoordinator.scrollTracking.pendingAvatarY ?? scrollCoordinator.scrollTracking.avatarTargetY)
                 }
             }
             .onChange(of: messages.count) {
@@ -1608,7 +1211,7 @@ struct MessageListView: View {
                     os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundInMessages")
                     recordScrollLoopEvent(.scrollToRequested)
                     // Anchor jumps bypass the coordinator — they are higher priority.
-                    bottomPinCoordinator.cancelActiveSession(reason: .deepLinkAnchorHandoff)
+                    scrollCoordinator.bottomPinCoordinator.cancelActiveSession(reason: .deepLinkAnchorHandoff)
                     withAnimation {
                         proxy.scrollTo(id, anchor: .center)
                     }
@@ -1636,114 +1239,60 @@ struct MessageListView: View {
                         anchorSetTime = nil
                         anchorTimeoutTask?.cancel()
                         anchorTimeoutTask = nil
-                        bottomPinCoordinator.reattach()
+                        scrollCoordinator.bottomPinCoordinator.reattach()
                         requestBottomPin(reason: .messageCount, proxy: proxy, animated: true)
                         return
                     }
                 }
-                if isNearBottom && !isSuppressingBottomScroll && anchorMessageId == nil {
+                if isNearBottom && !scrollCoordinator.isSuppressingBottomScroll && anchorMessageId == nil {
                     requestBottomPin(reason: .messageCount, proxy: proxy, animated: true)
-                } else if !hasReceivedScrollEvent && anchorMessageId == nil && !messages.isEmpty {
+                } else if !scrollCoordinator.hasReceivedScrollEvent && anchorMessageId == nil && !messages.isEmpty {
                     // History just loaded but the coordinator's initial-restore session
                     // may have already expired (500ms timeout). Force a fresh scroll-to-bottom
                     // so messages are visible without requiring user scroll interaction.
                     requestBottomPin(reason: .initialRestore, proxy: proxy)
-                } else if isSuppressingBottomScroll {
+                } else if scrollCoordinator.isSuppressingBottomScroll {
                     log.debug("Auto-scroll suppressed (bottom-scroll suppression active)")
                 }
             }
             .onChange(of: containerWidth) {
-                // Ignore sub-pixel jitter and initial zero value.
-                // Use a tight 2pt threshold so scroll suppression activates on
-                // any meaningful width change during divider drag — the previous
-                // 20pt dead-zone let intermediate reflows through without suppression,
-                // causing scroll position desync and disappearing messages.
                 guard containerWidth > 0, abs(containerWidth - lastHandledContainerWidth) > 2 else { return }
                 lastHandledContainerWidth = containerWidth
-
-                // Cancel competing scroll tasks to prevent jitter during resize
                 resizeScrollTask?.cancel()
-
-                resizeScrollTask = Task { @MainActor in
-                    // Temporarily suppress bottom auto-scroll so streaming/message-count
-                    // handlers don't fight with the resize stabilization.
-                    isSuppressingBottomScroll = true
-                    os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=resize")
-                    defer {
-                        if !Task.isCancelled {
-                            isSuppressingBottomScroll = false
-                            os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "off reason=resizeDone")
-                            resizeScrollTask = nil
-                        }
-                    }
-                    // Wait for layout to settle (~100ms ≈ 6 frames)
-                    try? await Task.sleep(nanoseconds: 100_000_000)
-                    guard !Task.isCancelled else { return }
-
-                    if isNearBottom && anchorMessageId == nil {
-                        // Pin to bottom without animation to avoid visual bounce.
-                        // Skip when an anchor is pending (deep-link / notification)
-                        // to avoid yanking the viewport away from the target message.
-                        // Only repin for genuinely off-screen anchors — transient
-                        // missing geometry waits for the next finite preference update.
-                        let resizeOutcome = MessageListBottomAnchorPolicy.verify(
-                            anchorMinY: anchorTracker.lastMinY,
-                            viewportHeight: scrollViewportHeight
-                        )
-                        if resizeOutcome == .needsRepin {
-                            requestBottomPin(reason: .resize, proxy: proxy)
-                        }
-                    }
-                    // If not near bottom or anchor is set, preserve viewport.
-                }
+                resizeScrollTask = scrollCoordinator.makeResizeTask(
+                    proxy: proxy,
+                    conversationId: conversationId,
+                    isNearBottom: isNearBottom,
+                    anchorMessageId: anchorMessageId,
+                    scrollViewportHeight: scrollViewportHeight,
+                    onComplete: { [self] in resizeScrollTask = nil }
+                )
             }
             .onChange(of: conversationId) { oldConversationId, _ in
-                // Keep the underlying NSScrollView instance stable across conversation
-                // switches (prevents default-scroller flash), and reset view-local
-                // scroll state explicitly instead of remounting the whole view.
+                // Reset view-local state that doesn't belong in the coordinator.
                 resizeScrollTask?.cancel()
                 resizeScrollTask = nil
-                expandSuppressionTask?.cancel()
-                expandSuppressionTask = nil
                 avatarSmoothingTask?.cancel()
                 avatarSmoothingTask = nil
-                scrollTracking.snapshotDebounceTask?.cancel()
-                scrollTracking.snapshotDebounceTask = nil
-                paginationTask?.cancel()
-                paginationTask = nil
-                isPaginationInFlight = false
-                wasPaginationTriggerInRange = false
-                isSuppressingBottomScroll = false
-                // Reset the coordinator for the new conversation — cancels any
-                // active pin session and resets to following state.
-                bottomPinCoordinator.reset(newConversationId: conversationId)
+                scrollCoordinator.resetForConversationSwitch(
+                    oldConversationId: oldConversationId,
+                    newConversationId: conversationId,
+                    isSending: isSending,
+                    assistantActivityPhase: assistantActivityPhase
+                )
                 isNearBottom = true
                 highlightedMessageId = nil
                 highlightDismissTask?.cancel()
                 highlightDismissTask = nil
-                anchorTracker.isVisible = true
-                // Reset lastMinY to .infinity so the AnchorMinYKey preference
-                // handler's 2pt dead-zone doesn't filter out the first real
-                // measurement after a conversation switch. A value of 0 could
-                // collide with the actual anchor position and prevent
-                // hasFreshAnchorMeasurement from becoming true.
-                anchorTracker.lastMinY = .infinity
-                hasReceivedScrollEvent = false
                 // Capture the new conversation's activity phase so a conversation
                 // already paused in awaiting_confirmation is correctly tracked.
                 phaseWhenSendingStopped = isSending ? "" : assistantActivityPhase
-                // Reset the OLD conversation's scroll-loop guard state so it
-                // doesn't leak into future sessions for that conversation.
-                if let oldConvId = oldConversationId {
-                    scrollLoopGuard.reset(conversationId: oldConvId.uuidString)
-                }
                 lastHandledContainerWidth = containerWidth
                 anchorTimeoutTask?.cancel()
                 anchorTimeoutTask = nil
                 hasPlayedTailEntryAnimation = false
-                // Avatar state (scrollTracking.avatarTargetY, avatarDisplayY, scrollTracking)
-                // is reset inside
-                // restoreScrollToBottom so the reset is shared with onAppear.
+                // Avatar state is reset inside restoreScrollToBottom so the
+                // reset is shared with onAppear.
                 restoreScrollToBottom(proxy: proxy)
             }
             .onChange(of: anchorMessageId) {
@@ -1751,10 +1300,10 @@ struct MessageListView: View {
                 // The nil transition fires during conversation switches (stale anchor
                 // cleanup) and must not cancel the restore just started.
                 if anchorMessageId != nil {
-                    scrollRestoreTask?.cancel()
-                    scrollRestoreTask = nil
+                    scrollCoordinator.scrollRestoreTask?.cancel()
+                    scrollCoordinator.scrollRestoreTask = nil
                     // Anchor jumps are higher priority — cancel any active pin session.
-                    bottomPinCoordinator.cancelActiveSession(reason: .deepLinkAnchorHandoff)
+                    scrollCoordinator.bottomPinCoordinator.cancelActiveSession(reason: .deepLinkAnchorHandoff)
                 }
                 // Record the timestamp when a new anchor is set so the
                 // pagination-exhaustion guard can measure elapsed time.
@@ -1793,7 +1342,7 @@ struct MessageListView: View {
                         anchorMessageId = nil
                         anchorSetTime = nil
                         anchorTimeoutTask = nil
-                        bottomPinCoordinator.reattach()
+                        scrollCoordinator.bottomPinCoordinator.reattach()
                         requestBottomPin(reason: .initialRestore, proxy: proxy, animated: true)
                     }
                 }


### PR DESCRIPTION
## Summary
- Creates `MessageListScrollCoordinator` consolidating all scroll-related state from MessageListView
- Preserves the reactive/non-reactive split: hot-path fields (dead-zone guards, smoothing state, precomputed cache) stay as plain stored properties, never triggering objectWillChange
- Moves scroll methods (restoreScrollToBottom, requestBottomPin, triggerPagination, etc.) into the coordinator
- Extracts ConversationScrollbarVisibilityController into its own file

## Implementation
- `MessageListScrollCoordinator` is a `@MainActor final class: ObservableObject`
- Non-reactive state: `ScrollTrackingState` (plain `var`), `anchorLastMinY`, `ChatBottomPinCoordinator`, `ChatScrollLoopGuard`, flags and tasks
- Reactive (`@Published`): `anchorIsVisible`, `isSuppressingBottomScroll`, `isPaginationInFlight`, `suppressScrollbarDuringConversationSwitch`
- `AnchorVisibilityTracker` retained as standalone class for test compatibility
- MessageListView.swift reduced from 2,395 to 1,751 lines

## Key Technical Choices
- Option (a) from the plan: `ScrollTrackingState` kept as a nested class instance (plain `var`, not `@Published`) so mutations bypass `objectWillChange`
- Thin delegation wrappers remain on the view for methods that need view-local `@State` (avatar display, highlight, etc.)
- `ConversationScrollbarVisibilityController` extracted to its own file to meet the 1,800-line target

## Testing
All existing tests pass unchanged:
- `ChatBottomPinCoordinatorTests` (46 tests)
- `ChatScrollLoopGuardTests` (27 tests)
- `MessageListBottomAnchorPolicyTests` (16 tests)
- `MessageListAnchorPerformanceTests` (3 tests)

Part of plan: scroll-audit-cleanup.md (PR 1 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
