### PR TITLE
feat: restore secret ingress checker with curated high-confidence patterns

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -135,6 +135,7 @@ describe("AssistantConfigSchema", () => {
     expect(result.secretDetection).toEqual({
       enabled: true,
       action: "redact",
+      blockIngress: true,
       entropyThreshold: 4.0,
       allowOneTimeSend: false,
     });
@@ -157,6 +158,7 @@ describe("AssistantConfigSchema", () => {
       secretDetection: {
         enabled: false,
         action: "block" as const,
+        blockIngress: false,
         entropyThreshold: 5.5,
       },
       auditLog: { retentionDays: 30 },
@@ -436,7 +438,10 @@ describe("AssistantConfigSchema", () => {
 
   test("defaults permissions.mode to workspace", () => {
     const result = AssistantConfigSchema.parse({});
-    expect(result.permissions).toEqual({ mode: "workspace", dangerouslySkipPermissions: false });
+    expect(result.permissions).toEqual({
+      mode: "workspace",
+      dangerouslySkipPermissions: false,
+    });
   });
 
   test("accepts explicit permissions.mode strict", () => {
@@ -1141,7 +1146,10 @@ describe("loadConfig with schema validation", () => {
   test("defaults permissions.mode to workspace when not specified", () => {
     writeConfig({});
     const config = loadConfig();
-    expect(config.permissions).toEqual({ mode: "workspace", dangerouslySkipPermissions: false });
+    expect(config.permissions).toEqual({
+      mode: "workspace",
+      dangerouslySkipPermissions: false,
+    });
   });
 
   test("loads explicit permissions.mode strict", () => {

--- a/assistant/src/__tests__/secret-ingress.test.ts
+++ b/assistant/src/__tests__/secret-ingress.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before any imports that depend on them
+// ---------------------------------------------------------------------------
+
+let mockConfig = {
+  secretDetection: {
+    enabled: true,
+    blockIngress: true,
+  },
+};
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+  invalidateConfigCache: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    silent: () => {},
+    child: function () {
+      return this;
+    },
+  }),
+}));
+
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => "/tmp/vellum-test-ingress",
+  getWorkspaceDir: () => "/tmp/vellum-test-ingress/workspace",
+}));
+
+import { checkIngressForSecrets } from "../security/secret-ingress.js";
+import { resetAllowlist } from "../security/secret-allowlist.js";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("checkIngressForSecrets", () => {
+  beforeEach(() => {
+    mockConfig = {
+      secretDetection: {
+        enabled: true,
+        blockIngress: true,
+      },
+    };
+    resetAllowlist();
+  });
+
+  afterEach(() => {
+    resetAllowlist();
+  });
+
+  // ── Blocked patterns ───────────────────────────────────────────────
+
+  test("blocks Google OAuth secret (GOCSPX-*)", () => {
+    const result = checkIngressForSecrets(
+      "My client secret is GOCSPX-abcdefghijklmnopqrstuvwxyz12",
+    );
+    expect(result.blocked).toBe(true);
+    expect(result.detectedTypes).toContain("Google OAuth Secret");
+    expect(result.userNotice).toBeDefined();
+  });
+
+  test("blocks GitHub PAT (ghp_*)", () => {
+    const result = checkIngressForSecrets(
+      "Here is my token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
+    );
+    expect(result.blocked).toBe(true);
+    expect(result.detectedTypes).toContain("GitHub Token");
+  });
+
+  test("blocks Slack bot token (xoxb-*)", () => {
+    const result = checkIngressForSecrets(
+      "Use this: xoxb-1234567890-9876543210-AbCdEfGhIjKlMnOpQrStUvWx",
+    );
+    expect(result.blocked).toBe(true);
+    expect(result.detectedTypes).toContain("Slack Bot Token");
+  });
+
+  test("blocks Anthropic API key (sk-ant-*)", () => {
+    const key =
+      "sk-ant-api03-abcDefGhiJklMnoPqrStuVwxYz0123456789AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfGhIj";
+    const result = checkIngressForSecrets(`Key: ${key}`);
+    expect(result.blocked).toBe(true);
+    expect(result.detectedTypes).toContain("Anthropic API Key");
+  });
+
+  test("blocks private key header", () => {
+    const result = checkIngressForSecrets(
+      "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAK...",
+    );
+    expect(result.blocked).toBe(true);
+    expect(result.detectedTypes).toContain("Private Key");
+  });
+
+  test("blocks AWS access key (AKIA*)", () => {
+    const result = checkIngressForSecrets("AWS key: AKIAIOSFODNN7EXAMPLE");
+    expect(result.blocked).toBe(true);
+    expect(result.detectedTypes).toContain("AWS Access Key");
+  });
+
+  test("blocks Stripe secret key (sk_live_*)", () => {
+    const result = checkIngressForSecrets("sk_live_abcdefghijklmnopqrstuvwx");
+    expect(result.blocked).toBe(true);
+    expect(result.detectedTypes).toContain("Stripe Secret Key");
+  });
+
+  test("blocks SendGrid API key", () => {
+    const result = checkIngressForSecrets(
+      "SG.abcdefghijklmnopqrstuv.ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrst",
+    );
+    expect(result.blocked).toBe(true);
+    expect(result.detectedTypes).toContain("SendGrid API Key");
+  });
+
+  test("blocks npm token", () => {
+    const result = checkIngressForSecrets(
+      "npm_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
+    );
+    expect(result.blocked).toBe(true);
+    expect(result.detectedTypes).toContain("npm Token");
+  });
+
+  test("blocks OpenAI project key (sk-proj-*)", () => {
+    const key = "sk-proj-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCd";
+    const result = checkIngressForSecrets(`My key: ${key}`);
+    expect(result.blocked).toBe(true);
+    expect(result.detectedTypes).toContain("OpenAI API Key");
+  });
+
+  test("blocks Google API key (AIza*)", () => {
+    const result = checkIngressForSecrets(
+      "AIzaSyA0123456789abcdefghijklmnopqrstuvw",
+    );
+    expect(result.blocked).toBe(true);
+    expect(result.detectedTypes).toContain("Google API Key");
+  });
+
+  test("blocks GitLab PAT (glpat-*)", () => {
+    const result = checkIngressForSecrets("glpat-abcdefghijklmnopqrst");
+    expect(result.blocked).toBe(true);
+    expect(result.detectedTypes).toContain("GitLab PAT");
+  });
+
+  // ── Not blocked (excluded patterns) ────────────────────────────────
+
+  test("does not block normal text", () => {
+    const result = checkIngressForSecrets(
+      "Hello, can you help me set up my project?",
+    );
+    expect(result.blocked).toBe(false);
+    expect(result.detectedTypes).toHaveLength(0);
+  });
+
+  test("does not block high-entropy hex (40-char git SHA)", () => {
+    const result = checkIngressForSecrets(
+      "Commit: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+    );
+    expect(result.blocked).toBe(false);
+  });
+
+  test("does not block UUID", () => {
+    const result = checkIngressForSecrets(
+      "ID: 550e8400-e29b-41d4-a716-446655440000",
+    );
+    expect(result.blocked).toBe(false);
+  });
+
+  test("does not block JWT (eyJ...)", () => {
+    const result = checkIngressForSecrets(
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U",
+    );
+    expect(result.blocked).toBe(false);
+  });
+
+  test("does not block password=mysecretvalue (generic assignment)", () => {
+    const result = checkIngressForSecrets(
+      'password=mysecretvalue\nsecret="hello world"',
+    );
+    expect(result.blocked).toBe(false);
+  });
+
+  test("does not block postgres connection string", () => {
+    const result = checkIngressForSecrets(
+      "postgres://user:pass@host:5432/mydb",
+    );
+    expect(result.blocked).toBe(false);
+  });
+
+  // ── Config flags ───────────────────────────────────────────────────
+
+  test("does not block when secretDetection.enabled is false", () => {
+    mockConfig = {
+      secretDetection: {
+        enabled: false,
+        blockIngress: true,
+      },
+    };
+    const result = checkIngressForSecrets(
+      "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
+    );
+    expect(result.blocked).toBe(false);
+  });
+
+  test("does not block when blockIngress is false", () => {
+    mockConfig = {
+      secretDetection: {
+        enabled: true,
+        blockIngress: false,
+      },
+    };
+    const result = checkIngressForSecrets(
+      "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
+    );
+    expect(result.blocked).toBe(false);
+  });
+
+  // ── Placeholder / test values ──────────────────────────────────────
+
+  test("does not block placeholder test keys (sk-test-*)", () => {
+    const key = "sk-proj-" + "test-placeholder-value-for-testing-demo";
+    // sk-proj- prefix with test- content after
+    const result = checkIngressForSecrets("sk-test-abc123");
+    expect(result.blocked).toBe(false);
+  });
+
+  test("does not block fake_ prefixed values", () => {
+    // A GitHub-like token with fake_ prefix
+    const result = checkIngressForSecrets(
+      "fake_ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
+    );
+    expect(result.blocked).toBe(false);
+  });
+
+  test("does not block repeated character patterns", () => {
+    // AKIA followed by 16 repeated X characters
+    const result = checkIngressForSecrets("AKIAXXXXXXXXXXXXXXXX");
+    expect(result.blocked).toBe(false);
+  });
+
+  // ── Multiple secrets ───────────────────────────────────────────────
+
+  test("reports multiple detected types", () => {
+    const result = checkIngressForSecrets(
+      "AWS: AKIAIOSFODNN7EXAMPLE\nGitHub: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
+    );
+    expect(result.blocked).toBe(true);
+    expect(result.detectedTypes).toContain("AWS Access Key");
+    expect(result.detectedTypes).toContain("GitHub Token");
+    expect(result.detectedTypes.length).toBe(2);
+  });
+
+  test("user notice does not echo secret values", () => {
+    const secret = "AKIAIOSFODNN7EXAMPLE";
+    const result = checkIngressForSecrets(`Key: ${secret}`);
+    expect(result.blocked).toBe(true);
+    expect(result.userNotice).toBeDefined();
+    expect(result.userNotice!).not.toContain(secret);
+  });
+});

--- a/assistant/src/__tests__/secret-ingress.test.ts
+++ b/assistant/src/__tests__/secret-ingress.test.ts
@@ -37,8 +37,8 @@ mock.module("../util/platform.js", () => ({
   getWorkspaceDir: () => "/tmp/vellum-test-ingress/workspace",
 }));
 
-import { checkIngressForSecrets } from "../security/secret-ingress.js";
 import { resetAllowlist } from "../security/secret-allowlist.js";
+import { checkIngressForSecrets } from "../security/secret-ingress.js";
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -227,8 +227,6 @@ describe("checkIngressForSecrets", () => {
   // ── Placeholder / test values ──────────────────────────────────────
 
   test("does not block placeholder test keys (sk-test-*)", () => {
-    const key = "sk-proj-" + "test-placeholder-value-for-testing-demo";
-    // sk-proj- prefix with test- content after
     const result = checkIngressForSecrets("sk-test-abc123");
     expect(result.blocked).toBe(false);
   });

--- a/assistant/src/config/schemas/security.ts
+++ b/assistant/src/config/schemas/security.ts
@@ -44,6 +44,12 @@ export const SecretDetectionConfigSchema = z
       .describe(
         "Shannon entropy threshold for detecting high-entropy strings as potential secrets",
       ),
+    blockIngress: z
+      .boolean({ error: "secretDetection.blockIngress must be a boolean" })
+      .default(true)
+      .describe(
+        "Whether to block user messages containing detected secrets at ingress",
+      ),
     allowOneTimeSend: z
       .boolean({ error: "secretDetection.allowOneTimeSend must be a boolean" })
       .default(false)
@@ -74,7 +80,9 @@ export const PermissionsConfigSchema = z
         "Permission mode — 'strict' requires explicit approval for all operations, 'workspace' allows operations within the workspace",
       ),
     dangerouslySkipPermissions: z
-      .boolean({ error: "permissions.dangerouslySkipPermissions must be a boolean" })
+      .boolean({
+        error: "permissions.dangerouslySkipPermissions must be a boolean",
+      })
       .default(false)
       .describe("Auto-accept all permission prompts without asking"),
   })

--- a/assistant/src/security/secret-ingress.ts
+++ b/assistant/src/security/secret-ingress.ts
@@ -10,7 +10,6 @@
  */
 
 import { getConfig } from "../config/loader.js";
-
 import { isAllowlisted } from "./secret-allowlist.js";
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/security/secret-ingress.ts
+++ b/assistant/src/security/secret-ingress.ts
@@ -1,0 +1,241 @@
+/**
+ * Ingress secret detection for user messages.
+ *
+ * Uses a curated subset of high-confidence, prefix-based patterns to
+ * deterministically block messages containing real secrets. Unlike
+ * `scanText()` from `secret-scanner.ts`, this intentionally excludes
+ * broad patterns (JWT, DB URLs, generic `password=`/`secret=` assignments,
+ * high-entropy hex/base64, encoded-secret detection) that cause false
+ * positives on legitimate user input.
+ */
+
+import { getConfig } from "../config/loader.js";
+
+import { isAllowlisted } from "./secret-allowlist.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface IngressCheckResult {
+  blocked: boolean;
+  detectedTypes: string[];
+  userNotice?: string;
+}
+
+// ---------------------------------------------------------------------------
+// High-confidence prefix-based patterns
+// ---------------------------------------------------------------------------
+
+interface SecretPattern {
+  label: string;
+  regex: RegExp;
+}
+
+const INGRESS_PATTERNS: SecretPattern[] = [
+  // AWS
+  { label: "AWS Access Key", regex: /AKIA[0-9A-Z]{16}/ },
+
+  // GitHub
+  { label: "GitHub Token", regex: /gh[pousr]_[A-Za-z0-9_]{36,}/ },
+  { label: "GitHub PAT", regex: /github_pat_[A-Za-z0-9_]{22,}/ },
+
+  // GitLab
+  { label: "GitLab PAT", regex: /glpat-[A-Za-z0-9\-_]{20,}/ },
+
+  // Stripe
+  { label: "Stripe Secret Key", regex: /sk_live_[A-Za-z0-9]{24,}/ },
+  { label: "Stripe Restricted Key", regex: /rk_live_[A-Za-z0-9]{24,}/ },
+
+  // Slack
+  {
+    label: "Slack Bot Token",
+    regex: /xoxb-[0-9]{10,}-[0-9]{10,}-[A-Za-z0-9]{24,}/,
+  },
+  {
+    label: "Slack User Token",
+    regex: /xoxp-[0-9]{10,}-[0-9]{10,}-[A-Za-z0-9]{24,}/,
+  },
+
+  // Telegram
+  { label: "Telegram Bot Token", regex: /[0-9]{8,10}:[A-Za-z0-9_-]{35}/ },
+
+  // Anthropic
+  { label: "Anthropic API Key", regex: /sk-ant-[A-Za-z0-9\-_]{80,}/ },
+
+  // OpenAI
+  { label: "OpenAI API Key", regex: /sk-proj-[A-Za-z0-9\-_]{40,}/ },
+
+  // Google
+  { label: "Google API Key", regex: /AIza[A-Za-z0-9\-_]{35}/ },
+  { label: "Google OAuth Secret", regex: /GOCSPX-[A-Za-z0-9\-_]{28}/ },
+
+  // Twilio
+  { label: "Twilio API Key", regex: /SK[0-9a-f]{32}/ },
+
+  // SendGrid
+  {
+    label: "SendGrid API Key",
+    regex: /SG\.[A-Za-z0-9\-_]{22}\.[A-Za-z0-9\-_]{43}/,
+  },
+
+  // npm
+  { label: "npm Token", regex: /npm_[A-Za-z0-9]{36}/ },
+
+  // Private keys
+  {
+    label: "Private Key",
+    regex: /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Placeholder detection (inline — not imported from secret-scanner.ts)
+// ---------------------------------------------------------------------------
+
+const KNOWN_PLACEHOLDERS = new Set([
+  "your-api-key-here",
+  "your_api_key_here",
+  "insert-your-key-here",
+  "insert_your_key_here",
+  "replace-with-your-key",
+  "replace_with_your_key",
+  "xxx",
+  "xxxxxxxx",
+  "test",
+  "example",
+  "sample",
+  "demo",
+  "placeholder",
+  "changeme",
+  "CHANGEME",
+  "TODO",
+  "FIXME",
+  "your-token-here",
+  "your_token_here",
+  "my-api-key",
+  "my_api_key",
+]);
+
+const PLACEHOLDER_PREFIXES = [
+  "sk-test-",
+  "sk_test_",
+  "fake_",
+  "fake-",
+  "dummy_",
+  "dummy-",
+  "test_",
+  "test-",
+  "example_",
+  "example-",
+  "sample_",
+  "sample-",
+  "mock_",
+  "mock-",
+];
+
+/**
+ * Check if the text immediately before a matched value indicates
+ * a placeholder context (e.g. "fake_", "test_").
+ */
+function isPlaceholderContext(preContext: string): boolean {
+  const lower = preContext.toLowerCase();
+  for (const prefix of PLACEHOLDER_PREFIXES) {
+    if (lower.endsWith(prefix)) return true;
+  }
+  return false;
+}
+
+/**
+ * Check if a matched value is a placeholder/test value that should not
+ * trigger blocking.
+ */
+function isPlaceholder(value: string): boolean {
+  const lower = value.toLowerCase();
+
+  // Known placeholder values
+  if (KNOWN_PLACEHOLDERS.has(lower)) return true;
+
+  // Placeholder prefixes
+  for (const prefix of PLACEHOLDER_PREFIXES) {
+    if (lower.startsWith(prefix)) return true;
+  }
+
+  // Repeated characters in the variable portion (e.g. "AKIA" + "X" x 16)
+  // Strip known prefixes to isolate the variable part
+  const variablePart = value
+    .replace(
+      /^(?:AKIA|gh[pousr]_|github_pat_|glpat-|sk_live_|rk_live_|xoxb-|xoxp-|sk-ant-|sk-proj-|AIza|GOCSPX-|SK|SG\.|npm_|-----BEGIN [A-Z ]*PRIVATE KEY-----)/,
+      "",
+    )
+    .replace(/[^A-Za-z0-9]/g, "");
+  if (variablePart.length >= 8) {
+    const firstChar = variablePart[0];
+    if (variablePart.split("").every((c) => c === firstChar)) return true;
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Check user message content for high-confidence secret patterns.
+ *
+ * Returns `{ blocked: true, detectedTypes, userNotice }` if secrets are
+ * found and blocking is enabled, otherwise `{ blocked: false }`.
+ */
+export function checkIngressForSecrets(content: string): IngressCheckResult {
+  const config = getConfig();
+
+  // Bail if secret detection is entirely disabled
+  if (!config.secretDetection.enabled) {
+    return { blocked: false, detectedTypes: [] };
+  }
+
+  // Bail if ingress blocking is disabled
+  if (!config.secretDetection.blockIngress) {
+    return { blocked: false, detectedTypes: [] };
+  }
+
+  const detectedTypes: string[] = [];
+
+  for (const { label, regex } of INGRESS_PATTERNS) {
+    // Use a global version to find all matches
+    const globalRegex = new RegExp(regex.source, "g");
+    let match: RegExpExecArray | null;
+
+    while ((match = globalRegex.exec(content)) !== null) {
+      const value = match[0];
+
+      // Skip placeholders and test values (check both the match and
+      // a small window before it for placeholder prefixes like "fake_")
+      const contextStart = Math.max(0, match.index - 10);
+      const preContext = content.slice(contextStart, match.index);
+      if (isPlaceholder(value) || isPlaceholderContext(preContext)) continue;
+
+      // Skip user-allowlisted values
+      if (isAllowlisted(value)) continue;
+
+      if (!detectedTypes.includes(label)) {
+        detectedTypes.push(label);
+      }
+    }
+  }
+
+  if (detectedTypes.length === 0) {
+    return { blocked: false, detectedTypes: [] };
+  }
+
+  return {
+    blocked: true,
+    detectedTypes,
+    userNotice:
+      `Message blocked: detected ` +
+      `${detectedTypes.length === 1 ? "a potential credential" : "potential credentials"} ` +
+      `(${detectedTypes.join(", ")}). ` +
+      `Use the secure credential prompt to provide sensitive values safely.`,
+  };
+}


### PR DESCRIPTION
## Summary
- Recreate `secret-ingress.ts` with curated high-confidence prefix-based patterns (no entropy, no JWT/DB/generic patterns)
- Restore `blockIngress` config flag in security schema (default true)
- Add comprehensive tests for pattern matching, exclusions, placeholders, and config flags

Part of plan: ingress-secret-scanning.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
