### PR TITLE
fix: accept empty request bodies on endpoints with optional JSON

### DIFF
--- a/assistant/src/runtime/routes/channel-readiness-routes.ts
+++ b/assistant/src/runtime/routes/channel-readiness-routes.ts
@@ -64,13 +64,18 @@ export async function handleRefreshChannelReadiness(
   req: Request,
 ): Promise<Response> {
   let body: { channel?: ChannelId; includeRemote?: boolean };
-  try {
-    body = (await req.json()) as typeof body;
-  } catch {
-    return Response.json(
-      { success: false, error: "Invalid JSON in request body" },
-      { status: 400 },
-    );
+  const text = await req.text();
+  if (!text.trim()) {
+    body = {};
+  } else {
+    try {
+      body = JSON.parse(text) as typeof body;
+    } catch {
+      return Response.json(
+        { success: false, error: "Invalid JSON in request body" },
+        { status: 400 },
+      );
+    }
   }
 
   const service = getReadinessService();

--- a/assistant/src/runtime/routes/integrations/twilio.ts
+++ b/assistant/src/runtime/routes/integrations/twilio.ts
@@ -271,17 +271,22 @@ export async function handleProvisionTwilioNumber(
   }
 
   let body: { country?: string; areaCode?: string };
-  try {
-    body = (await req.json()) as typeof body;
-  } catch {
-    return Response.json(
-      {
-        success: false,
-        hasCredentials: await hasTwilioCredentials(),
-        error: "Invalid JSON in request body",
-      },
-      { status: 400 },
-    );
+  const provisionText = await req.text();
+  if (!provisionText.trim()) {
+    body = {};
+  } else {
+    try {
+      body = JSON.parse(provisionText) as typeof body;
+    } catch {
+      return Response.json(
+        {
+          success: false,
+          hasCredentials: await hasTwilioCredentials(),
+          error: "Invalid JSON in request body",
+        },
+        { status: 400 },
+      );
+    }
   }
   const { accountSid, authToken } = await getTwilioCredentials();
   const country = body.country ?? "US";
@@ -406,17 +411,22 @@ export async function handleReleaseTwilioNumber(
   }
 
   let body: { phoneNumber?: string };
-  try {
-    body = (await req.json()) as typeof body;
-  } catch {
-    return Response.json(
-      {
-        success: false,
-        hasCredentials: await hasTwilioCredentials(),
-        error: "Invalid JSON in request body",
-      },
-      { status: 400 },
-    );
+  const releaseText = await req.text();
+  if (!releaseText.trim()) {
+    body = {};
+  } else {
+    try {
+      body = JSON.parse(releaseText) as typeof body;
+    } catch {
+      return Response.json(
+        {
+          success: false,
+          hasCredentials: await hasTwilioCredentials(),
+          error: "Invalid JSON in request body",
+        },
+        { status: 400 },
+      );
+    }
   }
   const raw = loadRawConfig();
   const twilio = (raw?.twilio ?? {}) as Record<string, unknown>;


### PR DESCRIPTION
Check body presence before parsing JSON. Fall back to {} for empty bodies while still rejecting malformed JSON. Fixes regression where Twilio provisioning and channel readiness refresh endpoints rejected nil/empty bodies.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
