### PR TITLE
fix: voice observer survives state transitions, contacts onChange fires initially

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -158,7 +158,7 @@ struct ContactsContainerView: View {
             .frame(maxWidth: 700, maxHeight: .infinity, alignment: .leading)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         }
-        .onChange(of: viewModel.contacts) { _, newContacts in
+        .onChange(of: viewModel.contacts, initial: true) { _, newContacts in
             // Default to assistant on first load (don't override existing selection)
             if selection == nil && !newContacts.isEmpty {
                 selection = .assistant

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -594,10 +594,15 @@ final class VoiceModeManager: ObservableObject {
         } onChange: { [weak self] in
             Task { @MainActor [weak self] in
                 guard let self,
-                      generation == self.voiceObservationGeneration,
-                      self.state == .listening,
-                      let service = self.openAIVoiceService else { return }
-                self.liveTranscription = service.livePartialText
+                      generation == self.voiceObservationGeneration else { return }
+                // Only update liveTranscription while actively listening.
+                // Always re-arm so the loop survives state transitions
+                // (e.g., .processing clears partial text but we need to
+                // keep observing for the next .listening turn).
+                if self.state == .listening,
+                   let service = self.openAIVoiceService {
+                    self.liveTranscription = service.livePartialText
+                }
                 self.observeVoiceServiceLoop(generation: generation) // re-arm
             }
         }


### PR DESCRIPTION
## Summary
- Voice observer loop now re-arms across state transitions (fixes loop dying during .processing)
- ContactsContainerView onChange(of: contacts) fires on initial load with `initial: true`

Addresses Codex P2 and Devin review feedback on PR #21305.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
