### PR TITLE
fix: revert Package.swift to .macOS("15.0") string form for swift-tools-version 5.9

### DIFF
--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -6,7 +6,7 @@ let appVersion = "0.5.10"
 let package = Package(
     name: "vellum-assistant",
     platforms: [
-        .macOS(.v15),
+        .macOS("15.0"),
         .iOS(.v17)
     ],
     products: [


### PR DESCRIPTION
## Summary
- Reverts `.macOS(.v15)` back to `.macOS("15.0")` — the `.v15` enum requires `swift-tools-version: 6.0` but this package uses `5.9`
- The original PR 0 correctly used the string form; the review fix incorrectly changed it to enum form

Part of plan: scroll-audit-cleanup.md (review fix round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
