### PR TITLE
fix: broken tests, dead code, Package.swift enum, confirmation focus regression

### DIFF
--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -6,7 +6,7 @@ let appVersion = "0.5.10"
 let package = Package(
     name: "vellum-assistant",
     platforms: [
-        .macOS("15.0"),
+        .macOS(.v15),
         .iOS(.v17)
     ],
     products: [

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
@@ -7,48 +7,6 @@ import VellumAssistantShared
 
 private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "MessageListScrollCoordinator")
 
-/// Holds the last-known distance-from-bottom without triggering SwiftUI
-/// re-renders. Only `isVisible` is @Published so re-renders happen only when
-/// the visible/invisible boundary is crossed — not on every scroll tick.
-///
-/// Retained as a standalone type for testability. The coordinator delegates
-/// anchor tracking to this class internally but exposes `anchorIsVisible`
-/// and `anchorLastMinY` as top-level properties for convenience.
-///
-/// `lastMinY` stores the distance-from-bottom (0 at the bottom, positive when
-/// scrolled up). The anchor is considered "visible" when the distance is at
-/// most 20pt.
-@MainActor final class AnchorVisibilityTracker: ObservableObject {
-    var lastMinY: CGFloat = .infinity  // NOT @Published — no re-render on scroll
-    @Published var isVisible: Bool = true
-
-    /// Updates the tracked distance-from-bottom and recalculates visibility.
-    /// Only publishes `isVisible` when the boundary is actually crossed
-    /// (visible ↔ invisible), not on every scroll tick — this prevents
-    /// SwiftUI re-renders during continuous scrolling.
-    func update(distanceFromBottom: CGFloat, viewportHeight: CGFloat) {
-        lastMinY = distanceFromBottom
-        let newVisible = distanceFromBottom >= -20 && distanceFromBottom <= 20
-        if isVisible != newVisible { isVisible = newVisible }
-    }
-
-    /// Returns `true` when the viewport height actually changed, so callers
-    /// can refresh any state tied to the visible geometry.
-    @discardableResult
-    func updateViewport(height: CGFloat, storedViewportHeight: inout CGFloat) -> Bool {
-        guard storedViewportHeight != height else { return false }
-        storedViewportHeight = height
-        // Don't recompute visibility before the distance-from-bottom has been
-        // measured — lastMinY starts at .infinity, and .infinity <= 20
-        // evaluates to false, incorrectly flipping isVisible to false and
-        // flashing the "Scroll to latest" button on short conversations.
-        guard lastMinY.isFinite else { return true }
-        let newVisible = lastMinY >= -20 && lastMinY <= 20
-        if isVisible != newVisible { isVisible = newVisible }
-        return true
-    }
-}
-
 /// Named reasons for suppressing bottom auto-scroll. Each reason has a defined
 /// timeout so callers don't need to manage independent timers.
 ///
@@ -226,7 +184,7 @@ final class MessageListScrollCoordinator: ObservableObject {
     /// Fires a single deferred re-pin attempt after the cooldown drains.
     var loopGuardRecoveryTask: Task<Void, Never>?
 
-    // MARK: - Anchor Visibility (mirrors AnchorVisibilityTracker)
+    // MARK: - Anchor Visibility
 
     /// Updates the tracked distance-from-bottom and recalculates visibility.
     /// Only publishes `anchorIsVisible` when the boundary is actually crossed

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -26,7 +26,7 @@ extension EnvironmentValues {
 /// evaluations but must NOT trigger SwiftUI re-renders when updated.
 /// These values serve as dead-zone guards and smoothing state — they
 /// are never read during body evaluation for rendering purposes.
-/// Pattern mirrors `AnchorVisibilityTracker.lastMinY` (not @Published).
+/// Pattern mirrors `anchorLastMinY` on the coordinator (not @Published).
 @MainActor final class ScrollTrackingState {
     /// Debounced task for transcript snapshot updates, coalescing rapid scroll
     /// events into a single snapshot capture per 150ms window.
@@ -978,6 +978,11 @@ struct MessageListView: View {
                     anchorMessageId: $anchorMessageId,
                     scrollViewportHeight: scrollViewportHeight
                 )
+            }
+            .onChange(of: currentPendingRequestId) {
+                #if os(macOS)
+                scrollCoordinator.handleConfirmationFocusIfNeeded(currentPendingRequestId: currentPendingRequestId)
+                #endif
             }
             // anchorMessageId changes are handled via task(id:) to avoid
             // counting as an onChange modifier while still reacting to

--- a/clients/macos/vellum-assistantTests/ConversationAvatarFollowerTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationAvatarFollowerTests.swift
@@ -2,118 +2,39 @@ import XCTest
 @testable import VellumAssistantLib
 
 final class ConversationAvatarFollowerTests: XCTestCase {
-    func testStreamingCoalescingUsesMinimumInterval() {
-        let now = Date(timeIntervalSince1970: 1_000)
-        let lastAppliedAt = now.addingTimeInterval(-0.04)
-
-        let delay = ConversationAvatarFollower.smoothingDelay(
-            isSending: true,
-            isThinking: false,
-            isLastMessageStreaming: true,
-            lastAppliedAt: lastAppliedAt,
-            now: now
-        )
-
-        XCTAssertEqual(delay, 0.06, accuracy: 0.001)
-    }
-
-    func testVisibilityBoundsMatchViewportGate() {
-        XCTAssertTrue(ConversationAvatarFollower.shouldShow(anchorY: -24, viewportHeight: 500))
-        XCTAssertTrue(ConversationAvatarFollower.shouldShow(anchorY: 524, viewportHeight: 500))
-        XCTAssertFalse(ConversationAvatarFollower.shouldShow(anchorY: -24.1, viewportHeight: 500))
-        XCTAssertFalse(ConversationAvatarFollower.shouldShow(anchorY: 524.1, viewportHeight: 500))
-        XCTAssertFalse(ConversationAvatarFollower.shouldShow(anchorY: .infinity, viewportHeight: 500))
-    }
-
-    func testIdleBypassesCoalescing() {
-        let now = Date(timeIntervalSince1970: 1_000)
-        let lastAppliedAt = now
-
-        let delay = ConversationAvatarFollower.smoothingDelay(
-            isSending: false,
-            isThinking: false,
-            isLastMessageStreaming: false,
-            lastAppliedAt: lastAppliedAt,
-            now: now
-        )
-
-        XCTAssertEqual(delay, 0, accuracy: 0.0001)
-    }
-
-    func testHiddenAnchorMovementDoesNotUpdateTarget() {
-        XCTAssertFalse(
-            ConversationAvatarFollower.shouldUpdateTarget(
-                previousAnchorY: 700,
-                newAnchorY: 920,
-                viewportHeight: 500
-            )
-        )
-        XCTAssertFalse(
-            ConversationAvatarFollower.shouldUpdateTarget(
-                previousAnchorY: -80,
-                newAnchorY: -180,
-                viewportHeight: 500
-            )
-        )
-    }
-
-    func testVisibilityTransitionsStillUpdateTarget() {
-        XCTAssertTrue(
-            ConversationAvatarFollower.shouldUpdateTarget(
-                previousAnchorY: 700,
-                newAnchorY: 520,
-                viewportHeight: 500
-            )
-        )
-        XCTAssertTrue(
-            ConversationAvatarFollower.shouldUpdateTarget(
-                previousAnchorY: 520,
-                newAnchorY: 700,
-                viewportHeight: 500
-            )
-        )
-        XCTAssertTrue(
-            ConversationAvatarFollower.shouldUpdateTarget(
-                previousAnchorY: 100,
-                newAnchorY: 140,
-                viewportHeight: 500
-            )
-        )
-    }
-
     @MainActor
     func testViewportChangeRecomputesVisibility() {
-        let tracker = AnchorVisibilityTracker()
+        let coordinator = MessageListScrollCoordinator()
         // Distance-from-bottom of 15 is within the 20pt visibility threshold.
-        tracker.lastMinY = 15
-        tracker.isVisible = false
+        coordinator.anchorLastMinY = 15
+        coordinator.anchorIsVisible = false
         var storedViewportHeight: CGFloat = 500
 
-        let changed = tracker.updateViewport(
+        let changed = coordinator.updateAnchorViewport(
             height: 540,
             storedViewportHeight: &storedViewportHeight
         )
 
         XCTAssertTrue(changed)
         XCTAssertEqual(storedViewportHeight, 540)
-        XCTAssertTrue(tracker.isVisible)
+        XCTAssertTrue(coordinator.anchorIsVisible)
     }
 
     @MainActor
     func testViewportChangeNoOpsWhenHeightIsUnchanged() {
-        let tracker = AnchorVisibilityTracker()
+        let coordinator = MessageListScrollCoordinator()
         // Distance-from-bottom of 50 is outside the 20pt threshold — not visible.
-        tracker.lastMinY = 50
-        tracker.isVisible = false
+        coordinator.anchorLastMinY = 50
+        coordinator.anchorIsVisible = false
         var storedViewportHeight: CGFloat = 540
 
-        let changed = tracker.updateViewport(
+        let changed = coordinator.updateAnchorViewport(
             height: 540,
             storedViewportHeight: &storedViewportHeight
         )
 
         XCTAssertFalse(changed)
         XCTAssertEqual(storedViewportHeight, 540)
-        XCTAssertFalse(tracker.isVisible)
+        XCTAssertFalse(coordinator.anchorIsVisible)
     }
 }

--- a/clients/macos/vellum-assistantTests/MessageListAnchorPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListAnchorPerformanceTests.swift
@@ -5,7 +5,7 @@ import XCTest
 // MARK: - MessageListView Anchor & Rendering Performance Baselines
 //
 // These tests establish XCTest performance baselines for:
-//   1. AnchorVisibilityTracker hot-path stress (called on every scroll frame)
+//   1. MessageListScrollCoordinator anchor hot-path stress (called on every scroll frame)
 //   2. Large conversation markdown pipeline throughput (cold cache)
 //   3. Attributed string cache hit performance (hot cache)
 //
@@ -13,6 +13,7 @@ import XCTest
 //   swift test --filter MessageListAnchorPerformanceTests  (from clients/macos/)
 // or via Xcode's Test navigator.
 
+@MainActor
 final class MessageListAnchorPerformanceTests: XCTestCase {
 
     // MARK: - Sample Data
@@ -77,15 +78,14 @@ final class MessageListAnchorPerformanceTests: XCTestCase {
     ```
     """
 
-    // MARK: - 1. AnchorVisibilityTracker Rapid-Update Stress Test
+    // MARK: - 1. Coordinator Anchor Rapid-Update Stress Test
 
-    /// Benchmarks calling update(distanceFromBottom:viewportHeight:) and
-    /// updateViewport(height:storedViewportHeight:) 10,000 times each in a
+    /// Benchmarks calling updateAnchor(distanceFromBottom:viewportHeight:) and
+    /// updateAnchorViewport(height:storedViewportHeight:) 10,000 times each in a
     /// tight loop. While individually trivial (O(1)), they are called on EVERY
     /// scroll frame. This test detects if any future refactoring adds overhead.
-    @MainActor
     func testAnchorVisibilityTrackerRapidUpdateStress() {
-        let tracker = AnchorVisibilityTracker()
+        let coordinator = MessageListScrollCoordinator()
         let viewportHeight: CGFloat = 800.0
 
         measure(metrics: [XCTClockMetric(), XCTCPUMetric()]) {
@@ -94,12 +94,12 @@ final class MessageListAnchorPerformanceTests: XCTestCase {
                 // Simulate scrolling: distanceFromBottom varies, crossing
                 // the visibility boundary (20pt threshold) frequently.
                 let distanceFromBottom = CGFloat(i % 100) - 10.0
-                tracker.update(distanceFromBottom: distanceFromBottom, viewportHeight: viewportHeight)
+                coordinator.updateAnchor(distanceFromBottom: distanceFromBottom, viewportHeight: viewportHeight)
             }
             for i in 0..<10_000 {
                 // Simulate viewport resizes mixed with position changes.
                 let height = 600.0 + CGFloat(i % 400)
-                tracker.updateViewport(height: height, storedViewportHeight: &storedViewportHeight)
+                coordinator.updateAnchorViewport(height: height, storedViewportHeight: &storedViewportHeight)
             }
         }
     }


### PR DESCRIPTION
## Summary
Fixes 4 gaps identified during plan review:
- Removes 5 broken test functions referencing deleted ConversationAvatarFollower methods
- Removes dead `AnchorVisibilityTracker` class, updates tests to use coordinator
- Changes `.macOS("15.0")` to `.macOS(.v15)` in Package.swift
- Restores `onChange(of: currentPendingRequestId)` for confirmation focus handoff

Part of plan: scroll-audit-cleanup.md (review fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
