### PR TITLE
fix: add assistantId validation to remote feature flag sync guard

### DIFF
--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -99,6 +99,14 @@ describe("RemoteFeatureFlagSync", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  test("skips sync when assistantId is empty", async () => {
+    const sync = new RemoteFeatureFlagSync(makeConfig({ assistantId: "" }));
+    await sync.start();
+    sync.stop();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   test("fetches and caches flags on successful response", async () => {
     fetchMock = mock(async () =>
       Response.json({

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -48,9 +48,13 @@ export class RemoteFeatureFlagSync {
   }
 
   async start(): Promise<void> {
-    if (!this.config.platformUrl || !this.config.platformApiKey) {
+    if (
+      !this.config.platformUrl ||
+      !this.config.assistantId ||
+      !this.config.platformApiKey
+    ) {
       log.warn(
-        "Remote feature flag sync disabled: missing platform URL or API key",
+        "Remote feature flag sync disabled: missing platform URL, assistant ID, or API key",
       );
       return;
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for gateway-remote-ff-poll.md.

**Gap:** Missing assistantId validation in start() guard
**What was expected:** The start() method should check for empty assistantId
**What was found:** Guard only checked platformUrl and platformApiKey
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
