### PR TITLE
fix: address review feedback on OAuth card cleanup

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/OAuthProviderServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/OAuthProviderServiceCard.swift
@@ -186,7 +186,7 @@ struct OAuthProviderServiceCard: View {
             }
 
             Divider()
-                .foregroundColor(VColor.borderBase)
+                .foregroundStyle(VColor.borderBase)
 
             HStack(spacing: VSpacing.sm) {
                 VButton(label: "Connect Another Account", leftIcon: "lucide-plus", style: .outlined, isDisabled: store.managedIsConnecting(for: providerKey)) {
@@ -196,7 +196,7 @@ struct OAuthProviderServiceCard: View {
                     VBusyIndicator(size: 8, color: VColor.contentTertiary)
                     Text("Waiting for authorization...")
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                 }
             }
         }
@@ -206,7 +206,7 @@ struct OAuthProviderServiceCard: View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             HStack(alignment: .bottom, spacing: VSpacing.sm) {
                 VTextField(
-                    "Email",
+                    "Account",
                     placeholder: "",
                     text: .constant(entry.account_label ?? "\(displayName) Account")
                 )


### PR DESCRIPTION
## Summary
- Replace `.foregroundColor()` with `.foregroundStyle()` per deprecated API watchlist (AGENTS.md)
- Change hardcoded "Email" label to provider-agnostic "Account" for non-email OAuth providers

Addresses review feedback from #21172.

## Test plan
- [ ] Verify Divider and "Waiting for authorization..." text render correctly with `.foregroundStyle()`
- [ ] Verify the text field label reads "Account" instead of "Email"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
