### PR TITLE
M1: CLI progress helper and hatch step events

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -55,6 +55,7 @@ import { generateInstanceName } from "../lib/random-name";
 import { validateAssistantName } from "../lib/retire-archive";
 import { leaseGuardianToken } from "../lib/guardian-token";
 import { archiveLogFile, resetLogFile } from "../lib/xdg-log";
+import { emitProgress } from "../lib/desktop-progress.js";
 
 export type { PollResult, WatchHatchingResult } from "../lib/gcp";
 
@@ -645,6 +646,8 @@ async function hatchLocal(
     name ?? process.env.VELLUM_ASSISTANT_NAME,
   );
 
+  emitProgress(1, 7, "Preparing workspace...");
+
   // Clean up stale local state: if daemon/gateway processes are running but
   // the lock file has no entries AND the daemon is not healthy, stop them
   // before starting fresh. A healthy daemon should be reused, not killed —
@@ -702,6 +705,8 @@ async function hatchLocal(
       }
     }
   }
+
+  emitProgress(2, 7, "Allocating resources...");
 
   // Reuse existing resources if re-hatching with --name that matches a known
   // local assistant, otherwise allocate fresh per-instance ports and directories.
@@ -763,10 +768,13 @@ async function hatchLocal(
     process.env.APP_VERSION = cliPkg.version;
   }
 
+  emitProgress(3, 7, "Writing configuration...");
   const defaultWorkspaceConfigPath = writeInitialConfig(configValues);
 
+  emitProgress(4, 7, "Starting assistant...");
   await startLocalDaemon(watch, resources, { defaultWorkspaceConfigPath });
 
+  emitProgress(5, 7, "Starting gateway...");
   let runtimeUrl = `http://127.0.0.1:${resources.gatewayPort}`;
   try {
     runtimeUrl = await startGateway(watch, resources);
@@ -782,6 +790,7 @@ async function hatchLocal(
 
   // Lease a guardian token so the desktop app can import it on first launch
   // instead of hitting /v1/guardian/init itself.
+  emitProgress(6, 7, "Securing connection...");
   try {
     await leaseGuardianToken(runtimeUrl, instanceName);
   } catch (err) {
@@ -813,6 +822,7 @@ async function hatchLocal(
     serviceGroupVersion: cliPkg.version ? `v${cliPkg.version}` : undefined,
     resources,
   };
+  emitProgress(7, 7, "Saving configuration...");
   if (!restart) {
     saveAssistantEntry(localEntry);
     setActiveAssistant(instanceName);

--- a/cli/src/lib/aws.ts
+++ b/cli/src/lib/aws.ts
@@ -11,6 +11,7 @@ import type { Species } from "./constants";
 import { leaseGuardianToken } from "./guardian-token";
 import { generateInstanceName } from "./random-name";
 import { exec, execOutput } from "./step-runner";
+import { emitProgress } from "./desktop-progress.js";
 
 const KEY_PAIR_NAME = "vellum-assistant";
 const DEFAULT_SSH_USER = "admin";
@@ -443,6 +444,7 @@ export async function hatchAws(
     console.log("\u{1F50D} Finding latest Debian AMI...");
     const amiId = await getLatestDebianAmi(region);
 
+    emitProgress(1, 5, "Preparing startup script...");
     const { script: startupScript, laptopBootstrapSecret } =
       await buildStartupScript(
         species,
@@ -455,6 +457,7 @@ export async function hatchAws(
     const startupScriptPath = join(tmpdir(), `${instanceName}-startup.sh`);
     writeFileSync(startupScriptPath, startupScript);
 
+    emitProgress(2, 5, "Launching instance...");
     console.log("\u{1F528} Launching instance...");
     let instanceId: string;
     try {
@@ -491,6 +494,7 @@ export async function hatchAws(
     const runtimeUrl = externalIp
       ? `http://${externalIp}:${GATEWAY_PORT}`
       : `http://${instanceName}:${GATEWAY_PORT}`;
+    emitProgress(3, 5, "Saving configuration...");
     const awsEntry: AssistantEntry = {
       assistantId: instanceName,
       runtimeUrl,
@@ -522,6 +526,7 @@ export async function hatchAws(
 
       if (externalIp) {
         const ip = externalIp;
+        emitProgress(4, 5, "Installing software...");
         const result = await watchHatching(
           () => pollAwsInstance(ip, keyPath),
           instanceName,
@@ -539,6 +544,7 @@ export async function hatchAws(
           process.exit(1);
         }
 
+        emitProgress(5, 5, "Finalizing...");
         try {
           await leaseGuardianToken(
             runtimeUrl,

--- a/cli/src/lib/desktop-progress.ts
+++ b/cli/src/lib/desktop-progress.ts
@@ -1,0 +1,22 @@
+/**
+ * Lightweight progress reporting for the desktop app.
+ *
+ * Writes structured `HATCH_PROGRESS:{...}` lines to stdout so the Electron
+ * wrapper can parse them and render a progress bar during hatch.
+ *
+ * This module intentionally has ZERO internal imports to avoid circular
+ * dependency issues — it is a leaf module.
+ */
+
+/**
+ * Emit a structured progress event to stdout.
+ *
+ * Only emits when `VELLUM_DESKTOP_APP` env var is set (desktop mode).
+ * The desktop app parses lines matching `HATCH_PROGRESS:{...}` to update
+ * its progress UI.
+ */
+export function emitProgress(step: number, total: number, label: string): void {
+  if (!process.env.VELLUM_DESKTOP_APP) return;
+  const payload = JSON.stringify({ step, total, label });
+  process.stdout.write(`HATCH_PROGRESS:${payload}\n`);
+}

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -26,6 +26,7 @@ import {
   resetLogFile,
   writeToLogFile,
 } from "./xdg-log";
+import { emitProgress } from "./desktop-progress.js";
 
 export type ServiceName = "assistant" | "credential-executor" | "gateway";
 
@@ -1076,6 +1077,7 @@ export async function hatchDocker(
   };
 
   try {
+    emitProgress(1, 6, "Checking Docker...");
     await ensureDockerInstalled();
 
     const instanceName = generateInstanceName(species, name);
@@ -1089,6 +1091,7 @@ export async function hatchDocker(
 
     let repoRoot: string | undefined;
 
+    emitProgress(2, 6, "Pulling images...");
     if (watch) {
       repoRoot = findRepoRoot();
       const localTag = `local-${instanceName}`;
@@ -1136,6 +1139,7 @@ export async function hatchDocker(
 
     const res = dockerResourceNames(instanceName);
 
+    emitProgress(3, 6, "Creating volumes...");
     log("📁 Creating network and volumes...");
     await exec("docker", ["network", "create", res.network]);
     await exec("docker", ["volume", "create", res.socketVolume]);
@@ -1173,6 +1177,7 @@ export async function hatchDocker(
       ? `${preExisting},${ownSecret}`
       : ownSecret;
 
+    emitProgress(4, 6, "Starting containers...");
     await startContainers(
       {
         signingKey,
@@ -1208,9 +1213,11 @@ export async function hatchDocker(
         networkName: res.network,
       },
     };
+    emitProgress(5, 6, "Saving configuration...");
     saveAssistantEntry(dockerEntry);
     setActiveAssistant(instanceName);
 
+    emitProgress(6, 6, "Waiting for services...");
     const { ready } = await waitForGatewayAndLease({
       bootstrapSecret: ownSecret,
       containerName: res.assistantContainer,

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -1091,8 +1091,8 @@ export async function hatchDocker(
 
     let repoRoot: string | undefined;
 
-    emitProgress(2, 6, "Pulling images...");
     if (watch) {
+      emitProgress(2, 6, "Building images...");
       repoRoot = findRepoRoot();
       const localTag = `local-${instanceName}`;
       imageTags.assistant = `vellum-assistant:${localTag}`;
@@ -1113,6 +1113,7 @@ export async function hatchDocker(
       await buildAllImages(repoRoot, imageTags, log);
       log("✅ Docker images built");
     } else {
+      emitProgress(2, 6, "Pulling images...");
       const version = cliPkg.version;
       const versionTag = version ? `v${version}` : "latest";
       log("🔍 Resolving image references...");

--- a/cli/src/lib/gcp.ts
+++ b/cli/src/lib/gcp.ts
@@ -14,6 +14,7 @@ import { leaseGuardianToken } from "./guardian-token";
 import { getPlatformUrl } from "./platform-client";
 import { generateInstanceName } from "./random-name";
 import { exec, execOutput } from "./step-runner";
+import { emitProgress } from "./desktop-progress.js";
 
 export async function getActiveProject(): Promise<string> {
   const output = await execOutput("gcloud", ["config", "get-value", "project"]);
@@ -522,6 +523,7 @@ export async function hatchGcp(
       );
       process.exit(1);
     }
+    emitProgress(1, 5, "Preparing startup script...");
     const { script: startupScript, laptopBootstrapSecret } =
       await buildStartupScript(
         species,
@@ -534,6 +536,7 @@ export async function hatchGcp(
     const startupScriptPath = join(tmpdir(), `${instanceName}-startup.sh`);
     writeFileSync(startupScriptPath, startupScript);
 
+    emitProgress(2, 5, "Launching instance...");
     console.log("\ud83d\udd28 Creating instance with startup script...");
     try {
       const createArgs = [
@@ -595,6 +598,7 @@ export async function hatchGcp(
     const runtimeUrl = externalIp
       ? `http://${externalIp}:${GATEWAY_PORT}`
       : `http://${instanceName}:${GATEWAY_PORT}`;
+    emitProgress(3, 5, "Saving configuration...");
     const gcpEntry: AssistantEntry = {
       assistantId: instanceName,
       runtimeUrl,
@@ -624,6 +628,7 @@ export async function hatchGcp(
       console.log("   Press Ctrl+C to detach (instance will keep running)");
       console.log("");
 
+      emitProgress(4, 5, "Installing software...");
       const result = await watchHatching(
         () => pollInstance(instanceName, project, zone, account),
         instanceName,
@@ -662,6 +667,7 @@ export async function hatchGcp(
         }
       }
 
+      emitProgress(5, 5, "Finalizing...");
       try {
         await leaseGuardianToken(
           runtimeUrl,


### PR DESCRIPTION
Part of #21195. Adds a HATCH_PROGRESS sentinel protocol to CLI hatch commands so the desktop app can render a progress bar during setup. Creates cli/src/lib/desktop-progress.ts helper and adds emitProgress calls to hatchLocal (7 steps), hatchDocker (6 steps), hatchGcp (5 steps), and hatchAws (5 steps).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
