### PR TITLE
fix: correct --provider-key to --provider in BYO auth-error hint

### DIFF
--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -457,7 +457,7 @@ Examples:
             } else {
               authHint =
                 `Hint: Request returned HTTP ${response.status}. The OAuth token may be expired or revoked.\n\n` +
-                `Run 'assistant oauth connections list --provider-key ${providerKey}' to check connection status.\n` +
+                `Run 'assistant oauth connections list --provider ${providerKey}' to check connection status.\n` +
                 `To reconnect, run 'assistant oauth connections connect --help'.`;
             }
             writeInfo(authHint);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for twinkly-pondering-dove.md.

**Gap:** Wrong flag name in BYO auth-error hint
**What was expected:** --provider (matching connections list command)
**What was found:** --provider-key (invalid flag)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
