### PR TITLE
fix: add retry logic and background reconnection for daemon restart resilience

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -52,6 +52,7 @@ final class ConversationRestorer {
     private let conversationHistoryClient: any ConversationHistoryClientProtocol
     private var connectionCancellable: AnyCancellable?
     private var disconnectCancellable: AnyCancellable?
+    private var fetchConversationListTask: Task<Void, Never>?
 
     weak var delegate: ConversationRestorerDelegate?
 
@@ -59,6 +60,10 @@ final class ConversationRestorer {
         self.connectionManager = connectionManager
         self.eventStreamClient = eventStreamClient
         self.conversationHistoryClient = conversationHistoryClient
+    }
+
+    deinit {
+        fetchConversationListTask?.cancel()
     }
 
     func startObserving(skipInitialFetch: Bool = false) {
@@ -323,13 +328,24 @@ final class ConversationRestorer {
     // MARK: - Private
 
     private func fetchConversationList() {
-        Task { [weak self] in
+        fetchConversationListTask = Task { [weak self] in
             guard let self else { return }
-            if let response = await conversationListClient.fetchConversationList(offset: 0, limit: 50) {
-                self.handleConversationListResponse(response)
-            } else {
-                self.delegate?.restoreLastActiveConversation()
+            // Cap at 2 attempts to limit worst-case restore delay (~32s with 15s
+            // per-request timeout) while still covering the daemon restart race.
+            let maxAttempts = 2
+            for attempt in 1...maxAttempts {
+                if let response = await conversationListClient.fetchConversationList(offset: 0, limit: 50) {
+                    self.handleConversationListResponse(response)
+                    return
+                }
+                if attempt < maxAttempts {
+                    log.warning("Conversation list fetch attempt \(attempt) of \(maxAttempts) failed, retrying in 2 seconds...")
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                    guard !Task.isCancelled else { return }
+                }
             }
+            log.warning("All \(maxAttempts) conversation list fetch attempts failed, falling back to last active conversation")
+            self.delegate?.restoreLastActiveConversation()
         }
     }
 }

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -136,6 +136,10 @@ public final class GatewayConnectionManager: ObservableObject {
     }
 
     func connectImpl(cancelAutoWake: Bool) async throws {
+        #if os(macOS)
+        reconnectionTask?.cancel()
+        reconnectionTask = nil
+        #endif
         disconnectInternal(cancelAutoWake: cancelAutoWake)
 
         isConnecting = true
@@ -153,10 +157,6 @@ public final class GatewayConnectionManager: ObservableObject {
             isAuthenticated = true
             isConnecting = false
             log.info("connect: connected successfully")
-            #if os(macOS)
-            reconnectionTask?.cancel()
-            reconnectionTask = nil
-            #endif
 
             eventStreamClient.startSSE()
         } catch {
@@ -178,8 +178,6 @@ public final class GatewayConnectionManager: ObservableObject {
                         isAuthenticated = true
                         isConnecting = false
                         log.info("connect: retry after auto-wake succeeded")
-                        reconnectionTask?.cancel()
-                        reconnectionTask = nil
                         eventStreamClient.startSSE()
                         return
                     } catch {

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -575,7 +575,7 @@ public final class GatewayConnectionManager: ObservableObject {
     /// to reconnect without calling `connectImpl()` (which would interfere via
     /// `disconnectInternal()`). Cancelled on explicit `disconnect()` or `reconfigure()`.
     private func startReconnectionLoop() {
-        guard isLocal else { return }
+        guard isLocal, shouldReconnect else { return }
         reconnectionTask?.cancel()
         reconnectionGeneration += 1
         let generation = reconnectionGeneration
@@ -587,6 +587,11 @@ public final class GatewayConnectionManager: ObservableObject {
                 // If another path (e.g. autoWakeIfAssistantDied) connected us, exit
                 guard !self.isConnected else {
                     log.info("reconnect-loop: already connected, exiting")
+                    break
+                }
+                // Honor explicit disconnect/reconfigure
+                guard self.shouldReconnect else {
+                    log.info("reconnect-loop: shouldReconnect is false, exiting")
                     break
                 }
 

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -97,6 +97,8 @@ public final class GatewayConnectionManager: ObservableObject {
     #if os(macOS)
     var lastAutoWakeAttempt: Date?
     var autoWakeTask: Task<Void, Never>?
+    var reconnectionTask: Task<Void, Never>?
+    var reconnectionGeneration: Int = 0
     #endif
 
     // MARK: - Event Stream
@@ -151,6 +153,10 @@ public final class GatewayConnectionManager: ObservableObject {
             isAuthenticated = true
             isConnecting = false
             log.info("connect: connected successfully")
+            #if os(macOS)
+            reconnectionTask?.cancel()
+            reconnectionTask = nil
+            #endif
 
             eventStreamClient.startSSE()
         } catch {
@@ -172,6 +178,8 @@ public final class GatewayConnectionManager: ObservableObject {
                         isAuthenticated = true
                         isConnecting = false
                         log.info("connect: retry after auto-wake succeeded")
+                        reconnectionTask?.cancel()
+                        reconnectionTask = nil
                         eventStreamClient.startSSE()
                         return
                     } catch {
@@ -179,6 +187,8 @@ public final class GatewayConnectionManager: ObservableObject {
                     }
                 }
             }
+
+            startReconnectionLoop()
             #endif
 
             isConnecting = false
@@ -190,6 +200,10 @@ public final class GatewayConnectionManager: ObservableObject {
     // MARK: - Disconnect
 
     public func disconnect() {
+        #if os(macOS)
+        reconnectionTask?.cancel()
+        reconnectionTask = nil
+        #endif
         disconnectInternal()
     }
 
@@ -218,6 +232,8 @@ public final class GatewayConnectionManager: ObservableObject {
     public func reconfigure(conversationKey: String? = nil) {
         self.conversationKey = conversationKey
         #if os(macOS)
+        reconnectionTask?.cancel()
+        reconnectionTask = nil
         autoWakeTask?.cancel()
         autoWakeTask = nil
         #endif
@@ -551,6 +567,83 @@ public final class GatewayConnectionManager: ObservableObject {
             self.autoWakeTask = nil
         }
     }
+
+    // MARK: - Background Reconnection Loop
+
+    /// Retries connection with increasing delays after the initial `connect()` fails.
+    /// Only applies to local assistants on macOS. Uses health checks and auto-wake
+    /// to reconnect without calling `connectImpl()` (which would interfere via
+    /// `disconnectInternal()`). Cancelled on explicit `disconnect()` or `reconfigure()`.
+    private func startReconnectionLoop() {
+        guard isLocal else { return }
+        reconnectionTask?.cancel()
+        reconnectionGeneration += 1
+        let generation = reconnectionGeneration
+        reconnectionTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let delays: [UInt64] = [3, 5, 10, 15] // seconds
+            var attempt = 0
+            while !Task.isCancelled {
+                // If another path (e.g. autoWakeIfAssistantDied) connected us, exit
+                guard !self.isConnected else {
+                    log.info("reconnect-loop: already connected, exiting")
+                    break
+                }
+
+                let delaySec = delays[min(attempt, delays.count - 1)]
+                log.info("reconnect-loop: attempt \(attempt + 1), waiting \(delaySec)s")
+                try? await Task.sleep(nanoseconds: delaySec * 1_000_000_000)
+                guard !Task.isCancelled else { break }
+
+                attempt += 1
+
+                do {
+                    try await self.performHealthCheck()
+                } catch {
+                    // Health check failed — try auto-wake if gateway unreachable
+                    if let wakeHandler = self.wakeHandler {
+                        let reachable = await HealthCheckClient.isReachable()
+                        if !reachable {
+                            // Cancel competing auto-wake triggered by performHealthCheck → setConnected(false)
+                            self.autoWakeTask?.cancel()
+                            self.autoWakeTask = nil
+                            log.info("reconnect-loop: gateway unreachable — attempting wake")
+                            do {
+                                try await wakeHandler()
+                                guard !Task.isCancelled else { break }
+                                try await self.performHealthCheck()
+                            } catch {
+                                log.warning("reconnect-loop: wake + health check failed: \(error)")
+                                continue
+                            }
+                        } else {
+                            log.warning("reconnect-loop: health check failed but gateway reachable: \(error)")
+                            continue
+                        }
+                    } else {
+                        log.warning("reconnect-loop: health check failed (no wake handler): \(error)")
+                        continue
+                    }
+                }
+
+                // If we reach here, health check succeeded
+                guard !Task.isCancelled else { break }
+                self.startHealthCheckLoop()
+                self.isAuthenticated = true
+                self.isConnecting = false
+                log.info("reconnect-loop: connected successfully after \(attempt) attempt(s)")
+                self.eventStreamClient.startSSE()
+                if self.reconnectionGeneration == generation {
+                    self.reconnectionTask = nil
+                }
+                return
+            }
+            log.info("reconnect-loop: cancelled")
+            if self.reconnectionGeneration == generation {
+                self.reconnectionTask = nil
+            }
+        }
+    }
     #endif
 
     // MARK: - Post-Sparkle Update Detection
@@ -634,6 +727,7 @@ public final class GatewayConnectionManager: ObservableObject {
     deinit {
         #if os(macOS)
         autoWakeTask?.cancel()
+        reconnectionTask?.cancel()
         #endif
     }
 }

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -613,6 +613,7 @@ public final class GatewayConnectionManager: ObservableObject {
                             self.autoWakeTask?.cancel()
                             self.autoWakeTask = nil
                             log.info("reconnect-loop: gateway unreachable — attempting wake")
+                            guard !Task.isCancelled, self.shouldReconnect else { break }
                             do {
                                 try await wakeHandler()
                                 guard !Task.isCancelled else { break }


### PR DESCRIPTION
## Summary
When the macOS app restarts (quit via Cmd+Q then relaunch via Spotlight), the old daemon may still be shutting down. This causes the initial connection to fail and the sidebar to show empty conversations for the entire session. This PR adds two layers of resilience:

1. **Conversation list fetch retry** — if the first fetch returns nil, retry up to 2 times with 2s delays before falling through to restoreLastActiveConversation()
2. **Background reconnection loop** — if the initial `connect()` call fails entirely, a background task retries with increasing delays (3s, 5s, 10s, 15s cap) using health checks and auto-wake until the daemon is ready

## Changes
- `ConversationRestorer.swift`: Added retry loop in `fetchConversationList()` with stored task for clean cancellation
- `GatewayConnectionManager.swift`: Added `startReconnectionLoop()` that fires from `connectImpl()`'s catch block on macOS local assistants, with generation-counter-based ownership guard, auto-wake integration, and proper cancellation in `disconnect()`/`reconfigure()`

## Milestone PRs (merged into feature branch)
- #21188: fix: add retry logic to conversation list fetch on app restart
- #21194: feat: add background reconnection loop when initial connect fails

## Project issue
Closes #21186

## Test plan
- [ ] Quit the app via Cmd+Q, wait 1-2 seconds, relaunch via Spotlight
- [ ] Verify conversations appear in the sidebar after reconnection
- [ ] Check logs for `reconnect-loop:` entries showing retry behavior
- [ ] Verify explicit disconnect (closing settings, switching assistants) cancels the reconnection loop