### PR TITLE
fix: gracefully fall back when CES bootstrap socket unavailable

### DIFF
--- a/assistant/src/credential-execution/process-manager.ts
+++ b/assistant/src/credential-execution/process-manager.ts
@@ -140,6 +140,18 @@ export function createCesProcessManager(
 
       if (managedAllowed) {
         discoveryResult = await discoverCes();
+        if (discoveryResult.mode === "unavailable") {
+          // The managed sidecar bootstrap socket is not present — this happens
+          // when the flag is enabled by default but the instance pre-dates the
+          // socket volume mount (e.g. existing Docker configs without the
+          // ces-bootstrap volume). Warn and fall back to local discovery so
+          // these deployments don't fail on upgrade.
+          log.warn(
+            { reason: discoveryResult.reason },
+            "CES managed sidecar bootstrap socket unavailable — falling back to local CES discovery",
+          );
+          discoveryResult = discoverLocalCes();
+        }
       } else {
         log.info(
           "CES managed sidecar feature flag is off — skipping managed discovery, falling back to local",


### PR DESCRIPTION
Adds runtime detection so the managed-sidecar discovery path falls back gracefully when the bootstrap socket volume is not mounted, preventing startup failures on older Docker configs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
