### PR TITLE
feat: poll platform feature flags endpoint from gateway

### DIFF
--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -1,0 +1,218 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+
+import type { RemoteFeatureFlagSyncConfig } from "../remote-feature-flag-sync.js";
+
+// ---------------------------------------------------------------------------
+// Isolated temp directory (mirrors feature-flags-route.test.ts pattern)
+// ---------------------------------------------------------------------------
+const testDir = join(
+  tmpdir(),
+  `vellum-remote-ff-sync-test-${randomBytes(6).toString("hex")}`,
+);
+const vellumRoot = join(testDir, ".vellum");
+const protectedDir = join(vellumRoot, "protected");
+
+const savedBaseDataDir = process.env.BASE_DATA_DIR;
+
+// ---------------------------------------------------------------------------
+// Mock fetchImpl
+// ---------------------------------------------------------------------------
+type FetchFn = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(
+  async () => new Response(),
+);
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Dynamic imports (after mock.module)
+// ---------------------------------------------------------------------------
+const { RemoteFeatureFlagSync } =
+  await import("../remote-feature-flag-sync.js");
+const { readRemoteFeatureFlags, clearRemoteFeatureFlagStoreCache } =
+  await import("../feature-flag-remote-store.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeConfig(
+  overrides: Partial<RemoteFeatureFlagSyncConfig> = {},
+): RemoteFeatureFlagSyncConfig {
+  return {
+    platformUrl: "https://assistant.vellum.ai",
+    assistantId: "asst-123",
+    platformApiKey: "test-api-key",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  process.env.BASE_DATA_DIR = testDir;
+  mkdirSync(protectedDir, { recursive: true });
+  clearRemoteFeatureFlagStoreCache();
+  fetchMock = mock(async () => new Response());
+});
+
+afterEach(() => {
+  if (savedBaseDataDir === undefined) {
+    delete process.env.BASE_DATA_DIR;
+  } else {
+    process.env.BASE_DATA_DIR = savedBaseDataDir;
+  }
+  try {
+    rmSync(testDir, { recursive: true, force: true });
+  } catch {
+    // best effort cleanup
+  }
+  clearRemoteFeatureFlagStoreCache();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("RemoteFeatureFlagSync", () => {
+  test("skips sync when platformUrl is empty", async () => {
+    const sync = new RemoteFeatureFlagSync(makeConfig({ platformUrl: "" }));
+    await sync.start();
+    sync.stop();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("skips sync when platformApiKey is empty", async () => {
+    const sync = new RemoteFeatureFlagSync(makeConfig({ platformApiKey: "" }));
+    await sync.start();
+    sync.stop();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("fetches and caches flags on successful response", async () => {
+    fetchMock = mock(async () =>
+      Response.json({
+        flags: { "feature_flags.browser.enabled": true },
+      }),
+    );
+
+    const sync = new RemoteFeatureFlagSync(makeConfig());
+    await sync.start();
+    sync.stop();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    clearRemoteFeatureFlagStoreCache();
+    const cached = readRemoteFeatureFlags();
+    expect(cached).toEqual({ "feature_flags.browser.enabled": true });
+  });
+
+  test("returns empty on non-OK response", async () => {
+    fetchMock = mock(
+      async () => new Response("Internal Server Error", { status: 500 }),
+    );
+
+    const sync = new RemoteFeatureFlagSync(makeConfig());
+    await sync.start();
+    sync.stop();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    clearRemoteFeatureFlagStoreCache();
+    const cached = readRemoteFeatureFlags();
+    expect(cached).toEqual({});
+  });
+
+  test("returns empty on network error", async () => {
+    fetchMock = mock(async () => {
+      throw new Error("Network failure");
+    });
+
+    const sync = new RemoteFeatureFlagSync(makeConfig());
+    // Should not throw — errors are caught and logged
+    await sync.start();
+    sync.stop();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("sends correct auth header", async () => {
+    fetchMock = mock(async () => Response.json({ flags: {} }));
+
+    const apiKey = "my-secret-key-42";
+    const sync = new RemoteFeatureFlagSync(
+      makeConfig({ platformApiKey: apiKey }),
+    );
+    await sync.start();
+    sync.stop();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe(`Api-Key ${apiKey}`);
+  });
+
+  test("constructs correct URL with assistant ID", async () => {
+    fetchMock = mock(async () => Response.json({ flags: {} }));
+
+    const cfg = makeConfig({
+      platformUrl: "https://platform.example.com",
+      assistantId: "asst-abc-999",
+    });
+    const sync = new RemoteFeatureFlagSync(cfg);
+    await sync.start();
+    sync.stop();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      "https://platform.example.com/v1/assistants/asst-abc-999/feature-flags/",
+    );
+  });
+
+  test("filters non-boolean values from response", async () => {
+    fetchMock = mock(async () =>
+      Response.json({
+        flags: {
+          "feature_flags.browser.enabled": true,
+          "feature_flags.contacts.enabled": "yes" as unknown,
+          "feature_flags.other.enabled": 1 as unknown,
+          "feature_flags.valid.enabled": false,
+        },
+      }),
+    );
+
+    const sync = new RemoteFeatureFlagSync(makeConfig());
+    await sync.start();
+    sync.stop();
+
+    clearRemoteFeatureFlagStoreCache();
+    const cached = readRemoteFeatureFlags();
+    expect(cached).toEqual({
+      "feature_flags.browser.enabled": true,
+      "feature_flags.valid.enabled": false,
+    });
+  });
+
+  test("returns empty when response is missing flags field", async () => {
+    fetchMock = mock(async () => Response.json({ data: "unexpected" }));
+
+    const sync = new RemoteFeatureFlagSync(makeConfig());
+    await sync.start();
+    sync.stop();
+
+    clearRemoteFeatureFlagStoreCache();
+    const cached = readRemoteFeatureFlags();
+    expect(cached).toEqual({});
+  });
+});

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1277,7 +1277,11 @@ async function main() {
   const featureFlagWatcher = new FeatureFlagWatcher();
   featureFlagWatcher.start();
 
-  const remoteFeatureFlagSync = new RemoteFeatureFlagSync();
+  const remoteFeatureFlagSync = new RemoteFeatureFlagSync({
+    platformUrl: process.env.VELLUM_PLATFORM_URL?.trim() ?? "",
+    assistantId: config.defaultAssistantId ?? "",
+    platformApiKey: process.env.VELLUM_PLATFORM_API_KEY?.trim() ?? "",
+  });
   // Intentionally fire-and-forget: remote flag fetch is best-effort;
   // the gateway continues with registry defaults if it fails.
   void remoteFeatureFlagSync.start();

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -1,4 +1,4 @@
-import { loadFeatureFlagDefaults } from "./feature-flag-defaults.js";
+import { fetchImpl } from "./fetch.js";
 import { writeRemoteFeatureFlags } from "./feature-flag-remote-store.js";
 import { getLogger } from "./logger.js";
 
@@ -21,6 +21,15 @@ function getPollIntervalMs(): number {
   return DEFAULT_POLL_INTERVAL_MS;
 }
 
+export type RemoteFeatureFlagSyncConfig = {
+  /** Base URL of the Vellum platform API (e.g. "https://assistant.vellum.ai"). Empty string disables remote sync. */
+  platformUrl: string;
+  /** Assistant ID to scope the feature flags request. */
+  assistantId: string;
+  /** Platform API key for authentication (Api-Key header). */
+  platformApiKey: string;
+};
+
 /**
  * Manages the lifecycle of syncing remote feature flags from the platform.
  *
@@ -32,8 +41,20 @@ function getPollIntervalMs(): number {
 export class RemoteFeatureFlagSync {
   private started = false;
   private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private readonly config: RemoteFeatureFlagSyncConfig;
+
+  constructor(config: RemoteFeatureFlagSyncConfig) {
+    this.config = config;
+  }
 
   async start(): Promise<void> {
+    if (!this.config.platformUrl || !this.config.platformApiKey) {
+      log.warn(
+        "Remote feature flag sync disabled: missing platform URL or API key",
+      );
+      return;
+    }
+
     this.started = true;
 
     try {
@@ -42,10 +63,6 @@ export class RemoteFeatureFlagSync {
       log.warn({ err }, "Failed to sync remote feature flags on startup");
     }
 
-    // TODO: Replace stub fetch with real platform API call to
-    // GET ${VELLUM_PLATFORM_URL}/v1/feature-flags (or similar).
-    // The poll interval ensures the gateway picks up flag changes
-    // without requiring a restart.
     const intervalMs = getPollIntervalMs();
     this.pollTimer = setInterval(() => {
       this.fetchAndCache().catch((err) => {
@@ -73,18 +90,45 @@ export class RemoteFeatureFlagSync {
     );
   }
 
-  /**
-   * Stub: returns the same values the registry provides so the net effect on
-   * resolution is zero until the real platform API replaces this.
-   */
   private async fetchRemoteFeatureFlags(): Promise<Record<string, boolean>> {
-    log.debug("Fetching remote feature flags (stub)");
+    const { platformUrl, assistantId, platformApiKey } = this.config;
 
-    const defaults = loadFeatureFlagDefaults();
-    const result: Record<string, boolean> = {};
-    for (const [key, entry] of Object.entries(defaults)) {
-      result[key] = entry.defaultEnabled;
+    const url = `${platformUrl}/v1/assistants/${assistantId}/feature-flags/`;
+    log.debug({ url }, "Fetching remote feature flags from platform");
+
+    const response = await fetchImpl(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Api-Key ${platformApiKey}`,
+        Accept: "application/json",
+      },
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!response.ok) {
+      log.warn(
+        { status: response.status, url },
+        "Platform feature flags request failed",
+      );
+      return {};
     }
+
+    const body = (await response.json()) as {
+      flags?: Record<string, boolean>;
+    };
+    if (!body.flags || typeof body.flags !== "object") {
+      log.warn("Platform feature flags response missing 'flags' field");
+      return {};
+    }
+
+    // Filter to boolean values only (defensive)
+    const result: Record<string, boolean> = {};
+    for (const [key, value] of Object.entries(body.flags)) {
+      if (typeof value === "boolean") {
+        result[key] = value;
+      }
+    }
+
     return result;
   }
 }


### PR DESCRIPTION
## Summary
- Accept platform config (URL, assistant ID, API key) in RemoteFeatureFlagSync constructor
- Replace stub fetchRemoteFeatureFlags() with real HTTP call to GET /v1/assistants/{assistantId}/feature-flags/
- Add tests covering config validation, successful fetch, error handling, auth header, and URL construction

Part of plan: gateway-remote-ff-poll.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
