### PR TITLE
refactor: replace .foregroundColor() with .foregroundStyle() in iOS app

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -496,7 +496,7 @@ struct ChatContentView: View {
                     if let statusText = viewModel.assistantStatusText, !statusText.isEmpty {
                         Text(statusText)
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
                     }
                     Spacer()
                 }
@@ -530,7 +530,7 @@ struct ChatContentView: View {
                     if let statusText = viewModel.assistantStatusText, !statusText.isEmpty {
                         Text(statusText)
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
                     }
                     Spacer()
                 }
@@ -548,16 +548,16 @@ struct ChatContentView: View {
     private func conversationErrorBanner(_ error: ConversationError) -> some View {
         HStack(spacing: VSpacing.sm) {
             VIconView(conversationErrorIcon(error.category), size: 14)
-                .foregroundColor(conversationErrorAccent(error.category))
+                .foregroundStyle(conversationErrorAccent(error.category))
 
             VStack(alignment: .leading, spacing: VSpacing.xxs) {
                 Text(error.message)
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
                     .lineLimit(2)
                 Text(error.recoverySuggestion)
                     .font(VFont.labelSmall)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
                     .lineLimit(1)
             }
 
@@ -567,7 +567,7 @@ struct ChatContentView: View {
                 Button(action: { viewModel.retryAfterConversationError() }) {
                     Text("Retry")
                         .font(VFont.labelDefault)
-                        .foregroundColor(.white)
+                        .foregroundStyle(.white)
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.xs)
                         .background(conversationErrorAccent(error.category))
@@ -577,7 +577,7 @@ struct ChatContentView: View {
 
             Button(action: { viewModel.dismissConversationError() }) {
                 VIconView(.x, size: 10)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
             }
             .accessibilityLabel("Dismiss")
         }
@@ -597,16 +597,16 @@ struct ChatContentView: View {
     private func genericErrorBanner(_ errorText: String) -> some View {
         HStack(spacing: VSpacing.sm) {
             VIconView(.triangleAlert, size: 14)
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
             VStack(alignment: .leading, spacing: VSpacing.xxs) {
                 Text(errorText)
                     .font(VFont.labelDefault)
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                     .lineLimit(2)
                 if viewModel.isConnectionError, let hint = viewModel.connectionDiagnosticHint {
                     Text(hint)
                         .font(VFont.labelSmall)
-                        .foregroundColor(.white.opacity(0.8))
+                        .foregroundStyle(.white.opacity(0.8))
                         .lineLimit(2)
                 }
             }
@@ -615,7 +615,7 @@ struct ChatContentView: View {
                 Button(action: { viewModel.sendAnyway() }) {
                     Text("Send Anyway")
                         .font(VFont.labelDefault)
-                        .foregroundColor(.white)
+                        .foregroundStyle(.white)
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.xs)
                         .background(Color.white.opacity(0.25)) // Intentional: translucent contrast on VColor.systemNegativeStrong banner
@@ -625,7 +625,7 @@ struct ChatContentView: View {
                 Button(action: { viewModel.retryLastMessage() }) {
                     Text("Retry")
                         .font(VFont.labelDefault)
-                        .foregroundColor(.white)
+                        .foregroundStyle(.white)
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.xs)
                         .background(Color.white.opacity(0.25)) // Intentional: translucent contrast on VColor.systemNegativeStrong banner
@@ -634,7 +634,7 @@ struct ChatContentView: View {
             }
             Button(action: { viewModel.dismissError() }) {
                 VIconView(.x, size: 14)
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
             }
             .accessibilityLabel("Dismiss")
         }
@@ -680,12 +680,12 @@ struct ChatContentView: View {
 
             HStack(spacing: VSpacing.md) {
                 VIconView(.sparkles, size: 48)
-                    .foregroundColor(VColor.primaryBase)
+                    .foregroundStyle(VColor.primaryBase)
 
                 if let greeting = viewModel.emptyStateGreeting {
                     Text(greeting)
                         .font(.system(size: 22, weight: .medium))
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                         .multilineTextAlignment(.leading)
                         .transition(.opacity)
                 }

--- a/clients/ios/Views/ChatTabView.swift
+++ b/clients/ios/Views/ChatTabView.swift
@@ -83,7 +83,7 @@ struct ChatTabView: View {
             }
         } label: {
             VIconView(showCopiedConfirmation ? .check : .share, size: 20)
-                .foregroundColor(showCopiedConfirmation ? VColor.systemPositiveStrong : VColor.contentTertiary)
+                .foregroundStyle(showCopiedConfirmation ? VColor.systemPositiveStrong : VColor.contentTertiary)
         }
         .disabled(!hasTextMessages)
     }

--- a/clients/ios/Views/ContentView.swift
+++ b/clients/ios/Views/ContentView.swift
@@ -131,7 +131,7 @@ struct ContentView: View {
                 .scaleEffect(1.5)
             Text("Connecting to your Assistant...")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -141,15 +141,15 @@ struct ContentView: View {
     private var connectionFailedView: some View {
         VStack(spacing: VSpacing.lg) {
             VIconView(.wifiOff, size: 48)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
 
             Text("Unable to Connect")
                 .font(VFont.titleMedium)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
 
             Text("Unable to reach your Assistant's gateway. This could mean your Assistant is offline, the tunnel is down, or the gateway is not active.")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, VSpacing.xl)
 
@@ -157,7 +157,7 @@ struct ContentView: View {
                 let delaySeconds = Int(min(pow(2.0, Double(retryCount - 1)) * 2.0, 30.0))
                 Text("Retrying in \(delaySeconds)s…")
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
             }
 
             VStack(spacing: VSpacing.md) {

--- a/clients/ios/Views/ConversationListView.swift
+++ b/clients/ios/Views/ConversationListView.swift
@@ -122,14 +122,14 @@ struct ChatsDisconnectedView: View {
         NavigationStack {
             VStack(spacing: VSpacing.lg) {
                 VIconView(.messageSquare, size: 48)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
                     .accessibilityHidden(true)
                 Text("Chats Require Connection")
                     .font(VFont.titleMedium)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
                 Text("Connect to your Assistant to start a conversation.")
                     .font(VFont.bodyMediumLighter)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, VSpacing.xl)
                 if onConnectTapped != nil {
@@ -276,7 +276,7 @@ struct ConversationListView: View {
             ProgressView()
             Text("Loading chats\u{2026}")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .navigationTitle("Chats")
@@ -651,7 +651,7 @@ struct ConversationListView: View {
                             .lineLimit(1)
                         if scheduleGroupHasPinned(group) {
                             VIconView(.pin, size: 10)
-                                .foregroundColor(VColor.primaryBase)
+                                .foregroundStyle(VColor.primaryBase)
                                 .accessibilityLabel("Pinned")
                         }
                         if scheduleGroupHasUnread(group) {
@@ -691,7 +691,7 @@ struct ConversationListView: View {
                     .lineLimit(1)
                 if store.isConnectedMode && conversation.isPinned {
                     VIconView(.pin, size: 10)
-                        .foregroundColor(VColor.primaryBase)
+                        .foregroundStyle(VColor.primaryBase)
                         .accessibilityLabel("Pinned")
                 }
                 if store.isConnectedMode && conversation.hasUnseenLatestAssistantMessage {
@@ -762,7 +762,7 @@ struct ConversationChatView: View {
                             showDebugPanel = true
                         } label: {
                             VIconView(.bug, size: 20)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                         }
                     }
                 }
@@ -801,22 +801,22 @@ struct ConversationChatView: View {
         Button(action: action) {
             HStack(spacing: VSpacing.sm) {
                 VIconView(.gitBranch, size: 14)
-                    .foregroundColor(VColor.primaryBase)
+                    .foregroundStyle(VColor.primaryBase)
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Forked from")
                         .font(VFont.labelSmall)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                     Text(forkParent.title ?? "Parent conversation")
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentDefault)
+                        .foregroundStyle(VColor.contentDefault)
                         .lineLimit(1)
                 }
 
                 Spacer()
 
                 VIconView(.chevronRight, size: 14)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
             }
             .padding(.horizontal, VSpacing.lg)
             .padding(.vertical, VSpacing.sm)
@@ -865,7 +865,7 @@ struct ConversationChatView: View {
             }
         } label: {
             VIconView(showCopiedConfirmation ? .check : .share, size: 20)
-                .foregroundColor(showCopiedConfirmation ? VColor.systemPositiveStrong : VColor.contentTertiary)
+                .foregroundStyle(showCopiedConfirmation ? VColor.systemPositiveStrong : VColor.contentTertiary)
         }
         .disabled(!hasTextMessages)
     }

--- a/clients/ios/Views/DebugPanelView.swift
+++ b/clients/ios/Views/DebugPanelView.swift
@@ -149,14 +149,14 @@ struct DebugPanelView: View {
         VStack(spacing: VSpacing.xxs) {
             HStack(spacing: VSpacing.xs) {
                 VIconView(icon, size: 11)
-                    .foregroundColor(color)
+                    .foregroundStyle(color)
                 Text(value)
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
             }
             Text(label)
                 .font(VFont.labelSmall)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
         }
     }
 
@@ -167,13 +167,13 @@ struct DebugPanelView: View {
         VStack(spacing: VSpacing.md) {
             Spacer()
             VIconView(icon, size: 36)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
             Text(title)
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
             Text(subtitle)
                 .font(VFont.labelDefault)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, VSpacing.xl)
             Spacer()
@@ -274,7 +274,7 @@ struct TraceTimelineIOSView: View {
                         }
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.xs)
-                        .foregroundColor(VColor.systemNegativeHover)
+                        .foregroundStyle(VColor.systemNegativeHover)
                         .background(VColor.surfaceActive)
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                         .overlay(
@@ -298,24 +298,24 @@ struct TraceTimelineIOSView: View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
             HStack(spacing: VSpacing.sm) {
                 VIconView(groupStatusIcon(groupStatus), size: 11)
-                    .foregroundColor(groupStatusColor(groupStatus))
+                    .foregroundStyle(groupStatusColor(groupStatus))
 
                 Text(requestId.isEmpty ? "System" : "Request \(requestId.prefix(8))")
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
 
                 if groupStatus == .cancelled {
                     Text("Cancelled")
                         .font(VFont.labelSmall)
-                        .foregroundColor(VColor.systemMidStrong)
+                        .foregroundStyle(VColor.systemMidStrong)
                 } else if groupStatus == .handedOff {
                     Text("Handed off")
                         .font(VFont.labelSmall)
-                        .foregroundColor(VColor.systemPositiveWeak)
+                        .foregroundStyle(VColor.systemPositiveWeak)
                 } else if groupStatus == .error {
                     Text("Error")
                         .font(VFont.labelSmall)
-                        .foregroundColor(VColor.systemNegativeStrong)
+                        .foregroundStyle(VColor.systemNegativeStrong)
                 }
 
                 Rectangle()
@@ -371,7 +371,7 @@ struct TraceTimelineIOSView: View {
                     traceRow(event: event)
                     if hasAttributes {
                         VIconView(isExpanded ? .chevronUp : .chevronDown, size: 10)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                             .frame(width: 18)
                     }
                 }
@@ -385,10 +385,10 @@ struct TraceTimelineIOSView: View {
                         HStack(spacing: VSpacing.sm) {
                             Text(key)
                                 .font(VFont.labelSmall)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                             Text(stringValue(attrs[key]))
                                 .font(VFont.labelSmall)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                                 .lineLimit(3)
                         }
                     }
@@ -408,18 +408,18 @@ struct TraceTimelineIOSView: View {
     private func traceRow(event: TraceStore.StoredEvent) -> some View {
         HStack(alignment: .top, spacing: VSpacing.sm) {
             VIconView(iconName(for: event.kind), size: 12)
-                .foregroundColor(statusColor(for: event.status))
+                .foregroundStyle(statusColor(for: event.status))
                 .frame(width: 20, alignment: .center)
 
             VStack(alignment: .leading, spacing: VSpacing.xxs) {
                 Text(event.summary)
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
                     .lineLimit(2)
 
                 Text(formattedTimestamp(event.timestampMs))
                     .font(VFont.labelSmall)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
             }
 
             Spacer(minLength: 0)

--- a/clients/ios/Views/IdentityView.swift
+++ b/clients/ios/Views/IdentityView.swift
@@ -150,7 +150,7 @@ struct IdentityView: View {
                 Section {
                     Text(introText)
                         .font(VFont.titleMedium)
-                        .foregroundColor(VColor.contentDefault)
+                        .foregroundStyle(VColor.contentDefault)
                         .frame(maxWidth: .infinity, alignment: .center)
                         .listRowBackground(Color.clear)
                         .listRowSeparator(.hidden)
@@ -174,16 +174,16 @@ struct IdentityView: View {
                 } label: {
                     HStack(spacing: VSpacing.sm) {
                         VIconView(.brain, size: 16)
-                            .foregroundColor(VColor.primaryBase)
+                            .foregroundStyle(VColor.primaryBase)
                             .frame(width: 24)
                         Text("Skills")
                             .font(VFont.bodyMediumLighter)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
                         Spacer()
                         if viewModel.installedSkillsCount > 0 {
                             Text("\(viewModel.installedSkillsCount)")
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                                 .padding(.horizontal, 8)
                                 .padding(.vertical, 2)
                                 .background(
@@ -203,16 +203,16 @@ struct IdentityView: View {
                 } label: {
                     HStack(spacing: VSpacing.sm) {
                         VIconView(.users, size: 16)
-                            .foregroundColor(VColor.primaryBase)
+                            .foregroundStyle(VColor.primaryBase)
                             .frame(width: 24)
                         Text("Contacts")
                             .font(VFont.bodyMediumLighter)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
                         Spacer()
                         if viewModel.contactsCount > 0 {
                             Text("\(viewModel.contactsCount)")
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                                 .padding(.horizontal, 8)
                                 .padding(.vertical, 2)
                                 .background(
@@ -232,16 +232,16 @@ struct IdentityView: View {
                 } label: {
                     HStack(spacing: VSpacing.sm) {
                         VIconView(.bookOpen, size: 16)
-                            .foregroundColor(VColor.primaryBase)
+                            .foregroundStyle(VColor.primaryBase)
                             .frame(width: 24)
                         Text("Memories")
                             .font(VFont.bodyMediumLighter)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
                         Spacer()
                         if viewModel.memoriesCount > 0 {
                             Text("\(viewModel.memoriesCount)")
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                                 .padding(.horizontal, 8)
                                 .padding(.vertical, 2)
                                 .background(
@@ -261,11 +261,11 @@ struct IdentityView: View {
                 } label: {
                     HStack(spacing: VSpacing.sm) {
                         VIconView(.folder, size: 16)
-                            .foregroundColor(VColor.primaryBase)
+                            .foregroundStyle(VColor.primaryBase)
                             .frame(width: 24)
                         Text("Browse Workspace")
                             .font(VFont.bodyMediumLighter)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
                     }
                 }
             }
@@ -292,12 +292,12 @@ struct IdentityView: View {
                 if !identity.name.isEmpty {
                     Text(identity.name)
                         .font(VFont.bodySmallEmphasised)
-                        .foregroundColor(VColor.contentDefault)
+                        .foregroundStyle(VColor.contentDefault)
                 }
                 if !identity.role.isEmpty {
                     Text(identity.role)
                         .font(VFont.bodyMediumLighter)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                 }
             }
 
@@ -313,16 +313,16 @@ struct IdentityView: View {
     private var disconnectedState: some View {
         VStack(spacing: VSpacing.lg) {
             VIconView(.monitor, size: 48)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
                 .accessibilityHidden(true)
 
             Text("Connect to your Assistant")
                 .font(VFont.titleMedium)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
 
             Text("Intelligence information is available when connected to your Assistant.")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, VSpacing.xl)
 
@@ -343,7 +343,7 @@ struct IdentityView: View {
             ProgressView()
             Text("Loading...")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/clients/ios/Views/InlineVideoEmbedView.swift
+++ b/clients/ios/Views/InlineVideoEmbedView.swift
@@ -43,10 +43,10 @@ struct InlineVideoEmbedView: View {
             // Provider attribution bar
             HStack(spacing: VSpacing.xs) {
                 VIconView(.video, size: 10)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
                 Text(provider.capitalized)
                     .font(VFont.labelSmall)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
                 Spacer()
             }
             .padding(.horizontal, VSpacing.sm)
@@ -93,7 +93,7 @@ struct InlineVideoEmbedView: View {
                     .frame(width: 56, height: 56)
                     .overlay(
                         VIconView(.play, size: 22)
-                            .foregroundColor(.white)
+                            .foregroundStyle(.white)
                             .offset(x: 2)
                     )
             }
@@ -121,10 +121,10 @@ struct InlineVideoEmbedView: View {
     private func failedView(_ message: String) -> some View {
         VStack(spacing: VSpacing.sm) {
             VIconView(.triangleAlert, size: 24)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
             Text("Failed to load video")
                 .font(VFont.labelDefault)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
             Button("Open in Safari") {
                 UIApplication.shared.open(embedURL)
             }

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -104,7 +104,7 @@ struct InputBarView: View {
             }) {
                 Text("Cancel")
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
             }
             .buttonStyle(.plain)
             .padding(.bottom, VSpacing.xs)
@@ -164,7 +164,7 @@ struct InputBarView: View {
             TextField("Message...", text: $text, axis: .vertical)
                 .textFieldStyle(.plain)
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
                 .padding(VSpacing.md)
                 .background(VColor.surfaceBase)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))

--- a/clients/ios/Views/Intelligence/ContactDetailView.swift
+++ b/clients/ios/Views/Intelligence/ContactDetailView.swift
@@ -42,7 +42,7 @@ struct ContactDetailView: View {
                 Section("Notes") {
                     Text(notes)
                         .font(VFont.bodyMediumLighter)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                 }
             }
 
@@ -110,7 +110,7 @@ struct ContactDetailView: View {
 
             Text(liveContact.displayName)
                 .font(VFont.titleMedium)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
 
             HStack(spacing: VSpacing.sm) {
                 roleBadge(liveContact.role)
@@ -118,7 +118,7 @@ struct ContactDetailView: View {
                 if let contactType = liveContact.contactType, !contactType.isEmpty {
                     Text(contactType.capitalized)
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                 }
             }
         }
@@ -136,12 +136,12 @@ struct ContactDetailView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(channel.address)
                         .font(VFont.bodyMediumLighter)
-                        .foregroundColor(VColor.contentDefault)
+                        .foregroundStyle(VColor.contentDefault)
 
                     HStack(spacing: 4) {
                         Text(channel.type.capitalized)
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
 
                         if channel.isPrimary {
                             Text("Primary")
@@ -149,7 +149,7 @@ struct ContactDetailView: View {
                                 .padding(.horizontal, 4)
                                 .padding(.vertical, 1)
                                 .background(Capsule().fill(Color.blue.opacity(0.15)))
-                                .foregroundColor(.blue)
+                                .foregroundStyle(.blue)
                         }
                     }
                 }
@@ -190,7 +190,7 @@ struct ContactDetailView: View {
             .padding(.horizontal, 5)
             .padding(.vertical, 1)
             .background(Capsule().fill(color.opacity(0.15)))
-            .foregroundColor(color)
+            .foregroundStyle(color)
     }
 
     private func policyBadge(_ policy: String) -> some View {
@@ -208,7 +208,7 @@ struct ContactDetailView: View {
             .padding(.horizontal, 5)
             .padding(.vertical, 1)
             .background(Capsule().fill(color.opacity(0.15)))
-            .foregroundColor(color)
+            .foregroundStyle(color)
     }
 
     private func roleBadge(_ role: String) -> some View {
@@ -225,7 +225,7 @@ struct ContactDetailView: View {
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
             .background(Capsule().fill(color.opacity(0.15)))
-            .foregroundColor(color)
+            .foregroundStyle(color)
     }
 
     // MARK: - Helpers
@@ -243,7 +243,7 @@ struct ContactDetailView: View {
         }()
 
         return VIconView(icon, size: 16)
-            .foregroundColor(VColor.primaryBase)
+            .foregroundStyle(VColor.primaryBase)
             .frame(width: 28)
     }
 
@@ -256,7 +256,7 @@ struct ContactDetailView: View {
 
         return Text(initials.isEmpty ? "?" : initials)
             .font(.system(size: size * 0.35, weight: .semibold))
-            .foregroundColor(.white)
+            .foregroundStyle(.white)
             .frame(width: size, height: size)
             .background(Circle().fill(VColor.primaryBase))
             .accessibilityHidden(true)
@@ -266,11 +266,11 @@ struct ContactDetailView: View {
         HStack {
             Text(label)
                 .font(VFont.labelDefault)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
             Spacer()
             Text(value)
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(label): \(value)")

--- a/clients/ios/Views/Intelligence/ContactsListView.swift
+++ b/clients/ios/Views/Intelligence/ContactsListView.swift
@@ -98,7 +98,7 @@ struct ContactsListView: View {
                 HStack(spacing: 4) {
                     Text(contact.displayName)
                         .font(VFont.bodyMediumLighter)
-                        .foregroundColor(VColor.contentDefault)
+                        .foregroundStyle(VColor.contentDefault)
 
                     roleBadge(contact.role)
                 }
@@ -117,7 +117,7 @@ struct ContactsListView: View {
             if contact.interactionCount > 0 {
                 Text("\(contact.interactionCount)")
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
             }
         }
         .padding(.vertical, 2)
@@ -137,7 +137,7 @@ struct ContactsListView: View {
 
         return Text(initials.isEmpty ? "?" : initials)
             .font(VFont.labelDefault)
-            .foregroundColor(.white)
+            .foregroundStyle(.white)
             .frame(width: 32, height: 32)
             .background(Circle().fill(VColor.primaryBase))
             .accessibilityHidden(true)
@@ -159,7 +159,7 @@ struct ContactsListView: View {
             .padding(.horizontal, 5)
             .padding(.vertical, 1)
             .background(Capsule().fill(color.opacity(0.15)))
-            .foregroundColor(color)
+            .foregroundStyle(color)
     }
 
     // MARK: - Channel Icon
@@ -177,7 +177,7 @@ struct ContactsListView: View {
         }()
 
         return VIconView(icon, size: 10)
-            .foregroundColor(VColor.contentTertiary)
+            .foregroundStyle(VColor.contentTertiary)
     }
 
     // MARK: - Empty States
@@ -185,16 +185,16 @@ struct ContactsListView: View {
     private var emptyState: some View {
         VStack(spacing: VSpacing.lg) {
             VIconView(.users, size: 48)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
                 .accessibilityHidden(true)
 
             Text("No Contacts")
                 .font(VFont.titleMedium)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
 
             Text("Contacts will appear here as people interact with your assistant.")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, VSpacing.xl)
         }
@@ -208,7 +208,7 @@ struct ContactsListView: View {
             ProgressView()
             Text("Loading contacts...")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/clients/ios/Views/Intelligence/InstalledSkillsView.swift
+++ b/clients/ios/Views/Intelligence/InstalledSkillsView.swift
@@ -87,7 +87,7 @@ struct InstalledSkillsView: View {
                 HStack(spacing: 4) {
                     Text(skill.name)
                         .font(VFont.bodyMediumLighter)
-                        .foregroundColor(VColor.contentDefault)
+                        .foregroundStyle(VColor.contentDefault)
 
                     stateBadge(skill.state)
                 }
@@ -95,7 +95,7 @@ struct InstalledSkillsView: View {
                 if !skill.description.isEmpty {
                     Text(skill.description)
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                         .lineLimit(2)
                 }
             }
@@ -125,7 +125,7 @@ struct InstalledSkillsView: View {
             .padding(.horizontal, 5)
             .padding(.vertical, 1)
             .background(Capsule().fill(color.opacity(0.15)))
-            .foregroundColor(color)
+            .foregroundStyle(color)
     }
 
     // MARK: - Empty States
@@ -133,16 +133,16 @@ struct InstalledSkillsView: View {
     private var emptyState: some View {
         VStack(spacing: VSpacing.lg) {
             VIconView(.brain, size: 48)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
                 .accessibilityHidden(true)
 
             Text("No Skills Installed")
                 .font(VFont.titleMedium)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
 
             Text("Ask your assistant in chat to search for and install new skills.")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, VSpacing.xl)
         }
@@ -156,7 +156,7 @@ struct InstalledSkillsView: View {
             ProgressView()
             Text("Loading skills...")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/clients/ios/Views/Intelligence/MemoriesListView.swift
+++ b/clients/ios/Views/Intelligence/MemoriesListView.swift
@@ -130,7 +130,7 @@ struct MemoriesListView: View {
                     Capsule()
                         .fill(isSelected ? VColor.primaryBase : VColor.surfaceActive)
                 )
-                .foregroundColor(isSelected ? .white : VColor.contentSecondary)
+                .foregroundStyle(isSelected ? .white : VColor.contentSecondary)
         }
         .buttonStyle(.plain)
         .accessibilityLabel("\(label) filter\(isSelected ? ", selected" : "")")
@@ -149,12 +149,12 @@ struct MemoriesListView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(item.subject)
                     .font(VFont.bodyMediumDefault)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
                     .lineLimit(1)
 
                 Text(item.statement)
                     .font(VFont.bodyMediumLighter)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
                     .lineLimit(2)
             }
 
@@ -162,7 +162,7 @@ struct MemoriesListView: View {
 
             Text(item.relativeLastSeen)
                 .font(VFont.labelDefault)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
         }
         .padding(.vertical, 2)
         .swipeActions(edge: .trailing) {
@@ -179,16 +179,16 @@ struct MemoriesListView: View {
     private var emptyState: some View {
         VStack(spacing: VSpacing.lg) {
             VIconView(.bookOpen, size: 48)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
                 .accessibilityHidden(true)
 
             Text("No Memories Yet")
                 .font(VFont.titleMedium)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
 
             Text("Your assistant learns from conversations.")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, VSpacing.xl)
         }
@@ -202,7 +202,7 @@ struct MemoriesListView: View {
             ProgressView()
             Text("Loading memories...")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/clients/ios/Views/Intelligence/MemoryItemCreateView.swift
+++ b/clients/ios/Views/Intelligence/MemoryItemCreateView.swift
@@ -37,7 +37,7 @@ struct MemoryItemCreateView: View {
                         if statement.isEmpty {
                             Text("What should the assistant remember?")
                                 .font(VFont.bodyMediumLighter)
-                                .foregroundColor(VColor.contentTertiary)
+                                .foregroundStyle(VColor.contentTertiary)
                                 .padding(.top, 8)
                                 .padding(.leading, 4)
                                 .allowsHitTesting(false)
@@ -50,11 +50,11 @@ struct MemoryItemCreateView: View {
                     HStack {
                         Text("Importance")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                         Spacer()
                         Text("\(Int(importance * 100))%")
                             .font(VFont.bodyMediumLighter)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
                     }
                     Slider(value: $importance, in: 0...1, step: 0.1)
                 }

--- a/clients/ios/Views/Intelligence/MemoryItemDetailView.swift
+++ b/clients/ios/Views/Intelligence/MemoryItemDetailView.swift
@@ -119,7 +119,7 @@ struct MemoryItemDetailView: View {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     Text("Subject")
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                     TextField("Subject", text: $editSubject)
                         .font(VFont.bodyMediumLighter)
                 }
@@ -127,7 +127,7 @@ struct MemoryItemDetailView: View {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     Text("Statement")
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                     TextEditor(text: $editStatement)
                         .font(VFont.bodyMediumLighter)
                         .frame(minHeight: 100)
@@ -138,10 +138,10 @@ struct MemoryItemDetailView: View {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     Text("Statement")
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                     Text(liveItem.statement)
                         .font(VFont.bodyMediumLighter)
-                        .foregroundColor(VColor.contentDefault)
+                        .foregroundStyle(VColor.contentDefault)
                 }
             }
         }
@@ -168,7 +168,7 @@ struct MemoryItemDetailView: View {
                 HStack {
                     Text("Kind")
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                     Spacer()
                     kindBadge(liveItem.kind)
                 }
@@ -182,14 +182,14 @@ struct MemoryItemDetailView: View {
                     HStack {
                         Text("Scope")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                         Spacer()
                         HStack(spacing: VSpacing.xxs) {
                             VIconView(.lock, size: 12)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                             Text(scopeLabel)
                                 .font(VFont.bodyMediumLighter)
-                                .foregroundColor(VColor.contentDefault)
+                                .foregroundStyle(VColor.contentDefault)
                         }
                     }
                     .accessibilityElement(children: .combine)
@@ -208,11 +208,11 @@ struct MemoryItemDetailView: View {
                     HStack {
                         Text("Importance")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                         Spacer()
                         Text("\(Int(editImportance * 100))%")
                             .font(VFont.bodyMediumLighter)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
                     }
                     Slider(value: $editImportance, in: 0...1, step: 0.1)
                 }
@@ -295,11 +295,11 @@ struct MemoryItemDetailView: View {
         HStack {
             Text(label)
                 .font(VFont.labelDefault)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
             Spacer()
             Text(value)
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(label): \(value)")
@@ -315,7 +315,7 @@ struct MemoryItemDetailView: View {
             .padding(.horizontal, 8)
             .padding(.vertical, 3)
             .background(Capsule().fill(color.opacity(0.15)))
-            .foregroundColor(color)
+            .foregroundStyle(color)
     }
 
     private func formatDate(_ date: Date) -> String {

--- a/clients/ios/Views/Intelligence/SkillDetailView.swift
+++ b/clients/ios/Views/Intelligence/SkillDetailView.swift
@@ -46,7 +46,7 @@ struct SkillDetailView: View {
                     if !inspected.skill.summary.isEmpty {
                         Text(inspected.skill.summary)
                             .font(VFont.bodyMediumLighter)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
                     }
 
                     if let owner = inspected.owner {
@@ -64,10 +64,10 @@ struct SkillDetailView: View {
                             VStack(alignment: .leading, spacing: VSpacing.xs) {
                                 Text("Changelog")
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.contentTertiary)
+                                    .foregroundStyle(VColor.contentTertiary)
                                 Text(changelog)
                                     .font(VFont.bodyMediumLighter)
-                                    .foregroundColor(VColor.contentSecondary)
+                                    .foregroundStyle(VColor.contentSecondary)
                             }
                         }
                     }
@@ -85,7 +85,7 @@ struct SkillDetailView: View {
                 Section("About") {
                     Text(error)
                         .font(VFont.bodyMediumLighter)
-                        .foregroundColor(.red)
+                        .foregroundStyle(.red)
                 }
             }
 
@@ -142,7 +142,7 @@ struct SkillDetailView: View {
                 Section("Files") {
                     Text(error)
                         .font(VFont.bodyMediumLighter)
-                        .foregroundColor(.red)
+                        .foregroundStyle(.red)
                 }
             } else if let filesResponse = skillsStore.selectedSkillFiles, !filesResponse.files.isEmpty {
                 Section("Files") {
@@ -187,12 +187,12 @@ struct SkillDetailView: View {
 
             Text(skill.name)
                 .font(VFont.titleMedium)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
 
             if !skill.description.isEmpty {
                 Text(skill.description)
                     .font(VFont.bodyMediumLighter)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
                     .multilineTextAlignment(.center)
             }
 
@@ -202,7 +202,7 @@ struct SkillDetailView: View {
                     Text("Update available")
                         .font(VFont.labelDefault)
                 }
-                .foregroundColor(VColor.primaryBase)
+                .foregroundStyle(VColor.primaryBase)
                 .accessibilityElement(children: .combine)
                 .accessibilityLabel("Update available for this skill")
             }
@@ -217,11 +217,11 @@ struct SkillDetailView: View {
         HStack {
             Text(label)
                 .font(VFont.labelDefault)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
             Spacer()
             Text(value)
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(label): \(value)")
@@ -244,25 +244,25 @@ struct SkillDetailView: View {
             } label: {
                 HStack(spacing: VSpacing.sm) {
                     VIconView(fileIcon(for: file.mimeType, fileName: file.name), size: 16)
-                        .foregroundColor(VColor.primaryBase)
+                        .foregroundStyle(VColor.primaryBase)
                         .frame(width: 24)
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text(file.path)
                             .font(VFont.bodyMediumLighter)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
                             .lineLimit(1)
 
                         Text(formatFileSize(file.size))
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                     }
 
                     Spacer()
 
                     if isText {
                         VIconView(isExpanded ? .chevronUp : .chevronDown, size: 12)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                     }
                 }
             }
@@ -272,7 +272,7 @@ struct SkillDetailView: View {
             if isExpanded, let content = file.content {
                 Text(content)
                     .font(VFont.bodyMediumDefault)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
                     .textSelection(.enabled)
                     .padding(VSpacing.sm)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/clients/ios/Views/LoginView.swift
+++ b/clients/ios/Views/LoginView.swift
@@ -18,19 +18,19 @@ struct LoginView: View {
 
             Text("Log in with Vellum")
                 .font(VFont.titleMedium)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
                 .multilineTextAlignment(.center)
 
             Text("Sign in to connect to your cloud assistant")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, VSpacing.xl)
 
             if let error = authManager.errorMessage {
                 Text(error)
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.systemNegativeStrong)
+                    .foregroundStyle(VColor.systemNegativeStrong)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, VSpacing.xl)
             }
@@ -58,7 +58,7 @@ struct LoginView: View {
             Button("Back") {
                 onCancel?()
             }
-            .foregroundColor(VColor.contentSecondary)
+            .foregroundStyle(VColor.contentSecondary)
             .disabled(authManager.isSubmitting)
 
             Spacer()

--- a/clients/ios/Views/OnboardingView.swift
+++ b/clients/ios/Views/OnboardingView.swift
@@ -74,19 +74,19 @@ struct OnboardingView: View {
                     .controlSize(.large)
                 Text("Setting up your assistant...")
                     .font(VFont.bodyMediumLighter)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
             } else {
                 VIconView(.triangleAlert, size: 48)
-                    .foregroundColor(VColor.systemNegativeStrong)
+                    .foregroundStyle(VColor.systemNegativeStrong)
 
                 Text("Setup Failed")
                     .font(VFont.titleMedium)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
 
                 if let error = managedBootstrapError {
                     Text(error)
                         .font(VFont.bodyMediumLighter)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, VSpacing.xl)
                 }
@@ -101,7 +101,7 @@ struct OnboardingView: View {
                     managedBootstrapError = nil
                     currentStep = .choosePath
                 }
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
             }
 
             Spacer()
@@ -158,12 +158,12 @@ struct WelcomeStep: View {
 
             Text("Welcome to Vellum Assistant")
                 .font(VFont.titleMedium)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
                 .multilineTextAlignment(.center)
 
             Text("AI-powered assistant for your iPhone")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
                 .multilineTextAlignment(.center)
 
             Spacer()
@@ -188,7 +188,7 @@ struct ChoosePathStep: View {
 
             Text("How would you like to connect?")
                 .font(VFont.titleMedium)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
                 .multilineTextAlignment(.center)
 
             VStack(spacing: VSpacing.lg) {
@@ -197,14 +197,14 @@ struct ChoosePathStep: View {
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
                             Text("Log in with Vellum")
                                 .font(VFont.bodyMediumEmphasised)
-                                .foregroundColor(VColor.contentDefault)
+                                .foregroundStyle(VColor.contentDefault)
                             Text("Connect to your cloud assistant")
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                         }
                         Spacer()
                         VIconView(.cloud, size: 20)
-                            .foregroundColor(VColor.primaryBase)
+                            .foregroundStyle(VColor.primaryBase)
                     }
                     .padding(VSpacing.lg)
                     .background(VColor.surfaceBase)
@@ -220,14 +220,14 @@ struct ChoosePathStep: View {
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
                             Text("Connect to Assistant")
                                 .font(VFont.bodyMediumEmphasised)
-                                .foregroundColor(VColor.contentDefault)
+                                .foregroundStyle(VColor.contentDefault)
                             Text("Connect via your local network")
                                 .font(VFont.labelDefault)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                         }
                         Spacer()
                         VIconView(.monitor, size: 20)
-                            .foregroundColor(VColor.primaryBase)
+                            .foregroundStyle(VColor.primaryBase)
                     }
                     .padding(VSpacing.lg)
                     .background(VColor.surfaceBase)
@@ -259,11 +259,11 @@ struct DaemonSetupStep: View {
 
             Text("Connect to Assistant")
                 .font(VFont.titleMedium)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
 
             Text("Scan the QR code from your Assistant to pair.")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, VSpacing.xl)
 
@@ -289,7 +289,7 @@ struct DaemonSetupStep: View {
                         .stroke(VColor.borderBase, lineWidth: 1)
                 )
             }
-            .foregroundColor(VColor.contentDefault)
+            .foregroundStyle(VColor.contentDefault)
             .padding(.horizontal, VSpacing.xl)
 
             Button("Continue") {
@@ -301,7 +301,7 @@ struct DaemonSetupStep: View {
             Button("Skip for now") {
                 onContinue?()
             }
-            .foregroundColor(VColor.contentSecondary)
+            .foregroundStyle(VColor.contentSecondary)
 
             Spacer()
         }
@@ -334,11 +334,11 @@ struct PermissionsStep: View {
 
             Text("Permissions")
                 .font(VFont.titleMedium)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
 
             Text("Grant permissions for voice input")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
                 .multilineTextAlignment(.center)
 
             VStack(spacing: VSpacing.lg) {
@@ -370,11 +370,11 @@ struct ReadyStep: View {
 
             Text("You're All Set!")
                 .font(VFont.titleMedium)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
 
             Text("Start chatting with your AI assistant")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
                 .multilineTextAlignment(.center)
 
             Button("Get Started") {

--- a/clients/ios/Views/Settings/ChannelsGuardianSection.swift
+++ b/clients/ios/Views/Settings/ChannelsGuardianSection.swift
@@ -80,7 +80,7 @@ struct ChannelsGuardianSection: View {
         VStack(alignment: .leading, spacing: 4) {
             HStack {
                 VIconView(.shieldCheck, size: 14)
-                    .foregroundColor(VColor.systemPositiveStrong)
+                    .foregroundStyle(VColor.systemPositiveStrong)
                 Text(guardian.displayName)
                     .font(.body)
             }
@@ -119,7 +119,7 @@ struct ChannelsGuardianSection: View {
                 showRevokeConfirmation = true
             } label: {
                 VIconView(.circleX, size: 14)
-                    .foregroundColor(VColor.systemNegativeStrong)
+                    .foregroundStyle(VColor.systemNegativeStrong)
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Revoke channel \(channel.address)")
@@ -163,7 +163,7 @@ struct ChannelsGuardianSection: View {
         Text(label)
             .font(.caption2)
             .fontWeight(.medium)
-            .foregroundColor(color)
+            .foregroundStyle(color)
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
             .background(color.opacity(0.15))
@@ -183,7 +183,7 @@ struct ChannelsGuardianSection: View {
         Text(label)
             .font(.caption2)
             .fontWeight(.medium)
-            .foregroundColor(color)
+            .foregroundStyle(color)
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
             .background(color.opacity(0.15))

--- a/clients/ios/Views/Settings/ConnectionSettingsSection.swift
+++ b/clients/ios/Views/Settings/ConnectionSettingsSection.swift
@@ -64,28 +64,28 @@ struct DaemonConnectionSection: View {
                         // Connected state
                         HStack {
                             VIconView(.circleCheck, size: 16)
-                                .foregroundColor(VColor.systemPositiveStrong)
+                                .foregroundStyle(VColor.systemPositiveStrong)
                             Text("Connected")
                                 .font(VFont.bodyMediumLighter)
-                                .foregroundColor(VColor.contentDefault)
+                                .foregroundStyle(VColor.contentDefault)
                         }
                     } else {
                         // Disconnected state — gateway configured but not connected
                         HStack {
                             VIconView(.circleAlert, size: 16)
-                                .foregroundColor(VColor.systemNegativeStrong)
+                                .foregroundStyle(VColor.systemNegativeStrong)
                             Text("Disconnected")
                                 .font(VFont.bodyMediumLighter)
-                                .foregroundColor(VColor.contentDefault)
+                                .foregroundStyle(VColor.contentDefault)
                         }
                     }
                     HStack {
                         Text("Gateway")
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
                         Spacer()
                         Text(url)
                             .font(VFont.bodyMediumDefault)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                             .lineLimit(1)
                             .truncationMode(.middle)
                     }
@@ -93,7 +93,7 @@ struct DaemonConnectionSection: View {
                     // Not configured state
                     Text("Scan a QR code from your Assistant to connect.")
                         .font(VFont.bodyMediumLighter)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                 }
             } header: {
                 Text("Connection")
@@ -161,7 +161,7 @@ struct DaemonConnectionSection: View {
                 if let error = authManager.errorMessage {
                     Text(error)
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.systemNegativeStrong)
+                        .foregroundStyle(VColor.systemNegativeStrong)
                 }
             } header: {
                 Text("Vellum Account")

--- a/clients/ios/Views/Settings/IntegrationsSection.swift
+++ b/clients/ios/Views/Settings/IntegrationsSection.swift
@@ -33,12 +33,12 @@ struct IntegrationsSection: View {
                                     .controlSize(.small)
                             } else if integration.connected {
                                 VIconView(.circleCheck, size: 16)
-                                    .foregroundColor(VColor.systemPositiveStrong)
+                                    .foregroundStyle(VColor.systemPositiveStrong)
                                 Button("Disconnect") {
                                     disconnectIntegration(integration.id)
                                 }
                                 .font(.caption)
-                                .foregroundColor(VColor.systemNegativeStrong)
+                                .foregroundStyle(VColor.systemNegativeStrong)
                             } else {
                                 Button("Connect") {
                                     connectIntegration(integration.id)

--- a/clients/ios/Views/Settings/ModelsServicesSection.swift
+++ b/clients/ios/Views/Settings/ModelsServicesSection.swift
@@ -87,10 +87,10 @@ struct ModelsServicesSection: View {
         } label: {
             HStack {
                 Text(provider.displayName)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
                 Spacer()
                 VIconView(hasKey ? .circleCheck : .info, size: 14)
-                    .foregroundColor(hasKey ? VColor.systemPositiveStrong : VColor.contentTertiary)
+                    .foregroundStyle(hasKey ? VColor.systemPositiveStrong : VColor.contentTertiary)
             }
         }
         .accessibilityLabel("\(provider.displayName), \(hasKey ? "key saved" : "no key set")")
@@ -145,7 +145,7 @@ private struct APIKeyDetailSheet: View {
                     if hasExistingKey {
                         HStack {
                             VIconView(.circleCheck, size: 16)
-                                .foregroundColor(VColor.systemPositiveStrong)
+                                .foregroundStyle(VColor.systemPositiveStrong)
                             Text("API key saved")
                             Spacer()
                         }

--- a/clients/ios/Views/Settings/PermissionRowView.swift
+++ b/clients/ios/Views/Settings/PermissionRowView.swift
@@ -47,7 +47,7 @@ struct PermissionRowView: View {
 
     private var statusIcon: some View {
         VIconView(statusVIcon, size: 14)
-            .foregroundColor(statusColor)
+            .foregroundStyle(statusColor)
     }
 
     private var statusVIcon: VIcon {

--- a/clients/ios/Views/Settings/PrivacySection.swift
+++ b/clients/ios/Views/Settings/PrivacySection.swift
@@ -52,7 +52,7 @@ struct PrivacySection: View {
         } label: {
             HStack {
                 Text(name)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
                 Spacer()
                 statusBadge(status)
             }
@@ -76,7 +76,7 @@ struct PrivacySection: View {
         Text(label)
             .font(.caption2)
             .fontWeight(.medium)
-            .foregroundColor(color)
+            .foregroundStyle(color)
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
             .background(color.opacity(0.15))

--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -75,7 +75,7 @@ struct QRPairingSheet: View {
         VStack(spacing: VSpacing.lg) {
             Text("Scan the QR code from your Assistant to pair.")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, VSpacing.xl)
 
@@ -88,7 +88,7 @@ struct QRPairingSheet: View {
 
             Text("Open Vellum on your Assistant, go to Settings \u{2192} Connect, and tap Show QR Code.")
                 .font(VFont.labelDefault)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, VSpacing.xl)
         }
@@ -104,7 +104,7 @@ struct QRPairingSheet: View {
                 .controlSize(.large)
             Text("Sending pairing request...")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
             Spacer()
         }
     }
@@ -116,15 +116,15 @@ struct QRPairingSheet: View {
             Spacer()
 
             VIconView(.laptop, size: 48)
-                .foregroundColor(VColor.primaryBase)
+                .foregroundStyle(VColor.primaryBase)
 
             Text("Waiting for Approval")
                 .font(VFont.titleMedium)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
 
             Text("Approve this pairing request on your Assistant to continue.")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, VSpacing.xl)
 
@@ -144,7 +144,7 @@ struct QRPairingSheet: View {
                 .controlSize(.large)
             Text("Connecting to Assistant...")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
             Spacer()
         }
     }
@@ -156,15 +156,15 @@ struct QRPairingSheet: View {
             Spacer()
 
             VIconView(.circleCheck, size: 64)
-                .foregroundColor(VColor.systemPositiveStrong)
+                .foregroundStyle(VColor.systemPositiveStrong)
 
             Text("Connected!")
                 .font(VFont.titleMedium)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
 
             Text("Your iPhone is now connected to your Assistant.")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
                 .multilineTextAlignment(.center)
 
             Spacer()
@@ -184,16 +184,16 @@ struct QRPairingSheet: View {
             Spacer()
 
             VIconView(.triangleAlert, size: 48)
-                .foregroundColor(VColor.systemNegativeStrong)
+                .foregroundStyle(VColor.systemNegativeStrong)
 
             Text("Pairing Failed")
                 .font(VFont.titleMedium)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
 
             if let message = errorMessage {
                 Text(message)
                     .font(VFont.bodyMediumLighter)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, VSpacing.xl)
             }
@@ -202,7 +202,7 @@ struct QRPairingSheet: View {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     Text("Debug Info")
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                     Group {
                         if let reason = failureReason {
                             Text("Reason: \(reason)")
@@ -213,7 +213,7 @@ struct QRPairingSheet: View {
                         Text("Request ID: \(String(payload.pairingRequestId.prefix(8)))…")
                     }
                     .font(.system(size: 11, design: .monospaced))
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
                 }
                 .padding(.horizontal, VSpacing.xl)
                 .padding(.vertical, VSpacing.sm)
@@ -238,7 +238,7 @@ struct QRPairingSheet: View {
                 Button("Cancel") {
                     dismiss()
                 }
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
             }
             .padding(.bottom, VSpacing.xxl)
         }

--- a/clients/ios/Views/Settings/RemindersSection.swift
+++ b/clients/ios/Views/Settings/RemindersSection.swift
@@ -80,7 +80,7 @@ struct RemindersSection: View {
         Text(label)
             .font(.caption2)
             .fontWeight(.medium)
-            .foregroundColor(color)
+            .foregroundStyle(color)
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
             .background(color.opacity(0.15))

--- a/clients/ios/Views/Settings/TrustRulesSection.swift
+++ b/clients/ios/Views/Settings/TrustRulesSection.swift
@@ -82,7 +82,7 @@ struct TrustRulesSection: View {
                     editingRule = rule
                 } label: {
                     VIconView(.pencil, size: 16)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                 }
             }
         }
@@ -101,7 +101,7 @@ struct TrustRulesSection: View {
         Text(label)
             .font(.caption2)
             .fontWeight(.medium)
-            .foregroundColor(color)
+            .foregroundStyle(color)
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
             .background(color.opacity(0.15))

--- a/clients/ios/Views/Settings/TwilioSettingsSection.swift
+++ b/clients/ios/Views/Settings/TwilioSettingsSection.swift
@@ -38,13 +38,13 @@ struct TwilioSettingsSection: View {
                         Spacer()
                         if hasCredentials {
                             VIconView(.circleCheck, size: 16)
-                                .foregroundColor(VColor.systemPositiveStrong)
+                                .foregroundStyle(VColor.systemPositiveStrong)
                             Text("Connected")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         } else {
                             VIconView(.circleX, size: 16)
-                                .foregroundColor(VColor.systemNegativeStrong)
+                                .foregroundStyle(VColor.systemNegativeStrong)
                             Text("Not configured")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
@@ -111,7 +111,7 @@ struct TwilioSettingsSection: View {
                                     if number.phoneNumber == phoneNumber {
                                         Text("Active")
                                             .font(.caption)
-                                            .foregroundColor(VColor.systemPositiveStrong)
+                                            .foregroundStyle(VColor.systemPositiveStrong)
                                     } else if assigningNumber == number.phoneNumber {
                                         ProgressView()
                                             .controlSize(.small)
@@ -163,7 +163,7 @@ struct TwilioSettingsSection: View {
                     if let error = errorMessage {
                         Text(error)
                             .font(.caption)
-                            .foregroundColor(VColor.systemNegativeStrong)
+                            .foregroundStyle(VColor.systemNegativeStrong)
                     }
                 }
             }

--- a/clients/ios/Views/Settings/VoiceSettingsSection.swift
+++ b/clients/ios/Views/Settings/VoiceSettingsSection.swift
@@ -124,7 +124,7 @@ private struct ElevenLabsKeySection: View {
             if hasExistingKey {
                 HStack {
                     VIconView(.circleCheck, size: 16)
-                        .foregroundColor(.green)
+                        .foregroundStyle(.green)
                     Text("API key saved")
                     Spacer()
                     Button("Remove", role: .destructive) {

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -199,7 +199,7 @@ struct AccountSection: View {
             if let error = authManager.errorMessage {
                 Text(error)
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.systemNegativeStrong)
+                    .foregroundStyle(VColor.systemNegativeStrong)
             }
         }
     }

--- a/clients/ios/Views/Things/AppsGridView.swift
+++ b/clients/ios/Views/Things/AppsGridView.swift
@@ -134,10 +134,10 @@ struct AppsGridView: View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             HStack(spacing: VSpacing.xs) {
                 VIconView(.pin, size: 14)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
                 Text("Pinned")
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
                     .textCase(.uppercase)
             }
             .padding(.horizontal, VSpacing.md)
@@ -158,7 +158,7 @@ struct AppsGridView: View {
             if !pinnedApps.isEmpty {
                 Text("Other Apps")
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
                     .textCase(.uppercase)
                     .padding(.horizontal, VSpacing.md)
             }
@@ -185,25 +185,25 @@ struct AppsGridView: View {
                     Spacer()
                     if isPinned(app.id) {
                         VIconView(.pin, size: 12)
-                            .foregroundColor(VColor.primaryBase)
+                            .foregroundStyle(VColor.primaryBase)
                     }
                 }
 
                 Text(app.name)
                     .font(VFont.bodyMediumEmphasised)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
                     .lineLimit(1)
 
                 if let description = app.description {
                     Text(description)
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                         .lineLimit(2)
                 }
 
                 Text(formattedDate(app.createdAt))
                     .font(VFont.labelDefault)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(VSpacing.md)
@@ -259,10 +259,10 @@ struct AppsGridView: View {
     private var shareSuccessBanner: some View {
         HStack(spacing: VSpacing.sm) {
             VIconView(.circleCheck, size: 16)
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
             Text("Shared to cloud")
                 .font(VFont.bodyMediumEmphasised)
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
         }
         .padding(.horizontal, VSpacing.md)
         .padding(.vertical, VSpacing.sm)
@@ -278,7 +278,7 @@ struct AppsGridView: View {
             ProgressView()
             Text("Loading apps...")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -286,11 +286,11 @@ struct AppsGridView: View {
     private var emptyView: some View {
         VStack(spacing: VSpacing.md) {
             VIconView(.layoutGrid, size: 48)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
                 .accessibilityHidden(true)
             Text("No apps yet")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityElement(children: .combine)

--- a/clients/ios/Views/Things/DocumentsListView.swift
+++ b/clients/ios/Views/Things/DocumentsListView.swift
@@ -89,22 +89,22 @@ struct DocumentsListView: View {
     private func documentRow(_ doc: DocumentListItem) -> some View {
         HStack(spacing: VSpacing.md) {
             VIconView(.fileText, size: 24)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(doc.title)
                     .font(VFont.bodyMediumEmphasised)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
                     .lineLimit(1)
 
                 HStack(spacing: VSpacing.sm) {
                     Text("\(doc.wordCount) words")
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
 
                     Text(formattedDate(doc.updatedAt))
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                 }
             }
 
@@ -123,7 +123,7 @@ struct DocumentsListView: View {
             ProgressView()
             Text("Loading documents...")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -131,11 +131,11 @@ struct DocumentsListView: View {
     private var emptyView: some View {
         VStack(spacing: VSpacing.md) {
             VIconView(.fileText, size: 48)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
                 .accessibilityHidden(true)
             Text("No documents yet")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityElement(children: .combine)

--- a/clients/ios/Views/Things/SharedAppsListView.swift
+++ b/clients/ios/Views/Things/SharedAppsListView.swift
@@ -80,13 +80,13 @@ struct SharedAppsListView: View {
                 HStack(spacing: VSpacing.xs) {
                     Text(app.name)
                         .font(VFont.bodyMediumEmphasised)
-                        .foregroundColor(VColor.contentDefault)
+                        .foregroundStyle(VColor.contentDefault)
                         .lineLimit(1)
 
                     if app.updateAvailable == true {
                         Text("Update")
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.primaryBase)
+                            .foregroundStyle(VColor.primaryBase)
                             .padding(.horizontal, 6)
                             .padding(.vertical, 2)
                             .background(VColor.primaryBase.opacity(0.15))
@@ -98,7 +98,7 @@ struct SharedAppsListView: View {
                     HStack(spacing: VSpacing.xs) {
                         Text(signer)
                             .font(VFont.labelDefault)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
                         trustBadge(app.trustTier)
                     }
                 }
@@ -107,7 +107,7 @@ struct SharedAppsListView: View {
             Spacer()
 
             VIconView(.chevronRight, size: 14)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
         }
         .padding(.vertical, VSpacing.xs)
         .accessibilityElement(children: .combine)
@@ -120,7 +120,7 @@ struct SharedAppsListView: View {
     private func trustBadge(_ tier: String) -> some View {
         Text(tier.capitalized)
             .font(VFont.labelDefault)
-            .foregroundColor(trustColor(tier))
+            .foregroundStyle(trustColor(tier))
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
             .background(trustColor(tier).opacity(0.15))
@@ -148,11 +148,11 @@ struct SharedAppsListView: View {
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
                             Text(app.name)
                                 .font(VFont.titleMedium)
-                                .foregroundColor(VColor.contentDefault)
+                                .foregroundStyle(VColor.contentDefault)
                             if let signer = app.signerDisplayName {
                                 Text("by \(signer)")
                                     .font(VFont.labelDefault)
-                                    .foregroundColor(VColor.contentSecondary)
+                                    .foregroundStyle(VColor.contentSecondary)
                             }
                         }
                     }
@@ -162,7 +162,7 @@ struct SharedAppsListView: View {
                     Section("Description") {
                         Text(description)
                             .font(VFont.bodyMediumLighter)
-                            .foregroundColor(VColor.contentDefault)
+                            .foregroundStyle(VColor.contentDefault)
                     }
                 }
 
@@ -172,16 +172,16 @@ struct SharedAppsListView: View {
                     }
                     LabeledContent("Bundle Size") {
                         Text(formattedSize(app.bundleSizeBytes))
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
                     }
                     LabeledContent("Installed") {
                         Text(app.installedAt)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
                     }
                     if let version = app.version {
                         LabeledContent("Version") {
                             Text(version)
-                                .foregroundColor(VColor.contentSecondary)
+                                .foregroundStyle(VColor.contentSecondary)
                         }
                     }
                 }
@@ -259,7 +259,7 @@ struct SharedAppsListView: View {
             ProgressView()
             Text("Loading shared apps...")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -267,11 +267,11 @@ struct SharedAppsListView: View {
     private var emptyView: some View {
         VStack(spacing: VSpacing.md) {
             VIconView(.package, size: 48)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
                 .accessibilityHidden(true)
             Text("No shared apps")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundStyle(VColor.contentSecondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityElement(children: .combine)

--- a/clients/ios/Views/Things/ThingsTabView.swift
+++ b/clients/ios/Views/Things/ThingsTabView.swift
@@ -44,14 +44,14 @@ struct ThingsDisconnectedView: View {
         NavigationStack {
             VStack(spacing: VSpacing.lg) {
                 VIconView(.layoutGrid, size: 48)
-                    .foregroundColor(VColor.contentTertiary)
+                    .foregroundStyle(VColor.contentTertiary)
                     .accessibilityHidden(true)
                 Text("Library Requires Connection")
                     .font(VFont.titleMedium)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
                 Text("Connect to your Assistant to browse apps, shared apps, and documents.")
                     .font(VFont.bodyMediumLighter)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundStyle(VColor.contentSecondary)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, VSpacing.xl)
                 if onConnectTapped != nil {

--- a/clients/ios/Views/VoiceOrbView.swift
+++ b/clients/ios/Views/VoiceOrbView.swift
@@ -130,7 +130,7 @@ struct VoiceOrbView: View {
 
             // Center icon
             VIconView(orbIcon, size: 18)
-                .foregroundColor(.white.opacity(0.9))
+                .foregroundStyle(.white.opacity(0.9))
         }
         .frame(width: orbSize + 60, height: orbSize + 60)
         .animation(.easeInOut(duration: state == .speaking ? 0.3 : 0.12), value: amp)
@@ -147,7 +147,7 @@ struct VoiceOrbView: View {
     private var stateLabel: some View {
         Text(stateLabelText)
             .font(VFont.labelDefault)
-            .foregroundColor(VColor.contentSecondary)
+            .foregroundStyle(VColor.contentSecondary)
             .animation(VAnimation.standard, value: stateLabelText)
     }
 

--- a/clients/ios/Views/WorkspaceBrowserView.swift
+++ b/clients/ios/Views/WorkspaceBrowserView.swift
@@ -28,11 +28,11 @@ struct WorkspaceBrowserView: View {
             } else if entries.isEmpty {
                 VStack(spacing: VSpacing.md) {
                     VIconView(.folder, size: 36)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                         .accessibilityHidden(true)
                     Text("Empty directory")
                         .font(VFont.bodyMediumLighter)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
@@ -267,13 +267,13 @@ struct WorkspaceBrowserView: View {
     private func directoryRow(_ entry: WorkspaceTreeEntry) -> some View {
         HStack(spacing: VSpacing.sm) {
             VIconView(.folder, size: 16)
-                .foregroundColor(VColor.primaryBase)
+                .foregroundStyle(VColor.primaryBase)
                 .frame(width: 24)
                 .accessibilityHidden(true)
 
             Text(entry.name)
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
 
             Spacer()
         }
@@ -284,26 +284,26 @@ struct WorkspaceBrowserView: View {
     private func fileRow(_ entry: WorkspaceTreeEntry) -> some View {
         HStack(spacing: VSpacing.sm) {
             VIconView(iconForMimeType(entry.mimeType), size: 16)
-                .foregroundColor(VColor.primaryBase)
+                .foregroundStyle(VColor.primaryBase)
                 .frame(width: 24)
                 .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(entry.name)
                     .font(VFont.bodyMediumLighter)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundStyle(VColor.contentDefault)
 
                 if let size = entry.size {
                     Text(formatFileSize(size))
                         .font(VFont.labelDefault)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                 }
             }
 
             Spacer()
 
             VIconView(.chevronRight, size: 12)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
                 .accessibilityHidden(true)
         }
         .accessibilityElement(children: .combine)

--- a/clients/ios/Views/WorkspaceFileSheet.swift
+++ b/clients/ios/Views/WorkspaceFileSheet.swift
@@ -29,17 +29,17 @@ struct WorkspaceFileSheet: View {
                         ProgressView()
                         Text("Loading file...")
                             .font(VFont.bodyMediumLighter)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else if let error {
                     VStack(spacing: VSpacing.md) {
                         VIconView(.triangleAlert, size: 36)
-                            .foregroundColor(VColor.contentTertiary)
+                            .foregroundStyle(VColor.contentTertiary)
                             .accessibilityHidden(true)
                         Text(error)
                             .font(VFont.bodyMediumLighter)
-                            .foregroundColor(VColor.contentSecondary)
+                            .foregroundStyle(VColor.contentSecondary)
                             .multilineTextAlignment(.center)
                     }
                     .padding(VSpacing.xl)
@@ -95,7 +95,7 @@ struct WorkspaceFileSheet: View {
         } else {
             Text("No content")
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
@@ -103,7 +103,7 @@ struct WorkspaceFileSheet: View {
     private func metadataView(_ response: WorkspaceFileResponse) -> some View {
         VStack(spacing: VSpacing.lg) {
             VIconView(.file, size: 48)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
                 .accessibilityHidden(true)
 
             VStack(spacing: VSpacing.sm) {
@@ -128,11 +128,11 @@ struct WorkspaceFileSheet: View {
         HStack {
             Text(label)
                 .font(VFont.labelDefault)
-                .foregroundColor(VColor.contentTertiary)
+                .foregroundStyle(VColor.contentTertiary)
                 .frame(width: 80, alignment: .leading)
             Text(value)
                 .font(VFont.bodyMediumLighter)
-                .foregroundColor(VColor.contentDefault)
+                .foregroundStyle(VColor.contentDefault)
                 .lineLimit(2)
             Spacer()
         }
@@ -206,11 +206,11 @@ private struct AuthenticatedImageView: View {
             } else if failed {
                 VStack(spacing: VSpacing.md) {
                     VIconView(.image, size: 36)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                         .accessibilityHidden(true)
                     Text("Unable to load image")
                         .font(VFont.bodyMediumLighter)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
@@ -249,11 +249,11 @@ private struct WorkspaceVideoPlayer: View {
             } else if failed {
                 VStack(spacing: VSpacing.md) {
                     VIconView(.triangleAlert, size: 36)
-                        .foregroundColor(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentTertiary)
                         .accessibilityHidden(true)
                     Text("Unable to load video")
                         .font(VFont.bodyMediumLighter)
-                        .foregroundColor(VColor.contentSecondary)
+                        .foregroundStyle(VColor.contentSecondary)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {


### PR DESCRIPTION
## Summary
- Replaces all .foregroundColor() with .foregroundStyle() in clients/ios/

Part of plan: macos15-modernization.md (PR 17 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
