### PR TITLE
fix: verify and fix bot-flagged recovery and suppression issues

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
@@ -379,6 +379,12 @@ final class MessageListScrollCoordinator: ObservableObject {
             loopGuardRecoveryTask = Task { @MainActor [weak self] in
                 try? await Task.sleep(nanoseconds: UInt64(ChatScrollLoopGuard.autoRecoveryDelay * 1_000_000_000))
                 guard !Task.isCancelled, let self else { return }
+                // Only re-pin if the user hasn't scrolled away during the delay.
+                guard self.bottomPinCoordinator.isFollowingBottom else {
+                    log.debug("Loop guard auto-recovery: skipping re-pin — user scrolled away for \(convId)")
+                    self.loopGuardRecoveryTask = nil
+                    return
+                }
                 log.debug("Loop guard auto-recovery: attempting re-pin for \(convId)")
                 os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested",
                             "target=bottomAnchor reason=loopGuardAutoRecovery")
@@ -646,6 +652,8 @@ final class MessageListScrollCoordinator: ObservableObject {
     func handleScrollUp() {
         scrollRestoreTask?.cancel()
         scrollRestoreTask = nil
+        loopGuardRecoveryTask?.cancel()
+        loopGuardRecoveryTask = nil
         clearAllSuppression()
         bottomPinCoordinator.handleUserAction(.scrollUp)
         hasReceivedScrollEvent = true
@@ -677,18 +685,10 @@ final class MessageListScrollCoordinator: ObservableObject {
         } else {
             os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=offBottomExpansion")
             recordScrollLoopEvent(.suppressionFlip, conversationId: conversationId, isNearBottom: isNearBottom, scrollViewportHeight: scrollViewportHeight)
-            // Add expansion suppression with auto-timeout. Override the default
-            // timeout task to also check resize/pagination guards.
-            suppression.insert(.expansion)
-            let key = ScrollSuppression.expansion.rawValue
-            suppressionTimeoutTasks[key]?.cancel()
-            suppressionTimeoutTasks[key] = Task { @MainActor [weak self] in
-                try? await Task.sleep(nanoseconds: ScrollSuppression.timeout(for: .expansion))
-                guard !Task.isCancelled, let self else { return }
-                if !isResizeActive && !self.isPaginationInFlight {
-                    self.removeSuppression(.expansion)
-                }
-            }
+            // Add expansion suppression with auto-timeout. Each OptionSet bit
+            // is independent, so removal is unconditional — no resize/pagination
+            // guards needed (those have their own suppression bits and timeouts).
+            addSuppression(.expansion)
         }
     }
 


### PR DESCRIPTION
## Summary
Verifies and fixes bot-flagged issues from plan review:
- **Gap D (VERIFIED — fixed):** Cancel `loopGuardRecoveryTask` in `handleScrollUp()` and add `isFollowingBottom` guard in the recovery callback to prevent yanking the user back to bottom after a loop guard trip.
- **Gap E (VERIFIED — fixed):** Replace custom expansion suppression timeout (with stale `isResizeActive` capture) with `addSuppression(.expansion)` which unconditionally removes the bit on timeout. OptionSet bits are independent; resize/pagination have their own bits and timeouts.
- **Gap F (FALSE POSITIVE):** `refreshMessageListVersionIfNeeded` correctly ignores `textSegments` changes — those are rendered by individual message views via their own bindings, not by `PrecomputedMessageListState` which only tracks message-list-level layout.

Part of plan: scroll-audit-cleanup.md (review fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
