### PR TITLE
Add memory recall log store with record, backfill, and query functions

### DIFF
--- a/assistant/src/__tests__/memory-recall-log-store.test.ts
+++ b/assistant/src/__tests__/memory-recall-log-store.test.ts
@@ -1,0 +1,187 @@
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = realpathSync(
+  mkdtempSync(join(tmpdir(), "memory-recall-log-store-test-")),
+);
+const workspaceDir = join(testDir, ".vellum", "workspace");
+
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => join(testDir, ".vellum"),
+  getDataDir: () => join(workspaceDir, "data"),
+  getWorkspaceDir: () => workspaceDir,
+  getConversationsDir: () => join(workspaceDir, "conversations"),
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+  }),
+}));
+
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import {
+  backfillMemoryRecallLogMessageId,
+  getMemoryRecallLogByMessageIds,
+  recordMemoryRecallLog,
+} from "../memory/memory-recall-log-store.js";
+import { memoryRecallLogs } from "../memory/schema.js";
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.delete(memoryRecallLogs).run();
+}
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe("memory-recall-log-store", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("round-trip: record → backfill messageId → query by messageId", () => {
+    const conversationId = "conv-1";
+    const messageId = "msg-1";
+
+    recordMemoryRecallLog({
+      conversationId,
+      enabled: true,
+      degraded: false,
+      provider: "anthropic",
+      model: "claude-sonnet",
+      degradationJson: { reason: "none" },
+      semanticHits: 5,
+      mergedCount: 3,
+      selectedCount: 2,
+      tier1Count: 1,
+      tier2Count: 1,
+      hybridSearchLatencyMs: 150,
+      sparseVectorUsed: true,
+      injectedTokens: 500,
+      latencyMs: 200,
+      topCandidatesJson: [{ id: "c1", score: 0.9 }],
+      injectedText: "some memory context",
+      reason: "user query matched memories",
+    });
+
+    backfillMemoryRecallLogMessageId(conversationId, messageId);
+
+    const result = getMemoryRecallLogByMessageIds([messageId]);
+    expect(result).not.toBeNull();
+    expect(result!.conversationId).toBe(conversationId);
+    expect(result!.messageId).toBe(messageId);
+    expect(result!.enabled).toBe(1);
+    expect(result!.degraded).toBe(0);
+    expect(result!.provider).toBe("anthropic");
+    expect(result!.model).toBe("claude-sonnet");
+    expect(result!.degradationJson).toEqual({ reason: "none" });
+    expect(result!.semanticHits).toBe(5);
+    expect(result!.mergedCount).toBe(3);
+    expect(result!.selectedCount).toBe(2);
+    expect(result!.tier1Count).toBe(1);
+    expect(result!.tier2Count).toBe(1);
+    expect(result!.hybridSearchLatencyMs).toBe(150);
+    expect(result!.sparseVectorUsed).toBe(1);
+    expect(result!.injectedTokens).toBe(500);
+    expect(result!.latencyMs).toBe(200);
+    expect(result!.topCandidatesJson).toEqual([{ id: "c1", score: 0.9 }]);
+    expect(result!.injectedText).toBe("some memory context");
+    expect(result!.reason).toBe("user query matched memories");
+    expect(result!.createdAt).toBeGreaterThan(0);
+  });
+
+  test("returns null when no log exists for a messageId", () => {
+    const result = getMemoryRecallLogByMessageIds(["nonexistent-msg"]);
+    expect(result).toBeNull();
+  });
+
+  test("returns null for empty messageIds array", () => {
+    const result = getMemoryRecallLogByMessageIds([]);
+    expect(result).toBeNull();
+  });
+
+  test("backfill only updates rows with NULL messageId", () => {
+    const conversationId = "conv-2";
+
+    // Record first log and backfill with msg-a
+    recordMemoryRecallLog({
+      conversationId,
+      enabled: true,
+      degraded: false,
+      semanticHits: 3,
+      mergedCount: 2,
+      selectedCount: 1,
+      tier1Count: 1,
+      tier2Count: 0,
+      hybridSearchLatencyMs: 100,
+      sparseVectorUsed: false,
+      injectedTokens: 300,
+      latencyMs: 150,
+      topCandidatesJson: [],
+    });
+    backfillMemoryRecallLogMessageId(conversationId, "msg-a");
+
+    // Record second log (messageId is still NULL)
+    recordMemoryRecallLog({
+      conversationId,
+      enabled: true,
+      degraded: true,
+      degradationJson: { reason: "timeout" },
+      semanticHits: 1,
+      mergedCount: 1,
+      selectedCount: 0,
+      tier1Count: 0,
+      tier2Count: 0,
+      hybridSearchLatencyMs: 50,
+      sparseVectorUsed: false,
+      injectedTokens: 0,
+      latencyMs: 80,
+      topCandidatesJson: [],
+    });
+
+    // Backfill second log with msg-b
+    backfillMemoryRecallLogMessageId(conversationId, "msg-b");
+
+    // Verify first log still has msg-a
+    const firstLog = getMemoryRecallLogByMessageIds(["msg-a"]);
+    expect(firstLog).not.toBeNull();
+    expect(firstLog!.messageId).toBe("msg-a");
+    expect(firstLog!.degraded).toBe(0);
+
+    // Verify second log has msg-b
+    const secondLog = getMemoryRecallLogByMessageIds(["msg-b"]);
+    expect(secondLog).not.toBeNull();
+    expect(secondLog!.messageId).toBe("msg-b");
+    expect(secondLog!.degraded).toBe(1);
+  });
+});

--- a/assistant/src/memory/memory-recall-log-store.ts
+++ b/assistant/src/memory/memory-recall-log-store.ts
@@ -1,0 +1,118 @@
+import { and, eq, inArray, isNull } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import { getDb } from "./db.js";
+import { memoryRecallLogs } from "./schema.js";
+
+export interface RecordMemoryRecallLogParams {
+  conversationId: string;
+  enabled: boolean;
+  degraded: boolean;
+  provider?: string;
+  model?: string;
+  degradationJson?: unknown;
+  semanticHits: number;
+  mergedCount: number;
+  selectedCount: number;
+  tier1Count: number;
+  tier2Count: number;
+  hybridSearchLatencyMs: number;
+  sparseVectorUsed: boolean;
+  injectedTokens: number;
+  latencyMs: number;
+  topCandidatesJson: unknown;
+  injectedText?: string;
+  reason?: string;
+}
+
+export function recordMemoryRecallLog(params: RecordMemoryRecallLogParams): void {
+  const db = getDb();
+  db.insert(memoryRecallLogs)
+    .values({
+      id: uuid(),
+      conversationId: params.conversationId,
+      messageId: null,
+      enabled: params.enabled ? 1 : 0,
+      degraded: params.degraded ? 1 : 0,
+      provider: params.provider ?? null,
+      model: params.model ?? null,
+      degradationJson: params.degradationJson
+        ? JSON.stringify(params.degradationJson)
+        : null,
+      semanticHits: params.semanticHits,
+      mergedCount: params.mergedCount,
+      selectedCount: params.selectedCount,
+      tier1Count: params.tier1Count,
+      tier2Count: params.tier2Count,
+      hybridSearchLatencyMs: params.hybridSearchLatencyMs,
+      sparseVectorUsed: params.sparseVectorUsed ? 1 : 0,
+      injectedTokens: params.injectedTokens,
+      latencyMs: params.latencyMs,
+      topCandidatesJson: JSON.stringify(params.topCandidatesJson),
+      injectedText: params.injectedText ?? null,
+      reason: params.reason ?? null,
+      createdAt: Date.now(),
+    })
+    .run();
+}
+
+export function backfillMemoryRecallLogMessageId(
+  conversationId: string,
+  messageId: string,
+): void {
+  const db = getDb();
+  db.update(memoryRecallLogs)
+    .set({ messageId })
+    .where(
+      and(
+        eq(memoryRecallLogs.conversationId, conversationId),
+        isNull(memoryRecallLogs.messageId),
+      ),
+    )
+    .run();
+}
+
+export interface MemoryRecallLogRow {
+  id: string;
+  conversationId: string;
+  messageId: string | null;
+  enabled: number;
+  degraded: number;
+  provider: string | null;
+  model: string | null;
+  degradationJson: unknown | null;
+  semanticHits: number;
+  mergedCount: number;
+  selectedCount: number;
+  tier1Count: number;
+  tier2Count: number;
+  hybridSearchLatencyMs: number;
+  sparseVectorUsed: number;
+  injectedTokens: number;
+  latencyMs: number;
+  topCandidatesJson: unknown;
+  injectedText: string | null;
+  reason: string | null;
+  createdAt: number;
+}
+
+export function getMemoryRecallLogByMessageIds(
+  messageIds: string[],
+): MemoryRecallLogRow | null {
+  if (messageIds.length === 0) return null;
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(memoryRecallLogs)
+    .where(inArray(memoryRecallLogs.messageId, messageIds))
+    .all();
+  if (rows.length === 0) return null;
+  const row = rows[0]!;
+  return {
+    ...row,
+    degradationJson: row.degradationJson
+      ? JSON.parse(row.degradationJson)
+      : null,
+    topCandidatesJson: JSON.parse(row.topCandidatesJson),
+  };
+}


### PR DESCRIPTION
## Summary
- Create memory-recall-log-store.ts with recordMemoryRecallLog, backfillMemoryRecallLogMessageId, and getMemoryRecallLogByMessageIds
- Add tests for round-trip persistence, null handling, and backfill isolation

Part of plan: memory-inspector-tab.md (PR 3 of 8)