### PR TITLE
M4: Progress bar UI, smooth interpolation, and HATCH_PROGRESS parsing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -25,6 +25,7 @@ struct HatchingStepView: View {
         state.hatchAvatarColor ?? .allCases[0]
     }
     @State private var completionTask: Task<Void, Never>?
+    @State private var progressTimer: Timer?
 
     var body: some View {
         VStack(spacing: VSpacing.lg) {
@@ -34,6 +35,10 @@ struct HatchingStepView: View {
                 .padding(.bottom, VSpacing.xl)
 
             statusText
+
+            if showProgressBar {
+                progressSection
+            }
 
             if state.hatchFailed {
                 failureButtons
@@ -63,10 +68,12 @@ struct HatchingStepView: View {
             if !hatchStarted {
                 hatchStarted = true
                 startHatching()
+                startProgressTimer()
             }
         }
         .onDisappear {
             completionTask?.cancel()
+            stopProgressTimer()
         }
         .onChange(of: state.hatchCompleted) { _, completed in
             if completed {
@@ -163,6 +170,26 @@ struct HatchingStepView: View {
         .frame(maxWidth: 320)
     }
 
+    // MARK: - Progress Bar
+
+    private var showProgressBar: Bool {
+        !state.hatchFailed && !state.hatchCompleted && !isCustomHardware && state.hatchStepLabel != nil
+    }
+
+    private var progressSection: some View {
+        VStack(spacing: VSpacing.xs) {
+            ProgressView(value: state.hatchProgressDisplay)
+                .progressViewStyle(.linear)
+                .frame(maxWidth: 240)
+            if let label = state.hatchStepLabel {
+                Text(label)
+                    .font(VFont.bodySmallDefault)
+                    .foregroundColor(VColor.contentTertiary)
+            }
+        }
+        .transition(.opacity.animation(.easeOut(duration: 0.3)))
+    }
+
     // MARK: - Failure Buttons
 
     private var failureButtons: some View {
@@ -236,9 +263,60 @@ struct HatchingStepView: View {
         // Brief delay so the user sees the waking animation before transition.
         // Stored as a cancellable Task so it's cleaned up if the view disappears.
         completionTask = Task {
-            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            try? await Task.sleep(nanoseconds: 500_000_000)
             guard !Task.isCancelled else { return }
             state.hatchCompleted = true
+        }
+    }
+
+    // MARK: - Progress Timer
+
+    private func startProgressTimer() {
+        progressTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { _ in
+            Task { @MainActor in
+                updateProgressDisplay()
+            }
+        }
+    }
+
+    private func stopProgressTimer() {
+        progressTimer?.invalidate()
+        progressTimer = nil
+    }
+
+    private func updateProgressDisplay() {
+        guard state.hatchStepLabel != nil else { return }
+
+        let target = state.hatchProgressTarget
+        let current = state.hatchProgressDisplay
+
+        if state.hatchCompleted {
+            // Animate to 100%
+            let diff = 1.0 - current
+            if diff > 0.001 {
+                state.hatchProgressDisplay = current + diff * 0.15
+            } else {
+                state.hatchProgressDisplay = 1.0
+                stopProgressTimer()
+            }
+            return
+        }
+
+        if state.hatchFailed {
+            stopProgressTimer()
+            return
+        }
+
+        // Ceiling: don't creep past next step boundary, cap at 95%
+        let nextStepProgress = Double(state.hatchCurrentStep + 1) / Double(max(state.hatchTotalSteps, 1))
+        let ceiling = min(nextStepProgress - 0.02, 0.95)
+
+        if current < target {
+            // Lerp quickly toward target (catches up in ~200ms)
+            state.hatchProgressDisplay = current + (target - current) * 0.15
+        } else if current < ceiling {
+            // Slow creep (~1% per second at 60fps)
+            state.hatchProgressDisplay = min(current + 0.0003, ceiling)
         }
     }
 
@@ -298,6 +376,26 @@ struct HatchingStepView: View {
                 try await cliLauncher.runRemoteHatch(config: config) { line in
                     Task { @MainActor in
                         log.info("CLI hatch output: \(line, privacy: .public)")
+
+                        // Parse progress sentinel
+                        if line.hasPrefix("HATCH_PROGRESS:") {
+                            // Ignore late events after success
+                            guard !state.hatchCompleted && completionTask == nil else { return }
+                            let json = String(line.dropFirst("HATCH_PROGRESS:".count))
+                            if let data = json.data(using: .utf8),
+                               let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                               let step = parsed["step"] as? Int,
+                               let total = parsed["total"] as? Int,
+                               let label = parsed["label"] as? String,
+                               total > 0, step >= 0, step <= total {
+                                state.hatchCurrentStep = step
+                                state.hatchTotalSteps = total
+                                state.hatchStepLabel = label
+                                state.hatchProgressTarget = Double(step) / Double(total)
+                            }
+                            return  // Don't append sentinel lines to hatchLogLines
+                        }
+
                         state.hatchLogLines.append(line)
 
                         // Detect the readiness sentinel from CLI output so we

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -395,7 +395,7 @@ struct HatchingStepView: View {
                                 state.hatchCurrentStep = step
                                 state.hatchTotalSteps = total
                                 state.hatchStepLabel = label
-                                state.hatchProgressTarget = Double(step) / Double(total)
+                                state.hatchProgressTarget = min(Double(step) / Double(total), 0.95)
                             }
                             return  // Don't append sentinel lines to hatchLogLines
                         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -68,12 +68,16 @@ struct HatchingStepView: View {
             if !hatchStarted {
                 hatchStarted = true
                 startHatching()
-                startProgressTimer()
             }
         }
         .onDisappear {
             completionTask?.cancel()
             stopProgressTimer()
+        }
+        .onChange(of: state.hatchStepLabel) { oldLabel, newLabel in
+            if oldLabel == nil, newLabel != nil {
+                startProgressTimer()
+            }
         }
         .onChange(of: state.hatchCompleted) { _, completed in
             if completed {
@@ -184,7 +188,7 @@ struct HatchingStepView: View {
             if let label = state.hatchStepLabel {
                 Text(label)
                     .font(VFont.bodySmallDefault)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
             }
         }
         .transition(.opacity.animation(.easeOut(duration: 0.3)))


### PR DESCRIPTION
## Summary
- Parses `HATCH_PROGRESS:{"step":N,"total":M,"label":"..."}` sentinel lines from CLI stdout in the `startRemoteHatch()` onOutput callback
- Adds a linear progress bar with step label below the status text, visible only when progress events are received (graceful fallback for old CLI)
- Implements smooth 60fps interpolation: lerp toward target, slow creep between steps (capped at 95%), and animate-to-100% on completion
- Reduces `handleHatchSuccess` delay from 1.5s to 0.5s (centralized post-complete delay moving to M5)

## Test plan
- [ ] Run a remote hatch and verify the progress bar appears and advances smoothly
- [ ] Verify progress bar does not appear for custom hardware pairing flows
- [ ] Verify progress bar disappears on failure
- [ ] Verify late HATCH_PROGRESS events after success are ignored
- [ ] Verify old CLI output (without HATCH_PROGRESS lines) still works without showing a progress bar

Part of #21195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
