### PR TITLE
M1: Wire protocol — Add cancel message types for host proxies

### DIFF
--- a/assistant/src/daemon/message-types/host-bash.ts
+++ b/assistant/src/daemon/message-types/host-bash.ts
@@ -15,6 +15,11 @@ export interface HostBashRequest {
   env?: Record<string, string>;
 }
 
+export interface HostBashCancelRequest {
+  type: "host_bash_cancel";
+  requestId: string;
+}
+
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
-export type _HostBashServerMessages = HostBashRequest;
+export type _HostBashServerMessages = HostBashRequest | HostBashCancelRequest;

--- a/assistant/src/daemon/message-types/host-cu.ts
+++ b/assistant/src/daemon/message-types/host-cu.ts
@@ -14,6 +14,11 @@ export interface HostCuRequest {
   reasoning?: string;
 }
 
+export interface HostCuCancelRequest {
+  type: "host_cu_cancel";
+  requestId: string;
+}
+
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
-export type _HostCuServerMessages = HostCuRequest;
+export type _HostCuServerMessages = HostCuRequest | HostCuCancelRequest;

--- a/assistant/src/daemon/message-types/host-file.ts
+++ b/assistant/src/daemon/message-types/host-file.ts
@@ -39,6 +39,11 @@ export type HostFileRequest =
   | HostFileWriteRequest
   | HostFileEditRequest;
 
+export interface HostFileCancelRequest {
+  type: "host_file_cancel";
+  requestId: string;
+}
+
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
-export type _HostFileServerMessages = HostFileRequest;
+export type _HostFileServerMessages = HostFileRequest | HostFileCancelRequest;

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1389,6 +1389,13 @@ public struct HostBashRequest: Decodable, Sendable {
     }
 }
 
+/// Cancellation signal from the daemon telling the client to abort an in-flight
+/// host bash execution identified by `requestId`.
+public struct HostBashCancelRequest: Decodable, Sendable {
+    public let type: String
+    public let requestId: String
+}
+
 /// Payload posted back to the daemon with the result of a host bash execution.
 public struct HostBashResultPayload: Codable, Sendable {
     public let requestId: String
@@ -1444,6 +1451,13 @@ public struct HostFileRequest: Decodable, Sendable {
     }
 }
 
+/// Cancellation signal from the daemon telling the client to abort an in-flight
+/// host file operation identified by `requestId`.
+public struct HostFileCancelRequest: Decodable, Sendable {
+    public let type: String
+    public let requestId: String
+}
+
 /// Payload posted back to the daemon with the result of a host file operation.
 public struct HostFileResultPayload: Codable, Sendable {
     public let requestId: String
@@ -1480,6 +1494,13 @@ public struct HostCuRequest: Decodable, Sendable {
         case stepNumber
         case reasoning
     }
+}
+
+/// Cancellation signal from the daemon telling the client to abort an in-flight
+/// host computer-use action identified by `requestId`.
+public struct HostCuCancelRequest: Decodable, Sendable {
+    public let type: String
+    public let requestId: String
 }
 
 /// Payload posted back to the daemon with the result of a host CU action execution.
@@ -2150,8 +2171,11 @@ public enum ServerMessage: Decodable, Sendable {
     case tokenRotated(TokenRotatedMessage)
     case identityChanged(IdentityChanged)
     case hostBashRequest(HostBashRequest)
+    case hostBashCancel(HostBashCancelRequest)
     case hostFileRequest(HostFileRequest)
+    case hostFileCancel(HostFileCancelRequest)
     case hostCuRequest(HostCuRequest)
+    case hostCuCancel(HostCuCancelRequest)
     case usageUpdate(UsageUpdate)
     case serviceGroupUpdateStarting(ServiceGroupUpdateStartingMessage)
     case serviceGroupUpdateProgress(ServiceGroupUpdateProgressMessage)
@@ -2579,12 +2603,21 @@ public enum ServerMessage: Decodable, Sendable {
         case "host_bash_request":
             let message = try HostBashRequest(from: decoder)
             self = .hostBashRequest(message)
+        case "host_bash_cancel":
+            let message = try HostBashCancelRequest(from: decoder)
+            self = .hostBashCancel(message)
         case "host_file_request":
             let message = try HostFileRequest(from: decoder)
             self = .hostFileRequest(message)
+        case "host_file_cancel":
+            let message = try HostFileCancelRequest(from: decoder)
+            self = .hostFileCancel(message)
         case "host_cu_request":
             let message = try HostCuRequest(from: decoder)
             self = .hostCuRequest(message)
+        case "host_cu_cancel":
+            let message = try HostCuCancelRequest(from: decoder)
+            self = .hostCuCancel(message)
         case "usage_update":
             let message = try UsageUpdate(from: decoder)
             self = .usageUpdate(message)


### PR DESCRIPTION
Part of #21263. Adds host_bash_cancel, host_file_cancel, and host_cu_cancel message types to both the daemon TypeScript message protocol and the Swift MessageTypes enum, enabling the daemon to notify the client when a proxy request should be cancelled.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
