### PR TITLE
fix: use AssistantDisplayName.resolve() for session overlay placeholder

### DIFF
--- a/clients/macos/vellum-assistant/Features/Session/SessionOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/SessionOverlayWindow.swift
@@ -545,7 +545,7 @@ final class SessionOverlayWindow {
         hstack.translatesAutoresizingMaskIntoConstraints = false
 
         let field = NSTextField()
-        let assistantName = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? "the assistant"
+        let assistantName = AssistantDisplayName.resolve(IdentityInfo.load()?.name, fallback: "the assistant")
         field.placeholderString = "Steer \(assistantName)..."
         field.font = NSFont.systemFont(ofSize: 13)
         field.textColor = NSColor(VColor.contentDefault)


### PR DESCRIPTION
Addresses feedback from #21274 — the placeholder was using the raw assistant ID (which can be a UUID) instead of the resolved display name.

Part of LUM-419
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
