### PR TITLE
fix: add providerOrder to DEPRECATED_FIELDS for graceful config migration

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -120,6 +120,10 @@ const DEPRECATED_FIELDS: Record<string, string> = {
     "rateLimit.maxTokensPerSession has been removed and is no longer enforced. " +
     "Per-session token budget tracking is no longer supported. " +
     "The field will be removed from your config file.",
+  providerOrder:
+    "providerOrder has been removed from the config schema. " +
+    "Provider selection is now handled automatically. " +
+    "The field will be removed from your config file.",
 };
 
 /**


### PR DESCRIPTION
Existing users with providerOrder in config.json now get a deprecation warning instead of a Zod parse error on startup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
