### PR TITLE
fix: extract query params from relative URLs in oauth request

### DIFF
--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -322,7 +322,24 @@ Examples:
               }
             }
           } else {
-            requestPath = url;
+            // Relative URL — extract embedded query params if present
+            const qIdx = url.indexOf("?");
+            if (qIdx !== -1) {
+              requestPath = url.slice(0, qIdx);
+              const embeddedParams = new URLSearchParams(url.slice(qIdx + 1));
+              for (const [key, value] of embeddedParams.entries()) {
+                const existing = queryFromUrl[key];
+                if (existing !== undefined) {
+                  queryFromUrl[key] = Array.isArray(existing)
+                    ? [...existing, value]
+                    : [existing, value];
+                } else {
+                  queryFromUrl[key] = value;
+                }
+              }
+            } else {
+              requestPath = url;
+            }
           }
 
           // -----------------------------------------------------------------


### PR DESCRIPTION
## Summary
Relative URLs with embedded query strings (e.g., /api/messages?limit=10) now have their query params properly extracted and merged, preventing malformed double-? URLs when combined with -G.

**Gap:** Relative URLs with query params produce malformed URLs
**What was expected:** Query params extracted and merged for relative URLs
**What was found:** Query params stayed embedded, causing double-? with -G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
