### PR TITLE
fix: skip body output for null responses in oauth request

### DIFF
--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -492,17 +492,19 @@ Examples:
           }
 
           // -----------------------------------------------------------------
-          // Output: body
+          // Output: body (skip for null bodies — HEAD requests, 204, etc.)
           // -----------------------------------------------------------------
-          const bodyStr =
-            typeof response.body === "string"
-              ? response.body
-              : JSON.stringify(response.body, null, 2);
+          if (response.body != null) {
+            const bodyStr =
+              typeof response.body === "string"
+                ? response.body
+                : JSON.stringify(response.body, null, 2);
 
-          if (opts.output) {
-            writeFileSync(opts.output, bodyStr, "utf-8");
-          } else {
-            process.stdout.write(bodyStr + "\n");
+            if (opts.output) {
+              writeFileSync(opts.output, bodyStr, "utf-8");
+            } else {
+              process.stdout.write(bodyStr + "\n");
+            }
           }
         } catch (err) {
           // Error case 7: Generic/unexpected errors


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for twinkly-pondering-dove.md.

**Gap:** Null response body serialized as literal 'null' string
**What was expected:** Empty output for HEAD/204 responses
**What was found:** JSON.stringify(null) produces 'null' string written to stdout/files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
