### PR TITLE
fix: trim sanitized text before sending to Fish Audio TTS

### DIFF
--- a/assistant/src/runtime/routes/tts-routes.ts
+++ b/assistant/src/runtime/routes/tts-routes.ts
@@ -50,8 +50,8 @@ export function ttsRouteDefinitions(): RouteDefinition[] {
           return httpError("BAD_REQUEST", "Message has no text content", 400);
         }
 
-        const sanitizedText = sanitizeForTts(result.text);
-        if (!sanitizedText.trim()) {
+        const sanitizedText = sanitizeForTts(result.text).trim();
+        if (!sanitizedText) {
           return httpError(
             "BAD_REQUEST",
             "Message has no speakable text content",


### PR DESCRIPTION
Applies trim to sanitizedText before both the emptiness check and the synthesizeWithFishAudio call, preventing whitespace-only text from being sent to the TTS API.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
