### PR TITLE
fix: correct scroll geometry formula and avatar positioning issues

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -135,7 +135,6 @@ struct ChatView: View {
     @State private var dragEndLocalMonitor: Any?
     @State private var dragEndGlobalMonitor: Any?
     @State private var containerWidth: CGFloat = 0
-    @State private var composerHeight: CGFloat = 0
 
     // MARK: - In-Chat Search (Cmd+F)
     @State private var isSearchActive = false
@@ -265,8 +264,7 @@ struct ChatView: View {
                             anchorMessageId: $anchorMessageId,
                             highlightedMessageId: $highlightedMessageId,
                             isNearBottom: $isNearBottom,
-                            containerWidth: containerWidth,
-                            composerHeight: composerHeight
+                            containerWidth: containerWidth
                         )
 
                         if let exhaustedError = creditsExhaustedError, exhaustedError.isCreditsExhausted {
@@ -324,12 +322,6 @@ struct ChatView: View {
                             conversationId: conversationId,
                             isInteractionEnabled: isInteractionEnabled
                         )
-                        .background(
-                            GeometryReader { geo in
-                                Color.clear.preference(key: ComposerHeightKey.self, value: geo.size.height)
-                            }
-                        )
-                        .onPreferenceChange(ComposerHeightKey.self) { composerHeight = $0 }
                     }
                 }
             }
@@ -825,11 +817,3 @@ private struct ChatContainerWidthKey: PreferenceKey {
     }
 }
 
-/// Propagates the composer section's measured height up to ChatView so it can
-/// forward it to MessageListView for viewport-pinned avatar offset calculation.
-private struct ComposerHeightKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
-    }
-}

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -146,9 +146,6 @@ struct MessageListView: View {
     /// Measured width of the chat container, used to detect sidebar/split resizes
     /// and stabilize scroll position during layout width changes.
     var containerWidth: CGFloat = 0
-    /// Height of the composer section, measured in ChatView and passed down
-    /// so the viewport-pinned avatar overlay can offset above the composer.
-    var composerHeight: CGFloat = 0
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
     @AppStorage("completedConversationCount") private var completedConversationCount: Int = 0
     @State private var identity: IdentityInfo? = IdentityInfo.load()
@@ -755,8 +752,12 @@ struct MessageListView: View {
             })
             .onScrollPhaseChange { oldPhase, newPhase in
                 scrollPhase = newPhase
-                if newPhase == .idle && oldPhase != .idle && isNearBottom {
+                if newPhase == .idle && oldPhase != .idle && scrollCoordinator.anchorIsVisible {
                     // User finished scrolling and ended up near the bottom — re-tether.
+                    // Uses anchorIsVisible (geometry-derived) instead of isNearBottom
+                    // to break the circular dependency: isNearBottom is only set by
+                    // handleScrollToBottom(), so checking it here would prevent
+                    // users from re-tethering by scrolling back to the bottom.
                     scrollCoordinator.handleScrollToBottom()
                 }
             }
@@ -805,7 +806,7 @@ struct MessageListView: View {
                 // Distance from bottom: how far the visible rect's bottom edge
                 // is from the content bottom. Replaces the AnchorMinYKey preference
                 // + hidden anchor view + GeometryReader + coordinate space conversion.
-                geo.contentOffset.y + geo.contentSize.height - geo.visibleRect.height
+                geo.contentSize.height - geo.contentOffset.y - geo.visibleRect.height
             } action: { _, distanceFromBottom in
                 // Filter non-finite values and apply 2pt dead-zone to reduce
                 // layout invalidation cascades during rapid scroll.
@@ -849,7 +850,7 @@ struct MessageListView: View {
             }
             .overlay(alignment: .bottom) {
                 conversationTailAvatar
-                    .padding(.bottom, composerHeight + ConversationAvatarFollower.verticalOffset)
+                    .padding(.bottom, ConversationAvatarFollower.verticalOffset)
             }
             .overlay(alignment: .bottom) {
                 if !isNearBottom && !scrollCoordinator.anchorIsVisible


### PR DESCRIPTION
## Summary
Verifies and fixes three bot-flagged issues from plan review:

- **Gap A (VERIFIED — fixed):** Distance-from-bottom formula had a sign error: `contentOffset.y + contentSize.height - visibleRect.height` should be `contentSize.height - contentOffset.y - visibleRect.height`. The old formula produced `2*(contentSize.height - visibleRect.height)` at the bottom instead of 0, breaking anchor visibility detection and the "Scroll to latest" button threshold.

- **Gap B (VERIFIED — fixed):** `onScrollPhaseChange` checked `isNearBottom` before calling `handleScrollToBottom()`, but `isNearBottom` is only set BY that handler (via `bottomPinCoordinator.onFollowStateChanged`), creating a circular dependency. Users who scrolled up and then scrolled back to the bottom with the trackpad could never re-tether. Fixed by checking `scrollCoordinator.anchorIsVisible` (geometry-derived) instead.

- **Gap C (VERIFIED — fixed):** Avatar overlay used `.padding(.bottom, composerHeight + verticalOffset)` but the ScrollView already sits above the ComposerSection in a VStack, so `composerHeight` was double-counted. Removed `composerHeight` from the padding and cleaned up the now-dead `composerHeight` plumbing (state var, preference key, GeometryReader).

Part of plan: scroll-audit-cleanup.md (review fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
