### PR TITLE
fix: replace phone icon with X for voice mode cancel

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -599,7 +599,7 @@ VStreamingWaveform(
 
                     VButton(
                         label: "End voice mode",
-                        iconOnly: VIcon.phoneCall.rawValue,
+                        iconOnly: VIcon.x.rawValue,
                         style: .danger,
                         iconSize: composerActionButtonSize,
                         action: { onEndVoiceMode?() }


### PR DESCRIPTION
Replace the phone/end-call icon with an X icon in the voice conversation composer cancel button, matching the dictation cancel pattern for better discoverability.

Part of #21180, closes #21181
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
