### PR TITLE
fix: default platform URL to dev-platform.vellum.ai in dev mode

### DIFF
--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -152,11 +152,15 @@ export function getPlatformBaseUrl(): string {
   } catch {
     // Config not yet available (early bootstrap) — fall through
   }
+  const defaultUrl =
+    str("VELLUM_DEV") === "1"
+      ? "https://dev-platform.vellum.ai"
+      : "https://platform.vellum.ai";
   return (
     configUrl ||
     str("VELLUM_PLATFORM_URL") ||
     _platformBaseUrlOverride ||
-    "https://platform.vellum.ai"
+    defaultUrl
   );
 }
 

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -266,6 +266,7 @@ async function startDaemonFromSource(
     ...process.env,
     RUNTIME_HTTP_PORT: process.env.RUNTIME_HTTP_PORT || "7821",
     VELLUM_CLOUD: "local",
+    VELLUM_DEV: "1",
   };
   if (resources) {
     env.BASE_DATA_DIR = resources.instanceDir;


### PR DESCRIPTION
## Summary
- `startDaemonFromSource` in the CLI was missing `VELLUM_DEV=1` in its env (the watch-mode variant already had it), so the assistant didn't know it was in dev mode when started via `vellum wake`
- `getPlatformBaseUrl()` now defaults to `https://dev-platform.vellum.ai` when `VELLUM_DEV=1`, instead of always falling back to production

## Test plan
- [ ] Run `vellum wake` from a source checkout — verify the Platform URL in Settings shows `dev-platform.vellum.ai`
- [ ] Set `VELLUM_PLATFORM_URL=https://custom.example.com` explicitly — verify it still takes precedence over the dev default
- [ ] Production builds (no `VELLUM_DEV`) still default to `platform.vellum.ai`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
