### PR TITLE
fix: match user persona name format in extraction prompt personalization

### DIFF
--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -203,7 +203,7 @@ Rules:
   // Try to extract user name from persona text
   let userName = "the user";
   if (userPersona) {
-    const nameMatch = userPersona.match(/\*\*Name:\*\*\s*(.+)/);
+    const nameMatch = userPersona.match(/Preferred name\/reference:\s*(.+)/);
     if (nameMatch) {
       userName = nameMatch[1].trim();
     }


### PR DESCRIPTION
Updates name extraction regex to match Preferred name/reference: from USER.md template instead of **Name:** from IDENTITY.md, so few-shot examples are properly personalized with the user's name.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
