### PR TITLE
fix: include preview metadata in DynamicPageSurfaceData asDictionary

### DIFF
--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -343,6 +343,18 @@ public struct DynamicPageSurfaceData: Sendable, Equatable {
         if let appId { dict["appId"] = appId }
         if let dirName { dict["dirName"] = dirName }
         if let appType { dict["appType"] = appType }
+        if let preview {
+            var previewDict: [String: Any] = ["title": preview.title]
+            if let subtitle = preview.subtitle { previewDict["subtitle"] = subtitle }
+            if let description = preview.description { previewDict["description"] = description }
+            if let icon = preview.icon { previewDict["icon"] = icon }
+            if let context = preview.context { previewDict["context"] = context }
+            if let previewImage = preview.previewImage { previewDict["previewImage"] = previewImage }
+            if let metrics = preview.metrics {
+                previewDict["metrics"] = metrics.map { ["label": $0.label, "value": $0.value] }
+            }
+            dict["preview"] = previewDict
+        }
         if let reloadGeneration { dict["reloadGeneration"] = reloadGeneration }
         if let status { dict["status"] = status }
         return dict


### PR DESCRIPTION
Adds the preview field to asDictionary output so preview metadata (title, subtitle, icon, metrics) is preserved during fallback reconstruction.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
