### PR TITLE
fix: preserve user_reported verificationState in PATCH handler

### DIFF
--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -597,7 +597,11 @@ export async function handleUpdateMemoryItem(
   // If sourceType was set (either directly or via mapping), also write verificationState
   if (body.sourceType !== undefined && body.verificationState === undefined) {
     set.verificationState =
-      body.sourceType === "tool" ? "user_confirmed" : "assistant_inferred";
+      body.sourceType === "tool"
+        ? "user_confirmed"
+        : existing.verificationState === "user_reported"
+          ? "user_reported"
+          : "assistant_inferred";
   }
 
   // If subject, statement, or kind changed, recompute fingerprint


### PR DESCRIPTION
Adds explicit mapping for user_reported in the sourceType→verificationState reverse path to prevent demotion to assistant_inferred.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
