### PR TITLE
M3: Progress model on OnboardingState with resets

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -195,6 +195,11 @@ struct HatchingStepView: View {
         state.hasExistingManagedAssistant = false
         state.hatchFailed = false
         state.hatchLogLines = []
+        state.hatchProgressTarget = 0.0
+        state.hatchProgressDisplay = 0.0
+        state.hatchStepLabel = nil
+        state.hatchTotalSteps = 1
+        state.hatchCurrentStep = 0
         hatchStarted = false
         failureReason = nil
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -95,6 +95,13 @@ final class OnboardingState {
     var hatchCompleted: Bool = false
     var hatchFailed: Bool = false
 
+    /// Progress bar state for the hatching flow.
+    var hatchProgressTarget: Double = 0.0    // 0..1, set by progress events
+    var hatchProgressDisplay: Double = 0.0   // 0..1, what the bar renders
+    var hatchStepLabel: String?              // nil = don't show bar yet
+    var hatchTotalSteps: Int = 1
+    var hatchCurrentStep: Int = 0
+
     /// Avatar traits generated during the hatching animation. Stored here
     /// (rather than as @State in HatchingStepView) so they survive view
     /// disappearance and are available to the post-hatch sync logic.
@@ -178,6 +185,11 @@ final class OnboardingState {
         hatchAvatarBodyShape = nil
         hatchAvatarEyeStyle = nil
         hatchAvatarColor = nil
+        hatchProgressTarget = 0.0
+        hatchProgressDisplay = 0.0
+        hatchStepLabel = nil
+        hatchTotalSteps = 1
+        hatchCurrentStep = 0
         hasHatched = false
         skippedAuth = false
         skippedAPIKeyEntry = false


### PR DESCRIPTION
Part of #21195. Adds five flat progress-tracking properties to OnboardingState (hatchProgressTarget, hatchProgressDisplay, hatchStepLabel, hatchTotalSteps, hatchCurrentStep) and resets them in both resetForRetry() and goBack().
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
