### PR TITLE
refactor: migrate NavigationHistory to @Observable and update MainWindowState forwarding

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -1,4 +1,5 @@
 import Combine
+import Observation
 import SwiftUI
 import VellumAssistantShared
 
@@ -20,9 +21,9 @@ public final class MainWindowState: ObservableObject {
     /// The single source of truth for what the main content area displays.
     let navigationHistory = NavigationHistory()
 
-    /// Forwards `navigationHistory.objectWillChange` so SwiftUI views
+    /// Bridges `@Observable` NavigationHistory changes into this
+    /// `ObservableObject`'s `objectWillChange` publisher so SwiftUI views
     /// observing this state also update when back/forward stacks change.
-    private var navigationHistoryCancellable: AnyCancellable?
 
     /// Tracks the last known selection for navigation history recording.
     /// Captured at the start of `didSet` (before any side effects) to avoid
@@ -136,8 +137,19 @@ public final class MainWindowState: ObservableObject {
 
     init() {
         self.layoutConfig = LayoutConfigStore.load()
-        self.navigationHistoryCancellable = navigationHistory.objectWillChange
-            .sink { [weak self] _ in self?.objectWillChange.send() }
+        observeNavigationHistory()
+    }
+
+    private func observeNavigationHistory() {
+        withObservationTracking {
+            _ = navigationHistory.backStack
+            _ = navigationHistory.forwardStack
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.objectWillChange.send()
+                self?.observeNavigationHistory() // re-arm
+            }
+        }
     }
 
     // MARK: - Selection Helpers

--- a/clients/macos/vellum-assistant/Features/MainWindow/NavigationHistory.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/NavigationHistory.swift
@@ -1,9 +1,11 @@
 import Foundation
+import Observation
 
 /// Manages back/forward navigation stacks for the main window,
 /// allowing users to retrace their steps through view selections.
 @MainActor
-final class NavigationHistory: ObservableObject {
+@Observable
+final class NavigationHistory {
 
     enum HistoryEntry: Equatable {
         case selection(ViewSelection)
@@ -30,8 +32,8 @@ final class NavigationHistory: ObservableObject {
         }
     }
 
-    @Published private(set) var backStack: [HistoryEntry] = []
-    @Published private(set) var forwardStack: [HistoryEntry] = []
+    private(set) var backStack: [HistoryEntry] = []
+    private(set) var forwardStack: [HistoryEntry] = []
 
     let maxDepth: Int = 50
 


### PR DESCRIPTION
## Summary
- Migrates NavigationHistory to @Observable
- Replaces Combine objectWillChange subscription with withObservationTracking bridge in MainWindowState

Part of plan: macos15-modernization.md (PR 5 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
