### PR TITLE
refactor: migrate OpenAIVoiceService to @Observable and update VoiceModeManager consumer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
@@ -30,29 +30,30 @@ enum VoiceServiceError: Error, LocalizedError {
 /// Voice service: SFSpeechRecognizer STT (on-device) + TTS (ElevenLabs REST API).
 /// Records audio, detects silence, transcribes via SFSpeechRecognizer, speaks via ElevenLabs.
 @MainActor
-final class OpenAIVoiceService: ObservableObject, VoiceServiceProtocol {
-    @Published var amplitude: Float = 0
-    @Published var speakingAmplitude: Float = 0
-    @Published var livePartialText: String = ""
+@Observable
+final class OpenAIVoiceService: VoiceServiceProtocol {
+    var amplitude: Float = 0
+    var speakingAmplitude: Float = 0
+    var livePartialText: String = ""
 
     // MARK: - Recording State
 
-    private let audioEngine = AVAudioEngine()
-    private var isRecording = false
+    @ObservationIgnored private let audioEngine = AVAudioEngine()
+    @ObservationIgnored private var isRecording = false
 
     /// Fires once when silence is detected after speech.
-    var onSilenceDetected: (() -> Void)?
+    @ObservationIgnored var onSilenceDetected: (() -> Void)?
     /// Callback fired when mic permission is granted after being requested.
-    var onMicrophoneAuthorized: (() -> Void)?
+    @ObservationIgnored var onMicrophoneAuthorized: (() -> Void)?
     /// Fires when speech is detected during TTS playback (barge-in).
-    var onBargeInDetected: (() -> Void)?
+    @ObservationIgnored var onBargeInDetected: (() -> Void)?
 
-    private var lastSpeechTime = Date()
-    private var recordingStartTime: Date?
-    private var silenceHandled = false
-    private var hasSpeechOccurred = false
-    private var enginePrewarmed = false
-    private var rmsLogCounter = 0
+    @ObservationIgnored private var lastSpeechTime = Date()
+    @ObservationIgnored private var recordingStartTime: Date?
+    @ObservationIgnored private var silenceHandled = false
+    @ObservationIgnored private var hasSpeechOccurred = false
+    @ObservationIgnored private var enginePrewarmed = false
+    @ObservationIgnored private var rmsLogCounter = 0
 
     private static let silenceThreshold: Float = 0.003
     private static let speechThreshold: Float = 0.003
@@ -61,22 +62,22 @@ final class OpenAIVoiceService: ObservableObject, VoiceServiceProtocol {
 
     // MARK: - SFSpeechRecognizer STT State
 
-    private var speechRecognizer: SFSpeechRecognizer?
-    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
-    private var recognitionTask: SFSpeechRecognitionTask?
+    @ObservationIgnored private var speechRecognizer: SFSpeechRecognizer?
+    @ObservationIgnored private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    @ObservationIgnored private var recognitionTask: SFSpeechRecognitionTask?
     /// The latest transcription text from the ongoing recognition task.
-    private var latestTranscription: String = ""
+    @ObservationIgnored private var latestTranscription: String = ""
     /// Continuation to deliver the final transcription when recording stops.
-    private var transcriptionContinuation: CheckedContinuation<String?, Never>?
+    @ObservationIgnored private var transcriptionContinuation: CheckedContinuation<String?, Never>?
 
     // MARK: - ElevenLabs TTS State
 
     /// Accumulated text from streaming deltas — sent to ElevenLabs when response completes.
-    private var ttsTextBuffer = ""
-    private var ttsOnComplete: (() -> Void)?
-    private var audioPlayer: AVAudioPlayer?
-    private var speakingTimer: Timer?
-    private var ttsTask: Task<Void, Never>?
+    @ObservationIgnored private var ttsTextBuffer = ""
+    @ObservationIgnored private var ttsOnComplete: (() -> Void)?
+    @ObservationIgnored private var audioPlayer: AVAudioPlayer?
+    @ObservationIgnored private var speakingTimer: Timer?
+    @ObservationIgnored private var ttsTask: Task<Void, Never>?
 
     /// Default ElevenLabs voice — "Amelia" (expressive, enthusiastic, British English).
     /// Mirrored from: assistant/src/config/elevenlabs-schema.ts (DEFAULT_ELEVENLABS_VOICE_ID)
@@ -446,7 +447,7 @@ final class OpenAIVoiceService: ObservableObject, VoiceServiceProtocol {
 
     // MARK: - Barge-in (interrupt TTS by speaking)
 
-    private var bargeInMonitorActive = false
+    @ObservationIgnored private var bargeInMonitorActive = false
 
     /// Start monitoring the mic for speech during TTS playback.
     /// Uses a higher threshold than normal to avoid picking up speaker output.

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import Observation
 import VellumAssistantShared
 import os
 
@@ -56,8 +57,8 @@ final class VoiceModeManager: ObservableObject {
     private var messageCancellable: AnyCancellable?
     /// Combine subscription to pause/resume conversation timeout during tool execution.
     private var isThinkingCancellable: AnyCancellable?
-    /// Combine subscription forwarding live partial transcription from the voice service.
-    private var liveTranscriptionCancellable: AnyCancellable?
+    /// Generation counter controlling the lifetime of the voice-service observation loop.
+    private var voiceObservationGeneration: Int = 0
 
     init(voiceService: any VoiceServiceProtocol = OpenAIVoiceService()) {
         self.voiceService = voiceService
@@ -144,14 +145,7 @@ final class VoiceModeManager: ObservableObject {
             }
 
         // Forward live partial transcription when listening
-        if let openAI = voiceService as? OpenAIVoiceService {
-            liveTranscriptionCancellable = openAI.$livePartialText
-                .receive(on: DispatchQueue.main)
-                .sink { [weak self] text in
-                    guard let self, self.state == .listening else { return }
-                    self.liveTranscription = text
-                }
-        }
+        startVoiceServiceObservation()
 
         // Pre-warm audio engine so first recording starts instantly
         voiceService.prewarmEngine()
@@ -208,8 +202,7 @@ final class VoiceModeManager: ObservableObject {
         messageCancellable = nil
         isThinkingCancellable?.cancel()
         isThinkingCancellable = nil
-        liveTranscriptionCancellable?.cancel()
-        liveTranscriptionCancellable = nil
+        stopVoiceServiceObservation()
         pendingPermissionIds = []
 
         chatViewModel = nil
@@ -576,6 +569,36 @@ final class VoiceModeManager: ObservableObject {
                 self.voiceService.stopBargeInMonitor()
                 self.state = .idle
                 self.startListening()
+            }
+        }
+    }
+
+    // MARK: - Voice Service Observation
+
+    /// Start observing the voice service's livePartialText. Called during activation.
+    private func startVoiceServiceObservation() {
+        voiceObservationGeneration += 1
+        observeVoiceServiceLoop(generation: voiceObservationGeneration)
+    }
+
+    /// Stop observing. Called from deactivate().
+    private func stopVoiceServiceObservation() {
+        voiceObservationGeneration += 1  // invalidates any in-flight re-arm
+    }
+
+    private func observeVoiceServiceLoop(generation: Int) {
+        guard generation == voiceObservationGeneration,
+              let service = openAIVoiceService else { return }
+        withObservationTracking {
+            _ = service.livePartialText
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self,
+                      generation == self.voiceObservationGeneration,
+                      self.state == .listening,
+                      let service = self.openAIVoiceService else { return }
+                self.liveTranscription = service.livePartialText
+                self.observeVoiceServiceLoop(generation: generation) // re-arm
             }
         }
     }


### PR DESCRIPTION
## Summary
- Migrates OpenAIVoiceService to @Observable
- Replaces Combine bridge with generation-guarded withObservationTracking in VoiceModeManager
- Handles optional service, listening-only guard, and deactivation teardown

Part of plan: macos15-modernization.md (PR 10 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
