### PR TITLE
refactor: pin avatar to viewport bottom instead of content-following preference cascade

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatScrollLoopGuard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatScrollLoopGuard.swift
@@ -14,9 +14,6 @@ import Foundation
 /// **Thresholds:**
 /// - More than 40 `anchorPreferenceChange` events in 2 seconds
 /// - More than 15 `scrollToRequested` events in 2 seconds
-/// - More than 50 `avatarFollowerUpdate` events in 2 seconds
-/// - More than 30 `avatarDisplayYApplied` events in 2 seconds
-/// - More than 60 `tailAnchorPreferenceChange` events in 2 seconds
 /// - More than 40 `bodyEvaluation` events in 2 seconds
 ///
 /// Once tripped, the guard emits at most one aggregate warning per cooldown
@@ -31,9 +28,6 @@ final class ChatScrollLoopGuard {
         case scrollToRequested
         case repinAttempt
         case suppressionFlip
-        case avatarFollowerUpdate
-        case avatarDisplayYApplied
-        case tailAnchorPreferenceChange
         case bodyEvaluation
     }
 
@@ -57,15 +51,6 @@ final class ChatScrollLoopGuard {
 
     /// Maximum scrollTo requests allowed in the detection window.
     static let scrollToThreshold: Int = 15
-
-    /// Maximum updateAvatarFollower() calls allowed in the detection window.
-    static let avatarFollowerThreshold: Int = 50
-
-    /// Maximum applyAvatarDisplayY() @State mutations allowed in the detection window.
-    static let avatarApplyThreshold: Int = 30
-
-    /// Maximum ConversationTailAnchorYKey preference fires allowed in the detection window.
-    static let tailAnchorThreshold: Int = 60
 
     /// Maximum body evaluations allowed in the detection window.
     static let bodyEvaluationThreshold: Int = 40
@@ -158,9 +143,6 @@ final class ChatScrollLoopGuard {
         // Check thresholds.
         let anchorCount = state.events[.anchorPreferenceChange]?.count ?? 0
         let scrollToCount = state.events[.scrollToRequested]?.count ?? 0
-        let avatarFollowerCount = state.events[.avatarFollowerUpdate]?.count ?? 0
-        let avatarApplyCount = state.events[.avatarDisplayYApplied]?.count ?? 0
-        let tailAnchorCount = state.events[.tailAnchorPreferenceChange]?.count ?? 0
         let bodyEvalCount = state.events[.bodyEvaluation]?.count ?? 0
 
         var trippedBy: EventKind?
@@ -168,12 +150,6 @@ final class ChatScrollLoopGuard {
             trippedBy = .anchorPreferenceChange
         } else if scrollToCount > Self.scrollToThreshold {
             trippedBy = .scrollToRequested
-        } else if avatarFollowerCount > Self.avatarFollowerThreshold {
-            trippedBy = .avatarFollowerUpdate
-        } else if avatarApplyCount > Self.avatarApplyThreshold {
-            trippedBy = .avatarDisplayYApplied
-        } else if tailAnchorCount > Self.tailAnchorThreshold {
-            trippedBy = .tailAnchorPreferenceChange
         } else if bodyEvalCount > Self.bodyEvaluationThreshold {
             trippedBy = .bodyEvaluation
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -135,6 +135,7 @@ struct ChatView: View {
     @State private var dragEndLocalMonitor: Any?
     @State private var dragEndGlobalMonitor: Any?
     @State private var containerWidth: CGFloat = 0
+    @State private var composerHeight: CGFloat = 0
 
     // MARK: - In-Chat Search (Cmd+F)
     @State private var isSearchActive = false
@@ -264,7 +265,8 @@ struct ChatView: View {
                             anchorMessageId: $anchorMessageId,
                             highlightedMessageId: $highlightedMessageId,
                             isNearBottom: $isNearBottom,
-                            containerWidth: containerWidth
+                            containerWidth: containerWidth,
+                            composerHeight: composerHeight
                         )
 
                         if let exhaustedError = creditsExhaustedError, exhaustedError.isCreditsExhausted {
@@ -322,6 +324,12 @@ struct ChatView: View {
                             conversationId: conversationId,
                             isInteractionEnabled: isInteractionEnabled
                         )
+                        .background(
+                            GeometryReader { geo in
+                                Color.clear.preference(key: ComposerHeightKey.self, value: geo.size.height)
+                            }
+                        )
+                        .onPreferenceChange(ComposerHeightKey.self) { composerHeight = $0 }
                     }
                 }
             }
@@ -811,6 +819,15 @@ struct ScrollWheelPassthrough: NSViewRepresentable {
 /// Propagates the chat container's measured width up to ChatView so it can
 /// forward it to MessageListView for resize-aware scroll stabilization.
 private struct ChatContainerWidthKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+/// Propagates the composer section's measured height up to ChatView so it can
+/// forward it to MessageListView for viewport-pinned avatar offset calculation.
+private struct ComposerHeightKey: PreferenceKey {
     static var defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = max(value, nextValue())

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
@@ -372,24 +372,10 @@ final class MessageListScrollCoordinator: ObservableObject {
         proxy: ScrollViewProxy,
         conversationId: UUID?,
         anchorMessageId: Binding<UUID?>,
-        scrollViewportHeight: CGFloat,
-        avatarSmoothingTask: inout Task<Void, Never>?,
-        isAvatarVisible: inout Bool,
-        avatarDisplayY: inout CGFloat
+        scrollViewportHeight: CGFloat
     ) {
         scrollRestoreTask?.cancel()
         hasFreshAnchorMeasurement = false
-
-        // Reset avatar follower state so the avatar starts hidden and only
-        // appears once the conversation tail anchor reports a fresh position.
-        avatarSmoothingTask?.cancel()
-        avatarSmoothingTask = nil
-        scrollTracking.avatarTargetY = .infinity
-        isAvatarVisible = false
-        avatarDisplayY = .infinity
-        scrollTracking.pendingAvatarY = nil
-        scrollTracking.avatarLastAppliedAt = nil
-        scrollTracking.lastTailAnchorY = .infinity
 
         // Route the initial restore through the coordinator for bounded retries.
         if anchorMessageId.wrappedValue == nil {
@@ -564,7 +550,6 @@ final class MessageListScrollCoordinator: ObservableObject {
 
         var sanitizer = NumericSanitizer()
         let safeAnchorMinY = sanitizer.sanitize(anchorLastMinY, field: "anchorMinY")
-        let safeTailAnchorY = sanitizer.sanitize(scrollTracking.lastTailAnchorY, field: "tailAnchorY")
         let safeViewportHeight = sanitizer.sanitize(scrollViewportHeight, field: "scrollViewportHeight")
         let safeContainerWidth = sanitizer.sanitize(containerWidth, field: "containerWidth")
         logNonFiniteGeometryOnce(sanitizer: sanitizer)
@@ -591,7 +576,6 @@ final class MessageListScrollCoordinator: ObservableObject {
             anchorMessageId: anchorMessageId?.uuidString,
             highlightedMessageId: highlightedMessageId?.uuidString,
             anchorMinY: safeAnchorMinY,
-            tailAnchorY: safeTailAnchorY,
             scrollViewportHeight: safeViewportHeight,
             containerWidth: safeContainerWidth,
             scrollLoopGuardCounts: guardCountsStringKeyed,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+AvatarFollower.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+AvatarFollower.swift
@@ -1,69 +1,8 @@
 import SwiftUI
 
 enum ConversationAvatarFollower {
-    static let coalesceInterval: TimeInterval = 0.1
     static let visibilityPadding: CGFloat = 24
     static let verticalOffset: CGFloat = 10
     static let avatarSize: CGFloat = 52
     static let bottomInset: CGFloat = avatarSize + verticalOffset + 2
-    static let spring = Animation.interactiveSpring(response: 0.28, dampingFraction: 0.84, blendDuration: 0.12)
-
-    static func shouldShow(anchorY: CGFloat, viewportHeight: CGFloat) -> Bool {
-        guard anchorY.isFinite, viewportHeight.isFinite else { return false }
-        return anchorY >= -visibilityPadding && anchorY <= viewportHeight + visibilityPadding
-    }
-
-    /// Hidden avatar positions do not affect rendering, so avoid updating the
-    /// stored target unless visibility changes or the visible avatar actually moves.
-    static func shouldUpdateTarget(
-        previousAnchorY: CGFloat,
-        newAnchorY: CGFloat,
-        viewportHeight: CGFloat,
-        movementThreshold: CGFloat = 20
-    ) -> Bool {
-        let wasVisible = shouldShow(anchorY: previousAnchorY, viewportHeight: viewportHeight)
-        let isVisible = shouldShow(anchorY: newAnchorY, viewportHeight: viewportHeight)
-
-        if wasVisible != isVisible { return true }
-        if previousAnchorY.isFinite != newAnchorY.isFinite { return true }
-        guard isVisible else { return false }
-        return abs(previousAnchorY - newAnchorY) > movementThreshold
-    }
-
-    static func shouldCoalesce(isSending: Bool, isThinking: Bool, isLastMessageStreaming: Bool) -> Bool {
-        isSending || isThinking || isLastMessageStreaming
-    }
-
-    static func coalescedDelay(lastAppliedAt: Date?, now: Date) -> TimeInterval {
-        guard let lastAppliedAt else { return 0 }
-        let elapsed = now.timeIntervalSince(lastAppliedAt)
-        return max(0, coalesceInterval - elapsed)
-    }
-
-    static func smoothingDelay(
-        isSending: Bool,
-        isThinking: Bool,
-        isLastMessageStreaming: Bool,
-        lastAppliedAt: Date?,
-        now: Date
-    ) -> TimeInterval {
-        guard shouldCoalesce(
-            isSending: isSending,
-            isThinking: isThinking,
-            isLastMessageStreaming: isLastMessageStreaming
-        ) else { return 0 }
-        return coalescedDelay(lastAppliedAt: lastAppliedAt, now: now)
-    }
-}
-
-/// Preference key that tracks the conversation-tail anchor's maxY so the avatar
-/// can follow the latest rendered content rather than staying pinned above input.
-struct ConversationTailAnchorYKey: PreferenceKey {
-    static var defaultValue: CGFloat = .infinity
-
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        // Use min so sibling views in the LazyVStack (which report the default
-        // value of .infinity) don't overwrite the anchor's actual Y position.
-        value = min(value, nextValue())
-    }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -28,17 +28,6 @@ extension EnvironmentValues {
 /// are never read during body evaluation for rendering purposes.
 /// Pattern mirrors `AnchorVisibilityTracker.lastMinY` (not @Published).
 @MainActor final class ScrollTrackingState {
-    /// Last reported ConversationTailAnchorYKey value.
-    /// Only used for the 2pt dead-zone check in the preference handler.
-    var lastTailAnchorY: CGFloat = .infinity
-    /// Pending avatar Y position awaiting smoothing delay.
-    var pendingAvatarY: CGFloat?
-    /// Timestamp of the last applied avatar display Y update.
-    var avatarLastAppliedAt: Date?
-    /// Non-reactive avatar anchor Y position. Only used for threshold
-    /// comparisons and visibility boundary detection — never read during
-    /// body evaluation for rendering, so mutations do not trigger re-renders.
-    var avatarTargetY: CGFloat = .infinity
     /// Debounced task for transcript snapshot updates, coalescing rapid scroll
     /// events into a single snapshot capture per 150ms window.
     var snapshotDebounceTask: Task<Void, Never>?
@@ -157,6 +146,9 @@ struct MessageListView: View {
     /// Measured width of the chat container, used to detect sidebar/split resizes
     /// and stabilize scroll position during layout width changes.
     var containerWidth: CGFloat = 0
+    /// Height of the composer section, measured in ChatView and passed down
+    /// so the viewport-pinned avatar overlay can offset above the composer.
+    var composerHeight: CGFloat = 0
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
     @AppStorage("completedConversationCount") private var completedConversationCount: Int = 0
     @State private var identity: IdentityInfo? = IdentityInfo.load()
@@ -191,9 +183,6 @@ struct MessageListView: View {
     @State private var resizeScrollTask: Task<Void, Never>?
     /// Task that clears the highlight flash after the animation duration.
     @State private var highlightDismissTask: Task<Void, Never>?
-    @State private var isAvatarVisible: Bool = false
-    @State private var avatarDisplayY: CGFloat = .infinity
-    @State private var avatarSmoothingTask: Task<Void, Never>?
     @State private var hasPlayedTailEntryAnimation = false
     /// Captures the `assistantActivityPhase` at the moment `isSending` goes false.
     /// Used to distinguish mid-turn tool-confirmation pauses (phase == "awaiting_confirmation")
@@ -474,164 +463,16 @@ struct MessageListView: View {
         return result
     }
 
-    private var lastRenderableMessage: ChatMessage? {
-        messages.last(where: {
-            if case .queued = $0.status { return false }
-            return true
-        })
-    }
-
-    private var isLastMessageStreaming: Bool {
-        lastRenderableMessage?.isStreaming == true
-    }
-
+    /// Whether the floating avatar should be visible. Derived from scroll
+    /// proximity to the bottom — the avatar appears when the user is near
+    /// the bottom of the conversation and disappears when scrolled up.
     private var shouldShowConversationTailAvatar: Bool {
-        // Intentionally show the avatar under the latest rendered conversation tail
-        // (user or assistant content), not only after the first assistant bubble.
         guard !visibleMessages.isEmpty else { return false }
-        return isAvatarVisible
+        return isNearBottom
     }
 
     private var shouldPlayTailEntryAnimation: Bool {
         !hasPlayedTailEntryAnimation && messages.count <= 2
-    }
-
-    private var shouldCoalesceAvatarUpdates: Bool {
-        ConversationAvatarFollower.shouldCoalesce(
-            isSending: isSending,
-            isThinking: isThinking,
-            isLastMessageStreaming: isLastMessageStreaming
-        )
-    }
-
-    private func applyAvatarDisplayY(forAnchorY anchorY: CGFloat) {
-        // Circuit breaker: suppress @State mutations when a scroll loop is detected.
-        let convIdString = conversationId?.uuidString ?? "unknown"
-        if scrollCoordinator.scrollLoopGuard.isTripped(conversationId: convIdString) { return }
-
-        let y = anchorY + ConversationAvatarFollower.verticalOffset
-        // Dead-zone: skip @State update when position hasn't moved meaningfully.
-        // Each avatarDisplayY change triggers a MessageListView body re-evaluation;
-        // sub-pixel jitter during scroll would otherwise cause continuous re-renders.
-        guard abs(avatarDisplayY - y) > 2 else { return }
-
-        // During streaming / sending / thinking, only allow the avatar to move
-        // downward (increasing Y).  Auto-scroll viewport adjustments can briefly
-        // report a smaller tail-anchor Y, which would yank the avatar back toward
-        // the top of the viewport.  Clamping to downward-only movement keeps the
-        // avatar tracking smoothly with the growing content.  When coalescing ends
-        // (streaming finishes), the onChange handler re-applies the true position.
-        if shouldCoalesceAvatarUpdates && avatarDisplayY.isFinite && y < avatarDisplayY {
-            return
-        }
-
-        recordScrollLoopEvent(.avatarDisplayYApplied)
-        scrollCoordinator.scrollTracking.avatarLastAppliedAt = Date()
-        // Set @State without withAnimation — the spring animation is applied via
-        // .animation() on the avatar view's .offset() modifier instead. This avoids
-        // wrapping the mutation in an animation transaction, which would cause SwiftUI
-        // to re-evaluate the body on each spring interpolation frame and feed layout
-        // shifts back into the tail anchor preference → avatar update cycle.
-        avatarDisplayY = y
-    }
-
-    private func updateAvatarFollower(anchorY: CGFloat) {
-        recordScrollLoopEvent(.avatarFollowerUpdate)
-        // Compute visibility once and update @State only on boundary crossings.
-        // During an active send, don't hide the avatar on transient non-finite
-        // anchors — the LazyVStack briefly deallocates the anchor view during
-        // re-layout (thinking indicator, rich UI expansion). Hiding would cause
-        // the avatar to flash off-screen via shouldShowConversationTailAvatar.
-        let nowVisible = anchorY.isFinite
-            && ConversationAvatarFollower.shouldShow(anchorY: anchorY, viewportHeight: scrollViewportHeight)
-        let convIdString = conversationId?.uuidString ?? "unknown"
-        let isTripped = scrollCoordinator.scrollLoopGuard.isTripped(conversationId: convIdString)
-        if isAvatarVisible != nowVisible {
-            // Circuit breaker: when tripped, only allow hiding (removing UI is safe).
-            // Showing (false→true) adds layout that could feed the loop — suppress it.
-            // Send guard: during send, don't hide on transient non-finite anchors.
-            if (!isTripped || !nowVisible) && (nowVisible || !isSending) {
-                isAvatarVisible = nowVisible
-            }
-        }
-
-        // Update non-reactive tracking position (no body re-evaluation).
-        if ConversationAvatarFollower.shouldUpdateTarget(
-            previousAnchorY: scrollCoordinator.scrollTracking.avatarTargetY,
-            newAnchorY: anchorY,
-            viewportHeight: scrollViewportHeight
-        ) {
-            scrollCoordinator.scrollTracking.avatarTargetY = anchorY
-        }
-
-        guard anchorY.isFinite else {
-            avatarSmoothingTask?.cancel()
-            avatarSmoothingTask = nil
-            scrollCoordinator.scrollTracking.pendingAvatarY = nil
-            scrollCoordinator.scrollTracking.avatarLastAppliedAt = nil
-            // During an active send, the LazyVStack may transiently deallocate
-            // the tail anchor view during re-layout (e.g. thinking indicator
-            // insertion, rich UI expansion), producing a non-finite preference.
-            // Keep the avatar at its last known position so it doesn't flash
-            // off-screen and back. Also suppress when circuit breaker is tripped
-            // to avoid @State mutations that feed the scroll loop.
-            if !isTripped && !isSending && avatarDisplayY != .infinity {
-                avatarDisplayY = .infinity
-            }
-            return
-        }
-
-        // Skip position tracking when the avatar is off-screen. The avatar
-        // overlay is hidden via shouldShowConversationTailAvatar, so updating
-        // avatarDisplayY for an invisible element just wastes layout passes.
-        guard nowVisible else {
-            avatarSmoothingTask?.cancel()
-            avatarSmoothingTask = nil
-            scrollCoordinator.scrollTracking.pendingAvatarY = nil
-            return
-        }
-
-        let now = Date()
-        let delay = ConversationAvatarFollower.smoothingDelay(
-            isSending: isSending,
-            isThinking: isThinking,
-            isLastMessageStreaming: isLastMessageStreaming,
-            lastAppliedAt: scrollCoordinator.scrollTracking.avatarLastAppliedAt,
-            now: now
-        )
-
-        if delay <= 0 {
-            avatarSmoothingTask?.cancel()
-            avatarSmoothingTask = nil
-            scrollCoordinator.scrollTracking.pendingAvatarY = nil
-            // Only apply @State avatar position when circuit breaker isn't tripped
-            if !isTripped {
-                applyAvatarDisplayY(forAnchorY: anchorY)
-            }
-            return
-        }
-
-        scrollCoordinator.scrollTracking.pendingAvatarY = anchorY
-        guard avatarSmoothingTask == nil else { return }
-
-        avatarSmoothingTask = Task { @MainActor in
-            do {
-                try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
-            } catch {
-                return
-            }
-            guard !Task.isCancelled else { return }
-            guard let pending = scrollCoordinator.scrollTracking.pendingAvatarY else {
-                avatarSmoothingTask = nil
-                return
-            }
-            scrollCoordinator.scrollTracking.pendingAvatarY = nil
-            // Only apply @State avatar position when circuit breaker isn't tripped
-            if !scrollCoordinator.scrollLoopGuard.isTripped(conversationId: conversationId?.uuidString ?? "unknown") {
-                applyAvatarDisplayY(forAnchorY: pending)
-            }
-            avatarSmoothingTask = nil
-        }
     }
 
     @ViewBuilder
@@ -646,7 +487,6 @@ struct MessageListView: View {
                 .padding(.horizontal, VSpacing.xl)
                 .frame(maxWidth: VSpacing.chatColumnMaxWidth)
                 .frame(maxWidth: .infinity)
-                .offset(y: avatarDisplayY)
                 .allowsHitTesting(false)
                 .accessibilityHidden(true)
             } else if let body = appearance.characterBodyShape,
@@ -662,8 +502,6 @@ struct MessageListView: View {
                     .padding(.horizontal, VSpacing.xl)
                     .frame(maxWidth: VSpacing.chatColumnMaxWidth)
                     .frame(maxWidth: .infinity)
-                    .offset(y: avatarDisplayY)
-                    .animation(ConversationAvatarFollower.spring, value: avatarDisplayY)
                     .accessibilityHidden(true)
                     .onAppear {
                         if shouldPlayTailEntryAnimation {
@@ -679,8 +517,6 @@ struct MessageListView: View {
                 .padding(.horizontal, VSpacing.xl)
                 .frame(maxWidth: VSpacing.chatColumnMaxWidth)
                 .frame(maxWidth: .infinity)
-                .offset(y: avatarDisplayY)
-                .animation(ConversationAvatarFollower.spring, value: avatarDisplayY)
                 .allowsHitTesting(false)
                 .accessibilityHidden(true)
             }
@@ -693,10 +529,7 @@ struct MessageListView: View {
             proxy: proxy,
             conversationId: conversationId,
             anchorMessageId: $anchorMessageId,
-            scrollViewportHeight: scrollViewportHeight,
-            avatarSmoothingTask: &avatarSmoothingTask,
-            isAvatarVisible: &isAvatarVisible,
-            avatarDisplayY: &avatarDisplayY
+            scrollViewportHeight: scrollViewportHeight
         )
     }
 
@@ -917,19 +750,6 @@ struct MessageListView: View {
                         compactingIndicatorRow()
                     }
 
-                    Color.clear
-                        .frame(height: 1)
-                        .id("conversation-tail-anchor")
-                        .background {
-                            GeometryReader { geo in
-                                Color.clear.preference(
-                                    key: ConversationTailAnchorYKey.self,
-                                    value: geo.frame(in: .named("chatScrollView")).maxY
-                                )
-                            }
-                        }
-                        .transaction { $0.disablesAnimations = true }
-
                     if !state.displayMessages.isEmpty && ConversationAvatarFollower.bottomInset > 0 {
                         Color.clear
                             .frame(height: ConversationAvatarFollower.bottomInset)
@@ -1011,15 +831,10 @@ struct MessageListView: View {
                 )
                 guard case .accept(let accepted) = decision else { return }
                 os_signpost(.begin, log: PerfSignposts.log, name: "viewportHeightChanged")
-                let viewportChanged = scrollCoordinator.updateAnchorViewport(
+                scrollCoordinator.updateAnchorViewport(
                     height: accepted,
                     storedViewportHeight: &scrollViewportHeight
                 )
-                if viewportChanged, scrollCoordinator.scrollTracking.lastTailAnchorY.isFinite {
-                    // Reconcile the avatar follower on resize so a hidden target
-                    // is refreshed before a later visibility transition reveals it.
-                    updateAvatarFollower(anchorY: scrollCoordinator.scrollTracking.lastTailAnchorY)
-                }
                 os_signpost(.end, log: PerfSignposts.log, name: "viewportHeightChanged")
             }
             .onScrollGeometryChange(for: CGFloat.self) { geo in
@@ -1056,27 +871,6 @@ struct MessageListView: View {
                     os_signpost(.end, log: PerfSignposts.log, name: "distanceFromBottomChanged")
                 }
             }
-            .onPreferenceChange(ConversationTailAnchorYKey.self) { anchorY in
-                // Filter non-finite tail anchor values and apply 2pt dead-zone
-                // to reduce layout invalidation cascades during rapid scroll.
-                let decision = PreferenceGeometryFilter.evaluate(
-                    newValue: anchorY,
-                    previous: scrollCoordinator.scrollTracking.lastTailAnchorY
-                )
-                guard case .accept(let accepted) = decision else { return }
-                recordScrollLoopEvent(.tailAnchorPreferenceChange)
-                scrollCoordinator.scrollTracking.lastTailAnchorY = accepted
-                // Defer to next run loop to prevent synchronous layout re-entry
-                // on macOS. This preference fires during placeSubviews; calling
-                // withAnimation (inside applyAvatarDisplayY) synchronously causes
-                // _PaddingLayout.sizeThatFits to be re-entered, creating an infinite
-                // layout cycle when avatar properties change concurrently with a
-                // ToolConfirmationBubble in the message list.
-                Task { @MainActor in
-                    updateAvatarFollower(anchorY: accepted)
-                }
-            }
-            .transaction { $0.disablesAnimations = true }
             .onPreferenceChange(PaginationSentinelMinYKey.self) { sentinelMinY in
                 scrollCoordinator.handlePaginationSentinel(
                     sentinelMinY: sentinelMinY,
@@ -1089,8 +883,9 @@ struct MessageListView: View {
                     loadPreviousMessagePage: loadPreviousMessagePage
                 )
             }
-            .overlay(alignment: .topLeading) {
+            .overlay(alignment: .bottom) {
                 conversationTailAvatar
+                    .padding(.bottom, composerHeight + ConversationAvatarFollower.verticalOffset)
             }
             .overlay(alignment: .bottom) {
                 if !isNearBottom && !scrollCoordinator.anchorIsVisible
@@ -1179,8 +974,6 @@ struct MessageListView: View {
                 anchorTimeoutTask = nil
                 resizeScrollTask?.cancel()
                 resizeScrollTask = nil
-                avatarSmoothingTask?.cancel()
-                avatarSmoothingTask = nil
                 highlightDismissTask?.cancel()
                 highlightDismissTask = nil
                 highlightedMessageId = nil
@@ -1232,11 +1025,6 @@ struct MessageListView: View {
                     if !hasEverSentMessage && messages.contains(where: { $0.role == .user }) {
                         hasEverSentMessage = true
                     }
-                }
-            }
-            .onChange(of: shouldCoalesceAvatarUpdates) {
-                if !shouldCoalesceAvatarUpdates {
-                    updateAvatarFollower(anchorY: scrollCoordinator.scrollTracking.pendingAvatarY ?? scrollCoordinator.scrollTracking.avatarTargetY)
                 }
             }
             .onChange(of: messages.count) {
@@ -1310,8 +1098,6 @@ struct MessageListView: View {
                 // Reset view-local state that doesn't belong in the coordinator.
                 resizeScrollTask?.cancel()
                 resizeScrollTask = nil
-                avatarSmoothingTask?.cancel()
-                avatarSmoothingTask = nil
                 scrollCoordinator.resetForConversationSwitch(
                     oldConversationId: oldConversationId,
                     newConversationId: conversationId,

--- a/clients/macos/vellum-assistantTests/ChatScrollLoopGuardTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatScrollLoopGuardTests.swift
@@ -323,121 +323,7 @@ final class ChatScrollLoopGuardTests: XCTestCase {
         }
     }
 
-    // MARK: - New Hot-Path Event Kinds
-
-    func testAvatarFollowerBurstTripsGuard() {
-        var timestamp: TimeInterval = 1000.0
-        var tripped = false
-
-        // Fire 51 avatarFollowerUpdate events in under 2 seconds (exceeds threshold of 50).
-        for _ in 0..<55 {
-            let result = guard_.record(
-                .avatarFollowerUpdate,
-                conversationId: conversationId,
-                timestamp: timestamp
-            )
-            if let snapshot = result {
-                XCTAssertFalse(tripped, "Guard should trip exactly once per cooldown window")
-                tripped = true
-                XCTAssertEqual(snapshot.trippedBy, .avatarFollowerUpdate)
-                XCTAssertGreaterThan(snapshot.counts[.avatarFollowerUpdate] ?? 0, ChatScrollLoopGuard.avatarFollowerThreshold)
-            }
-            timestamp += 0.035
-        }
-
-        XCTAssertTrue(tripped, "Guard should have tripped for avatar follower burst")
-    }
-
-    func testAvatarFollowerNormalRateDoesNotTrip() {
-        var timestamp: TimeInterval = 1000.0
-
-        // 20 events in 2 seconds — well under threshold of 50.
-        for _ in 0..<20 {
-            let result = guard_.record(
-                .avatarFollowerUpdate,
-                conversationId: conversationId,
-                timestamp: timestamp
-            )
-            XCTAssertNil(result, "Normal-rate avatar follower updates should not trip the guard")
-            timestamp += 0.1
-        }
-    }
-
-    func testAvatarDisplayYAppliedBurstTripsGuard() {
-        var timestamp: TimeInterval = 1000.0
-        var tripped = false
-
-        // Fire 31 avatarDisplayYApplied events in under 2 seconds (exceeds threshold of 30).
-        for _ in 0..<35 {
-            let result = guard_.record(
-                .avatarDisplayYApplied,
-                conversationId: conversationId,
-                timestamp: timestamp
-            )
-            if let snapshot = result {
-                XCTAssertFalse(tripped)
-                tripped = true
-                XCTAssertEqual(snapshot.trippedBy, .avatarDisplayYApplied)
-                XCTAssertGreaterThan(snapshot.counts[.avatarDisplayYApplied] ?? 0, ChatScrollLoopGuard.avatarApplyThreshold)
-            }
-            timestamp += 0.055
-        }
-
-        XCTAssertTrue(tripped, "Guard should have tripped for avatar display Y burst")
-    }
-
-    func testAvatarDisplayYAppliedNormalRateDoesNotTrip() {
-        var timestamp: TimeInterval = 1000.0
-
-        // 15 events in 2 seconds — under threshold of 30.
-        for _ in 0..<15 {
-            let result = guard_.record(
-                .avatarDisplayYApplied,
-                conversationId: conversationId,
-                timestamp: timestamp
-            )
-            XCTAssertNil(result)
-            timestamp += 0.13
-        }
-    }
-
-    func testTailAnchorPreferenceBurstTripsGuard() {
-        var timestamp: TimeInterval = 1000.0
-        var tripped = false
-
-        // Fire 61 tailAnchorPreferenceChange events in under 2 seconds (exceeds threshold of 60).
-        for _ in 0..<65 {
-            let result = guard_.record(
-                .tailAnchorPreferenceChange,
-                conversationId: conversationId,
-                timestamp: timestamp
-            )
-            if let snapshot = result {
-                XCTAssertFalse(tripped)
-                tripped = true
-                XCTAssertEqual(snapshot.trippedBy, .tailAnchorPreferenceChange)
-                XCTAssertGreaterThan(snapshot.counts[.tailAnchorPreferenceChange] ?? 0, ChatScrollLoopGuard.tailAnchorThreshold)
-            }
-            timestamp += 0.03
-        }
-
-        XCTAssertTrue(tripped, "Guard should have tripped for tail anchor preference burst")
-    }
-
-    func testTailAnchorPreferenceNormalRateDoesNotTrip() {
-        var timestamp: TimeInterval = 1000.0
-
-        // 30 events in 2 seconds — under threshold of 60.
-        for _ in 0..<30 {
-            let result = guard_.record(
-                .tailAnchorPreferenceChange,
-                conversationId: conversationId,
-                timestamp: timestamp
-            )
-            XCTAssertNil(result)
-            timestamp += 0.066
-        }
-    }
+    // MARK: - Body Evaluation Event Kind
 
     func testBodyEvaluationBurstTripsGuard() {
         var timestamp: TimeInterval = 1000.0
@@ -477,13 +363,13 @@ final class ChatScrollLoopGuardTests: XCTestCase {
         }
     }
 
-    func testNewEventKindsCooldownRearms() {
+    func testBodyEvaluationCooldownRearms() {
         var timestamp: TimeInterval = 1000.0
         var tripCount = 0
 
-        // Trip via avatarFollowerUpdate.
-        for _ in 0..<55 {
-            if guard_.record(.avatarFollowerUpdate, conversationId: conversationId, timestamp: timestamp) != nil {
+        // Trip via bodyEvaluation.
+        for _ in 0..<50 {
+            if guard_.record(.bodyEvaluation, conversationId: conversationId, timestamp: timestamp) != nil {
                 tripCount += 1
             }
             timestamp += 0.035
@@ -494,8 +380,8 @@ final class ChatScrollLoopGuardTests: XCTestCase {
         timestamp += ChatScrollLoopGuard.cooldownDuration + 0.1
 
         // Second burst: should re-arm and trip again.
-        for _ in 0..<55 {
-            if guard_.record(.avatarFollowerUpdate, conversationId: conversationId, timestamp: timestamp) != nil {
+        for _ in 0..<50 {
+            if guard_.record(.bodyEvaluation, conversationId: conversationId, timestamp: timestamp) != nil {
                 tripCount += 1
             }
             timestamp += 0.035
@@ -510,18 +396,18 @@ final class ChatScrollLoopGuardTests: XCTestCase {
 
         // Record a mix of events.
         for _ in 0..<10 {
-            guard_.record(.avatarFollowerUpdate, conversationId: conversationId, timestamp: timestamp)
+            guard_.record(.bodyEvaluation, conversationId: conversationId, timestamp: timestamp)
             timestamp += 0.01
         }
         for _ in 0..<5 {
-            guard_.record(.bodyEvaluation, conversationId: conversationId, timestamp: timestamp)
+            guard_.record(.anchorPreferenceChange, conversationId: conversationId, timestamp: timestamp)
             timestamp += 0.01
         }
 
         let counts = guard_.currentCounts(conversationId: conversationId, timestamp: timestamp)
-        XCTAssertEqual(counts[.avatarFollowerUpdate], 10)
-        XCTAssertEqual(counts[.bodyEvaluation], 5)
-        XCTAssertNil(counts[.anchorPreferenceChange], "Unrecorded kinds should not appear")
+        XCTAssertEqual(counts[.bodyEvaluation], 10)
+        XCTAssertEqual(counts[.anchorPreferenceChange], 5)
+        XCTAssertNil(counts[.scrollToRequested], "Unrecorded kinds should not appear")
     }
 
     func testCurrentCountsPrunesStaleEntries() {
@@ -529,7 +415,7 @@ final class ChatScrollLoopGuardTests: XCTestCase {
 
         // Record events that will become stale.
         for _ in 0..<10 {
-            guard_.record(.avatarFollowerUpdate, conversationId: conversationId, timestamp: timestamp)
+            guard_.record(.bodyEvaluation, conversationId: conversationId, timestamp: timestamp)
             timestamp += 0.01
         }
 
@@ -538,12 +424,12 @@ final class ChatScrollLoopGuardTests: XCTestCase {
 
         // Record a few fresh events.
         for _ in 0..<3 {
-            guard_.record(.avatarFollowerUpdate, conversationId: conversationId, timestamp: timestamp)
+            guard_.record(.bodyEvaluation, conversationId: conversationId, timestamp: timestamp)
             timestamp += 0.01
         }
 
         let counts = guard_.currentCounts(conversationId: conversationId, timestamp: timestamp)
-        XCTAssertEqual(counts[.avatarFollowerUpdate], 3, "Stale entries outside the window should be excluded")
+        XCTAssertEqual(counts[.bodyEvaluation], 3, "Stale entries outside the window should be excluded")
     }
 
     func testCurrentCountsReturnsEmptyForUnknownConversation() {


### PR DESCRIPTION
## Summary
- Removes `ConversationTailAnchorYKey` preference and entire avatar following pipeline
- Replaces content-following avatar with viewport-pinned `.overlay(alignment: .bottom)` offset by composer height
- Adds `composerHeight` parameter from ChatView to MessageListView
- Eliminates `_PaddingLayout.sizeThatFits` re-entrance crash vector

Part of plan: scroll-audit-cleanup.md (PR 3 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
