### PR TITLE
fix: remove trailing commas that break Swift compilation in settings cards

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/EmbeddingServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/EmbeddingServiceCard.swift
@@ -165,8 +165,8 @@ struct EmbeddingServiceCard: View {
                         draftProvider = newValue
                     }
                 ),
-                options: providerOptions,
-                )
+                options: providerOptions
+            )
         }
     }
 
@@ -185,7 +185,7 @@ struct EmbeddingServiceCard: View {
             placeholder: placeholder,
             text: $apiKeyText,
             isSecure: true,
-            errorMessage: store.embeddingKeySaveError,
+            errorMessage: store.embeddingKeySaveError
         )
         .id("embedding-api-key-\(draftProvider)-\(placeholder)")
     }
@@ -196,7 +196,7 @@ struct EmbeddingServiceCard: View {
         VTextField(
             "Model",
             placeholder: defaultModelForProvider.isEmpty ? "Enter model name" : defaultModelForProvider,
-            text: $draftModel,
+            text: $draftModel
         )
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -312,7 +312,7 @@ struct InferenceServiceCard: View {
                 selection: $draftProvider,
                 options: store.dynamicProviderIds.map { provider in
                     (label: store.dynamicProviderDisplayName(provider), value: provider)
-                },
+                }
             )
         }
     }
@@ -334,7 +334,7 @@ struct InferenceServiceCard: View {
             placeholder: placeholder,
             text: $apiKeyText,
             isSecure: true,
-            errorMessage: store.apiKeySaveError,
+            errorMessage: store.apiKeySaveError
         )
         .disabled(store.apiKeySaving)
     }

--- a/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
@@ -195,7 +195,7 @@ struct WebSearchServiceCard: View {
                 selection: $draftProvider,
                 options: availableProviders.map { provider in
                     (label: SettingsStore.webSearchProviderDisplayNames[provider] ?? provider, value: provider)
-                },
+                }
             )
         }
     }


### PR DESCRIPTION
## Summary
- Remove 6 trailing commas before closing parentheses in `EmbeddingServiceCard.swift`, `InferenceServiceCard.swift`, and `WebSearchServiceCard.swift`
- Swift does not allow trailing commas in function/initializer argument lists, causing compilation failures
- Also fixes misaligned closing parenthesis indentation in `EmbeddingServiceCard.swift`

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
