### PR TITLE
fix: replace last deprecated String(contentsOf:) in DynamicPageSurfaceView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -310,7 +310,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
 
         // Edit animator — DOM morphing with animation (runs at document end so window.vellum exists).
         if let animatorURL = ResourceBundle.bundle.url(forResource: "vellum-edit-animator", withExtension: "js"),
-           let animatorJS = try? String(contentsOf: animatorURL) {
+           let animatorJS = try? String(contentsOf: animatorURL, encoding: .utf8) {
             let animatorScript = WKUserScript(source: animatorJS, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
             contentController.addUserScript(animatorScript)
         }


### PR DESCRIPTION
## Summary
- Fixes the one remaining deprecated `String(contentsOf:)` call (vellum-edit-animator.js load at line 313)

Part of plan: macos15-modernization.md (deprecation cleanup)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
