### PR TITLE
refactor: migrate single-property macOS view models to @Observable (batch 2)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -39,7 +39,7 @@ struct ChatBubble: View {
     var processingStatusText: String?
     /// Whether the message-tts feature flag is enabled. Passed from the parent.
     var isTTSEnabled: Bool = false
-    @StateObject private var audioPlayer = MessageAudioPlayer()
+    @State private var audioPlayer = MessageAudioPlayer()
     @State private var isHovered = false
     /// Stores async-parsed segments for large messages (>500 chars) that missed the
     /// synchronous cache. Keyed by text content so multiple segments can be in flight.

--- a/clients/macos/vellum-assistant/Features/Chat/MessageAudioPlayer.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageAudioPlayer.swift
@@ -7,15 +7,16 @@ import VellumAssistantShared
 /// Each ChatBubble owns its own instance so multiple messages can have
 /// independent playback state.
 @MainActor
-final class MessageAudioPlayer: NSObject, ObservableObject, AVAudioPlayerDelegate {
-    @Published var isLoading: Bool = false
-    @Published var isPlaying: Bool = false
-    @Published var error: String? = nil
-    @Published var isNotConfigured: Bool = false
-    @Published var isFeatureDisabled: Bool = false
+@Observable
+final class MessageAudioPlayer: NSObject, AVAudioPlayerDelegate {
+    var isLoading: Bool = false
+    var isPlaying: Bool = false
+    var error: String? = nil
+    var isNotConfigured: Bool = false
+    var isFeatureDisabled: Bool = false
 
-    private var audioPlayer: AVAudioPlayer?
-    private let ttsClient: any TTSClientProtocol
+    @ObservationIgnored private var audioPlayer: AVAudioPlayer?
+    @ObservationIgnored private let ttsClient: any TTSClientProtocol
 
     init(ttsClient: any TTSClientProtocol = TTSClient()) {
         self.ttsClient = ttsClient

--- a/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
@@ -5,7 +5,8 @@ import VellumAssistantShared
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AppListManager")
 
 @MainActor
-final class AppListManager: ObservableObject {
+@Observable
+final class AppListManager {
 
     struct AppItem: Identifiable, Codable, Hashable {
         let id: String
@@ -89,12 +90,12 @@ final class AppListManager: ObservableObject {
         }
     }
 
-    @Published var apps: [AppItem] = []
+    var apps: [AppItem] = []
 
     /// IDs of apps the user explicitly removed. Prevents daemon sync from re-adding them.
-    private var removedAppIds: Set<String> = []
+    @ObservationIgnored private var removedAppIds: Set<String> = []
 
-    private let fileURL: URL
+    @ObservationIgnored private let fileURL: URL
 
     /// Only pinned apps, sorted by pinnedOrder ascending.
     var pinnedApps: [AppItem] {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -9,7 +9,7 @@ extension Notification.Name {
 
 struct MainWindowView: View {
     @ObservedObject var conversationManager: ConversationManager
-    @ObservedObject var appListManager: AppListManager
+    var appListManager: AppListManager
     var zoomManager: ZoomManager
     /// Plain `let` instead of `@ObservedObject` so SwiftUI doesn't observe
     /// TraceStore mutations when the DebugPanel isn't visible. DebugPanel

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -3,7 +3,7 @@ import VellumAssistantShared
 
 /// Full-screen apps grid view showing all apps as a flat card grid with search.
 struct AppsGridView: View {
-    @ObservedObject var appListManager: AppListManager
+    var appListManager: AppListManager
     let connectionManager: GatewayConnectionManager
     let gatewayBaseURL: String
     let onOpenApp: (String) -> Void

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -2,7 +2,7 @@ import VellumAssistantShared
 import SwiftUI
 
 struct SurfaceContainerView: View {
-    @ObservedObject var viewModel: SurfaceViewModel
+    var viewModel: SurfaceViewModel
 
     private var surface: Surface { viewModel.surface }
 

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -8,15 +8,16 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 /// Observable view model that holds the current surface state.
 /// Kept alive across updates so that child SwiftUI views preserve their @State (e.g. form inputs).
 @MainActor
-final class SurfaceViewModel: ObservableObject {
-    @Published var surface: Surface
-    let onAction: (String, [String: Any]?) -> Void
-    let onDismiss: () -> Void
-    let appId: String?
-    let onDataRequest: ((String, String, String?, [String: Any]?) -> Void)?
-    let onCoordinatorReady: ((DynamicPageSurfaceView.Coordinator) -> Void)?
-    let onLinkOpen: ((String, [String: Any]?) -> Void)?
-    let sandboxMode: Bool
+@Observable
+final class SurfaceViewModel {
+    var surface: Surface
+    @ObservationIgnored let onAction: (String, [String: Any]?) -> Void
+    @ObservationIgnored let onDismiss: () -> Void
+    @ObservationIgnored let appId: String?
+    @ObservationIgnored let onDataRequest: ((String, String, String?, [String: Any]?) -> Void)?
+    @ObservationIgnored let onCoordinatorReady: ((DynamicPageSurfaceView.Coordinator) -> Void)?
+    @ObservationIgnored let onLinkOpen: ((String, [String: Any]?) -> Void)?
+    @ObservationIgnored let sandboxMode: Bool
 
     init(
         surface: Surface,
@@ -44,57 +45,58 @@ final class SurfaceViewModel: ObservableObject {
 /// Each surface is displayed in a floating, non-activating panel positioned at the bottom-right
 /// of the screen, using a floating, non-activating NSPanel.
 @MainActor
-final class SurfaceManager: ObservableObject {
+@Observable
+final class SurfaceManager {
 
-    // MARK: - Published State
+    // MARK: - Reactive State
 
-    @Published var activeSurfaces: [String: Surface] = [:]
+    var activeSurfaces: [String: Surface] = [:]
 
-    // MARK: - Private State
+    // MARK: - Non-reactive Bookkeeping
 
-    private var panels: [String: NSPanel] = [:]
-    private var viewModels: [String: SurfaceViewModel] = [:]
+    @ObservationIgnored private var panels: [String: NSPanel] = [:]
+    @ObservationIgnored private var viewModels: [String: SurfaceViewModel] = [:]
 
     /// Tracks appId per surface for persistent app RPC routing.
-    var surfaceAppIds: [String: String] = [:]
+    @ObservationIgnored var surfaceAppIds: [String: String] = [:]
 
     /// Tracks Coordinator per surface for routing data responses back to WebView.
-    var surfaceCoordinators: [String: DynamicPageSurfaceView.Coordinator] = [:]
+    @ObservationIgnored var surfaceCoordinators: [String: DynamicPageSurfaceView.Coordinator] = [:]
 
     /// Ordered list of surface IDs for deterministic stacking positions.
-    private var surfaceOrder: [String] = []
+    @ObservationIgnored private var surfaceOrder: [String] = []
 
     /// Surfaces that have already sent an action to the daemon.
     /// Prevents duplicate actions (e.g. submit followed by dismiss) from racing.
-    private var respondedSurfaces: Set<String> = []
+    @ObservationIgnored private var respondedSurfaces: Set<String> = []
 
     /// Surfaces routed to the workspace instead of floating NSPanels.
     /// Tracked so that update/dismiss messages can be forwarded via notifications.
-    private var workspaceRoutedSurfaces: Set<String> = []
+    @ObservationIgnored private var workspaceRoutedSurfaces: Set<String> = []
 
-    private var closeObservers: [String: Any] = [:]
+    @ObservationIgnored private var closeObservers: [String: Any] = [:]
 
-    private let panelWidth: CGFloat = 380
-    private let panelMargin: CGFloat = 20
-    private let panelSpacing: CGFloat = 10
+    @ObservationIgnored private let panelWidth: CGFloat = 380
+    @ObservationIgnored private let panelMargin: CGFloat = 20
+    @ObservationIgnored private let panelSpacing: CGFloat = 10
 
     // MARK: - Action Callback
 
     /// Called when a user interacts with a surface action button.
     /// Parameters: conversationId (optional), surfaceId, actionId, optional data dictionary.
-    var onAction: ((String?, String, String, [String: Any]?) -> Void)?
+    @ObservationIgnored var onAction: ((String?, String, String, [String: Any]?) -> Void)?
 
     /// Called when a persistent app's JS makes a data request via the RPC bridge.
     /// Parameters: surfaceId, callId, method, appId, recordId, data.
-    var onDataRequest: ((String, String, String, String, String?, [String: Any]?) -> Void)?
+    @ObservationIgnored var onDataRequest: ((String, String, String, String, String?, [String: Any]?) -> Void)?
 
     /// When set, dynamic pages with `display != "inline"` route to the full-window
     /// workspace instead of opening as floating NSPanels.
-    var onDynamicPageShow: ((UiSurfaceShowMessage) -> Void)?
+    @ObservationIgnored var onDynamicPageShow: ((UiSurfaceShowMessage) -> Void)?
 
     /// Called when a dynamic page requests opening an external link.
     /// Parameters: url string, optional metadata dictionary.
-    var onLinkOpen: ((String, [String: Any]?) -> Void)?
+    @ObservationIgnored var onLinkOpen: ((String, [String: Any]?) -> Void)?
 
     // MARK: - Show
 

--- a/clients/macos/vellum-assistant/Features/Terminal/SSHTerminalView.swift
+++ b/clients/macos/vellum-assistant/Features/Terminal/SSHTerminalView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// and the `TerminalSessionManager` that communicates with the platform terminal API.
 struct SSHTerminalView: NSViewRepresentable {
 
-    @ObservedObject var sessionManager: TerminalSessionManager
+    var sessionManager: TerminalSessionManager
 
     func makeNSView(context: Context) -> TerminalView {
         let terminalView = TerminalView(frame: .zero)

--- a/clients/macos/vellum-assistant/Features/Terminal/SSHTerminalWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Terminal/SSHTerminalWindow.swift
@@ -79,7 +79,7 @@ final class SSHTerminalWindow {
 /// SwiftUI root view for the terminal window, composing the terminal view
 /// with a status toolbar.
 private struct SSHTerminalContentView: View {
-    @ObservedObject var sessionManager: TerminalSessionManager
+    var sessionManager: TerminalSessionManager
 
     var body: some View {
         VStack(spacing: 0) {

--- a/clients/macos/vellum-assistant/Features/Terminal/TerminalSessionManager.swift
+++ b/clients/macos/vellum-assistant/Features/Terminal/TerminalSessionManager.swift
@@ -8,9 +8,10 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 /// Handles connecting, streaming output, buffering input, resizing, reconnecting,
 /// and cleaning up sessions. Drives UI state via the published `status` property.
 @MainActor
-final class TerminalSessionManager: ObservableObject {
+@Observable
+final class TerminalSessionManager {
 
-    // MARK: - Published State
+    // MARK: - Reactive State
 
     enum Status: Equatable {
         case idle
@@ -21,34 +22,34 @@ final class TerminalSessionManager: ObservableObject {
         case closed
     }
 
-    @Published private(set) var status: Status = .idle
+    private(set) var status: Status = .idle
 
     // MARK: - Configuration
 
-    private let apiClient: TerminalAPIClient
+    @ObservationIgnored private let apiClient: TerminalAPIClient
 
     /// Called with base64-encoded PTY output bytes as they arrive from the stream.
-    var onData: ((String) -> Void)?
+    @ObservationIgnored var onData: ((String) -> Void)?
 
     // MARK: - Session State
 
-    private var sessionId: String?
-    private var cancelSSE: (() -> Void)?
-    private var sseTask: Task<Void, Never>?
+    @ObservationIgnored private var sessionId: String?
+    @ObservationIgnored private var cancelSSE: (() -> Void)?
+    @ObservationIgnored private var sseTask: Task<Void, Never>?
 
     // Input buffering — batches keystrokes and flushes every 50ms.
-    private var inputBuffer: String = ""
-    private var inputFlushTimer: Timer?
-    private static let inputFlushInterval: TimeInterval = 0.05
+    @ObservationIgnored private var inputBuffer: String = ""
+    @ObservationIgnored private var inputFlushTimer: Timer?
+    @ObservationIgnored private static let inputFlushInterval: TimeInterval = 0.05
 
     // Resize debouncing — only the last resize within 150ms is sent.
-    private var resizeTimer: Timer?
-    private var pendingResize: (cols: Int, rows: Int)?
-    private var lastDimensions: (cols: Int, rows: Int)?
-    private static let resizeDebounceInterval: TimeInterval = 0.15
+    @ObservationIgnored private var resizeTimer: Timer?
+    @ObservationIgnored private var pendingResize: (cols: Int, rows: Int)?
+    @ObservationIgnored private var lastDimensions: (cols: Int, rows: Int)?
+    @ObservationIgnored private static let resizeDebounceInterval: TimeInterval = 0.15
 
     // Sequence deduplication for output events.
-    private var highWaterMark: Int = -1
+    @ObservationIgnored private var highWaterMark: Int = -1
 
     // MARK: - Init
 


### PR DESCRIPTION
## Summary
- Migrates SurfaceViewModel, SurfaceManager, AppListManager, TerminalSessionManager, MessageAudioPlayer to @Observable
- Non-reactive bookkeeping marked @ObservationIgnored

Part of plan: macos15-modernization.md (PR 4 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
