### PR TITLE
M5: Process group kill for grandchild cleanup

### DIFF
--- a/assistant/src/signals/bash.ts
+++ b/assistant/src/signals/bash.ts
@@ -138,11 +138,12 @@ export function handleBashSignal(filename: string): void {
   const child = spawn("bash", ["-c", command], {
     cwd: getWorkspaceDir(),
     stdio: ["ignore", "pipe", "pipe"],
+    detached: true,
   });
 
   const timer = setTimeout(() => {
     timedOut = true;
-    child.kill("SIGKILL");
+    process.kill(-child.pid!, "SIGKILL");
   }, effectiveTimeout);
 
   child.stdout.on("data", (data: Buffer) => {

--- a/assistant/src/signals/bash.ts
+++ b/assistant/src/signals/bash.ts
@@ -143,7 +143,11 @@ export function handleBashSignal(filename: string): void {
 
   const timer = setTimeout(() => {
     timedOut = true;
-    process.kill(-child.pid!, "SIGKILL");
+    try {
+      process.kill(-child.pid!, "SIGKILL");
+    } catch {
+      // Process group may have already exited.
+    }
   }, effectiveTimeout);
 
   child.stdout.on("data", (data: Buffer) => {

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -209,16 +209,28 @@ class HostShellTool implements Tool {
 
       const timer = setTimeout(() => {
         timedOut = true;
-        process.kill(-child.pid!, "SIGKILL");
+        try {
+          process.kill(-child.pid!, "SIGKILL");
+        } catch {
+          // Process group may have already exited.
+        }
       }, timeoutMs);
 
       // Cooperative cancellation via AbortSignal
       const onAbort = () => {
-        process.kill(-child.pid!, "SIGKILL");
+        try {
+          process.kill(-child.pid!, "SIGKILL");
+        } catch {
+          // Process group may have already exited.
+        }
       };
       if (context.signal) {
         if (context.signal.aborted) {
-          process.kill(-child.pid!, "SIGKILL");
+          try {
+            process.kill(-child.pid!, "SIGKILL");
+          } catch {
+            // Process group may have already exited.
+          }
         } else {
           context.signal.addEventListener("abort", onAbort, { once: true });
         }

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -204,20 +204,21 @@ class HostShellTool implements Tool {
         cwd: workingDir,
         env: hostEnv,
         stdio: ["ignore", "pipe", "pipe"],
+        detached: true,
       });
 
       const timer = setTimeout(() => {
         timedOut = true;
-        child.kill("SIGKILL");
+        process.kill(-child.pid!, "SIGKILL");
       }, timeoutMs);
 
       // Cooperative cancellation via AbortSignal
       const onAbort = () => {
-        child.kill("SIGKILL");
+        process.kill(-child.pid!, "SIGKILL");
       };
       if (context.signal) {
         if (context.signal.aborted) {
-          child.kill("SIGKILL");
+          process.kill(-child.pid!, "SIGKILL");
         } else {
           context.signal.addEventListener("abort", onAbort, { once: true });
         }

--- a/assistant/src/tools/skills/sandbox-runner.ts
+++ b/assistant/src/tools/skills/sandbox-runner.ts
@@ -159,20 +159,21 @@ function spawnRunner(
       cwd: runDir,
       env,
       stdio: ["ignore", "pipe", "pipe"],
+      detached: true,
     });
 
     const timer = setTimeout(() => {
       timedOut = true;
-      child.kill("SIGKILL");
+      process.kill(-child.pid!, "SIGKILL");
     }, timeoutMs);
 
     // Cooperative cancellation via AbortSignal
     const onAbort = () => {
-      child.kill("SIGKILL");
+      process.kill(-child.pid!, "SIGKILL");
     };
     if (context.signal) {
       if (context.signal.aborted) {
-        child.kill("SIGKILL");
+        process.kill(-child.pid!, "SIGKILL");
       } else {
         context.signal.addEventListener("abort", onAbort, { once: true });
       }

--- a/assistant/src/tools/skills/sandbox-runner.ts
+++ b/assistant/src/tools/skills/sandbox-runner.ts
@@ -164,16 +164,28 @@ function spawnRunner(
 
     const timer = setTimeout(() => {
       timedOut = true;
-      process.kill(-child.pid!, "SIGKILL");
+      try {
+        process.kill(-child.pid!, "SIGKILL");
+      } catch {
+        // Process group may have already exited.
+      }
     }, timeoutMs);
 
     // Cooperative cancellation via AbortSignal
     const onAbort = () => {
-      process.kill(-child.pid!, "SIGKILL");
+      try {
+        process.kill(-child.pid!, "SIGKILL");
+      } catch {
+        // Process group may have already exited.
+      }
     };
     if (context.signal) {
       if (context.signal.aborted) {
-        process.kill(-child.pid!, "SIGKILL");
+        try {
+          process.kill(-child.pid!, "SIGKILL");
+        } catch {
+          // Process group may have already exited.
+        }
       } else {
         context.signal.addEventListener("abort", onAbort, { once: true });
       }

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -329,20 +329,21 @@ class ShellTool implements Tool {
         cwd: context.workingDir,
         env,
         stdio: ["ignore", "pipe", "pipe"],
+        detached: true,
       });
 
       const timer = setTimeout(() => {
         timedOut = true;
-        child.kill("SIGKILL");
+        process.kill(-child.pid!, "SIGKILL");
       }, timeoutMs);
 
       // Cooperative cancellation via AbortSignal
       const onAbort = () => {
-        child.kill("SIGKILL");
+        process.kill(-child.pid!, "SIGKILL");
       };
       if (context.signal) {
         if (context.signal.aborted) {
-          child.kill("SIGKILL");
+          process.kill(-child.pid!, "SIGKILL");
         } else {
           context.signal.addEventListener("abort", onAbort, { once: true });
         }

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -334,16 +334,28 @@ class ShellTool implements Tool {
 
       const timer = setTimeout(() => {
         timedOut = true;
-        process.kill(-child.pid!, "SIGKILL");
+        try {
+          process.kill(-child.pid!, "SIGKILL");
+        } catch {
+          // Process group may have already exited.
+        }
       }, timeoutMs);
 
       // Cooperative cancellation via AbortSignal
       const onAbort = () => {
-        process.kill(-child.pid!, "SIGKILL");
+        try {
+          process.kill(-child.pid!, "SIGKILL");
+        } catch {
+          // Process group may have already exited.
+        }
       };
       if (context.signal) {
         if (context.signal.aborted) {
-          process.kill(-child.pid!, "SIGKILL");
+          try {
+            process.kill(-child.pid!, "SIGKILL");
+          } catch {
+            // Process group may have already exited.
+          }
         } else {
           context.signal.addEventListener("abort", onAbort, { once: true });
         }


### PR DESCRIPTION
## Summary
- Part of #21263
- Spawns tool child processes with `detached: true` to create a new process group via `setsid()`
- Replaces `child.kill("SIGKILL")` with `process.kill(-child.pid!, "SIGKILL")` to kill the entire process group, preventing grandchild process leaks on macOS

## Files modified
- `assistant/src/tools/terminal/shell.ts`
- `assistant/src/tools/host-terminal/host-shell.ts`
- `assistant/src/tools/skills/sandbox-runner.ts`
- `assistant/src/signals/bash.ts`

## Test plan
- [ ] Verify long-running shell commands with grandchild processes are cleaned up on abort/timeout
- [ ] Verify normal command execution still works (detached doesn't change behavior for awaited processes)
- [ ] On macOS: confirm sandbox-exec wrapper + bash + grandchildren all terminate
- [ ] On Linux: confirm bwrap still works (redundant but harmless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
