### PR TITLE
fix(clients): prevent stale org ID from causing 403s after logout/login

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -237,15 +237,14 @@ extension AppDelegate {
                 // Self-hosted (local or remote): clear auth state but keep the
                 // app running. The user can sign in again from Settings > General.
 
-                // Restore connectedAssistantId and connectedOrganizationId —
-                // authManager.logout() clears both from UserDefaults, but the
-                // app stays running in this path and subsystems (avatar, gateway
-                // resolution, API key sync, Sentry tagging, billing) need them.
+                // Restore connectedAssistantId — authManager.logout() clears it
+                // from UserDefaults, but the app stays running in this path and
+                // the assistant process is still active.
+                // Do NOT restore connectedOrganizationId: the org ID may belong
+                // to a different environment (e.g. dev vs prod). Letting bootstrap
+                // re-resolve it on the next login ensures it matches the session.
                 if let connectedAssistantId {
                     UserDefaults.standard.set(connectedAssistantId, forKey: "connectedAssistantId")
-                }
-                if let connectedOrganizationId {
-                    UserDefaults.standard.set(connectedOrganizationId, forKey: "connectedOrganizationId")
                 }
 
                 actorTokenBootstrapTask?.cancel()

--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -76,13 +76,19 @@ public final class LocalAssistantBootstrapService {
         let installId = DeviceIdStore.getOrCreate()
 
         // Resolve the user's organization ID — required for all platform API calls.
+        // Always fetch the org list to validate any persisted ID, since the persisted
+        // value may belong to a different environment (e.g. dev vs prod).
         let organizationId: String
-        if let persistedOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") {
-            organizationId = persistedOrgId
-            log.info("Using persisted organization: \(organizationId, privacy: .public)")
-        } else {
-            do {
-                let orgs = try await authService.getOrganizations()
+        do {
+            let orgs = try await authService.getOrganizations()
+            let persistedOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
+            if let persistedOrgId, orgs.contains(where: { $0.id == persistedOrgId }) {
+                organizationId = persistedOrgId
+                log.info("Validated persisted organization: \(organizationId, privacy: .public)")
+            } else {
+                if persistedOrgId != nil {
+                    log.warning("Persisted organization ID not found in user's orgs — re-resolving")
+                }
                 switch orgs.count {
                 case 0:
                     throw LocalBootstrapError.registrationFailed("No organizations found for this account")
@@ -93,13 +99,13 @@ public final class LocalAssistantBootstrapService {
                 }
                 UserDefaults.standard.set(organizationId, forKey: "connectedOrganizationId")
                 log.info("Resolved organization: \(organizationId, privacy: .public)")
-            } catch let error as LocalBootstrapError {
-                throw error
-            } catch let error as PlatformAPIError {
-                throw mapPlatformError(error, context: .registration)
-            } catch {
-                throw LocalBootstrapError.registrationFailed(error.localizedDescription)
             }
+        } catch let error as LocalBootstrapError {
+            throw error
+        } catch let error as PlatformAPIError {
+            throw mapPlatformError(error, context: .registration)
+        } catch {
+            throw LocalBootstrapError.registrationFailed(error.localizedDescription)
         }
 
         // Step 1: Ensure registration (idempotent)

--- a/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
@@ -166,15 +166,19 @@ public final class ManagedAssistantBootstrapService {
         log.warning("Provisioning poll timed out for \(assistantId, privacy: .public) after \(timeout)s — proceeding to health check")
     }
 
-    /// Resolve the organization ID, preferring the persisted value.
+    /// Resolve the organization ID, validating any persisted value against the
+    /// user's actual org list to prevent stale cross-environment IDs.
     private func resolveOrganizationId() async throws -> String {
-        if let persistedOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") {
-            log.info("Using persisted organization: \(persistedOrgId, privacy: .public)")
-            return persistedOrgId
-        }
-
         do {
             let orgs = try await authService.getOrganizations()
+            let persistedOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
+            if let persistedOrgId, orgs.contains(where: { $0.id == persistedOrgId }) {
+                log.info("Validated persisted organization: \(persistedOrgId, privacy: .public)")
+                return persistedOrgId
+            }
+            if persistedOrgId != nil {
+                log.warning("Persisted organization ID not found in user's orgs — re-resolving")
+            }
             switch orgs.count {
             case 0:
                 throw ManagedBootstrapError.serverError(statusCode: 0, detail: "No organizations found for this account")


### PR DESCRIPTION
## Summary
- Self-hosted logout was restoring `connectedOrganizationId` after `authManager.logout()` cleared it. If the persisted org ID belonged to a different environment (e.g. dev vs prod), the next login's bootstrap would reuse the stale value, causing **403 errors** on all org-scoped platform API calls (credentials, billing, registration).
- Stop restoring `connectedOrganizationId` on self-hosted logout — let bootstrap re-resolve it on next login.
- Both `LocalAssistantBootstrapService` and `ManagedAssistantBootstrapService` now validate the persisted org ID against the user's actual org list before using it, so stale IDs self-heal regardless of how they got persisted.

## Test plan
- [ ] Log in on a production build, verify credentials bootstrap succeeds and billing loads
- [ ] Log out and log back in, verify org ID is re-resolved correctly
- [ ] With a stale org ID in UserDefaults (from a different env), verify bootstrap detects the mismatch and re-resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
