### PR TITLE
fix: preserve cached feature flags on fetch error

### DIFF
--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -117,33 +117,71 @@ describe("RemoteFeatureFlagSync", () => {
     expect(cached).toEqual({ "feature_flags.browser.enabled": true });
   });
 
-  test("returns empty on non-OK response", async () => {
+  test("preserves cached flags on non-OK response", async () => {
+    // First, seed cached flags with a successful fetch
+    fetchMock = mock(async () =>
+      Response.json({
+        flags: { "feature_flags.browser.enabled": true },
+      }),
+    );
+
+    const sync1 = new RemoteFeatureFlagSync(makeConfig());
+    await sync1.start();
+    sync1.stop();
+
+    clearRemoteFeatureFlagStoreCache();
+    expect(readRemoteFeatureFlags()).toEqual({
+      "feature_flags.browser.enabled": true,
+    });
+
+    // Now simulate a non-OK response — cached flags should be preserved
     fetchMock = mock(
       async () => new Response("Internal Server Error", { status: 500 }),
     );
 
-    const sync = new RemoteFeatureFlagSync(makeConfig());
-    await sync.start();
-    sync.stop();
+    const sync2 = new RemoteFeatureFlagSync(makeConfig());
+    await sync2.start();
+    sync2.stop();
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
     clearRemoteFeatureFlagStoreCache();
     const cached = readRemoteFeatureFlags();
-    expect(cached).toEqual({});
+    expect(cached).toEqual({ "feature_flags.browser.enabled": true });
   });
 
-  test("returns empty on network error", async () => {
+  test("preserves cached flags on network error", async () => {
+    // First, seed cached flags with a successful fetch
+    fetchMock = mock(async () =>
+      Response.json({
+        flags: { "feature_flags.browser.enabled": true },
+      }),
+    );
+
+    const sync1 = new RemoteFeatureFlagSync(makeConfig());
+    await sync1.start();
+    sync1.stop();
+
+    clearRemoteFeatureFlagStoreCache();
+    expect(readRemoteFeatureFlags()).toEqual({
+      "feature_flags.browser.enabled": true,
+    });
+
+    // Now simulate a network error — cached flags should be preserved
     fetchMock = mock(async () => {
       throw new Error("Network failure");
     });
 
-    const sync = new RemoteFeatureFlagSync(makeConfig());
+    const sync2 = new RemoteFeatureFlagSync(makeConfig());
     // Should not throw — errors are caught and logged
-    await sync.start();
-    sync.stop();
+    await sync2.start();
+    sync2.stop();
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    clearRemoteFeatureFlagStoreCache();
+    const cached = readRemoteFeatureFlags();
+    expect(cached).toEqual({ "feature_flags.browser.enabled": true });
   });
 
   test("sends correct auth header", async () => {
@@ -204,15 +242,32 @@ describe("RemoteFeatureFlagSync", () => {
     });
   });
 
-  test("returns empty when response is missing flags field", async () => {
+  test("preserves cached flags when response is missing flags field", async () => {
+    // First, seed cached flags with a successful fetch
+    fetchMock = mock(async () =>
+      Response.json({
+        flags: { "feature_flags.browser.enabled": true },
+      }),
+    );
+
+    const sync1 = new RemoteFeatureFlagSync(makeConfig());
+    await sync1.start();
+    sync1.stop();
+
+    clearRemoteFeatureFlagStoreCache();
+    expect(readRemoteFeatureFlags()).toEqual({
+      "feature_flags.browser.enabled": true,
+    });
+
+    // Now simulate a response with missing flags field — cached flags should be preserved
     fetchMock = mock(async () => Response.json({ data: "unexpected" }));
 
-    const sync = new RemoteFeatureFlagSync(makeConfig());
-    await sync.start();
-    sync.stop();
+    const sync2 = new RemoteFeatureFlagSync(makeConfig());
+    await sync2.start();
+    sync2.stop();
 
     clearRemoteFeatureFlagStoreCache();
     const cached = readRemoteFeatureFlags();
-    expect(cached).toEqual({});
+    expect(cached).toEqual({ "feature_flags.browser.enabled": true });
   });
 });

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -83,6 +83,10 @@ export class RemoteFeatureFlagSync {
 
   private async fetchAndCache(): Promise<void> {
     const values = await this.fetchRemoteFeatureFlags();
+    if (values === null) {
+      log.debug("Skipping cache write — fetch returned no usable data");
+      return;
+    }
     writeRemoteFeatureFlags(values);
     log.info(
       { count: Object.keys(values).length },
@@ -90,7 +94,10 @@ export class RemoteFeatureFlagSync {
     );
   }
 
-  private async fetchRemoteFeatureFlags(): Promise<Record<string, boolean>> {
+  private async fetchRemoteFeatureFlags(): Promise<Record<
+    string,
+    boolean
+  > | null> {
     const { platformUrl, assistantId, platformApiKey } = this.config;
 
     const url = `${platformUrl}/v1/assistants/${assistantId}/feature-flags/`;
@@ -110,7 +117,7 @@ export class RemoteFeatureFlagSync {
         { status: response.status, url },
         "Platform feature flags request failed",
       );
-      return {};
+      return null;
     }
 
     const body = (await response.json()) as {
@@ -118,7 +125,7 @@ export class RemoteFeatureFlagSync {
     };
     if (!body.flags || typeof body.flags !== "object") {
       log.warn("Platform feature flags response missing 'flags' field");
-      return {};
+      return null;
     }
 
     // Filter to boolean values only (defensive)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for gateway-remote-ff-poll.md.

**Gap:** Error/non-OK fetch responses overwrite cached good flags with empty map
**What was expected:** Previously cached flags should be preserved on fetch failure
**What was found:** fetchRemoteFeatureFlags() returned {} on error, which overwrote cached state
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
