### PR TITLE
fix: Scroll to latest button bypasses loop guard and suppression checks

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
@@ -266,21 +266,40 @@ final class MessageListScrollCoordinator: ObservableObject {
     /// conversation ID. Lets bootstrap-window requests coalesce normally.
     static let bootstrapConversationId = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
 
-    /// Routes an automatic bottom-follow request through the coordinator.
+    /// Routes a bottom-follow request through the coordinator.
     /// Returns `false` when the scroll loop guard is tripped, suppressing the request.
+    /// Pass `userInitiated: true` for explicit user actions (e.g. "Scroll to latest" button)
+    /// to bypass the loop guard and suppression checks — user intent always wins.
     @discardableResult
     func requestBottomPin(
         reason: BottomPinRequestReason,
         proxy: ScrollViewProxy,
         conversationId: UUID?,
-        animated: Bool = false
+        animated: Bool = false,
+        userInitiated: Bool = false
     ) -> Bool {
         let convIdString = (conversationId ?? Self.bootstrapConversationId).uuidString
-        if scrollLoopGuard.isTripped(conversationId: convIdString) {
+        if !userInitiated, scrollLoopGuard.isTripped(conversationId: convIdString) {
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested",
                         "target=bottomAnchor reason=circuitBreakerSuppressed-requestBottomPin")
             return false
         }
+
+        // User-initiated scrolls bypass the coordinator session and suppression
+        // checks entirely — user intent always wins over defensive guards.
+        if userInitiated {
+            os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested",
+                        "target=bottomAnchor reason=userInitiated")
+            if animated {
+                withAnimation(VAnimation.fast) {
+                    proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                }
+            } else {
+                proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+            }
+            return true
+        }
+
         let convId = conversationId ?? Self.bootstrapConversationId
         bottomPinCoordinator.requestPin(
             reason: reason,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -529,13 +529,15 @@ struct MessageListView: View {
     private func requestBottomPin(
         reason: BottomPinRequestReason,
         proxy: ScrollViewProxy,
-        animated: Bool = false
+        animated: Bool = false,
+        userInitiated: Bool = false
     ) {
         scrollCoordinator.requestBottomPin(
             reason: reason,
             proxy: proxy,
             conversationId: conversationId,
-            animated: animated
+            animated: animated,
+            userInitiated: userInitiated
         )
     }
 
@@ -861,7 +863,7 @@ struct MessageListView: View {
                         scrollCoordinator.hasReceivedScrollEvent = true
                         // Signal the coordinator to reattach and scroll to bottom.
                         scrollCoordinator.bottomPinCoordinator.handleUserAction(.jumpToLatest)
-                        requestBottomPin(reason: .initialRestore, proxy: proxy, animated: true)
+                        requestBottomPin(reason: .initialRestore, proxy: proxy, animated: true, userInitiated: true)
                     }) {
                         HStack(spacing: VSpacing.xs) {
                             VIconView(.arrowDown, size: 10)


### PR DESCRIPTION
## Summary
- Adds `userInitiated` parameter to `requestBottomPin` that bypasses loop guard and suppression checks
- "Scroll to latest" button passes `userInitiated: true`, scrolling directly via `proxy.scrollTo()`
- System-initiated auto-scrolls (message count, resize, expansion) still respect all guards

Part of plan: scroll-audit-cleanup.md (review fix round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
