### PR TITLE
fix: move debounced summary job upsert inside transaction

### DIFF
--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -159,15 +159,14 @@ export async function indexMessageNow(
         tx,
       );
     }
-  });
 
-  // Debounced outside the transaction — each new message pushes the summary
-  // job's runAfter forward so it only fires once the conversation is idle.
-  upsertDebouncedJob(
-    "build_conversation_summary",
-    { conversationId: input.conversationId },
-    Date.now() + SUMMARY_DEBOUNCE_MS,
-  );
+    upsertDebouncedJob(
+      "build_conversation_summary",
+      { conversationId: input.conversationId },
+      Date.now() + SUMMARY_DEBOUNCE_MS,
+      tx,
+    );
+  });
 
   if (skippedEmbedJobs > 0) {
     log.debug(

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -90,13 +90,21 @@ export function enqueueMemoryJob(
  * Upsert a debounced job: if a pending job of the same type and conversation
  * already exists, push its `runAfter` forward instead of creating a duplicate.
  * This prevents rapid message indexing from spawning redundant jobs.
+ *
+ * Pass a `dbOverride` (transaction handle) to make this call atomic with
+ * surrounding writes.
  */
 export function upsertDebouncedJob(
   type: MemoryJobType,
   payload: { conversationId: string },
   runAfter: number,
+  dbOverride?: Parameters<ReturnType<typeof getDb>["transaction"]>[0] extends (
+    tx: infer T,
+  ) => unknown
+    ? T
+    : never,
 ): void {
-  const db = getDb();
+  const db = dbOverride ?? getDb();
   const existing = db
     .select()
     .from(memoryJobs)
@@ -114,7 +122,7 @@ export function upsertDebouncedJob(
       .where(eq(memoryJobs.id, existing.id))
       .run();
   } else {
-    enqueueMemoryJob(type, payload, runAfter);
+    enqueueMemoryJob(type, payload, runAfter, dbOverride);
   }
 }
 


### PR DESCRIPTION
Moves upsertDebouncedJob inside the transaction to eliminate the crash window between segment commit and job scheduling.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
