### PR TITLE
feat: block user messages containing secrets at HTTP and CLI ingress

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -318,7 +318,9 @@ export async function startCli(): Promise<void> {
   }
 
   /** Send a user message via signal file to the daemon. */
-  async function sendUserMessage(content: string): Promise<boolean> {
+  async function sendUserMessage(
+    content: string,
+  ): Promise<{ ok: boolean; error?: string; message?: string }> {
     try {
       const signalsDir = getSignalsDir();
       mkdirSync(signalsDir, { recursive: true });
@@ -337,9 +339,17 @@ export async function startCli(): Promise<void> {
         }),
       );
 
-      const accepted = await new Promise<boolean>((resolve) => {
+      const result = await new Promise<{
+        ok: boolean;
+        error?: string;
+        message?: string;
+      }>((resolve) => {
         let settled = false;
-        const settle = (value: boolean): void => {
+        const settle = (value: {
+          ok: boolean;
+          error?: string;
+          message?: string;
+        }): void => {
           if (settled) return;
           settled = true;
           watcher.close();
@@ -350,13 +360,16 @@ export async function startCli(): Promise<void> {
         const checkResult = (): void => {
           try {
             const raw = readFileSync(resultPath, "utf-8");
-            const result = JSON.parse(raw) as {
+            const parsed = JSON.parse(raw) as {
               ok?: boolean;
               accepted?: boolean;
               requestId?: string;
+              error?: string;
+              message?: string;
             };
-            if (result.requestId === requestId) {
-              settle(result.ok === true && result.accepted !== false);
+            if (parsed.requestId === requestId) {
+              const ok = parsed.ok === true && parsed.accepted !== false;
+              settle({ ok, error: parsed.error, message: parsed.message });
             }
           } catch {
             // Result file not yet readable; ignore.
@@ -369,16 +382,16 @@ export async function startCli(): Promise<void> {
           }
         });
 
-        const timeoutId = setTimeout(() => settle(false), 10_000);
+        const timeoutId = setTimeout(() => settle({ ok: false }), 10_000);
 
         if (existsSync(resultPath)) {
           checkResult();
         }
       });
 
-      return accepted;
+      return result;
     } catch {
-      return false;
+      return { ok: false };
     }
   }
 
@@ -673,12 +686,16 @@ export async function startCli(): Promise<void> {
           const content = pendingUserContent;
           pendingUserContent = null;
           lastResponse = "";
-          sendUserMessage(content).then((ok) => {
-            if (ok) {
+          sendUserMessage(content).then((result) => {
+            if (result.ok) {
               generating = true;
               spinner.start("Thinking...");
             } else {
-              process.stdout.write("[Not connected — message not sent]\n");
+              if (result.error === "secret_blocked" && result.message) {
+                process.stdout.write(`${result.message}\n`);
+              } else {
+                process.stdout.write("[Not connected — message not sent]\n");
+              }
               prompt();
             }
           });
@@ -1290,9 +1307,13 @@ export async function startCli(): Promise<void> {
 
     // Regular user message
     lastResponse = "";
-    sendUserMessage(content).then((ok) => {
-      if (!ok) {
-        process.stdout.write("[Not connected — message not sent]\n");
+    sendUserMessage(content).then((result) => {
+      if (!result.ok) {
+        if (result.error === "secret_blocked" && result.message) {
+          process.stdout.write(`${result.message}\n`);
+        } else {
+          process.stdout.write("[Not connected — message not sent]\n");
+        }
         prompt();
         return;
       }

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -40,16 +40,14 @@ import { updateMetaFile } from "../memory/conversation-disk-view.js";
 import { getOrCreateConversation } from "../memory/conversation-key-store.js";
 import { buildSystemPrompt } from "../prompts/system-prompt.js";
 import { RateLimitProvider } from "../providers/ratelimit.js";
-import {
-  getProvider,
-  initializeProviders,
-} from "../providers/registry.js";
+import { getProvider, initializeProviders } from "../providers/registry.js";
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getSigningKeyFingerprint } from "../runtime/auth/token-service.js";
 import { bridgeConfirmationRequestToGuardian } from "../runtime/confirmation-request-guardian-bridge.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
+import { checkIngressForSecrets } from "../security/secret-ingress.js";
 import { registerCancelCallback } from "../signals/cancel.js";
 import { registerConversationUndoCallback } from "../signals/conversation-undo.js";
 import { appendEventToStream } from "../signals/event-stream.js";
@@ -512,6 +510,16 @@ export class DaemonServer {
     );
 
     registerUserMessageCallback(async (params) => {
+      // Block messages containing known-format secrets before persistence
+      const ingressResult = checkIngressForSecrets(params.content);
+      if (ingressResult.blocked) {
+        return {
+          accepted: false,
+          error: "secret_blocked" as const,
+          message: ingressResult.userNotice,
+        };
+      }
+
       const { conversationId } = getOrCreateConversation(
         params.conversationKey,
       );
@@ -706,9 +714,7 @@ export class DaemonServer {
 
       const createPromise = (async () => {
         const config = getConfig();
-        let provider = getProvider(
-          config.services.inference.provider,
-        );
+        let provider = getProvider(config.services.inference.provider);
         const { rateLimit } = config;
         if (rateLimit.maxRequestsPerMinute > 0) {
           provider = new RateLimitProvider(

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -57,6 +57,7 @@ import {
 import { searchConversations } from "../../memory/conversation-queries.js";
 import { getConfiguredProvider } from "../../providers/provider-send-message.js";
 import type { Provider } from "../../providers/types.js";
+import { checkIngressForSecrets } from "../../security/secret-ingress.js";
 import { getLogger } from "../../util/logger.js";
 import { silentlyWithLog } from "../../util/silently.js";
 import { buildAssistantEvent } from "../assistant-event.js";
@@ -638,6 +639,7 @@ export async function handleSendMessage(
     interface?: string;
     conversationType?: string;
     automated?: boolean;
+    bypassSecretCheck?: boolean;
   };
 
   const { conversationKey, content, attachmentIds } = body;
@@ -701,6 +703,22 @@ export async function handleSendMessage(
         "BAD_REQUEST",
         `Attachment IDs not found: ${missing.join(", ")}`,
         400,
+      );
+    }
+  }
+
+  // Block messages containing known-format secrets before any persistence
+  if (trimmedContent.length > 0 && !body.bypassSecretCheck) {
+    const ingressResult = checkIngressForSecrets(trimmedContent);
+    if (ingressResult.blocked) {
+      return Response.json(
+        {
+          accepted: false,
+          error: "secret_blocked",
+          message: ingressResult.userNotice,
+          detectedTypes: ingressResult.detectedTypes,
+        },
+        { status: 422 },
       );
     }
   }

--- a/assistant/src/signals/user-message.ts
+++ b/assistant/src/signals/user-message.ts
@@ -30,7 +30,7 @@ type UserMessageCallback = (params: {
   content: string;
   sourceChannel: string;
   sourceInterface: string;
-}) => Promise<{ accepted: boolean }>;
+}) => Promise<{ accepted: boolean; error?: string; message?: string }>;
 
 let _sendUserMessage: UserMessageCallback | null = null;
 
@@ -134,7 +134,13 @@ export async function handleUserMessageSignal(filename: string): Promise<void> {
       { accepted: result.accepted },
       "User message dispatched via signal file",
     );
-    writeResult({ ok: true, accepted: result.accepted, requestId });
+    writeResult({
+      ok: true,
+      accepted: result.accepted,
+      requestId,
+      ...(result.error ? { error: result.error } : {}),
+      ...(result.message ? { message: result.message } : {}),
+    });
   } catch (err) {
     log.error({ err }, "Failed to handle user-message signal");
     writeResult({


### PR DESCRIPTION
## Summary
- Wire `checkIngressForSecrets` into POST /v1/messages handler with `bypassSecretCheck` support
- Add ingress check to CLI signal callback before `persistAndProcessMessage`
- Extend signal result and CLI to display secret-blocked notice instead of generic connection error

Part of plan: ingress-secret-scanning.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
