### PR TITLE
refactor: replace .foregroundColor() with .foregroundStyle() in Design System

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/VCodeView.swift
+++ b/clients/shared/DesignSystem/Components/Display/VCodeView.swift
@@ -486,24 +486,24 @@ public struct VCodeSearchBar: View {
         VStack(spacing: 0) {
             HStack(spacing: VSpacing.sm) {
                 VIconView(.search, size: 12)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
 
                 TextField("Search...", text: $searchQuery)
                     .textFieldStyle(.plain)
                     .font(VFont.bodyMediumDefault)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
                     .focused($isFocused)
                     .onSubmit { goToNextMatch() }
 
                 if !searchQuery.isEmpty {
                     Text(matchCount > 0 ? "\(currentMatchIndex + 1) of \(matchCount)" : "No results")
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                         .fixedSize()
 
                     Button(action: goToPreviousMatch) {
                         VIconView(.chevronUp, size: 12)
-                            .foregroundColor(matchCount > 0 ? VColor.contentDefault : VColor.contentTertiary)
+                            .foregroundStyle(matchCount > 0 ? VColor.contentDefault : VColor.contentTertiary)
                     }
                     .buttonStyle(.plain)
                     .disabled(matchCount == 0)
@@ -511,7 +511,7 @@ public struct VCodeSearchBar: View {
 
                     Button(action: goToNextMatch) {
                         VIconView(.chevronDown, size: 12)
-                            .foregroundColor(matchCount > 0 ? VColor.contentDefault : VColor.contentTertiary)
+                            .foregroundStyle(matchCount > 0 ? VColor.contentDefault : VColor.contentTertiary)
                     }
                     .buttonStyle(.plain)
                     .disabled(matchCount == 0)
@@ -520,7 +520,7 @@ public struct VCodeSearchBar: View {
 
                 Button(action: onDismiss) {
                     VIconView(.x, size: 12)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Close search")

--- a/clients/shared/DesignSystem/Components/Display/VDiffView.swift
+++ b/clients/shared/DesignSystem/Components/Display/VDiffView.swift
@@ -70,7 +70,7 @@ public struct VDiffView: View {
         return HStack(spacing: 0) {
             Text(line.isEmpty ? " " : String(line))
                 .font(VFont.bodySmallDefault)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
                 .fixedSize(horizontal: true, vertical: true)
             Spacer(minLength: 0)
         }

--- a/clients/shared/DesignSystem/Components/Display/VEmptyState.swift
+++ b/clients/shared/DesignSystem/Components/Display/VEmptyState.swift
@@ -28,15 +28,15 @@ public struct VEmptyState: View {
         VStack(spacing: VSpacing.lg) {
             if let icon = icon {
                 VIconView(.resolve(icon), size: 48)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
             }
             Text(title)
                 .font(VFont.bodyMediumDefault)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
             if let subtitle = subtitle {
                 Text(subtitle)
                     .font(VFont.bodyMediumLighter)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
             }
             if let actionLabel, let action {
                 VButton(

--- a/clients/shared/DesignSystem/Components/Layout/VModal.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VModal.swift
@@ -65,7 +65,7 @@ public struct VModal<Content: View, Footer: View>: View {
                             Text("Back")
                                 .font(VFont.bodyMediumDefault)
                         }
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                         .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
@@ -80,7 +80,7 @@ public struct VModal<Content: View, Footer: View>: View {
                 if let closeAction {
                     Button(action: closeAction) {
                         VIconView(.x, size: 12)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                             .frame(width: 32, height: 32)
                             .contentShape(Rectangle())
                     }
@@ -123,12 +123,12 @@ public struct VModal<Content: View, Footer: View>: View {
             if !title.isEmpty {
                 Text(title)
                     .font(VFont.titleSmall)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
             }
             if let subtitle {
                 Text(subtitle)
                     .font(VFont.bodyMediumLighter)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
             }
         }
     }

--- a/clients/shared/DesignSystem/Components/Layout/VSidePanel.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSidePanel.swift
@@ -25,7 +25,7 @@ public struct VSidePanel<PinnedContent: View, Content: View>: View {
             HStack {
                 Text(uppercased ? title.uppercased() : title)
                     .font(titleFont)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
                 Spacer()
                 if let onClose = onClose {
                     VButton(label: "Close", iconOnly: "xmark", style: .ghost, action: onClose)

--- a/clients/shared/DesignSystem/Components/Navigation/VSegmentedControl.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VSegmentedControl.swift
@@ -50,7 +50,7 @@ public struct VSegmentedControl<SelectionValue: Hashable>: View {
                     VStack(spacing: VSpacing.xs) {
                         Text(item.label)
                             .font(VFont.labelDefault)
-                            .foregroundColor(selection == item.tag ? VColor.contentDefault : VColor.contentTertiary)
+                            .foregroundStyle(selection == item.tag ? VColor.contentDefault : VColor.contentTertiary)
                             .padding(.horizontal, VSpacing.xl)
                             .padding(.vertical, VSpacing.xs)
 
@@ -123,12 +123,12 @@ private struct PillSegment: View {
             Group {
                 if let icon {
                     VIconView(.resolve(icon), size: size == .compact ? 10 : 12)
-                        .foregroundColor(isSelected ? VColor.contentDefault : VColor.contentTertiary)
+                        .foregroundStyle(isSelected ? VColor.contentDefault : VColor.contentTertiary)
                 } else {
                     Text(label)
                         .font(size == .compact ? VFont.labelDefault : VFont.bodyMediumLighter)
                         .fixedSize()
-                        .foregroundColor(isSelected ? selectedTextColor : VColor.contentSecondary)
+                        .foregroundStyle(isSelected ? selectedTextColor : VColor.contentSecondary)
                 }
             }
             .padding(.horizontal, icon != nil ? VSpacing.sm : (size == .compact ? VSpacing.sm : VSpacing.lg))

--- a/clients/shared/DesignSystem/Components/Navigation/VThemeToggle.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VThemeToggle.swift
@@ -34,7 +34,7 @@ public struct VThemeToggle: View {
             if showLabel {
                 Text("Theme")
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentDisabled)
+                    .foregroundStyle(VColor.contentDisabled)
                 Spacer()
             }
             segmentedControl

--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -46,7 +46,7 @@ public struct VButton: View {
                     VIconView(.resolve(iconOnly), size: size == .inline ? 10 : 13)
                         .frame(width: size == .inline ? 12 : 20, height: size == .inline ? 12 : 20)
                 }
-                .foregroundColor(iconColor ?? iconOnlyForegroundColor)
+                .foregroundStyle(iconColor ?? iconOnlyForegroundColor)
             } else {
                 HStack(spacing: 6) {
                     if let leftIcon {
@@ -135,7 +135,7 @@ public struct VButtonStyle: ButtonStyle {
         let shape = RoundedRectangle(cornerRadius: cornerRadius)
 
         configuration.label
-            .foregroundColor(foregroundColor)
+            .foregroundStyle(foregroundColor)
             .modifier(ButtonLayoutModifier(
                 style: style,
                 size: size,

--- a/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
@@ -52,7 +52,7 @@ public struct VSplitButton<MenuContent: View>: View {
                     Text(label)
                         .font(size == .regular ? VFont.bodyMediumDefault : VFont.labelDefault)
                 }
-                .foregroundColor(foregroundColor)
+                .foregroundStyle(foregroundColor)
                 .padding(.horizontal, size == .regular ? VSpacing.md : VSpacing.sm)
                 .frame(height: zoneHeight)
                 .background(zoneBackgroundColor(isHovered: isPrimaryHovered))
@@ -73,7 +73,7 @@ public struct VSplitButton<MenuContent: View>: View {
                     .frame(width: dropdownWidth, height: zoneHeight)
 
                 VIconView(.chevronDown, size: 11)
-                    .foregroundColor(foregroundColor)
+                    .foregroundStyle(foregroundColor)
                     .frame(width: dropdownWidth, height: zoneHeight)
                     .allowsHitTesting(false)
 

--- a/clients/shared/DesignSystem/Core/Display/VDisclosureSection.swift
+++ b/clients/shared/DesignSystem/Core/Display/VDisclosureSection.swift
@@ -43,18 +43,18 @@ public struct VDisclosureSection<Content: View>: View {
                 HStack(spacing: VSpacing.sm) {
                     if let icon {
                         VIconView(.resolve(icon), size: 14)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                             .frame(width: 20)
                     }
 
                     VStack(alignment: .leading, spacing: VSpacing.xxs) {
                         Text(title)
                             .font(VFont.bodyMediumEmphasised)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
                         if let subtitle {
                             Text(subtitle)
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                                 .lineLimit(1)
                                 .truncationMode(.middle)
                         }
@@ -63,7 +63,7 @@ public struct VDisclosureSection<Content: View>: View {
                     Spacer()
 
                     VIconView(.chevronRight, size: 10)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                         .rotationEffect(.degrees(isExpanded ? 90 : 0))
                         .animation(VAnimation.fast, value: isExpanded)
                 }

--- a/clients/shared/DesignSystem/Core/Feedback/VBadge.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VBadge.swift
@@ -52,7 +52,7 @@ public struct VBadge: View {
         case .count(let count):
             Text("\(count)")
                 .font(VFont.labelDefault)
-                .foregroundColor(VColor.auxWhite)
+                .foregroundStyle(VColor.auxWhite)
                 .padding(.horizontal, VSpacing.sm)
                 .padding(.vertical, VSpacing.xxs)
                 .background(color)
@@ -67,7 +67,7 @@ public struct VBadge: View {
         case .label(let text):
             Text(text)
                 .font(VFont.labelDefault)
-                .foregroundColor(labelForegroundColor)
+                .foregroundStyle(labelForegroundColor)
                 .padding(.horizontal, VSpacing.sm)
                 .padding(.vertical, labelVerticalPadding)
                 .background(labelBackgroundColor)

--- a/clients/shared/DesignSystem/Core/Feedback/VInfoTooltip.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VInfoTooltip.swift
@@ -23,7 +23,7 @@ public struct VInfoTooltip: View {
 
     public var body: some View {
         VIconView(.info, size: 12)
-            .foregroundColor(VColor.contentTertiary)
+            .foregroundStyle(VColor.contentTertiary)
             .frame(width: 16, height: 16)
             .contentShape(Rectangle())
             .help(tooltip)

--- a/clients/shared/DesignSystem/Core/Feedback/VInlineMessage.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VInlineMessage.swift
@@ -20,13 +20,13 @@ public struct VInlineMessage: View {
     public var body: some View {
         HStack(alignment: .top, spacing: VSpacing.xs) {
             VIconView(icon, size: 12)
-                .foregroundColor(foregroundColor)
+                .foregroundStyle(foregroundColor)
                 .padding(.top, 1)
                 .accessibilityHidden(true)
 
             Text(message)
                 .font(VFont.labelDefault)
-                .foregroundColor(foregroundColor)
+                .foregroundStyle(foregroundColor)
                 .fixedSize(horizontal: false, vertical: true)
         }
         .padding(.horizontal, VSpacing.sm)

--- a/clients/shared/DesignSystem/Core/Feedback/VShortcutTag.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VShortcutTag.swift
@@ -25,7 +25,7 @@ public struct VShortcutTag: View {
             Text(text)
                 .font(VFont.labelDefault)
         }
-        .foregroundColor(tagColor)
+        .foregroundStyle(tagColor)
         .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.xs)
         .background(

--- a/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
@@ -83,7 +83,7 @@ public struct VSkillTypePill: View {
             Text(type.label)
                 .font(VFont.labelDefault)
         }
-        .foregroundColor(type.foregroundColor)
+        .foregroundStyle(type.foregroundColor)
         .padding(.horizontal, VSpacing.md)
         .padding(.vertical, VSpacing.xs)
         .background(

--- a/clients/shared/DesignSystem/Core/Feedback/VTag.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VTag.swift
@@ -22,11 +22,11 @@ public struct VTag: View {
         HStack(spacing: VSpacing.xs) {
             if let icon {
                 VIconView(icon, size: 12)
-                    .foregroundColor(color)
+                    .foregroundStyle(color)
             }
             Text(label)
                 .font(VFont.bodySmallEmphasised)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
         }
         .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.xs)

--- a/clients/shared/DesignSystem/Core/Feedback/VToast.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VToast.swift
@@ -47,10 +47,10 @@ public struct VToast: View {
     public var body: some View {
         HStack(spacing: VSpacing.md) {
             VIconView(vIcon, size: 14)
-                .foregroundColor(iconColor)
+                .foregroundStyle(iconColor)
             Text(message)
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
                 .lineLimit(3)
 
             Spacer(minLength: 0)
@@ -74,7 +74,7 @@ public struct VToast: View {
                             }
                         } label: {
                             VIconView(showCopied ? .check : .copy, size: 12)
-                                .foregroundColor(showCopied ? VColor.systemPositiveStrong : VColor.contentSecondary)
+                                .foregroundStyle(showCopied ? VColor.systemPositiveStrong : VColor.contentSecondary)
                                 .frame(width: 24, height: 24)
                         }
                         .buttonStyle(.plain)
@@ -90,7 +90,7 @@ public struct VToast: View {
                     if let onDismiss {
                         Button(action: onDismiss) {
                             VIconView(.x, size: 12)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                                 .frame(width: 24, height: 24)
                         }
                         .buttonStyle(.plain)

--- a/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
@@ -62,7 +62,7 @@ public struct VDropdown<T: Hashable>: View {
             if let label {
                 Text(label)
                     .font(VFont.bodySmallDefault)
-                    .foregroundColor(isEnabled ? VColor.contentSecondary : VColor.contentDisabled)
+                    .foregroundStyle(isEnabled ? VColor.contentSecondary : VColor.contentDisabled)
                     .accessibilityHidden(true)
             }
 
@@ -88,16 +88,16 @@ public struct VDropdown<T: Hashable>: View {
                     HStack(spacing: size == .small ? VSpacing.xs : VSpacing.sm) {
                         if let resolvedIcon = icon ?? optionIcon?(selection) {
                             VIconView(resolvedIcon, size: size.iconSize)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                         }
 
                         Group {
                             if let selectedLabel {
                                 Text(selectedLabel)
-                                    .foregroundColor(VColor.contentDefault)
+                                    .foregroundStyle(VColor.contentDefault)
                             } else {
                                 Text(placeholder)
-                                    .foregroundColor(VColor.contentTertiary)
+                                    .foregroundStyle(VColor.contentTertiary)
                             }
                         }
                         .font(size.font)
@@ -105,7 +105,7 @@ public struct VDropdown<T: Hashable>: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                     VIconView(.chevronDown, size: size.iconSize)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                         .accessibilityHidden(true)
                 }
                 .padding(.horizontal, size.horizontalPadding)
@@ -124,7 +124,7 @@ public struct VDropdown<T: Hashable>: View {
             if let errorMessage {
                 Text(errorMessage)
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.systemNegativeStrong)
+                    .foregroundStyle(VColor.systemNegativeStrong)
                     .accessibilityHidden(true)
             }
         }

--- a/clients/shared/DesignSystem/Core/Inputs/VSearchBar.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VSearchBar.swift
@@ -13,18 +13,18 @@ public struct VSearchBar: View {
     public var body: some View {
         HStack(spacing: VSpacing.md) {
             VIconView(.search, size: 12)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
 
             TextField(placeholder, text: $text)
                 .textFieldStyle(.plain)
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
                 .focused($isFocused)
 
             if !text.isEmpty {
                 Button(action: { text = "" }) {
                     VIconView(.circleX, size: 12)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Clear search")

--- a/clients/shared/DesignSystem/Core/Inputs/VTextEditor.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VTextEditor.swift
@@ -23,7 +23,7 @@ public struct VTextEditor: View {
             .lineLimit(1...100)
             .textFieldStyle(.plain)
             .font(VFont.bodyMediumLighter)
-            .foregroundColor(VColor.contentDefault)
+            .foregroundStyle(VColor.contentDefault)
             .focused($isFocused)
             .frame(minHeight: minHeight, maxHeight: maxHeight, alignment: .topLeading)
             .padding(.horizontal, VSpacing.md)

--- a/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
@@ -201,14 +201,14 @@ public struct VTextField: View {
             if let label {
                 Text(label)
                     .font(VFont.bodySmallDefault)
-                    .foregroundColor(isEnabled ? VColor.contentSecondary : VColor.contentDisabled)
+                    .foregroundStyle(isEnabled ? VColor.contentSecondary : VColor.contentDisabled)
                     .accessibilityHidden(true)
             }
 
             HStack(spacing: size.horizontalPadding) {
                 if let leadingIcon {
                     VIconView(.resolve(leadingIcon), size: size.iconSize)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                         .accessibilityHidden(true)
                 }
 
@@ -216,7 +216,7 @@ public struct VTextField: View {
 
                 if let trailingIcon {
                     VIconView(.resolve(trailingIcon), size: size.iconSize)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                         .accessibilityHidden(true)
                 }
             }
@@ -228,7 +228,7 @@ public struct VTextField: View {
             if let errorMessage {
                 Text(errorMessage)
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.systemNegativeStrong)
+                    .foregroundStyle(VColor.systemNegativeStrong)
                     .accessibilityHidden(true)
             }
         }
@@ -242,13 +242,13 @@ public struct VTextField: View {
                 SecureField(placeholder, text: $text)
                     .textFieldStyle(.plain)
                     .font(font)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
                     .onSubmit { onSubmit?() }
             } else {
                 TextField(placeholder, text: $text)
                     .textFieldStyle(.plain)
                     .font(font)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
                     .onSubmit { onSubmit?() }
             }
         }

--- a/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
@@ -55,12 +55,12 @@ public struct VToggle: View {
                     if let label {
                         Text(label)
                             .font(VFont.bodyMediumDefault)
-                            .foregroundColor(isEnabled ? VColor.contentDefault : VColor.contentDisabled)
+                            .foregroundStyle(isEnabled ? VColor.contentDefault : VColor.contentDisabled)
                     }
                     if let helperText {
                         Text(helperText)
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                     }
                 }
             }

--- a/clients/shared/DesignSystem/Core/Navigation/VSidebarRow.swift
+++ b/clients/shared/DesignSystem/Core/Navigation/VSidebarRow.swift
@@ -13,7 +13,7 @@ import SwiftUI
 ///
 /// // With trailing content:
 /// VSidebarRow(label: "Identity", isActive: true, action: { }) {
-///     Text("5").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+///     Text("5").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
 /// }
 /// ```
 public struct VSidebarRow<Trailing: View>: View {
@@ -60,12 +60,12 @@ public struct VSidebarRow<Trailing: View>: View {
         HStack(spacing: isExpanded ? VSpacing.xs : 0) {
             if let icon {
                 VIconView(.resolve(icon), size: 13)
-                    .foregroundColor(iconColor)
+                    .foregroundStyle(iconColor)
                     .frame(width: Self.iconSlotSize, height: Self.iconSlotSize)
             }
             Text(label)
                 .font(VFont.bodyMediumDefault)
-                .foregroundColor(textColor)
+                .foregroundStyle(textColor)
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .frame(width: isExpanded ? nil : 0, alignment: .leading)

--- a/clients/shared/DesignSystem/Core/Navigation/VTab.swift
+++ b/clients/shared/DesignSystem/Core/Navigation/VTab.swift
@@ -54,7 +54,7 @@ public struct VTab: View {
                     Spacer().frame(width: 16)
                 }
             }
-            .foregroundColor(isSelected && (style == .pill || style == .rectangular) ? VColor.contentDefault : (isSelected ? VColor.contentDefault : VColor.contentSecondary))
+            .foregroundStyle(isSelected && (style == .pill || style == .rectangular) ? VColor.contentDefault : (isSelected ? VColor.contentDefault : VColor.contentSecondary))
             .padding(.horizontal, VSpacing.lg)
             .frame(height: 32)
             .contentShape(RoundedRectangle(cornerRadius: cornerRadius))
@@ -64,7 +64,7 @@ public struct VTab: View {
             if isCloseable, let onClose = onClose {
                 Button(action: onClose) {
                     VIconView(.x, size: 10)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Close \(label)")

--- a/clients/shared/DesignSystem/Gallery/Sections/AppIconGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/AppIconGallerySection.swift
@@ -20,13 +20,13 @@ struct AppIconGallerySection: View {
                         let icon = VAppIconGenerator.generate(from: app)
                         VStack(spacing: VSpacing.sm) {
                             VIconView(icon, size: 28)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                                 .frame(width: 64, height: 64)
                                 .background(VColor.surfaceBase)
                                 .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
                             Text(app)
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                         }
                     }
                 }

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -73,7 +73,7 @@ struct ButtonsGallerySection: View {
                 // All Variants grid
                 Text("All Variants")
                     .font(VFont.bodySmallEmphasised)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
 
                 VCard {
                     HStack(spacing: VSpacing.xl) {
@@ -115,24 +115,24 @@ struct ButtonsGallerySection: View {
                 // Ghost states
                 Text("Ghost States")
                     .font(VFont.bodySmallEmphasised)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
 
                 VCard {
                     HStack(spacing: VSpacing.xl) {
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("Default").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Default").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VButton(label: "Edit", iconOnly: VIcon.pencil.rawValue, style: .ghost) {}
                         }
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("Active").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Active").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VButton(label: "Edit", iconOnly: VIcon.pencil.rawValue, style: .ghost, isActive: true) {}
                         }
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("Disabled").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Disabled").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VButton(label: "Edit", iconOnly: VIcon.pencil.rawValue, style: .ghost, isDisabled: true) {}
                         }
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("Active + Disabled").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Active + Disabled").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VButton(label: "Edit", iconOnly: VIcon.pencil.rawValue, style: .ghost, isDisabled: true, isActive: true) {}
                         }
                     }
@@ -149,15 +149,15 @@ struct ButtonsGallerySection: View {
                 VCard {
                     HStack(spacing: VSpacing.xl) {
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("Primary").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Primary").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VButton(label: "More", iconOnly: VIcon.ellipsis.rawValue, style: .primary) {}
                         }
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("Danger").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Danger").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .danger) {}
                         }
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("Contrast").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Contrast").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VButton(label: "Stop", iconOnly: VIcon.square.rawValue, style: .contrast) {}
                         }
                     }
@@ -174,15 +174,15 @@ struct ButtonsGallerySection: View {
                 VCard {
                     HStack(spacing: VSpacing.xl) {
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("Close").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Close").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VButton(label: "Close", iconOnly: VIcon.x.rawValue, style: .outlined) {}
                         }
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("History").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("History").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VButton(label: "History", iconOnly: VIcon.history.rawValue, style: .outlined) {}
                         }
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("Publish").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Publish").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VButton(label: "Publish", iconOnly: VIcon.arrowUpRight.rawValue, style: .outlined) {}
                         }
                     }
@@ -199,19 +199,19 @@ struct ButtonsGallerySection: View {
                 VCard {
                     HStack(spacing: VSpacing.xl) {
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("Add").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Add").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VButton(label: "Add", iconOnly: VIcon.plus.rawValue, style: .ghost) {}
                         }
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("Call").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Call").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VButton(label: "Call", iconOnly: VIcon.phoneCall.rawValue, style: .ghost) {}
                         }
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("Record").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Record").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VButton(label: "Record", iconOnly: VIcon.mic.rawValue, style: .ghost) {}
                         }
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("Close").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Close").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VButton(label: "Close", iconOnly: VIcon.x.rawValue, style: .ghost) {}
                         }
                     }
@@ -228,23 +228,23 @@ struct ButtonsGallerySection: View {
                 VCard {
                     HStack(spacing: VSpacing.xl) {
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("Copy").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Copy").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VButton(label: "Copy", iconOnly: VIcon.copy.rawValue, style: .ghost, size: .inline) {}
                         }
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("Edit").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Edit").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VButton(label: "Edit", iconOnly: VIcon.pencil.rawValue, style: .ghost, size: .inline) {}
                         }
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("Close").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Close").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VButton(label: "Close", iconOnly: VIcon.x.rawValue, style: .ghost, size: .inline) {}
                         }
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("Inline in text").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Inline in text").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             HStack(spacing: VSpacing.xs) {
                                 Text("\"key\": \"value\"")
                                     .font(VFont.bodyMediumDefault)
-                                    .foregroundColor(VColor.contentDefault)
+                                    .foregroundStyle(VColor.contentDefault)
                                 VButton(label: "Copy", iconOnly: VIcon.copy.rawValue, style: .ghost, size: .inline) {}
                             }
                         }
@@ -267,11 +267,11 @@ struct ButtonsGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.xl) {
                         Text("Styles")
                             .font(VFont.bodySmallEmphasised)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
 
                         HStack(spacing: VSpacing.lg) {
                             VStack(alignment: .leading, spacing: VSpacing.md) {
-                                Text("Primary").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Primary").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VSplitButton(label: "Allow", icon: VIcon.check.rawValue, style: .primary, action: {}) {
                                     Section("Duration") {
                                         Button("Allow once") {}
@@ -285,7 +285,7 @@ struct ButtonsGallerySection: View {
                             }
 
                             VStack(alignment: .leading, spacing: VSpacing.md) {
-                                Text("Outlined").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Outlined").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VSplitButton(label: "Save", style: .outlined, action: {}) {
                                     Button("Save as draft") {}
                                     Button("Save and publish") {}
@@ -294,7 +294,7 @@ struct ButtonsGallerySection: View {
                             }
 
                             VStack(alignment: .leading, spacing: VSpacing.md) {
-                                Text("Danger").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Danger").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VSplitButton(label: "Delete", icon: VIcon.trash.rawValue, style: .danger, action: {}) {
                                     Button("Delete selected") {}
                                     Button("Delete all") {}
@@ -302,7 +302,7 @@ struct ButtonsGallerySection: View {
                             }
 
                             VStack(alignment: .leading, spacing: VSpacing.md) {
-                                Text("Long Label").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Long Label").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VSplitButton(label: "Allow for this conversation", icon: VIcon.check.rawValue, style: .primary, action: {}) {
                                     Button("Allow once") {}
                                     Button("Allow always") {}

--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -20,7 +20,7 @@ struct ChatGallerySection: View {
                         HStack {
                             Text("Amplitude: \(String(format: "%.2f", voiceComposerAmplitude))")
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                             Slider(value: $voiceComposerAmplitude, in: 0...1, step: 0.05)
                                 .frame(maxWidth: 200)
                         }
@@ -29,7 +29,7 @@ struct ChatGallerySection: View {
 
                         Text("Conversation style (voice mode)")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
                         VStreamingWaveform(
                             amplitude: voiceComposerAmplitude,
                             isActive: true,
@@ -42,7 +42,7 @@ struct ChatGallerySection: View {
 
                         Text("Dictation style (inline dictation)")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
                         VStreamingWaveform(
                             amplitude: voiceComposerAmplitude,
                             isActive: true,
@@ -100,7 +100,7 @@ struct ChatGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.lg) {
                         Text("SubagentStatusChip")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
 
                         SubagentStatusChip(
                             subagent: SubagentInfo(id: "g-1", label: "Research Agent", status: .running)
@@ -128,7 +128,7 @@ struct ChatGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.lg) {
                         Text("SubagentConversationView")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
 
                         SubagentConversationView(
                             subagent: SubagentInfo(id: "t-1", label: "Research Agent", status: .running),
@@ -175,7 +175,7 @@ struct ChatGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.lg) {
                         Text("Completed (success)")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                         ToolCallChip(toolCall: ToolCallData(
                             toolName: "bash",
                             inputSummary: "ls -la /Users/test/project",
@@ -187,7 +187,7 @@ struct ChatGallerySection: View {
 
                         Text("Completed (error)")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                         ToolCallChip(toolCall: ToolCallData(
                             toolName: "bash",
                             inputSummary: "rm -rf /important",
@@ -200,7 +200,7 @@ struct ChatGallerySection: View {
 
                         Text("File edit (success)")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                         ToolCallChip(toolCall: ToolCallData(
                             toolName: "file_edit",
                             inputSummary: "/src/Config.swift",
@@ -212,7 +212,7 @@ struct ChatGallerySection: View {
 
                         Text("In progress")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                         ToolCallChip(toolCall: ToolCallData(
                             toolName: "file_read",
                             inputSummary: "/src/main.swift",
@@ -236,7 +236,7 @@ struct ChatGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.lg) {
                         Text("CurrentStepIndicator — in progress with multiple steps")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                         CurrentStepIndicator(
                             toolCalls: [
                                 ToolCallData(
@@ -263,7 +263,7 @@ struct ChatGallerySection: View {
 
                         Text("CurrentStepIndicator — completed")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                         CurrentStepIndicator(
                             toolCalls: [
                                 ToolCallData(
@@ -287,7 +287,7 @@ struct ChatGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.lg) {
                         Text("ToolCallProgressBar — multi-step with one in progress")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                         ToolCallProgressBar(toolCalls: [
                             ToolCallData(
                                 toolName: "Web Search",
@@ -316,7 +316,7 @@ struct ChatGallerySection: View {
 
                         Text("ToolCallProgressBar — completed with error")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                         ToolCallProgressBar(toolCalls: [
                             ToolCallData(
                                 toolName: "Web Search",
@@ -354,7 +354,7 @@ struct ChatGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.lg) {
                         Text("TypingIndicatorView — animated dots while assistant is thinking")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
 
                         HStack {
                             TypingIndicatorView()
@@ -365,19 +365,19 @@ struct ChatGallerySection: View {
 
                         Text("AssistantProgressView — macOS only (clients/macos/)")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                         Text("Unified container for all tool progress states. Smoothly morphs between thinking, running, streaming code, and completed phases. Not available in the shared gallery because it depends on macOS-only imports.")
                             .font(VFont.labelSmall)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
 
                         Divider().background(VColor.borderBase)
 
                         Text("RunningIndicator — macOS only (clients/macos/)")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                         Text("Spinning arc indicator used alongside tool progress views. Not available in the shared gallery because it depends on macOS-only imports.")
                             .font(VFont.labelSmall)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                     }
                 }
             }
@@ -396,7 +396,7 @@ struct ChatGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.lg) {
                         Text("Collapsed — approved")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                         ToolConfirmationBubble(
                             confirmation: ToolConfirmationData(
                                 requestId: "gallery-approved",
@@ -415,7 +415,7 @@ struct ChatGallerySection: View {
 
                         Text("Collapsed — denied")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                         ToolConfirmationBubble(
                             confirmation: ToolConfirmationData(
                                 requestId: "gallery-denied",
@@ -434,7 +434,7 @@ struct ChatGallerySection: View {
 
                         Text("Collapsed — timed out")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                         ToolConfirmationBubble(
                             confirmation: ToolConfirmationData(
                                 requestId: "gallery-timeout",
@@ -455,7 +455,7 @@ struct ChatGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.lg) {
                         Text("Pending — low risk")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                         ToolConfirmationBubble(
                             confirmation: ToolConfirmationData(
                                 requestId: "gallery-low",
@@ -474,7 +474,7 @@ struct ChatGallerySection: View {
 
                         Text("Pending — medium risk with always-allow")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                         ToolConfirmationBubble(
                             confirmation: ToolConfirmationData(
                                 requestId: "gallery-medium",
@@ -503,7 +503,7 @@ struct ChatGallerySection: View {
 
                         Text("Pending — high risk")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                         ToolConfirmationBubble(
                             confirmation: ToolConfirmationData(
                                 requestId: "gallery-high",

--- a/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
@@ -23,7 +23,7 @@ struct DisplayGallerySection: View {
                         HStack {
                             Text("Padding: \(Int(cardPadding))pt")
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                             Slider(value: $cardPadding, in: 0...48, step: 4)
                                 .frame(maxWidth: 200)
                         }
@@ -33,7 +33,7 @@ struct DisplayGallerySection: View {
                         VCard(padding: cardPadding) {
                             Text("Card content with \(Int(cardPadding))pt padding")
                                 .font(VFont.bodyMediumLighter)
-                                .foregroundColor(VColor.contentDefault)
+                                .foregroundStyle(VColor.contentDefault)
                         }
                     }
                 }
@@ -41,7 +41,7 @@ struct DisplayGallerySection: View {
                 // Padding variants
                 Text("Padding Variants")
                     .font(VFont.bodySmallEmphasised)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
 
                 HStack(spacing: VSpacing.lg) {
                     ForEach([
@@ -55,10 +55,10 @@ struct DisplayGallerySection: View {
                             VStack(spacing: VSpacing.xs) {
                                 Text(name)
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.contentDefault)
+                                    .foregroundStyle(VColor.contentDefault)
                                 Text("\(Int(padding))pt")
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.contentTertiary)
+                                    .foregroundStyle(VColor.contentTertiary)
                             }
                         }
                     }
@@ -165,7 +165,7 @@ struct DisplayGallerySection: View {
 
                 Text("With Action Button")
                     .font(VFont.bodySmallEmphasised)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
 
                 HStack(spacing: VSpacing.lg) {
                     VCard {
@@ -209,7 +209,7 @@ struct DisplayGallerySection: View {
                 ) {
                     Text("Expanded content is visible")
                         .font(VFont.bodyMediumLighter)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                 }
                 .padding(VSpacing.lg)
                 .vCard(background: VColor.surfaceOverlay)
@@ -221,7 +221,7 @@ struct DisplayGallerySection: View {
                 ) {
                     Text("This content is hidden")
                         .font(VFont.bodyMediumLighter)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                 }
                 .padding(VSpacing.lg)
                 .vCard(background: VColor.surfaceOverlay)
@@ -243,13 +243,13 @@ struct DisplayGallerySection: View {
                         VListRow(onTap: {}) {
                             HStack {
                                 VIconView(.fileText, size: 14)
-                                    .foregroundColor(VColor.primaryBase)
+                                    .foregroundStyle(VColor.primaryBase)
                                 Text("Tappable row with icon")
                                     .font(VFont.bodyMediumLighter)
-                                    .foregroundColor(VColor.contentDefault)
+                                    .foregroundStyle(VColor.contentDefault)
                                 Spacer()
                                 VIconView(.chevronRight, size: 10)
-                                    .foregroundColor(VColor.contentTertiary)
+                                    .foregroundStyle(VColor.contentTertiary)
                             }
                         }
 
@@ -258,10 +258,10 @@ struct DisplayGallerySection: View {
                         VListRow(onTap: {}) {
                             HStack {
                                 VIconView(.folder, size: 14)
-                                    .foregroundColor(VColor.systemNegativeHover)
+                                    .foregroundStyle(VColor.systemNegativeHover)
                                 Text("Another tappable row")
                                     .font(VFont.bodyMediumLighter)
-                                    .foregroundColor(VColor.contentDefault)
+                                    .foregroundStyle(VColor.contentDefault)
                                 Spacer()
                                 VBadge(style: .count(3))
                             }
@@ -272,7 +272,7 @@ struct DisplayGallerySection: View {
                         VListRow {
                             Text("Static row (no tap action)")
                                 .font(VFont.bodyMediumLighter)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                         }
                     }
                 }
@@ -303,7 +303,7 @@ struct DisplayGallerySection: View {
                             )
                             Text(label)
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                         }
                     }
                 }
@@ -357,7 +357,7 @@ struct DisplayGallerySection: View {
 
                 Text("With maxHeight constraint")
                     .font(VFont.bodySmallEmphasised)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
 
                 VCard {
                     VDiffView(Self.sampleDiff, maxHeight: 120)
@@ -382,7 +382,7 @@ struct DisplayGallerySection: View {
                             VStack(spacing: VSpacing.sm) {
                                 Text("Conversation")
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.contentSecondary)
+                                    .foregroundStyle(VColor.contentSecondary)
                                 VStreamingWaveform(
                                     amplitude: waveformAmplitude,
                                     isActive: waveformActive,
@@ -394,7 +394,7 @@ struct DisplayGallerySection: View {
                             VStack(spacing: VSpacing.sm) {
                                 Text("Dictation")
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.contentSecondary)
+                                    .foregroundStyle(VColor.contentSecondary)
                                 VStreamingWaveform(
                                     amplitude: waveformAmplitude,
                                     isActive: waveformActive,
@@ -410,7 +410,7 @@ struct DisplayGallerySection: View {
                         HStack {
                             Text("Amplitude: \(String(format: "%.2f", waveformAmplitude))")
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                             Slider(value: Binding(
                                 get: { Double(waveformAmplitude) },
                                 set: { waveformAmplitude = Float($0) }
@@ -420,7 +420,7 @@ struct DisplayGallerySection: View {
 
                         Toggle("Active", isOn: $waveformActive)
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
                     }
                 }
             }

--- a/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -21,7 +21,7 @@ struct FeedbackGallerySection: View {
                         HStack {
                             Text("Count: \(Int(badgeCount))")
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                             Slider(value: $badgeCount, in: 1...99, step: 1)
                                 .frame(maxWidth: 200)
                         }
@@ -31,19 +31,19 @@ struct FeedbackGallerySection: View {
                         // Count row
                         HStack(spacing: VSpacing.xl) {
                             VStack(spacing: VSpacing.xs) {
-                                Text("Accent").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Accent").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VBadge(style: .count(Int(badgeCount)), color: VColor.primaryBase)
                             }
                             VStack(spacing: VSpacing.xs) {
-                                Text("Success").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Success").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VBadge(style: .count(Int(badgeCount)), color: VColor.systemPositiveStrong)
                             }
                             VStack(spacing: VSpacing.xs) {
-                                Text("Error").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Error").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VBadge(style: .count(Int(badgeCount)), color: VColor.systemNegativeStrong)
                             }
                             VStack(spacing: VSpacing.xs) {
-                                Text("Warning").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Warning").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VBadge(style: .count(Int(badgeCount)), color: VColor.systemMidStrong)
                             }
                         }
@@ -51,7 +51,7 @@ struct FeedbackGallerySection: View {
                         // Dot row
                         HStack(spacing: VSpacing.xl) {
                             VStack(spacing: VSpacing.xs) {
-                                Text("Dot").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Dot").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 HStack(spacing: VSpacing.md) {
                                     VBadge(style: .dot, color: VColor.primaryBase)
                                     VBadge(style: .dot, color: VColor.systemPositiveStrong)
@@ -63,7 +63,7 @@ struct FeedbackGallerySection: View {
 
                         // Label with tone (subtle)
                         VStack(alignment: .leading, spacing: VSpacing.sm) {
-                            Text("Subtle labels").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Subtle labels").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             HStack(spacing: VSpacing.lg) {
                                 VBadge(label: "Accent", tone: .accent)
                                 VBadge(label: "Neutral", tone: .neutral)
@@ -77,7 +77,7 @@ struct FeedbackGallerySection: View {
 
                         // Label with tone (solid)
                         VStack(alignment: .leading, spacing: VSpacing.sm) {
-                            Text("Solid labels").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Solid labels").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             HStack(spacing: VSpacing.lg) {
                                 VBadge(label: "Accent", tone: .accent, emphasis: .solid)
                                 VBadge(label: "Neutral", tone: .neutral, emphasis: .solid)
@@ -116,7 +116,7 @@ struct FeedbackGallerySection: View {
 
                         // With icon
                         VStack(alignment: .leading, spacing: VSpacing.sm) {
-                            Text("With icon").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("With icon").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             HStack(spacing: VSpacing.lg) {
                                 VTag("Identity", color: VColor.funTeal, icon: .user)
                                 VTag("Event", color: VColor.funPink, icon: .calendar)
@@ -140,27 +140,27 @@ struct FeedbackGallerySection: View {
                 VCard {
                     HStack(spacing: VSpacing.xxl) {
                         VStack(spacing: VSpacing.md) {
-                            Text("Small (14)").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Small (14)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VLoadingIndicator(size: 14, color: VColor.primaryBase)
                         }
                         VStack(spacing: VSpacing.md) {
-                            Text("Default (20)").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Default (20)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VLoadingIndicator()
                         }
                         VStack(spacing: VSpacing.md) {
-                            Text("Large (32)").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Large (32)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VLoadingIndicator(size: 32, color: VColor.primaryBase)
                         }
                         VStack(spacing: VSpacing.md) {
-                            Text("Success").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Success").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VLoadingIndicator(color: VColor.systemPositiveStrong)
                         }
                         VStack(spacing: VSpacing.md) {
-                            Text("Error").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Error").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VLoadingIndicator(color: VColor.systemNegativeStrong)
                         }
                         VStack(spacing: VSpacing.md) {
-                            Text("Warning").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Warning").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VLoadingIndicator(color: VColor.systemMidStrong)
                         }
                     }
@@ -272,11 +272,11 @@ struct FeedbackGallerySection: View {
                         // Text only
                         HStack(spacing: VSpacing.lg) {
                             VStack(spacing: VSpacing.xs) {
-                                Text("Text only").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Text only").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VShortcutTag("\u{2318}K")
                             }
                             VStack(spacing: VSpacing.xs) {
-                                Text("Text only").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Text only").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VShortcutTag("\u{2318}G")
                             }
                         }
@@ -286,11 +286,11 @@ struct FeedbackGallerySection: View {
                         // With icon
                         HStack(spacing: VSpacing.lg) {
                             VStack(spacing: VSpacing.xs) {
-                                Text("With icon").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("With icon").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VShortcutTag("fn", icon: "mic.fill")
                             }
                             VStack(spacing: VSpacing.xs) {
-                                Text("With icon").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("With icon").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VShortcutTag("Esc", icon: "escape")
                             }
                         }
@@ -313,23 +313,23 @@ struct FeedbackGallerySection: View {
                         // Size variants
                         HStack(spacing: VSpacing.xl) {
                             VStack(spacing: VSpacing.xs) {
-                                Text("Regular (default)").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Regular (default)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VCopyButton(text: "Hello, world!")
                             }
                             VStack(spacing: VSpacing.xs) {
-                                Text("Compact").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Compact").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VCopyButton(text: "Compact copy", size: .compact)
                             }
                             VStack(spacing: VSpacing.xs) {
-                                Text("Inline (18×18)").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Inline (18×18)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VCopyButton(text: "Inline copy", size: .inline)
                             }
                             VStack(spacing: VSpacing.xs) {
-                                Text("Custom frame (20pt)").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Custom frame (20pt)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VCopyButton(text: "Small frame", iconSize: 20)
                             }
                             VStack(spacing: VSpacing.xs) {
-                                Text("Large frame (28pt)").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Large frame (28pt)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VCopyButton(text: "Large frame", iconSize: 28)
                             }
                         }
@@ -339,7 +339,7 @@ struct FeedbackGallerySection: View {
                         // Custom hint
                         HStack(spacing: VSpacing.xl) {
                             VStack(spacing: VSpacing.xs) {
-                                Text("Custom tooltip").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Custom tooltip").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VCopyButton(text: "api_key_123", accessibilityHint: "Copy API key")
                             }
                         }
@@ -362,15 +362,15 @@ struct FeedbackGallerySection: View {
                         // Size variants
                         HStack(spacing: VSpacing.xxl) {
                             VStack(spacing: VSpacing.md) {
-                                Text("Small (6)").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Small (6)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VBusyIndicator(size: 6)
                             }
                             VStack(spacing: VSpacing.md) {
-                                Text("Default (10)").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Default (10)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VBusyIndicator()
                             }
                             VStack(spacing: VSpacing.md) {
-                                Text("Large (16)").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Large (16)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VBusyIndicator(size: 16)
                             }
                         }
@@ -380,15 +380,15 @@ struct FeedbackGallerySection: View {
                         // Color variants
                         HStack(spacing: VSpacing.xxl) {
                             VStack(spacing: VSpacing.md) {
-                                Text("Accent").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Accent").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VBusyIndicator(color: VColor.primaryBase)
                             }
                             VStack(spacing: VSpacing.md) {
-                                Text("Success").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Success").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VBusyIndicator(color: VColor.systemPositiveStrong)
                             }
                             VStack(spacing: VSpacing.md) {
-                                Text("Error").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Error").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VBusyIndicator(color: VColor.systemNegativeStrong)
                             }
                         }
@@ -410,7 +410,7 @@ struct FeedbackGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.xl) {
                         // Text line
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Text line").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Text line").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VSkeletonBone(height: 14)
                         }
 
@@ -418,7 +418,7 @@ struct FeedbackGallerySection: View {
 
                         // Title
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Title").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Title").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VSkeletonBone(width: 200, height: 20)
                         }
 
@@ -426,7 +426,7 @@ struct FeedbackGallerySection: View {
 
                         // Avatar
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Avatar").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Avatar").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VSkeletonBone(width: 40, height: 40, radius: VRadius.pill)
                         }
 
@@ -434,7 +434,7 @@ struct FeedbackGallerySection: View {
 
                         // Paragraph
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Paragraph").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Paragraph").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VStack(alignment: .leading, spacing: VSpacing.sm) {
                                 VSkeletonBone(height: 14)
                                 VSkeletonBone(width: 280, height: 14)
@@ -479,7 +479,7 @@ struct FeedbackGallerySection: View {
                     HStack(spacing: VSpacing.xs) {
                         Text("Some setting")
                             .font(VFont.bodyMediumLighter)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
                         VInfoTooltip("Explanation of this setting.")
                     }
                 }

--- a/clients/shared/DesignSystem/Gallery/Sections/IconsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/IconsGallerySection.swift
@@ -31,7 +31,7 @@ struct IconsGallerySection: View {
 
                 Text("\(filteredIcons.count) icons")
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
 
                 VCard {
                     LazyVGrid(
@@ -41,11 +41,11 @@ struct IconsGallerySection: View {
                         ForEach(filteredIcons, id: \.rawValue) { icon in
                             VStack(spacing: VSpacing.xs) {
                                 VIconView(icon, size: 20)
-                                    .foregroundColor(VColor.contentDefault)
+                                    .foregroundStyle(VColor.contentDefault)
                                     .frame(width: 32, height: 32)
                                 Text(icon.rawValue.replacingOccurrences(of: "lucide-", with: ""))
                                     .font(VFont.labelSmall)
-                                    .foregroundColor(VColor.contentTertiary)
+                                    .foregroundStyle(VColor.contentTertiary)
                                     .lineLimit(1)
                                     .truncationMode(.tail)
                             }

--- a/clients/shared/DesignSystem/Gallery/Sections/InputsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/InputsGallerySection.swift
@@ -42,12 +42,12 @@ struct InputsGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.xl) {
                         Text("Live value: \"\(textFieldValue)\"")
                             .font(VFont.bodyMediumDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
 
                         Divider().background(VColor.borderBase)
 
                         // --- States ---
-                        Text("States").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                        Text("States").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
 
                         HStack(alignment: .top, spacing: VSpacing.xl) {
                             VStack(alignment: .leading, spacing: VSpacing.lg) {
@@ -107,11 +107,11 @@ struct InputsGallerySection: View {
                         Divider().background(VColor.borderBase)
 
                         // --- Icons ---
-                        Text("Icons").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                        Text("Icons").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
 
                         HStack(alignment: .top, spacing: VSpacing.xl) {
                             VStack(alignment: .leading, spacing: VSpacing.md) {
-                                Text("Leading icon").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Leading icon").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VTextField(
                                     placeholder: "Search...",
                                     text: $textFieldValue,
@@ -120,7 +120,7 @@ struct InputsGallerySection: View {
                             }
 
                             VStack(alignment: .leading, spacing: VSpacing.md) {
-                                Text("Trailing icon").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Trailing icon").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VTextField(
                                     placeholder: "Enter email...",
                                     text: $textFieldValue,
@@ -129,7 +129,7 @@ struct InputsGallerySection: View {
                             }
 
                             VStack(alignment: .leading, spacing: VSpacing.md) {
-                                Text("Both icons").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Both icons").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VTextField(
                                     placeholder: "Search files...",
                                     text: $textFieldValue,
@@ -142,7 +142,7 @@ struct InputsGallerySection: View {
                         Divider().background(VColor.borderBase)
 
                         // --- Label + Icon ---
-                        Text("Label with icon").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                        Text("Label with icon").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
 
                         VTextField(
                             "Tool Name",
@@ -154,17 +154,17 @@ struct InputsGallerySection: View {
                         Divider().background(VColor.borderBase)
 
                         // --- Width Variants ---
-                        Text("Width variants").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                        Text("Width variants").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
 
                         VStack(alignment: .leading, spacing: VSpacing.md) {
                             Text("Full width (default maxWidth: .infinity)")
-                                .font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                .font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VTextField(placeholder: "Fills available width...", text: $textFieldValue)
                         }
 
                         VStack(alignment: .leading, spacing: VSpacing.md) {
                             Text("Constrained width (maxWidth: 400)")
-                                .font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                .font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VTextField(
                                 placeholder: "Settings card width...",
                                 text: $textFieldValue,
@@ -175,11 +175,11 @@ struct InputsGallerySection: View {
                         Divider().background(VColor.borderBase)
 
                         // --- Custom Font ---
-                        Text("Custom font").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                        Text("Custom font").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
 
                         HStack(alignment: .top, spacing: VSpacing.xl) {
                             VStack(alignment: .leading, spacing: VSpacing.md) {
-                                Text("Monospaced (VFont.bodyMediumDefault)").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Monospaced (VFont.bodyMediumDefault)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VTextField(
                                     placeholder: "Enter command...",
                                     text: $textFieldValue,
@@ -188,7 +188,7 @@ struct InputsGallerySection: View {
                             }
 
                             VStack(alignment: .leading, spacing: VSpacing.md) {
-                                Text("Monospaced secure").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Monospaced secure").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VTextField(
                                     placeholder: "Enter secret...",
                                     text: $secureFieldValue,
@@ -201,11 +201,11 @@ struct InputsGallerySection: View {
                         Divider().background(VColor.borderBase)
 
                         // --- Size Variants ---
-                        Text("Size variants").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                        Text("Size variants").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
 
                         HStack(alignment: .top, spacing: VSpacing.xl) {
                             VStack(alignment: .leading, spacing: VSpacing.md) {
-                                Text("Regular (default)").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Regular (default)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VTextField(
                                     "Label",
                                     placeholder: "Regular size...",
@@ -214,7 +214,7 @@ struct InputsGallerySection: View {
                             }
 
                             VStack(alignment: .leading, spacing: VSpacing.md) {
-                                Text("Small").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Small").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VTextField(
                                     "Label",
                                     placeholder: "Small size...",
@@ -226,7 +226,7 @@ struct InputsGallerySection: View {
 
                         HStack(alignment: .top, spacing: VSpacing.xl) {
                             VStack(alignment: .leading, spacing: VSpacing.md) {
-                                Text("Regular with icons").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Regular with icons").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VTextField(
                                     placeholder: "Search...",
                                     text: $textFieldValue,
@@ -236,7 +236,7 @@ struct InputsGallerySection: View {
                             }
 
                             VStack(alignment: .leading, spacing: VSpacing.md) {
-                                Text("Small with icons").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Small with icons").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VTextField(
                                     placeholder: "Search...",
                                     text: $smallTextFieldValue,
@@ -250,11 +250,11 @@ struct InputsGallerySection: View {
                         Divider().background(VColor.borderBase)
 
                         // --- External Focus Control ---
-                        Text("External focus control").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                        Text("External focus control").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
 
                         VStack(alignment: .leading, spacing: VSpacing.md) {
                             Text("Pass a FocusState<Bool>.Binding via isFocused: to control focus programmatically.")
-                                .font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                .font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VAdaptiveStack(horizontalAlignment: .bottom) {
                                 VTextField(
                                     "Focusable field",
@@ -286,24 +286,24 @@ struct InputsGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.xl) {
                         Text("Live value: \(Int(sliderValue))")
                             .font(VFont.bodyMediumDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
 
                         Divider().background(VColor.borderBase)
 
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("Default (0–100, step 1)").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Default (0–100, step 1)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VSlider(value: $sliderValue)
                         }
 
                         VStack(alignment: .leading, spacing: VSpacing.md) {
                             Text("With tick marks (0–100, step 5): \(Int(sliderSteppedValue))")
-                                .font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                .font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VSlider(value: $sliderSteppedValue, range: 0...100, step: 5, showTickMarks: true)
                         }
 
                         VStack(alignment: .leading, spacing: VSpacing.md) {
                             Text("Small range (1–10, step 1): \(Int(sliderSmallValue))")
-                                .font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                .font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VSlider(value: $sliderSmallValue, range: 1...10, step: 1, showTickMarks: true)
                         }
                     }
@@ -326,14 +326,14 @@ struct InputsGallerySection: View {
                             VStack(alignment: .leading) {
                                 Text("Min Height: \(Int(minHeight))")
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.contentSecondary)
+                                    .foregroundStyle(VColor.contentSecondary)
                                 Slider(value: $minHeight, in: 40...200, step: 10)
                                     .frame(maxWidth: 200)
                             }
                             VStack(alignment: .leading) {
                                 Text("Max Height: \(Int(maxHeight))")
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.contentSecondary)
+                                    .foregroundStyle(VColor.contentSecondary)
                                 Slider(value: $maxHeight, in: 100...400, step: 20)
                                     .frame(maxWidth: 200)
                             }
@@ -350,7 +350,7 @@ struct InputsGallerySection: View {
 
                         Text("Characters: \(textEditorValue.count)")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                     }
                 }
             }
@@ -369,22 +369,22 @@ struct InputsGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.xl) {
                         Text("Toggle A: \(toggleA ? "ON" : "OFF")  |  Toggle B: \(toggleB ? "ON" : "OFF")")
                             .font(VFont.bodyMediumDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
 
                         Divider().background(VColor.borderBase)
 
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("With label").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("With label").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VToggle(isOn: $toggleA, label: "Enable feature")
                         }
 
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("Without label").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Without label").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VToggle(isOn: $toggleB)
                         }
 
                         VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("Non-interactive").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Non-interactive").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VToggle(isOn: .constant(true), label: "Read-only toggle", interactive: false)
                         }
                     }
@@ -406,12 +406,12 @@ struct InputsGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.xl) {
                         Text("Live value: \"\(dropdownValue)\"")
                             .font(VFont.bodyMediumDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
 
                         Divider().background(VColor.borderBase)
 
                         // --- States ---
-                        Text("States").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                        Text("States").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
 
                         HStack(alignment: .top, spacing: VSpacing.xl) {
                             VStack(alignment: .leading, spacing: VSpacing.lg) {
@@ -507,11 +507,11 @@ struct InputsGallerySection: View {
                         Divider().background(VColor.borderBase)
 
                         // --- Size Variants ---
-                        Text("Size variants").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                        Text("Size variants").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
 
                         HStack(alignment: .top, spacing: VSpacing.xl) {
                             VStack(alignment: .leading, spacing: VSpacing.md) {
-                                Text("Regular (default)").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Regular (default)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VDropdown(
                                     "Label",
                                     placeholder: "Regular size...",
@@ -526,7 +526,7 @@ struct InputsGallerySection: View {
                             }
 
                             VStack(alignment: .leading, spacing: VSpacing.md) {
-                                Text("Small").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                                Text("Small").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VDropdown(
                                     "Label",
                                     placeholder: "Small size...",

--- a/clients/shared/DesignSystem/Gallery/Sections/LayoutGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/LayoutGallerySection.swift
@@ -27,10 +27,10 @@ struct LayoutGallerySection: View {
                             VStack(alignment: .leading, spacing: VSpacing.xs) {
                                 Text("Tool Name")
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.contentTertiary)
+                                    .foregroundStyle(VColor.contentTertiary)
                                 Text("Select a Tool")
                                     .font(VFont.bodyMediumLighter)
-                                    .foregroundColor(VColor.contentSecondary)
+                                    .foregroundStyle(VColor.contentSecondary)
                                     .padding(VSpacing.sm)
                                     .frame(maxWidth: .infinity, alignment: .leading)
                                     .background(VColor.surfaceActive)
@@ -39,10 +39,10 @@ struct LayoutGallerySection: View {
                             VStack(alignment: .leading, spacing: VSpacing.xs) {
                                 Text("Tool Name")
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.contentTertiary)
+                                    .foregroundStyle(VColor.contentTertiary)
                                 Text("Select a Tool")
                                     .font(VFont.bodyMediumLighter)
-                                    .foregroundColor(VColor.contentSecondary)
+                                    .foregroundStyle(VColor.contentSecondary)
                                     .padding(VSpacing.sm)
                                     .frame(maxWidth: .infinity, alignment: .leading)
                                     .background(VColor.surfaceActive)
@@ -72,10 +72,10 @@ struct LayoutGallerySection: View {
                         VStack(alignment: .leading, spacing: VSpacing.lg) {
                             Text("Sub-screen content goes here")
                                 .font(VFont.bodyMediumLighter)
-                                .foregroundColor(VColor.contentDefault)
+                                .foregroundStyle(VColor.contentDefault)
                             Text("Use backAction and closeAction to add navigation controls to the modal header.")
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                         }
                     }
                     .frame(width: 360, height: 200)
@@ -98,7 +98,7 @@ struct LayoutGallerySection: View {
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
                             Text("Container Width: \(Int(adaptiveContainerWidth))pt")
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                             Slider(value: $adaptiveContainerWidth, in: 150...600, step: 10)
                                 .frame(maxWidth: 300)
                         }
@@ -137,10 +137,10 @@ struct LayoutGallerySection: View {
                         VStack(alignment: .leading, spacing: VSpacing.md) {
                             Text("Panel content goes here")
                                 .font(VFont.bodyMediumLighter)
-                                .foregroundColor(VColor.contentDefault)
+                                .foregroundStyle(VColor.contentDefault)
                             Text("This panel has a title header with a close button and scrollable content area.")
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                         }
                     }
                     .frame(width: 300, height: 200)
@@ -165,10 +165,10 @@ struct LayoutGallerySection: View {
                         VStack(alignment: .leading, spacing: VSpacing.md) {
                             Text("Tab \(pinnedTabSelection + 1) content")
                                 .font(VFont.bodyMediumLighter)
-                                .foregroundColor(VColor.contentDefault)
+                                .foregroundStyle(VColor.contentDefault)
                             Text("The tab bar above stays pinned while this content scrolls.")
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                         }
                     }
                     .frame(width: 300, height: 250)
@@ -192,7 +192,7 @@ struct LayoutGallerySection: View {
                             VStack(alignment: .leading) {
                                 Text("Panel Width: \(Int(panelWidth))")
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.contentSecondary)
+                                    .foregroundStyle(VColor.contentSecondary)
                                 Slider(value: $panelWidth, in: 200...400, step: 20)
                                     .frame(maxWidth: 200)
                             }
@@ -207,10 +207,10 @@ struct LayoutGallerySection: View {
                             VStack {
                                 Text("Main Content")
                                     .font(VFont.titleLarge)
-                                    .foregroundColor(VColor.contentDefault)
+                                    .foregroundStyle(VColor.contentDefault)
                                 Text("This is the primary area")
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.contentSecondary)
+                                    .foregroundStyle(VColor.contentSecondary)
                             }
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
                             .background(VColor.surfaceBase)
@@ -218,7 +218,7 @@ struct LayoutGallerySection: View {
                             VSidePanel(title: "Details", onClose: { showPanel = false }, pinnedContent: { EmptyView() }) {
                                 Text("Side panel content")
                                     .font(VFont.bodyMediumLighter)
-                                    .foregroundColor(VColor.contentSecondary)
+                                    .foregroundStyle(VColor.contentSecondary)
                             }
                         }
                         .frame(height: 250)
@@ -247,7 +247,7 @@ struct LayoutGallerySection: View {
                             Toggle("Show Dock", isOn: $showDock)
                             Text("Dock Width: \(Int(dockWidth))")
                                 .font(VFont.bodyMediumDefault)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                         }
 
                         Divider().background(VColor.borderBase)
@@ -258,20 +258,20 @@ struct LayoutGallerySection: View {
                         ) {
                             VStack {
                                 VIconView(.panelLeft, size: 20)
-                                    .foregroundColor(VColor.contentTertiary)
+                                    .foregroundStyle(VColor.contentTertiary)
                                 Text("Dock")
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.contentSecondary)
+                                    .foregroundStyle(VColor.contentSecondary)
                             }
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
                             .background(VColor.surfaceOverlay)
                         } workspace: {
                             VStack {
                                 VIconView(.layoutGrid, size: 20)
-                                    .foregroundColor(VColor.contentTertiary)
+                                    .foregroundStyle(VColor.contentTertiary)
                                 Text("Workspace")
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.contentSecondary)
+                                    .foregroundStyle(VColor.contentSecondary)
                             }
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
                             .background(VColor.surfaceBase)

--- a/clients/shared/DesignSystem/Gallery/Sections/ModifiersGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ModifiersGallerySection.swift
@@ -25,13 +25,13 @@ struct ModifiersGallerySection: View {
                             VStack(spacing: VSpacing.md) {
                                 Text("Sample content")
                                     .font(VFont.bodyMediumLighter)
-                                    .foregroundColor(VColor.contentDefault)
+                                    .foregroundStyle(VColor.contentDefault)
                                     .padding(VSpacing.xl)
                                     .vCard(radius: radius)
 
                                 Text(".\(name) (\(Int(radius))pt)")
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.contentTertiary)
+                                    .foregroundStyle(VColor.contentTertiary)
                             }
                         }
                     }
@@ -40,7 +40,7 @@ struct ModifiersGallerySection: View {
                 // Background colors
                 Text("Background Colors")
                     .font(VFont.bodySmallEmphasised)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
 
                 VCard {
                     HStack(spacing: VSpacing.lg) {
@@ -54,13 +54,13 @@ struct ModifiersGallerySection: View {
                             VStack(spacing: VSpacing.md) {
                                 Text("Sample content")
                                     .font(VFont.bodyMediumLighter)
-                                    .foregroundColor(VColor.contentDefault)
+                                    .foregroundStyle(VColor.contentDefault)
                                     .padding(VSpacing.xl)
                                     .vCard(background: color)
 
                                 Text(name)
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.contentTertiary)
+                                    .foregroundStyle(VColor.contentTertiary)
                             }
                         }
                     }
@@ -81,13 +81,13 @@ struct ModifiersGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.md) {
                         Text("Hover over the items below to see the pointer cursor:")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
 
                         HStack(spacing: VSpacing.lg) {
                             Button("Button") {}
                                 .buttonStyle(.plain)
                                 .font(VFont.bodyMediumLighter)
-                                .foregroundColor(VColor.contentDefault)
+                                .foregroundStyle(VColor.contentDefault)
                                 .padding(VSpacing.md)
                                 .background(VColor.surfaceBase)
                                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
@@ -99,7 +99,7 @@ struct ModifiersGallerySection: View {
 
                             Text("Tappable label")
                                 .font(VFont.bodyMediumLighter)
-                                .foregroundColor(VColor.primaryBase)
+                                .foregroundStyle(VColor.primaryBase)
                                 .padding(VSpacing.md)
                                 .contentShape(Rectangle())
                                 .pointerCursor()
@@ -122,25 +122,25 @@ struct ModifiersGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.md) {
                         Text("Hover over the items below to see native tooltips:")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
 
                         HStack(spacing: VSpacing.lg) {
                             VIconView(.pin, size: 16)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                                 .frame(width: 32, height: 32)
                                 .background(VColor.surfaceBase)
                                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                                 .nativeTooltip("Pinned")
 
                             VIconView(.circleAlert, size: 16)
-                                .foregroundColor(VColor.systemNegativeStrong)
+                                .foregroundStyle(VColor.systemNegativeStrong)
                                 .frame(width: 32, height: 32)
                                 .background(VColor.surfaceBase)
                                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                                 .nativeTooltip("Error")
 
                             VIconView(.lock, size: 16)
-                                .foregroundColor(VColor.primaryBase)
+                                .foregroundStyle(VColor.primaryBase)
                                 .frame(width: 32, height: 32)
                                 .background(VColor.surfaceBase)
                                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
@@ -164,7 +164,7 @@ struct ModifiersGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.md) {
                         Text("Hover over the items below (200ms delay):")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
 
                         HStack(spacing: VSpacing.lg) {
                             VButton(label: "Mic", iconOnly: VIcon.mic.rawValue, style: .ghost) {}
@@ -177,7 +177,7 @@ struct ModifiersGallerySection: View {
                                 .vTooltip("Send message")
 
                             VIconView(.info, size: 16)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                                 .frame(width: 32, height: 32)
                                 .background(VColor.surfaceBase)
                                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
@@ -186,7 +186,7 @@ struct ModifiersGallerySection: View {
 
                         Text("Bottom edge placement:")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
 
                         HStack(spacing: VSpacing.lg) {
                             VButton(label: "Copy", iconOnly: VIcon.copy.rawValue, style: .ghost) {}
@@ -213,12 +213,12 @@ struct ModifiersGallerySection: View {
                     VStack(spacing: VSpacing.md) {
                         Text("With .vPanelBackground()")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
 
                         VStack(spacing: VSpacing.md) {
                             Text("Panel content")
                                 .font(VFont.bodyMediumLighter)
-                                .foregroundColor(VColor.contentDefault)
+                                .foregroundStyle(VColor.contentDefault)
                         }
                         .frame(width: 200, height: 100)
                         .vPanelBackground()
@@ -232,12 +232,12 @@ struct ModifiersGallerySection: View {
                     VStack(spacing: VSpacing.md) {
                         Text("Without (default background)")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
 
                         VStack(spacing: VSpacing.md) {
                             Text("Regular content")
                                 .font(VFont.bodyMediumLighter)
-                                .foregroundColor(VColor.contentDefault)
+                                .foregroundStyle(VColor.contentDefault)
                         }
                         .frame(width: 200, height: 100)
                         .background(VColor.surfaceOverlay)
@@ -264,11 +264,11 @@ struct ModifiersGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.md) {
                         Text("condition = true (bold applied)")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
 
                         Text("Hello, world!")
                             .font(VFont.bodyMediumLighter)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
                             .if(true) { view in
                                 view.bold()
                             }
@@ -277,11 +277,11 @@ struct ModifiersGallerySection: View {
 
                         Text("condition = false (no change)")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
 
                         Text("Hello, world!")
                             .font(VFont.bodyMediumLighter)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
                             .if(false) { view in
                                 view.bold()
                             }
@@ -331,17 +331,17 @@ struct ModifiersGallerySection: View {
                 VCard {
                     HStack(spacing: VSpacing.lg) {
                         VStack(spacing: VSpacing.md) {
-                            Text("Non-interactive (default)").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Non-interactive (default)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             Text("Widget content")
                                 .font(VFont.bodyMediumLighter)
-                                .foregroundColor(VColor.contentDefault)
+                                .foregroundStyle(VColor.contentDefault)
                                 .inlineWidgetCard()
                         }
                         VStack(spacing: VSpacing.md) {
-                            Text("Interactive (hover highlight)").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Interactive (hover highlight)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             Text("Clickable widget")
                                 .font(VFont.bodyMediumLighter)
-                                .foregroundColor(VColor.contentDefault)
+                                .foregroundStyle(VColor.contentDefault)
                                 .inlineWidgetCard(interactive: true)
                         }
                     }

--- a/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
@@ -32,7 +32,7 @@ struct NavigationGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.xl) {
                         Text("Selected: \(segmentItems[segmentSelection])")
                             .font(VFont.bodyMediumDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
 
                         Divider().background(VColor.borderBase)
 
@@ -42,7 +42,7 @@ struct NavigationGallerySection: View {
                         VCard {
                             Text("Content for \"\(segmentItems[segmentSelection])\" tab")
                                 .font(VFont.bodyMediumLighter)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                                 .frame(maxWidth: .infinity)
                                 .padding(VSpacing.xl)
                         }
@@ -61,7 +61,7 @@ struct NavigationGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.xl) {
                         Text("Selected: \(pillSelection)")
                             .font(VFont.bodyMediumDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
 
                         Divider().background(VColor.borderBase)
 
@@ -117,7 +117,7 @@ struct NavigationGallerySection: View {
 
                 VCard {
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
-                        Text("States").font(VFont.bodySmallEmphasised).foregroundColor(VColor.contentSecondary)
+                        Text("States").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
 
                         VSidebarRow(icon: VIcon.brain.rawValue, label: "Intelligence", isActive: sidebarRowActive == "Intelligence") {
                             sidebarRowActive = "Intelligence"
@@ -133,7 +133,7 @@ struct NavigationGallerySection: View {
 
                 VCard {
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
-                        Text("Without Icon").font(VFont.bodySmallEmphasised).foregroundColor(VColor.contentSecondary)
+                        Text("Without Icon").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
 
                         VSidebarRow(label: "Overview", isActive: false) {}
                         VSidebarRow(label: "VButton", isActive: true) {}
@@ -143,7 +143,7 @@ struct NavigationGallerySection: View {
 
                 VCard {
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
-                        Text("Trailing Icon (Disclosure)").font(VFont.bodySmallEmphasised).foregroundColor(VColor.contentSecondary)
+                        Text("Trailing Icon (Disclosure)").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
 
                         VSidebarRow(
                             icon: VIcon.layers.rawValue,
@@ -167,29 +167,29 @@ struct NavigationGallerySection: View {
 
                 VCard {
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
-                        Text("Trailing Content").font(VFont.bodySmallEmphasised).foregroundColor(VColor.contentSecondary)
+                        Text("Trailing Content").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
 
                         VSidebarRow(label: "All", isActive: true, action: {}) {
                             Text("42")
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                         }
                         VSidebarRow(label: "Identity", action: {}) {
                             Text("12")
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                         }
                         VSidebarRow(label: "Preference", action: {}) {
                             Text("8")
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                         }
                     }
                 }
 
                 VCard {
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
-                        Text("Collapsed Mode").font(VFont.bodySmallEmphasised).foregroundColor(VColor.contentSecondary)
+                        Text("Collapsed Mode").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
 
                         HStack(spacing: VSpacing.md) {
                             VSidebarRow(icon: VIcon.brain.rawValue, label: "Intelligence", isExpanded: false) {}
@@ -230,10 +230,10 @@ struct NavigationGallerySection: View {
                         VStack {
                             Text(tabs[selectedTab].label)
                                 .font(VFont.titleMedium)
-                                .foregroundColor(VColor.contentDefault)
+                                .foregroundStyle(VColor.contentDefault)
                             Text("Tab content area")
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                         }
                         .frame(maxWidth: .infinity)
                         .frame(height: 120)
@@ -244,24 +244,24 @@ struct NavigationGallerySection: View {
                 // Tab states
                 Text("Tab States (Pill)")
                     .font(VFont.bodySmallEmphasised)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
 
                 VCard {
                     HStack(spacing: VSpacing.lg) {
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Default").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Default").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VTab(label: "Tab", icon: VIcon.file.rawValue, onSelect: {})
                         }
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Selected").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Selected").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VTab(label: "Tab", icon: VIcon.file.rawValue, isSelected: true, onSelect: {})
                         }
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Not closeable").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Not closeable").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VTab(label: "Tab", icon: VIcon.file.rawValue, isCloseable: false, onSelect: {})
                         }
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("No icon").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("No icon").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VTab(label: "Plain Tab", isCloseable: false, onSelect: {})
                         }
                     }
@@ -270,24 +270,24 @@ struct NavigationGallerySection: View {
                 // Flat-style tab states
                 Text("Tab States (Flat)")
                     .font(VFont.bodySmallEmphasised)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
 
                 VCard {
                     HStack(spacing: VSpacing.lg) {
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Default").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Default").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VTab(label: "Conversation 1", style: .flat, onSelect: {})
                         }
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Selected").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Selected").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VTab(label: "Conversation 1", isSelected: true, style: .flat, onSelect: {})
                         }
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Closeable").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Closeable").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VTab(label: "Conversation 2", style: .flat, onSelect: {}, onClose: {})
                         }
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Selected + Closeable").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Selected + Closeable").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VTab(label: "Conversation 2", isSelected: true, style: .flat, onSelect: {}, onClose: {})
                         }
                     }
@@ -296,24 +296,24 @@ struct NavigationGallerySection: View {
                 // Rectangular-style tab states
                 Text("Tab States (Rectangular)")
                     .font(VFont.bodySmallEmphasised)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
 
                 VCard {
                     HStack(spacing: VSpacing.lg) {
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Default").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Default").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VTab(label: "Tab", icon: VIcon.file.rawValue, style: .rectangular, onSelect: {})
                         }
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Selected").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Selected").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VTab(label: "Tab", icon: VIcon.file.rawValue, isSelected: true, style: .rectangular, onSelect: {})
                         }
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Closeable").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Closeable").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VTab(label: "Tab", icon: VIcon.file.rawValue, style: .rectangular, onSelect: {}, onClose: {})
                         }
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Selected + Closeable").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Selected + Closeable").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VTab(label: "Tab", icon: VIcon.file.rawValue, isSelected: true, style: .rectangular, onSelect: {}, onClose: {})
                         }
                     }
@@ -362,17 +362,17 @@ struct NavigationGallerySection: View {
                 VCard {
                     VStack(alignment: .leading, spacing: VSpacing.lg) {
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Icon Pill (default)").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Icon Pill (default)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VThemeToggle()
                         }
                         Divider().background(VColor.borderBase)
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Label Pill").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("Label Pill").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VThemeToggle(style: .labelPill)
                         }
                         Divider().background(VColor.borderBase)
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("No label").font(VFont.labelDefault).foregroundColor(VColor.contentTertiary)
+                            Text("No label").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VThemeToggle(showLabel: false)
                         }
                     }

--- a/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
@@ -17,7 +17,7 @@ struct TokensGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.lg) {
                         Text("Semantic Tokens")
                             .font(VFont.bodySmallEmphasised)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
 
                         let semanticTokens = VSemanticColorToken.allCases
 
@@ -31,10 +31,10 @@ struct TokensGallerySection: View {
                                     }
                                     Text(token.rawValue)
                                         .font(VFont.labelDefault)
-                                        .foregroundColor(VColor.contentSecondary)
+                                        .foregroundStyle(VColor.contentSecondary)
                                     Text("\(pair.lightHex) / \(pair.darkHex)")
                                         .font(VFont.labelSmall)
-                                        .foregroundColor(VColor.contentTertiary)
+                                        .foregroundStyle(VColor.contentTertiary)
                                 }
                             }
                         }
@@ -45,7 +45,7 @@ struct TokensGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.lg) {
                         Text("Syntax Colors")
                             .font(VFont.bodySmallEmphasised)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
 
                         let syntaxTokens: [(String, Color)] = [
                             ("syntaxString", VColor.syntaxString),
@@ -69,7 +69,7 @@ struct TokensGallerySection: View {
                                         )
                                     Text(name)
                                         .font(VFont.labelDefault)
-                                        .foregroundColor(VColor.contentSecondary)
+                                        .foregroundStyle(VColor.contentSecondary)
                                 }
                             }
                         }
@@ -122,7 +122,7 @@ struct TokensGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.md) {
                         Text("Token Reference")
                             .font(VFont.bodySmallEmphasised)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
                             .padding(.bottom, VSpacing.xs)
 
                         let tokens: [(String, String, String, Font)] = [
@@ -146,22 +146,22 @@ struct TokensGallerySection: View {
                             HStack(alignment: .top, spacing: VSpacing.lg) {
                                 Text("VFont.\(name)")
                                     .font(VFont.bodySmallDefault)
-                                    .foregroundColor(VColor.contentEmphasized)
+                                    .foregroundStyle(VColor.contentEmphasized)
                                     .frame(width: 200, alignment: .leading)
 
                                 Text(spec)
                                     .font(VFont.bodySmallDefault)
-                                    .foregroundColor(VColor.contentTertiary)
+                                    .foregroundStyle(VColor.contentTertiary)
                                     .frame(width: 130, alignment: .leading)
 
                                 Text(usage)
                                     .font(VFont.bodySmallDefault)
-                                    .foregroundColor(VColor.contentTertiary)
+                                    .foregroundStyle(VColor.contentTertiary)
                                     .frame(maxWidth: .infinity, alignment: .leading)
 
                                 Text("Aa")
                                     .font(font)
-                                    .foregroundColor(VColor.contentDefault)
+                                    .foregroundStyle(VColor.contentDefault)
                                     .frame(width: 60, alignment: .trailing)
                             }
                         }
@@ -192,7 +192,7 @@ struct TokensGallerySection: View {
                             HStack(spacing: VSpacing.lg) {
                                 Text("\(name) (\(Int(value))pt)")
                                     .font(VFont.bodySmallDefault)
-                                    .foregroundColor(VColor.contentSecondary)
+                                    .foregroundStyle(VColor.contentSecondary)
                                     .frame(width: 120, alignment: .trailing)
                                 RoundedRectangle(cornerRadius: VRadius.xs)
                                     .fill(VColor.primaryBase)
@@ -233,10 +233,10 @@ struct TokensGallerySection: View {
                                     )
                                 Text(name)
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.contentSecondary)
+                                    .foregroundStyle(VColor.contentSecondary)
                                 Text("\(Int(radius))pt")
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.contentTertiary)
+                                    .foregroundStyle(VColor.contentTertiary)
                             }
                         }
                     }
@@ -269,7 +269,7 @@ struct TokensGallerySection: View {
                                     .vShadow(shadow)
                                 Text(name)
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.contentSecondary)
+                                    .foregroundStyle(VColor.contentSecondary)
                             }
                         }
                     }
@@ -304,11 +304,11 @@ struct TokensGallerySection: View {
                             HStack(spacing: VSpacing.lg) {
                                 Text(name)
                                     .font(VFont.bodySmallDefault)
-                                    .foregroundColor(VColor.contentDefault)
+                                    .foregroundStyle(VColor.contentDefault)
                                     .frame(width: 80, alignment: .trailing)
                                 Text(description)
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.contentTertiary)
+                                    .foregroundStyle(VColor.contentTertiary)
                             }
                         }
                     }
@@ -333,15 +333,15 @@ struct TokensGallerySection: View {
             Color.clear.frame(width: Self.matrixSizeWidth)
             Text("Regular")
                 .font(VFont.bodySmallEmphasised)
-                .foregroundColor(VColor.contentDisabled)
+                .foregroundStyle(VColor.contentDisabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
             Text("Medium")
                 .font(VFont.bodySmallEmphasised)
-                .foregroundColor(VColor.contentDisabled)
+                .foregroundStyle(VColor.contentDisabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
             Text("Semi-bold")
                 .font(VFont.bodySmallEmphasised)
-                .foregroundColor(VColor.contentDisabled)
+                .foregroundStyle(VColor.contentDisabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.horizontal, VSpacing.lg)
@@ -358,11 +358,11 @@ struct TokensGallerySection: View {
         HStack(spacing: 0) {
             Text(group)
                 .font(VFont.bodySmallEmphasised)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
                 .frame(width: Self.matrixGroupWidth, alignment: .leading)
             Text("\(size)px")
                 .font(VFont.bodySmallEmphasised)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
                 .frame(width: Self.matrixSizeWidth, alignment: .leading)
             typeMatrixCell(regular)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -380,7 +380,7 @@ struct TokensGallerySection: View {
         if let (name, font) = token {
             Text(name)
                 .font(font)
-                .foregroundColor(VColor.contentEmphasized)
+                .foregroundStyle(VColor.contentEmphasized)
         } else {
             RoundedRectangle(cornerRadius: VRadius.xs)
                 .fill(VColor.surfaceBase.opacity(0.5))
@@ -400,7 +400,7 @@ struct TokensGallerySection: View {
             .overlay(alignment: .topLeading) {
                 Text(label)
                     .font(VFont.labelSmall)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
                     .padding(4)
             }
     }

--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -246,7 +246,7 @@ private struct VTooltipContent: View {
         Text(text)
             .fixedSize()
             .font(VFont.labelDefault)
-            .foregroundColor(VColor.contentDefault)
+            .foregroundStyle(VColor.contentDefault)
             .padding(.horizontal, VSpacing.sm)
             .padding(.vertical, VSpacing.xs)
             .background(VColor.surfaceLift)


### PR DESCRIPTION
## Summary
- Replaces all .foregroundColor() with .foregroundStyle() in clients/shared/DesignSystem/

Part of plan: macos15-modernization.md (PR 14 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
