### PR TITLE
Add Memory tab case to inspector and thread memoryRecall through view state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryTab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryTab.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct MessageInspectorMemoryTab: View {
+    let memoryRecall: MemoryRecallData?
+
+    var body: some View {
+        VEmptyState(
+            title: "Memory",
+            subtitle: "Memory recall debugging information will appear here.",
+            icon: VIcon.brain.rawValue
+        )
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
@@ -124,7 +124,7 @@ struct MessageInspectorView: View {
                 }
 
                 HStack(spacing: VSpacing.sm) {
-                    ForEach(0..<4, id: \.self) { _ in
+                    ForEach(0..<5, id: \.self) { _ in
                         VSkeletonBone(width: 88, height: 32, radius: VRadius.md)
                     }
                     Spacer()
@@ -313,6 +313,8 @@ struct MessageInspectorView: View {
         switch viewState.selectedDetailTab {
         case .overview:
             MessageInspectorOverviewTab(entry: entry)
+        case .memory:
+            MessageInspectorMemoryTab(memoryRecall: viewState.memoryRecall)
         case .prompt:
             MessageInspectorPromptTab(entry: entry)
         case .response:
@@ -535,6 +537,7 @@ enum RawPayloadPane: String, CaseIterable {
 
 enum MessageInspectorDetailTab: String, CaseIterable {
     case overview
+    case memory
     case prompt
     case response
     case raw
@@ -543,6 +546,8 @@ enum MessageInspectorDetailTab: String, CaseIterable {
         switch self {
         case .overview:
             return "Overview"
+        case .memory:
+            return "Memory"
         case .prompt:
             return "Prompt"
         case .response:
@@ -556,6 +561,8 @@ enum MessageInspectorDetailTab: String, CaseIterable {
         switch self {
         case .overview:
             return .layoutGrid
+        case .memory:
+            return .brain
         case .prompt:
             return .scrollText
         case .response:
@@ -569,6 +576,7 @@ enum MessageInspectorDetailTab: String, CaseIterable {
 struct MessageInspectorViewState {
     private(set) var loadState: MessageInspectorLoadState = .loading
     private(set) var logs: [LLMRequestLogEntry] = []
+    private(set) var memoryRecall: MemoryRecallData?
     private(set) var selectedLogID: String?
     private(set) var selectedDetailTab: MessageInspectorDetailTab = .overview
     private(set) var selectedRawPane: RawPayloadPane = .request
@@ -605,6 +613,7 @@ struct MessageInspectorViewState {
         case .loaded(let response):
             let orderedLogs = Self.ordered(response.logs)
             logs = orderedLogs
+            memoryRecall = response.memoryRecall
 
             guard !orderedLogs.isEmpty else {
                 loadState = .empty
@@ -622,10 +631,12 @@ struct MessageInspectorViewState {
             selectedLogID = orderedLogs.first?.id
         case .empty:
             logs = []
+            memoryRecall = nil
             loadState = .empty
             selectedLogID = nil
         case .failed:
             logs = []
+            memoryRecall = nil
             loadState = .failed
             selectedLogID = nil
         }

--- a/clients/macos/vellum-assistantTests/MessageInspectorViewTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorViewTests.swift
@@ -50,8 +50,78 @@ final class MessageInspectorViewTests: XCTestCase {
         XCTAssertEqual(state.selectedDetailTab, .raw)
     }
 
-    private func makeResponse(logs: [LLMRequestLogEntry]) -> LLMContextResponse {
-        LLMContextResponse(messageId: "message-1", logs: logs)
+    func testMemoryRecallIsThreadedThroughViewState() {
+        var state = MessageInspectorViewState()
+
+        let requestToken = state.beginLoading(resetSelection: true)
+        let recall = MemoryRecallData(
+            enabled: true,
+            degraded: false,
+            provider: "anthropic",
+            model: nil,
+            degradation: nil,
+            semanticHits: 3,
+            mergedCount: 2,
+            selectedCount: 1,
+            tier1Count: 1,
+            tier2Count: 0,
+            hybridSearchLatencyMs: 15,
+            sparseVectorUsed: false,
+            injectedTokens: 200,
+            latencyMs: 42,
+            reason: nil,
+            topCandidates: [],
+            injectedText: nil
+        )
+        state.finishLoading(with: .loaded(makeResponse(logs: [
+            makeLog(id: "a", createdAt: 1_000)
+        ], memoryRecall: recall)), requestToken: requestToken)
+
+        XCTAssertEqual(state.memoryRecall?.enabled, true)
+        XCTAssertEqual(state.memoryRecall?.latencyMs, 42)
+        XCTAssertEqual(state.memoryRecall?.semanticHits, 3)
+    }
+
+    func testMemoryRecallClearedOnEmpty() {
+        var state = MessageInspectorViewState()
+
+        let loadToken = state.beginLoading(resetSelection: true)
+        let recall = MemoryRecallData(
+            enabled: true,
+            degraded: false,
+            provider: nil,
+            model: nil,
+            degradation: nil,
+            semanticHits: 0,
+            mergedCount: 0,
+            selectedCount: 0,
+            tier1Count: 0,
+            tier2Count: 0,
+            hybridSearchLatencyMs: 5,
+            sparseVectorUsed: false,
+            injectedTokens: 0,
+            latencyMs: 5,
+            reason: nil,
+            topCandidates: [],
+            injectedText: nil
+        )
+        state.finishLoading(with: .loaded(makeResponse(logs: [
+            makeLog(id: "a", createdAt: 1_000)
+        ], memoryRecall: recall)), requestToken: loadToken)
+        XCTAssertNotNil(state.memoryRecall)
+
+        let emptyToken = state.beginLoading(resetSelection: true)
+        state.finishLoading(with: .empty, requestToken: emptyToken)
+        XCTAssertNil(state.memoryRecall)
+    }
+
+    func testMemoryTabCaseExists() {
+        let tab = MessageInspectorDetailTab.memory
+        XCTAssertEqual(tab.label, "Memory")
+    }
+
+    private func makeResponse(logs: [LLMRequestLogEntry], memoryRecall: MemoryRecallData? = nil) -> LLMContextResponse {
+        LLMContextResponse(messageId: "message-1", logs: logs, memoryRecall: memoryRecall)
     }
 
     private func makeLog(


### PR DESCRIPTION
## Summary
- Add .memory case to MessageInspectorDetailTab with brain icon
- Thread memoryRecall from LLMContextResponse through MessageInspectorViewState
- Create stub MessageInspectorMemoryTab with placeholder empty state
- Update tests for new tab case

Part of plan: memory-inspector-tab.md (PR 7 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
