### PR TITLE
feat: Hatch progress bar for setup flow

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -55,6 +55,7 @@ import { generateInstanceName } from "../lib/random-name";
 import { validateAssistantName } from "../lib/retire-archive";
 import { leaseGuardianToken } from "../lib/guardian-token";
 import { archiveLogFile, resetLogFile } from "../lib/xdg-log";
+import { emitProgress } from "../lib/desktop-progress.js";
 
 export type { PollResult, WatchHatchingResult } from "../lib/gcp";
 
@@ -645,6 +646,8 @@ async function hatchLocal(
     name ?? process.env.VELLUM_ASSISTANT_NAME,
   );
 
+  emitProgress(1, 7, "Preparing workspace...");
+
   // Clean up stale local state: if daemon/gateway processes are running but
   // the lock file has no entries AND the daemon is not healthy, stop them
   // before starting fresh. A healthy daemon should be reused, not killed —
@@ -702,6 +705,8 @@ async function hatchLocal(
       }
     }
   }
+
+  emitProgress(2, 7, "Allocating resources...");
 
   // Reuse existing resources if re-hatching with --name that matches a known
   // local assistant, otherwise allocate fresh per-instance ports and directories.
@@ -763,10 +768,13 @@ async function hatchLocal(
     process.env.APP_VERSION = cliPkg.version;
   }
 
+  emitProgress(3, 7, "Writing configuration...");
   const defaultWorkspaceConfigPath = writeInitialConfig(configValues);
 
+  emitProgress(4, 7, "Starting assistant...");
   await startLocalDaemon(watch, resources, { defaultWorkspaceConfigPath });
 
+  emitProgress(5, 7, "Starting gateway...");
   let runtimeUrl = `http://127.0.0.1:${resources.gatewayPort}`;
   try {
     runtimeUrl = await startGateway(watch, resources);
@@ -782,6 +790,7 @@ async function hatchLocal(
 
   // Lease a guardian token so the desktop app can import it on first launch
   // instead of hitting /v1/guardian/init itself.
+  emitProgress(6, 7, "Securing connection...");
   try {
     await leaseGuardianToken(runtimeUrl, instanceName);
   } catch (err) {
@@ -813,6 +822,7 @@ async function hatchLocal(
     serviceGroupVersion: cliPkg.version ? `v${cliPkg.version}` : undefined,
     resources,
   };
+  emitProgress(7, 7, "Saving configuration...");
   if (!restart) {
     saveAssistantEntry(localEntry);
     setActiveAssistant(instanceName);

--- a/cli/src/lib/aws.ts
+++ b/cli/src/lib/aws.ts
@@ -11,6 +11,7 @@ import type { Species } from "./constants";
 import { leaseGuardianToken } from "./guardian-token";
 import { generateInstanceName } from "./random-name";
 import { exec, execOutput } from "./step-runner";
+import { emitProgress } from "./desktop-progress.js";
 
 const KEY_PAIR_NAME = "vellum-assistant";
 const DEFAULT_SSH_USER = "admin";
@@ -443,6 +444,7 @@ export async function hatchAws(
     console.log("\u{1F50D} Finding latest Debian AMI...");
     const amiId = await getLatestDebianAmi(region);
 
+    emitProgress(1, 5, "Preparing startup script...");
     const { script: startupScript, laptopBootstrapSecret } =
       await buildStartupScript(
         species,
@@ -455,6 +457,7 @@ export async function hatchAws(
     const startupScriptPath = join(tmpdir(), `${instanceName}-startup.sh`);
     writeFileSync(startupScriptPath, startupScript);
 
+    emitProgress(2, 5, "Launching instance...");
     console.log("\u{1F528} Launching instance...");
     let instanceId: string;
     try {
@@ -491,6 +494,7 @@ export async function hatchAws(
     const runtimeUrl = externalIp
       ? `http://${externalIp}:${GATEWAY_PORT}`
       : `http://${instanceName}:${GATEWAY_PORT}`;
+    emitProgress(3, 5, "Saving configuration...");
     const awsEntry: AssistantEntry = {
       assistantId: instanceName,
       runtimeUrl,
@@ -522,6 +526,7 @@ export async function hatchAws(
 
       if (externalIp) {
         const ip = externalIp;
+        emitProgress(4, 5, "Installing software...");
         const result = await watchHatching(
           () => pollAwsInstance(ip, keyPath),
           instanceName,
@@ -539,6 +544,7 @@ export async function hatchAws(
           process.exit(1);
         }
 
+        emitProgress(5, 5, "Finalizing...");
         try {
           await leaseGuardianToken(
             runtimeUrl,

--- a/cli/src/lib/desktop-progress.ts
+++ b/cli/src/lib/desktop-progress.ts
@@ -1,0 +1,22 @@
+/**
+ * Lightweight progress reporting for the desktop app.
+ *
+ * Writes structured `HATCH_PROGRESS:{...}` lines to stdout so the Electron
+ * wrapper can parse them and render a progress bar during hatch.
+ *
+ * This module intentionally has ZERO internal imports to avoid circular
+ * dependency issues — it is a leaf module.
+ */
+
+/**
+ * Emit a structured progress event to stdout.
+ *
+ * Only emits when `VELLUM_DESKTOP_APP` env var is set (desktop mode).
+ * The desktop app parses lines matching `HATCH_PROGRESS:{...}` to update
+ * its progress UI.
+ */
+export function emitProgress(step: number, total: number, label: string): void {
+  if (!process.env.VELLUM_DESKTOP_APP) return;
+  const payload = JSON.stringify({ step, total, label });
+  process.stdout.write(`HATCH_PROGRESS:${payload}\n`);
+}

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -26,6 +26,7 @@ import {
   resetLogFile,
   writeToLogFile,
 } from "./xdg-log";
+import { emitProgress } from "./desktop-progress.js";
 
 export type ServiceName = "assistant" | "credential-executor" | "gateway";
 
@@ -1076,6 +1077,7 @@ export async function hatchDocker(
   };
 
   try {
+    emitProgress(1, 6, "Checking Docker...");
     await ensureDockerInstalled();
 
     const instanceName = generateInstanceName(species, name);
@@ -1090,6 +1092,7 @@ export async function hatchDocker(
     let repoRoot: string | undefined;
 
     if (watch) {
+      emitProgress(2, 6, "Building images...");
       repoRoot = findRepoRoot();
       const localTag = `local-${instanceName}`;
       imageTags.assistant = `vellum-assistant:${localTag}`;
@@ -1110,6 +1113,7 @@ export async function hatchDocker(
       await buildAllImages(repoRoot, imageTags, log);
       log("✅ Docker images built");
     } else {
+      emitProgress(2, 6, "Pulling images...");
       const version = cliPkg.version;
       const versionTag = version ? `v${version}` : "latest";
       log("🔍 Resolving image references...");
@@ -1136,6 +1140,7 @@ export async function hatchDocker(
 
     const res = dockerResourceNames(instanceName);
 
+    emitProgress(3, 6, "Creating volumes...");
     log("📁 Creating network and volumes...");
     await exec("docker", ["network", "create", res.network]);
     await exec("docker", ["volume", "create", res.socketVolume]);
@@ -1173,6 +1178,7 @@ export async function hatchDocker(
       ? `${preExisting},${ownSecret}`
       : ownSecret;
 
+    emitProgress(4, 6, "Starting containers...");
     await startContainers(
       {
         signingKey,
@@ -1208,9 +1214,11 @@ export async function hatchDocker(
         networkName: res.network,
       },
     };
+    emitProgress(5, 6, "Saving configuration...");
     saveAssistantEntry(dockerEntry);
     setActiveAssistant(instanceName);
 
+    emitProgress(6, 6, "Waiting for services...");
     const { ready } = await waitForGatewayAndLease({
       bootstrapSecret: ownSecret,
       containerName: res.assistantContainer,

--- a/cli/src/lib/gcp.ts
+++ b/cli/src/lib/gcp.ts
@@ -14,6 +14,7 @@ import { leaseGuardianToken } from "./guardian-token";
 import { getPlatformUrl } from "./platform-client";
 import { generateInstanceName } from "./random-name";
 import { exec, execOutput } from "./step-runner";
+import { emitProgress } from "./desktop-progress.js";
 
 export async function getActiveProject(): Promise<string> {
   const output = await execOutput("gcloud", ["config", "get-value", "project"]);
@@ -522,6 +523,7 @@ export async function hatchGcp(
       );
       process.exit(1);
     }
+    emitProgress(1, 5, "Preparing startup script...");
     const { script: startupScript, laptopBootstrapSecret } =
       await buildStartupScript(
         species,
@@ -534,6 +536,7 @@ export async function hatchGcp(
     const startupScriptPath = join(tmpdir(), `${instanceName}-startup.sh`);
     writeFileSync(startupScriptPath, startupScript);
 
+    emitProgress(2, 5, "Launching instance...");
     console.log("\ud83d\udd28 Creating instance with startup script...");
     try {
       const createArgs = [
@@ -595,6 +598,7 @@ export async function hatchGcp(
     const runtimeUrl = externalIp
       ? `http://${externalIp}:${GATEWAY_PORT}`
       : `http://${instanceName}:${GATEWAY_PORT}`;
+    emitProgress(3, 5, "Saving configuration...");
     const gcpEntry: AssistantEntry = {
       assistantId: instanceName,
       runtimeUrl,
@@ -624,6 +628,7 @@ export async function hatchGcp(
       console.log("   Press Ctrl+C to detach (instance will keep running)");
       console.log("");
 
+      emitProgress(4, 5, "Installing software...");
       const result = await watchHatching(
         () => pollInstance(instanceName, project, zone, account),
         instanceName,
@@ -662,6 +667,7 @@ export async function hatchGcp(
         }
       }
 
+      emitProgress(5, 5, "Finalizing...");
       try {
         await leaseGuardianToken(
           runtimeUrl,

--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -582,26 +582,48 @@ final class VellumCli {
         // Accumulate stderr so the error message includes the actual failure reason.
         let stderrAccumulator = StderrAccumulator()
 
+        // Line buffers: readabilityHandler delivers arbitrary Data chunks,
+        // not guaranteed line-delimited strings. We accumulate bytes and
+        // split on newline (0x0A) so onOutput always receives complete lines.
+        let newlineByte: UInt8 = 0x0A
+        var stdoutBuffer = Data()
+        var stderrBuffer = Data()
+        let bufferQueue = DispatchQueue(label: "com.vellum.cli.line-buffer")
+
         stdoutHandle.readabilityHandler = { handle in
             let data = handle.availableData
-            guard !data.isEmpty, let line = String(data: data, encoding: .utf8) else {
-                return
-            }
-            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                onOutput(trimmed)
+            guard !data.isEmpty else { return }
+            bufferQueue.sync {
+                stdoutBuffer.append(data)
+                while let newlineIndex = stdoutBuffer.firstIndex(of: newlineByte) {
+                    let lineData = stdoutBuffer[stdoutBuffer.startIndex..<newlineIndex]
+                    stdoutBuffer = Data(stdoutBuffer[(newlineIndex + 1)...])
+                    if let line = String(data: lineData, encoding: .utf8) {
+                        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            onOutput(trimmed)
+                        }
+                    }
+                }
             }
         }
 
         stderrHandle.readabilityHandler = { handle in
             let data = handle.availableData
-            guard !data.isEmpty, let line = String(data: data, encoding: .utf8) else {
-                return
-            }
-            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                stderrAccumulator.append(trimmed)
-                onOutput(trimmed)
+            guard !data.isEmpty else { return }
+            bufferQueue.sync {
+                stderrBuffer.append(data)
+                while let newlineIndex = stderrBuffer.firstIndex(of: newlineByte) {
+                    let lineData = stderrBuffer[stderrBuffer.startIndex..<newlineIndex]
+                    stderrBuffer = Data(stderrBuffer[(newlineIndex + 1)...])
+                    if let line = String(data: lineData, encoding: .utf8) {
+                        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            stderrAccumulator.append(trimmed)
+                            onOutput(trimmed)
+                        }
+                    }
+                }
             }
         }
 
@@ -614,6 +636,65 @@ final class VellumCli {
             proc.terminationHandler = { finished in
                 stdoutHandle.readabilityHandler = nil
                 stderrHandle.readabilityHandler = nil
+
+                // Drain any data that arrived after the last readabilityHandler
+                // callback but before we nil'd the handlers. Feed it through
+                // the line buffers so complete lines are emitted, then flush
+                // any remaining partial line.
+                let remainingStdout = stdoutHandle.availableData
+                let remainingStderr = stderrHandle.availableData
+
+                bufferQueue.sync {
+                    // Process remaining stdout through line buffer
+                    if !remainingStdout.isEmpty {
+                        stdoutBuffer.append(remainingStdout)
+                        while let newlineIndex = stdoutBuffer.firstIndex(of: newlineByte) {
+                            let lineData = stdoutBuffer[stdoutBuffer.startIndex..<newlineIndex]
+                            stdoutBuffer = Data(stdoutBuffer[(newlineIndex + 1)...])
+                            if let line = String(data: lineData, encoding: .utf8) {
+                                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                                if !trimmed.isEmpty {
+                                    onOutput(trimmed)
+                                }
+                            }
+                        }
+                    }
+
+                    // Process remaining stderr through line buffer
+                    if !remainingStderr.isEmpty {
+                        stderrBuffer.append(remainingStderr)
+                        while let newlineIndex = stderrBuffer.firstIndex(of: newlineByte) {
+                            let lineData = stderrBuffer[stderrBuffer.startIndex..<newlineIndex]
+                            stderrBuffer = Data(stderrBuffer[(newlineIndex + 1)...])
+                            if let line = String(data: lineData, encoding: .utf8) {
+                                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                                if !trimmed.isEmpty {
+                                    stderrAccumulator.append(trimmed)
+                                    onOutput(trimmed)
+                                }
+                            }
+                        }
+                    }
+
+                    // Flush any remaining partial lines in the buffers
+                    if let line = String(data: stdoutBuffer, encoding: .utf8) {
+                        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            onOutput(trimmed)
+                        }
+                    }
+                    stdoutBuffer = Data()
+
+                    if let line = String(data: stderrBuffer, encoding: .utf8) {
+                        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            stderrAccumulator.append(trimmed)
+                            onOutput(trimmed)
+                        }
+                    }
+                    stderrBuffer = Data()
+                }
+
                 continuation.resume(returning: finished.terminationStatus)
             }
             do {
@@ -680,20 +761,48 @@ final class VellumCli {
 
         let stderrAccumulator = StderrAccumulator()
 
+        // Line buffers: readabilityHandler delivers arbitrary Data chunks,
+        // not guaranteed line-delimited strings. We accumulate bytes and
+        // split on newline (0x0A) so onOutput always receives complete lines.
+        let newlineByte: UInt8 = 0x0A
+        var stdoutBuffer = Data()
+        var stderrBuffer = Data()
+        let bufferQueue = DispatchQueue(label: "com.vellum.cli.pair-line-buffer")
+
         stdoutHandle.readabilityHandler = { handle in
             let data = handle.availableData
-            guard !data.isEmpty, let line = String(data: data, encoding: .utf8) else { return }
-            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty { onOutput(trimmed) }
+            guard !data.isEmpty else { return }
+            bufferQueue.sync {
+                stdoutBuffer.append(data)
+                while let newlineIndex = stdoutBuffer.firstIndex(of: newlineByte) {
+                    let lineData = stdoutBuffer[stdoutBuffer.startIndex..<newlineIndex]
+                    stdoutBuffer = Data(stdoutBuffer[(newlineIndex + 1)...])
+                    if let line = String(data: lineData, encoding: .utf8) {
+                        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            onOutput(trimmed)
+                        }
+                    }
+                }
+            }
         }
 
         stderrHandle.readabilityHandler = { handle in
             let data = handle.availableData
-            guard !data.isEmpty, let line = String(data: data, encoding: .utf8) else { return }
-            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                stderrAccumulator.append(trimmed)
-                onOutput(trimmed)
+            guard !data.isEmpty else { return }
+            bufferQueue.sync {
+                stderrBuffer.append(data)
+                while let newlineIndex = stderrBuffer.firstIndex(of: newlineByte) {
+                    let lineData = stderrBuffer[stderrBuffer.startIndex..<newlineIndex]
+                    stderrBuffer = Data(stderrBuffer[(newlineIndex + 1)...])
+                    if let line = String(data: lineData, encoding: .utf8) {
+                        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            stderrAccumulator.append(trimmed)
+                            onOutput(trimmed)
+                        }
+                    }
+                }
             }
         }
 
@@ -703,6 +812,65 @@ final class VellumCli {
             proc.terminationHandler = { finished in
                 stdoutHandle.readabilityHandler = nil
                 stderrHandle.readabilityHandler = nil
+
+                // Drain any data that arrived after the last readabilityHandler
+                // callback but before we nil'd the handlers. Feed it through
+                // the line buffers so complete lines are emitted, then flush
+                // any remaining partial line.
+                let remainingStdout = stdoutHandle.availableData
+                let remainingStderr = stderrHandle.availableData
+
+                bufferQueue.sync {
+                    // Process remaining stdout through line buffer
+                    if !remainingStdout.isEmpty {
+                        stdoutBuffer.append(remainingStdout)
+                        while let newlineIndex = stdoutBuffer.firstIndex(of: newlineByte) {
+                            let lineData = stdoutBuffer[stdoutBuffer.startIndex..<newlineIndex]
+                            stdoutBuffer = Data(stdoutBuffer[(newlineIndex + 1)...])
+                            if let line = String(data: lineData, encoding: .utf8) {
+                                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                                if !trimmed.isEmpty {
+                                    onOutput(trimmed)
+                                }
+                            }
+                        }
+                    }
+
+                    // Process remaining stderr through line buffer
+                    if !remainingStderr.isEmpty {
+                        stderrBuffer.append(remainingStderr)
+                        while let newlineIndex = stderrBuffer.firstIndex(of: newlineByte) {
+                            let lineData = stderrBuffer[stderrBuffer.startIndex..<newlineIndex]
+                            stderrBuffer = Data(stderrBuffer[(newlineIndex + 1)...])
+                            if let line = String(data: lineData, encoding: .utf8) {
+                                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                                if !trimmed.isEmpty {
+                                    stderrAccumulator.append(trimmed)
+                                    onOutput(trimmed)
+                                }
+                            }
+                        }
+                    }
+
+                    // Flush any remaining partial lines in the buffers
+                    if let line = String(data: stdoutBuffer, encoding: .utf8) {
+                        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            onOutput(trimmed)
+                        }
+                    }
+                    stdoutBuffer = Data()
+
+                    if let line = String(data: stderrBuffer, encoding: .utf8) {
+                        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            stderrAccumulator.append(trimmed)
+                            onOutput(trimmed)
+                        }
+                    }
+                    stderrBuffer = Data()
+                }
+
                 continuation.resume(returning: finished.terminationStatus)
             }
             do {

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -195,6 +195,11 @@ struct HatchingStepView: View {
         state.hasExistingManagedAssistant = false
         state.hatchFailed = false
         state.hatchLogLines = []
+        state.hatchProgressTarget = 0.0
+        state.hatchProgressDisplay = 0.0
+        state.hatchStepLabel = nil
+        state.hatchTotalSteps = 1
+        state.hatchCurrentStep = 0
         hatchStarted = false
         failureReason = nil
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -26,6 +26,7 @@ struct HatchingStepView: View {
     }
     @State private var completionTask: Task<Void, Never>?
     @State private var progressTimer: Timer?
+    @State private var progressStartTime: CFAbsoluteTime?
 
     var body: some View {
         VStack(spacing: VSpacing.lg) {
@@ -282,7 +283,20 @@ struct HatchingStepView: View {
 
     // MARK: - Progress Timer
 
+    /// Estimated hatch duration per hosting mode, used to pace the progress bar.
+    /// The bar uses an asymptotic curve so it never stalls even if the actual
+    /// duration exceeds this estimate — it just moves more slowly.
+    private var estimatedDuration: TimeInterval {
+        switch state.cloudProvider {
+        case "local": return 10
+        case "docker": return 120
+        case "gcp", "aws": return 300
+        default: return 60
+        }
+    }
+
     private func startProgressTimer() {
+        progressStartTime = CFAbsoluteTimeGetCurrent()
         progressTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { _ in
             Task { @MainActor in
                 updateProgressDisplay()
@@ -296,9 +310,8 @@ struct HatchingStepView: View {
     }
 
     private func updateProgressDisplay() {
-        guard state.hatchStepLabel != nil else { return }
+        guard state.hatchStepLabel != nil, let startTime = progressStartTime else { return }
 
-        let target = state.hatchProgressTarget
         let current = state.hatchProgressDisplay
 
         if state.hatchCompleted {
@@ -318,17 +331,12 @@ struct HatchingStepView: View {
             return
         }
 
-        // Ceiling: don't creep past next step boundary, cap at 95%
-        let nextStepProgress = Double(state.hatchCurrentStep + 1) / Double(max(state.hatchTotalSteps, 1))
-        let ceiling = min(nextStepProgress - 0.02, 0.95)
-
-        if current < target {
-            // Lerp quickly toward target (catches up in ~200ms)
-            state.hatchProgressDisplay = current + (target - current) * 0.15
-        } else if current < ceiling {
-            // Slow creep (~1% per second at 60fps)
-            state.hatchProgressDisplay = min(current + 0.0003, ceiling)
-        }
+        // Asymptotic time-based progress: 0.95 * (1 - e^(-t/estimated))
+        // Never reaches 95% no matter how long — always appears to be moving.
+        // estimatedDuration controls the pace: at 1x estimate the bar is ~60%.
+        let elapsed = CFAbsoluteTimeGetCurrent() - startTime
+        let timeProgress = 0.95 * (1.0 - exp(-elapsed / estimatedDuration))
+        state.hatchProgressDisplay = timeProgress
     }
 
     // MARK: - Hatching / Pairing

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -25,6 +25,7 @@ struct HatchingStepView: View {
         state.hatchAvatarColor ?? .allCases[0]
     }
     @State private var completionTask: Task<Void, Never>?
+    @State private var progressTimer: Timer?
 
     var body: some View {
         VStack(spacing: VSpacing.lg) {
@@ -34,6 +35,10 @@ struct HatchingStepView: View {
                 .padding(.bottom, VSpacing.xl)
 
             statusText
+
+            if showProgressBar {
+                progressSection
+            }
 
             if state.hatchFailed {
                 failureButtons
@@ -67,6 +72,12 @@ struct HatchingStepView: View {
         }
         .onDisappear {
             completionTask?.cancel()
+            stopProgressTimer()
+        }
+        .onChange(of: state.hatchStepLabel) { oldLabel, newLabel in
+            if oldLabel == nil, newLabel != nil {
+                startProgressTimer()
+            }
         }
         .onChange(of: state.hatchCompleted) { _, completed in
             if completed {
@@ -163,6 +174,26 @@ struct HatchingStepView: View {
         .frame(maxWidth: 320)
     }
 
+    // MARK: - Progress Bar
+
+    private var showProgressBar: Bool {
+        !state.hatchFailed && !state.hatchCompleted && !isCustomHardware && state.hatchStepLabel != nil
+    }
+
+    private var progressSection: some View {
+        VStack(spacing: VSpacing.xs) {
+            ProgressView(value: state.hatchProgressDisplay)
+                .progressViewStyle(.linear)
+                .frame(maxWidth: 240)
+            if let label = state.hatchStepLabel {
+                Text(label)
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+        }
+        .transition(.opacity.animation(.easeOut(duration: 0.3)))
+    }
+
     // MARK: - Failure Buttons
 
     private var failureButtons: some View {
@@ -236,9 +267,60 @@ struct HatchingStepView: View {
         // Brief delay so the user sees the waking animation before transition.
         // Stored as a cancellable Task so it's cleaned up if the view disappears.
         completionTask = Task {
-            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            try? await Task.sleep(nanoseconds: 500_000_000)
             guard !Task.isCancelled else { return }
             state.hatchCompleted = true
+        }
+    }
+
+    // MARK: - Progress Timer
+
+    private func startProgressTimer() {
+        progressTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { _ in
+            Task { @MainActor in
+                updateProgressDisplay()
+            }
+        }
+    }
+
+    private func stopProgressTimer() {
+        progressTimer?.invalidate()
+        progressTimer = nil
+    }
+
+    private func updateProgressDisplay() {
+        guard state.hatchStepLabel != nil else { return }
+
+        let target = state.hatchProgressTarget
+        let current = state.hatchProgressDisplay
+
+        if state.hatchCompleted {
+            // Animate to 100%
+            let diff = 1.0 - current
+            if diff > 0.001 {
+                state.hatchProgressDisplay = current + diff * 0.15
+            } else {
+                state.hatchProgressDisplay = 1.0
+                stopProgressTimer()
+            }
+            return
+        }
+
+        if state.hatchFailed {
+            stopProgressTimer()
+            return
+        }
+
+        // Ceiling: don't creep past next step boundary, cap at 95%
+        let nextStepProgress = Double(state.hatchCurrentStep + 1) / Double(max(state.hatchTotalSteps, 1))
+        let ceiling = min(nextStepProgress - 0.02, 0.95)
+
+        if current < target {
+            // Lerp quickly toward target (catches up in ~200ms)
+            state.hatchProgressDisplay = current + (target - current) * 0.15
+        } else if current < ceiling {
+            // Slow creep (~1% per second at 60fps)
+            state.hatchProgressDisplay = min(current + 0.0003, ceiling)
         }
     }
 
@@ -298,6 +380,26 @@ struct HatchingStepView: View {
                 try await cliLauncher.runRemoteHatch(config: config) { line in
                     Task { @MainActor in
                         log.info("CLI hatch output: \(line, privacy: .public)")
+
+                        // Parse progress sentinel
+                        if line.hasPrefix("HATCH_PROGRESS:") {
+                            // Ignore late events after success
+                            guard !state.hatchCompleted && completionTask == nil else { return }
+                            let json = String(line.dropFirst("HATCH_PROGRESS:".count))
+                            if let data = json.data(using: .utf8),
+                               let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                               let step = parsed["step"] as? Int,
+                               let total = parsed["total"] as? Int,
+                               let label = parsed["label"] as? String,
+                               total > 0, step >= 0, step <= total {
+                                state.hatchCurrentStep = step
+                                state.hatchTotalSteps = total
+                                state.hatchStepLabel = label
+                                state.hatchProgressTarget = min(Double(step) / Double(total), 0.95)
+                            }
+                            return  // Don't append sentinel lines to hatchLogLines
+                        }
+
                         state.hatchLogLines.append(line)
 
                         // Detect the readiness sentinel from CLI output so we

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -69,6 +69,13 @@ struct HatchingStepView: View {
                 hatchStarted = true
                 startHatching()
             }
+
+            // In the managed path, hatchStepLabel is set before HatchingStepView
+            // appears, so .onChange(of: hatchStepLabel) never fires. Start the
+            // progress timer eagerly when the label is already present.
+            if state.hatchStepLabel != nil {
+                startProgressTimer()
+            }
         }
         .onDisappear {
             completionTask?.cancel()

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -391,7 +391,7 @@ struct HatchingStepView: View {
                         // Parse progress sentinel
                         if line.hasPrefix("HATCH_PROGRESS:") {
                             // Ignore late events after success
-                            guard !state.hatchCompleted && completionTask == nil else { return }
+                            guard !state.hatchCompleted else { return }
                             let json = String(line.dropFirst("HATCH_PROGRESS:".count))
                             if let data = json.data(using: .utf8),
                                let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -17,6 +17,8 @@ struct OnboardingFlowView: View {
     @State private var isBootstrappingManaged = false
     @State private var isResolvingAssociatedManagedAssistant = false
     @State private var managedBootstrapError: String?
+    @State private var didCallComplete = false
+    @State private var completionDelayTask: Task<Void, Never>?
 
     private static let appIcon: NSImage? = {
         guard let path = ResourceBundle.bundle.path(forResource: "vellum-app-icon", ofType: "png") else { return nil }
@@ -196,6 +198,8 @@ struct OnboardingFlowView: View {
             )
             if !isAuthenticated && managedSignInEnabled && state.currentStep > 0 {
                 log.info("User signed out during managed onboarding — returning to welcome screen")
+                completionDelayTask?.cancel()
+                didCallComplete = false
                 isBootstrappingManaged = false
                 managedBootstrapError = nil
                 withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
@@ -236,8 +240,18 @@ struct OnboardingFlowView: View {
         }
         .onChange(of: state.hatchCompleted) { _, completed in
             if completed {
-                onComplete()
+                guard !didCallComplete else { return }
+                didCallComplete = true
+                completionDelayTask = Task {
+                    try? await Task.sleep(nanoseconds: 1_000_000_000)
+                    guard !Task.isCancelled else { return }
+                    guard state.hatchCompleted else { return }
+                    onComplete()
+                }
             }
+        }
+        .onDisappear {
+            completionDelayTask?.cancel()
         }
     }
 
@@ -352,6 +366,12 @@ struct OnboardingFlowView: View {
     /// (`assistants/{assistantId}/health`) until the runtime responds successfully.
     private func awaitManagedAssistantReady(assistantId: String) async {
         // Phase 1: Wait for the platform to finish provisioning.
+        guard !state.hatchCompleted else { return }
+        state.hatchTotalSteps = 3
+        state.hatchCurrentStep = 1
+        state.hatchStepLabel = "Provisioning assistant..."
+        state.hatchProgressTarget = 0.33
+
         do {
             try await ManagedAssistantBootstrapService.shared.awaitAssistantProvisioned(assistantId: assistantId)
         } catch {
@@ -361,6 +381,11 @@ struct OnboardingFlowView: View {
         }
 
         // Phase 2: Poll the assistant-scoped gateway health endpoint.
+        guard !state.hatchCompleted else { return }
+        state.hatchCurrentStep = 2
+        state.hatchStepLabel = "Connecting to assistant..."
+        state.hatchProgressTarget = 0.66
+
         let timeout: TimeInterval = 120
         let start = CFAbsoluteTimeGetCurrent()
         var lastError: Error?
@@ -374,6 +399,9 @@ struct OnboardingFlowView: View {
                 ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
                 if response.isSuccess {
                     log.info("Managed assistant \(assistantId, privacy: .public) is ready")
+                    state.hatchCurrentStep = 3
+                    state.hatchStepLabel = "Ready"
+                    state.hatchProgressTarget = 1.0
                     state.hatchCompleted = true
                     return
                 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -200,6 +200,10 @@ struct OnboardingFlowView: View {
                 log.info("User signed out during managed onboarding — returning to welcome screen")
                 completionDelayTask?.cancel()
                 didCallComplete = false
+                state.isHatching = false
+                state.isManagedHatch = false
+                state.hatchCompleted = false
+                state.hatchFailed = false
                 isBootstrappingManaged = false
                 managedBootstrapError = nil
                 withAnimation(.spring(duration: 0.6, bounce: 0.15)) {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -204,6 +204,11 @@ struct OnboardingFlowView: View {
                 state.isManagedHatch = false
                 state.hatchCompleted = false
                 state.hatchFailed = false
+                state.hatchProgressTarget = 0.0
+                state.hatchProgressDisplay = 0.0
+                state.hatchStepLabel = nil
+                state.hatchTotalSteps = 1
+                state.hatchCurrentStep = 0
                 isBootstrappingManaged = false
                 managedBootstrapError = nil
                 withAnimation(.spring(duration: 0.6, bounce: 0.15)) {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -95,6 +95,13 @@ final class OnboardingState {
     var hatchCompleted: Bool = false
     var hatchFailed: Bool = false
 
+    /// Progress bar state for the hatching flow.
+    var hatchProgressTarget: Double = 0.0    // 0..1, set by progress events
+    var hatchProgressDisplay: Double = 0.0   // 0..1, what the bar renders
+    var hatchStepLabel: String?              // nil = don't show bar yet
+    var hatchTotalSteps: Int = 1
+    var hatchCurrentStep: Int = 0
+
     /// Avatar traits generated during the hatching animation. Stored here
     /// (rather than as @State in HatchingStepView) so they survive view
     /// disappearance and are available to the post-hatch sync logic.
@@ -178,6 +185,11 @@ final class OnboardingState {
         hatchAvatarBodyShape = nil
         hatchAvatarEyeStyle = nil
         hatchAvatarColor = nil
+        hatchProgressTarget = 0.0
+        hatchProgressDisplay = 0.0
+        hatchStepLabel = nil
+        hatchTotalSteps = 1
+        hatchCurrentStep = 0
         hasHatched = false
         skippedAuth = false
         skippedAPIKeyEntry = false


### PR DESCRIPTION
## Summary
Adds a smooth, continuous progress bar to the hatching/setup flow so users see real-time progress during assistant setup across all hosting modes. The CLI emits structured `HATCH_PROGRESS:` sentinel events, the desktop app parses them via line-buffered I/O, and a creep interpolation timer ensures the bar never looks frozen between steps.

## Changes
- **CLI progress helper** (`cli/src/lib/desktop-progress.ts`): New leaf module with `emitProgress()`, emits `HATCH_PROGRESS:{"step":N,"total":M,"label":"..."}` on stdout in desktop mode only
- **Hatch step events**: 23 progress events across `hatchLocal` (7), `hatchDocker` (6), `hatchGcp` (5), `hatchAws` (5)
- **Line-buffered I/O** (`VellumCli.swift`): `runRemoteHatch()` and `runPair()` deliver complete lines, preventing split/merged sentinel lines
- **Progress model** (`OnboardingState.swift`): 5 flat properties for progress tracking, reset in `resetForRetry()` and `goBack()`
- **Progress bar UI** (`HatchingStepView.swift`): `ProgressView` + step label below status text, 60fps creep timer with lerp, 95% ceiling, lazy timer start
- **Managed path progress** (`OnboardingFlowView.swift`): 3 progress updates at provisioning/connecting/ready phases
- **Centralized completion delay**: 1.0s post-hatchCompleted delay with auth-state guard and one-shot protection

## Milestone PRs (merged into feature branch)
- #21201: M1 — CLI progress helper and hatch step events
- #21202: M2 — Line-buffered stdout/stderr in VellumCli.swift
- #21208: M3 — Progress model on OnboardingState with resets
- #21212: M4 — Progress bar UI, smooth interpolation, and HATCH_PROGRESS parsing
- #21217: M5 — Managed path progress and centralized completion delay

## Project issue
Closes #21195

## Test plan
- [ ] Local hatch: progress bar appears, advances through 7 steps, animates to 100% on success
- [ ] Docker hatch: 6 steps with correct labels (Building vs Pulling depending on watch mode)
- [ ] Managed hatch: 3 steps (Provisioning, Connecting, Ready)
- [ ] Custom hardware pairing: NO progress bar appears
- [ ] Retry / Go Back: progress resets
- [ ] Old CLI binary: bar never appears, existing UX unchanged
- [ ] Auth sign-out during delay: onComplete cancelled
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
