### PR TITLE
fix: replace 'owner' with 'guardian' in skill catalog copy (JARVIS-275)

### DIFF
--- a/assistant/src/config/bundled-skills/skills-catalog/SKILL.md
+++ b/assistant/src/config/bundled-skills/skills-catalog/SKILL.md
@@ -43,10 +43,10 @@ Returns matching skills with their slug, source, install counts, and security au
 
 ### Installing a community skill
 
-**Trust model - check the source owner before installing:**
+**Trust model - check the source guardian before installing:**
 
 - **Vellum-owned** (`vellum-ai/*`): First-party skills published by the Vellum team. Install these directly without prompting - they are vetted and trusted.
-- **Third-party** (any other owner): Ask the user for permission first. Present the skill name, source, audit results, and install count. Say something like: "I found a community skill that could help, but it's published by a third party - we haven't vetted it. Want to install it anyway?"
+- **Third-party** (any other guardian): Ask the user for permission first. Present the skill name, source, audit results, and install count. Say something like: "I found a community skill that could help, but it's published by a third party - we haven't vetted it. Want to install it anyway?"
 
 ```bash
 assistant skills add <owner>/<repo>@<skill-name>
@@ -69,7 +69,7 @@ Once installed, the skill appears in the workspace skills directory and can be l
 2. **User wants a capability not covered by bundled skills** - "Can you do X?"
    - Search with `assistant skills search "<query>"`
    - Present matching results with descriptions, install counts, and audit badges
-   - Check the source owner to determine trust level (see trust model above)
+   - Check the source guardian to determine trust level (see trust model above)
    - Install with `assistant skills add <owner>/<repo>@<skill-name>`
    - Load it with `skill_load`
 


### PR DESCRIPTION
## Summary
- Replace "source owner" → "source guardian" in the skills-catalog trust model copy (3 instances)
- CLI syntax `<owner>/<repo>` unchanged — that refers to the GitHub repo owner, not the skill trust concept

## Test plan
- [ ] Verify skill catalog instructions use "guardian" terminology

Closes JARVIS-275

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
