### PR TITLE
fix: warn when managed account validation is skipped

### DIFF
--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -283,6 +283,10 @@ Examples:
                     return;
                   }
                 }
+              } else {
+                writeInfo(
+                  `Warning: Could not validate account "${opts.account}" — platform client not available. Proceeding without account validation.`,
+                );
               }
             } else {
               const conn = getActiveConnection(providerKey, {


### PR DESCRIPTION
## Summary
Adds a warning when --account is passed with a managed provider but the platform client is unavailable, so the user knows account validation was skipped.

**Gap:** Managed account pre-flight silently skipped
**What was expected:** Warning when account validation can't run
**What was found:** Silently skipped, no indication to user
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
