### PR TITLE
Persist memory recall data from agent loop and backfill messageId

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -25,6 +25,7 @@ import {
   backfillMessageIdOnLogs,
   recordRequestLog,
 } from "../memory/llm-request-log-store.js";
+import { backfillMemoryRecallLogMessageId } from "../memory/memory-recall-log-store.js";
 import type { ContentBlock, ImageContent } from "../providers/types.js";
 import type { DirectiveRequest } from "./assistant-attachments.js";
 import {
@@ -736,6 +737,15 @@ export async function handleMessageComplete(
     deps.rlog.warn(
       { err },
       "Failed to backfill message_id on LLM request logs (non-fatal)",
+    );
+  }
+
+  try {
+    backfillMemoryRecallLogMessageId(deps.ctx.conversationId, assistantMsg.id);
+  } catch (err) {
+    deps.rlog.warn(
+      { err },
+      "Failed to backfill message_id on memory recall log (non-fatal)",
     );
   }
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -47,6 +47,7 @@ import {
   rebuildConversationDiskViewFromDbState,
   syncMessageToDisk,
 } from "../memory/conversation-disk-view.js";
+import { recordMemoryRecallLog } from "../memory/memory-recall-log-store.js";
 import {
   isReplaceableTitle,
   queueGenerateConversationTitle,
@@ -612,6 +613,32 @@ export async function runAgentLoopImpl(
     );
 
     const { recall } = memoryResult;
+
+    try {
+      recordMemoryRecallLog({
+        conversationId: ctx.conversationId,
+        enabled: recall.enabled,
+        degraded: recall.degraded,
+        provider: recall.provider,
+        model: recall.model,
+        degradationJson: recall.degradation,
+        semanticHits: recall.semanticHits,
+        mergedCount: recall.mergedCount,
+        selectedCount: recall.selectedCount,
+        tier1Count: recall.tier1Count ?? 0,
+        tier2Count: recall.tier2Count ?? 0,
+        hybridSearchLatencyMs: recall.hybridSearchMs ?? 0,
+        sparseVectorUsed: recall.sparseVectorUsed ?? false,
+        injectedTokens: recall.injectedTokens,
+        latencyMs: recall.latencyMs,
+        topCandidatesJson: recall.topCandidates,
+        injectedText: recall.injectedText || undefined,
+        reason: recall.reason,
+      });
+    } catch (err) {
+      log.warn({ err }, "Failed to persist memory recall log (non-fatal)");
+    }
+
     runMessages = memoryResult.runMessages;
 
     // Build active surface context


### PR DESCRIPTION
## Summary
- Record memory recall metrics to memory_recall_logs after each turn
- Backfill messageId in handleMessageComplete alongside LLM request log backfill
- Fire-and-forget with try/catch to avoid breaking the agent loop

Part of plan: memory-inspector-tab.md (PR 4 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
