### PR TITLE
fix: use non-blocking NSOpenPanel in FileUploadSurfaceView

### DIFF
--- a/clients/shared/Features/Surfaces/FileUploadSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/FileUploadSurfaceView.swift
@@ -201,10 +201,11 @@ public struct FileUploadSurfaceView: View {
             }
         }
 
-        guard panel.runModal() == .OK else { return }
-
-        for url in panel.urls {
-            addFile(from: url)
+        panel.begin { response in
+            guard response == .OK else { return }
+            for url in panel.urls {
+                addFile(from: url)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace `panel.runModal()` with `panel.begin()` in `FileUploadSurfaceView.browseFiles()`
- `runModal()` fails with "The open file operation failed to connect to the open and save panel service" when called from a SwiftUI inline surface context
- `panel.begin()` presents the panel asynchronously, avoiding the XPC connection issue

## Test plan
- [ ] Open a conversation with a file upload surface (e.g. "do you have file uploader tool?")
- [ ] Click "Browse files" — file picker should open without error
- [ ] Select a file and verify it appears in the upload list
- [ ] Verify drag-and-drop still works

Closes JARVIS-314

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
