### PR TITLE
fix: fall back to mtimeMs when birthtimeMs unavailable for journal entries

### DIFF
--- a/assistant/src/memory/journal-memory.ts
+++ b/assistant/src/memory/journal-memory.ts
@@ -155,8 +155,10 @@ export function upsertJournalMemoriesFromDisk(
         const stat = statSync(filepath);
         if (!stat.isFile()) continue;
 
+        // Fall back to mtimeMs when birthtimeMs is unavailable (returns 0 on Linux ext4, NFS, Docker overlayfs)
+        const fileBirthtimeMs = stat.birthtimeMs > 0 ? stat.birthtimeMs : stat.mtimeMs;
         // Only process files created during or after this message
-        if (stat.birthtimeMs < messageCreatedAt) continue;
+        if (fileBirthtimeMs < messageCreatedAt) continue;
 
         if (upsertSingleJournalFile(filepath, filename, messageCreatedAt, scopeId, messageId, db)) {
           upserted += 1;
@@ -185,8 +187,10 @@ export function upsertJournalMemoriesFromDisk(
             const stat = statSync(filepath);
             if (!stat.isFile()) continue;
 
+            // Fall back to mtimeMs when birthtimeMs is unavailable (returns 0 on Linux ext4, NFS, Docker overlayfs)
+            const fileBirthtimeMs = stat.birthtimeMs > 0 ? stat.birthtimeMs : stat.mtimeMs;
             // Only process files created during or after this message
-            if (stat.birthtimeMs < messageCreatedAt) continue;
+            if (fileBirthtimeMs < messageCreatedAt) continue;
 
             if (upsertSingleJournalFile(filepath, filename, messageCreatedAt, scopeId, messageId, db)) {
               upserted += 1;

--- a/assistant/src/prompts/journal-context.ts
+++ b/assistant/src/prompts/journal-context.ts
@@ -88,7 +88,9 @@ export function buildJournalContext(
         const filepath = join(journalDir, f);
         const stat = statSync(filepath);
         if (!stat.isFile()) return [];
-        return [{ filename: f, filepath, birthtimeMs: stat.birthtimeMs }];
+        // Fall back to mtimeMs when birthtimeMs is unavailable (returns 0 on Linux ext4, NFS, Docker overlayfs)
+        const birthtimeMs = stat.birthtimeMs > 0 ? stat.birthtimeMs : stat.mtimeMs;
+        return [{ filename: f, filepath, birthtimeMs }];
       } catch {
         return [];
       }


### PR DESCRIPTION
Falls back to file modification time when creation time is unavailable (returns 0 on Linux ext4, NFS, Docker overlayfs), preventing epoch timestamps and incorrect sorting.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
