### PR TITLE
fix: update guardrail text to reflect new-tab navigation behavior

### DIFF
--- a/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
+++ b/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
@@ -227,7 +227,7 @@ For non-interactive channels, provide all URLs and instructions as text messages
 ## Guardrails
 
 - **No browser automation tools.** Path A uses `host_bash` + `/tmp/vellum-nav.sh` for navigation only.
-- **Browser-aware tab reuse.** The nav helper detects the browser each time. Falls back to `open` for unknown browsers.
+- **Browser-aware new-tab navigation.** The nav helper opens a new tab in the current browser window. Falls back to `open` for unknown browsers.
 - **Do not delete and recreate OAuth clients.** That orphans stored credentials.
 - **Do not leave the credential dialog early.** The Client Secret may be shown only once.
 - **Provider UI drift is normal.** Adapt instructions while preserving the same end state.


### PR DESCRIPTION
Addresses feedback from #21272 — the guardrail text still referenced tab reuse after the navigation was changed to open new tabs.

Part of LUM-419
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
