### PR TITLE
fix: transform memory recall log to API-compatible shape

### DIFF
--- a/assistant/src/__tests__/memory-recall-log-store.test.ts
+++ b/assistant/src/__tests__/memory-recall-log-store.test.ts
@@ -98,26 +98,23 @@ describe("memory-recall-log-store", () => {
 
     const result = getMemoryRecallLogByMessageIds([messageId]);
     expect(result).not.toBeNull();
-    expect(result!.conversationId).toBe(conversationId);
-    expect(result!.messageId).toBe(messageId);
-    expect(result!.enabled).toBe(1);
-    expect(result!.degraded).toBe(0);
+    expect(result!.enabled).toBe(true);
+    expect(result!.degraded).toBe(false);
     expect(result!.provider).toBe("anthropic");
     expect(result!.model).toBe("claude-sonnet");
-    expect(result!.degradationJson).toEqual({ reason: "none" });
+    expect(result!.degradation).toEqual({ reason: "none" });
     expect(result!.semanticHits).toBe(5);
     expect(result!.mergedCount).toBe(3);
     expect(result!.selectedCount).toBe(2);
     expect(result!.tier1Count).toBe(1);
     expect(result!.tier2Count).toBe(1);
     expect(result!.hybridSearchLatencyMs).toBe(150);
-    expect(result!.sparseVectorUsed).toBe(1);
+    expect(result!.sparseVectorUsed).toBe(true);
     expect(result!.injectedTokens).toBe(500);
     expect(result!.latencyMs).toBe(200);
-    expect(result!.topCandidatesJson).toEqual([{ id: "c1", score: 0.9 }]);
+    expect(result!.topCandidates).toEqual([{ id: "c1", score: 0.9 }]);
     expect(result!.injectedText).toBe("some memory context");
     expect(result!.reason).toBe("user query matched memories");
-    expect(result!.createdAt).toBeGreaterThan(0);
   });
 
   test("returns null when no log exists for a messageId", () => {
@@ -175,13 +172,11 @@ describe("memory-recall-log-store", () => {
     // Verify first log still has msg-a
     const firstLog = getMemoryRecallLogByMessageIds(["msg-a"]);
     expect(firstLog).not.toBeNull();
-    expect(firstLog!.messageId).toBe("msg-a");
-    expect(firstLog!.degraded).toBe(0);
+    expect(firstLog!.degraded).toBe(false);
 
     // Verify second log has msg-b
     const secondLog = getMemoryRecallLogByMessageIds(["msg-b"]);
     expect(secondLog).not.toBeNull();
-    expect(secondLog!.messageId).toBe("msg-b");
-    expect(secondLog!.degraded).toBe(1);
+    expect(secondLog!.degraded).toBe(true);
   });
 });

--- a/assistant/src/memory/memory-recall-log-store.ts
+++ b/assistant/src/memory/memory-recall-log-store.ts
@@ -72,33 +72,29 @@ export function backfillMemoryRecallLogMessageId(
     .run();
 }
 
-export interface MemoryRecallLogRow {
-  id: string;
-  conversationId: string;
-  messageId: string | null;
-  enabled: number;
-  degraded: number;
+export interface MemoryRecallLog {
+  enabled: boolean;
+  degraded: boolean;
   provider: string | null;
   model: string | null;
-  degradationJson: unknown | null;
+  degradation: unknown | null;
   semanticHits: number;
   mergedCount: number;
   selectedCount: number;
   tier1Count: number;
   tier2Count: number;
   hybridSearchLatencyMs: number;
-  sparseVectorUsed: number;
+  sparseVectorUsed: boolean;
   injectedTokens: number;
   latencyMs: number;
-  topCandidatesJson: unknown;
+  topCandidates: unknown;
   injectedText: string | null;
   reason: string | null;
-  createdAt: number;
 }
 
 export function getMemoryRecallLogByMessageIds(
   messageIds: string[],
-): MemoryRecallLogRow | null {
+): MemoryRecallLog | null {
   if (messageIds.length === 0) return null;
   const db = getDb();
   const rows = db
@@ -109,10 +105,24 @@ export function getMemoryRecallLogByMessageIds(
   if (rows.length === 0) return null;
   const row = rows[0]!;
   return {
-    ...row,
-    degradationJson: row.degradationJson
+    enabled: !!row.enabled,
+    degraded: !!row.degraded,
+    provider: row.provider,
+    model: row.model,
+    degradation: row.degradationJson
       ? JSON.parse(row.degradationJson)
       : null,
-    topCandidatesJson: JSON.parse(row.topCandidatesJson),
+    semanticHits: row.semanticHits,
+    mergedCount: row.mergedCount,
+    selectedCount: row.selectedCount,
+    tier1Count: row.tier1Count,
+    tier2Count: row.tier2Count,
+    hybridSearchLatencyMs: row.hybridSearchLatencyMs,
+    sparseVectorUsed: !!row.sparseVectorUsed,
+    injectedTokens: row.injectedTokens,
+    latencyMs: row.latencyMs,
+    topCandidates: JSON.parse(row.topCandidatesJson),
+    injectedText: row.injectedText,
+    reason: row.reason,
   };
 }


### PR DESCRIPTION
## Summary
Fixes wire-format mismatch between the memory recall log store and the Swift client model.

**Gap:** API returns raw DB row with integer booleans and *Json field names
**What was expected:** JSON matching Swift MemoryRecallData with boolean true/false and proper field names
**What was found:** Raw row with enabled: 1, degradationJson, topCandidatesJson that breaks Swift JSONDecoder