### PR TITLE
feat: add background reconnection loop when initial connect fails

### DIFF
--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -97,6 +97,7 @@ public final class GatewayConnectionManager: ObservableObject {
     #if os(macOS)
     var lastAutoWakeAttempt: Date?
     var autoWakeTask: Task<Void, Never>?
+    var reconnectionTask: Task<Void, Never>?
     #endif
 
     // MARK: - Event Stream
@@ -179,6 +180,8 @@ public final class GatewayConnectionManager: ObservableObject {
                     }
                 }
             }
+
+            startReconnectionLoop()
             #endif
 
             isConnecting = false
@@ -190,6 +193,10 @@ public final class GatewayConnectionManager: ObservableObject {
     // MARK: - Disconnect
 
     public func disconnect() {
+        #if os(macOS)
+        reconnectionTask?.cancel()
+        reconnectionTask = nil
+        #endif
         disconnectInternal()
     }
 
@@ -218,6 +225,8 @@ public final class GatewayConnectionManager: ObservableObject {
     public func reconfigure(conversationKey: String? = nil) {
         self.conversationKey = conversationKey
         #if os(macOS)
+        reconnectionTask?.cancel()
+        reconnectionTask = nil
         autoWakeTask?.cancel()
         autoWakeTask = nil
         #endif
@@ -551,6 +560,68 @@ public final class GatewayConnectionManager: ObservableObject {
             self.autoWakeTask = nil
         }
     }
+
+    // MARK: - Background Reconnection Loop
+
+    /// Retries connection with increasing delays after the initial `connect()` fails.
+    /// Only applies to local assistants on macOS. Uses health checks and auto-wake
+    /// to reconnect without calling `connectImpl()` (which would interfere via
+    /// `disconnectInternal()`). Cancelled on explicit `disconnect()` or `reconfigure()`.
+    private func startReconnectionLoop() {
+        guard isLocal else { return }
+        reconnectionTask?.cancel()
+        reconnectionTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let delays: [UInt64] = [3, 5, 10, 15] // seconds
+            var attempt = 0
+            while !Task.isCancelled {
+                let delaySec = delays[min(attempt, delays.count - 1)]
+                log.info("reconnect-loop: attempt \(attempt + 1), waiting \(delaySec)s")
+                try? await Task.sleep(nanoseconds: delaySec * 1_000_000_000)
+                guard !Task.isCancelled else { break }
+
+                attempt += 1
+
+                do {
+                    try await self.performHealthCheck()
+                } catch {
+                    // Health check failed — try auto-wake if gateway unreachable
+                    if let wakeHandler = self.wakeHandler {
+                        let reachable = await HealthCheckClient.isReachable()
+                        if !reachable {
+                            log.info("reconnect-loop: gateway unreachable — attempting wake")
+                            do {
+                                try await wakeHandler()
+                                guard !Task.isCancelled else { break }
+                                try await self.performHealthCheck()
+                            } catch {
+                                log.warning("reconnect-loop: wake + health check failed: \(error)")
+                                continue
+                            }
+                        } else {
+                            log.warning("reconnect-loop: health check failed but gateway reachable: \(error)")
+                            continue
+                        }
+                    } else {
+                        log.warning("reconnect-loop: health check failed (no wake handler): \(error)")
+                        continue
+                    }
+                }
+
+                // If we reach here, health check succeeded
+                guard !Task.isCancelled else { break }
+                self.startHealthCheckLoop()
+                self.isAuthenticated = true
+                self.isConnecting = false
+                log.info("reconnect-loop: connected successfully after \(attempt) attempt(s)")
+                self.eventStreamClient.startSSE()
+                self.reconnectionTask = nil
+                return
+            }
+            log.info("reconnect-loop: cancelled")
+            self.reconnectionTask = nil
+        }
+    }
     #endif
 
     // MARK: - Post-Sparkle Update Detection
@@ -634,6 +705,7 @@ public final class GatewayConnectionManager: ObservableObject {
     deinit {
         #if os(macOS)
         autoWakeTask?.cancel()
+        reconnectionTask?.cancel()
         #endif
     }
 }

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -98,6 +98,7 @@ public final class GatewayConnectionManager: ObservableObject {
     var lastAutoWakeAttempt: Date?
     var autoWakeTask: Task<Void, Never>?
     var reconnectionTask: Task<Void, Never>?
+    var reconnectionGeneration: Int = 0
     #endif
 
     // MARK: - Event Stream
@@ -576,8 +577,9 @@ public final class GatewayConnectionManager: ObservableObject {
     private func startReconnectionLoop() {
         guard isLocal else { return }
         reconnectionTask?.cancel()
-        var task: Task<Void, Never>?
-        task = Task { @MainActor [weak self] in
+        reconnectionGeneration += 1
+        let generation = reconnectionGeneration
+        reconnectionTask = Task { @MainActor [weak self] in
             guard let self else { return }
             let delays: [UInt64] = [3, 5, 10, 15] // seconds
             var attempt = 0
@@ -631,17 +633,16 @@ public final class GatewayConnectionManager: ObservableObject {
                 self.isConnecting = false
                 log.info("reconnect-loop: connected successfully after \(attempt) attempt(s)")
                 self.eventStreamClient.startSSE()
-                if self.reconnectionTask === task {
+                if self.reconnectionGeneration == generation {
                     self.reconnectionTask = nil
                 }
                 return
             }
             log.info("reconnect-loop: cancelled")
-            if self.reconnectionTask === task {
+            if self.reconnectionGeneration == generation {
                 self.reconnectionTask = nil
             }
         }
-        reconnectionTask = task
     }
     #endif
 

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -152,6 +152,10 @@ public final class GatewayConnectionManager: ObservableObject {
             isAuthenticated = true
             isConnecting = false
             log.info("connect: connected successfully")
+            #if os(macOS)
+            reconnectionTask?.cancel()
+            reconnectionTask = nil
+            #endif
 
             eventStreamClient.startSSE()
         } catch {
@@ -173,6 +177,8 @@ public final class GatewayConnectionManager: ObservableObject {
                         isAuthenticated = true
                         isConnecting = false
                         log.info("connect: retry after auto-wake succeeded")
+                        reconnectionTask?.cancel()
+                        reconnectionTask = nil
                         eventStreamClient.startSSE()
                         return
                     } catch {
@@ -570,11 +576,18 @@ public final class GatewayConnectionManager: ObservableObject {
     private func startReconnectionLoop() {
         guard isLocal else { return }
         reconnectionTask?.cancel()
-        reconnectionTask = Task { @MainActor [weak self] in
+        var task: Task<Void, Never>?
+        task = Task { @MainActor [weak self] in
             guard let self else { return }
             let delays: [UInt64] = [3, 5, 10, 15] // seconds
             var attempt = 0
             while !Task.isCancelled {
+                // If another path (e.g. autoWakeIfAssistantDied) connected us, exit
+                guard !self.isConnected else {
+                    log.info("reconnect-loop: already connected, exiting")
+                    break
+                }
+
                 let delaySec = delays[min(attempt, delays.count - 1)]
                 log.info("reconnect-loop: attempt \(attempt + 1), waiting \(delaySec)s")
                 try? await Task.sleep(nanoseconds: delaySec * 1_000_000_000)
@@ -589,6 +602,9 @@ public final class GatewayConnectionManager: ObservableObject {
                     if let wakeHandler = self.wakeHandler {
                         let reachable = await HealthCheckClient.isReachable()
                         if !reachable {
+                            // Cancel competing auto-wake triggered by performHealthCheck → setConnected(false)
+                            self.autoWakeTask?.cancel()
+                            self.autoWakeTask = nil
                             log.info("reconnect-loop: gateway unreachable — attempting wake")
                             do {
                                 try await wakeHandler()
@@ -615,12 +631,17 @@ public final class GatewayConnectionManager: ObservableObject {
                 self.isConnecting = false
                 log.info("reconnect-loop: connected successfully after \(attempt) attempt(s)")
                 self.eventStreamClient.startSSE()
-                self.reconnectionTask = nil
+                if self.reconnectionTask === task {
+                    self.reconnectionTask = nil
+                }
                 return
             }
             log.info("reconnect-loop: cancelled")
-            self.reconnectionTask = nil
+            if self.reconnectionTask === task {
+                self.reconnectionTask = nil
+            }
         }
+        reconnectionTask = task
     }
     #endif
 


### PR DESCRIPTION
When the macOS app restarts and the daemon is still shutting down, the initial connect() call fails. Since setupGatewayConnectionManager() is guarded by a one-shot hasSetupDaemon flag, no retry ever happens. This adds a startReconnectionLoop() that fires from connectImpl()'s catch block, retrying with increasing delays (3s, 5s, 10s, 15s cap) using health checks and auto-wake until the daemon is ready. The loop is cancelled on explicit disconnect() or reconfigure() calls.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
