### PR TITLE
refactor: migrate shared stores to @Observable with cross-platform verification (batch 4)

### DIFF
--- a/clients/ios/Views/IdentityView.swift
+++ b/clients/ios/Views/IdentityView.swift
@@ -16,12 +16,18 @@ final class IdentityViewModel {
     var contactsStore: ContactsStore?
     var memoriesStore: MemoryItemsStore?
 
-    // Cached counts — updated via Combine when the stores' @Published properties change.
+    // SkillsStore is still ObservableObject, so we keep a Combine subscription for it.
     var installedSkillsCount: Int = 0
-    var contactsCount: Int = 0
-    var memoriesCount: Int = 0
 
-    private var cancellables: Set<AnyCancellable> = []
+    // Computed counts — derived directly from @Observable stores.
+    var contactsCount: Int {
+        contactsStore?.contacts.count ?? 0
+    }
+    var memoriesCount: Int {
+        memoriesStore?.items.count ?? 0
+    }
+
+    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
 
     func setUp(connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient) {
         cancellables.removeAll()
@@ -37,19 +43,8 @@ final class IdentityViewModel {
             .sink { [weak self] count in self?.installedSkillsCount = count }
             .store(in: &cancellables)
 
-        contacts.$contacts
-            .map(\.count)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] count in self?.contactsCount = count }
-            .store(in: &cancellables)
-
         let memories = MemoryItemsStore(memoryItemClient: MemoryItemClient())
         memoriesStore = memories
-        memories.$items
-            .map(\.count)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] count in self?.memoriesCount = count }
-            .store(in: &cancellables)
 
         skills.fetchSkills(force: true)
         contacts.loadContacts()
@@ -65,8 +60,6 @@ final class IdentityViewModel {
         contactsStore = nil
         memoriesStore = nil
         installedSkillsCount = 0
-        contactsCount = 0
-        memoriesCount = 0
     }
 
     var identityClient: IdentityClientProtocol = IdentityClient()

--- a/clients/ios/Views/Intelligence/ContactDetailView.swift
+++ b/clients/ios/Views/Intelligence/ContactDetailView.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 
 struct ContactDetailView: View {
     let contact: ContactPayload
-    @ObservedObject var contactsStore: ContactsStore
+    var contactsStore: ContactsStore
     @Environment(\.dismiss) private var dismiss
     @State private var showDeleteConfirmation = false
     @State private var channelForPolicyEdit: ContactChannelPayload?

--- a/clients/ios/Views/Intelligence/ContactsListView.swift
+++ b/clients/ios/Views/Intelligence/ContactsListView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import VellumAssistantShared
 
 struct ContactsListView: View {
-    @ObservedObject var contactsStore: ContactsStore
+    var contactsStore: ContactsStore
     @State private var searchQuery = ""
     @State private var contactToDelete: ContactPayload?
     @State private var showDeleteConfirmation = false

--- a/clients/ios/Views/Intelligence/MemoriesListView.swift
+++ b/clients/ios/Views/Intelligence/MemoriesListView.swift
@@ -19,7 +19,7 @@ private enum MemoryStatusFilter: String, CaseIterable {
 }
 
 struct MemoriesListView: View {
-    @ObservedObject var store: MemoryItemsStore
+    var store: MemoryItemsStore
     @State private var searchText = ""
     @State private var selectedKind: String? = nil
     @State private var statusFilter: MemoryStatusFilter = .active

--- a/clients/ios/Views/Intelligence/MemoryItemCreateView.swift
+++ b/clients/ios/Views/Intelligence/MemoryItemCreateView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import VellumAssistantShared
 
 struct MemoryItemCreateView: View {
-    @ObservedObject var store: MemoryItemsStore
+    var store: MemoryItemsStore
     @Environment(\.dismiss) private var dismiss
 
     @State private var kind: String = "identity"

--- a/clients/ios/Views/Intelligence/MemoryItemDetailView.swift
+++ b/clients/ios/Views/Intelligence/MemoryItemDetailView.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 
 struct MemoryItemDetailView: View {
     let item: MemoryItemPayload
-    @ObservedObject var store: MemoryItemsStore
+    var store: MemoryItemsStore
     @Environment(\.dismiss) private var dismiss
 
     @State private var isEditing = false

--- a/clients/ios/Views/Settings/ChannelsGuardianSection.swift
+++ b/clients/ios/Views/Settings/ChannelsGuardianSection.swift
@@ -4,8 +4,8 @@ import VellumAssistantShared
 
 /// Settings section for viewing guardian status and approved contact channel policies.
 struct ChannelsGuardianSection: View {
-    @ObservedObject var channelTrustStore: ChannelTrustStore
-    @ObservedObject var contactsStore: ContactsStore
+    var channelTrustStore: ChannelTrustStore
+    var contactsStore: ContactsStore
     @State private var showRevokeConfirmation = false
     @State private var channelToRevoke: ContactChannelPayload?
 

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -19,7 +19,7 @@ struct ContactsContainerView: View {
     var isEmailEnabled: Bool = false
     var showToast: ((String, ToastInfo.Style) -> Void)?
 
-    @StateObject private var viewModel: ContactsViewModel
+    @State private var viewModel: ContactsViewModel
     @State private var selection: ContactSelection? = .assistant
 
     private let contactClient: ContactClientProtocol = ContactClient()
@@ -30,7 +30,7 @@ struct ContactsContainerView: View {
         self.conversationManager = conversationManager
         self.isEmailEnabled = isEmailEnabled
         self.showToast = showToast
-        _viewModel = StateObject(wrappedValue: ContactsViewModel(connectionManager: connectionManager, eventStreamClient: eventStreamClient))
+        _viewModel = State(wrappedValue: ContactsViewModel(connectionManager: connectionManager, eventStreamClient: eventStreamClient))
     }
 
     var body: some View {
@@ -158,7 +158,7 @@ struct ContactsContainerView: View {
             .frame(maxWidth: 700, maxHeight: .infinity, alignment: .leading)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         }
-        .onReceive(viewModel.$contacts) { newContacts in
+        .onChange(of: viewModel.contacts) { _, newContacts in
             // Default to assistant on first load (don't override existing selection)
             if selection == nil && !newContacts.isEmpty {
                 selection = .assistant

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 /// Contacts list panel for the Settings > Contacts page.
 @MainActor
 struct ContactsListView: View {
-    @ObservedObject var viewModel: ContactsViewModel
+    @Bindable var viewModel: ContactsViewModel
     @Binding var selection: ContactSelection?
 
     @State private var hoveredContactId: String?

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
@@ -1,4 +1,3 @@
-import Combine
 import Foundation
 import SwiftUI
 import VellumAssistantShared
@@ -6,15 +5,23 @@ import VellumAssistantShared
 /// ViewModel for the contacts list, providing daemon HTTP integration
 /// for loading and filtering contacts. Delegates data operations to
 /// the shared ContactsStore.
-@MainActor
-final class ContactsViewModel: ObservableObject {
+@MainActor @Observable
+final class ContactsViewModel {
 
-    // MARK: - Published State
+    // MARK: - State
 
-    @Published var contacts: [ContactPayload] = []
-    @Published var isLoading = false
-    @Published var isCreatingContact = false
-    @Published var searchQuery = ""
+    var isCreatingContact = false
+    var searchQuery = ""
+
+    // MARK: - Computed Properties (forwarded from ContactsStore)
+
+    var contacts: [ContactPayload] {
+        contactsStore?.contacts ?? []
+    }
+
+    var isLoading: Bool {
+        contactsStore?.isLoading ?? false
+    }
 
     // MARK: - Dependencies
 
@@ -24,13 +31,7 @@ final class ContactsViewModel: ObservableObject {
 
     init(connectionManager: GatewayConnectionManager?, eventStreamClient: EventStreamClient? = nil) {
         if let connectionManager, let eventStreamClient {
-            let store = ContactsStore(connectionManager: connectionManager, eventStreamClient: eventStreamClient)
-            self.contactsStore = store
-
-            store.$contacts
-                .assign(to: &$contacts)
-            store.$isLoading
-                .assign(to: &$isLoading)
+            self.contactsStore = ContactsStore(connectionManager: connectionManager, eventStreamClient: eventStreamClient)
         } else {
             self.contactsStore = nil
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -65,7 +65,7 @@ private enum MemoryStatusFilter: String, CaseIterable {
 struct MemoriesPanel: View {
     let connectionManager: GatewayConnectionManager
     @Binding var focusedMemoryId: String?
-    @StateObject private var store: MemoryItemsStore
+    @State private var store: MemoryItemsStore
     @State private var showCreateSheet = false
     @State private var selectedItem: MemoryItemPayload?
     @State private var selectedKind: MemoryKind?
@@ -78,7 +78,7 @@ struct MemoriesPanel: View {
     init(connectionManager: GatewayConnectionManager, focusedMemoryId: Binding<String?> = .constant(nil)) {
         self.connectionManager = connectionManager
         _focusedMemoryId = focusedMemoryId
-        _store = StateObject(wrappedValue: MemoryItemsStore(memoryItemClient: MemoryItemClient()))
+        _store = State(wrappedValue: MemoryItemsStore(memoryItemClient: MemoryItemClient()))
     }
 
     /// Kinds to show in the sidebar filter. Excludes system-managed kinds.

--- a/clients/shared/Features/ChannelTrust/ChannelTrustStore.swift
+++ b/clients/shared/Features/ChannelTrust/ChannelTrustStore.swift
@@ -1,4 +1,3 @@
-import Combine
 import Foundation
 
 /// Cross-platform store for guardian state, channel trust/policy management,
@@ -6,30 +5,36 @@ import Foundation
 ///
 /// Composes `ContactsStore` for guardian contact state and `GatewayConnectionManager`
 /// for pending guardian action operations.
-@MainActor
-public final class ChannelTrustStore: ObservableObject {
+@MainActor @Observable
+public final class ChannelTrustStore {
+
+    // MARK: - Computed State (derived from ContactsStore)
+
+    /// The guardian contact, derived from ContactsStore.
+    public var guardianContact: ContactPayload? {
+        contactsStore.contacts.first { $0.role == "guardian" }
+    }
+
+    /// Channels belonging to the guardian contact.
+    public var guardianChannels: [ContactChannelPayload] {
+        guardianContact?.channels ?? []
+    }
 
     // MARK: - Published State
 
-    /// The guardian contact, forwarded from ContactsStore.
-    @Published public var guardianContact: ContactPayload?
-
-    /// Channels belonging to the guardian contact.
-    @Published public var guardianChannels: [ContactChannelPayload] = []
-
     /// Pending guardian decision prompts for the current conversation.
-    @Published public var pendingActions: [GuardianDecisionPromptWire] = []
+    public var pendingActions: [GuardianDecisionPromptWire] = []
 
     /// Whether a pending-actions fetch is in progress.
-    @Published public var isLoadingActions = false
+    public var isLoadingActions = false
 
     // MARK: - Private State
 
-    private let connectionManager: GatewayConnectionManager
+    @ObservationIgnored private let connectionManager: GatewayConnectionManager
     private let contactsStore: ContactsStore
-    private let guardianClient: GuardianClientProtocol
-    private var fetchTask: Task<Void, Never>?
-    private var decideTask: Task<Void, Never>?
+    @ObservationIgnored private let guardianClient: GuardianClientProtocol
+    @ObservationIgnored private var fetchTask: Task<Void, Never>?
+    @ObservationIgnored private var decideTask: Task<Void, Never>?
 
     // MARK: - Init
 
@@ -37,15 +42,6 @@ public final class ChannelTrustStore: ObservableObject {
         self.connectionManager = connectionManager
         self.contactsStore = contactsStore
         self.guardianClient = guardianClient
-
-        // Forward guardian state from ContactsStore
-        contactsStore.$contacts
-            .map { contacts in contacts.first { $0.role == "guardian" } }
-            .assign(to: &$guardianContact)
-
-        $guardianContact
-            .map { $0?.channels ?? [] }
-            .assign(to: &$guardianChannels)
     }
 
     deinit {

--- a/clients/shared/Features/Contacts/ContactsStore.swift
+++ b/clients/shared/Features/Contacts/ContactsStore.swift
@@ -1,4 +1,3 @@
-import Combine
 import Foundation
 
 /// Cross-platform store for contacts data operations.
@@ -7,13 +6,13 @@ import Foundation
 /// and deleting contacts. Platform-specific UI state (search filtering,
 /// panel presentation, etc.) remains in the platform view model that
 /// delegates here.
-@MainActor
-public final class ContactsStore: ObservableObject {
+@MainActor @Observable
+public final class ContactsStore {
 
     // MARK: - Published State
 
-    @Published public var contacts: [ContactPayload] = []
-    @Published public var isLoading = false
+    public var contacts: [ContactPayload] = []
+    public var isLoading = false
 
     // MARK: - Computed Properties
 
@@ -29,12 +28,12 @@ public final class ContactsStore: ObservableObject {
 
     // MARK: - Private State
 
-    private let connectionManager: GatewayConnectionManager
-    private let eventStreamClient: EventStreamClient
-    private let contactClient: ContactClientProtocol
-    private var contactsChangedTask: Task<Void, Never>?
-    private var subscriptionTask: Task<Void, Never>?
-    private var reconnectObserver: NSObjectProtocol?
+    @ObservationIgnored private let connectionManager: GatewayConnectionManager
+    @ObservationIgnored private let eventStreamClient: EventStreamClient
+    @ObservationIgnored private let contactClient: ContactClientProtocol
+    @ObservationIgnored private var contactsChangedTask: Task<Void, Never>?
+    @ObservationIgnored private var subscriptionTask: Task<Void, Never>?
+    @ObservationIgnored private var reconnectObserver: NSObjectProtocol?
 
     // MARK: - Init
 

--- a/clients/shared/Features/Memory/MemoryItemsStore.swift
+++ b/clients/shared/Features/Memory/MemoryItemsStore.swift
@@ -2,20 +2,20 @@ import Foundation
 
 /// Shared store for memory item CRUD operations with filter state.
 /// Used by both macOS and iOS memory list views.
-@MainActor
-public final class MemoryItemsStore: ObservableObject {
-    @Published public var items: [MemoryItemPayload] = []
-    @Published public var total: Int = 0
-    @Published public var isLoading = false
+@MainActor @Observable
+public final class MemoryItemsStore {
+    public var items: [MemoryItemPayload] = []
+    public var total: Int = 0
+    public var isLoading = false
 
     // Filter state
-    @Published public var kindFilter: String? = nil
-    @Published public var statusFilter: String? = "active"
-    @Published public var searchText: String = ""
-    @Published public var sortField: String = "lastSeenAt"
-    @Published public var sortOrder: String = "desc"
+    public var kindFilter: String? = nil
+    public var statusFilter: String? = "active"
+    public var searchText: String = ""
+    public var sortField: String = "lastSeenAt"
+    public var sortOrder: String = "desc"
 
-    private let memoryItemClient: MemoryItemClientProtocol
+    @ObservationIgnored private let memoryItemClient: MemoryItemClientProtocol
 
     public init(memoryItemClient: MemoryItemClientProtocol) {
         self.memoryItemClient = memoryItemClient


### PR DESCRIPTION
## Summary
- Migrates ContactsStore, MemoryItemsStore, ChannelTrustStore, ContactsViewModel to @Observable
- Replaces Combine forwarding with computed properties (both source and target are @Observable)
- Updates all macOS and iOS consumer call sites

Part of plan: macos15-modernization.md (PR 8 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
