### PR TITLE
fix: make extraction errors retryable and skip enqueue when LLM disabled

### DIFF
--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -151,7 +151,7 @@ export async function indexMessageNow(
       );
     }
 
-    if (shouldExtract && isTrustedActor && !input.automated) {
+    if (shouldExtract && isTrustedActor && !input.automated && config.extraction.useLLM) {
       enqueueMemoryJob(
         "extract_items",
         { messageId: input.messageId, scopeId: input.scopeId ?? "default" },
@@ -185,7 +185,11 @@ export async function indexMessageNow(
     log.info("Skipping extraction jobs for automated message");
   }
 
-  const extractionGated = !isTrustedActor || !!input.automated;
+  if (!config.extraction.useLLM && shouldExtract && isTrustedActor && !input.automated) {
+    log.info("Skipping extraction job: LLM extraction is disabled (useLLM=false)");
+  }
+
+  const extractionGated = !isTrustedActor || !!input.automated || !config.extraction.useLLM;
   const enqueuedJobs =
     segments.length -
     skippedEmbedJobs +

--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -11,7 +11,7 @@ import {
   getConfiguredProvider,
   userMessage,
 } from "../providers/provider-send-message.js";
-import { BackendUnavailableError } from "../util/errors.js";
+import { BackendUnavailableError, ProviderError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import { truncate } from "../util/truncate.js";
 import { maybeEnqueueConversationStartersJob } from "./conversation-starters-cadence.js";
@@ -486,12 +486,20 @@ async function extractItemsWithLLM(
 
   const toolBlock = extractToolUse(response);
   if (!toolBlock) {
-    throw new Error("No tool_use block in LLM extraction response");
+    throw new ProviderError(
+      "No tool_use block in LLM extraction response",
+      "unknown",
+      502,
+    );
   }
 
   const input = toolBlock.input as { items?: LLMExtractedItem[] };
   if (!Array.isArray(input.items)) {
-    throw new Error("Invalid items structure in LLM extraction response");
+    throw new ProviderError(
+      "Invalid items structure in LLM extraction response",
+      "unknown",
+      502,
+    );
   }
 
   // Build set of known existing item IDs for supersession validation

--- a/assistant/src/memory/job-utils.ts
+++ b/assistant/src/memory/job-utils.ts
@@ -106,6 +106,11 @@ export function classifyError(err: unknown): ErrorCategory {
     }
   }
 
+  // BackendUnavailableError is transient — the provider or backend may come back online
+  if (err instanceof BackendUnavailableError) {
+    return "retryable";
+  }
+
   // Unknown errors default to fatal to avoid infinite retry loops
   return "fatal";
 }


### PR DESCRIPTION
Ensures BackendUnavailableError is classified as retryable for transient provider outages. Skips extraction enqueue when useLLM is false to avoid no-op jobs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
