### PR TITLE
fix: replace phone icon with X for voice mode cancel (LUM-409)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -599,7 +599,7 @@ VStreamingWaveform(
 
                     VButton(
                         label: "End voice mode",
-                        iconOnly: VIcon.phoneCall.rawValue,
+                        iconOnly: VIcon.x.rawValue,
                         style: .danger,
                         iconSize: composerActionButtonSize,
                         action: { onEndVoiceMode?() }


### PR DESCRIPTION
## Summary
Replace the phone/end-call icon with an X icon for the voice mode cancel button, matching the dictation cancel pattern for better discoverability. Users couldn't find the UI control to cancel in-progress voice tasks because the phone icon didn't communicate "cancel."

## Changes
- Changed `VIcon.phoneCall` → `VIcon.x` in `ComposerView.swift` voice conversation composer

## Milestone PRs (merged into feature branch)
- #21182: fix: replace phone icon with X for voice mode cancel

## Project issue
Closes #21180

## Linear
Closes LUM-409

## Test plan
- [ ] Start a live voice conversation
- [ ] Verify the cancel button now shows an X icon instead of a phone icon
- [ ] Verify clicking the X button still ends the voice mode
- [ ] Verify dictation mode X button is unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
