### PR TITLE
fix: remove rigid scope category assertions from OAuth setup instructions

### DIFF
--- a/skills/google-oauth-applescript/SKILL.md
+++ b/skills/google-oauth-applescript/SKILL.md
@@ -135,11 +135,17 @@ host_bash:
 > 1. Click **Add or Remove Scopes** → scroll to **"Manually add scopes"** → **paste** (Cmd+V) → click **Update**
 > 2. Back on the main page, scroll down and click **Save**
 >
-> You should see:
+> You should see all 7 scopes listed across the three categories (Non-sensitive, Sensitive, Restricted):
 >
-> - **Non-sensitive:** `userinfo.email`, `contacts.readonly`
-> - **Sensitive:** `calendar.readonly`, `calendar.events`, `gmail.send`
-> - **Restricted:** `gmail.modify`, `gmail.readonly`
+> - `userinfo.email`
+> - `contacts.readonly`
+> - `calendar.readonly`
+> - `calendar.events`
+> - `gmail.send`
+> - `gmail.modify`
+> - `gmail.readonly`
+>
+> **Note:** GCP may categorize these scopes differently than you'd expect — that's fine, as long as all 7 are present.
 >
 > **Quick note:** The `gmail.modify` and `gmail.send` scopes are what allow me to draft and send emails on your behalf. If you'd rather I only have read access to your email for now, you can uncheck those two - everything else will still work fine, and you can always come back and add them later.
 


### PR DESCRIPTION
## Summary
- Updated the Google OAuth skill instructions to not assert exact scope-to-category mappings
- GCP may categorize scopes differently than expected (user saw 4 sensitive vs our listed 3)
- Now tells users to verify all 7 scopes are present, noting categories may vary

Part of LUM-419

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
