### PR TITLE
refactor: migrate ChatErrorManager to @Observable and update ChatViewModel forwarding

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -2293,6 +2293,27 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         let msgMgr = viewModel.messageManager
         let errMgr = viewModel.errorManager
 
+        // Bridge @Observable ChatErrorManager into Combine so the rest of
+        // the pipeline stays unchanged. A withObservationTracking loop
+        // detects changes to errorText / conversationError and pushes
+        // snapshots into a CurrentValueSubject.
+        let errorSubject = CurrentValueSubject<(String?, ConversationError?), Never>(
+            (errMgr.errorText, errMgr.conversationError)
+        )
+
+        func observeErrors() {
+            withObservationTracking {
+                _ = errMgr.errorText
+                _ = errMgr.conversationError
+            } onChange: {
+                Task { @MainActor in
+                    errorSubject.send((errMgr.errorText, errMgr.conversationError))
+                    observeErrors() // re-arm
+                }
+            }
+        }
+        observeErrors()
+
         // Combine busy-state publishers with error and message publishers.
         // Error state: errorText or conversationError non-nil.
         // WaitingForInput: hasPendingConfirmation (derived from messages).
@@ -2304,11 +2325,11 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             msgMgr.$messages
         )
         .combineLatest(
-            errMgr.$errorText,
-            errMgr.$conversationError
+            errorSubject
         )
-        .map { busyTuple, errorText, conversationError in
+        .map { busyTuple, errorTuple in
             let (isSending, isThinking, pendingQueuedCount, messages) = busyTuple
+            let (errorText, conversationError) = errorTuple
             let hasError = errorText != nil || conversationError != nil
             let hasPendingConfirmation = messages.contains(where: { $0.confirmation?.state == .pending })
             let isBusy = isSending || isThinking || pendingQueuedCount > 0

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1287,7 +1287,7 @@ struct MainWindowView: View {
 /// the correct conversation's ViewModel — even if the user switches conversations while a
 /// toast is visible.
 private struct ErrorToastOverlay: View {
-    @ObservedObject var errorManager: ChatErrorManager
+    var errorManager: ChatErrorManager
     let onOpenModelsAndServices: () -> Void
     let onRetryConversationError: () -> Void
     let onCopyDebugInfo: () -> Void

--- a/clients/shared/Features/Chat/ChatErrorManager.swift
+++ b/clients/shared/Features/Chat/ChatErrorManager.swift
@@ -11,42 +11,43 @@ import Network
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ChatErrorManager")
 
-/// Owns error-related @Published properties that were previously part of ChatViewModel.
+/// Owns error-related properties that were previously part of ChatViewModel.
 /// ChatViewModel holds a reference to this object and forwards reads/writes via
 /// computed properties so every existing call site continues to compile without
 /// modification.
 @MainActor
-public final class ChatErrorManager: ObservableObject {
+@Observable
+public final class ChatErrorManager {
 
     /// Human-readable error string shown in the error banner.
-    @Published public var errorText: String?
+    public var errorText: String?
 
     /// Typed conversation error, richer than `errorText` and used for structured retry UI.
-    @Published public var conversationError: ConversationError?
+    public var conversationError: ConversationError?
 
     /// Whether the conversation error is already displayed as an inline error card
     /// in the message list. When true, the toast overlay suppresses its duplicate
     /// display while downstream consumers (credits-exhausted recovery, sidebar state,
     /// iOS banner) continue to see the typed error state.
-    @Published public var isConversationErrorDisplayedInline: Bool = false
+    public var isConversationErrorDisplayedInline: Bool = false
 
     /// Supplemental diagnostic hint shown alongside a daemon connection error.
     /// Nil when no connection error is active or the error has been dismissed.
-    @Published public var connectionDiagnosticHint: String? = nil
+    public var connectionDiagnosticHint: String? = nil
 
     // MARK: - Retry state
 
     /// Whether the current error is a daemon/assistant connection failure.
-    @Published public var isConnectionError: Bool = false
+    public var isConnectionError: Bool = false
 
     /// Whether the current error is a secret-ingress block that can be bypassed.
-    @Published public var isSecretBlockError: Bool = false
+    public var isSecretBlockError: Bool = false
 
     /// Whether the current error is retryable (send failure, not a connection error).
-    @Published public var isRetryableError: Bool = false
+    public var isRetryableError: Bool = false
 
     /// Whether there is a failed user message that can be retried.
-    @Published public var hasRetryPayload: Bool = false
+    public var hasRetryPayload: Bool = false
 
     // MARK: - Connection diagnostics
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -177,6 +177,34 @@ public final class ChatViewModel: ObservableObject {
         objectWillChange.send()
     }
 
+    // MARK: - @Observable → ObservableObject bridge for ChatErrorManager
+
+    /// Recursively observe all tracked properties on the @Observable
+    /// ChatErrorManager and forward changes into ChatViewModel's
+    /// ObservableObject objectWillChange via the coalesced publish path.
+    private func observeErrorManager() {
+        withObservationTracking {
+            // Touch every tracked property so the observation system
+            // registers interest in all of them.
+            _ = errorManager.errorText
+            _ = errorManager.conversationError
+            _ = errorManager.isConversationErrorDisplayedInline
+            _ = errorManager.connectionDiagnosticHint
+            _ = errorManager.isConnectionError
+            _ = errorManager.isSecretBlockError
+            _ = errorManager.isRetryableError
+            _ = errorManager.hasRetryPayload
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.scheduleCoalescedPublish()
+                #if DEBUG
+                self?.trackPublish(source: "errorManager")
+                #endif
+                self?.observeErrorManager() // re-arm
+            }
+        }
+    }
+
     // MARK: - Debug publish-rate counters
 
     private static let stallLog = OSLog(subsystem: "com.vellum.assistant", category: "LayoutStall")
@@ -1102,14 +1130,11 @@ public final class ChatViewModel: ObservableObject {
                 #endif
             }
             .store(in: &cancellables)
-        errorManager.objectWillChange
-            .sink { [weak self] _ in
-                self?.scheduleCoalescedPublish()
-                #if DEBUG
-                self?.trackPublish(source: "errorManager")
-                #endif
-            }
-            .store(in: &cancellables)
+        // ChatErrorManager is @Observable — bridge its changes into
+        // ChatViewModel's ObservableObject objectWillChange via
+        // withObservationTracking so views that read error state through
+        // ChatViewModel's computed forwarding properties still update.
+        observeErrorManager()
 
         // Surface attachment validation errors in the error manager so the UI
         // can show them without the attachment manager needing a direct reference.


### PR DESCRIPTION
## Summary
- Migrates ChatErrorManager from ObservableObject to @Observable
- Updates ChatViewModel to bridge error state changes via withObservationTracking instead of Combine objectWillChange forwarding
- Updates ConversationManager to bridge @Observable error properties into its Combine pipeline via CurrentValueSubject
- Updates ErrorToastOverlay to use plain var instead of @ObservedObject

Part of plan: macos15-modernization.md (PR 9 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
