### PR TITLE
feat: broadcast heartbeat conversation creation to desktop client

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -1100,6 +1100,12 @@ export async function runDaemon(): Promise<void> {
           },
         }),
       alerter: (alert) => server.broadcast(alert),
+      onConversationCreated: (info) =>
+        server.broadcast({
+          type: "heartbeat_conversation_created",
+          conversationId: info.conversationId,
+          title: info.title,
+        }),
     });
     heartbeat.start();
     server.setHeartbeatService(heartbeat);

--- a/assistant/src/daemon/message-types/schedules.ts
+++ b/assistant/src/daemon/message-types/schedules.ts
@@ -84,6 +84,13 @@ export interface HeartbeatAlert {
   body: string;
 }
 
+/** Server push — broadcast when a heartbeat creates a conversation. */
+export interface HeartbeatConversationCreated {
+  type: "heartbeat_conversation_created";
+  conversationId: string;
+  title: string;
+}
+
 export interface HeartbeatConfigResponse {
   type: "heartbeat_config_response";
   enabled: boolean;
@@ -141,6 +148,7 @@ export type _SchedulesClientMessages =
 export type _SchedulesServerMessages =
   | SchedulesListResponse
   | HeartbeatAlert
+  | HeartbeatConversationCreated
   | HeartbeatConfigResponse
   | HeartbeatRunsListResponse
   | HeartbeatRunNowResponse

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -17,6 +17,10 @@ export interface HeartbeatDeps {
     content: string,
   ) => Promise<{ messageId: string }>;
   alerter: (alert: HeartbeatAlert) => void;
+  onConversationCreated?: (info: {
+    conversationId: string;
+    title: string;
+  }) => void;
   /** Override for current hour (0-23), for testing. */
   getCurrentHour?: () => number;
 }
@@ -132,6 +136,11 @@ export class HeartbeatService {
         source: "heartbeat",
         origin: "heartbeat",
         systemHint: "Heartbeat",
+      });
+
+      this.deps.onConversationCreated?.({
+        conversationId: conversation.id,
+        title: "Heartbeat",
       });
 
       await this.deps.processMessage(conversation.id, prompt);

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -207,6 +207,13 @@ extension AppDelegate {
                         scheduleJobId: msg.scheduleJobId,
                         title: msg.title
                     )
+                case .heartbeatConversationCreated(let msg):
+                    guard !self.isBootstrapping else { break }
+                    self.ensureMainWindowExists()
+                    self.mainWindow?.conversationManager.createHeartbeatConversation(
+                        conversationId: msg.conversationId,
+                        title: msg.title
+                    )
                 case .notificationConversationCreated(let msg):
                     guard !self.isBootstrapping else { break }
                     self.handleNotificationConversationCreated(msg)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -627,6 +627,18 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         log.info("Created notification conversation \(localId) for conversation \(conversationId) (source: \(sourceEventName))")
     }
 
+    /// Create a visible conversation bound to a heartbeat-created conversation.
+    /// Called when the daemon broadcasts `heartbeat_conversation_created` so the user
+    /// sees heartbeat conversations in the sidebar without a full refresh.
+    func createHeartbeatConversation(conversationId: String, title: String) {
+        guard let localId = createBackgroundConversation(
+            conversationId: conversationId,
+            title: title,
+            source: "heartbeat"
+        ) else { return }
+        log.info("Created heartbeat conversation \(localId) for conversation \(conversationId)")
+    }
+
     func closeConversation(id: UUID) {
         // No-op if only 1 conversation remains
         guard conversations.count > 1 else { return }

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -3249,6 +3249,19 @@ public struct SchedulesListResponseSchedule: Codable, Sendable {
     }
 }
 
+/// Server push — broadcast when a heartbeat creates a conversation, so the client can show it in the sidebar.
+public struct HeartbeatConversationCreated: Codable, Sendable {
+    public let type: String
+    public let conversationId: String
+    public let title: String
+
+    public init(type: String, conversationId: String, title: String) {
+        self.type = type
+        self.conversationId = conversationId
+        self.title = title
+    }
+}
+
 /// Server push — broadcast when a schedule creates a conversation, so the client can show it as a chat conversation.
 public struct ScheduleConversationCreated: Codable, Sendable {
     public let type: String

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2119,6 +2119,7 @@ public enum ServerMessage: Decodable, Sendable {
     case workItemCancelResponse(WorkItemCancelResponse)
     case taskRunConversationCreated(TaskRunConversationCreated)
     case scheduleConversationCreated(ScheduleConversationCreated)
+    case heartbeatConversationCreated(HeartbeatConversationCreated)
     case subagentSpawned(SubagentSpawned)
     case subagentStatusChanged(SubagentStatusChanged)
     indirect case subagentEvent(SubagentEventMessage)
@@ -2485,6 +2486,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "schedule_conversation_created":
             let message = try ScheduleConversationCreated(from: decoder)
             self = .scheduleConversationCreated(message)
+        case "heartbeat_conversation_created":
+            let message = try HeartbeatConversationCreated(from: decoder)
+            self = .heartbeatConversationCreated(message)
         case "subagent_spawned":
             let message = try SubagentSpawned(from: decoder)
             self = .subagentSpawned(message)


### PR DESCRIPTION
## Summary
- Add `heartbeat_conversation_created` server push message type to the daemon-client protocol
- Wire `onConversationCreated` callback in HeartbeatService to broadcast when a heartbeat conversation is created
- Handle the new message in the macOS client to show heartbeat conversations in the sidebar immediately
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
