### PR TITLE
Implement full Memory tab UI with status, funnel, candidates, and injected text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryTab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryTab.swift
@@ -1,14 +1,446 @@
+import Foundation
 import SwiftUI
 import VellumAssistantShared
+
+// MARK: - Model
+
+struct MessageInspectorMemoryTabModel: Equatable {
+    struct Row: Identifiable, Equatable {
+        let label: String
+        let value: String
+
+        var id: String { label }
+    }
+
+    struct CandidateRow: Identifiable, Equatable {
+        let id: String
+        let key: String
+        let type: String
+        let kind: String
+        let finalScore: String
+        let semanticScore: String
+        let recencyScore: String
+    }
+
+    let isEnabled: Bool
+    let hasData: Bool
+    let disabledReason: String?
+    let statusRows: [Row]
+    let funnelRows: [Row]
+    let searchRows: [Row]
+    let candidates: [CandidateRow]
+    let injectedText: String?
+    let degradationReason: String?
+    let degradationSemanticUnavailable: Bool
+    let degradationFallbackSources: String?
+
+    init(memoryRecall: MemoryRecallData?) {
+        guard let recall = memoryRecall else {
+            isEnabled = false
+            hasData = false
+            disabledReason = nil
+            statusRows = []
+            funnelRows = []
+            searchRows = []
+            candidates = []
+            injectedText = nil
+            degradationReason = nil
+            degradationSemanticUnavailable = false
+            degradationFallbackSources = nil
+            return
+        }
+
+        hasData = true
+        isEnabled = recall.enabled
+
+        if !recall.enabled {
+            disabledReason = recall.reason ?? "Memory recall was disabled for this turn."
+            statusRows = []
+            funnelRows = []
+            searchRows = []
+            candidates = []
+            injectedText = nil
+            degradationReason = nil
+            degradationSemanticUnavailable = false
+            degradationFallbackSources = nil
+            return
+        }
+
+        disabledReason = nil
+
+        statusRows = [
+            .init(label: "Status", value: recall.degraded ? "Degraded" : "Active"),
+            .init(label: "Provider", value: Self.displayText(recall.provider)),
+            .init(label: "Model", value: Self.displayText(recall.model)),
+            .init(label: "Total latency", value: "\(recall.latencyMs) ms"),
+        ]
+
+        funnelRows = [
+            .init(label: "Semantic hits", value: Self.formatCount(recall.semanticHits)),
+            .init(label: "After merge", value: Self.formatCount(recall.mergedCount)),
+            .init(label: "Tier 1", value: Self.formatCount(recall.tier1Count)),
+            .init(label: "Tier 2", value: Self.formatCount(recall.tier2Count)),
+            .init(label: "Selected", value: Self.formatCount(recall.selectedCount)),
+            .init(label: "Injected tokens", value: Self.formatCount(recall.injectedTokens)),
+        ]
+
+        searchRows = [
+            .init(label: "Hybrid search", value: "\(recall.hybridSearchLatencyMs) ms"),
+            .init(label: "Sparse vectors", value: recall.sparseVectorUsed ? "Used" : "Dense only"),
+        ]
+
+        candidates = recall.topCandidates
+            .sorted { $0.finalScore > $1.finalScore }
+            .enumerated()
+            .map { index, candidate in
+                CandidateRow(
+                    id: "\(index)-\(candidate.key)",
+                    key: candidate.key,
+                    type: candidate.type,
+                    kind: candidate.kind,
+                    finalScore: Self.formatScore(candidate.finalScore),
+                    semanticScore: Self.formatScore(candidate.semantic),
+                    recencyScore: Self.formatScore(candidate.recency)
+                )
+            }
+
+        injectedText = recall.injectedText
+
+        if let degradation = recall.degradation {
+            degradationReason = degradation.reason
+            degradationSemanticUnavailable = degradation.semanticUnavailable
+            degradationFallbackSources = degradation.fallbackSources.isEmpty
+                ? nil
+                : degradation.fallbackSources.joined(separator: ", ")
+        } else {
+            degradationReason = nil
+            degradationSemanticUnavailable = false
+            degradationFallbackSources = nil
+        }
+    }
+
+    private static func displayText(_ value: String?) -> String {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return "Unavailable"
+        }
+        return value
+    }
+
+    private static func formatCount(_ value: Int) -> String {
+        numberFormatter.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
+
+    private static func formatScore(_ value: Double) -> String {
+        String(format: "%.3f", value)
+    }
+
+    private static let numberFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter
+    }()
+}
+
+// MARK: - View
 
 struct MessageInspectorMemoryTab: View {
     let memoryRecall: MemoryRecallData?
 
+    private var model: MessageInspectorMemoryTabModel {
+        MessageInspectorMemoryTabModel(memoryRecall: memoryRecall)
+    }
+
     var body: some View {
+        Group {
+            if !model.hasData {
+                noDataState
+            } else if !model.isEnabled {
+                disabledState
+            } else {
+                enabledContent
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(VColor.surfaceBase)
+    }
+
+    // MARK: - Enabled content
+
+    private var enabledContent: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: VSpacing.lg) {
+                scopeBanner
+                statusCard
+                funnelCard
+                searchDetailsCard
+
+                if !model.candidates.isEmpty {
+                    candidatesCard
+                }
+
+                if model.injectedText != nil {
+                    injectedTextCard
+                }
+
+                if model.degradationReason != nil {
+                    degradationCard
+                }
+            }
+            .padding(VSpacing.lg)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+    }
+
+    // MARK: - Scope banner
+
+    private var scopeBanner: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Turn-level recall")
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(VColor.contentDefault)
+
+            Text("Memory recall runs once per turn. This data applies to all LLM calls for this message.")
+                .font(VFont.bodyMediumLighter)
+                .foregroundStyle(VColor.contentSecondary)
+        }
+        .padding(VSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(VColor.surfaceOverlay)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+    }
+
+    // MARK: - Status card
+
+    private var statusCard: some View {
+        VCard {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                cardHeader(title: "Status", subtitle: "Provider, model, and latency for this recall.")
+
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    ForEach(model.statusRows) { row in
+                        metadataRow(row)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Funnel card
+
+    private var funnelCard: some View {
+        VCard {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                cardHeader(title: "Retrieval funnel", subtitle: "How memories were filtered from semantic search to injection.")
+
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    ForEach(model.funnelRows) { row in
+                        metadataRow(row)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Search details card
+
+    private var searchDetailsCard: some View {
+        VCard {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                cardHeader(title: "Search details", subtitle: nil)
+
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    ForEach(model.searchRows) { row in
+                        metadataRow(row)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Candidates card
+
+    private var candidatesCard: some View {
+        VCard {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                cardHeader(
+                    title: "Top candidates",
+                    subtitle: "\(model.candidates.count) candidate(s) ranked by final score."
+                )
+
+                LazyVStack(alignment: .leading, spacing: VSpacing.sm) {
+                    ForEach(model.candidates) { candidate in
+                        candidateRow(candidate)
+                    }
+                }
+            }
+        }
+    }
+
+    private func candidateRow(_ candidate: MessageInspectorMemoryTabModel.CandidateRow) -> some View {
+        HStack(alignment: .top, spacing: VSpacing.md) {
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text(candidate.key)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(VColor.contentDefault)
+                    .lineLimit(2)
+
+                HStack(spacing: VSpacing.xs) {
+                    chip(candidate.type)
+                    chip(candidate.kind)
+                }
+            }
+
+            Spacer(minLength: VSpacing.sm)
+
+            VStack(alignment: .trailing, spacing: VSpacing.xxs) {
+                Text(candidate.finalScore)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+
+                HStack(spacing: VSpacing.xs) {
+                    Text("sem \(candidate.semanticScore)")
+                        .font(VFont.labelSmall)
+                        .foregroundStyle(VColor.contentTertiary)
+
+                    Text("rec \(candidate.recencyScore)")
+                        .font(VFont.labelSmall)
+                        .foregroundStyle(VColor.contentTertiary)
+                }
+            }
+        }
+        .padding(VSpacing.sm)
+        .background(VColor.surfaceBase)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+    }
+
+    private func chip(_ text: String) -> some View {
+        Text(text)
+            .font(VFont.labelSmall)
+            .foregroundStyle(VColor.contentSecondary)
+            .padding(.horizontal, VSpacing.xs)
+            .padding(.vertical, VSpacing.xxs)
+            .background(VColor.surfaceBase)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+    }
+
+    // MARK: - Injected text card
+
+    private var injectedTextCard: some View {
+        VCard {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                HStack(alignment: .firstTextBaseline, spacing: VSpacing.sm) {
+                    cardHeader(title: "Injected memory context", subtitle: nil)
+
+                    Spacer(minLength: VSpacing.md)
+
+                    VCopyButton(
+                        text: model.injectedText ?? "",
+                        size: .compact,
+                        accessibilityHint: "Copy injected memory context"
+                    )
+                }
+
+                HighlightedTextView(
+                    text: .constant(model.injectedText ?? ""),
+                    language: .plain,
+                    isEditable: false,
+                    isActivelyEditing: .constant(false)
+                )
+                .frame(maxWidth: .infinity)
+                .frame(minHeight: 120, maxHeight: 400)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            }
+        }
+    }
+
+    // MARK: - Degradation card
+
+    private var degradationCard: some View {
+        VCard {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                cardHeader(title: "Degradation", subtitle: nil)
+
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    metadataRow(.init(label: "Reason", value: model.degradationReason ?? "Unknown"))
+
+                    metadataRow(.init(
+                        label: "Semantic unavailable",
+                        value: model.degradationSemanticUnavailable ? "Yes" : "No"
+                    ))
+
+                    if let sources = model.degradationFallbackSources {
+                        metadataRow(.init(label: "Fallback sources", value: sources))
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Disabled state
+
+    private var disabledState: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: VSpacing.lg) {
+                VCard {
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
+                        cardHeader(
+                            title: "Memory disabled",
+                            subtitle: nil
+                        )
+
+                        Text(model.disabledReason ?? "Memory recall was disabled for this turn.")
+                            .font(VFont.bodyMediumLighter)
+                            .foregroundStyle(VColor.contentSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+            .padding(VSpacing.lg)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+    }
+
+    // MARK: - No data state
+
+    private var noDataState: some View {
         VEmptyState(
-            title: "Memory",
-            subtitle: "Memory recall debugging information will appear here.",
+            title: "No memory data",
+            subtitle: "Memory recall information is not available for this message.",
             icon: VIcon.brain.rawValue
         )
+        .frame(minHeight: 280)
+    }
+
+    // MARK: - Shared helpers
+
+    private func cardHeader(title: String, subtitle: String?) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxs) {
+            Text(title)
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(VColor.contentDefault)
+
+            if let subtitle, !subtitle.isEmpty {
+                Text(subtitle)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+        }
+    }
+
+    private func metadataRow(_ row: MessageInspectorMemoryTabModel.Row) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: VSpacing.md) {
+            Text(row.label)
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+
+            Spacer(minLength: VSpacing.sm)
+
+            Text(row.value)
+                .font(VFont.bodyMediumLighter)
+                .foregroundStyle(VColor.contentDefault)
+                .multilineTextAlignment(.trailing)
+                .fixedSize(horizontal: false, vertical: true)
+                .textSelection(.enabled)
+        }
     }
 }

--- a/clients/macos/vellum-assistantTests/MessageInspectorMemoryTabTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorMemoryTabTests.swift
@@ -1,0 +1,253 @@
+import Foundation
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+final class MessageInspectorMemoryTabTests: XCTestCase {
+
+    // MARK: - No data state
+
+    func testNilRecallProducesNoDataState() {
+        let model = MessageInspectorMemoryTabModel(memoryRecall: nil)
+
+        XCTAssertFalse(model.hasData)
+        XCTAssertFalse(model.isEnabled)
+        XCTAssertNil(model.disabledReason)
+        XCTAssertTrue(model.statusRows.isEmpty)
+        XCTAssertTrue(model.funnelRows.isEmpty)
+        XCTAssertTrue(model.searchRows.isEmpty)
+        XCTAssertTrue(model.candidates.isEmpty)
+        XCTAssertNil(model.injectedText)
+        XCTAssertNil(model.degradationReason)
+    }
+
+    // MARK: - Disabled state
+
+    func testDisabledRecallSurfacesReasonAndSkipsAllCards() {
+        let recall = makeRecall(enabled: false, reason: "Memory is turned off in settings.")
+        let model = MessageInspectorMemoryTabModel(memoryRecall: recall)
+
+        XCTAssertTrue(model.hasData)
+        XCTAssertFalse(model.isEnabled)
+        XCTAssertEqual(model.disabledReason, "Memory is turned off in settings.")
+        XCTAssertTrue(model.statusRows.isEmpty)
+        XCTAssertTrue(model.funnelRows.isEmpty)
+        XCTAssertTrue(model.searchRows.isEmpty)
+        XCTAssertTrue(model.candidates.isEmpty)
+        XCTAssertNil(model.injectedText)
+    }
+
+    func testDisabledRecallWithNilReasonUsesFallback() {
+        let recall = makeRecall(enabled: false, reason: nil)
+        let model = MessageInspectorMemoryTabModel(memoryRecall: recall)
+
+        XCTAssertEqual(model.disabledReason, "Memory recall was disabled for this turn.")
+    }
+
+    // MARK: - Enabled — status card
+
+    func testEnabledActiveRecallProducesStatusRows() {
+        let recall = makeRecall(
+            enabled: true,
+            degraded: false,
+            provider: "qdrant",
+            model: "bge-m3",
+            latencyMs: 142
+        )
+        let model = MessageInspectorMemoryTabModel(memoryRecall: recall)
+
+        XCTAssertTrue(model.isEnabled)
+        XCTAssertEqual(model.statusRows.map(\.label), ["Status", "Provider", "Model", "Total latency"])
+        XCTAssertEqual(model.statusRows[0].value, "Active")
+        XCTAssertEqual(model.statusRows[1].value, "qdrant")
+        XCTAssertEqual(model.statusRows[2].value, "bge-m3")
+        XCTAssertEqual(model.statusRows[3].value, "142 ms")
+    }
+
+    func testDegradedStatusShowsDegradedLabel() {
+        let recall = makeRecall(enabled: true, degraded: true)
+        let model = MessageInspectorMemoryTabModel(memoryRecall: recall)
+
+        XCTAssertEqual(model.statusRows.first(where: { $0.label == "Status" })?.value, "Degraded")
+    }
+
+    func testNilProviderAndModelShowUnavailable() {
+        let recall = makeRecall(enabled: true, provider: nil, model: nil)
+        let model = MessageInspectorMemoryTabModel(memoryRecall: recall)
+
+        XCTAssertEqual(model.statusRows.first(where: { $0.label == "Provider" })?.value, "Unavailable")
+        XCTAssertEqual(model.statusRows.first(where: { $0.label == "Model" })?.value, "Unavailable")
+    }
+
+    // MARK: - Enabled — funnel card
+
+    func testFunnelRowsReflectRecallCounts() {
+        let recall = makeRecall(
+            enabled: true,
+            semanticHits: 48,
+            mergedCount: 32,
+            selectedCount: 10,
+            tier1Count: 20,
+            tier2Count: 12,
+            injectedTokens: 1_234
+        )
+        let model = MessageInspectorMemoryTabModel(memoryRecall: recall)
+
+        XCTAssertEqual(model.funnelRows.map(\.label), [
+            "Semantic hits", "After merge", "Tier 1", "Tier 2", "Selected", "Injected tokens"
+        ])
+        XCTAssertEqual(model.funnelRows[0].value, "48")
+        XCTAssertEqual(model.funnelRows[1].value, "32")
+        XCTAssertEqual(model.funnelRows[2].value, "20")
+        XCTAssertEqual(model.funnelRows[3].value, "12")
+        XCTAssertEqual(model.funnelRows[4].value, "10")
+        XCTAssertEqual(model.funnelRows[5].value, "1,234")
+    }
+
+    // MARK: - Enabled — search details
+
+    func testSearchDetailsReflectHybridSearchData() {
+        let recall = makeRecall(
+            enabled: true,
+            hybridSearchLatencyMs: 87,
+            sparseVectorUsed: true
+        )
+        let model = MessageInspectorMemoryTabModel(memoryRecall: recall)
+
+        XCTAssertEqual(model.searchRows.map(\.label), ["Hybrid search", "Sparse vectors"])
+        XCTAssertEqual(model.searchRows[0].value, "87 ms")
+        XCTAssertEqual(model.searchRows[1].value, "Used")
+    }
+
+    func testSparseVectorNotUsedShowsDenseOnly() {
+        let recall = makeRecall(enabled: true, sparseVectorUsed: false)
+        let model = MessageInspectorMemoryTabModel(memoryRecall: recall)
+
+        XCTAssertEqual(model.searchRows.first(where: { $0.label == "Sparse vectors" })?.value, "Dense only")
+    }
+
+    // MARK: - Enabled — candidates
+
+    func testCandidatesSortedByFinalScoreDescending() {
+        let recall = makeRecall(
+            enabled: true,
+            topCandidates: [
+                MemoryRecallCandidate(key: "low", type: "fact", kind: "core", finalScore: 0.3, semantic: 0.2, recency: 0.5),
+                MemoryRecallCandidate(key: "high", type: "preference", kind: "inferred", finalScore: 0.9, semantic: 0.8, recency: 0.7),
+                MemoryRecallCandidate(key: "mid", type: "fact", kind: "core", finalScore: 0.6, semantic: 0.5, recency: 0.4),
+            ]
+        )
+        let model = MessageInspectorMemoryTabModel(memoryRecall: recall)
+
+        XCTAssertEqual(model.candidates.count, 3)
+        XCTAssertEqual(model.candidates.map(\.key), ["high", "mid", "low"])
+        XCTAssertEqual(model.candidates[0].finalScore, "0.900")
+        XCTAssertEqual(model.candidates[0].semanticScore, "0.800")
+        XCTAssertEqual(model.candidates[0].recencyScore, "0.700")
+        XCTAssertEqual(model.candidates[0].type, "preference")
+        XCTAssertEqual(model.candidates[0].kind, "inferred")
+    }
+
+    func testEmptyCandidatesProducesEmptyArray() {
+        let recall = makeRecall(enabled: true, topCandidates: [])
+        let model = MessageInspectorMemoryTabModel(memoryRecall: recall)
+
+        XCTAssertTrue(model.candidates.isEmpty)
+    }
+
+    // MARK: - Enabled — injected text
+
+    func testInjectedTextPassedThrough() {
+        let recall = makeRecall(enabled: true, injectedText: "User prefers dark mode. Lives in SF.")
+        let model = MessageInspectorMemoryTabModel(memoryRecall: recall)
+
+        XCTAssertEqual(model.injectedText, "User prefers dark mode. Lives in SF.")
+    }
+
+    func testNilInjectedTextProducesNil() {
+        let recall = makeRecall(enabled: true, injectedText: nil)
+        let model = MessageInspectorMemoryTabModel(memoryRecall: recall)
+
+        XCTAssertNil(model.injectedText)
+    }
+
+    // MARK: - Enabled — degradation
+
+    func testDegradationCardPopulatedWhenPresent() {
+        let degradation = MemoryRecallDegradation(
+            semanticUnavailable: true,
+            reason: "Qdrant index not ready",
+            fallbackSources: ["recency", "frequency"]
+        )
+        let recall = makeRecall(enabled: true, degraded: true, degradation: degradation)
+        let model = MessageInspectorMemoryTabModel(memoryRecall: recall)
+
+        XCTAssertEqual(model.degradationReason, "Qdrant index not ready")
+        XCTAssertTrue(model.degradationSemanticUnavailable)
+        XCTAssertEqual(model.degradationFallbackSources, "recency, frequency")
+    }
+
+    func testNoDegradationLeavesFieldsNil() {
+        let recall = makeRecall(enabled: true, degraded: false, degradation: nil)
+        let model = MessageInspectorMemoryTabModel(memoryRecall: recall)
+
+        XCTAssertNil(model.degradationReason)
+        XCTAssertFalse(model.degradationSemanticUnavailable)
+        XCTAssertNil(model.degradationFallbackSources)
+    }
+
+    func testEmptyFallbackSourcesProducesNil() {
+        let degradation = MemoryRecallDegradation(
+            semanticUnavailable: false,
+            reason: "Timeout",
+            fallbackSources: []
+        )
+        let recall = makeRecall(enabled: true, degradation: degradation)
+        let model = MessageInspectorMemoryTabModel(memoryRecall: recall)
+
+        XCTAssertEqual(model.degradationReason, "Timeout")
+        XCTAssertNil(model.degradationFallbackSources)
+    }
+
+    // MARK: - Helpers
+
+    private func makeRecall(
+        enabled: Bool,
+        degraded: Bool = false,
+        provider: String? = "qdrant",
+        model: String? = "bge-m3",
+        degradation: MemoryRecallDegradation? = nil,
+        semanticHits: Int = 0,
+        mergedCount: Int = 0,
+        selectedCount: Int = 0,
+        tier1Count: Int = 0,
+        tier2Count: Int = 0,
+        hybridSearchLatencyMs: Int = 0,
+        sparseVectorUsed: Bool = false,
+        injectedTokens: Int = 0,
+        latencyMs: Int = 0,
+        reason: String? = nil,
+        topCandidates: [MemoryRecallCandidate] = [],
+        injectedText: String? = nil
+    ) -> MemoryRecallData {
+        MemoryRecallData(
+            enabled: enabled,
+            degraded: degraded,
+            provider: provider,
+            model: model,
+            degradation: degradation,
+            semanticHits: semanticHits,
+            mergedCount: mergedCount,
+            selectedCount: selectedCount,
+            tier1Count: tier1Count,
+            tier2Count: tier2Count,
+            hybridSearchLatencyMs: hybridSearchLatencyMs,
+            sparseVectorUsed: sparseVectorUsed,
+            injectedTokens: injectedTokens,
+            latencyMs: latencyMs,
+            reason: reason,
+            topCandidates: topCandidates,
+            injectedText: injectedText
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Replace stub MessageInspectorMemoryTab with full implementation
- Add status, retrieval funnel, search details, top candidates, injected text, and degradation cards
- Create MessageInspectorMemoryTabModel for display-ready data extraction
- Handle disabled, degraded, and no-data states
- Add tests

Part of plan: memory-inspector-tab.md (PR 8 of 8)