### PR TITLE
fix: recover orphaned LLM request logs in context inspector

### DIFF
--- a/assistant/src/__tests__/llm-request-log-turn-query.test.ts
+++ b/assistant/src/__tests__/llm-request-log-turn-query.test.ts
@@ -41,6 +41,8 @@ mock.module("../config/loader.js", () => ({
   }),
 }));
 
+import { sql } from "drizzle-orm";
+
 import {
   addMessage,
   createConversation,
@@ -266,5 +268,67 @@ describe("getRequestLogsByMessageId — turn-aware query", () => {
     const firstTurnLogs = getRequestLogsByMessageId(a1.id);
     expect(firstTurnLogs).toHaveLength(1);
     expect(firstTurnLogs[0]?.messageId).toBe(a1.id);
+  });
+
+  test("recovers orphaned logs from deleted intermediate messages", () => {
+    // Simulate a turn where intermediate messages were deleted but logs remain.
+    // Use explicit timestamps via raw SQL to avoid timing-dependent flakes.
+    const T = 1_700_000_000_000;
+    const db = getDb();
+    const conv = createConversation("orphan-test");
+
+    // Insert messages with controlled timestamps via raw SQL.
+    db.run(
+      sql`INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('u1-o', ${conv.id}, 'user', '"Do the task"', ${T})`,
+    );
+    db.run(
+      sql`INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('a3-o', ${conv.id}, 'assistant', '"Done!"', ${T + 30000})`,
+    );
+
+    // Orphaned log 1: message_id points to a deleted message
+    db.insert(llmRequestLogs)
+      .values({
+        id: "log-orphan-1",
+        conversationId: conv.id,
+        messageId: "deleted-msg-A1",
+        provider: "anthropic",
+        requestPayload: '{"step":1}',
+        responsePayload: '{"tool":"bash"}',
+        createdAt: T + 5000,
+      })
+      .run();
+
+    // Orphaned log 2
+    db.insert(llmRequestLogs)
+      .values({
+        id: "log-orphan-2",
+        conversationId: conv.id,
+        messageId: "deleted-msg-A2",
+        provider: "anthropic",
+        requestPayload: '{"step":2}',
+        responsePayload: '{"tool":"file_write"}',
+        createdAt: T + 15_000,
+      })
+      .run();
+
+    // Surviving log: backfilled to the surviving assistant message
+    db.insert(llmRequestLogs)
+      .values({
+        id: "log-surviving",
+        conversationId: conv.id,
+        messageId: "a3-o",
+        provider: "anthropic",
+        requestPayload: '{"step":3}',
+        responsePayload: '{"text":"Done!"}',
+        createdAt: T + 29_000,
+      })
+      .run();
+
+    // Query from the surviving assistant message → should find all 3 logs
+    const logs = getRequestLogsByMessageId("a3-o");
+    expect(logs).toHaveLength(3);
+    expect(logs[0]?.id).toBe("log-orphan-1");
+    expect(logs[1]?.id).toBe("log-orphan-2");
+    expect(logs[2]?.id).toBe("log-surviving");
   });
 });

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -7,6 +7,7 @@ import {
   desc,
   eq,
   gt,
+  gte,
   inArray,
   isNull,
   lte,
@@ -1646,6 +1647,129 @@ function isToolResultMessage(role: string, content: string): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Returns the time boundaries (start/end `createdAt` values) for the turn
+ * containing the given message. The bounds span from the real user message
+ * that started the turn to just before the real user message that starts the
+ * next turn (or to the end of the conversation if this is the last turn).
+ *
+ * Also extends the end boundary to capture orphaned LLM request logs from
+ * deleted intermediate messages (e.g. removed by retry/deleteLastExchange).
+ *
+ * Returns null if the message is the only one in the conversation.
+ */
+export function getTurnTimeBounds(
+  conversationId: string,
+  messageCreatedAt: number,
+): { startTime: number; endTime: number } | null {
+  const db = getDb();
+
+  // Walk backward (by rowid, not just createdAt) to find the real user
+  // message that starts this turn.
+  const rowidSubquery = sql`(
+    SELECT rowid FROM messages
+    WHERE conversation_id = ${conversationId}
+      AND created_at <= ${messageCreatedAt}
+    ORDER BY rowid DESC LIMIT 1
+  )`;
+  const backwardRows = db
+    .select({
+      role: messages.role,
+      content: messages.content,
+      createdAt: messages.createdAt,
+    })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, conversationId),
+        sql`rowid <= ${rowidSubquery}`,
+      ),
+    )
+    .orderBy(sql`rowid DESC`)
+    .limit(50)
+    .all();
+
+  let startTime = messageCreatedAt;
+  for (const row of backwardRows) {
+    if (row.role === "user" && !isToolResultMessage(row.role, row.content)) {
+      startTime = row.createdAt;
+      break;
+    }
+  }
+
+  // Walk forward (by rowid) to find the next real user message.
+  const forwardRowidSubquery = sql`(
+    SELECT rowid FROM messages
+    WHERE conversation_id = ${conversationId}
+      AND created_at >= ${messageCreatedAt}
+    ORDER BY rowid DESC LIMIT 1
+  )`;
+  const forwardRows = db
+    .select({
+      role: messages.role,
+      content: messages.content,
+      createdAt: messages.createdAt,
+    })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, conversationId),
+        sql`rowid > ${forwardRowidSubquery}`,
+      ),
+    )
+    .orderBy(sql`rowid ASC`)
+    .limit(50)
+    .all();
+
+  let endTime = messageCreatedAt;
+  let nextTurnStart: number | null = null;
+  for (const row of forwardRows) {
+    if (row.role === "user" && !isToolResultMessage(row.role, row.content)) {
+      nextTurnStart = row.createdAt;
+      break;
+    }
+    endTime = row.createdAt;
+  }
+
+  // When the next turn start has a strictly greater timestamp, use it minus
+  // 1ms as the hard upper bound. When timestamps collide (e.g. in tests),
+  // don't extend — the message-ID-based query is authoritative.
+  if (nextTurnStart != null && nextTurnStart > endTime) {
+    endTime = nextTurnStart - 1;
+  }
+
+  // Extend end boundary to the latest log that falls within the turn window.
+  // Orphaned logs from deleted intermediate messages may have timestamps
+  // beyond any surviving message. Cap at 30 minutes to avoid sweeping in
+  // logs from a much later turn.
+  const MAX_TURN_DURATION_MS = 30 * 60 * 1000;
+  const hardCeiling = nextTurnStart != null && nextTurnStart > startTime
+    ? nextTurnStart - 1
+    : startTime + MAX_TURN_DURATION_MS;
+
+  if (hardCeiling > endTime) {
+    const latestLog = db
+      .select({ createdAt: llmRequestLogs.createdAt })
+      .from(llmRequestLogs)
+      .where(
+        and(
+          eq(llmRequestLogs.conversationId, conversationId),
+          gte(llmRequestLogs.createdAt, startTime),
+          lte(llmRequestLogs.createdAt, hardCeiling),
+        ),
+      )
+      .orderBy(desc(llmRequestLogs.createdAt))
+      .limit(1)
+      .get();
+
+    if (latestLog && latestLog.createdAt > endTime) {
+      endTime = latestLog.createdAt;
+    }
+  }
+
+  return { startTime, endTime };
 }
 
 /**

--- a/assistant/src/memory/llm-request-log-store.ts
+++ b/assistant/src/memory/llm-request-log-store.ts
@@ -1,13 +1,24 @@
-import { and, eq, gte, inArray, isNull, lte } from "drizzle-orm";
+import { and, eq, gte, inArray, isNull, lte, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import {
   getAssistantMessageIdsInTurn,
   getMessageById,
+  getTurnTimeBounds,
   messageMetadataSchema,
 } from "./conversation-crud.js";
 import { getDb } from "./db.js";
-import { llmRequestLogs } from "./schema.js";
+import { llmRequestLogs, messages } from "./schema.js";
+
+type LogRow = {
+  id: string;
+  conversationId: string;
+  messageId: string | null;
+  provider: string | null;
+  requestPayload: string;
+  responsePayload: string;
+  createdAt: number;
+};
 
 export function recordRequestLog(
   conversationId: string,
@@ -77,15 +88,7 @@ export function backfillMessageIdOnLogs(
  * given message IDs, ordered by `createdAt ASC`. Uses the existing
  * `idx_llm_request_logs_message_id` index via `inArray`.
  */
-function selectLogsByMessageIds(messageIds: string[]): Array<{
-  id: string;
-  conversationId: string;
-  messageId: string | null;
-  provider: string | null;
-  requestPayload: string;
-  responsePayload: string;
-  createdAt: number;
-}> {
+function selectLogsByMessageIds(messageIds: string[]): LogRow[] {
   if (messageIds.length === 0) return [];
   const db = getDb();
   return db
@@ -104,26 +107,90 @@ function selectLogsByMessageIds(messageIds: string[]): Array<{
     .all();
 }
 
-export function getRequestLogsByMessageId(messageId: string): Array<{
-  id: string;
-  conversationId: string;
-  messageId: string | null;
-  provider: string | null;
-  requestPayload: string;
-  responsePayload: string;
-  createdAt: number;
-}> {
+/**
+ * Find orphaned logs — logs whose `message_id` references a message that no
+ * longer exists in the DB. These are left behind when intermediate assistant
+ * messages are deleted (e.g. by retry/deleteLastExchange).
+ *
+ * Scoped to a single conversation and a time range to avoid cross-turn bleed.
+ */
+function selectOrphanedLogsInRange(
+  conversationId: string,
+  startTime: number,
+  endTime: number,
+): LogRow[] {
+  if (endTime <= startTime) return [];
+  const db = getDb();
+  // LEFT JOIN messages → filter where message row IS NULL (orphaned).
+  return db
+    .select({
+      id: llmRequestLogs.id,
+      conversationId: llmRequestLogs.conversationId,
+      messageId: llmRequestLogs.messageId,
+      provider: llmRequestLogs.provider,
+      requestPayload: llmRequestLogs.requestPayload,
+      responsePayload: llmRequestLogs.responsePayload,
+      createdAt: llmRequestLogs.createdAt,
+    })
+    .from(llmRequestLogs)
+    .leftJoin(messages, eq(llmRequestLogs.messageId, messages.id))
+    .where(
+      and(
+        eq(llmRequestLogs.conversationId, conversationId),
+        gte(llmRequestLogs.createdAt, startTime),
+        lte(llmRequestLogs.createdAt, endTime),
+        sql`${messages.id} IS NULL`,
+        sql`${llmRequestLogs.messageId} IS NOT NULL`,
+      ),
+    )
+    .orderBy(llmRequestLogs.createdAt)
+    .all();
+}
+
+export function getRequestLogsByMessageId(messageId: string): LogRow[] {
   // Resolve all assistant message IDs in the same turn so the inspector
   // shows every LLM call from the entire agent turn, not just the queried message.
   const turnMessageIds = getAssistantMessageIdsInTurn(messageId);
   const turnLogs = selectLogsByMessageIds(turnMessageIds);
+
+  // Orphaned-log recovery: intermediate assistant messages within a turn can
+  // be deleted (e.g. by retry / deleteLastExchange) while their
+  // llm_request_logs rows survive. When that happens the message-ID-based
+  // query misses those logs. We detect orphaned logs (logs whose message_id
+  // references a deleted message) within the turn's time window and merge
+  // them with the message-ID-based results.
+  const message = getMessageById(messageId);
+  if (message) {
+    const bounds = getTurnTimeBounds(message.conversationId, message.createdAt);
+    if (bounds) {
+      const orphanedLogs = selectOrphanedLogsInRange(
+        message.conversationId,
+        bounds.startTime,
+        bounds.endTime,
+      );
+      if (orphanedLogs.length > 0) {
+        const seen = new Set(turnLogs.map((l) => l.id));
+        const merged = [...turnLogs];
+        for (const log of orphanedLogs) {
+          if (!seen.has(log.id)) {
+            merged.push(log);
+            seen.add(log.id);
+          }
+        }
+        merged.sort(
+          (a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id),
+        );
+        return merged;
+      }
+    }
+  }
+
   if (turnLogs.length > 0) {
     return turnLogs;
   }
 
   // Fork-source fallback: if no logs found for the turn, check whether
   // the queried message was forked from a source and resolve that source's turn.
-  const message = getMessageById(messageId);
   if (!message?.metadata) {
     return [];
   }


### PR DESCRIPTION
## Summary
- **Root cause**: intermediate assistant messages from tool-use turns get deleted (via retry/deleteLastExchange) but their `llm_request_logs` entries survive with `message_id` pointing to non-existent messages. The inspector only found logs for surviving messages, showing only the final LLM call.
- **Fix**: added orphaned-log recovery in `getRequestLogsByMessageId` — uses a LEFT JOIN to detect logs whose `message_id` references a deleted message, scoped within the turn's time bounds via new `getTurnTimeBounds()` helper.
- **Test**: added "recovers orphaned logs from deleted intermediate messages" test with deterministic timestamps verifying all 3 logs (2 orphaned + 1 surviving) are returned.

## Test plan
- [x] Existing tests pass: `bun test src/__tests__/llm-request-log-turn-query.test.ts` (5 pass)
- [x] Route tests pass: `bun test src/__tests__/llm-context-route-provider.test.ts` (4 pass)
- [x] Normalization tests pass: `bun test src/__tests__/llm-context-normalization.test.ts` (14 pass)
- [x] Type-check clean: `bunx tsc --noEmit`
- [x] Lint clean: `bun run lint`
- [x] Verified against production DB: conversations with deleted intermediate messages now return all LLM logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
