### PR TITLE
refactor: replace preference-key scroll tracking with onScrollGeometryChange

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListPreferenceGeometry.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListPreferenceGeometry.swift
@@ -45,8 +45,8 @@ enum PreferenceGeometryFilter {
     ///   - previous: The last accepted (stored) value. Pass `.infinity` when
     ///     no measurement has been recorded yet.
     ///   - deadZone: The minimum absolute change required for acceptance.
-    ///     Pass `0` to disable dead-zone suppression (used by keys where
-    ///     every finite change matters, such as `ScrollViewportHeightKey`).
+    ///     Pass `0` to disable dead-zone suppression (used by handlers where
+    ///     every finite change matters).
     /// - Returns: A `PreferenceFilterDecision` describing whether and how
     ///   the caller should act on the new value.
     static func evaluate(

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
@@ -6,24 +6,28 @@ import VellumAssistantShared
 
 private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "MessageListScrollCoordinator")
 
-/// Holds the last-known anchor minY without triggering SwiftUI re-renders.
-/// Only `isVisible` is @Published so re-renders happen only when the
-/// visible/invisible boundary is crossed — not on every scroll tick.
+/// Holds the last-known distance-from-bottom without triggering SwiftUI
+/// re-renders. Only `isVisible` is @Published so re-renders happen only when
+/// the visible/invisible boundary is crossed — not on every scroll tick.
 ///
 /// Retained as a standalone type for testability. The coordinator delegates
 /// anchor tracking to this class internally but exposes `anchorIsVisible`
 /// and `anchorLastMinY` as top-level properties for convenience.
+///
+/// `lastMinY` stores the distance-from-bottom (0 at the bottom, positive when
+/// scrolled up). The anchor is considered "visible" when the distance is at
+/// most 20pt.
 @MainActor final class AnchorVisibilityTracker: ObservableObject {
     var lastMinY: CGFloat = .infinity  // NOT @Published — no re-render on scroll
     @Published var isVisible: Bool = true
 
-    /// Updates the tracked minY and recalculates visibility.
+    /// Updates the tracked distance-from-bottom and recalculates visibility.
     /// Only publishes `isVisible` when the boundary is actually crossed
     /// (visible ↔ invisible), not on every scroll tick — this prevents
     /// SwiftUI re-renders during continuous scrolling.
-    func update(minY: CGFloat, viewportHeight: CGFloat) {
-        lastMinY = minY
-        let newVisible = minY >= -20 && minY <= viewportHeight + 20
+    func update(distanceFromBottom: CGFloat, viewportHeight: CGFloat) {
+        lastMinY = distanceFromBottom
+        let newVisible = distanceFromBottom >= -20 && distanceFromBottom <= 20
         if isVisible != newVisible { isVisible = newVisible }
     }
 
@@ -33,12 +37,12 @@ private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "Me
     func updateViewport(height: CGFloat, storedViewportHeight: inout CGFloat) -> Bool {
         guard storedViewportHeight != height else { return false }
         storedViewportHeight = height
-        // Don't recompute visibility before the anchor position has been
-        // measured — lastMinY starts at .infinity, and .infinity <= height + 20
+        // Don't recompute visibility before the distance-from-bottom has been
+        // measured — lastMinY starts at .infinity, and .infinity <= 20
         // evaluates to false, incorrectly flipping isVisible to false and
         // flashing the "Scroll to latest" button on short conversations.
         guard lastMinY.isFinite else { return true }
-        let newVisible = lastMinY >= -20 && lastMinY <= height + 20
+        let newVisible = lastMinY >= -20 && lastMinY <= 20
         if isVisible != newVisible { isVisible = newVisible }
         return true
     }
@@ -164,8 +168,8 @@ final class MessageListScrollCoordinator: ObservableObject {
     /// the current conversation loaded.
     var hasReceivedScrollEvent: Bool = false
 
-    /// Whether the AnchorMinYKey preference has fired since the last scroll
-    /// restore began.
+    /// Whether the distance-from-bottom scroll geometry has fired since the
+    /// last scroll restore began.
     var hasFreshAnchorMeasurement: Bool = false
 
     /// Tracks whether the pagination sentinel was previously inside the trigger band.
@@ -195,12 +199,17 @@ final class MessageListScrollCoordinator: ObservableObject {
 
     // MARK: - Anchor Visibility (mirrors AnchorVisibilityTracker)
 
-    /// Updates the tracked anchor minY and recalculates visibility.
+    /// Updates the tracked distance-from-bottom and recalculates visibility.
     /// Only publishes `anchorIsVisible` when the boundary is actually crossed
     /// (visible ↔ invisible), not on every scroll tick.
-    func updateAnchor(minY: CGFloat, viewportHeight: CGFloat) {
-        anchorLastMinY = minY
-        let newVisible = minY >= -20 && minY <= viewportHeight + 20
+    ///
+    /// `distanceFromBottom` is 0 when the scroll view is pinned to the bottom
+    /// and grows as the user scrolls up. The anchor is considered "visible"
+    /// (i.e. the bottom of the content is within the viewport) when the
+    /// distance is at most 20pt.
+    func updateAnchor(distanceFromBottom: CGFloat, viewportHeight: CGFloat) {
+        anchorLastMinY = distanceFromBottom
+        let newVisible = distanceFromBottom >= -20 && distanceFromBottom <= 20
         if anchorIsVisible != newVisible { anchorIsVisible = newVisible }
     }
 
@@ -210,12 +219,12 @@ final class MessageListScrollCoordinator: ObservableObject {
     func updateAnchorViewport(height: CGFloat, storedViewportHeight: inout CGFloat) -> Bool {
         guard storedViewportHeight != height else { return false }
         storedViewportHeight = height
-        // Don't recompute visibility before the anchor position has been
-        // measured — anchorLastMinY starts at .infinity, and .infinity <= height + 20
+        // Don't recompute visibility before the distance-from-bottom has been
+        // measured — anchorLastMinY starts at .infinity, and .infinity <= 20
         // evaluates to false, incorrectly flipping anchorIsVisible to false and
         // flashing the "Scroll to latest" button on short conversations.
         guard anchorLastMinY.isFinite else { return true }
-        let newVisible = anchorLastMinY >= -20 && anchorLastMinY <= height + 20
+        let newVisible = anchorLastMinY >= -20 && anchorLastMinY <= 20
         if anchorIsVisible != newVisible { anchorIsVisible = newVisible }
         return true
     }
@@ -666,8 +675,8 @@ final class MessageListScrollCoordinator: ObservableObject {
         }
     }
 
-    /// Handles the AnchorMinYKey preference change when the value is non-finite,
-    /// marking the anchor as off-screen.
+    /// Handles a non-finite distance-from-bottom value by marking the anchor
+    /// as off-screen.
     func handleNonFiniteAnchor() {
         if anchorIsVisible {
             anchorIsVisible = false
@@ -760,7 +769,7 @@ final class MessageListScrollCoordinator: ObservableObject {
         return true
     }
 
-    /// Handles the AnchorMinYKey preference change when the value is accepted (finite, past dead-zone).
+    /// Handles an accepted distance-from-bottom value (finite, past dead-zone).
     /// Returns true if a direct scroll-to-bottom was issued (first measurement after conversation switch).
     @discardableResult
     func handleAcceptedAnchorMinY(
@@ -775,7 +784,7 @@ final class MessageListScrollCoordinator: ObservableObject {
         highlightedMessageId: UUID?
     ) -> Bool {
         recordScrollLoopEvent(.anchorPreferenceChange, conversationId: conversationId, isNearBottom: isNearBottom, scrollViewportHeight: scrollViewportHeight)
-        updateAnchor(minY: accepted, viewportHeight: scrollViewportHeight)
+        updateAnchor(distanceFromBottom: accepted, viewportHeight: scrollViewportHeight)
         var didDirectScroll = false
         let convIdString = conversationId?.uuidString ?? "unknown"
         if !hasFreshAnchorMeasurement {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -174,8 +174,8 @@ struct MessageListView: View {
     /// Consolidates all scroll-related state: anchor tracking, scroll loop guard,
     /// bottom pin coordinator, suppression flags, and scroll-related tasks.
     @StateObject private var scrollCoordinator = MessageListScrollCoordinator()
-    /// The scroll view's viewport height, captured via preference key. Used by
-    /// the anchor GeometryReader to determine if the anchor is within bounds.
+    /// The scroll view's viewport height, captured via onScrollGeometryChange.
+    /// Used for anchor visibility checks and bottom-pin verification.
     @State private var scrollViewportHeight: CGFloat = .infinity
     /// Timestamp when anchorMessageId was set. Used together with pagination
     /// exhaustion to decide when a stale anchor should be cleared.
@@ -941,19 +941,11 @@ struct MessageListView: View {
                         .onAppear {
                             // Only auto-tether on initial load (before any scroll events).
                             // After the user has scrolled, rely on onScrollPhaseChange and
-                            // anchorTracker preference tracking to manage isNearBottom —
+                            // onScrollGeometryChange tracking to manage isNearBottom —
                             // LazyVStack fires onAppear in the prefetch zone (several screens
                             // ahead) which would prematurely re-tether during normal scrolling.
                             if !scrollCoordinator.hasReceivedScrollEvent {
                                 isNearBottom = true
-                            }
-                        }
-                        .background {
-                            GeometryReader { geo in
-                                Color.clear.preference(
-                                    key: AnchorMinYKey.self,
-                                    value: geo.frame(in: .named("chatScrollView")).minY
-                                )
                             }
                         }
                 }
@@ -977,11 +969,6 @@ struct MessageListView: View {
                     scrollViewportHeight: scrollViewportHeight
                 )
             })
-            .background {
-                GeometryReader { geo in
-                    Color.clear.preference(key: ScrollViewportHeightKey.self, value: geo.size.height)
-                }
-            }
             .onScrollPhaseChange { oldPhase, newPhase in
                 scrollPhase = newPhase
                 if newPhase == .idle && oldPhase != .idle && isNearBottom {
@@ -1010,18 +997,20 @@ struct MessageListView: View {
                 }
             }
             .scrollIndicators(.automatic)
-            .onPreferenceChange(ScrollViewportHeightKey.self) { height in
+            .onScrollGeometryChange(for: CGFloat.self) { geo in
+                geo.visibleRect.height
+            } action: { _, newHeight in
                 // Filter non-finite viewport heights and sub-pixel jitter.
                 // A 0.5pt dead-zone prevents floating-point rounding differences
                 // between render passes from triggering continuous @State mutations
                 // (scrollViewportHeight) which would create a runaway render loop.
                 let decision = PreferenceGeometryFilter.evaluate(
-                    newValue: height,
+                    newValue: newHeight,
                     previous: scrollViewportHeight,
                     deadZone: 0.5
                 )
                 guard case .accept(let accepted) = decision else { return }
-                os_signpost(.begin, log: PerfSignposts.log, name: "viewportHeightPreferenceChange")
+                os_signpost(.begin, log: PerfSignposts.log, name: "viewportHeightChanged")
                 let viewportChanged = scrollCoordinator.updateAnchorViewport(
                     height: accepted,
                     storedViewportHeight: &scrollViewportHeight
@@ -1031,14 +1020,18 @@ struct MessageListView: View {
                     // is refreshed before a later visibility transition reveals it.
                     updateAvatarFollower(anchorY: scrollCoordinator.scrollTracking.lastTailAnchorY)
                 }
-                os_signpost(.end, log: PerfSignposts.log, name: "viewportHeightPreferenceChange")
+                os_signpost(.end, log: PerfSignposts.log, name: "viewportHeightChanged")
             }
-            .transaction { $0.disablesAnimations = true }
-            .onPreferenceChange(AnchorMinYKey.self) { minY in
-                // Filter non-finite anchor values and apply 2pt dead-zone to
-                // reduce layout invalidation cascades during rapid scroll.
+            .onScrollGeometryChange(for: CGFloat.self) { geo in
+                // Distance from bottom: how far the visible rect's bottom edge
+                // is from the content bottom. Replaces the AnchorMinYKey preference
+                // + hidden anchor view + GeometryReader + coordinate space conversion.
+                geo.contentOffset.y + geo.contentSize.height - geo.visibleRect.height
+            } action: { _, distanceFromBottom in
+                // Filter non-finite values and apply 2pt dead-zone to reduce
+                // layout invalidation cascades during rapid scroll.
                 let decision = PreferenceGeometryFilter.evaluate(
-                    newValue: minY,
+                    newValue: distanceFromBottom,
                     previous: scrollCoordinator.anchorLastMinY
                 )
                 switch decision {
@@ -1048,7 +1041,7 @@ struct MessageListView: View {
                 case .rejectDeadZone:
                     return
                 case .accept(let accepted):
-                    os_signpost(.begin, log: PerfSignposts.log, name: "anchorMinYPreferenceChange")
+                    os_signpost(.begin, log: PerfSignposts.log, name: "distanceFromBottomChanged")
                     scrollCoordinator.handleAcceptedAnchorMinY(
                         accepted: accepted,
                         scrollViewportHeight: scrollViewportHeight,
@@ -1060,10 +1053,9 @@ struct MessageListView: View {
                         containerWidth: containerWidth,
                         highlightedMessageId: highlightedMessageId
                     )
-                    os_signpost(.end, log: PerfSignposts.log, name: "anchorMinYPreferenceChange")
+                    os_signpost(.end, log: PerfSignposts.log, name: "distanceFromBottomChanged")
                 }
             }
-            .transaction { $0.disablesAnimations = true }
             .onPreferenceChange(ConversationTailAnchorYKey.self) { anchorY in
                 // Filter non-finite tail anchor values and apply 2pt dead-zone
                 // to reduce layout invalidation cascades during rapid scroll.
@@ -1102,7 +1094,7 @@ struct MessageListView: View {
             }
             .overlay(alignment: .bottom) {
                 if !isNearBottom && !scrollCoordinator.anchorIsVisible
-                    && scrollCoordinator.anchorLastMinY > scrollViewportHeight + 20
+                    && scrollCoordinator.anchorLastMinY > 20
                 {
                     Button(action: {
                         os_signpost(.event, log: PerfSignposts.log, name: "scrollToLatestPressed")
@@ -1672,29 +1664,6 @@ private struct MessageCellView: View, Equatable {
     }
 }
 
-/// Preference key used to propagate the scroll view's viewport height from a
-/// background GeometryReader up to the MessageListView so the anchor-visibility
-/// check can compare the anchor's Y position against the viewport bounds.
-private struct ScrollViewportHeightKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        // Use max so sibling views in the same .background block (which report
-        // the default value of 0) don't overwrite the real viewport height.
-        value = max(value, nextValue())
-    }
-}
-
-/// Preference key that propagates the anchor's Y position (in the chatScrollView
-/// coordinate space) from the GeometryReader up to the MessageListView.
-private struct AnchorMinYKey: PreferenceKey {
-    static var defaultValue: CGFloat = .infinity
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        // Use min so sibling views in the LazyVStack (which report the default
-        // value of .infinity) don't overwrite the anchor's actual Y position.
-        value = min(value, nextValue())
-    }
-}
-
 /// Preference key that propagates the pagination sentinel's minY (in the
 /// `chatScrollView` coordinate space) so the geometry-based pagination
 /// trigger can evaluate whether the sentinel has entered the top band.
@@ -1723,8 +1692,12 @@ enum MessageListBottomAnchorPolicy {
 
     static let repinTolerance: CGFloat = 2
 
-    /// Evaluates the bottom-anchor position against the viewport and returns
+    /// Evaluates the distance-from-bottom against a tolerance and returns
     /// a structured outcome describing the result.
+    ///
+    /// `anchorMinY` now holds the distance-from-bottom (0 at the bottom,
+    /// positive when scrolled up). `viewportHeight` is still passed for
+    /// finite-geometry gating but is not used in the comparison.
     static func verify(
         anchorMinY: CGFloat,
         viewportHeight: CGFloat,
@@ -1733,7 +1706,7 @@ enum MessageListBottomAnchorPolicy {
         guard anchorMinY.isFinite, viewportHeight.isFinite else {
             return .geometryUnavailable
         }
-        if anchorMinY > viewportHeight + tolerance {
+        if anchorMinY > tolerance {
             return .needsRepin
         }
         return .anchored

--- a/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
@@ -673,16 +673,17 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
 
     /// Verifies that the anchor policy correctly distinguishes between
     /// genuinely off-screen anchors and unavailable geometry.
+    /// `anchorMinY` now represents distance-from-bottom (0 = at bottom).
     func testVerificationOutcomeDistinguishesGeometryStates() {
-        // Finite, in-bounds anchor
+        // Finite, at bottom (distance = 0)
         let anchored = MessageListBottomAnchorPolicy.verify(
-            anchorMinY: 500, viewportHeight: 600
+            anchorMinY: 0, viewportHeight: 600
         )
         XCTAssertEqual(anchored, .anchored)
 
-        // Finite, genuinely off-screen
+        // Finite, scrolled far from bottom
         let offScreen = MessageListBottomAnchorPolicy.verify(
-            anchorMinY: 700, viewportHeight: 600
+            anchorMinY: 100, viewportHeight: 600
         )
         XCTAssertEqual(offScreen, .needsRepin)
 
@@ -694,7 +695,7 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
 
         // Non-finite viewport (geometry not yet measured)
         let infiniteViewport = MessageListBottomAnchorPolicy.verify(
-            anchorMinY: 500, viewportHeight: .infinity
+            anchorMinY: 0, viewportHeight: .infinity
         )
         XCTAssertEqual(infiniteViewport, .geometryUnavailable)
 
@@ -845,20 +846,21 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
 
     /// Verifies that the legacy `needsRepin` helper still collapses
     /// `geometryUnavailable` into `true` for backwards compatibility.
+    /// `anchorMinY` is now distance-from-bottom (0 = at bottom).
     func testLegacyNeedsRepinCollapsesGeometryUnavailable() {
         // geometryUnavailable -> true (backwards-compatible behavior)
         XCTAssertTrue(MessageListBottomAnchorPolicy.needsRepin(
             anchorMinY: .infinity, viewportHeight: 600
         ))
 
-        // anchored -> false
+        // anchored (distance 0 = at bottom) -> false
         XCTAssertFalse(MessageListBottomAnchorPolicy.needsRepin(
-            anchorMinY: 500, viewportHeight: 600
+            anchorMinY: 0, viewportHeight: 600
         ))
 
-        // needsRepin -> true
+        // needsRepin (scrolled far from bottom) -> true
         XCTAssertTrue(MessageListBottomAnchorPolicy.needsRepin(
-            anchorMinY: 700, viewportHeight: 600
+            anchorMinY: 100, viewportHeight: 600
         ))
     }
 }

--- a/clients/macos/vellum-assistantTests/ConversationAvatarFollowerTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationAvatarFollowerTests.swift
@@ -84,7 +84,8 @@ final class ConversationAvatarFollowerTests: XCTestCase {
     @MainActor
     func testViewportChangeRecomputesVisibility() {
         let tracker = AnchorVisibilityTracker()
-        tracker.lastMinY = 520
+        // Distance-from-bottom of 15 is within the 20pt visibility threshold.
+        tracker.lastMinY = 15
         tracker.isVisible = false
         var storedViewportHeight: CGFloat = 500
 
@@ -101,7 +102,8 @@ final class ConversationAvatarFollowerTests: XCTestCase {
     @MainActor
     func testViewportChangeNoOpsWhenHeightIsUnchanged() {
         let tracker = AnchorVisibilityTracker()
-        tracker.lastMinY = 520
+        // Distance-from-bottom of 50 is outside the 20pt threshold — not visible.
+        tracker.lastMinY = 50
         tracker.isVisible = false
         var storedViewportHeight: CGFloat = 540
 

--- a/clients/macos/vellum-assistantTests/MessageListAnchorPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListAnchorPerformanceTests.swift
@@ -79,7 +79,7 @@ final class MessageListAnchorPerformanceTests: XCTestCase {
 
     // MARK: - 1. AnchorVisibilityTracker Rapid-Update Stress Test
 
-    /// Benchmarks calling update(minY:viewportHeight:) and
+    /// Benchmarks calling update(distanceFromBottom:viewportHeight:) and
     /// updateViewport(height:storedViewportHeight:) 10,000 times each in a
     /// tight loop. While individually trivial (O(1)), they are called on EVERY
     /// scroll frame. This test detects if any future refactoring adds overhead.
@@ -91,10 +91,10 @@ final class MessageListAnchorPerformanceTests: XCTestCase {
         measure(metrics: [XCTClockMetric(), XCTCPUMetric()]) {
             var storedViewportHeight: CGFloat = 800.0
             for i in 0..<10_000 {
-                // Simulate scrolling: minY varies from well above to well below
-                // the viewport, crossing the visibility boundary frequently.
-                let minY = CGFloat(i % 1600) - 400.0
-                tracker.update(minY: minY, viewportHeight: viewportHeight)
+                // Simulate scrolling: distanceFromBottom varies, crossing
+                // the visibility boundary (20pt threshold) frequently.
+                let distanceFromBottom = CGFloat(i % 100) - 10.0
+                tracker.update(distanceFromBottom: distanceFromBottom, viewportHeight: viewportHeight)
             }
             for i in 0..<10_000 {
                 // Simulate viewport resizes mixed with position changes.

--- a/clients/macos/vellum-assistantTests/MessageListBottomAnchorPolicyTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListBottomAnchorPolicyTests.swift
@@ -5,25 +5,28 @@ final class MessageListBottomAnchorPolicyTests: XCTestCase {
 
     // MARK: - needsRepin (existing API — behavior preserved)
 
-    func testNeedsRepinWhenAnchorFallsBelowViewport() {
+    /// `anchorMinY` now represents distance-from-bottom (0 = at bottom,
+    /// positive = scrolled up). `needsRepin` returns true when the distance
+    /// exceeds the tolerance.
+    func testNeedsRepinWhenScrolledFarFromBottom() {
         XCTAssertTrue(
             MessageListBottomAnchorPolicy.needsRepin(
-                anchorMinY: 540,
+                anchorMinY: 40,
                 viewportHeight: 500
             )
         )
     }
 
-    func testDoesNotRepinWhenAnchorAlreadyWithinTolerance() {
+    func testDoesNotRepinWhenWithinTolerance() {
         XCTAssertFalse(
             MessageListBottomAnchorPolicy.needsRepin(
-                anchorMinY: 500.5,
+                anchorMinY: 0.5,
                 viewportHeight: 500
             )
         )
         XCTAssertFalse(
             MessageListBottomAnchorPolicy.needsRepin(
-                anchorMinY: 502,
+                anchorMinY: 2,
                 viewportHeight: 500
             )
         )
@@ -38,19 +41,19 @@ final class MessageListBottomAnchorPolicyTests: XCTestCase {
         )
         XCTAssertTrue(
             MessageListBottomAnchorPolicy.needsRepin(
-                anchorMinY: 500,
+                anchorMinY: 0,
                 viewportHeight: .infinity
             )
         )
     }
 
-    // MARK: - verify (new decision API)
+    // MARK: - verify (decision API)
 
     // -- Anchored outcomes --
 
-    func testVerifyAnchoredWhenExactlyAtViewportBottom() {
+    func testVerifyAnchoredWhenExactlyAtBottom() {
         let outcome = MessageListBottomAnchorPolicy.verify(
-            anchorMinY: 500,
+            anchorMinY: 0,
             viewportHeight: 500
         )
         XCTAssertEqual(outcome, .anchored)
@@ -58,15 +61,16 @@ final class MessageListBottomAnchorPolicyTests: XCTestCase {
 
     func testVerifyAnchoredWhenWithinTolerance() {
         let outcome = MessageListBottomAnchorPolicy.verify(
-            anchorMinY: 501.5,
+            anchorMinY: 1.5,
             viewportHeight: 500
         )
         XCTAssertEqual(outcome, .anchored)
     }
 
-    func testVerifyAnchoredWhenAnchorAboveViewportBottom() {
+    func testVerifyAnchoredWhenNegativeDistanceFromBottom() {
+        // Negative distance means content is shorter than viewport (overscroll).
         let outcome = MessageListBottomAnchorPolicy.verify(
-            anchorMinY: 400,
+            anchorMinY: -5,
             viewportHeight: 500
         )
         XCTAssertEqual(outcome, .anchored)
@@ -74,9 +78,9 @@ final class MessageListBottomAnchorPolicyTests: XCTestCase {
 
     // -- NeedsRepin outcomes --
 
-    func testVerifyNeedsRepinWhenAnchorBelowViewport() {
+    func testVerifyNeedsRepinWhenScrolledFarFromBottom() {
         let outcome = MessageListBottomAnchorPolicy.verify(
-            anchorMinY: 540,
+            anchorMinY: 40,
             viewportHeight: 500
         )
         XCTAssertEqual(outcome, .needsRepin)
@@ -84,7 +88,7 @@ final class MessageListBottomAnchorPolicyTests: XCTestCase {
 
     func testVerifyNeedsRepinJustOutsideTolerance() {
         let outcome = MessageListBottomAnchorPolicy.verify(
-            anchorMinY: 502.01,
+            anchorMinY: 2.01,
             viewportHeight: 500
         )
         XCTAssertEqual(outcome, .needsRepin)
@@ -102,7 +106,7 @@ final class MessageListBottomAnchorPolicyTests: XCTestCase {
 
     func testVerifyGeometryUnavailableWhenViewportIsInfinity() {
         let outcome = MessageListBottomAnchorPolicy.verify(
-            anchorMinY: 500,
+            anchorMinY: 0,
             viewportHeight: .infinity
         )
         XCTAssertEqual(outcome, .geometryUnavailable)
@@ -126,7 +130,7 @@ final class MessageListBottomAnchorPolicyTests: XCTestCase {
 
     func testVerifyGeometryUnavailableWhenViewportIsNaN() {
         let outcome = MessageListBottomAnchorPolicy.verify(
-            anchorMinY: 500,
+            anchorMinY: 0,
             viewportHeight: .nan
         )
         XCTAssertEqual(outcome, .geometryUnavailable)
@@ -144,11 +148,11 @@ final class MessageListBottomAnchorPolicyTests: XCTestCase {
 
     func testNeedsRepinAgreesWithVerifyForFiniteInputs() {
         let cases: [(CGFloat, CGFloat)] = [
-            (400, 500),
-            (500, 500),
-            (501, 500),
-            (502, 500),
-            (540, 500),
+            (-5, 500),    // negative distance (overscroll) — anchored
+            (0, 500),     // at bottom — anchored
+            (1, 500),     // within tolerance — anchored
+            (2, 500),     // at tolerance boundary — anchored
+            (40, 500),    // scrolled up — needsRepin
         ]
         for (anchor, viewport) in cases {
             let outcome = MessageListBottomAnchorPolicy.verify(

--- a/clients/macos/vellum-assistantTests/MessageListPreferenceGeometryTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListPreferenceGeometryTests.swift
@@ -191,8 +191,7 @@ final class MessageListPreferenceGeometryTests: XCTestCase {
     // MARK: - Zero dead-zone (disabled suppression)
 
     /// When dead-zone is 0, every finite change is accepted regardless of
-    /// magnitude. This is used for preference keys like ScrollViewportHeightKey
-    /// where every change matters.
+    /// magnitude. This is used for handlers where every change matters.
     func testZeroDeadZoneAcceptsSmallChange() {
         let result = PreferenceGeometryFilter.evaluate(
             newValue: 100.5,


### PR DESCRIPTION
## Summary
- Replaces `ScrollViewportHeightKey` and `AnchorMinYKey` preference keys with `onScrollGeometryChange` modifiers
- Removes hidden anchor views and `GeometryReader` from the scroll tracking hot path
- Keeps `PreferenceGeometryFilter` for remaining tail-anchor and pagination preference handlers
- Updates `isNearBottom` to use distance-from-bottom directly

Part of plan: scroll-audit-cleanup.md (PR 2 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
