### PR TITLE
M2: Line-buffered stdout/stderr in VellumCli.swift

### DIFF
--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -723,20 +723,48 @@ final class VellumCli {
 
         let stderrAccumulator = StderrAccumulator()
 
+        // Line buffers: readabilityHandler delivers arbitrary Data chunks,
+        // not guaranteed line-delimited strings. We accumulate bytes and
+        // split on newline (0x0A) so onOutput always receives complete lines.
+        let newlineByte: UInt8 = 0x0A
+        var stdoutBuffer = Data()
+        var stderrBuffer = Data()
+        let bufferQueue = DispatchQueue(label: "com.vellum.cli.pair-line-buffer")
+
         stdoutHandle.readabilityHandler = { handle in
             let data = handle.availableData
-            guard !data.isEmpty, let line = String(data: data, encoding: .utf8) else { return }
-            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty { onOutput(trimmed) }
+            guard !data.isEmpty else { return }
+            bufferQueue.sync {
+                stdoutBuffer.append(data)
+                while let newlineIndex = stdoutBuffer.firstIndex(of: newlineByte) {
+                    let lineData = stdoutBuffer[stdoutBuffer.startIndex..<newlineIndex]
+                    stdoutBuffer = Data(stdoutBuffer[(newlineIndex + 1)...])
+                    if let line = String(data: lineData, encoding: .utf8) {
+                        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            onOutput(trimmed)
+                        }
+                    }
+                }
+            }
         }
 
         stderrHandle.readabilityHandler = { handle in
             let data = handle.availableData
-            guard !data.isEmpty, let line = String(data: data, encoding: .utf8) else { return }
-            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                stderrAccumulator.append(trimmed)
-                onOutput(trimmed)
+            guard !data.isEmpty else { return }
+            bufferQueue.sync {
+                stderrBuffer.append(data)
+                while let newlineIndex = stderrBuffer.firstIndex(of: newlineByte) {
+                    let lineData = stderrBuffer[stderrBuffer.startIndex..<newlineIndex]
+                    stderrBuffer = Data(stderrBuffer[(newlineIndex + 1)...])
+                    if let line = String(data: lineData, encoding: .utf8) {
+                        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            stderrAccumulator.append(trimmed)
+                            onOutput(trimmed)
+                        }
+                    }
+                }
             }
         }
 
@@ -746,6 +774,27 @@ final class VellumCli {
             proc.terminationHandler = { finished in
                 stdoutHandle.readabilityHandler = nil
                 stderrHandle.readabilityHandler = nil
+
+                // Flush any remaining data in the line buffers as final lines.
+                bufferQueue.sync {
+                    if let line = String(data: stdoutBuffer, encoding: .utf8) {
+                        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            onOutput(trimmed)
+                        }
+                    }
+                    stdoutBuffer = Data()
+
+                    if let line = String(data: stderrBuffer, encoding: .utf8) {
+                        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            stderrAccumulator.append(trimmed)
+                            onOutput(trimmed)
+                        }
+                    }
+                    stderrBuffer = Data()
+                }
+
                 continuation.resume(returning: finished.terminationStatus)
             }
             do {

--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -637,8 +637,46 @@ final class VellumCli {
                 stdoutHandle.readabilityHandler = nil
                 stderrHandle.readabilityHandler = nil
 
-                // Flush any remaining data in the line buffers as final lines.
+                // Drain any data that arrived after the last readabilityHandler
+                // callback but before we nil'd the handlers. Feed it through
+                // the line buffers so complete lines are emitted, then flush
+                // any remaining partial line.
+                let remainingStdout = stdoutHandle.availableData
+                let remainingStderr = stderrHandle.availableData
+
                 bufferQueue.sync {
+                    // Process remaining stdout through line buffer
+                    if !remainingStdout.isEmpty {
+                        stdoutBuffer.append(remainingStdout)
+                        while let newlineIndex = stdoutBuffer.firstIndex(of: newlineByte) {
+                            let lineData = stdoutBuffer[stdoutBuffer.startIndex..<newlineIndex]
+                            stdoutBuffer = Data(stdoutBuffer[(newlineIndex + 1)...])
+                            if let line = String(data: lineData, encoding: .utf8) {
+                                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                                if !trimmed.isEmpty {
+                                    onOutput(trimmed)
+                                }
+                            }
+                        }
+                    }
+
+                    // Process remaining stderr through line buffer
+                    if !remainingStderr.isEmpty {
+                        stderrBuffer.append(remainingStderr)
+                        while let newlineIndex = stderrBuffer.firstIndex(of: newlineByte) {
+                            let lineData = stderrBuffer[stderrBuffer.startIndex..<newlineIndex]
+                            stderrBuffer = Data(stderrBuffer[(newlineIndex + 1)...])
+                            if let line = String(data: lineData, encoding: .utf8) {
+                                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                                if !trimmed.isEmpty {
+                                    stderrAccumulator.append(trimmed)
+                                    onOutput(trimmed)
+                                }
+                            }
+                        }
+                    }
+
+                    // Flush any remaining partial lines in the buffers
                     if let line = String(data: stdoutBuffer, encoding: .utf8) {
                         let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
                         if !trimmed.isEmpty {
@@ -775,8 +813,46 @@ final class VellumCli {
                 stdoutHandle.readabilityHandler = nil
                 stderrHandle.readabilityHandler = nil
 
-                // Flush any remaining data in the line buffers as final lines.
+                // Drain any data that arrived after the last readabilityHandler
+                // callback but before we nil'd the handlers. Feed it through
+                // the line buffers so complete lines are emitted, then flush
+                // any remaining partial line.
+                let remainingStdout = stdoutHandle.availableData
+                let remainingStderr = stderrHandle.availableData
+
                 bufferQueue.sync {
+                    // Process remaining stdout through line buffer
+                    if !remainingStdout.isEmpty {
+                        stdoutBuffer.append(remainingStdout)
+                        while let newlineIndex = stdoutBuffer.firstIndex(of: newlineByte) {
+                            let lineData = stdoutBuffer[stdoutBuffer.startIndex..<newlineIndex]
+                            stdoutBuffer = Data(stdoutBuffer[(newlineIndex + 1)...])
+                            if let line = String(data: lineData, encoding: .utf8) {
+                                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                                if !trimmed.isEmpty {
+                                    onOutput(trimmed)
+                                }
+                            }
+                        }
+                    }
+
+                    // Process remaining stderr through line buffer
+                    if !remainingStderr.isEmpty {
+                        stderrBuffer.append(remainingStderr)
+                        while let newlineIndex = stderrBuffer.firstIndex(of: newlineByte) {
+                            let lineData = stderrBuffer[stderrBuffer.startIndex..<newlineIndex]
+                            stderrBuffer = Data(stderrBuffer[(newlineIndex + 1)...])
+                            if let line = String(data: lineData, encoding: .utf8) {
+                                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                                if !trimmed.isEmpty {
+                                    stderrAccumulator.append(trimmed)
+                                    onOutput(trimmed)
+                                }
+                            }
+                        }
+                    }
+
+                    // Flush any remaining partial lines in the buffers
                     if let line = String(data: stdoutBuffer, encoding: .utf8) {
                         let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
                         if !trimmed.isEmpty {

--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -582,26 +582,48 @@ final class VellumCli {
         // Accumulate stderr so the error message includes the actual failure reason.
         let stderrAccumulator = StderrAccumulator()
 
+        // Line buffers: readabilityHandler delivers arbitrary Data chunks,
+        // not guaranteed line-delimited strings. We accumulate bytes and
+        // split on newline (0x0A) so onOutput always receives complete lines.
+        let newlineByte: UInt8 = 0x0A
+        var stdoutBuffer = Data()
+        var stderrBuffer = Data()
+        let bufferQueue = DispatchQueue(label: "com.vellum.cli.line-buffer")
+
         stdoutHandle.readabilityHandler = { handle in
             let data = handle.availableData
-            guard !data.isEmpty, let line = String(data: data, encoding: .utf8) else {
-                return
-            }
-            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                onOutput(trimmed)
+            guard !data.isEmpty else { return }
+            bufferQueue.sync {
+                stdoutBuffer.append(data)
+                while let newlineIndex = stdoutBuffer.firstIndex(of: newlineByte) {
+                    let lineData = stdoutBuffer[stdoutBuffer.startIndex..<newlineIndex]
+                    stdoutBuffer = Data(stdoutBuffer[(newlineIndex + 1)...])
+                    if let line = String(data: lineData, encoding: .utf8) {
+                        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            onOutput(trimmed)
+                        }
+                    }
+                }
             }
         }
 
         stderrHandle.readabilityHandler = { handle in
             let data = handle.availableData
-            guard !data.isEmpty, let line = String(data: data, encoding: .utf8) else {
-                return
-            }
-            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                stderrAccumulator.append(trimmed)
-                onOutput(trimmed)
+            guard !data.isEmpty else { return }
+            bufferQueue.sync {
+                stderrBuffer.append(data)
+                while let newlineIndex = stderrBuffer.firstIndex(of: newlineByte) {
+                    let lineData = stderrBuffer[stderrBuffer.startIndex..<newlineIndex]
+                    stderrBuffer = Data(stderrBuffer[(newlineIndex + 1)...])
+                    if let line = String(data: lineData, encoding: .utf8) {
+                        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            stderrAccumulator.append(trimmed)
+                            onOutput(trimmed)
+                        }
+                    }
+                }
             }
         }
 
@@ -614,6 +636,27 @@ final class VellumCli {
             proc.terminationHandler = { finished in
                 stdoutHandle.readabilityHandler = nil
                 stderrHandle.readabilityHandler = nil
+
+                // Flush any remaining data in the line buffers as final lines.
+                bufferQueue.sync {
+                    if let line = String(data: stdoutBuffer, encoding: .utf8) {
+                        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            onOutput(trimmed)
+                        }
+                    }
+                    stdoutBuffer = Data()
+
+                    if let line = String(data: stderrBuffer, encoding: .utf8) {
+                        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            stderrAccumulator.append(trimmed)
+                            onOutput(trimmed)
+                        }
+                    }
+                    stderrBuffer = Data()
+                }
+
                 continuation.resume(returning: finished.terminationStatus)
             }
             do {


### PR DESCRIPTION
## Summary
- Adds line buffering to `VellumCli.runRemoteHatch()` so stdout/stderr from CLI child processes are delivered as complete lines
- Uses a serial `DispatchQueue` to synchronize buffer access across readability and termination handlers
- Flushes remaining buffer contents in the termination handler before resuming the continuation

Part of #21195.

## Test plan
- [ ] Verify remote hatch still works end-to-end (docker, GCP, AWS)
- [ ] Verify `HATCH_PROGRESS:` sentinel lines are parsed correctly even when split across data chunks
- [ ] Verify stderr accumulator still captures all error output for failure diagnostics
- [ ] Verify no duplicate or missing lines in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
