### PR TITLE
chore: remove now-redundant #available(macOS 15, *) guards in ScreenRecorder

### DIFF
--- a/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
+++ b/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
@@ -797,9 +797,7 @@ final class ScreenRecorder: NSObject {
             config.channelCount = 2
         }
 
-        // SCStreamConfiguration.captureMicrophone and SCStreamOutputType.microphone
-        // require macOS 15+ despite being declared in the macOS 14 SDK headers.
-        if includeMicrophone, #available(macOS 15, *) {
+        if includeMicrophone {
             config.captureMicrophone = true
         }
 
@@ -846,9 +844,9 @@ final class ScreenRecorder: NSObject {
             aInput = input
         }
 
-        // Microphone input: AAC (optional — separate track, macOS 15+)
+        // Microphone input: AAC (optional — separate track)
         var mInput: AVAssetWriterInput?
-        if includeMicrophone, #available(macOS 15, *) {
+        if includeMicrophone {
             let micSettings: [String: Any] = [
                 AVFormatIDKey: kAudioFormatMPEG4AAC,
                 AVSampleRateKey: 48000,
@@ -872,11 +870,7 @@ final class ScreenRecorder: NSObject {
             log.info("System audio: sampleRate=48000, channels=2, bitRate=128000")
         }
         if includeMicrophone {
-            if #available(macOS 15, *) {
-                log.info("Microphone audio: sampleRate=48000, channels=1, bitRate=64000")
-            } else {
-                log.info("Microphone requested but macOS 15+ required — skipped")
-            }
+            log.info("Microphone audio: sampleRate=48000, channels=1, bitRate=64000")
         }
 
         // Create stream and output delegate — the delegate forwards sample
@@ -891,7 +885,7 @@ final class ScreenRecorder: NSObject {
             if includeAudio {
                 try captureStream.addStreamOutput(delegate, type: .audio, sampleHandlerQueue: outputQueue)
             }
-            if includeMicrophone, #available(macOS 15, *) {
+            if includeMicrophone {
                 try captureStream.addStreamOutput(delegate, type: .microphone, sampleHandlerQueue: outputQueue)
             }
         } catch {


### PR DESCRIPTION
## Summary
- Removes all `#available(macOS 15, *)` guards in ScreenRecorder.swift — microphone capture configuration, audio input setup, microphone logging, and stream output attachment are now unconditional since the deployment floor is macOS 15.

Part of plan: macos15-modernization.md (PR 1 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
