### PR TITLE
fix: add retry logic to conversation list fetch on app restart

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -334,6 +334,7 @@ final class ConversationRestorer {
                 if attempt < maxAttempts {
                     log.warning("Conversation list fetch attempt \(attempt) of \(maxAttempts) failed, retrying in 2 seconds...")
                     try? await Task.sleep(nanoseconds: 2_000_000_000)
+                    guard !Task.isCancelled else { return }
                 }
             }
             log.warning("All \(maxAttempts) conversation list fetch attempts failed, falling back to last active conversation")

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -325,7 +325,9 @@ final class ConversationRestorer {
     private func fetchConversationList() {
         Task { [weak self] in
             guard let self else { return }
-            let maxAttempts = 3
+            // Cap at 2 attempts to limit worst-case restore delay (~32s with 15s
+            // per-request timeout) while still covering the daemon restart race.
+            let maxAttempts = 2
             for attempt in 1...maxAttempts {
                 if let response = await conversationListClient.fetchConversationList(offset: 0, limit: 50) {
                     self.handleConversationListResponse(response)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -52,6 +52,7 @@ final class ConversationRestorer {
     private let conversationHistoryClient: any ConversationHistoryClientProtocol
     private var connectionCancellable: AnyCancellable?
     private var disconnectCancellable: AnyCancellable?
+    private var fetchConversationListTask: Task<Void, Never>?
 
     weak var delegate: ConversationRestorerDelegate?
 
@@ -59,6 +60,10 @@ final class ConversationRestorer {
         self.connectionManager = connectionManager
         self.eventStreamClient = eventStreamClient
         self.conversationHistoryClient = conversationHistoryClient
+    }
+
+    deinit {
+        fetchConversationListTask?.cancel()
     }
 
     func startObserving(skipInitialFetch: Bool = false) {
@@ -323,7 +328,7 @@ final class ConversationRestorer {
     // MARK: - Private
 
     private func fetchConversationList() {
-        Task { [weak self] in
+        fetchConversationListTask = Task { [weak self] in
             guard let self else { return }
             // Cap at 2 attempts to limit worst-case restore delay (~32s with 15s
             // per-request timeout) while still covering the daemon restart race.

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -325,11 +325,19 @@ final class ConversationRestorer {
     private func fetchConversationList() {
         Task { [weak self] in
             guard let self else { return }
-            if let response = await conversationListClient.fetchConversationList(offset: 0, limit: 50) {
-                self.handleConversationListResponse(response)
-            } else {
-                self.delegate?.restoreLastActiveConversation()
+            let maxAttempts = 3
+            for attempt in 1...maxAttempts {
+                if let response = await conversationListClient.fetchConversationList(offset: 0, limit: 50) {
+                    self.handleConversationListResponse(response)
+                    return
+                }
+                if attempt < maxAttempts {
+                    log.warning("Conversation list fetch attempt \(attempt) of \(maxAttempts) failed, retrying in 2 seconds...")
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                }
             }
+            log.warning("All \(maxAttempts) conversation list fetch attempts failed, falling back to last active conversation")
+            self.delegate?.restoreLastActiveConversation()
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds a retry loop (up to 3 attempts with 2-second delays) to `fetchConversationList()` so transient daemon unavailability during quit/restart doesn't leave the sidebar permanently empty
- Logs a warning on each retry attempt and when all attempts are exhausted for observability
- Preserves existing behavior: immediate success on first attempt still works identically, and the `.first()` Combine operator is unchanged

## Test plan
- [ ] Launch app normally — conversation list loads on first attempt, no warnings logged
- [ ] Kill daemon process while app is running, then relaunch — verify conversation list eventually loads after retry
- [ ] Simulate 3 consecutive fetch failures — verify fallback to `restoreLastActiveConversation()` and warning logs appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
