### PR TITLE
refactor: migrate AmbientAgent to @Observable and update PanelCoordinator/ThreadWindow consumers

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -8,15 +8,18 @@ import os
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AmbientAgent")
 
 @MainActor
-public final class AmbientAgent: ObservableObject {
-    let knowledgeStore = KnowledgeStore()
-    var connectionManager: GatewayConnectionManager?
+@Observable
+public final class AmbientAgent {
+    @ObservationIgnored let knowledgeStore = KnowledgeStore()
+    @ObservationIgnored var connectionManager: GatewayConnectionManager?
     weak var appDelegate: AppDelegate?
 
     /// When a WatchSession is active (from chat-initiated watch), capture is skipped.
+    /// Tracked (not @ObservationIgnored) because PanelCoordinator and ThreadWindow
+    /// read this property for watch progress UI.
     var activeWatchSession: WatchSession?
 
-    private var cancellables = Set<AnyCancellable>()
+    @ObservationIgnored private var cancellables = Set<AnyCancellable>()
 
     var knowledge: KnowledgeStore { knowledgeStore }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -592,7 +592,7 @@ struct ActiveChatViewWrapper: View {
     var showInspectButton: Bool = false
     var isTTSEnabled: Bool = false
     let connectionManager: GatewayConnectionManager
-    @ObservedObject var ambientAgent: AmbientAgent
+    var ambientAgent: AmbientAgent
     @ObservedObject var settingsStore: SettingsStore
     let conversationManager: ConversationManager
     let onMicrophoneToggle: () -> Void

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -174,7 +174,7 @@ private struct ThreadWindowContentView: View {
     let conversationLocalId: UUID
     @ObservedObject var conversationManager: ConversationManager
     @ObservedObject var settingsStore: SettingsStore
-    @ObservedObject var ambientAgent: AmbientAgent
+    var ambientAgent: AmbientAgent
     let onFork: (String) -> Void
 
     @State private var anchorMessageId: UUID?


### PR DESCRIPTION
## Summary
- Migrates AmbientAgent to @Observable with activeWatchSession tracked, dependencies @ObservationIgnored
- Updates PanelCoordinator, ThreadWindow, MainWindowView call sites

Part of plan: macos15-modernization.md (PR 6 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
