### PR TITLE
fix: preserve existing sourceType on extraction re-upsert

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
@@ -50,7 +50,7 @@ function upsertMemoryItem(opts: {
           Math.max(existing.importance ?? 0, opts.importance),
         ),
         lastSeenAt: now,
-        sourceType: "extraction",
+        sourceType: existing.sourceType === "tool" ? "tool" : "extraction",
       })
       .where(eq(memoryItems.id, existing.id))
       .run();


### PR DESCRIPTION
Prevents extraction upsert from overwriting tool-sourced sourceType values. On conflict, the existing sourceType is preserved instead of being unconditionally set to 'extraction'.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
