### PR TITLE
fix: truncate output file when response body is null

### DIFF
--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -527,6 +527,10 @@ Examples:
             } else {
               process.stdout.write(bodyStr + "\n");
             }
+          } else if (opts.output) {
+            // Truncate the output file so stale content from a previous run
+            // doesn't persist when the response has no body (HEAD, 204, etc.)
+            writeFileSync(opts.output, "", "utf-8");
           }
         } catch (err) {
           // Error case 7: Generic/unexpected errors


### PR DESCRIPTION
## Summary
When --output is set and response body is null (HEAD/204), write an empty file instead of leaving stale content.

**Gap:** Output file not truncated for null bodies
**What was expected:** Empty file for null-body responses with --output
**What was found:** File not touched, stale content persists
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
