### PR TITLE
fix: return null from journal context when no entries are readable

### DIFF
--- a/assistant/src/prompts/journal-context.ts
+++ b/assistant/src/prompts/journal-context.ts
@@ -129,5 +129,8 @@ export function buildJournalContext(
     sections.push(header + "\n" + content);
   }
 
+  // If all readFileSync calls failed, sections only contains the header — return null
+  if (sections.length === 1) return null;
+
   return sections.join("\n\n");
 }


### PR DESCRIPTION
Checks if any actual journal content was read after the file loop. Returns null instead of an empty # Journal header when all reads fail, preventing system prompt pollution.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
