### PR TITLE
M5: Managed path progress and centralized completion delay

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -198,6 +198,8 @@ struct OnboardingFlowView: View {
             )
             if !isAuthenticated && managedSignInEnabled && state.currentStep > 0 {
                 log.info("User signed out during managed onboarding — returning to welcome screen")
+                completionDelayTask?.cancel()
+                didCallComplete = false
                 isBootstrappingManaged = false
                 managedBootstrapError = nil
                 withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
@@ -243,6 +245,7 @@ struct OnboardingFlowView: View {
                 completionDelayTask = Task {
                     try? await Task.sleep(nanoseconds: 1_000_000_000)
                     guard !Task.isCancelled else { return }
+                    guard state.hatchCompleted else { return }
                     onComplete()
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -17,6 +17,8 @@ struct OnboardingFlowView: View {
     @State private var isBootstrappingManaged = false
     @State private var isResolvingAssociatedManagedAssistant = false
     @State private var managedBootstrapError: String?
+    @State private var didCallComplete = false
+    @State private var completionDelayTask: Task<Void, Never>?
 
     private static let appIcon: NSImage? = {
         guard let path = ResourceBundle.bundle.path(forResource: "vellum-app-icon", ofType: "png") else { return nil }
@@ -236,8 +238,17 @@ struct OnboardingFlowView: View {
         }
         .onChange(of: state.hatchCompleted) { _, completed in
             if completed {
-                onComplete()
+                guard !didCallComplete else { return }
+                didCallComplete = true
+                completionDelayTask = Task {
+                    try? await Task.sleep(nanoseconds: 1_000_000_000)
+                    guard !Task.isCancelled else { return }
+                    onComplete()
+                }
             }
+        }
+        .onDisappear {
+            completionDelayTask?.cancel()
         }
     }
 
@@ -352,6 +363,12 @@ struct OnboardingFlowView: View {
     /// (`assistants/{assistantId}/health`) until the runtime responds successfully.
     private func awaitManagedAssistantReady(assistantId: String) async {
         // Phase 1: Wait for the platform to finish provisioning.
+        guard !state.hatchCompleted else { return }
+        state.hatchTotalSteps = 3
+        state.hatchCurrentStep = 1
+        state.hatchStepLabel = "Provisioning assistant..."
+        state.hatchProgressTarget = 0.33
+
         do {
             try await ManagedAssistantBootstrapService.shared.awaitAssistantProvisioned(assistantId: assistantId)
         } catch {
@@ -361,6 +378,11 @@ struct OnboardingFlowView: View {
         }
 
         // Phase 2: Poll the assistant-scoped gateway health endpoint.
+        guard !state.hatchCompleted else { return }
+        state.hatchCurrentStep = 2
+        state.hatchStepLabel = "Connecting to assistant..."
+        state.hatchProgressTarget = 0.66
+
         let timeout: TimeInterval = 120
         let start = CFAbsoluteTimeGetCurrent()
         var lastError: Error?
@@ -374,6 +396,9 @@ struct OnboardingFlowView: View {
                 ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
                 if response.isSuccess {
                     log.info("Managed assistant \(assistantId, privacy: .public) is ready")
+                    state.hatchCurrentStep = 3
+                    state.hatchStepLabel = "Ready"
+                    state.hatchProgressTarget = 1.0
                     state.hatchCompleted = true
                     return
                 }


### PR DESCRIPTION
## Summary
- Adds progress updates at three phase boundaries in `awaitManagedAssistantReady()`: provisioning (step 1/3, 33%), connecting (step 2/3, 66%), and ready (step 3/3, 100%)
- Replaces the immediate `onComplete()` call in the `hatchCompleted` handler with a 1.0s delayed version so users see the progress bar reach 100% and the "Ready" label before onboarding closes
- Adds `hatchCompleted` guard checks before each phase update to prevent race conditions

## Test plan
- [ ] Run managed bootstrap flow end-to-end; verify progress bar advances through "Provisioning assistant..." -> "Connecting to assistant..." -> "Ready" labels
- [ ] Verify the progress bar visually reaches 100% and pauses ~1s before the onboarding view dismisses
- [ ] Verify CLI/local/docker hatch paths still work (they use the 0.5s pre-delay in HatchingStepView + the 1.0s post-delay here, totaling ~1.5s)
- [ ] Verify that navigating away during the delay (e.g., view disappears) cancels the completion task cleanly

Part of #21195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
