### PR TITLE
refactor: migrate TaskProgressOverlayManager to @Observable and update MessageListView consumer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -150,12 +150,11 @@ struct MessageListView: View {
     @AppStorage("completedConversationCount") private var completedConversationCount: Int = 0
     @State private var identity: IdentityInfo? = IdentityInfo.load()
     @State private var appearance = AvatarAppearanceManager.shared
-    /// Read once at the list level and passed down to each ChatBubble so that
-    /// individual bubbles don't each subscribe to the shared ObservableObject.
-    /// Only the active surface ID is needed here (to suppress inline rendering).
-    /// Observing the full TaskProgressOverlayManager would cause the entire
-    /// message list to re-render on every frequent `data` progress tick.
-    @State private var activeSurfaceId: String?
+    /// Read at the list level and passed down to each ChatBubble so that
+    /// individual bubbles don't each subscribe to the shared manager.
+    /// With @Observable fine-grained tracking, reading only `activeSurfaceId`
+    /// won't trigger re-renders on frequent `data` progress ticks.
+    private var taskProgressManager = TaskProgressOverlayManager.shared
     /// Consolidates all scroll-related state: anchor tracking, scroll loop guard,
     /// bottom pin coordinator, suppression flags, and scroll-related tasks.
     @StateObject private var scrollCoordinator = MessageListScrollCoordinator()
@@ -670,7 +669,7 @@ struct MessageListView: View {
                                 shouldShowThinkingIndicator: state.shouldShowThinkingIndicator,
                                 assistantStatusText: state.effectiveStatusText,
                                 dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
-                                activeSurfaceId: activeSurfaceId,
+                                activeSurfaceId: taskProgressManager.activeSurfaceId,
                                 isHighlighted: highlightedMessageId == messageId,
                                 mediaEmbedSettings: mediaEmbedSettings,
                                 onConfirmationAllow: onConfirmationAllow,
@@ -1019,9 +1018,6 @@ struct MessageListView: View {
                     window.makeFirstResponder(nil)
                     scrollCoordinator.lastAutoFocusedRequestId = requestId
                 }
-            }
-            .onReceive(TaskProgressOverlayManager.shared.$activeSurfaceId) { newId in
-                activeSurfaceId = newId
             }
         }
     }

--- a/clients/shared/Features/Chat/TaskProgressOverlayManager.swift
+++ b/clients/shared/Features/Chat/TaskProgressOverlayManager.swift
@@ -1,5 +1,4 @@
 #if os(macOS)
-import Combine
 import SwiftUI
 import AppKit
 import os
@@ -9,43 +8,37 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 /// Manages a floating NSPanel that shows a task_progress widget pinned to the
 /// top-right of the screen. Follows BrowserPiPManager / SessionOverlayWindow patterns.
 @MainActor
-public final class TaskProgressOverlayManager: ObservableObject {
+@Observable
+public final class TaskProgressOverlayManager {
     public static let shared = TaskProgressOverlayManager()
 
-    @Published var data: TaskProgressData?
+    var data: TaskProgressData?
     /// The surface ID currently shown in the floating overlay.
     /// ChatView uses this to suppress inline rendering for the same surface.
-    @Published public private(set) var activeSurfaceId: String?
+    public private(set) var activeSurfaceId: String?
 
-    private var panel: NSPanel?
-    private var dismissTask: Task<Void, Never>?
+    @ObservationIgnored private var panel: NSPanel?
+    @ObservationIgnored private var dismissTask: Task<Void, Never>?
 
     // MARK: - Debug publish-rate counters
 
     #if DEBUG
     private static let perfLog = OSLog(subsystem: "com.vellum.assistant", category: "PerfCounters")
-    private var publishCount = 0
-    private var lastRateLogTime = Date()
-    private var debugCancellable: AnyCancellable?
+    @ObservationIgnored private var publishCount = 0
+    @ObservationIgnored private var lastRateLogTime = Date()
 
-    private func trackPublish() {
+    private func trackDataUpdate() {
         publishCount += 1
         let now = Date()
         if now.timeIntervalSince(lastRateLogTime) >= 5 {
-            os_log(.debug, log: Self.perfLog, "TaskProgressOverlayManager publish rate: %d/5s", publishCount)
+            os_log(.debug, log: Self.perfLog, "TaskProgressOverlayManager update rate: %d/5s", publishCount)
             publishCount = 0
             lastRateLogTime = now
         }
     }
     #endif
 
-    private init() {
-        #if DEBUG
-        // Observe own objectWillChange to track publish frequency.
-        debugCancellable = self.objectWillChange
-            .sink { [weak self] _ in self?.trackPublish() }
-        #endif
-    }
+    private init() {}
 
     // MARK: - Public API
 
@@ -67,6 +60,9 @@ public final class TaskProgressOverlayManager: ObservableObject {
     public func update(data: TaskProgressData, surfaceId: String) {
         guard surfaceId == self.activeSurfaceId else { return }
         self.data = data
+        #if DEBUG
+        trackDataUpdate()
+        #endif
 
         // Resize panel to fit updated content
         if let panel, let fittingSize = panel.contentView?.fittingSize {
@@ -160,7 +156,7 @@ public final class TaskProgressOverlayManager: ObservableObject {
 // MARK: - Overlay SwiftUI View
 
 private struct TaskProgressOverlayView: View {
-    @ObservedObject var manager: TaskProgressOverlayManager
+    var manager: TaskProgressOverlayManager
 
     var body: some View {
         VStack(spacing: 0) {


### PR DESCRIPTION
## Summary
- Migrates TaskProgressOverlayManager to @Observable (data stays tracked, activeSurfaceId stays tracked)
- Replaces debug objectWillChange hook with simple counter in update()
- Simplifies MessageListView: removes @State forwarding, reads activeSurfaceId directly

Part of plan: macos15-modernization.md (PR 11 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
