### PR TITLE
refactor: migrate SkillsManager to @Observable and adapt SkillsStore Combine forwarding

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -10,7 +10,7 @@ struct AgentPanelContent: View {
     var onSkillsChanged: (() -> Void)?
     let connectionManager: GatewayConnectionManager
 
-    @StateObject private var skillsManager: SkillsManager
+    @State private var skillsManager: SkillsManager
     @State private var selectedInstalledSkillId: String?
     @State private var skillToDelete: SkillInfo?
     @State private var selectedCategory: SkillCategory?
@@ -20,7 +20,7 @@ struct AgentPanelContent: View {
         self.onInvokeSkill = onInvokeSkill
         self.onSkillsChanged = onSkillsChanged
         self.connectionManager = connectionManager
-        _skillsManager = StateObject(wrappedValue: SkillsManager(connectionManager: connectionManager))
+        _skillsManager = State(wrappedValue: SkillsManager(connectionManager: connectionManager))
     }
 
     private var normalizedSkillQuery: String {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 /// Full-page detail view for an installed skill, showing metadata and a two-pane file browser.
 struct SkillDetailView: View {
     let skill: SkillInfo
-    @ObservedObject var skillsManager: SkillsManager
+    var skillsManager: SkillsManager
     let onBack: () -> Void
     let onDelete: (SkillInfo) -> Void
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -3,19 +3,22 @@ import Combine
 import VellumAssistantShared
 
 @MainActor
-final class SkillsManager: ObservableObject {
+@Observable
+final class SkillsManager {
     let skillsStore: SkillsStore
 
     // Forward all published properties from SkillsStore so existing views
-    // continue to work via @ObservedObject on SkillsManager unchanged.
-    @Published var skills: [SkillInfo] = []
-    @Published var loadedBodies: [String: String] = [:]
-    @Published var isLoading = false
-    @Published var uninstallResult: SkillsStore.UninstallResult?
-    @Published var isUninstalling = false
-    @Published var selectedSkillFiles: SkillDetailFilesHTTPResponse?
-    @Published var isLoadingSkillFiles = false
-    @Published var skillFilesError: String?
+    // continue to work via observation on SkillsManager unchanged.
+    var skills: [SkillInfo] = []
+    var loadedBodies: [String: String] = [:]
+    var isLoading = false
+    var uninstallResult: SkillsStore.UninstallResult?
+    var isUninstalling = false
+    var selectedSkillFiles: SkillDetailFilesHTTPResponse?
+    var isLoadingSkillFiles = false
+    var skillFilesError: String?
+
+    @ObservationIgnored private var cancellables = Set<AnyCancellable>()
 
     // Kept for source compatibility with existing macOS views.
     typealias UninstallResult = SkillsStore.UninstallResult
@@ -27,14 +30,14 @@ final class SkillsManager: ObservableObject {
 
     /// Wire up Combine subscriptions to forward SkillsStore state.
     private func bindStore() {
-        skillsStore.$skills.assign(to: &$skills)
-        skillsStore.$loadedBodies.assign(to: &$loadedBodies)
-        skillsStore.$isLoading.assign(to: &$isLoading)
-        skillsStore.$uninstallResult.assign(to: &$uninstallResult)
-        skillsStore.$isUninstalling.assign(to: &$isUninstalling)
-        skillsStore.$selectedSkillFiles.assign(to: &$selectedSkillFiles)
-        skillsStore.$isLoadingSkillFiles.assign(to: &$isLoadingSkillFiles)
-        skillsStore.$skillFilesError.assign(to: &$skillFilesError)
+        skillsStore.$skills.sink { [weak self] in self?.skills = $0 }.store(in: &cancellables)
+        skillsStore.$loadedBodies.sink { [weak self] in self?.loadedBodies = $0 }.store(in: &cancellables)
+        skillsStore.$isLoading.sink { [weak self] in self?.isLoading = $0 }.store(in: &cancellables)
+        skillsStore.$uninstallResult.sink { [weak self] in self?.uninstallResult = $0 }.store(in: &cancellables)
+        skillsStore.$isUninstalling.sink { [weak self] in self?.isUninstalling = $0 }.store(in: &cancellables)
+        skillsStore.$selectedSkillFiles.sink { [weak self] in self?.selectedSkillFiles = $0 }.store(in: &cancellables)
+        skillsStore.$isLoadingSkillFiles.sink { [weak self] in self?.isLoadingSkillFiles = $0 }.store(in: &cancellables)
+        skillsStore.$skillFilesError.sink { [weak self] in self?.skillFilesError = $0 }.store(in: &cancellables)
     }
 
     // MARK: - Delegated Operations


### PR DESCRIPTION
## Summary
- Migrates SkillsManager to @Observable
- Replaces .assign(to:) with .sink for forwarding from ObservableObject SkillsStore
- Updates AgentPanel and SkillDetailView call sites

Part of plan: macos15-modernization.md (PR 12 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
