### PR TITLE
fix: replace deprecated String(contentsOf:) with String(contentsOf:encoding:) in DynamicPageSurfaceView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -63,7 +63,7 @@ extension DynamicPageSurfaceView {
     static let designSystemCSS: String = {
         guard let url = ResourceBundle.bundle.url(
             forResource: "vellum-design-system", withExtension: "css"
-        ), let css = try? String(contentsOf: url) else {
+        ), let css = try? String(contentsOf: url, encoding: .utf8) else {
             log.error("Failed to load vellum-design-system.css from resource bundle")
             assertionFailure("vellum-design-system.css not found in resource bundle")
             return ""
@@ -79,7 +79,7 @@ extension DynamicPageSurfaceView {
     static let widgetJS: String = {
         guard let url = ResourceBundle.bundle.url(
             forResource: "vellum-widgets", withExtension: "js"
-        ), let js = try? String(contentsOf: url) else {
+        ), let js = try? String(contentsOf: url, encoding: .utf8) else {
             log.error("Failed to load vellum-widgets.js from resource bundle")
             assertionFailure("vellum-widgets.js not found in resource bundle")
             return ""


### PR DESCRIPTION
## Summary
- Replaces 3 deprecated `String(contentsOf:)` calls with `String(contentsOf:encoding: .utf8)` in DynamicPageSurfaceView.swift
- `String(contentsOf:)` was deprecated in macOS 15 in favor of the explicit encoding variant

Part of plan: macos15-modernization.md (deprecation cleanup)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
