### PR TITLE
fix: sanitize bot tokens in gateway error response bodies

### DIFF
--- a/gateway/src/telegram/api.ts
+++ b/gateway/src/telegram/api.ts
@@ -126,7 +126,7 @@ async function retryableFetch<T>(
         description
           ? `Telegram ${method} failed: ${description}`
           : body
-            ? `Telegram ${method} failed with status ${response.status}: ${body}`
+            ? `Telegram ${method} failed with status ${response.status}: ${redactTelegramBotTokens(body)}`
             : `Telegram ${method} failed with status ${response.status}`,
       );
     }
@@ -149,7 +149,7 @@ async function retryableFetch<T>(
         description
           ? `Telegram ${method} failed: ${description}`
           : body
-            ? `Telegram ${method} failed with status ${response.status}: ${body}`
+            ? `Telegram ${method} failed with status ${response.status}: ${redactTelegramBotTokens(body)}`
             : `Telegram ${method} failed with status ${response.status}`,
       );
       log.warn(
@@ -171,7 +171,7 @@ async function retryableFetch<T>(
     } catch {
       throw new Error(
         body
-          ? `Telegram ${method} failed: unparseable response body: ${body}`
+          ? `Telegram ${method} failed: unparseable response body: ${redactTelegramBotTokens(body)}`
           : `Telegram ${method} failed with status ${response.status}: empty response`,
       );
     }


### PR DESCRIPTION
Pass response body through redactTelegramBotTokens() before interpolating into error messages to prevent potential bot token leakage in logs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
