### PR TITLE
fix: use positional arg in managed auth-error hint for platform status

### DIFF
--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -452,7 +452,7 @@ Examples:
             if (managed) {
               authHint =
                 `Hint: Request returned HTTP ${response.status}. The OAuth token may be expired or revoked.\n\n` +
-                `Run 'assistant oauth platform status --provider ${providerKey}' to check connection health.\n` +
+                `Run 'assistant oauth platform status ${providerKey}' to check connection health.\n` +
                 `To reconnect, run 'assistant oauth platform connect --help'.`;
             } else {
               authHint =


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for twinkly-pondering-dove.md.

**Gap:** Wrong syntax in managed auth-error hint
**What was expected:** assistant oauth platform status <provider> (positional)
**What was found:** assistant oauth platform status --provider <provider> (invalid flag)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
