### PR TITLE
fix: stop hiding main window during computer use sessions

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Conversations.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Conversations.swift
@@ -202,11 +202,6 @@ extension AppDelegate {
         self.overlayWindow = overlay
         self.ambientAgent.pause()
 
-        // Hide main window so the target app becomes frontmost for CU
-        if mainWindow?.isVisible == true {
-            mainWindow?.hide()
-        }
-
         // Watch for terminal states and auto-dismiss after a delay.
         // Use Combine sink instead of async publisher to avoid holding
         // a long-lived task that blocks forever if terminal state is never reached.
@@ -252,9 +247,5 @@ extension AppDelegate {
         activeOverlayConversationId = nil
         ambientAgent.resume()
 
-        // Restore main window if it was hidden
-        if mainWindow?.isVisible == false {
-            mainWindow?.show()
-        }
     }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -214,6 +214,15 @@ extension AppDelegate {
             return
         }
 
+        // Don't revert to .accessory while a computer use session is active —
+        // the session overlay needs to remain visible even when the app loses
+        // focus to another app (e.g. during wizard flows interacting with
+        // browser windows).
+        if currentSession?.state.isActiveSession == true
+            || activeHostCuProxy?.state.isActiveSession == true {
+            return
+        }
+
         let hasVisibleWindows = NSApp.windows.contains { win in
             win.isVisible
             && win !== closedWindow

--- a/clients/macos/vellum-assistant/ComputerUse/HostCuSessionProxy.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/HostCuSessionProxy.swift
@@ -16,6 +16,18 @@ enum SessionState: Equatable {
     case responded(answer: String, steps: Int)
     case failed(reason: String)
     case cancelled
+
+    /// Whether the session is actively in progress (running, thinking, paused,
+    /// or awaiting confirmation). Used to prevent the app from reverting to
+    /// `.accessory` activation policy while the user needs the overlay visible.
+    var isActiveSession: Bool {
+        switch self {
+        case .running, .thinking, .paused, .awaitingConfirmation:
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 /// Protocol that abstracts the session interface needed by `SessionOverlayWindow`.


### PR DESCRIPTION
## Summary
- Removed `mainWindow?.hide()` during CU session startup and corresponding `mainWindow?.show()` on dismiss
- The hiding was originally to keep the assistant out of its own screenshots, but this is no longer necessary
- It caused the assistant to disappear during multi-step wizard flows (e.g., OAuth setup), leaving users with no guidance
- Also adds `isActiveSession` guard in `revertActivationPolicyIfNoWindows` to prevent reverting to `.accessory` activation policy during active CU sessions

Part of LUM-419

## Human attention needed
Window management behavior change during CU sessions — the main window now stays visible. Please verify the overlay still works correctly on top of other windows.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
