### PR TITLE
fix: animate drawer offset transition and prevent VSplitView layout jitter

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1232,6 +1232,7 @@ struct MainWindowView: View {
             )
             .frame(width: drawerWidth)
             .offset(x: 16 + VSpacing.sm, y: -drawerY)
+            .animation(VAnimation.snappy, value: sidebarExpanded)
             .zIndex(10)
             .transition(.scale(scale: 0.96, anchor: .bottom).combined(with: .opacity))
         }

--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -27,6 +27,7 @@ public struct VSplitView<Main: View, Panel: View>: View {
                     .clipShape(RoundedRectangle(cornerRadius: mainCornerRadius ?? VRadius.lg))
                     .padding([.bottom, .leading], VSpacing.xs)
                     .padding(.trailing, showPanel ? 0 : VSpacing.xs)
+                    .animation(nil, value: showPanel)  // Don't animate main pane resize
 
                 // Panel slides in from right, pushing content
                 if showPanel, let panel = panel {


### PR DESCRIPTION
## Summary
- Adds animation to drawer offset for smooth sidebar state transitions
- Adds .animation(nil, value: showPanel) to VSplitView main pane to prevent resize interpolation
- Panel slide-in/out still animates via HStack-level animation

Part of plan: scroll-layout-jitter.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
