### PR TITLE
fix: use bodyMediumEmphasised for regular VButton labels

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -53,7 +53,7 @@ public struct VButton: View {
                         VIconView(.resolve(leftIcon), size: textIconSize)
                     }
                     Text(label)
-                        .font(size == .compact || size == .pill ? VFont.labelDefault : VFont.bodyLargeEmphasised)
+                        .font(size == .compact || size == .pill ? VFont.labelDefault : VFont.bodyMediumEmphasised)
                     if isFullWidth && (leftIcon != nil || rightIcon != nil) {
                         Spacer(minLength: 0)
                     }


### PR DESCRIPTION
## Summary
- Change regular-sized VButton font from `bodyLargeEmphasised` (16pt) to `bodyMediumEmphasised` (14pt)
- Same DM Sans 500 weight, just tighter sizing for a cleaner look
- Compact/pill buttons remain unchanged (`labelDefault`)

## Test plan
- [ ] Verify regular-sized buttons across the app render with 14pt text
- [ ] Verify compact and pill buttons are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
