### PR TITLE
fix: preserve accounts key in secrets list response for backwards compat

### DIFF
--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -532,7 +532,7 @@ export async function handleListSecrets(): Promise<Response> {
       return { type: "api_key" as const, name: account };
     });
 
-    return Response.json({ secrets });
+    return Response.json({ secrets, accounts: secrets });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return httpError("INTERNAL_ERROR", message, 500);


### PR DESCRIPTION
Returns both accounts and secrets keys in the GET /v1/secrets response so existing callers reading .accounts continue to work.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
