### PR TITLE
fix: remove opacity fade on daemon loading overlay to prevent message bleed-through

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -399,7 +399,6 @@ struct MainWindowView: View {
                 onRetry: { rewakeAssistant() },
                 onSendLogs: { AppDelegate.shared?.showLogReportWindow(reason: .appCrash) }
             )
-            .transition(.opacity)
         }
     }
 


### PR DESCRIPTION
## Summary
When the macOS app reconnects after quit/restart, the daemon loading overlay fades out with a 0.25s opacity transition. During this fade, real conversation messages become partially visible underneath the semi-transparent overlay. This PR removes the fade so the overlay disappears instantly, relying on the chat-level skeleton for smooth visual transitions.

## Changes
- Removed `.transition(.opacity)` from `assistantLoadingOverlayIfNeeded` in MainWindowView.swift

## Milestone PRs (merged into feature branch)
- #21223: fix: remove opacity transition from daemon loading overlay

## Project issue
Closes #21221

## Test plan
- [ ] Quit the app via Cmd+Q, wait 1-2 seconds, relaunch via Spotlight
- [ ] Verify no conversation message content is visible behind the loading skeleton
- [ ] Trigger a crash via Developer Settings, relaunch and verify clean transition
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
