### PR TITLE
fix: clean up managed OAuth connection row with design system components

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/OAuthProviderServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/OAuthProviderServiceCard.swift
@@ -179,51 +179,48 @@ struct OAuthProviderServiceCard: View {
     }
 
     private var managedConnectionsList: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
             ForEach(store.managedConnections(for: providerKey), id: \.id) { entry in
                 managedConnectionRow(for: entry)
+                    .padding(.vertical, VSpacing.xs)
             }
-            VButton(label: "Connect Another Account", style: .outlined, isDisabled: store.managedIsConnecting(for: providerKey)) {
-                store.startManagedOAuthConnect(providerKey: providerKey, userId: currentUserId)
-            }
-            if store.managedIsConnecting(for: providerKey) {
-                Text("Waiting for authorization...")
-                    .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentTertiary)
+
+            Divider()
+                .foregroundColor(VColor.borderBase)
+
+            HStack(spacing: VSpacing.sm) {
+                VButton(label: "Connect Another Account", leftIcon: "lucide-plus", style: .outlined, isDisabled: store.managedIsConnecting(for: providerKey)) {
+                    store.startManagedOAuthConnect(providerKey: providerKey, userId: currentUserId)
+                }
+                if store.managedIsConnecting(for: providerKey) {
+                    VBusyIndicator(size: 8, color: VColor.contentTertiary)
+                    Text("Waiting for authorization...")
+                        .font(VFont.labelDefault)
+                        .foregroundColor(VColor.contentTertiary)
+                }
             }
         }
     }
 
     private func managedConnectionRow(for entry: OAuthConnectionEntry) -> some View {
-        HStack(alignment: .top) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(entry.account_label ?? "\(displayName) Account")
-                    .font(VFont.bodyMediumLighter)
-                    .foregroundColor(VColor.contentDefault)
-                if let scopes = entry.scopes_granted, !scopes.isEmpty {
-                    FlowLayout(spacing: 4) {
-                        ForEach(scopes.sorted(), id: \.self) { scope in
-                            Text(friendlyScopeName(scope))
-                                .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentSecondary)
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, 2)
-                                .background(VColor.surfaceBase)
-                                .clipShape(RoundedRectangle(cornerRadius: 4))
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 4)
-                                        .stroke(VColor.borderBase, lineWidth: 1)
-                                )
-                        }
-                    }
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack(alignment: .bottom, spacing: VSpacing.sm) {
+                VTextField(
+                    "Email",
+                    placeholder: "",
+                    text: .constant(entry.account_label ?? "\(displayName) Account")
+                )
+                .disabled(true)
+                VButton(label: "Disconnect", style: .danger) {
+                    store.disconnectManagedOAuthConnection(entry.id, providerKey: providerKey, userId: currentUserId)
                 }
             }
-            Spacer()
-            Text("Connected")
-                .font(VFont.labelDefault)
-                .foregroundColor(VColor.systemPositiveStrong)
-            VButton(label: "Disconnect", style: .danger) {
-                store.disconnectManagedOAuthConnection(entry.id, providerKey: providerKey, userId: currentUserId)
+            if let scopes = entry.scopes_granted, !scopes.isEmpty {
+                FlowLayout(spacing: VSpacing.xs) {
+                    ForEach(scopes.sorted(), id: \.self) { scope in
+                        VTag(friendlyScopeName(scope), color: VColor.primaryBase)
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replace hand-rolled scope tags with `VTag` design system component
- Display connected email in a disabled `VTextField` with "Email" label instead of plain text
- Remove redundant "Connected" status tag — the connection row itself implies connected state
- Add divider and plus icon to "Connect Another Account" button, with inline spinner for connecting state

## Test plan
- [ ] Open Settings > Google OAuth > Managed tab with a connected account
- [ ] Verify email displays in a labeled, disabled text field
- [ ] Verify scope tags use the design system `VTag` style
- [ ] Verify Disconnect button aligns with the email input field
- [ ] Verify "Connect Another Account" shows plus icon and spinner when connecting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
