### PR TITLE
M2: Defer scroll-to-bottom by one main-actor hop

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBottomPinCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBottomPinCoordinator.swift
@@ -278,74 +278,84 @@ final class ChatBottomPinCoordinator {
         sessionGeneration += 1
         let generation = sessionGeneration
 
-        // Immediate first attempt — synchronous so callers see the result
-        // before yielding (important for tests and single-frame UI updates).
-        guard var session = activeSession else { return }
-        session.recordAttempt()
-        activeSession = session
-        log.debug("[BottomPin] immediateAttempt sid=\(session.sessionId) reason=\(session.reason.rawValue) animated=\(animated) attempt=\(session.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(session.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
-        let pinned = onPinRequested?(session.reason, animated) ?? false
+        guard let session = activeSession else { return }
 
-        if pinned {
-            log.debug("[BottomPin] success sid=\(session.sessionId) attempt=\(session.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(session.elapsedMs)")
-            completeSession(generation: generation)
-            return
-        }
+        // Defer the first attempt by one main-actor hop so the scroll request
+        // doesn't compound with the message-append layout transaction.
+        // This splits the mega-layout into two smaller passes.
+        // Precedent: ConversationTailAnchorYKey handler already uses
+        // Task { @MainActor in } for the same reason (layout re-entry).
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard self.sessionGeneration == generation else { return }
 
-        // Async bounded retry loop for subsequent attempts.
-        sessionTask = Task { @MainActor [weak self] in
-            while !Task.isCancelled {
-                guard let self else { break }
-                guard self.sessionGeneration == generation else {
-                    if let s = self.activeSession {
-                        log.debug("[BottomPin] generationMismatch sid=\(s.sessionId) staleGen=\(generation) currentGen=\(self.sessionGeneration)")
+            guard var deferredSession = self.activeSession else { return }
+            deferredSession.recordAttempt()
+            self.activeSession = deferredSession
+            log.debug("[BottomPin] immediateAttempt sid=\(deferredSession.sessionId) reason=\(deferredSession.reason.rawValue) animated=\(animated) attempt=\(deferredSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(deferredSession.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
+            let pinned = self.onPinRequested?(self.activeSession?.reason ?? session.reason, animated) ?? false
+
+            if pinned {
+                log.debug("[BottomPin] success sid=\(deferredSession.sessionId) attempt=\(deferredSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(deferredSession.elapsedMs)")
+                self.completeSession(generation: generation)
+                return
+            }
+
+            // Start the async bounded retry loop only if immediate attempt failed.
+            self.sessionTask = Task { @MainActor [weak self] in
+                while !Task.isCancelled {
+                    guard let self else { break }
+                    guard self.sessionGeneration == generation else {
+                        if let s = self.activeSession {
+                            log.debug("[BottomPin] generationMismatch sid=\(s.sessionId) staleGen=\(generation) currentGen=\(self.sessionGeneration)")
+                        }
+                        break
                     }
-                    break
-                }
-                guard var currentSession = self.activeSession else { break }
-                guard !currentSession.isExhausted else {
-                    log.debug("[BottomPin] exhausted sid=\(currentSession.sessionId) attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(currentSession.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
-                    break
+                    guard var currentSession = self.activeSession else { break }
+                    guard !currentSession.isExhausted else {
+                        log.debug("[BottomPin] exhausted sid=\(currentSession.sessionId) attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(currentSession.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
+                        break
+                    }
+
+                    // Check session timeout.
+                    let elapsed = CFAbsoluteTimeGetCurrent() - currentSession.startTime
+                    if elapsed > Self.sessionTimeout {
+                        let elapsedMs = Int(elapsed * 1000)
+                        log.debug("[BottomPin] timeout sid=\(currentSession.sessionId) attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
+                        break
+                    }
+
+                    do {
+                        try await Task.sleep(nanoseconds: Self.retryInterval)
+                    } catch {
+                        break
+                    }
+                    guard !Task.isCancelled else { break }
+
+                    // Re-check follow state after sleep — user may have scrolled up.
+                    guard self.isFollowingBottom else {
+                        log.debug("[BottomPin] retryAborted sid=\(currentSession.sessionId) reason=detachedDuringSleep attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(currentSession.elapsedMs) isFollowingBottom=false")
+                        break
+                    }
+
+                    currentSession.recordAttempt()
+                    self.activeSession = currentSession
+                    log.debug("[BottomPin] retryAttempt sid=\(currentSession.sessionId) reason=\(currentSession.reason.rawValue) animated=\(animated) attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(currentSession.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
+                    let succeeded = self.onPinRequested?(currentSession.reason, animated) ?? false
+
+                    if succeeded {
+                        log.debug("[BottomPin] success sid=\(currentSession.sessionId) attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(currentSession.elapsedMs)")
+                        self.completeSession(generation: generation)
+                        return
+                    }
                 }
 
-                // Check session timeout.
-                let elapsed = CFAbsoluteTimeGetCurrent() - currentSession.startTime
-                if elapsed > Self.sessionTimeout {
-                    let elapsedMs = Int(elapsed * 1000)
-                    log.debug("[BottomPin] timeout sid=\(currentSession.sessionId) attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
-                    break
+                // Clean up if we fell through without completing.
+                if let self, let s = self.activeSession, self.sessionGeneration == generation {
+                    log.debug("[BottomPin] sessionEnd sid=\(s.sessionId) attempt=\(s.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(s.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
                 }
-
-                do {
-                    try await Task.sleep(nanoseconds: Self.retryInterval)
-                } catch {
-                    break
-                }
-                guard !Task.isCancelled else { break }
-
-                // Re-check follow state after sleep — user may have scrolled up.
-                guard self.isFollowingBottom else {
-                    log.debug("[BottomPin] retryAborted sid=\(currentSession.sessionId) reason=detachedDuringSleep attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(currentSession.elapsedMs) isFollowingBottom=false")
-                    break
-                }
-
-                currentSession.recordAttempt()
-                self.activeSession = currentSession
-                log.debug("[BottomPin] retryAttempt sid=\(currentSession.sessionId) reason=\(currentSession.reason.rawValue) animated=\(animated) attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(currentSession.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
-                let succeeded = self.onPinRequested?(currentSession.reason, animated) ?? false
-
-                if succeeded {
-                    log.debug("[BottomPin] success sid=\(currentSession.sessionId) attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(currentSession.elapsedMs)")
-                    self.completeSession(generation: generation)
-                    return
-                }
+                self?.completeSession(generation: generation)
             }
-
-            // Clean up if we fell through without completing.
-            if let self, let s = self.activeSession, self.sessionGeneration == generation {
-                log.debug("[BottomPin] sessionEnd sid=\(s.sessionId) attempt=\(s.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(s.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
-            }
-            self?.completeSession(generation: generation)
         }
     }
 


### PR DESCRIPTION
## Summary
- Wrap the synchronous immediate `proxy.scrollTo()` in `ChatBottomPinCoordinator.startSessionTask()` with `Task { @MainActor in }` to defer by one main-actor hop
- This splits the mega layout transaction into two smaller passes — message append and scroll update happen in separate transactions instead of one 2.5-second block
- The retry loop creation is also moved inside the deferred Task so it only starts if the deferred immediate attempt fails

## Test plan
- [ ] Verify scroll-to-bottom still works when new messages arrive during streaming
- [ ] Verify the scroll animation is still smooth (at most one frame delay, imperceptible)
- [ ] Verify detach/reattach behavior is unchanged — scrolling up still detaches, clicking "Jump to latest" still reattaches
- [ ] Verify coalescing behavior during initial load grace period still works correctly

Part of #21203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
