### PR TITLE
Extend LLM context endpoint to include memory recall data

### DIFF
--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -43,7 +43,9 @@ import {
   performConversationSearch,
 } from "../../daemon/handlers/conversation-history.js";
 import { deleteQueuedMessage } from "../../daemon/handlers/conversations.js";
+import { getAssistantMessageIdsInTurn } from "../../memory/conversation-crud.js";
 import { getRequestLogsByMessageId } from "../../memory/llm-request-log-store.js";
+import { getMemoryRecallLogByMessageIds } from "../../memory/memory-recall-log-store.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 import { normalizeLlmContextPayloads } from "./llm-context-normalization.js";
@@ -412,6 +414,9 @@ export function conversationQueryRouteDefinitions(
           return httpError("BAD_REQUEST", "message id is required", 400);
         }
         const logs = getRequestLogsByMessageId(messageId);
+        const turnMessageIds = getAssistantMessageIdsInTurn(messageId);
+        const memoryRecallLog =
+          getMemoryRecallLogByMessageIds(turnMessageIds);
         return Response.json({
           messageId,
           logs: logs.map((log) => {
@@ -444,6 +449,7 @@ export function conversationQueryRouteDefinitions(
               ...result,
             };
           }),
+          memoryRecall: memoryRecallLog ?? null,
         });
       },
     },


### PR DESCRIPTION
## Summary
- Add memoryRecall field to GET /v1/messages/:id/llm-context response
- Query memory_recall_logs by turn message IDs using getMemoryRecallLogByMessageIds
- Returns null for messages without recall data (backwards compatible)

Part of plan: memory-inspector-tab.md (PR 5 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
