### PR TITLE
fix: cap composer suggestion height at 2 lines

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -255,7 +255,7 @@ struct ComposerView: View {
         let hasSlashHighlight = slashCommandRange != nil
 
         return ScrollView(.vertical, showsIndicators: false) {
-            ZStack(alignment: .leading) {
+            ZStack(alignment: .topLeading) {
                 composerTextOverlays(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
                 composerInputField(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
             }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -192,7 +192,7 @@ struct ComposerView: View {
                 .font(font)
                 .foregroundColor(VColor.contentSecondary.opacity(0.55)))
                 .lineSpacing(4)
-                .lineLimit(1...)
+                .lineLimit(2)
                 .allowsHitTesting(false)
                 .accessibilityHidden(true)
         }
@@ -264,7 +264,7 @@ struct ComposerView: View {
         }
         .scrollBounceBehavior(.basedOnSize)
         .defaultScrollAnchor(.bottom)
-        .frame(minHeight: composerActionButtonSize, maxHeight: inputText.isEmpty ? composerActionButtonSize : composerMaxHeight)
+        .frame(minHeight: composerActionButtonSize, maxHeight: inputText.isEmpty && ghostSuffix == nil ? composerActionButtonSize : composerMaxHeight)
         .accessibilityLabel("Message")
         .frame(maxWidth: .infinity)
         .background(


### PR DESCRIPTION
## Summary
Fix the macOS composer so that when an autosuggestion (ghost text) is longer than 2 lines, the composer height is capped at 2 lines instead of expanding to show the full suggestion. The ghost text overlay now uses `.lineLimit(2)` and the height constraint allows 2 lines when a suggestion is present with empty input.

## Changes
- Cap ghost text overlay to 2 lines with `.lineLimit(2)` in `composerTextOverlays()`
- Adjust `maxHeight` logic so composer shows up to 2 lines when a suggestion is active with empty input (previously capped at 1 line/32pt)
- User-typed text continues to expand normally up to 300pt

## Milestone PRs (merged into feature branch)
- #21240: M1: Cap ghost text at 2 lines and adjust composer height constraints

## Project issue
Closes #21238

## Test plan
- [ ] Open the macOS app and start a conversation
- [ ] Wait for a follow-up suggestion to appear in the composer
- [ ] Verify the suggestion text is capped at 2 visible lines with truncation
- [ ] Verify the composer does not expand beyond 2 lines for the suggestion
- [ ] Type multi-line text manually and verify the composer still expands normally up to 300pt
- [ ] Verify Tab still accepts the suggestion correctly
- [ ] Verify slash commands still work with no visual regression
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
