### PR TITLE
fix: preserve duplicate query params in oauth request URL parsing

### DIFF
--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -305,14 +305,21 @@ Examples:
           // -----------------------------------------------------------------
           let baseUrl: string | undefined;
           let requestPath: string;
-          const queryFromUrl: Record<string, string> = {};
+          const queryFromUrl: Record<string, string | string[]> = {};
 
           if (url.startsWith("http://") || url.startsWith("https://")) {
             const parsed = new URL(url);
             baseUrl = `${parsed.protocol}//${parsed.host}`;
             requestPath = parsed.pathname;
             for (const [key, value] of parsed.searchParams.entries()) {
-              queryFromUrl[key] = value;
+              const existing = queryFromUrl[key];
+              if (existing !== undefined) {
+                queryFromUrl[key] = Array.isArray(existing)
+                  ? [...existing, value]
+                  : [existing, value];
+              } else {
+                queryFromUrl[key] = value;
+              }
             }
           } else {
             requestPath = url;
@@ -358,7 +365,14 @@ Examples:
                 // Parse as URL-encoded query params
                 const bodyParams = new URLSearchParams(rawBody);
                 for (const [key, value] of bodyParams.entries()) {
-                  query[key] = value;
+                  const existing = query[key];
+                  if (existing !== undefined) {
+                    query[key] = Array.isArray(existing)
+                      ? [...existing, value]
+                      : [existing, value];
+                  } else {
+                    query[key] = value;
+                  }
                 }
               } else if (
                 rawBody !== null &&
@@ -368,7 +382,15 @@ Examples:
                 for (const [key, value] of Object.entries(
                   rawBody as Record<string, unknown>,
                 )) {
-                  query[key] = String(value);
+                  const existing = query[key];
+                  const strValue = String(value);
+                  if (existing !== undefined) {
+                    query[key] = Array.isArray(existing)
+                      ? [...existing, strValue]
+                      : [existing, strValue];
+                  } else {
+                    query[key] = strValue;
+                  }
                 }
               }
             } else {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for twinkly-pondering-dove.md.

**Gap:** Duplicate query params silently dropped when parsing absolute URLs
**What was expected:** Repeated query parameters preserved as arrays
**What was found:** Record<string, string> overwrites duplicate keys
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
