### PR TITLE
fix: correct client secret retrieval instructions in OAuth setup

### DIFF
--- a/skills/google-oauth-applescript/SKILL.md
+++ b/skills/google-oauth-applescript/SKILL.md
@@ -155,7 +155,7 @@ Open: `https://console.cloud.google.com/auth/clients/create?project=PROJECT_ID`
 
 A modal should appear with the **Client ID** and **Client Secret**. Tell the user to keep it open.
 
-> **Heads up:** Google sometimes has a slight delay, so the modal may only show your Client ID without the Client Secret. If that happens, don't worry - click the **Download JSON** button (downward arrow icon) on the modal. Open the downloaded file and you'll find your `client_secret` in there. It's a little annoying, but it works every time.
+> **Heads up:** Google sometimes has a slight delay, so the modal may only show your Client ID without the Client Secret. If that happens, don't worry - close the modal and navigate to `https://console.cloud.google.com/auth/clients?project=PROJECT_ID`. Click on the client you just created (look for the name you used, e.g. "Vellum Assistant"). Under **Client secrets**, find the row with a copy button, click it, and paste the secret into the secure credential input when prompted.
 
 ---
 


### PR DESCRIPTION
## Summary
- Replaced broken "Download JSON" fallback instructions with the correct path to copy client secret
- The JSON download button on GCP's OAuth client modal doesn't work
- New instructions: go to clients list → click on client → copy secret from Client secrets section

Part of LUM-419
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
