### PR TITLE
fix: add Send Anyway bypass to CLI for secret-blocked messages

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -320,6 +320,7 @@ export async function startCli(): Promise<void> {
   /** Send a user message via signal file to the daemon. */
   async function sendUserMessage(
     content: string,
+    options?: { bypassSecretCheck?: boolean },
   ): Promise<{ ok: boolean; error?: string; message?: string }> {
     try {
       const signalsDir = getSignalsDir();
@@ -336,6 +337,9 @@ export async function startCli(): Promise<void> {
           sourceChannel: "vellum",
           interface: "cli",
           requestId,
+          ...(options?.bypassSecretCheck
+            ? { bypassSecretCheck: true }
+            : undefined),
         }),
       );
 
@@ -693,10 +697,30 @@ export async function startCli(): Promise<void> {
             } else {
               if (result.error === "secret_blocked" && result.message) {
                 process.stdout.write(`${result.message}\n`);
+                rl.question("Send anyway? (y/N): ", (answer) => {
+                  if (answer.trim().toLowerCase() === "y") {
+                    lastResponse = "";
+                    sendUserMessage(content, {
+                      bypassSecretCheck: true,
+                    }).then((retryResult) => {
+                      if (retryResult.ok) {
+                        generating = true;
+                        spinner.start("Thinking...");
+                      } else {
+                        process.stdout.write(
+                          "[Not connected — message not sent]\n",
+                        );
+                        prompt();
+                      }
+                    });
+                  } else {
+                    prompt();
+                  }
+                });
               } else {
                 process.stdout.write("[Not connected — message not sent]\n");
+                prompt();
               }
-              prompt();
             }
           });
         } else {
@@ -1311,10 +1335,30 @@ export async function startCli(): Promise<void> {
       if (!result.ok) {
         if (result.error === "secret_blocked" && result.message) {
           process.stdout.write(`${result.message}\n`);
+          rl.question("Send anyway? (y/N): ", (answer) => {
+            if (answer.trim().toLowerCase() === "y") {
+              lastResponse = "";
+              sendUserMessage(content, { bypassSecretCheck: true }).then(
+                (retryResult) => {
+                  if (retryResult.ok) {
+                    generating = true;
+                    spinner.start("Thinking...");
+                  } else {
+                    process.stdout.write(
+                      "[Not connected — message not sent]\n",
+                    );
+                    prompt();
+                  }
+                },
+              );
+            } else {
+              prompt();
+            }
+          });
         } else {
           process.stdout.write("[Not connected — message not sent]\n");
+          prompt();
         }
-        prompt();
         return;
       }
       generating = true;

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -511,13 +511,15 @@ export class DaemonServer {
 
     registerUserMessageCallback(async (params) => {
       // Block messages containing known-format secrets before persistence
-      const ingressResult = checkIngressForSecrets(params.content);
-      if (ingressResult.blocked) {
-        return {
-          accepted: false,
-          error: "secret_blocked" as const,
-          message: ingressResult.userNotice,
-        };
+      if (!params.bypassSecretCheck) {
+        const ingressResult = checkIngressForSecrets(params.content);
+        if (ingressResult.blocked) {
+          return {
+            accepted: false,
+            error: "secret_blocked" as const,
+            message: ingressResult.userNotice,
+          };
+        }
       }
 
       const { conversationId } = getOrCreateConversation(

--- a/assistant/src/signals/user-message.ts
+++ b/assistant/src/signals/user-message.ts
@@ -30,6 +30,7 @@ type UserMessageCallback = (params: {
   content: string;
   sourceChannel: string;
   sourceInterface: string;
+  bypassSecretCheck?: boolean;
 }) => Promise<{ accepted: boolean; error?: string; message?: string }>;
 
 let _sendUserMessage: UserMessageCallback | null = null;
@@ -91,6 +92,7 @@ export async function handleUserMessageSignal(filename: string): Promise<void> {
       sourceChannel?: string;
       interface?: string;
       requestId?: string;
+      bypassSecretCheck?: boolean;
     };
     const { requestId } = parsed;
     parsedRequestId = requestId;
@@ -128,6 +130,7 @@ export async function handleUserMessageSignal(filename: string): Promise<void> {
       content: parsed.content,
       sourceChannel: parsed.sourceChannel ?? "vellum",
       sourceInterface: parsed.interface ?? "cli",
+      bypassSecretCheck: parsed.bypassSecretCheck === true,
     });
 
     log.info(


### PR DESCRIPTION
## Summary
Fixes gap: CLI path has no bypassSecretCheck escape hatch.

- Add `bypassSecretCheck` field to CLI signal payload and thread it through `handleUserMessageSignal` to the daemon callback
- Skip `checkIngressForSecrets` in daemon callback when bypass flag is set
- Prompt CLI user with "Send anyway? (y/N)" when a message is blocked by secret detection, matching the macOS client's "Send Anyway" button behavior

Part of JARVIS-336
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
