### PR TITLE
fix: improve OAuth authorization URL presentation in CLI output

### DIFF
--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -707,7 +707,7 @@ Examples:
               });
             } else {
               process.stdout.write(
-                `Open this URL to authorize:\n\n${result.authUrl}\n\nThe connection will complete automatically once you authorize.\n`,
+                `\n**Authorize with ${resolvedServiceKey}**\n\n[Click here to authorize](${result.authUrl})\n\nThe connection will complete automatically once you authorize.\n`,
               );
             }
             return;


### PR DESCRIPTION
## Summary
- Improved the plain text output of `assistant oauth connections connect` when in deferred mode
- The authorization URL is now presented with markdown-style formatting and a friendly label that includes the service name
- Previously showed a raw URL buried in tool output; now formatted as a clickable markdown link with a bold header

Part of LUM-419

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
