### PR TITLE
fix: enable useLLM in extract_items job payload tests

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -2281,55 +2281,67 @@ describe("Memory regressions", () => {
 
   // PR-18: extract_items jobs carry scopeId through the async pipeline
   test("extract_items job payload includes scopeId from private conversation", async () => {
-    const conv = createConversation({
-      title: "Private scope job test",
-      conversationType: "private",
-    });
-    expect(conv.memoryScopeId).toMatch(/^private:/);
+    // These tests verify job payload contents, so LLM extraction must be
+    // enabled — otherwise the indexer skips enqueuing extract_items entirely.
+    TEST_CONFIG.memory.extraction.useLLM = true;
+    try {
+      const conv = createConversation({
+        title: "Private scope job test",
+        conversationType: "private",
+      });
+      expect(conv.memoryScopeId).toMatch(/^private:/);
 
-    await addMessage(
-      conv.id,
-      "user",
-      "Important data that should trigger extraction in private scope.",
-    );
+      await addMessage(
+        conv.id,
+        "user",
+        "Important data that should trigger extraction in private scope.",
+      );
 
-    const db = getDb();
-    const extractJobs = db
-      .select()
-      .from(memoryJobs)
-      .where(eq(memoryJobs.type, "extract_items"))
-      .all();
+      const db = getDb();
+      const extractJobs = db
+        .select()
+        .from(memoryJobs)
+        .where(eq(memoryJobs.type, "extract_items"))
+        .all();
 
-    expect(extractJobs.length).toBeGreaterThan(0);
-    const lastJob = extractJobs[extractJobs.length - 1];
-    const payload = JSON.parse(lastJob.payload) as Record<string, unknown>;
-    expect(payload.scopeId).toBe(conv.memoryScopeId);
+      expect(extractJobs.length).toBeGreaterThan(0);
+      const lastJob = extractJobs[extractJobs.length - 1];
+      const payload = JSON.parse(lastJob.payload) as Record<string, unknown>;
+      expect(payload.scopeId).toBe(conv.memoryScopeId);
+    } finally {
+      TEST_CONFIG.memory.extraction.useLLM = false;
+    }
   });
 
   test("extract_items job payload defaults scopeId to default for standard conversations", async () => {
-    const conv = createConversation({
-      title: "Standard scope job test",
-      conversationType: "standard",
-    });
-    expect(conv.memoryScopeId).toBe("default");
+    TEST_CONFIG.memory.extraction.useLLM = true;
+    try {
+      const conv = createConversation({
+        title: "Standard scope job test",
+        conversationType: "standard",
+      });
+      expect(conv.memoryScopeId).toBe("default");
 
-    await addMessage(
-      conv.id,
-      "user",
-      "Regular content for extraction in default scope.",
-    );
+      await addMessage(
+        conv.id,
+        "user",
+        "Regular content for extraction in default scope.",
+      );
 
-    const db = getDb();
-    const extractJobs = db
-      .select()
-      .from(memoryJobs)
-      .where(eq(memoryJobs.type, "extract_items"))
-      .all();
+      const db = getDb();
+      const extractJobs = db
+        .select()
+        .from(memoryJobs)
+        .where(eq(memoryJobs.type, "extract_items"))
+        .all();
 
-    expect(extractJobs.length).toBeGreaterThan(0);
-    const lastJob = extractJobs[extractJobs.length - 1];
-    const payload = JSON.parse(lastJob.payload) as Record<string, unknown>;
-    expect(payload.scopeId).toBe("default");
+      expect(extractJobs.length).toBeGreaterThan(0);
+      const lastJob = extractJobs[extractJobs.length - 1];
+      const payload = JSON.parse(lastJob.payload) as Record<string, unknown>;
+      expect(payload.scopeId).toBe("default");
+    } finally {
+      TEST_CONFIG.memory.extraction.useLLM = false;
+    }
   });
 
   // PR-19: memory_save respects explicit scopeId parameter


### PR DESCRIPTION
## Summary
- Two tests (`extract_items job payload includes scopeId from private conversation` and `extract_items job payload defaults scopeId to default for standard conversations`) fail because #21320 added `config.extraction.useLLM` as a gate for `extract_items` job creation, but the test config has `useLLM: false`.
- Fix: temporarily set `useLLM: true` in these two tests since they specifically need extraction jobs to be enqueued.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23517649200/job/68453662423
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
