### PR TITLE
M1: Cap ghost text at 2 lines and adjust composer height constraints

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -192,7 +192,7 @@ struct ComposerView: View {
                 .font(font)
                 .foregroundColor(VColor.contentSecondary.opacity(0.55)))
                 .lineSpacing(4)
-                .lineLimit(1...)
+                .lineLimit(2)
                 .allowsHitTesting(false)
                 .accessibilityHidden(true)
         }
@@ -264,7 +264,7 @@ struct ComposerView: View {
         }
         .scrollBounceBehavior(.basedOnSize)
         .defaultScrollAnchor(.bottom)
-        .frame(minHeight: composerActionButtonSize, maxHeight: inputText.isEmpty ? composerActionButtonSize : composerMaxHeight)
+        .frame(minHeight: composerActionButtonSize, maxHeight: inputText.isEmpty && ghostSuffix == nil ? composerActionButtonSize : composerMaxHeight)
         .accessibilityLabel("Message")
         .frame(maxWidth: .infinity)
         .background(


### PR DESCRIPTION
Cap the ghost text (autosuggestion) overlay in the macOS composer at 2 lines so long suggestions don't expand the composer height excessively. Changes: (1) lineLimit(2) on ghost text overlay, (2) allow 2-line height when suggestion is present with empty input. Closes #21239. Part of #21238.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
