### PR TITLE
feat: block channel messages containing secrets at ingress

### DIFF
--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -20,6 +20,7 @@ import {
 } from "../../memory/conversation-attention-store.js";
 import * as deliveryChannels from "../../memory/delivery-channels.js";
 import * as deliveryCrud from "../../memory/delivery-crud.js";
+import * as deliveryStatus from "../../memory/delivery-status.js";
 import * as externalConversationStore from "../../memory/external-conversation-store.js";
 import { canonicalizeInboundIdentity } from "../../util/canonicalize-identity.js";
 import { getLogger } from "../../util/logger.js";
@@ -641,7 +642,7 @@ export async function handleChannelInbound(
   // For new (non-duplicate) messages, run the secret ingress check
   // synchronously, then fire off the agent loop in the background.
   if (!result.duplicate && processMessage) {
-    runSecretIngressCheck({
+    const ingressResult = runSecretIngressCheck({
       eventId: result.eventId,
       sourceChannel,
       conversationExternalId,
@@ -659,30 +660,42 @@ export async function handleChannelInbound(
       canonicalAssistantId,
     });
 
-    // Fire-and-forget: process the message and deliver the reply in the background.
-    // The HTTP response returns immediately so the gateway webhook is not blocked.
-    // The onEvent callback in processMessage registers pending interactions, and
-    // approval interception (above) handles decisions via the pending-interactions tracker.
-    processChannelMessageInBackground({
-      processMessage,
-      conversationId: result.conversationId,
-      eventId: result.eventId,
-      content: trimmedContent,
-      attachmentIds: hasAttachments ? attachmentIds : undefined,
-      sourceChannel,
-      sourceInterface,
-      externalChatId: conversationExternalId,
-      trustCtx,
-      metadataHints,
-      metadataUxBrief,
-      commandIntent,
-      sourceLanguageCode,
-      replyCallbackUrl,
-      mintBearerToken,
-      assistantId: canonicalAssistantId,
-      approvalCopyGenerator,
-      chatType: sourceChatType,
-    });
+    if (ingressResult.blocked) {
+      // Intentional block — mark the event as processed (not failed/dead-lettered).
+      deliveryStatus.markProcessed(result.eventId);
+      log.info(
+        {
+          eventId: result.eventId,
+          detectedTypes: ingressResult.detectedTypes,
+        },
+        "Channel message blocked at ingress: contains secrets",
+      );
+    } else {
+      // Fire-and-forget: process the message and deliver the reply in the background.
+      // The HTTP response returns immediately so the gateway webhook is not blocked.
+      // The onEvent callback in processMessage registers pending interactions, and
+      // approval interception (above) handles decisions via the pending-interactions tracker.
+      processChannelMessageInBackground({
+        processMessage,
+        conversationId: result.conversationId,
+        eventId: result.eventId,
+        content: trimmedContent,
+        attachmentIds: hasAttachments ? attachmentIds : undefined,
+        sourceChannel,
+        sourceInterface,
+        externalChatId: conversationExternalId,
+        trustCtx,
+        metadataHints,
+        metadataUxBrief,
+        commandIntent,
+        sourceLanguageCode,
+        replyCallbackUrl,
+        mintBearerToken,
+        assistantId: canonicalAssistantId,
+        approvalCopyGenerator,
+        chatType: sourceChatType,
+      });
+    }
   }
 
   return Response.json({

--- a/assistant/src/runtime/routes/inbound-stages/secret-ingress-check.ts
+++ b/assistant/src/runtime/routes/inbound-stages/secret-ingress-check.ts
@@ -9,6 +9,7 @@ import type { ChannelId } from "../../../channels/types.js";
 import type { TrustContext } from "../../../daemon/conversation-runtime-assembly.js";
 import { recordConversationSeenSignal } from "../../../memory/conversation-attention-store.js";
 import * as deliveryCrud from "../../../memory/delivery-crud.js";
+import { checkIngressForSecrets } from "../../../security/secret-ingress.js";
 import { getLogger } from "../../../util/logger.js";
 
 const log = getLogger("runtime-http");
@@ -35,10 +36,21 @@ export interface SecretIngressCheckParams {
   canonicalAssistantId: string;
 }
 
+export interface SecretIngressCheckResult {
+  blocked: boolean;
+  detectedTypes?: string[];
+}
+
 /**
- * Persist the raw payload and record a Telegram seen signal.
+ * Persist the raw payload, scan for secrets, and record a Telegram seen signal.
+ *
+ * Returns `{ blocked: true, detectedTypes }` when the message contains
+ * known-format secrets — the caller should skip background dispatch and mark
+ * the event as processed (not failed/dead-lettered).
  */
-export function runSecretIngressCheck(params: SecretIngressCheckParams): void {
+export function runSecretIngressCheck(
+  params: SecretIngressCheckParams,
+): SecretIngressCheckResult {
   const {
     eventId,
     sourceChannel,
@@ -73,6 +85,20 @@ export function runSecretIngressCheck(params: SecretIngressCheckParams): void {
     assistantId: canonicalAssistantId,
   });
 
+  // ── Secret ingress scan ──
+  // Scan trimmedContent (post-transcription) so secrets introduced via
+  // transcribed audio are also caught.
+  const ingressResult = checkIngressForSecrets(trimmedContent);
+  if (ingressResult.blocked) {
+    // Clear stored payload to prevent secret-bearing content on disk.
+    deliveryCrud.clearPayload(eventId);
+    log.warn(
+      { eventId, detectedTypes: ingressResult.detectedTypes },
+      "Channel message blocked at ingress: secret detected",
+    );
+    return { blocked: true, detectedTypes: ingressResult.detectedTypes };
+  }
+
   // Record inferred seen signal for non-duplicate Telegram inbound messages
   if (sourceChannel === "telegram") {
     try {
@@ -99,4 +125,6 @@ export function runSecretIngressCheck(params: SecretIngressCheckParams): void {
       );
     }
   }
+
+  return { blocked: false };
 }

--- a/assistant/src/security/secret-ingress.ts
+++ b/assistant/src/security/secret-ingress.ts
@@ -188,14 +188,15 @@ function isPlaceholder(value: string): boolean {
  */
 export function checkIngressForSecrets(content: string): IngressCheckResult {
   const config = getConfig();
+  const secretDetection = config?.secretDetection;
 
-  // Bail if secret detection is entirely disabled
-  if (!config.secretDetection.enabled) {
+  // Bail if secret detection config is missing or entirely disabled
+  if (!secretDetection?.enabled) {
     return { blocked: false, detectedTypes: [] };
   }
 
   // Bail if ingress blocking is disabled
-  if (!config.secretDetection.blockIngress) {
+  if (!secretDetection.blockIngress) {
     return { blocked: false, detectedTypes: [] };
   }
 


### PR DESCRIPTION
## Summary
- Wire `checkIngressForSecrets` into channel ingress `runSecretIngressCheck`
- Block channel messages with secrets before background dispatch, mark events as processed
- Clear stored payloads when secrets detected to prevent secret persistence on disk

Part of plan: ingress-secret-scanning.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
