### PR TITLE
fix: remove opacity transition from daemon loading overlay

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -399,7 +399,6 @@ struct MainWindowView: View {
                 onRetry: { rewakeAssistant() },
                 onSendLogs: { AppDelegate.shared?.showLogReportWindow(reason: .appCrash) }
             )
-            .transition(.opacity)
         }
     }
 


### PR DESCRIPTION
## Summary
- Remove `.transition(.opacity)` from `assistantLoadingOverlayIfNeeded` to prevent conversation messages bleeding through the semi-transparent overlay during the 0.25s fade-out animation on app restart/reconnection.
- The overlay now disappears instantly when `showDaemonLoading` becomes false. The chat-level skeleton in ChatView already provides smooth visual transitions.

## Test plan
- [ ] Launch the app and trigger a daemon restart (e.g., kill the daemon process)
- [ ] Verify the loading overlay appears immediately
- [ ] Verify the overlay disappears instantly without a fade-out that reveals messages underneath
- [ ] Confirm the chat skeleton transition still looks smooth

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
