### PR TITLE
M4: Thread AbortSignal into MCP tool calls

### DIFF
--- a/assistant/src/__tests__/mcp-abort-signal.test.ts
+++ b/assistant/src/__tests__/mcp-abort-signal.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, jest, mock, test } from "bun:test";
+
+// Mock secure-keys so McpOAuthProvider doesn't try to access the credential store
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: jest.fn().mockResolvedValue(null),
+  setSecureKeyAsync: jest.fn().mockResolvedValue(true),
+  deleteSecureKeyAsync: jest.fn().mockResolvedValue("deleted"),
+}));
+
+const { McpClient } = await import("../mcp/client.js");
+const { McpServerManager } = await import("../mcp/manager.js");
+const { createMcpTool } = await import("../tools/mcp/mcp-tool-factory.js");
+
+describe("MCP AbortSignal threading", () => {
+  describe("McpClient.callTool", () => {
+    test("forwards signal to the SDK client.callTool options", async () => {
+      const client = new McpClient("test-server");
+
+      const callToolSpy = jest.fn().mockResolvedValue({
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      });
+
+      // Monkey-patch to mark as connected and capture callTool args
+      (client as any).connected = true;
+      (client as any).client = { callTool: callToolSpy };
+
+      const ac = new AbortController();
+      await client.callTool("my-tool", { foo: "bar" }, ac.signal);
+
+      expect(callToolSpy).toHaveBeenCalledTimes(1);
+      const [params, resultSchema, options] = callToolSpy.mock.calls[0];
+      expect(params).toEqual({ name: "my-tool", arguments: { foo: "bar" } });
+      expect(resultSchema).toBeUndefined();
+      expect(options).toEqual({ signal: ac.signal });
+    });
+
+    test("passes undefined signal cleanly (no regression)", async () => {
+      const client = new McpClient("test-server");
+
+      const callToolSpy = jest.fn().mockResolvedValue({
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      });
+
+      (client as any).connected = true;
+      (client as any).client = { callTool: callToolSpy };
+
+      await client.callTool("my-tool", { foo: "bar" });
+
+      expect(callToolSpy).toHaveBeenCalledTimes(1);
+      const [_params, _resultSchema, options] = callToolSpy.mock.calls[0];
+      expect(options).toEqual({ signal: undefined });
+    });
+
+    test("already-aborted signal causes the SDK call to reject", async () => {
+      const client = new McpClient("test-server");
+
+      const callToolSpy = jest
+        .fn()
+        .mockImplementation((_p: any, _r: any, opts: any) => {
+          if (opts?.signal?.aborted) {
+            return Promise.reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            );
+          }
+          return Promise.resolve({
+            content: [{ type: "text", text: "ok" }],
+            isError: false,
+          });
+        });
+
+      (client as any).connected = true;
+      (client as any).client = { callTool: callToolSpy };
+
+      const ac = new AbortController();
+      ac.abort();
+
+      await expect(client.callTool("my-tool", {}, ac.signal)).rejects.toThrow(
+        "The operation was aborted.",
+      );
+    });
+  });
+
+  describe("McpServerManager.callTool", () => {
+    test("forwards signal to the underlying McpClient.callTool", async () => {
+      const manager = new McpServerManager();
+
+      const callToolSpy = jest.fn().mockResolvedValue({
+        content: "result",
+        isError: false,
+      });
+
+      const fakeClient = { callTool: callToolSpy, serverId: "test-server" };
+      (manager as any).clients.set("test-server", fakeClient);
+
+      const ac = new AbortController();
+      await manager.callTool("test-server", "my-tool", { x: 1 }, ac.signal);
+
+      expect(callToolSpy).toHaveBeenCalledWith("my-tool", { x: 1 }, ac.signal);
+    });
+
+    test("passes undefined signal when not provided", async () => {
+      const manager = new McpServerManager();
+
+      const callToolSpy = jest.fn().mockResolvedValue({
+        content: "result",
+        isError: false,
+      });
+
+      const fakeClient = { callTool: callToolSpy, serverId: "test-server" };
+      (manager as any).clients.set("test-server", fakeClient);
+
+      await manager.callTool("test-server", "my-tool", { x: 1 });
+
+      expect(callToolSpy).toHaveBeenCalledWith("my-tool", { x: 1 }, undefined);
+    });
+  });
+
+  describe("createMcpTool execute", () => {
+    test("threads context.signal through manager.callTool", async () => {
+      const callToolSpy = jest.fn().mockResolvedValue({
+        content: "tool result",
+        isError: false,
+      });
+
+      const fakeManager = { callTool: callToolSpy } as any;
+
+      const tool = createMcpTool(
+        {
+          name: "my-tool",
+          description: "A test tool",
+          inputSchema: { type: "object", properties: {} },
+        },
+        "test-server",
+        {
+          transport: { type: "stdio", command: "echo", args: [] },
+          enabled: true,
+          defaultRiskLevel: "high",
+          maxTools: 100,
+        },
+        fakeManager,
+      );
+
+      const ac = new AbortController();
+      await tool.execute(
+        { someArg: "value" },
+        {
+          workingDir: "/tmp",
+          conversationId: "conv-1",
+          signal: ac.signal,
+          trustClass: "guardian",
+        },
+      );
+
+      expect(callToolSpy).toHaveBeenCalledWith(
+        "test-server",
+        "my-tool",
+        { someArg: "value" },
+        ac.signal,
+      );
+    });
+
+    test("passes undefined signal when context has no signal", async () => {
+      const callToolSpy = jest.fn().mockResolvedValue({
+        content: "tool result",
+        isError: false,
+      });
+
+      const fakeManager = { callTool: callToolSpy } as any;
+
+      const tool = createMcpTool(
+        {
+          name: "my-tool",
+          description: "A test tool",
+          inputSchema: { type: "object", properties: {} },
+        },
+        "test-server",
+        {
+          transport: { type: "stdio", command: "echo", args: [] },
+          enabled: true,
+          defaultRiskLevel: "high",
+          maxTools: 100,
+        },
+        fakeManager,
+      );
+
+      await tool.execute(
+        { someArg: "value" },
+        {
+          workingDir: "/tmp",
+          conversationId: "conv-1",
+          trustClass: "guardian",
+        },
+      );
+
+      expect(callToolSpy).toHaveBeenCalledWith(
+        "test-server",
+        "my-tool",
+        { someArg: "value" },
+        undefined,
+      );
+    });
+  });
+});

--- a/assistant/src/mcp/client.ts
+++ b/assistant/src/mcp/client.ts
@@ -159,12 +159,17 @@ export class McpClient {
   async callTool(
     name: string,
     args: Record<string, unknown>,
+    signal?: AbortSignal,
   ): Promise<McpCallResult> {
     if (!this.connected) {
       throw new Error(`MCP client "${this.serverId}" is not connected`);
     }
 
-    const result = await this.client.callTool({ name, arguments: args });
+    const result = await this.client.callTool(
+      { name, arguments: args },
+      undefined,
+      { signal },
+    );
     const isError = result.isError === true;
 
     // Handle structuredContent if present

--- a/assistant/src/mcp/manager.ts
+++ b/assistant/src/mcp/manager.ts
@@ -127,12 +127,13 @@ export class McpServerManager {
     serverId: string,
     toolName: string,
     args: Record<string, unknown>,
+    signal?: AbortSignal,
   ) {
     const client = this.clients.get(serverId);
     if (!client) {
       throw new Error(`MCP server "${serverId}" not found`);
     }
-    return client.callTool(toolName, args);
+    return client.callTool(toolName, args, signal);
   }
 
   getClient(serverId: string): McpClient | undefined {

--- a/assistant/src/tools/mcp/mcp-tool-factory.ts
+++ b/assistant/src/tools/mcp/mcp-tool-factory.ts
@@ -62,7 +62,7 @@ export function createMcpTool(
 
     async execute(
       input: Record<string, unknown>,
-      _context: ToolContext,
+      context: ToolContext,
     ): Promise<ToolExecutionResult> {
       try {
         // Strip injected activity before sending to MCP server
@@ -77,6 +77,7 @@ export function createMcpTool(
           serverId,
           metadata.name,
           forwardInput,
+          context.signal,
         );
         return {
           content: result.content,


### PR DESCRIPTION
## Summary
- Part of #21263
- Threads `context.signal` (AbortSignal) through the entire MCP tool call chain: `mcp-tool-factory` → `McpServerManager` → `McpClient` → MCP SDK's `client.callTool()`
- Enables cooperative cancellation of in-flight MCP tool calls when the user presses stop

## Changes
- **`assistant/src/tools/mcp/mcp-tool-factory.ts`**: Changed `_context` to `context` and passes `context.signal` to `manager.callTool()`
- **`assistant/src/mcp/manager.ts`**: Added optional `signal?: AbortSignal` parameter to `callTool()`, forwarded to `client.callTool()`
- **`assistant/src/mcp/client.ts`**: Added optional `signal?: AbortSignal` parameter to `callTool()`, passed to SDK's `client.callTool()` as `options.signal`
- **`assistant/src/__tests__/mcp-abort-signal.test.ts`**: New test file with 7 tests verifying signal threading through all layers

## Test plan
- [x] Signal is passed through factory → manager → client → SDK
- [x] Already-aborted signal causes the call to reject with AbortError
- [x] Undefined signal passes through cleanly (no regression)
- [x] Existing MCP tests still pass (mcp-client-auth, mcp-health-check, mcp-cli)
- [x] TypeScript type-check passes with no errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
