### PR TITLE
fix: use plain text instead of markdown for OAuth URL in terminal output

### DIFF
--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -707,7 +707,7 @@ Examples:
               });
             } else {
               process.stdout.write(
-                `\n**Authorize with ${resolvedServiceKey}**\n\n[Click here to authorize](${result.authUrl})\n\nThe connection will complete automatically once you authorize.\n`,
+                `\nAuthorize with ${resolvedServiceKey}:\n\n${result.authUrl}\n\nThe connection will complete automatically once you authorize.\n`,
               );
             }
             return;


### PR DESCRIPTION
Addresses feedback from #21276 — markdown link syntax doesn't render in terminals. Now uses plain text with the service name header.

Part of LUM-419
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
