### PR TITLE
refactor: remove ObservableObject conformance from non-observable classes

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -11,7 +11,7 @@ import os
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AppDelegate")
 
 @MainActor
-public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
+public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// The canonical product name shown in menus and the About panel.
     /// Use this instead of hardcoding "Vellum" so the name is defined
     /// in one place.

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -3,7 +3,7 @@ import MetricKit
 import os
 @preconcurrency import Sentry
 
-@MainActor final class MetricKitManager: NSObject, ObservableObject {
+@MainActor final class MetricKitManager: NSObject {
     private let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant",
         category: "MetricKit"


### PR DESCRIPTION
## Summary
- Removes ObservableObject from MetricKitManager and AppDelegate (zero @Published properties, never observed)

Part of plan: macos15-modernization.md (PR 2 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
