### PR TITLE
refactor: remove ScrollViewScrollerHider — use native .scrollIndicators(.hidden) on macOS 15

### DIFF
--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -150,7 +150,6 @@ struct RecordingSourcePickerView: View {
             sourceListContent
             ScrollView {
                 sourceListContent
-                    .background(ScrollViewScrollerHider())
             }
             .scrollIndicators(.hidden)
         }
@@ -352,41 +351,3 @@ struct RecordingSourcePickerView: View {
         .padding(.vertical, VSpacing.md)
     }
 }
-
-// MARK: - Scroll View Helpers
-
-/// Finds the nearest NSScrollView ancestor and hides its scrollers,
-/// overriding the macOS "Show scroll bars: Always" system preference.
-/// Walks the full superview chain as a fallback if `enclosingScrollView`
-/// returns nil (which can happen with SwiftUI's internal hosting layers).
-private struct ScrollViewScrollerHider: NSViewRepresentable {
-    func makeNSView(context: Context) -> NSView {
-        let view = NSView()
-        DispatchQueue.main.async { hideScrollers(from: view) }
-        return view
-    }
-
-    func updateNSView(_ nsView: NSView, context: Context) {
-        DispatchQueue.main.async { hideScrollers(from: nsView) }
-    }
-
-    private func hideScrollers(from view: NSView) {
-        // Try the fast path first
-        if let scrollView = view.enclosingScrollView {
-            scrollView.hasVerticalScroller = false
-            scrollView.hasHorizontalScroller = false
-            return
-        }
-        // Walk the full superview chain looking for any NSScrollView
-        var current: NSView? = view.superview
-        while let ancestor = current {
-            if let scrollView = ancestor as? NSScrollView {
-                scrollView.hasVerticalScroller = false
-                scrollView.hasHorizontalScroller = false
-                return
-            }
-            current = ancestor.superview
-        }
-    }
-}
-


### PR DESCRIPTION
## Summary
- Removes the `ScrollViewScrollerHider` NSViewRepresentable that walked the AppKit view hierarchy to force-hide scroll bars
- The native SwiftUI `.scrollIndicators(.hidden)` modifier (already present on the ScrollView) properly overrides the "Always show scroll bars" system preference on macOS 15+, making the NSViewRepresentable redundant

Part of plan: macos15-modernization.md (PR 13 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
