### PR TITLE
fix: sort imports in conversation-agent-loop.ts

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -47,13 +47,13 @@ import {
   rebuildConversationDiskViewFromDbState,
   syncMessageToDisk,
 } from "../memory/conversation-disk-view.js";
-import { recordMemoryRecallLog } from "../memory/memory-recall-log-store.js";
 import {
   isReplaceableTitle,
   queueGenerateConversationTitle,
   queueRegenerateConversationTitle,
   UNTITLED_FALLBACK,
 } from "../memory/conversation-title-service.js";
+import { recordMemoryRecallLog } from "../memory/memory-recall-log-store.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import type { Provider } from "../providers/types.js";


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `conversation-agent-loop.ts` by reordering the `recordMemoryRecallLog` import to its alphabetically correct position

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23519339713/job/68459045426