### PR TITLE
fix: use assistant name in session overlay placeholder text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Session/SessionOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/SessionOverlayWindow.swift
@@ -545,7 +545,8 @@ final class SessionOverlayWindow {
         hstack.translatesAutoresizingMaskIntoConstraints = false
 
         let field = NSTextField()
-        field.placeholderString = "Steer the agent..."
+        let assistantName = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? "the assistant"
+        field.placeholderString = "Steer \(assistantName)..."
         field.font = NSFont.systemFont(ofSize: 13)
         field.textColor = NSColor(VColor.contentDefault)
         field.backgroundColor = NSColor(VColor.surfaceActive)


### PR DESCRIPTION
## Summary
- Changed "Steer the agent..." placeholder in the session overlay to use the assistant's actual name from UserDefaults
- Falls back to "Steer the assistant..." when no name is available
- Consistent with how other parts of the UI reference the assistant by name

Part of LUM-419

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
