### PR TITLE
fix: open URLs in new browser tab instead of replacing active tab

### DIFF
--- a/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
+++ b/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
@@ -40,13 +40,13 @@ host_bash:
     BROWSER=$(plutil -convert json -o - ~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist 2>/dev/null | python3 -c "import json,sys;[print(h.get('LSHandlerRoleAll','')) for h in json.load(sys.stdin).get('LSHandlers',[]) if h.get('LSHandlerURLScheme')=='https']" 2>/dev/null)
     case "$BROWSER" in
       com.google.chrome)
-        osascript -e "tell application \"Google Chrome\" to set URL of active tab of front window to \"$URL\"" 2>/dev/null || open "$URL" ;;
+        osascript -e "tell application \"Google Chrome\" to tell front window to make new tab with properties {URL:\"$URL\"}" 2>/dev/null || open "$URL" ;;
       com.apple.safari)
-        osascript -e "tell application \"Safari\" to set URL of current tab of front window to \"$URL\"" 2>/dev/null || open "$URL" ;;
+        osascript -e "tell application \"Safari\" to tell front window to set current tab to (make new tab with properties {URL:\"$URL\"})" 2>/dev/null || open "$URL" ;;
       company.thebrowser.Browser)
-        osascript -e "tell application \"Arc\" to set URL of active tab of front window to \"$URL\"" 2>/dev/null || open "$URL" ;;
+        osascript -e "tell application \"Arc\" to tell front window to make new tab with properties {URL:\"$URL\"}" 2>/dev/null || open "$URL" ;;
       com.brave.Browser)
-        osascript -e "tell application \"Brave Browser\" to set URL of active tab of front window to \"$URL\"" 2>/dev/null || open "$URL" ;;
+        osascript -e "tell application \"Brave Browser\" to tell front window to make new tab with properties {URL:\"$URL\"}" 2>/dev/null || open "$URL" ;;
       *)
         open "$URL" ;;
     esac
@@ -62,7 +62,7 @@ host_bash:
   command: /tmp/vellum-nav.sh "TARGET_URL"
 ```
 
-The helper detects the default browser and navigates in the existing tab. Falls back to opening a new tab when no window exists.
+The helper detects the default browser and opens a new tab in the existing window. Falls back to opening a new tab when no window exists.
 
 ### Rules
 


### PR DESCRIPTION
## Summary
- Changed the collaborative guided flow navigation helper to open URLs in a **new tab** instead of replacing the active tab
- During dogfooding, the old behavior dropped a user from their meeting when the wizard navigated in their current tab
- Updated AppleScript commands for Chrome, Safari, Arc, and Brave to use `make new tab` instead of `set URL of active tab`

Part of LUM-419
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
