### PR TITLE
fix: tighten ingress patterns and fix signal result type

### DIFF
--- a/assistant/src/__tests__/secret-ingress.test.ts
+++ b/assistant/src/__tests__/secret-ingress.test.ts
@@ -151,6 +151,22 @@ describe("checkIngressForSecrets", () => {
     expect(result.detectedTypes).toContain("GitLab PAT");
   });
 
+  test("blocks Telegram Bot Token", () => {
+    const result = checkIngressForSecrets(
+      "Bot token: 123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi",
+    );
+    expect(result.blocked).toBe(true);
+    expect(result.detectedTypes).toContain("Telegram Bot Token");
+  });
+
+  test("blocks Twilio API Key (SK*)", () => {
+    const result = checkIngressForSecrets(
+      "Twilio key: SK0123456789abcdef0123456789abcdef",
+    );
+    expect(result.blocked).toBe(true);
+    expect(result.detectedTypes).toContain("Twilio API Key");
+  });
+
   // ── Not blocked (excluded patterns) ────────────────────────────────
 
   test("does not block normal text", () => {

--- a/assistant/src/security/secret-ingress.ts
+++ b/assistant/src/security/secret-ingress.ts
@@ -57,7 +57,7 @@ const INGRESS_PATTERNS: SecretPattern[] = [
   },
 
   // Telegram
-  { label: "Telegram Bot Token", regex: /[0-9]{8,10}:[A-Za-z0-9_-]{35}/ },
+  { label: "Telegram Bot Token", regex: /\b[0-9]{8,10}:[A-Za-z0-9_-]{35}\b/ },
 
   // Anthropic
   { label: "Anthropic API Key", regex: /sk-ant-[A-Za-z0-9\-_]{80,}/ },
@@ -70,7 +70,7 @@ const INGRESS_PATTERNS: SecretPattern[] = [
   { label: "Google OAuth Secret", regex: /GOCSPX-[A-Za-z0-9\-_]{28}/ },
 
   // Twilio
-  { label: "Twilio API Key", regex: /SK[0-9a-f]{32}/ },
+  { label: "Twilio API Key", regex: /\bSK[0-9a-f]{32}\b/ },
 
   // SendGrid
   {

--- a/assistant/src/signals/user-message.ts
+++ b/assistant/src/signals/user-message.ts
@@ -58,7 +58,13 @@ export async function handleUserMessageSignal(filename: string): Promise<void> {
 
   const writeResult = (
     data:
-      | { ok: true; accepted: boolean; requestId: string }
+      | {
+          ok: true;
+          accepted: boolean;
+          requestId: string;
+          error?: string;
+          message?: string;
+        }
       | { ok: false; error: string; requestId: string | null },
   ): void => {
     try {


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for ingress-secret-scanning.md.

- Add word boundaries to Telegram and Twilio patterns to reduce false positive risk
- Add unit tests for Telegram and Twilio pattern detection
- Fix writeResult type annotation to include error/message fields on ok:true variant

Part of JARVIS-336
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
