### PR TITLE
fix: add provider arg to remaining platform status hints

### DIFF
--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -277,7 +277,7 @@ Examples:
                   if (connections.length === 0) {
                     writeError(
                       `Error: No active platform connection found for "${providerKey}" with account "${opts.account}".\n\n` +
-                        `Run 'assistant oauth platform status' to see connected accounts for this provider.\n` +
+                        `Run 'assistant oauth platform status ${providerKey}' to see connected accounts for this provider.\n` +
                         `To connect a new account, run 'assistant oauth platform connect --help'.`,
                     );
                     return;
@@ -435,7 +435,7 @@ Examples:
             if (managed) {
               writeError(
                 `Error: No active platform OAuth connection found for "${providerKey}".\n\n` +
-                  `Run 'assistant oauth platform status' to check connection status.\n` +
+                  `Run 'assistant oauth platform status ${providerKey}' to check connection status.\n` +
                   `To connect, run 'assistant oauth platform connect --help'.`,
               );
             } else {


### PR DESCRIPTION
## Summary
Fixes 2 remaining instances where 'assistant oauth platform status' hints were missing the required provider positional argument.

**Gap:** platform status hints missing provider arg
**What was expected:** All platform status hints include the provider key
**What was found:** 2 locations omitted the required positional arg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
