### PR TITLE
refactor: migrate macOS adapter view models to @Observable (batch 3)

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/WatchSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/WatchSession.swift
@@ -6,28 +6,29 @@ import os
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "WatchSession")
 
 @MainActor
-public final class WatchSession: ObservableObject {
+@Observable
+public final class WatchSession {
     public enum State { case idle, capturing, complete, cancelled }
 
-    @Published public var state: State = .idle
-    @Published public var captureCount: Int = 0
-    @Published public var totalExpected: Int = 0
-    @Published public var elapsedSeconds: Double = 0
-    @Published public var currentApp: String = ""
+    public var state: State = .idle
+    public var captureCount: Int = 0
+    public var totalExpected: Int = 0
+    public var elapsedSeconds: Double = 0
+    public var currentApp: String = ""
 
     public let watchId: String
     public let conversationId: String
     public let durationSeconds: Int
     public let intervalSeconds: Int
 
-    private var connectionManager: (GatewayConnectionManager)?
-    private let computerUseClient: any ComputerUseClientProtocol = ComputerUseClient()
-    private var captureTask: Task<Void, Never>?
-    private var elapsedTask: Task<Void, Never>?
-    private var startedAt: Date?
-    private let screenCapture = ScreenCapture()
-    private let ocr = ScreenOCR()
-    private var previousOcrText: String = ""
+    @ObservationIgnored private var connectionManager: (GatewayConnectionManager)?
+    @ObservationIgnored private let computerUseClient: any ComputerUseClientProtocol = ComputerUseClient()
+    @ObservationIgnored private var captureTask: Task<Void, Never>?
+    @ObservationIgnored private var elapsedTask: Task<Void, Never>?
+    @ObservationIgnored private var startedAt: Date?
+    @ObservationIgnored private let screenCapture = ScreenCapture()
+    @ObservationIgnored private let ocr = ScreenOCR()
+    @ObservationIgnored private var previousOcrText: String = ""
 
     public init(watchId: String, conversationId: String, durationSeconds: Int, intervalSeconds: Int) {
         self.watchId = watchId

--- a/clients/macos/vellum-assistant/E2ETesting/E2EStatusOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/E2ETesting/E2EStatusOverlayWindow.swift
@@ -79,11 +79,12 @@ struct E2EStatus: Codable {
 // MARK: - View Model
 
 @MainActor
-final class E2EStatusOverlayViewModel: ObservableObject {
-    @Published var currentStatus: E2EStatus?
+@Observable
+final class E2EStatusOverlayViewModel {
+    var currentStatus: E2EStatus?
 
-    private let statusFilePath: String
-    private var pollTimer: Timer?
+    @ObservationIgnored private let statusFilePath: String
+    @ObservationIgnored private var pollTimer: Timer?
 
     init(statusFilePath: String) {
         self.statusFilePath = statusFilePath
@@ -112,7 +113,7 @@ final class E2EStatusOverlayViewModel: ObservableObject {
 // MARK: - View
 
 struct E2EStatusOverlayView: View {
-    @ObservedObject var viewModel: E2EStatusOverlayViewModel
+    var viewModel: E2EStatusOverlayViewModel
 
     @State private var dotOpacity: Double = 1.0
 

--- a/clients/macos/vellum-assistant/Features/Chat/WatchProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/WatchProgressView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import VellumAssistantShared
 
 struct WatchProgressView: View {
-    @ObservedObject var session: WatchSession
+    var session: WatchSession
     let onStop: () -> Void
 
     @State private var isPulsing = false

--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
@@ -8,7 +8,7 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 /// Built-in document editor view using Toast UI Editor.
 /// Displayed in the Directory panel's Documents tab.
 struct DocumentEditorView: NSViewRepresentable {
-    @ObservedObject var documentManager: DocumentManager
+    var documentManager: DocumentManager
     let onContentChanged: (String, String, Int) -> Void
 
     func makeCoordinator() -> Coordinator {

--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
@@ -8,36 +8,37 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 /// Manages the state of the built-in document editor.
 /// One active document at a time, displayed in the Directory panel's Documents tab.
 @MainActor
-final class DocumentManager: ObservableObject {
-    @Published var hasActiveDocument: Bool = false
-    @Published var title: String = "Untitled Document"
-    @Published var surfaceId: String?
-    @Published var conversationId: String?
-    @Published var isSaving: Bool = false
-    @Published var lastSaveError: String?
+@Observable
+final class DocumentManager {
+    var hasActiveDocument: Bool = false
+    var title: String = "Untitled Document"
+    var surfaceId: String?
+    var conversationId: String?
+    var isSaving: Bool = false
+    var lastSaveError: String?
 
     /// Current document content and metadata.
     /// `nil` means the editor has not yet received any content (uninitialized).
     /// `""` means the user intentionally deleted all text.
     private(set) var currentContent: String? = nil
-    @Published var wordCount: Int = 0
+    var wordCount: Int = 0
 
     /// Initial content from daemon persisted for panel reopen after the coordinator consumes pendingInitialContent
     private(set) var initialContent: String = ""
 
     /// Pending initial content to be set when coordinator becomes ready
-    private var pendingInitialContent: String?
+    @ObservationIgnored private var pendingInitialContent: String?
 
     /// Debounced auto-save task cancelled and rescheduled on every content update
-    private var autoSaveTask: Task<Void, Never>?
+    @ObservationIgnored private var autoSaveTask: Task<Void, Never>?
 
     /// Reference to daemon client for saving documents
-    weak var connectionManager: GatewayConnectionManager?
-    private let documentClient: DocumentClientProtocol = DocumentClient()
+    @ObservationIgnored weak var connectionManager: GatewayConnectionManager?
+    @ObservationIgnored private let documentClient: DocumentClientProtocol = DocumentClient()
 
     /// Reference to the document editor coordinator for sending content updates.
     /// Set by DocumentEditorView when the coordinator is ready.
-    var editorCoordinator: DocumentEditorCoordinator? {
+    @ObservationIgnored var editorCoordinator: DocumentEditorCoordinator? {
         didSet {
             // When coordinator becomes ready, apply any pending initial content
             if let coordinator = editorCoordinator, let content = pendingInitialContent {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -51,7 +51,7 @@ struct MainWindowView: View {
     let ambientAgent: AmbientAgent
     let settingsStore: SettingsStore
     let authManager: AuthManager
-    @ObservedObject var documentManager: DocumentManager
+    var documentManager: DocumentManager
     let onMicrophoneToggle: () -> Void
     @ObservedObject var voiceModeManager: VoiceModeManager
     @ObservedObject var updateManager: UpdateManager

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DocumentEditorPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DocumentEditorPanel.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import VellumAssistantShared
 
 struct DocumentEditorPanelView: View {
-    @ObservedObject var documentManager: DocumentManager
+    var documentManager: DocumentManager
     let connectionManager: GatewayConnectionManager
     let onClose: () -> Void
 


### PR DESCRIPTION
## Summary
- Migrates DocumentManager, E2EStatusOverlayViewModel, WatchSession to @Observable
- Non-reactive bookkeeping marked @ObservationIgnored

Part of plan: macos15-modernization.md (PR 7 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
