### PR TITLE
refactor: migrate local-only view models to @Observable (batch 1)

### DIFF
--- a/clients/ios/Views/InlineVideoEmbedView.swift
+++ b/clients/ios/Views/InlineVideoEmbedView.swift
@@ -12,7 +12,7 @@ struct InlineVideoEmbedView: View {
     let videoID: String
     let embedURL: URL
 
-    @StateObject private var stateManager = InlineVideoEmbedStateManager()
+    @State private var stateManager = InlineVideoEmbedStateManager()
 
     /// The embed URL enriched with autoplay/rel query parameters, built on
     /// first play request. Falls back to the raw `embedURL` if the provider

--- a/clients/macos/vellum-assistant/App/DevModeManager.swift
+++ b/clients/macos/vellum-assistant/App/DevModeManager.swift
@@ -1,4 +1,3 @@
-import Combine
 import Foundation
 
 /// Lightweight manager for dev mode state, backed by UserDefaults.
@@ -7,10 +6,11 @@ import Foundation
 /// `installCLISymlinkIfNeeded`) can check dev mode without triggering
 /// the full `SettingsStore` lazy initialization and its network fetches.
 @MainActor
-public final class DevModeManager: ObservableObject {
+@Observable
+public final class DevModeManager {
     public static let shared = DevModeManager()
 
-    @Published public var isDevMode: Bool {
+    public var isDevMode: Bool {
         didSet { UserDefaults.standard.set(isDevMode, forKey: "devModeEnabled") }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
@@ -11,7 +11,7 @@ struct InlineVideoEmbedCard: View {
     let videoID: String
     let embedURL: URL
 
-    @StateObject private var stateManager = InlineVideoEmbedStateManager()
+    @State private var stateManager = InlineVideoEmbedStateManager()
 
     /// The embed URL enriched with autoplay/rel query parameters, built on
     /// first play request. Falls back to the raw `embedURL` if the provider

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputView.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputView.swift
@@ -8,7 +8,7 @@ struct QuickInputConversation: Identifiable {
 }
 
 struct QuickInputView: View {
-    @ObservedObject var textModel: QuickInputTextModel
+    @Bindable var textModel: QuickInputTextModel
     let onSubmit: (String) -> Void
     let onDismiss: () -> Void
     let onSelectConversation: ((UUID, String) -> Void)?

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
@@ -12,12 +12,13 @@ private class KeyablePanel: NSPanel {
 /// Observable model that lets QuickInputWindow inject text (e.g. from voice)
 /// into the SwiftUI QuickInputView's text field.
 @MainActor
-final class QuickInputTextModel: ObservableObject {
-    @Published var text = ""
-    @Published var isRecording = false
+@Observable
+final class QuickInputTextModel {
+    var text = ""
+    var isRecording = false
     /// When set, the user has selected an existing conversation to continue.
-    @Published var selectedConversationId: UUID?
-    @Published var selectedConversationTitle: String?
+    var selectedConversationId: UUID?
+    var selectedConversationTitle: String?
 }
 
 /// A borderless, floating NSPanel that hosts the Quick Input text field.

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -14,7 +14,7 @@ struct SettingsBillingTab: View {
     @State private var topUpError: String?
     @State private var hostWindow: NSWindow?
     @State private var inviteCode: String = ""
-    @ObservedObject private var devModeManager = DevModeManager.shared
+    private var devModeManager: DevModeManager { DevModeManager.shared }
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -21,7 +21,7 @@ private struct UnifiedFeatureFlag: Identifiable {
 @MainActor
 struct SettingsDeveloperTab: View {
     @ObservedObject var store: SettingsStore
-    @ObservedObject private var devModeManager = DevModeManager.shared
+    private var devModeManager: DevModeManager { DevModeManager.shared }
     var connectionManager: GatewayConnectionManager?
     var featureFlagClient: FeatureFlagClientProtocol = FeatureFlagClient()
     var authManager: AuthManager

--- a/clients/macos/vellum-assistant/Recording/RecordingHUDWindow.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingHUDWindow.swift
@@ -83,11 +83,12 @@ final class RecordingHUDWindow {
 // MARK: - View Model
 
 @MainActor
-final class RecordingHUDViewModel: ObservableObject {
-    @Published var elapsedSeconds: Int = 0
-    @Published var isRecording = true
-    @Published var isPaused = false
-    @Published var failureMessage: String?
+@Observable
+final class RecordingHUDViewModel {
+    var elapsedSeconds: Int = 0
+    var isRecording = true
+    var isPaused = false
+    var failureMessage: String?
 
     private var timer: Timer?
     private let onStop: () -> Void
@@ -144,7 +145,7 @@ final class RecordingHUDViewModel: ObservableObject {
 // MARK: - View
 
 struct RecordingHUDView: View {
-    @ObservedObject var viewModel: RecordingHUDViewModel
+    var viewModel: RecordingHUDViewModel
 
     @State private var dotOpacity: Double = 1.0
 

--- a/clients/shared/Features/Chat/MediaEmbeds/InlineVideoEmbedState.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/InlineVideoEmbedState.swift
@@ -16,8 +16,9 @@ public enum InlineVideoEmbedState: Equatable {
 /// All mutations are main-actor–isolated because the state
 /// feeds directly into SwiftUI views.
 @MainActor
-public final class InlineVideoEmbedStateManager: ObservableObject {
-    @Published public private(set) var state: InlineVideoEmbedState = .placeholder
+@Observable
+public final class InlineVideoEmbedStateManager {
+    public private(set) var state: InlineVideoEmbedState = .placeholder
 
     public init() {}
 


### PR DESCRIPTION
## Summary
- Migrates QuickInputTextModel, DevModeManager, InlineVideoEmbedStateManager, RecordingHUDViewModel to @Observable
- Updates all call sites (@StateObject→@State, @ObservedObject→var/computed/@Bindable)

Part of plan: macos15-modernization.md (PR 3 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
