### PR TITLE
fix: remove unused payloadSection and payloadViewportHeight from MessageInspectorView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
@@ -7,7 +7,6 @@ struct MessageInspectorView: View {
 
     private let llmContextClient: any LLMContextClientProtocol
     private let callRailWidth: CGFloat = 260
-    private let payloadViewportHeight: CGFloat = 560
 
     @State private var viewState = MessageInspectorViewState()
     @State private var payloadModels: [String: MessageInspectorPayloadModel] = [:]
@@ -357,15 +356,6 @@ struct MessageInspectorView: View {
             get: { viewState.selectedRawPane },
             set: { viewState.selectRawPane($0) }
         )
-    }
-
-    private func payloadSection(title: String, key: String) -> some View {
-        MessageInspectorPayloadView(
-            title: title,
-            model: payloadBinding(for: key),
-            viewportHeight: payloadViewportHeight
-        )
-        .frame(maxWidth: .infinity, alignment: .topLeading)
     }
 
     private func payloadBinding(for key: String) -> Binding<MessageInspectorPayloadModel> {


### PR DESCRIPTION
Removes dead code left behind by the tabbed raw payload refactor: payloadSection computed property and payloadViewportHeight state variable.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
