### PR TITLE
fix: use function replacement and escape script tags in app asset inlining

### DIFF
--- a/assistant/src/memory/app-store.ts
+++ b/assistant/src/memory/app-store.ts
@@ -75,10 +75,10 @@ export function inlineDistAssets(appDir: string, html: string): string {
   // Inline main.js
   const jsPath = join(distDir, "main.js");
   if (existsSync(jsPath)) {
-    const js = readFileSync(jsPath, "utf-8");
+    const js = readFileSync(jsPath, "utf-8").replace(/<\/script>/g, "<\\/script>");
     html = html.replace(
       /<script\s+type="module"\s+src="main\.js"\s*><\/script>/,
-      `<script type="module">${js}</script>`,
+      () => `<script type="module">${js}</script>`,
     );
   }
 
@@ -88,7 +88,7 @@ export function inlineDistAssets(appDir: string, html: string): string {
     const css = readFileSync(cssPath, "utf-8");
     html = html.replace(
       /<link\s+rel="stylesheet"\s+href="main\.css"\s*>/,
-      `<style>${css}</style>`,
+      () => `<style>${css}</style>`,
     );
   }
 


### PR DESCRIPTION
Uses function replacement callbacks to avoid String.replace special pattern corruption, and escapes </script> as <\/script> in inlined JS to prevent HTML parser breakage.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
