### PR TITLE
Open OAuth auth URLs directly in browser without confirmation

### DIFF
--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -120,6 +120,16 @@ export async function orchestrateOAuthConnect(
   options: OAuthConnectOptions,
 ): Promise<OAuthConnectResult> {
   const resolvedService = resolveService(options.service);
+  log.info(
+    {
+      rawService: options.service,
+      resolvedService,
+      isInteractive: options.isInteractive,
+      hasOpenUrl: !!options.openUrl,
+      hasSendToClient: !!options.sendToClient,
+    },
+    "orchestrateOAuthConnect: starting",
+  );
 
   // Read provider config from the DB
   const providerRow = getProvider(resolvedService);
@@ -198,6 +208,20 @@ export async function orchestrateOAuthConnect(
       safeError: true,
     };
   }
+
+  log.info(
+    {
+      service: resolvedService,
+      authUrl,
+      tokenUrl,
+      scopeCount: finalScopes.length,
+      callbackTransport,
+      loopbackPort,
+      hasClientSecret: !!options.clientSecret,
+      clientIdPrefix: options.clientId.substring(0, 12) + "…",
+    },
+    "orchestrateOAuthConnect: resolved provider config",
+  );
 
   const oauthConfig = {
     authUrl,
@@ -331,19 +355,31 @@ export async function orchestrateOAuthConnect(
   // -----------------------------------------------------------------------
   // Interactive path — open browser, block until completion
   // -----------------------------------------------------------------------
+  log.info(
+    { service: resolvedService, callbackTransport, loopbackPort },
+    "orchestrateOAuthConnect: entering interactive path",
+  );
   try {
     const { tokens, grantedScopes, rawTokenResponse } = await startOAuth2Flow(
       oauthConfig,
       {
         openUrl: (url) => {
+          log.info(
+            { service: resolvedService, urlLength: url.length },
+            "orchestrateOAuthConnect: openUrl callback fired, delivering auth URL to client",
+          );
           if (options.openUrl) {
+            log.info("orchestrateOAuthConnect: using options.openUrl");
             options.openUrl(url);
           } else if (options.sendToClient) {
+            log.info("orchestrateOAuthConnect: using sendToClient with open_url event");
             options.sendToClient({
               type: "open_url",
               url,
               title: `Connect ${resolvedService}`,
             });
+          } else {
+            log.warn("orchestrateOAuthConnect: no openUrl or sendToClient available — auth URL will not reach the user");
           }
         },
       },
@@ -354,6 +390,11 @@ export async function orchestrateOAuthConnect(
           : undefined,
     );
 
+    log.info(
+      { service: resolvedService, grantedScopeCount: grantedScopes.length },
+      "orchestrateOAuthConnect: interactive flow completed, exchanged code for tokens",
+    );
+
     // Parse account identifier from the provider's identity endpoint.
     // Best-effort — format varies by provider and may fail.
     let parsedAccountIdentifier: string | undefined;
@@ -361,6 +402,10 @@ export async function orchestrateOAuthConnect(
       try {
         parsedAccountIdentifier = await behavior.identityVerifier(
           tokens.accessToken,
+        );
+        log.info(
+          { service: resolvedService, parsedAccountIdentifier },
+          "orchestrateOAuthConnect: identity verified",
         );
       } catch {
         // Non-fatal
@@ -375,6 +420,11 @@ export async function orchestrateOAuthConnect(
       parsedAccountIdentifier,
     });
 
+    log.info(
+      { service: resolvedService, accountInfo },
+      "orchestrateOAuthConnect: tokens stored, connect complete",
+    );
+
     return {
       success: true,
       deferred: false,
@@ -384,6 +434,10 @@ export async function orchestrateOAuthConnect(
   } catch (err: unknown) {
     const message =
       err instanceof Error ? err.message : "Unknown error during OAuth flow";
+    log.error(
+      { service: resolvedService, err },
+      "orchestrateOAuthConnect: interactive flow failed",
+    );
     return {
       success: false,
       error: `Error connecting "${resolvedService}": ${message}`,

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -289,6 +289,11 @@ function startLoopbackServerAndWaitForCode(
     let boundRedirectUri = "";
 
     const server: Server = createServer((req, res) => {
+      log.info(
+        { method: req.method, url: req.url, settled },
+        "oauth2 loopback: received request",
+      );
+
       if (settled) {
         res.writeHead(400, { "Content-Type": "text/html" });
         res.end(renderLoopbackPage("Authorization already completed", false));
@@ -298,6 +303,7 @@ function startLoopbackServerAndWaitForCode(
       const url = new URL(req.url ?? "/", `http://127.0.0.1`);
 
       if (url.pathname !== LOOPBACK_CALLBACK_PATH) {
+        log.info({ pathname: url.pathname }, "oauth2 loopback: non-callback path, returning 404");
         res.writeHead(404, { "Content-Type": "text/plain" });
         res.end("Not found");
         return;
@@ -308,6 +314,7 @@ function startLoopbackServerAndWaitForCode(
       const error = url.searchParams.get("error");
 
       if (callbackState !== state) {
+        log.warn("oauth2 loopback: state mismatch in callback");
         res.writeHead(400, { "Content-Type": "text/html" });
         res.end(renderLoopbackPage("Invalid state parameter", false));
         return;
@@ -317,6 +324,7 @@ function startLoopbackServerAndWaitForCode(
 
       if (error) {
         const errorDesc = url.searchParams.get("error_description") ?? error;
+        log.error({ error, errorDesc }, "oauth2 loopback: authorization denied by user/provider");
         res.writeHead(200, { "Content-Type": "text/html" });
         res.end(
           renderLoopbackPage(`Authorization failed: ${errorDesc}`, false),
@@ -327,6 +335,7 @@ function startLoopbackServerAndWaitForCode(
       }
 
       if (!code) {
+        log.error("oauth2 loopback: callback missing authorization code");
         res.writeHead(400, { "Content-Type": "text/html" });
         res.end(renderLoopbackPage("Missing authorization code", false));
         cleanup();
@@ -334,6 +343,7 @@ function startLoopbackServerAndWaitForCode(
         return;
       }
 
+      log.info("oauth2 loopback: authorization code received, exchanging for tokens");
       res.writeHead(200, { "Content-Type": "text/html" });
       res.end(
         renderLoopbackPage(
@@ -347,6 +357,10 @@ function startLoopbackServerAndWaitForCode(
 
     const timeout = setTimeout(() => {
       if (!settled) {
+        log.warn(
+          { timeoutMs: LOOPBACK_TIMEOUT_MS, state },
+          "oauth2 loopback: callback timed out — no authorization code received",
+        );
         settled = true;
         cleanup();
         reject(new Error("OAuth2 loopback callback timed out"));
@@ -359,9 +373,19 @@ function startLoopbackServerAndWaitForCode(
       server.close();
     }
 
+    log.info(
+      { requestedPort: loopbackPort ?? "random" },
+      "oauth2 loopback: binding server",
+    );
+
     server.listen(loopbackPort ?? 0, "localhost", () => {
       const addr = server.address() as { port: number };
       boundRedirectUri = `http://localhost:${addr.port}${LOOPBACK_CALLBACK_PATH}`;
+
+      log.info(
+        { port: addr.port, redirectUri: boundRedirectUri },
+        "oauth2 loopback: server listening",
+      );
 
       const authParams = new URLSearchParams({
         ...config.extraParams,
@@ -375,10 +399,19 @@ function startLoopbackServerAndWaitForCode(
       });
 
       const authUrl = `${config.authUrl}?${authParams}`;
+      log.info(
+        { authUrlLength: authUrl.length, state },
+        "oauth2 loopback: built auth URL, calling openUrl callback",
+      );
       callbacks.openUrl(authUrl);
+      log.info("oauth2 loopback: openUrl callback returned");
     });
 
     server.on("error", (err) => {
+      log.error(
+        { err: err.message, loopbackPort },
+        "oauth2 loopback: server error",
+      );
       if (!settled) {
         settled = true;
         cleanup();
@@ -686,6 +719,16 @@ export async function startOAuth2Flow(
   // Determine transport: explicit option > auto-detect from config
   const transport =
     options?.callbackTransport ?? (hasPublicUrl ? "gateway" : "loopback");
+
+  log.info(
+    {
+      transport,
+      hasPublicUrl,
+      explicitTransport: options?.callbackTransport,
+      loopbackPort: options?.loopbackPort,
+    },
+    "startOAuth2Flow: resolved transport",
+  );
 
   if (transport === "gateway") {
     if (!hasPublicUrl) {

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -290,7 +290,11 @@ function startLoopbackServerAndWaitForCode(
 
     const server: Server = createServer((req, res) => {
       log.info(
-        { method: req.method, url: req.url, settled },
+        {
+          method: req.method,
+          path: new URL(req.url ?? "/", "http://127.0.0.1").pathname,
+          settled,
+        },
         "oauth2 loopback: received request",
       );
 
@@ -303,7 +307,10 @@ function startLoopbackServerAndWaitForCode(
       const url = new URL(req.url ?? "/", `http://127.0.0.1`);
 
       if (url.pathname !== LOOPBACK_CALLBACK_PATH) {
-        log.info({ pathname: url.pathname }, "oauth2 loopback: non-callback path, returning 404");
+        log.info(
+          { pathname: url.pathname },
+          "oauth2 loopback: non-callback path, returning 404",
+        );
         res.writeHead(404, { "Content-Type": "text/plain" });
         res.end("Not found");
         return;
@@ -324,7 +331,10 @@ function startLoopbackServerAndWaitForCode(
 
       if (error) {
         const errorDesc = url.searchParams.get("error_description") ?? error;
-        log.error({ error, errorDesc }, "oauth2 loopback: authorization denied by user/provider");
+        log.error(
+          { error, errorDesc },
+          "oauth2 loopback: authorization denied by user/provider",
+        );
         res.writeHead(200, { "Content-Type": "text/html" });
         res.end(
           renderLoopbackPage(`Authorization failed: ${errorDesc}`, false),
@@ -343,7 +353,9 @@ function startLoopbackServerAndWaitForCode(
         return;
       }
 
-      log.info("oauth2 loopback: authorization code received, exchanging for tokens");
+      log.info(
+        "oauth2 loopback: authorization code received, exchanging for tokens",
+      );
       res.writeHead(200, { "Content-Type": "text/html" });
       res.end(
         renderLoopbackPage(

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -160,8 +160,22 @@ extension AppDelegate {
                         log.error("[open_url] Failed to parse URL from open_url event: \(msg.url.prefix(80))")
                         break
                     }
-                    log.info("[open_url] Opening URL directly in default browser: \(msg.url.prefix(80))…")
-                    NSWorkspace.shared.open(url)
+                    // Auto-open https URLs (trusted daemon origin); prompt for other schemes
+                    if url.scheme == "https" {
+                        log.info("[open_url] Opening https URL directly in default browser")
+                        NSWorkspace.shared.open(url)
+                    } else {
+                        log.info("[open_url] Non-https scheme (\(url.scheme ?? "nil")), showing confirmation")
+                        let alert = NSAlert()
+                        alert.messageText = "Open External Link?"
+                        alert.informativeText = msg.url
+                        alert.alertStyle = .informational
+                        alert.addButton(withTitle: "Open in Browser")
+                        alert.addButton(withTitle: "Cancel")
+                        if alert.runModal() == .alertFirstButtonReturn {
+                            NSWorkspace.shared.open(url)
+                        }
+                    }
                 case .navigateSettings(let msg):
                     self.showSettingsTab(msg.tab)
                 case .acpPermissionRequest(let msg):

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -155,16 +155,13 @@ extension AppDelegate {
                 case .skillStateChanged:
                     self.refreshSkillsCache()
                 case .openUrl(let msg):
-                    guard let url = URL(string: msg.url) else { break }
-                    let alert = NSAlert()
-                    alert.messageText = "Open External Link?"
-                    alert.informativeText = msg.url
-                    alert.alertStyle = .informational
-                    alert.addButton(withTitle: "Open in Browser")
-                    alert.addButton(withTitle: "Cancel")
-                    if alert.runModal() == .alertFirstButtonReturn {
-                        NSWorkspace.shared.open(url)
+                    log.info("[open_url] Received open_url event: urlLength=\(msg.url.count), title=\(msg.title ?? "<none>")")
+                    guard let url = URL(string: msg.url) else {
+                        log.error("[open_url] Failed to parse URL from open_url event: \(msg.url.prefix(80))")
+                        break
                     }
+                    log.info("[open_url] Opening URL directly in default browser: \(msg.url.prefix(80))…")
+                    NSWorkspace.shared.open(url)
                 case .navigateSettings(let msg):
                     self.showSettingsTab(msg.tab)
                 case .acpPermissionRequest(let msg):


### PR DESCRIPTION
## Summary
- Removes the confirmation dialog from the macOS app's `open_url` SSE event handler — OAuth auth URLs now open directly in the default browser instead of showing an "Open External Link?" popup that could flash and disappear
- Adds comprehensive logging throughout the OAuth connect flow (orchestrator, loopback server, and macOS event handler) to aid debugging connection issues

## Test plan
- [ ] Trigger Google OAuth connect flow from the app and verify the auth URL opens directly in the browser without a popup
- [ ] Check assistant logs for the new `orchestrateOAuthConnect:` and `oauth2 loopback:` log lines during the flow
- [ ] Verify the full flow completes (auth → callback → token exchange → connection stored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
