### PR TITLE
refactor: replace .foregroundColor() with .foregroundStyle() in shared Features

### DIFF
--- a/clients/shared/Features/Chat/ApprovalActionRow.swift
+++ b/clients/shared/Features/Chat/ApprovalActionRow.swift
@@ -40,7 +40,7 @@ public struct GuardianApprovalActionRow: View {
                         .controlSize(.small)
                     Text("Submitting...")
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                 }
             }
         }

--- a/clients/shared/Features/Chat/ApprovalStatusRow.swift
+++ b/clients/shared/Features/Chat/ApprovalStatusRow.swift
@@ -26,7 +26,7 @@ public struct ApprovalStatusRow: View {
 
             Text(label)
                 .font(VFont.labelDefault)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
 
             Spacer()
         }
@@ -37,13 +37,13 @@ public struct ApprovalStatusRow: View {
         switch outcome {
         case .approved:
             VIconView(.circleCheck, size: 12)
-                .foregroundColor(VColor.systemPositiveStrong)
+                .foregroundStyle(VColor.systemPositiveStrong)
         case .denied:
             VIconView(.circleX, size: 12)
-                .foregroundColor(VColor.systemNegativeStrong)
+                .foregroundStyle(VColor.systemNegativeStrong)
         case .stale, .timedOut:
             VIconView(.clock, size: 12)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
         }
     }
 }

--- a/clients/shared/Features/Chat/CommandListBubble.swift
+++ b/clients/shared/Features/Chat/CommandListBubble.swift
@@ -44,7 +44,7 @@ public struct CommandListBubble: View {
             // Header
             Text("COMMANDS")
                 .font(VFont.labelSmall)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
                 .tracking(0.5)
                 .padding(.horizontal, VSpacing.lg)
                 .padding(.top, VSpacing.sm)
@@ -55,12 +55,12 @@ public struct CommandListBubble: View {
                 HStack(spacing: VSpacing.sm) {
                     Text(command.id)
                         .font(VFont.bodySmallDefault)
-                        .foregroundColor(VColor.primaryBase)
+                        .foregroundStyle(VColor.primaryBase)
                         .frame(width: 100, alignment: .leading)
 
                     Text(command.description)
                         .font(VFont.bodyMediumLighter)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
 
                     Spacer()
                 }

--- a/clients/shared/Features/Chat/CurrentStepIndicator.swift
+++ b/clients/shared/Features/Chat/CurrentStepIndicator.swift
@@ -49,7 +49,7 @@ public struct CurrentStepIndicator: View {
                 // Spinner or checkmark
                 if let current = current, current.isComplete {
                     VIconView(.circleCheck, size: 14)
-                        .foregroundColor(VColor.primaryBase)
+                        .foregroundStyle(VColor.primaryBase)
                 } else {
                     ProgressView()
                         .scaleEffect(0.7)
@@ -63,20 +63,20 @@ public struct CurrentStepIndicator: View {
                         // Show tool name if available, otherwise show generic "Thinking..."
                         Text(current?.friendlyName ?? "Thinking...")
                             .font(VFont.bodyMediumDefault)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
 
                         // Progress counter inline with title
                         if totalCount > 1 {
                             Text("(\(completedCount)/\(totalCount))")
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                         }
                     }
 
                     if isLoading {
                         Text("Working...")
                             .font(VFont.labelSmall)
-                            .foregroundColor(VColor.primaryBase)
+                            .foregroundStyle(VColor.primaryBase)
                             .opacity(pulseOpacity)
                     }
                 }
@@ -85,7 +85,7 @@ public struct CurrentStepIndicator: View {
 
                 // Chevron to indicate it's clickable
                 VIconView(.chevronRight, size: 10)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
             }
             .padding(.horizontal, VSpacing.md)
             .padding(.vertical, VSpacing.sm)

--- a/clients/shared/Features/Chat/GuardianDecisionBubble.swift
+++ b/clients/shared/Features/Chat/GuardianDecisionBubble.swift
@@ -53,17 +53,17 @@ public struct GuardianDecisionBubble: View {
             // Kind-aware header
             HStack(spacing: VSpacing.sm) {
                 VIconView(config.icon, size: 14)
-                    .foregroundColor(config.accent)
+                    .foregroundStyle(config.accent)
 
                 Text(config.title)
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
             }
 
             // Question text (primary interaction prompt)
             Text(decision.questionText)
                 .font(VFont.bodyMediumEmphasised)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
                 .fixedSize(horizontal: false, vertical: true)
 
             // Action buttons (primary interaction)
@@ -82,10 +82,10 @@ public struct GuardianDecisionBubble: View {
                     if let toolName = decision.toolName, !toolName.isEmpty {
                         HStack(spacing: VSpacing.xs) {
                             VIconView(.wrench, size: 10)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                             Text(toolName)
                                 .font(VFont.bodySmallDefault)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                         }
                     }
 
@@ -93,10 +93,10 @@ public struct GuardianDecisionBubble: View {
                         HStack(spacing: VSpacing.xs) {
                             Text("Ref:")
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                             Text(decision.requestCode)
                                 .font(VFont.bodySmallDefault)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                         }
                     }
                 }

--- a/clients/shared/Features/Chat/InlineChatErrorAlert.swift
+++ b/clients/shared/Features/Chat/InlineChatErrorAlert.swift
@@ -84,16 +84,16 @@ public struct InlineChatErrorAlert: View {
                 // Header: icon + category title
                 HStack(spacing: VSpacing.xs) {
                     VIconView(icon, size: 13)
-                        .foregroundColor(accentColor)
+                        .foregroundStyle(accentColor)
                     Text(categoryTitle)
                         .font(VFont.bodyMediumDefault)
-                        .foregroundColor(VColor.contentEmphasized)
+                        .foregroundStyle(VColor.contentEmphasized)
                 }
 
                 // Error message body
                 Text(message)
                     .font(VFont.bodyMediumLighter)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
                     .textSelection(.enabled)
                     .fixedSize(horizontal: false, vertical: true)
 
@@ -101,7 +101,7 @@ public struct InlineChatErrorAlert: View {
                 if let suggestion = recoverySuggestion {
                     Text(suggestion)
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
@@ -113,7 +113,7 @@ public struct InlineChatErrorAlert: View {
                             Text("Retry")
                         }
                         .font(VFont.labelDefault)
-                        .foregroundColor(accentColor)
+                        .foregroundStyle(accentColor)
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.xs)
                         .background(accentColor.opacity(0.1))

--- a/clients/shared/Features/Chat/InlineWidgets/CompletedSurfaceChip.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/CompletedSurfaceChip.swift
@@ -13,17 +13,17 @@ public struct CompletedSurfaceChip: View {
     public var body: some View {
         HStack(spacing: VSpacing.sm) {
             VIconView(.circleCheck, size: 12)
-                .foregroundColor(VColor.systemPositiveStrong)
+                .foregroundStyle(VColor.systemPositiveStrong)
 
             if let title {
                 Text(title)
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
             }
 
             Text(summary)
                 .font(VFont.labelDefault)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
         }
         .padding(.horizontal, VSpacing.md)
         .padding(.vertical, VSpacing.sm)

--- a/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
@@ -34,14 +34,14 @@ struct InlineAppCreatedCard: View {
 
                 Text(preview.title)
                     .font(VFont.bodyMediumEmphasised)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
                     .lineLimit(2)
             }
 
             if let description = preview.description, !description.isEmpty {
                 Text(description)
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
                     .lineLimit(3)
             }
 

--- a/clients/shared/Features/Chat/InlineWidgets/InlineCardWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineCardWidget.swift
@@ -29,12 +29,12 @@ public struct InlineCardWidget: View {
             VStack(alignment: .leading, spacing: VSpacing.xxs) {
                 Text(data.title)
                     .font(VFont.bodySmallEmphasised)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
 
                 if let subtitle = data.subtitle {
                     Text(subtitle)
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                 }
             }
 
@@ -42,7 +42,7 @@ public struct InlineCardWidget: View {
             if !data.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 Text(markdownBody)
                     .font(VFont.bodyMediumLighter)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
                     .textSelection(.enabled)
             }
 
@@ -63,10 +63,10 @@ public struct InlineCardWidget: View {
                 VStack(alignment: .leading, spacing: VSpacing.xxs) {
                     Text(item.label)
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                     Text(item.value)
                         .font(VFont.bodyMediumDefault)
-                        .foregroundColor(VColor.contentDefault)
+                        .foregroundStyle(VColor.contentDefault)
                 }
             }
         }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineDocumentPreview.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineDocumentPreview.swift
@@ -17,18 +17,18 @@ public struct InlineDocumentPreview: View {
         } label: {
             HStack(spacing: VSpacing.sm) {
                 VIconView(.fileText, size: 20)
-                    .foregroundColor(VColor.primaryBase)
+                    .foregroundStyle(VColor.primaryBase)
 
                 VStack(alignment: .leading, spacing: VSpacing.xxs) {
                     Text(data.title)
                         .font(VFont.bodyMediumEmphasised)
-                        .foregroundColor(VColor.contentDefault)
+                        .foregroundStyle(VColor.contentDefault)
                         .lineLimit(2)
 
                     if let subtitle = data.subtitle {
                         Text(subtitle)
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                             .lineLimit(1)
                     }
                 }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineDynamicPagePreview.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineDynamicPagePreview.swift
@@ -45,13 +45,13 @@ public struct InlineDynamicPagePreview: View {
                     VStack(alignment: .leading, spacing: VSpacing.xxs) {
                         Text(preview.title)
                             .font(VFont.bodyMediumEmphasised)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
                             .lineLimit(2)
 
                         if let subtitle = preview.subtitle {
                             Text(subtitle)
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                                 .lineLimit(1)
                         }
                     }
@@ -60,7 +60,7 @@ public struct InlineDynamicPagePreview: View {
                 if let description = preview.description, !description.isEmpty {
                     Text(description)
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                         .lineLimit(3)
                 }
 
@@ -84,10 +84,10 @@ public struct InlineDynamicPagePreview: View {
         VStack(alignment: .leading, spacing: VSpacing.xxs) {
             Text(label)
                 .font(VFont.labelSmall)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
             Text(value)
                 .font(VFont.labelDefault)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
                 .lineLimit(1)
         }
         .padding(.horizontal, VSpacing.sm)

--- a/clients/shared/Features/Chat/InlineWidgets/InlineFallbackChip.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineFallbackChip.swift
@@ -11,11 +11,11 @@ public struct InlineFallbackChip: View {
     public var body: some View {
         HStack(spacing: VSpacing.sm) {
             VIconView(.layers, size: 12)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
 
             Text("Interactive \(surfaceType.rawValue) surface")
                 .font(VFont.labelDefault)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
         }
         .padding(.horizontal, VSpacing.md)
         .padding(.vertical, VSpacing.sm)

--- a/clients/shared/Features/Chat/InlineWidgets/InlineListWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineListWidget.swift
@@ -38,12 +38,12 @@ public struct InlineListWidget: View {
             VStack(alignment: .leading, spacing: VSpacing.xxs) {
                 Text(item.title)
                     .font(VFont.bodyMediumDefault)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
 
                 if let subtitle = item.subtitle {
                     Text(subtitle)
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                         .lineLimit(1)
                 }
             }
@@ -52,7 +52,7 @@ public struct InlineListWidget: View {
 
             if data.selectionMode != .none {
                 VIconView(isSelected ? .circleCheck : .circle, size: 14)
-                    .foregroundColor(isSelected ? VColor.primaryBase : VColor.contentTertiary)
+                    .foregroundStyle(isSelected ? VColor.primaryBase : VColor.contentTertiary)
             }
         }
         .padding(.vertical, VSpacing.sm)

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -83,7 +83,7 @@ public struct InlineSurfaceRouter: View {
             if !isTemplateCard, !isDynamicPreview, !isDocumentPreview, let title = surface.title {
                 Text(title)
                     .font(VFont.titleSmall)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
             }
 
             surfaceContent
@@ -106,7 +106,7 @@ public struct InlineSurfaceRouter: View {
                     }
                 } label: {
                     VIconView(.arrowUpRight, size: 10)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                         .padding(VSpacing.xs)
                         .background(
                             RoundedRectangle(cornerRadius: VRadius.sm)
@@ -125,7 +125,7 @@ public struct InlineSurfaceRouter: View {
                         )
                     } label: {
                         VIconView(.arrowUpRight, size: 10)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
                             .padding(VSpacing.xs)
                             .background(
                                 RoundedRectangle(cornerRadius: VRadius.sm)
@@ -158,7 +158,7 @@ public struct InlineSurfaceRouter: View {
             VLoadingIndicator(size: 14, color: VColor.contentSecondary)
             Text(surface.title ?? "Loading surface…")
                 .font(VFont.labelDefault)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
         }
         .padding(VSpacing.md)
         .frame(maxWidth: 540, alignment: .leading)
@@ -177,10 +177,10 @@ public struct InlineSurfaceRouter: View {
     private var strippedFailedPlaceholder: some View {
         HStack(spacing: VSpacing.sm) {
             VIconView(.triangleAlert, size: 12)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
             Text("Failed to load surface")
                 .font(VFont.labelDefault)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
         }
         .padding(VSpacing.md)
         .frame(maxWidth: 540, alignment: .leading)
@@ -322,10 +322,10 @@ public struct InlineSurfaceRouter: View {
                 Spacer()
                 HStack(spacing: VSpacing.sm) {
                     VIconView(.circleCheck, size: 12)
-                        .foregroundColor(VColor.systemPositiveStrong)
+                        .foregroundStyle(VColor.systemPositiveStrong)
                     Text(label)
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentDefault)
+                        .foregroundStyle(VColor.contentDefault)
                 }
                 .padding(.horizontal, VSpacing.md)
                 .padding(.vertical, VSpacing.sm)
@@ -350,7 +350,7 @@ public struct InlineSurfaceRouter: View {
                     } label: {
                         Text(action.label)
                             .font(VFont.bodyMediumDefault)
-                            .foregroundColor(buttonForeground(action.style))
+                            .foregroundStyle(buttonForeground(action.style))
                             .padding(.horizontal, VSpacing.lg)
                             .padding(.vertical, VSpacing.sm)
                             .background(

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -41,7 +41,7 @@ public struct InlineTableWidget: View {
                         toggleSelectAll()
                     } label: {
                         VIconView(allSelected ? .circleCheck : .circle, size: 14)
-                            .foregroundColor(allSelected ? VColor.primaryBase : VColor.contentTertiary)
+                            .foregroundStyle(allSelected ? VColor.primaryBase : VColor.contentTertiary)
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel(allSelected ? "Deselect all" : "Select all")
@@ -53,7 +53,7 @@ public struct InlineTableWidget: View {
                 ForEach(data.columns) { column in
                     Text(column.label)
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                         .columnFrame(column.width)
                         .textSelection(.enabled)
                 }
@@ -71,7 +71,7 @@ public struct InlineTableWidget: View {
             if let caption = data.caption {
                 Text(caption)
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
                     .padding(.top, VSpacing.xs)
             }
         }
@@ -94,7 +94,7 @@ public struct InlineTableWidget: View {
                     toggleSelection(row.id)
                 } label: {
                     VIconView(isSelected ? .circleCheck : .circle, size: 14)
-                        .foregroundColor(isSelected ? VColor.primaryBase : VColor.contentTertiary)
+                        .foregroundStyle(isSelected ? VColor.primaryBase : VColor.contentTertiary)
                 }
                 .buttonStyle(.plain)
                 .frame(width: 28)
@@ -126,11 +126,11 @@ public struct InlineTableWidget: View {
             if let icon = value?.icon,
                let vIcon = SFSymbolMapping.icon(forSFSymbol: icon) {
                 VIconView(vIcon, size: 12)
-                    .foregroundColor(resolveIconColor(value?.iconColor))
+                    .foregroundStyle(resolveIconColor(value?.iconColor))
             }
             Text(value?.text ?? "")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
                 .lineLimit(2)
                 .textSelection(.enabled)
         }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTaskProgressWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTaskProgressWidget.swift
@@ -80,7 +80,7 @@ public struct InlineTaskProgressWidget: View {
         HStack(alignment: .center, spacing: VSpacing.sm) {
             Text(data.title)
                 .font(VFont.bodySmallEmphasised)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
 
             Spacer()
 
@@ -97,7 +97,7 @@ public struct InlineTaskProgressWidget: View {
             Text(label)
                 .font(VFont.labelDefault)
         }
-        .foregroundColor(color)
+        .foregroundStyle(color)
         .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.xxs)
         .background(
@@ -127,12 +127,12 @@ public struct InlineTaskProgressWidget: View {
             VStack(alignment: .leading, spacing: VSpacing.xxs) {
                 Text(step.label)
                     .font(VFont.bodyMediumDefault)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
 
                 if let detail = step.detail {
                     Text(detail)
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                 }
             }
 
@@ -148,20 +148,20 @@ public struct InlineTaskProgressWidget: View {
         switch status {
         case "completed":
             VIconView(.circleCheck, size: 14)
-                .foregroundColor(VColor.systemPositiveStrong)
+                .foregroundStyle(VColor.systemPositiveStrong)
         case "in_progress":
             ProgressView()
                 .controlSize(.small)
                 .tint(VColor.systemMidStrong)
         case "waiting":
             VIconView(.clock, size: 14)
-                .foregroundColor(VColor.systemMidStrong)
+                .foregroundStyle(VColor.systemMidStrong)
         case "failed":
             VIconView(.circleX, size: 14)
-                .foregroundColor(VColor.systemNegativeStrong)
+                .foregroundStyle(VColor.systemNegativeStrong)
         default:
             VIconView(.circle, size: 14)
-                .foregroundColor(VColor.contentDisabled)
+                .foregroundStyle(VColor.contentDisabled)
         }
     }
 

--- a/clients/shared/Features/Chat/InlineWidgets/InlineWeatherWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineWeatherWidget.swift
@@ -220,7 +220,7 @@ public struct InlineWeatherWidget: View {
                 VStack(alignment: .leading, spacing: 0) {
                     Text(data.location)
                         .font(VFont.bodySmallEmphasised)
-                        .foregroundColor(VColor.contentDefault)
+                        .foregroundStyle(VColor.contentDefault)
                 }
                 Spacer()
                 Picker("", selection: $useFahrenheit) {
@@ -237,10 +237,10 @@ public struct InlineWeatherWidget: View {
                 HStack(alignment: .top, spacing: 0) {
                     Text("\(data.currentTemp(useFahrenheit: useFahrenheit))")
                         .font(.system(size: 48, weight: .thin, design: .rounded))
-                        .foregroundColor(VColor.contentDefault)
+                        .foregroundStyle(VColor.contentDefault)
                     Text("°")
                         .font(.system(size: 28, weight: .thin, design: .rounded))
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                         .offset(y: 4)
                 }
 
@@ -249,23 +249,23 @@ public struct InlineWeatherWidget: View {
                     HStack(spacing: VSpacing.xs) {
                         if let firstItem = data.forecast.first {
                             VIconView(SFSymbolMapping.icon(forSFSymbol: firstItem.icon, fallback: .cloud), size: 14)
-                                .foregroundColor(iconColor(for: firstItem.icon))
+                                .foregroundStyle(iconColor(for: firstItem.icon))
                         }
                         Text(data.condition)
                             .font(VFont.bodyMediumDefault)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
                     }
 
                     // Feels like
                     Text("Feels like \(data.feelsLike(useFahrenheit: useFahrenheit))°")
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
 
                     // H/L
                     if let hl = todayHighLow {
                         Text("H:\(hl.high)°  L:\(hl.low)°")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
                     }
                 }
                 .padding(.top, VSpacing.sm)
@@ -279,7 +279,7 @@ public struct InlineWeatherWidget: View {
                 } icon: {
                     VIconView(.wind, size: 12)
                 }
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
 
                 Label {
                     Text("\(data.humidity)%")
@@ -287,7 +287,7 @@ public struct InlineWeatherWidget: View {
                 } icon: {
                     VIconView(.droplets, size: 12)
                 }
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
             }
         }
         .padding(.vertical, VSpacing.sm)
@@ -300,10 +300,10 @@ public struct InlineWeatherWidget: View {
             // Header
             HStack(spacing: VSpacing.xs) {
                 VIconView(.clock, size: 12)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
                 Text("HOURLY FORECAST")
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
                 Spacer()
             }
             .padding(.vertical, VSpacing.sm)
@@ -317,15 +317,15 @@ public struct InlineWeatherWidget: View {
                         VStack(spacing: VSpacing.sm) {
                             Text(item.time)
                                 .font(item.time == "Now" ? VFont.bodyMediumEmphasised : VFont.labelDefault)
-                                .foregroundColor(VColor.contentDefault)
+                                .foregroundStyle(VColor.contentDefault)
 
                             VIconView(SFSymbolMapping.icon(forSFSymbol: item.icon, fallback: .cloud), size: 18)
-                                .foregroundColor(iconColor(for: item.icon))
+                                .foregroundStyle(iconColor(for: item.icon))
                                 .frame(height: 22)
 
                             Text("\(item.temp(useFahrenheit: useFahrenheit))°")
                                 .font(VFont.bodyMediumDefault)
-                                .foregroundColor(VColor.contentDefault)
+                                .foregroundStyle(VColor.contentDefault)
                         }
                         .frame(minWidth: 44)
                     }
@@ -340,10 +340,10 @@ public struct InlineWeatherWidget: View {
     private var dailyForecastHeader: some View {
         HStack {
             VIconView(.calendar, size: 12)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
             Text("\(data.forecast.count)-DAY FORECAST")
                 .font(VFont.labelDefault)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
             Spacer()
         }
         .padding(.vertical, VSpacing.sm)
@@ -359,19 +359,19 @@ public struct InlineWeatherWidget: View {
             // Day name
             Text(item.day)
                 .font(item.day == "Today" ? VFont.bodyMediumEmphasised : VFont.bodyMediumDefault)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
                 .frame(width: 46, alignment: .leading)
 
             // Weather icon + optional precip
             VStack(spacing: VSpacing.xxs) {
                 VIconView(SFSymbolMapping.icon(forSFSymbol: item.icon, fallback: .cloud), size: 16)
-                    .foregroundColor(iconColor(for: item.icon))
+                    .foregroundStyle(iconColor(for: item.icon))
                     .frame(width: 24, height: 20)
 
                 if let precip = item.precip {
                     Text("\(precip)%")
                         .font(VFont.labelSmall)
-                        .foregroundColor(VColor.systemNegativeHover)
+                        .foregroundStyle(VColor.systemNegativeHover)
                 }
             }
             .frame(width: 36)
@@ -379,7 +379,7 @@ public struct InlineWeatherWidget: View {
             // Low temp
             Text("\(low)°")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
                 .frame(width: 32, alignment: .trailing)
 
             // Temperature bar
@@ -388,7 +388,7 @@ public struct InlineWeatherWidget: View {
             // High temp
             Text("\(high)°")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
                 .frame(width: 32, alignment: .trailing)
         }
         .padding(.vertical, VSpacing.sm)

--- a/clients/shared/Features/Chat/MarkdownRenderer.swift
+++ b/clients/shared/Features/Chat/MarkdownRenderer.swift
@@ -20,7 +20,7 @@ private struct CodeBlockView: View {
                 if !lang.isEmpty {
                     Text(lang)
                         .font(VFont.bodySmallDefault)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                 }
                 Spacer()
                 Button(action: copyCode) {
@@ -31,7 +31,7 @@ private struct CodeBlockView: View {
                                 .font(VFont.bodySmallDefault)
                         }
                     }
-                    .foregroundColor(showCopied ? VColor.systemPositiveStrong : VColor.contentTertiary)
+                    .foregroundStyle(showCopied ? VColor.systemPositiveStrong : VColor.contentTertiary)
                 }
                 .buttonStyle(.plain)
             }
@@ -40,7 +40,7 @@ private struct CodeBlockView: View {
 
             Text(code)
                 .font(VFont.bodyMediumDefault)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
                 .padding(VSpacing.sm)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .textSelection(.enabled)
@@ -247,13 +247,13 @@ public struct MarkdownRenderer: View {
         case .heading(let level, let text):
             Text(inlineMarkdown(text))
                 .font(level <= 2 ? VFont.bodySmallEmphasised : VFont.bodyMediumDefault)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
         case .paragraph(let text):
             Text(inlineMarkdown(text))
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
                 .tint(VColor.primaryBase)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .textSelection(.enabled)
@@ -267,11 +267,11 @@ public struct MarkdownRenderer: View {
                     HStack(alignment: .top, spacing: VSpacing.xs) {
                         Text(ordered ? "\(index + 1)." : "•")
                             .font(VFont.bodyMediumLighter)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
                             .frame(minWidth: ordered ? 24 : 12, alignment: .leading)
                         Text(inlineMarkdown(item))
                             .font(VFont.bodyMediumLighter)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
                             .tint(VColor.primaryBase)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .textSelection(.enabled)

--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -132,10 +132,10 @@ public struct MessageBubbleView: View {
                 if message.status == .pendingOffline {
                     HStack(spacing: VSpacing.xs) {
                         VIconView(.history, size: 11)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                         Text("Pending")
                             .font(VFont.labelSmall)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                     }
                     .padding(.horizontal, VSpacing.sm)
                 }
@@ -144,16 +144,16 @@ public struct MessageBubbleView: View {
                 if message.role == .user && message.status == .sendFailed {
                     HStack(spacing: VSpacing.xs) {
                         VIconView(.triangleAlert, size: 11)
-                            .foregroundColor(VColor.systemNegativeStrong)
+                            .foregroundStyle(VColor.systemNegativeStrong)
                         Text("Failed to send")
                             .font(VFont.labelSmall)
-                            .foregroundColor(VColor.systemNegativeStrong)
+                            .foregroundStyle(VColor.systemNegativeStrong)
                         Button {
                             onRetryFailedMessage?(message.id)
                         } label: {
                             Text("Retry")
                                 .font(VFont.labelSmall.weight(.medium))
-                                .foregroundColor(VColor.primaryBase)
+                                .foregroundStyle(VColor.primaryBase)
                         }
                         .buttonStyle(.plain)
                     }
@@ -266,7 +266,7 @@ public struct MessageBubbleView: View {
         if isUser {
             Text(text)
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
                 .padding(VSpacing.md)
                 .background(VColor.surfaceActive)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))

--- a/clients/shared/Features/Chat/ModelListBubble.swift
+++ b/clients/shared/Features/Chat/ModelListBubble.swift
@@ -45,17 +45,17 @@ public struct ModelListBubble: View {
                 HStack(spacing: VSpacing.sm) {
                     Text(group.name)
                         .font(VFont.labelSmall)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                         .tracking(0.5)
                     Spacer()
                     if group.hasKey {
                         Text("connected")
                             .font(VFont.labelSmall)
-                            .foregroundColor(VColor.systemPositiveStrong)
+                            .foregroundStyle(VColor.systemPositiveStrong)
                     } else {
                         Text("no key")
                             .font(VFont.labelSmall)
-                            .foregroundColor(VColor.systemNegativeHover)
+                            .foregroundStyle(VColor.systemNegativeHover)
                     }
                 }
                 .padding(.horizontal, VSpacing.lg)
@@ -67,7 +67,7 @@ public struct ModelListBubble: View {
                     HStack(spacing: VSpacing.sm) {
                         if model.isCurrent {
                             VIconView(.circleCheck, size: 11)
-                                .foregroundColor(VColor.primaryBase)
+                                .foregroundStyle(VColor.primaryBase)
                                 .frame(width: 16)
                         } else {
                             Color.clear.frame(width: 16, height: 1)
@@ -75,13 +75,13 @@ public struct ModelListBubble: View {
 
                         Text(model.displayName)
                             .font(model.isCurrent ? VFont.bodyMediumEmphasised : VFont.bodyMediumLighter)
-                            .foregroundColor(group.hasKey ? VColor.contentDefault : VColor.contentTertiary)
+                            .foregroundStyle(group.hasKey ? VColor.contentDefault : VColor.contentTertiary)
 
                         Spacer()
 
                         Text(model.id)
                             .font(VFont.bodySmallDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                     }
                     .padding(.horizontal, VSpacing.lg)
                     .padding(.vertical, VSpacing.xs + 2)
@@ -91,7 +91,7 @@ public struct ModelListBubble: View {
             // Footer
             Text("Use Settings -> Models & Services to switch models, or `keys set <provider> <key>` to add a provider.")
                 .font(VFont.labelSmall)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
                 .padding(.horizontal, VSpacing.lg)
                 .padding(.top, VSpacing.md)
                 .padding(.bottom, VSpacing.sm)

--- a/clients/shared/Features/Chat/SkillInvocationChip.swift
+++ b/clients/shared/Features/Chat/SkillInvocationChip.swift
@@ -17,15 +17,15 @@ public struct SkillInvocationChip: View {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
                 Text("Using skill")
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
 
                 Text(data.name)
                     .font(VFont.bodyMediumDefault)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
 
                 Text(data.description)
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
                     .lineLimit(2)
             }
         }

--- a/clients/shared/Features/Chat/SubagentConversationView.swift
+++ b/clients/shared/Features/Chat/SubagentConversationView.swift
@@ -96,11 +96,11 @@ public struct SubagentConversationView: View {
             // Label (clickable, turns blue on hover like Slack)
             Text(subagent.label)
                 .font(VFont.labelDefault)
-                .foregroundColor(isHovered ? VColor.primaryBase : VColor.contentDefault)
+                .foregroundStyle(isHovered ? VColor.primaryBase : VColor.contentDefault)
 
             // Status icon
             VIconView(statusIcon, size: 9)
-                .foregroundColor(statusColor)
+                .foregroundStyle(statusColor)
 
             // Animated dots while running
             if isRunning {
@@ -113,18 +113,18 @@ public struct SubagentConversationView: View {
             if replyCount > 0 {
                 Text("\(replyCount) repl\(replyCount == 1 ? "y" : "ies")")
                     .font(VFont.labelDefault)
-                    .foregroundColor(isHovered ? VColor.primaryBase : VColor.systemPositiveStrong)
+                    .foregroundStyle(isHovered ? VColor.primaryBase : VColor.systemPositiveStrong)
             } else if isRunning {
                 Text("Working...")
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
                     .italic()
             }
 
             // Abort button
             if isRunning, let onAbort {
                 VIconView(.x, size: 9)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
                     .padding(VSpacing.xs)
                     .contentShape(Rectangle())
                     .highPriorityGesture(TapGesture().onEnded { onAbort() })
@@ -134,7 +134,7 @@ public struct SubagentConversationView: View {
 
             // View conversation arrow
             VIconView(.chevronRight, size: 9)
-                .foregroundColor(isHovered ? VColor.primaryBase : VColor.contentTertiary)
+                .foregroundStyle(isHovered ? VColor.primaryBase : VColor.contentTertiary)
         }
         .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.sm)

--- a/clients/shared/Features/Chat/SubagentStatusChip.swift
+++ b/clients/shared/Features/Chat/SubagentStatusChip.swift
@@ -42,13 +42,13 @@ public struct SubagentStatusChip: View {
     private func chipContent(phase: Int) -> some View {
         HStack(spacing: VSpacing.sm) {
             VIconView(statusIcon, size: 11)
-                .foregroundColor(statusColor)
+                .foregroundStyle(statusColor)
 
             VStack(alignment: .leading, spacing: 1) {
                 HStack(spacing: VSpacing.xs) {
                     Text(subagent.label)
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentDefault)
+                        .foregroundStyle(VColor.contentDefault)
 
                     if !subagent.isTerminal {
                         // Animated dots
@@ -66,7 +66,7 @@ public struct SubagentStatusChip: View {
                 if let error = subagent.error, !error.isEmpty {
                     Text(error)
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.systemNegativeStrong)
+                        .foregroundStyle(VColor.systemNegativeStrong)
                         .lineLimit(2)
                 }
             }
@@ -75,7 +75,7 @@ public struct SubagentStatusChip: View {
 
             if !subagent.isTerminal, let onAbort {
                 VIconView(.x, size: 9)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
                     .padding(VSpacing.xs)
                     .contentShape(Rectangle())
                     .highPriorityGesture(TapGesture().onEnded { onAbort() })

--- a/clients/shared/Features/Chat/TaskProgressOverlayManager.swift
+++ b/clients/shared/Features/Chat/TaskProgressOverlayManager.swift
@@ -171,7 +171,7 @@ private struct TaskProgressOverlayView: View {
                         manager.close()
                     } label: {
                         VIconView(.x, size: 10)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
                     }
                     .buttonStyle(.plain)
                     .padding(.top, VSpacing.sm)

--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -93,12 +93,12 @@ public struct ToolCallChip: View {
                 HStack(spacing: VSpacing.xs) {
                     // Tool-specific icon
                     VIconView(toolCall.toolIcon, size: 12)
-                        .foregroundColor(toolCall.isError ? VColor.systemNegativeStrong : VColor.contentSecondary)
+                        .foregroundStyle(toolCall.isError ? VColor.systemNegativeStrong : VColor.contentSecondary)
 
                     // Plain-language description of what was done
                     Text(toolCall.actionDescription)
                         .font(VFont.labelDefault)
-                        .foregroundColor(toolCall.isError ? VColor.systemNegativeStrong : VColor.contentDefault)
+                        .foregroundStyle(toolCall.isError ? VColor.systemNegativeStrong : VColor.contentDefault)
                         .lineLimit(1)
                         .truncationMode(.tail)
                         .help(toolCall.actionDescription)
@@ -112,7 +112,7 @@ public struct ToolCallChip: View {
                     } else if hasExpandableContent {
                         // Chevron for expandable result
                         VIconView(isExpanded ? .chevronDown : .chevronRight, size: 9)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                     }
                 }
                 .padding(.horizontal, VSpacing.md)
@@ -132,17 +132,17 @@ public struct ToolCallChip: View {
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         Text("Technical details")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                             .textCase(.uppercase)
 
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
                             Text(toolCall.friendlyName)
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                             if !resolvedInputFull.isEmpty {
                                 Text(resolvedInputFull)
                                     .font(VFont.bodySmallDefault)
-                                    .foregroundColor(VColor.contentSecondary)
+                                    .foregroundStyle(VColor.contentSecondary)
                                     .textSelection(.enabled)
                                     .fixedSize(horizontal: false, vertical: true)
                             }
@@ -189,7 +189,7 @@ public struct ToolCallChip: View {
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
                             Text("Output")
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                                 .textCase(.uppercase)
 
                             if let exitCode = Self.parseExitCode(from: result) {
@@ -197,15 +197,15 @@ public struct ToolCallChip: View {
                                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                                     HStack(spacing: VSpacing.xs) {
                                         VIconView(.triangleAlert, size: 11)
-                                            .foregroundColor(VColor.systemNegativeStrong)
+                                            .foregroundStyle(VColor.systemNegativeStrong)
                                         Text("Exit code \(exitCode)")
                                             .font(VFont.labelDefault)
-                                            .foregroundColor(VColor.systemNegativeStrong)
+                                            .foregroundStyle(VColor.systemNegativeStrong)
                                     }
                                     if let explanation = Self.exitCodeExplanation(exitCode) {
                                         Text(explanation)
                                             .font(VFont.labelDefault)
-                                            .foregroundColor(VColor.contentSecondary)
+                                            .foregroundStyle(VColor.contentSecondary)
                                     }
                                     // Show any additional output beyond the tag itself
                                     let extraOutput = result
@@ -214,17 +214,17 @@ public struct ToolCallChip: View {
                                     if !extraOutput.isEmpty {
                                         Text(extraOutput)
                                             .font(VFont.bodySmallDefault)
-                                            .foregroundColor(VColor.contentSecondary)
+                                            .foregroundStyle(VColor.contentSecondary)
                                             .textSelection(.enabled)
                                     }
                                 }
                             } else if result == "<command_completed />" {
                                 HStack(spacing: VSpacing.xs) {
                                     VIconView(.circleCheck, size: 11)
-                                        .foregroundColor(VColor.primaryBase)
+                                        .foregroundStyle(VColor.primaryBase)
                                     Text("Command completed successfully (no output).")
                                         .font(VFont.labelDefault)
-                                        .foregroundColor(VColor.contentSecondary)
+                                        .foregroundStyle(VColor.contentSecondary)
                                 }
                             } else {
                                 let lineCount = cachedResultLineCount ?? Self.countLines(in: result)
@@ -234,7 +234,7 @@ public struct ToolCallChip: View {
                                     ScrollView {
                                         Text(result)
                                             .font(VFont.bodySmallDefault)
-                                            .foregroundColor(VColor.contentSecondary)
+                                            .foregroundStyle(VColor.contentSecondary)
                                             .frame(maxWidth: .infinity, alignment: .leading)
                                             .textSelection(.enabled)
                                     }
@@ -242,7 +242,7 @@ public struct ToolCallChip: View {
                                 } else {
                                     Text(result)
                                         .font(VFont.bodySmallDefault)
-                                        .foregroundColor(VColor.contentSecondary)
+                                        .foregroundStyle(VColor.contentSecondary)
                                         .frame(maxWidth: .infinity, alignment: .leading)
                                         .textSelection(.enabled)
                                         .fixedSize(horizontal: false, vertical: true)

--- a/clients/shared/Features/Chat/ToolCallProgressBar.swift
+++ b/clients/shared/Features/Chat/ToolCallProgressBar.swift
@@ -77,11 +77,11 @@ public struct ToolCallProgressBar: View {
                     if toolCall.isError {
                         // Error icon
                         VIconView(.x, size: 8)
-                            .foregroundColor(VColor.auxWhite)
+                            .foregroundStyle(VColor.auxWhite)
                     } else {
                         // Checkmark
                         VIconView(.check, size: 8)
-                            .foregroundColor(VColor.auxWhite)
+                            .foregroundStyle(VColor.auxWhite)
                     }
                 } else {
                     // Outlined circle for in-progress
@@ -111,7 +111,7 @@ public struct ToolCallProgressBar: View {
     private func stepLabel(for toolCall: ToolCallData) -> some View {
         Text(toolCall.friendlyName)
             .font(VFont.labelSmall)
-            .foregroundColor(stepTextColor(for: toolCall))
+            .foregroundStyle(stepTextColor(for: toolCall))
             .lineLimit(1)
             .multilineTextAlignment(.center)
     }
@@ -146,11 +146,11 @@ public struct ToolCallProgressBar: View {
             // Header
             HStack {
                 VIconView(.terminal, size: 12)
-                    .foregroundColor(toolCall.isError ? VColor.systemNegativeStrong : VColor.primaryBase)
+                    .foregroundStyle(toolCall.isError ? VColor.systemNegativeStrong : VColor.primaryBase)
 
                 Text(toolCall.friendlyName)
                     .font(VFont.bodyMediumDefault)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
 
                 Spacer()
 
@@ -160,7 +160,7 @@ public struct ToolCallProgressBar: View {
                     }
                 } label: {
                     VIconView(.x, size: 10)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Close details")
@@ -171,11 +171,11 @@ public struct ToolCallProgressBar: View {
                 VStack(alignment: .leading, spacing: VSpacing.xxs) {
                     Text("Input")
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
 
                     Text(toolCall.inputSummary)
                         .font(VFont.bodyMediumDefault)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                         .textSelection(.enabled)
                 }
             }
@@ -185,7 +185,7 @@ public struct ToolCallProgressBar: View {
                 VStack(alignment: .leading, spacing: VSpacing.xxs) {
                     Text("Screenshot")
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
 
                     #if os(macOS)
                     Image(nsImage: cachedImage)
@@ -208,21 +208,21 @@ public struct ToolCallProgressBar: View {
                 VStack(alignment: .leading, spacing: VSpacing.xxs) {
                     Text("Result")
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
 
                     if let exitCode = ToolCallChip.parseExitCode(from: result) {
                         VStack(alignment: .leading, spacing: VSpacing.xxs) {
                             HStack(spacing: VSpacing.xs) {
                                 VIconView(.triangleAlert, size: 11)
-                                    .foregroundColor(VColor.systemNegativeStrong)
+                                    .foregroundStyle(VColor.systemNegativeStrong)
                                 Text("Exit code \(exitCode)")
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.systemNegativeStrong)
+                                    .foregroundStyle(VColor.systemNegativeStrong)
                             }
                             if let explanation = ToolCallChip.exitCodeExplanation(exitCode) {
                                 Text(explanation)
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.contentSecondary)
+                                    .foregroundStyle(VColor.contentSecondary)
                             }
                             let extraOutput = result
                                 .replacingOccurrences(of: #"<command_exit code="\d+" />"#, with: "", options: .regularExpression)
@@ -230,23 +230,23 @@ public struct ToolCallProgressBar: View {
                             if !extraOutput.isEmpty {
                                 Text(extraOutput)
                                     .font(VFont.bodySmallDefault)
-                                    .foregroundColor(VColor.contentSecondary)
+                                    .foregroundStyle(VColor.contentSecondary)
                                     .textSelection(.enabled)
                             }
                         }
                     } else if result == "<command_completed />" {
                         HStack(spacing: VSpacing.xs) {
                             VIconView(.circleCheck, size: 11)
-                                .foregroundColor(VColor.primaryBase)
+                                .foregroundStyle(VColor.primaryBase)
                             Text("Command completed successfully (no output).")
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                         }
                     } else {
                         ScrollView {
                             Text(result)
                                 .font(VFont.bodySmallDefault)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .textSelection(.enabled)
                         }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -111,16 +111,16 @@ public struct ToolConfirmationBubble: View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
             HStack(spacing: VSpacing.sm) {
                 VIconView(.shield, size: 16)
-                    .foregroundColor(VColor.primaryBase)
+                    .foregroundStyle(VColor.primaryBase)
 
                 Text(confirmation.permissionFriendlyName)
                     .font(VFont.bodyMediumEmphasised)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
             }
 
             Text(confirmation.humanDescription)
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
 
             HStack(spacing: VSpacing.sm) {
                 VButton(label: "Open System Settings", style: .primary) {
@@ -174,17 +174,17 @@ public struct ToolConfirmationBubble: View {
     private var commandExplanationBanner: some View {
         HStack(alignment: .top, spacing: VSpacing.sm) {
             VIconView(.info, size: 14)
-                .foregroundColor(VColor.primaryBase)
+                .foregroundStyle(VColor.primaryBase)
                 .padding(.top, 1)
 
             VStack(alignment: .leading, spacing: VSpacing.xs) {
                 Text("What is this?")
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
 
                 Text("Sometimes your assistant needs to run commands on your computer to complete tasks \u{2014} like installing software, checking settings, or organizing files. You\u{2019}ll always be asked for permission first, and nothing runs without your approval.")
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
@@ -229,12 +229,12 @@ public struct ToolConfirmationBubble: View {
                 } label: {
                     HStack(alignment: .firstTextBaseline, spacing: VSpacing.xxs) {
                         VIconView(.chevronRight, size: 9)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
                             .rotationEffect(.degrees(showTechnicalDetails ? 90 : 0))
                             .frame(width: 9, height: 9)
                         Text(showTechnicalDetails ? "Hide details" : "Show details")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
                     }
                     .offset(x: -1)
                 }
@@ -315,7 +315,7 @@ public struct ToolConfirmationBubble: View {
         ScrollView {
             Text(content)
                 .font(VFont.bodySmallDefault)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .textSelection(.enabled)
         }
@@ -334,7 +334,7 @@ public struct ToolConfirmationBubble: View {
     private var descriptionText: some View {
         Text(confirmation.humanDescription)
             .font(VFont.labelDefault)
-            .foregroundColor(VColor.contentTertiary)
+            .foregroundStyle(VColor.contentTertiary)
     }
 
     // MARK: - Diff Disclosure
@@ -350,9 +350,9 @@ public struct ToolConfirmationBubble: View {
                 HStack(spacing: 3) {
                     Text("View diff")
                         .font(.system(size: 10))
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                     VIconView(showDiff ? .chevronUp : .chevronDown, size: 8)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                 }
                 .contentShape(Rectangle())
             }
@@ -364,7 +364,7 @@ public struct ToolConfirmationBubble: View {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     Text(diffInfo.filePath)
                         .font(VFont.bodySmallDefault)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
 
                     if computedDiff.isEmpty {
                         codePreviewBlock(diffInfo.newContent, maxHeight: 260)
@@ -455,7 +455,7 @@ public struct ToolConfirmationBubble: View {
     private var confirmationDescription: some View {
         Text(confirmation.humanDescription)
             .font(VFont.bodyMediumEmphasised)
-            .foregroundColor(VColor.contentDefault)
+            .foregroundStyle(VColor.contentDefault)
             .fixedSize(horizontal: false, vertical: true)
     }
 

--- a/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
@@ -73,14 +73,14 @@ public struct ConfirmationSurfaceView: View {
                     .foregroundStyle(data.destructive ? VColor.systemNegativeStrong : VColor.systemMidStrong)
                 Text(inlineMarkdown(data.message))
                     .font(VFont.bodySmallEmphasised)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
             }
 
             // Detail text
             if let detail = data.detail {
                 Text(inlineMarkdown(detail))
                     .font(VFont.bodyMediumLighter)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
             }
 
             // Action buttons
@@ -112,16 +112,16 @@ public struct ConfirmationSurfaceView: View {
             switch action {
             case .confirmed:
                 VIconView(.circleCheck, size: 12)
-                    .foregroundColor(VColor.systemPositiveStrong)
+                    .foregroundStyle(VColor.systemPositiveStrong)
                 Text(data.confirmedLabel ?? "Done")
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
             case .cancelled:
                 VIconView(.circleX, size: 12)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
                 Text(data.cancelLabel ?? "Dismissed")
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
             }
         }
         .padding(.horizontal, VSpacing.md)

--- a/clients/shared/Features/Surfaces/FileUploadSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/FileUploadSurfaceView.swift
@@ -22,7 +22,7 @@ public struct FileUploadSurfaceView: View {
             // Prompt text
             Text(data.prompt)
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
                 .textSelection(.enabled)
 
             // Drop zone
@@ -32,7 +32,7 @@ public struct FileUploadSurfaceView: View {
             if let errorMessage = errorMessage {
                 Text(errorMessage)
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.systemNegativeStrong)
+                    .foregroundStyle(VColor.systemNegativeStrong)
                     .textSelection(.enabled)
             }
 
@@ -80,16 +80,16 @@ public struct FileUploadSurfaceView: View {
 
             VStack(spacing: VSpacing.md) {
                 VIconView(.arrowDownToLine, size: 28)
-                    .foregroundColor(isDragOver ? VColor.primaryBase : VColor.contentTertiary)
+                    .foregroundStyle(isDragOver ? VColor.primaryBase : VColor.contentTertiary)
 
                 Text("Drop files here")
                     .font(VFont.bodyMediumLighter)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
 
                 Button(action: { browseFiles() }) {
                     Text("Browse files")
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.primaryBase)
+                        .foregroundStyle(VColor.primaryBase)
                 }
                 .buttonStyle(.plain)
             }
@@ -114,13 +114,13 @@ public struct FileUploadSurfaceView: View {
                     VStack(alignment: .leading, spacing: 2) {
                         Text(file.filename)
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
                             .lineLimit(1)
                             .textSelection(.enabled)
 
                         Text(formatFileSize(file.size))
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                             .textSelection(.enabled)
                     }
 
@@ -128,7 +128,7 @@ public struct FileUploadSurfaceView: View {
 
                     Button(action: { removeFile(at: index) }) {
                         VIconView(.circleX, size: 14)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                     }
                     .buttonStyle(.plain)
                 }
@@ -148,13 +148,13 @@ public struct FileUploadSurfaceView: View {
             if data.maxFiles > 1 {
                 Text("Max \(data.maxFiles) files")
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
                     .textSelection(.enabled)
             }
             if let types = data.acceptedTypes, !types.isEmpty {
                 Text(types.joined(separator: ", "))
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
                     .textSelection(.enabled)
             }
         }
@@ -173,7 +173,7 @@ public struct FileUploadSurfaceView: View {
                 .clipped()
         } else {
             VIconView(iconName(for: file.mimeType), size: 20)
-                .foregroundColor(VColor.primaryBase)
+                .foregroundStyle(VColor.primaryBase)
                 .frame(width: 32, height: 32)
         }
     }

--- a/clients/shared/Features/Surfaces/FormSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/FormSurfaceView.swift
@@ -33,12 +33,12 @@ public struct FormSurfaceView: View {
                 let page = pages[safePageIndex]
                 Text(page.title)
                     .font(VFont.bodySmallEmphasised)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
 
                 if let desc = page.description {
                     Text(desc)
                         .font(VFont.bodyMediumLighter)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                 }
 
                 if hasPasswordFields {
@@ -55,7 +55,7 @@ public struct FormSurfaceView: View {
                 if let description = data.description {
                     Text(description)
                         .font(VFont.bodyMediumLighter)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                 }
 
                 if hasPasswordFields {
@@ -97,7 +97,7 @@ public struct FormSurfaceView: View {
             Spacer()
             Text("\(currentPage + 1) of \(totalPages)")
                 .font(VFont.labelDefault)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
         }
     }
 
@@ -159,7 +159,7 @@ public struct FormSurfaceView: View {
                 Text("Secured input")
                     .font(VFont.labelDefault)
             }
-            .foregroundColor(VColor.contentSecondary)
+            .foregroundStyle(VColor.contentSecondary)
             .padding(.horizontal, VSpacing.md)
             .padding(.vertical, VSpacing.xs)
             .background(VColor.surfaceOverlay.opacity(0.5))
@@ -170,10 +170,10 @@ public struct FormSurfaceView: View {
             VStack(alignment: .leading, spacing: VSpacing.sm) {
                 Text("Password Security")
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
                 Text("Password values are masked in the UI using a secure text field. Submitted values are sent to the assistant for processing and are not logged.")
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
             .padding(VSpacing.lg)
@@ -226,11 +226,11 @@ public struct FormSurfaceView: View {
         HStack(spacing: VSpacing.xxs) {
             Text(field.label)
                 .font(VFont.labelDefault)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
             if field.required {
                 Text("*")
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.systemNegativeStrong)
+                    .foregroundStyle(VColor.systemNegativeStrong)
             }
         }
     }
@@ -248,7 +248,7 @@ public struct FormSurfaceView: View {
         }
         .pickerStyle(.menu)
         .font(VFont.bodyMediumLighter)
-        .foregroundColor(VColor.contentDefault)
+        .foregroundStyle(VColor.contentDefault)
     }
 
     // MARK: - Bindings
@@ -350,7 +350,7 @@ public struct FormSurfaceView: View {
                 .controlSize(.small)
             Text("Submitting\u{2026}")
                 .font(VFont.bodyMediumDefault)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
         }
         .frame(maxWidth: .infinity)
         .frame(height: 32)


### PR DESCRIPTION
## Summary
- Replaces all .foregroundColor() with .foregroundStyle() in clients/shared/Features/

Part of plan: macos15-modernization.md (PR 15 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
