### PR TITLE
Add DDL migration 194 for memory_recall_logs table

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -35,6 +35,7 @@ import {
   createTasksAndWorkItemsTables,
   createWatchersAndLogsTables,
   migrateAddSourceTypeColumns,
+  migrateCreateMemoryRecallLogs,
   migrateAssistantContactMetadata,
   migrateBackfillAudioAttachmentMimeTypes,
   migrateBackfillContactInteractionStats,
@@ -507,6 +508,9 @@ export function initializeDb(): void {
 
   // 90. Add source_type and source_message_role columns to memory_items
   migrateAddSourceTypeColumns(database);
+
+  // 91. Memory recall logs table for inspector memory tab
+  migrateCreateMemoryRecallLogs(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/194-memory-recall-logs.ts
+++ b/assistant/src/memory/migrations/194-memory-recall-logs.ts
@@ -1,0 +1,50 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_create_memory_recall_logs_v1";
+
+/**
+ * Create the memory_recall_logs table for the inspector memory tab.
+ */
+export function migrateCreateMemoryRecallLogs(database: DrizzleDb): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    const raw = getSqliteFrom(database);
+
+    raw.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS memory_recall_logs (
+        id TEXT PRIMARY KEY,
+        conversation_id TEXT NOT NULL,
+        message_id TEXT,
+        enabled INTEGER NOT NULL,
+        degraded INTEGER NOT NULL,
+        provider TEXT,
+        model TEXT,
+        degradation_json TEXT,
+        semantic_hits INTEGER NOT NULL,
+        merged_count INTEGER NOT NULL,
+        selected_count INTEGER NOT NULL,
+        tier1_count INTEGER NOT NULL,
+        tier2_count INTEGER NOT NULL,
+        hybrid_search_latency_ms INTEGER NOT NULL,
+        sparse_vector_used INTEGER NOT NULL,
+        injected_tokens INTEGER NOT NULL,
+        latency_ms INTEGER NOT NULL,
+        top_candidates_json TEXT NOT NULL,
+        injected_text TEXT,
+        reason TEXT,
+        created_at INTEGER NOT NULL
+      )
+    `);
+
+    raw.exec(/*sql*/ `
+      CREATE INDEX IF NOT EXISTS idx_memory_recall_logs_message_id
+      ON memory_recall_logs (message_id)
+    `);
+
+    raw.exec(/*sql*/ `
+      CREATE INDEX IF NOT EXISTS idx_memory_recall_logs_conversation_id
+      ON memory_recall_logs (conversation_id)
+    `);
+  });
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -132,6 +132,7 @@ export { migrateCallSessionSkipDisclosure } from "./190-call-session-skip-disclo
 export { migrateBackfillAudioAttachmentMimeTypes } from "./191-backfill-audio-attachment-mime-types.js";
 export { migrateContactsUserFileColumn } from "./192-contacts-user-file-column.js";
 export { migrateAddSourceTypeColumns } from "./193-add-source-type-columns.js";
+export { migrateCreateMemoryRecallLogs } from "./194-memory-recall-logs.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,


### PR DESCRIPTION
## Summary
- Create migration 194 with CREATE TABLE IF NOT EXISTS for memory_recall_logs
- Register migration in index.ts barrel export
- Add migration call as step 91 in db-init.ts

Part of plan: memory-inspector-tab.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21343" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
