### PR TITLE
fix: make ChatScrollLoopGuard a true circuit breaker that halts scroll cascades

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatScrollLoopGuard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatScrollLoopGuard.swift
@@ -77,6 +77,11 @@ final class ChatScrollLoopGuard {
     /// The guard re-arms only after a full quiet window elapses with no events.
     static let cooldownDuration: TimeInterval = 2.0
 
+    /// After the guard trips and cooldown expires with no events for this duration,
+    /// the auto-recovery mechanism schedules a single deferred re-pin attempt.
+    /// This prevents the UI from getting stuck in a "never scrolls again" state.
+    static let autoRecoveryDelay: TimeInterval = 1.0
+
     // MARK: - Internal State
 
     private struct ConversationState {
@@ -91,11 +96,19 @@ final class ChatScrollLoopGuard {
 
         /// Whether the guard is currently in cooldown (suppressing warnings).
         var inCooldown: Bool = false
+
+        /// Whether the guard has tripped and needs a recovery re-pin once
+        /// cooldown expires. Set to `true` when tripping, cleared when recovery fires.
+        var needsRecoveryRepin: Bool = false
     }
 
     private var states: [String: ConversationState] = [:]
 
     // MARK: - Public API
+
+    /// Callback invoked when the guard recovers from a trip and a re-pin
+    /// should be attempted. Set by the coordinator during configuration.
+    var onRecoveryNeeded: ((_ conversationId: String) -> Void)?
 
     /// Records an event and returns an aggregate snapshot if the guard trips.
     ///
@@ -126,6 +139,16 @@ final class ChatScrollLoopGuard {
         if state.inCooldown, let lastEvent = state.lastEventTime {
             if timestamp - lastEvent >= Self.cooldownDuration {
                 state.inCooldown = false
+                // Auto-recovery: when cooldown expires, schedule a single re-pin
+                // attempt so the UI doesn't get stuck in a "never scrolls" state.
+                if state.needsRecoveryRepin {
+                    state.needsRecoveryRepin = false
+                    // Save state before firing the callback (callback may re-enter).
+                    states[conversationId] = state
+                    onRecoveryNeeded?(conversationId)
+                    // Re-read in case the callback mutated state.
+                    state = states[conversationId] ?? state
+                }
             }
         }
 
@@ -158,7 +181,8 @@ final class ChatScrollLoopGuard {
         var snapshot: AggregateSnapshot?
 
         if let trippedKind = trippedBy, !state.inCooldown {
-            // Build the aggregate counts for all event kinds.
+            // Build the aggregate counts for all event kinds — full histogram
+            // for post-mortem analysis, not just the triggering event kind.
             var counts: [EventKind: Int] = [:]
             for eventKind in EventKind.allCases {
                 let count = state.events[eventKind]?.count ?? 0
@@ -177,6 +201,7 @@ final class ChatScrollLoopGuard {
 
             state.lastTripTime = timestamp
             state.inCooldown = true
+            state.needsRecoveryRepin = true
         }
 
         states[conversationId] = state

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
@@ -130,6 +130,10 @@ final class MessageListScrollCoordinator: ObservableObject {
     /// and app restarts.
     var scrollRestoreTask: Task<Void, Never>?
 
+    /// In-flight auto-recovery task scheduled after the loop guard trips.
+    /// Fires a single deferred re-pin attempt after the cooldown drains.
+    var loopGuardRecoveryTask: Task<Void, Never>?
+
     // MARK: - Anchor Visibility (mirrors AnchorVisibilityTracker)
 
     /// Updates the tracked anchor minY and recalculates visibility.
@@ -164,18 +168,27 @@ final class MessageListScrollCoordinator: ObservableObject {
     static let bootstrapConversationId = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
 
     /// Routes an automatic bottom-follow request through the coordinator.
+    /// Returns `false` when the scroll loop guard is tripped, suppressing the request.
+    @discardableResult
     func requestBottomPin(
         reason: BottomPinRequestReason,
         proxy: ScrollViewProxy,
         conversationId: UUID?,
         animated: Bool = false
-    ) {
+    ) -> Bool {
+        let convIdString = (conversationId ?? Self.bootstrapConversationId).uuidString
+        if scrollLoopGuard.isTripped(conversationId: convIdString) {
+            os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested",
+                        "target=bottomAnchor reason=circuitBreakerSuppressed-requestBottomPin")
+            return false
+        }
         let convId = conversationId ?? Self.bootstrapConversationId
         bottomPinCoordinator.requestPin(
             reason: reason,
             conversationId: convId,
             animated: animated
         )
+        return true
     }
 
     /// Configures the coordinator's callbacks to wire pin requests back to
@@ -215,6 +228,23 @@ final class MessageListScrollCoordinator: ObservableObject {
         }
         bottomPinCoordinator.onFollowStateChanged = { isFollowing in
             isNearBottom.wrappedValue = isFollowing
+        }
+
+        // Wire auto-recovery: when the loop guard's cooldown expires, schedule
+        // a single deferred re-pin attempt so the UI doesn't get stuck.
+        scrollLoopGuard.onRecoveryNeeded = { [weak self] convId in
+            guard let self else { return }
+            loopGuardRecoveryTask?.cancel()
+            loopGuardRecoveryTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: UInt64(ChatScrollLoopGuard.autoRecoveryDelay * 1_000_000_000))
+                guard !Task.isCancelled, let self else { return }
+                log.debug("Loop guard auto-recovery: attempting re-pin for \(convId)")
+                os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested",
+                            "target=bottomAnchor reason=loopGuardAutoRecovery")
+                self.bottomPinCoordinator.reattach()
+                self.requestBottomPin(reason: .initialRestore, proxy: proxy, conversationId: conversationId, animated: true)
+                self.loopGuardRecoveryTask = nil
+            }
         }
 
         // If detach() was called before this callback was wired up, sync
@@ -351,9 +381,13 @@ final class MessageListScrollCoordinator: ObservableObject {
         let timestamp = ProcessInfo.processInfo.systemUptime
 
         if let snapshot = scrollLoopGuard.record(kind, conversationId: convId, timestamp: timestamp) {
-            let countsDescription = snapshot.counts.map { "\($0.key.rawValue)=\($0.value)" }.joined(separator: " ")
+            // Log the full event histogram (all event kinds, including zeros)
+            // for post-mortem analysis — not just the kinds with non-zero counts.
+            let fullHistogram = ChatScrollLoopGuard.EventKind.allCases
+                .map { "\($0.rawValue)=\(snapshot.counts[$0] ?? 0)" }
+                .joined(separator: " ")
             log.warning(
-                "Scroll loop detected — trippedBy=\(snapshot.trippedBy.rawValue) window=\(snapshot.windowDuration)s \(countsDescription) isNearBottom=\(isNearBottom) hasReceivedScrollEvent=\(self.hasReceivedScrollEvent) anchorMessageId=\(String(describing: anchorMessageId)) anchorLastMinY=\(self.anchorLastMinY) viewportHeight=\(scrollViewportHeight)"
+                "Scroll loop detected — trippedBy=\(snapshot.trippedBy.rawValue) window=\(snapshot.windowDuration)s \(fullHistogram) isNearBottom=\(isNearBottom) hasReceivedScrollEvent=\(self.hasReceivedScrollEvent) anchorMessageId=\(String(describing: anchorMessageId)) anchorLastMinY=\(self.anchorLastMinY) viewportHeight=\(scrollViewportHeight)"
             )
             var sanitizer = NumericSanitizer()
             let safeScrollOffsetY = sanitizer.sanitize(anchorLastMinY, field: "scrollOffsetY")
@@ -362,7 +396,7 @@ final class MessageListScrollCoordinator: ObservableObject {
             ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
                 kind: .scrollLoopDetected,
                 conversationId: convId,
-                reason: "trippedBy=\(snapshot.trippedBy.rawValue) \(countsDescription)",
+                reason: "trippedBy=\(snapshot.trippedBy.rawValue) \(fullHistogram)",
                 isPinnedToBottom: isNearBottom,
                 isUserScrolling: hasReceivedScrollEvent,
                 scrollOffsetY: safeScrollOffsetY,
@@ -465,11 +499,14 @@ final class MessageListScrollCoordinator: ObservableObject {
         scrollRestoreTask = nil
         paginationTask?.cancel()
         paginationTask = nil
+        loopGuardRecoveryTask?.cancel()
+        loopGuardRecoveryTask = nil
         isPaginationInFlight = false
         scrollTracking.snapshotDebounceTask?.cancel()
         scrollTracking.snapshotDebounceTask = nil
         bottomPinCoordinator.cancelActiveSession(reason: .conversationSwitch)
         bottomPinCoordinator.onPinRequested = nil
+        scrollLoopGuard.onRecoveryNeeded = nil
     }
 
     /// Handles physical scroll-wheel/trackpad upward movement.
@@ -631,9 +668,12 @@ final class MessageListScrollCoordinator: ObservableObject {
         recordScrollLoopEvent(.anchorPreferenceChange, conversationId: conversationId, isNearBottom: isNearBottom, scrollViewportHeight: scrollViewportHeight)
         updateAnchor(minY: accepted, viewportHeight: scrollViewportHeight)
         var didDirectScroll = false
+        let convIdString = conversationId?.uuidString ?? "unknown"
         if !hasFreshAnchorMeasurement {
             hasFreshAnchorMeasurement = true
-            if !hasReceivedScrollEvent && anchorMessageId == nil {
+            if !hasReceivedScrollEvent && anchorMessageId == nil
+                && !scrollLoopGuard.isTripped(conversationId: convIdString)
+            {
                 proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                 didDirectScroll = true
             }
@@ -663,6 +703,8 @@ final class MessageListScrollCoordinator: ObservableObject {
         scrollTracking.snapshotDebounceTask = nil
         paginationTask?.cancel()
         paginationTask = nil
+        loopGuardRecoveryTask?.cancel()
+        loopGuardRecoveryTask = nil
         isPaginationInFlight = false
         wasPaginationTriggerInRange = false
         isSuppressingBottomScroll = false

--- a/clients/macos/vellum-assistantTests/ChatScrollLoopGuardTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatScrollLoopGuardTests.swift
@@ -589,4 +589,78 @@ final class ChatScrollLoopGuardTests: XCTestCase {
         XCTAssertFalse(guard_.isTripped(conversationId: conversationId),
                         "isTripped should return false after cooldown expires and quiet window elapses")
     }
+
+    // MARK: - Circuit Breaker: Trip → Suppression → Recovery
+
+    func testTripSuppressesRequestsThenAutoRecovers() {
+        var timestamp: TimeInterval = 1000.0
+
+        // Phase 1: Trip the guard by exceeding the scrollTo threshold.
+        var tripped = false
+        for _ in 0..<20 {
+            if guard_.record(.scrollToRequested, conversationId: conversationId, timestamp: timestamp) != nil {
+                tripped = true
+            }
+            timestamp += 0.1
+        }
+        XCTAssertTrue(tripped, "Guard should trip from scrollTo burst")
+
+        // Phase 2: Verify isTripped returns true — callers must early-return.
+        XCTAssertTrue(guard_.isTripped(conversationId: conversationId),
+                       "isTripped must return true while in cooldown")
+
+        // Phase 3: Wire up recovery callback and verify it fires after cooldown.
+        var recoveryConversationId: String?
+        guard_.onRecoveryNeeded = { convId in
+            recoveryConversationId = convId
+        }
+
+        // Advance past the cooldown duration with no events.
+        timestamp += ChatScrollLoopGuard.cooldownDuration + 0.1
+
+        // Record a single event to trigger cooldown expiry and auto-recovery.
+        guard_.record(.anchorPreferenceChange, conversationId: conversationId, timestamp: timestamp)
+
+        // Phase 4: Verify recovery fired and guard is no longer tripped.
+        XCTAssertEqual(recoveryConversationId, conversationId,
+                        "onRecoveryNeeded should fire with the correct conversation ID after cooldown")
+        XCTAssertFalse(guard_.isTripped(conversationId: conversationId),
+                        "isTripped should return false after cooldown recovery")
+
+        // Phase 5: Verify the guard can trip again (re-armed).
+        var trippedAgain = false
+        for _ in 0..<20 {
+            if guard_.record(.scrollToRequested, conversationId: conversationId, timestamp: timestamp) != nil {
+                trippedAgain = true
+            }
+            timestamp += 0.1
+        }
+        XCTAssertTrue(trippedAgain, "Guard should re-arm and trip again after recovery")
+    }
+
+    func testRecoveryOnlyFiresOnce() {
+        var timestamp: TimeInterval = 1000.0
+
+        // Trip the guard.
+        for _ in 0..<50 {
+            guard_.record(.anchorPreferenceChange, conversationId: conversationId, timestamp: timestamp)
+            timestamp += 0.03
+        }
+        XCTAssertTrue(guard_.isTripped(conversationId: conversationId))
+
+        var recoveryCount = 0
+        guard_.onRecoveryNeeded = { _ in
+            recoveryCount += 1
+        }
+
+        // First recovery after cooldown.
+        timestamp += ChatScrollLoopGuard.cooldownDuration + 0.1
+        guard_.record(.anchorPreferenceChange, conversationId: conversationId, timestamp: timestamp)
+        XCTAssertEqual(recoveryCount, 1, "Recovery should fire exactly once")
+
+        // Subsequent events should not re-fire recovery (no new trip).
+        timestamp += 0.1
+        guard_.record(.anchorPreferenceChange, conversationId: conversationId, timestamp: timestamp)
+        XCTAssertEqual(recoveryCount, 1, "Recovery should not fire again without a new trip")
+    }
 }


### PR DESCRIPTION
## Summary
- Makes `isTripped()` authoritative: all scroll-to-bottom paths early-return when tripped
- Adds auto-recovery: after 1 second of quiet, schedules a single deferred re-pin attempt
- Logs full event histogram on trip for post-mortem analysis
- Adds test verifying trip → suppression → recovery cycle

Part of plan: scroll-audit-cleanup.md (PR 7 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
