### PR TITLE
feat: enrich Slack thread replies with parent message context [JARVIS-350]

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -82,6 +82,7 @@ import {
   createSlackSocketModeClient,
   type SlackSocketModeClient,
 } from "./slack/socket-mode.js";
+import { fetchThreadContext } from "./slack/thread-context.js";
 import { handleInbound } from "./handlers/handle-inbound.js";
 import { checkAuthRateLimit } from "./http/middleware/rate-limit.js";
 import {
@@ -1182,25 +1183,56 @@ async function main() {
     );
     if (!botToken || !appToken) return;
 
+    const slackSocketConfig: {
+      appToken: string;
+      botToken: string;
+      gatewayConfig: typeof config;
+      botUserId?: string;
+    } = {
+      appToken,
+      botToken,
+      gatewayConfig: config,
+    };
+
     slackSocketClient = createSlackSocketModeClient(
-      {
-        appToken,
-        botToken,
-        gatewayConfig: config,
-      },
+      slackSocketConfig,
       (normalized) => {
         const { threadTs, channel } = normalized;
         const replyCallbackUrl = `${config.gatewayInternalBaseUrl}/deliver/slack?threadTs=${encodeURIComponent(threadTs)}&channel=${encodeURIComponent(channel)}`;
 
-        handleInbound(config, normalized.event, {
-          replyCallbackUrl,
-          routingOverride: normalized.routing,
-        }).catch((err) => {
-          log.error(
-            { err, channel, threadTs },
-            "Failed to forward Slack event to runtime",
-          );
-        });
+        // Check if this is a thread reply (threadTs differs from the message's own ts)
+        const messageTs = normalized.event.source.messageId;
+        const isThreadReply = messageTs !== undefined && threadTs !== messageTs;
+
+        const forward = (threadContextHint?: string) => {
+          const hints: string[] = [];
+          if (threadContextHint) hints.push(threadContextHint);
+
+          handleInbound(config, normalized.event, {
+            replyCallbackUrl,
+            routingOverride: normalized.routing,
+            ...(hints.length > 0 ? { transportMetadata: { hints } } : {}),
+          }).catch((err) => {
+            log.error(
+              { err, channel, threadTs },
+              "Failed to forward Slack event to runtime",
+            );
+          });
+        };
+
+        if (isThreadReply && botToken) {
+          fetchThreadContext(
+            channel,
+            threadTs,
+            messageTs,
+            botToken,
+            slackSocketConfig.botUserId,
+          )
+            .then((context) => forward(context ?? undefined))
+            .catch(() => forward());
+        } else {
+          forward();
+        }
       },
     );
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1183,26 +1183,23 @@ async function main() {
     );
     if (!botToken || !appToken) return;
 
-    const slackSocketConfig: {
-      appToken: string;
-      botToken: string;
-      gatewayConfig: typeof config;
-      botUserId?: string;
-    } = {
-      appToken,
-      botToken,
-      gatewayConfig: config,
-    };
-
     slackSocketClient = createSlackSocketModeClient(
-      slackSocketConfig,
+      { appToken, botToken, gatewayConfig: config },
       (normalized) => {
         const { threadTs, channel } = normalized;
         const replyCallbackUrl = `${config.gatewayInternalBaseUrl}/deliver/slack?threadTs=${encodeURIComponent(threadTs)}&channel=${encodeURIComponent(channel)}`;
 
-        // Check if this is a thread reply (threadTs differs from the message's own ts)
+        // Check if this is a regular thread reply (not an edit or callback action).
+        // Edits and callbacks don't benefit from thread context and would just add
+        // unnecessary Slack API traffic + latency.
         const messageTs = normalized.event.source.messageId;
-        const isThreadReply = messageTs !== undefined && threadTs !== messageTs;
+        const isEdit = !!normalized.event.message.isEdit;
+        const isCallback = !!normalized.event.message.callbackData;
+        const isThreadReply =
+          messageTs !== undefined &&
+          threadTs !== messageTs &&
+          !isEdit &&
+          !isCallback;
 
         const forward = (threadContextHint?: string) => {
           const hints: string[] = [];
@@ -1221,13 +1218,7 @@ async function main() {
         };
 
         if (isThreadReply && botToken) {
-          fetchThreadContext(
-            channel,
-            threadTs,
-            messageTs,
-            botToken,
-            slackSocketConfig.botUserId,
-          )
+          fetchThreadContext(channel, threadTs, messageTs, botToken)
             .then((context) => forward(context ?? undefined))
             .catch(() => forward());
         } else {

--- a/gateway/src/slack/thread-context.test.ts
+++ b/gateway/src/slack/thread-context.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+type FetchFn = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(
+  async () => new Response(),
+);
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { fetchThreadContext } = await import("./thread-context.js");
+const { clearUserInfoCache, clearInFlightFetches } =
+  await import("./normalize.js");
+
+function mockSlackApi(
+  threadMessages: Array<{
+    user?: string;
+    text?: string;
+    ts?: string;
+    bot_id?: string;
+    username?: string;
+  }>,
+  userNames: Record<string, string> = {},
+) {
+  fetchMock = mock(async (url: string | URL | Request) => {
+    const urlStr = typeof url === "string" ? url : url.toString();
+    if (urlStr.includes("conversations.replies")) {
+      return Response.json({ ok: true, messages: threadMessages });
+    }
+    if (urlStr.includes("users.info")) {
+      const userId = new URL(urlStr).searchParams.get("user");
+      const name = userNames[userId!] ?? userId;
+      return Response.json({
+        ok: true,
+        user: { name: userId, profile: { display_name: name } },
+      });
+    }
+    return Response.json({ ok: false });
+  });
+}
+
+describe("fetchThreadContext", () => {
+  beforeEach(() => {
+    clearUserInfoCache();
+    clearInFlightFetches();
+  });
+
+  it("returns formatted context for a thread with parent and replies", async () => {
+    mockSlackApi(
+      [
+        { user: "U001", text: "What should we work on today?", ts: "1000.0" },
+        { user: "U002", text: "Let's fix the login bug", ts: "1000.1" },
+        { user: "U001", text: "Sounds good, on it!", ts: "1000.2" },
+      ],
+      { U001: "Alice", U002: "Bob" },
+    );
+
+    const result = await fetchThreadContext(
+      "C123",
+      "1000.0",
+      "1000.3", // current message ts, excluded from context
+      "xoxb-test-token",
+    );
+
+    expect(result).toContain("reply in a Slack thread (3 prior messages)");
+    expect(result).toContain("[Alice]: What should we work on today?");
+    expect(result).toContain("[Bob]: Let's fix the login bug");
+    expect(result).toContain("[Alice]: Sounds good, on it!");
+  });
+
+  it("returns parent-only context when thread has just one message", async () => {
+    mockSlackApi(
+      [{ user: "U001", text: "Check out this dashboard", ts: "1000.0" }],
+      { U001: "Alice" },
+    );
+
+    const result = await fetchThreadContext(
+      "C123",
+      "1000.0",
+      "1000.1",
+      "xoxb-test-token",
+    );
+
+    expect(result).toContain("reply to the following Slack message");
+    expect(result).toContain("[Alice]: Check out this dashboard");
+  });
+
+  it("labels bot messages as Assistant", async () => {
+    mockSlackApi(
+      [
+        { user: "U001", text: "Help me with this", ts: "1000.0" },
+        {
+          user: "UBOT",
+          text: "Sure, let me look into it",
+          ts: "1000.1",
+          bot_id: "B123",
+        },
+      ],
+      { U001: "Alice" },
+    );
+
+    const result = await fetchThreadContext(
+      "C123",
+      "1000.0",
+      "1000.2",
+      "xoxb-test-token",
+      "UBOT",
+    );
+
+    expect(result).toContain("[Alice]: Help me with this");
+    expect(result).toContain("[Assistant]: Sure, let me look into it");
+  });
+
+  it("also labels messages by botUserId (without bot_id field) as Assistant", async () => {
+    mockSlackApi(
+      [
+        { user: "U001", text: "Hey bot", ts: "1000.0" },
+        { user: "UBOT", text: "Hello!", ts: "1000.1" },
+      ],
+      { U001: "Alice" },
+    );
+
+    const result = await fetchThreadContext(
+      "C123",
+      "1000.0",
+      "1000.2",
+      "xoxb-test-token",
+      "UBOT",
+    );
+
+    expect(result).toContain("[Assistant]: Hello!");
+  });
+
+  it("excludes the current message from context", async () => {
+    mockSlackApi(
+      [
+        { user: "U001", text: "Parent message", ts: "1000.0" },
+        { user: "U002", text: "This is the current reply", ts: "1000.1" },
+      ],
+      { U001: "Alice", U002: "Bob" },
+    );
+
+    const result = await fetchThreadContext(
+      "C123",
+      "1000.0",
+      "1000.1", // matches second message — should be excluded
+      "xoxb-test-token",
+    );
+
+    expect(result).toContain("reply to the following Slack message");
+    expect(result).toContain("[Alice]: Parent message");
+    expect(result).not.toContain("This is the current reply");
+  });
+
+  it("returns null when API returns error", async () => {
+    fetchMock = mock(async () =>
+      Response.json({ ok: false, error: "channel_not_found" }),
+    );
+
+    const result = await fetchThreadContext(
+      "C123",
+      "1000.0",
+      "1000.1",
+      "xoxb-test-token",
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when all messages are excluded", async () => {
+    mockSlackApi([{ user: "U001", text: "Only message", ts: "1000.0" }]);
+
+    const result = await fetchThreadContext(
+      "C123",
+      "1000.0",
+      "1000.0", // matches the only message
+      "xoxb-test-token",
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null on HTTP error", async () => {
+    fetchMock = mock(async () => new Response("Server Error", { status: 500 }));
+
+    const result = await fetchThreadContext(
+      "C123",
+      "1000.0",
+      "1000.1",
+      "xoxb-test-token",
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/gateway/src/slack/thread-context.test.ts
+++ b/gateway/src/slack/thread-context.test.ts
@@ -89,7 +89,7 @@ describe("fetchThreadContext", () => {
     expect(result).toContain("[Alice]: Check out this dashboard");
   });
 
-  it("labels bot messages as Assistant", async () => {
+  it("resolves all authors by display name including bots", async () => {
     mockSlackApi(
       [
         { user: "U001", text: "Help me with this", ts: "1000.0" },
@@ -100,7 +100,7 @@ describe("fetchThreadContext", () => {
           bot_id: "B123",
         },
       ],
-      { U001: "Alice" },
+      { U001: "Alice", UBOT: "Pax" },
     );
 
     const result = await fetchThreadContext(
@@ -108,31 +108,10 @@ describe("fetchThreadContext", () => {
       "1000.0",
       "1000.2",
       "xoxb-test-token",
-      "UBOT",
     );
 
     expect(result).toContain("[Alice]: Help me with this");
-    expect(result).toContain("[Assistant]: Sure, let me look into it");
-  });
-
-  it("also labels messages by botUserId (without bot_id field) as Assistant", async () => {
-    mockSlackApi(
-      [
-        { user: "U001", text: "Hey bot", ts: "1000.0" },
-        { user: "UBOT", text: "Hello!", ts: "1000.1" },
-      ],
-      { U001: "Alice" },
-    );
-
-    const result = await fetchThreadContext(
-      "C123",
-      "1000.0",
-      "1000.2",
-      "xoxb-test-token",
-      "UBOT",
-    );
-
-    expect(result).toContain("[Assistant]: Hello!");
+    expect(result).toContain("[Pax]: Sure, let me look into it");
   });
 
   it("excludes the current message from context", async () => {
@@ -154,6 +133,32 @@ describe("fetchThreadContext", () => {
     expect(result).toContain("reply to the following Slack message");
     expect(result).toContain("[Alice]: Parent message");
     expect(result).not.toContain("This is the current reply");
+  });
+
+  it("keeps parent + most recent replies for long threads", async () => {
+    // Simulate a thread with 20 messages (parent + 19 replies)
+    const messages = Array.from({ length: 20 }, (_, i) => ({
+      user: "U001",
+      text: `Message ${i}`,
+      ts: `1000.${i}`,
+    }));
+    mockSlackApi(messages, { U001: "Alice" });
+
+    const result = await fetchThreadContext(
+      "C123",
+      "1000.0",
+      "9999.0", // current message not in the list
+      "xoxb-test-token",
+    );
+
+    // Should include the parent (Message 0) and the 14 most recent
+    expect(result).toContain("[Alice]: Message 0\n");
+    // Middle messages (1-5) should be trimmed
+    expect(result).not.toContain("Message 1\n");
+    expect(result).not.toContain("Message 5\n");
+    // Recent messages should be present
+    expect(result).toContain("[Alice]: Message 19");
+    expect(result).toContain("[Alice]: Message 6\n");
   });
 
   it("returns null when API returns error", async () => {

--- a/gateway/src/slack/thread-context.ts
+++ b/gateway/src/slack/thread-context.ts
@@ -12,8 +12,19 @@ import { resolveSlackUser } from "./normalize.js";
 
 const log = getLogger("slack-thread-context");
 
-/** Maximum number of thread messages to include in context. */
-const MAX_THREAD_MESSAGES = 15;
+/**
+ * Maximum number of thread messages to include in context.
+ * We fetch more than this to ensure we can always include the parent
+ * message plus the most recent replies.
+ */
+const MAX_CONTEXT_MESSAGES = 15;
+
+/**
+ * We over-fetch so we can take the parent + tail of the thread.
+ * Slack returns messages chronologically, so without over-fetching
+ * long threads would only show the oldest (least relevant) replies.
+ */
+const FETCH_LIMIT = 50;
 
 /** Timeout for the conversations.replies API call. */
 const FETCH_TIMEOUT_MS = 5_000;
@@ -36,14 +47,12 @@ interface SlackReplyMessage {
  * @param threadTs - Thread timestamp (parent message ts)
  * @param currentMessageTs - The current message's ts (excluded from context)
  * @param botToken - Bot OAuth token for API calls
- * @param botUserId - Bot's own user ID (to label bot messages)
  */
 export async function fetchThreadContext(
   channel: string,
   threadTs: string,
   currentMessageTs: string,
   botToken: string,
-  botUserId?: string,
 ): Promise<string | null> {
   try {
     const controller = new AbortController();
@@ -52,7 +61,7 @@ export async function fetchThreadContext(
     const params = new URLSearchParams({
       channel,
       ts: threadTs,
-      limit: String(MAX_THREAD_MESSAGES),
+      limit: String(FETCH_LIMIT),
       inclusive: "true",
     });
 
@@ -90,19 +99,29 @@ export async function fetchThreadContext(
     }
 
     // Exclude the current message from context (it's the user's new message)
-    const contextMessages = data.messages.filter(
+    const allContext = data.messages.filter(
       (msg) => msg.ts !== currentMessageTs,
     );
 
-    if (contextMessages.length === 0) return null;
+    if (allContext.length === 0) return null;
+
+    // Keep the parent message (first) + most recent replies to stay within
+    // budget. For threads with many messages, the middle is trimmed so the
+    // assistant sees the original topic and the latest conversation.
+    let contextMessages: SlackReplyMessage[];
+    if (allContext.length <= MAX_CONTEXT_MESSAGES) {
+      contextMessages = allContext;
+    } else {
+      const parent = allContext[0]!;
+      const recentReplies = allContext.slice(-(MAX_CONTEXT_MESSAGES - 1));
+      contextMessages = [parent, ...recentReplies];
+    }
 
     // Resolve user display names (best-effort, uses cache)
     const formattedMessages = await Promise.all(
       contextMessages.map(async (msg) => {
         let authorLabel: string;
-        if (msg.bot_id || (botUserId && msg.user === botUserId)) {
-          authorLabel = "Assistant";
-        } else if (msg.user) {
+        if (msg.user) {
           const userInfo = await resolveSlackUser(msg.user, botToken).catch(
             () => undefined,
           );

--- a/gateway/src/slack/thread-context.ts
+++ b/gateway/src/slack/thread-context.ts
@@ -1,0 +1,134 @@
+/**
+ * Fetches Slack thread context (parent message + recent replies) for thread
+ * replies so the assistant has context about what the user is referring to.
+ *
+ * Uses `conversations.replies` to retrieve the thread history and formats
+ * it as a human-readable context string suitable for transport hints.
+ */
+
+import { fetchImpl } from "../fetch.js";
+import { getLogger } from "../logger.js";
+import { resolveSlackUser } from "./normalize.js";
+
+const log = getLogger("slack-thread-context");
+
+/** Maximum number of thread messages to include in context. */
+const MAX_THREAD_MESSAGES = 15;
+
+/** Timeout for the conversations.replies API call. */
+const FETCH_TIMEOUT_MS = 5_000;
+
+interface SlackReplyMessage {
+  user?: string;
+  text?: string;
+  ts?: string;
+  bot_id?: string;
+  username?: string;
+}
+
+/**
+ * Fetch thread context for a Slack thread reply.
+ *
+ * Returns a formatted string containing the parent message and recent thread
+ * replies, or null if the fetch fails or the thread has no useful content.
+ *
+ * @param channel - Slack channel ID
+ * @param threadTs - Thread timestamp (parent message ts)
+ * @param currentMessageTs - The current message's ts (excluded from context)
+ * @param botToken - Bot OAuth token for API calls
+ * @param botUserId - Bot's own user ID (to label bot messages)
+ */
+export async function fetchThreadContext(
+  channel: string,
+  threadTs: string,
+  currentMessageTs: string,
+  botToken: string,
+  botUserId?: string,
+): Promise<string | null> {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    const params = new URLSearchParams({
+      channel,
+      ts: threadTs,
+      limit: String(MAX_THREAD_MESSAGES),
+      inclusive: "true",
+    });
+
+    const resp = await fetchImpl(
+      `https://slack.com/api/conversations.replies?${params.toString()}`,
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${botToken}` },
+        signal: controller.signal,
+      },
+    );
+
+    clearTimeout(timeout);
+
+    if (!resp.ok) {
+      log.warn(
+        { status: resp.status, channel, threadTs },
+        "conversations.replies HTTP error",
+      );
+      return null;
+    }
+
+    const data = (await resp.json()) as {
+      ok?: boolean;
+      messages?: SlackReplyMessage[];
+      error?: string;
+    };
+
+    if (!data.ok || !data.messages?.length) {
+      log.debug(
+        { error: data.error, channel, threadTs },
+        "conversations.replies returned no messages",
+      );
+      return null;
+    }
+
+    // Exclude the current message from context (it's the user's new message)
+    const contextMessages = data.messages.filter(
+      (msg) => msg.ts !== currentMessageTs,
+    );
+
+    if (contextMessages.length === 0) return null;
+
+    // Resolve user display names (best-effort, uses cache)
+    const formattedMessages = await Promise.all(
+      contextMessages.map(async (msg) => {
+        let authorLabel: string;
+        if (msg.bot_id || (botUserId && msg.user === botUserId)) {
+          authorLabel = "Assistant";
+        } else if (msg.user) {
+          const userInfo = await resolveSlackUser(msg.user, botToken).catch(
+            () => undefined,
+          );
+          authorLabel = userInfo?.displayName ?? msg.user;
+        } else {
+          authorLabel = msg.username ?? "Unknown";
+        }
+
+        const text = msg.text?.trim() || "(no text)";
+        return `[${authorLabel}]: ${text}`;
+      }),
+    );
+
+    const isParentOnly =
+      contextMessages.length === 1 && contextMessages[0]!.ts === threadTs;
+    const header = isParentOnly
+      ? "This message is a reply to the following Slack message"
+      : `This message is a reply in a Slack thread (${contextMessages.length} prior messages)`;
+
+    return `${header}:\n\n${formattedMessages.join("\n\n")}`;
+  } catch (err) {
+    // AbortError from timeout or any other fetch failure — non-fatal
+    log.debug(
+      { err, channel, threadTs },
+      "Failed to fetch thread context (non-fatal)",
+    );
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- When a user replies in a Slack thread mentioning the bot, the assistant now receives the parent message and recent thread history as context via `conversations.replies`
- Context is passed as a transport hint through the existing pipeline — no daemon/assistant changes needed
- All failures are non-fatal (5s timeout, graceful fallback to no context)

Closes JARVIS-350

## Test plan
- [x] 8 new unit tests covering multi-message threads, parent-only context, bot labeling, current-message exclusion, API errors, and HTTP failures
- [x] All 44 existing Slack tests pass
- [x] TypeScript type check clean
- [ ] Manual test: mention bot in a Slack thread and verify it understands the parent message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
