### PR TITLE
fix: replace deprecated AVFoundation APIs in InlineVideoAttachmentView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -291,12 +291,12 @@ struct InlineVideoAttachmentView: View {
             return
         }
 
-        let asset = AVAsset(url: fileURL)
+        let asset = AVURLAsset(url: fileURL)
         let generator = AVAssetImageGenerator(asset: asset)
         generator.appliesPreferredTrackTransform = true
         generator.maximumSize = CGSize(width: 720, height: 720)
 
-        if let cgImage = try? generator.copyCGImage(at: .zero, actualTime: nil) {
+        if let (cgImage, _) = try? await generator.image(at: .zero) {
             let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
 
             let w = CGFloat(cgImage.width)
@@ -335,7 +335,7 @@ struct InlineVideoAttachmentView: View {
     }
 
     private func playFromFile(_ fileURL: URL) async {
-        let asset = AVAsset(url: fileURL)
+        let asset = AVURLAsset(url: fileURL)
         if let tracks = try? await asset.load(.tracks),
            let videoTrack = tracks.first(where: { $0.mediaType == .video }),
            let size = try? await videoTrack.load(.naturalSize),


### PR DESCRIPTION
## Summary
- Replaces 2x deprecated `AVAsset(url:)` with `AVURLAsset(url:)`
- Replaces deprecated synchronous `copyCGImage(at:actualTime:)` with async `image(at:)`

Part of plan: macos15-modernization.md (deprecation cleanup)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
