### PR TITLE
fix: remove parent animation modifier that causes layout interpolation during view switches

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1106,15 +1106,18 @@ struct MainWindowView: View {
             topBarView
 
             // Main container: sidebar + content with uniform padding
-            HStack(spacing: 16) {
-                if !isSettingsOpen {
-                    sidebarView
-                        .animation(VAnimation.panel, value: sidebarExpanded)
-                }
+            HStack(spacing: 0) {
+                sidebarView
+                    .frame(width: isSettingsOpen ? 0 : (sidebarExpanded ? sidebarExpandedWidth : sidebarCollapsedWidth))
+                    .clipped()
+                    .opacity(isSettingsOpen ? 0 : 1)
+                    .allowsHitTesting(!isSettingsOpen)
+                    .animation(VAnimation.panel, value: sidebarExpanded)
+                    .animation(VAnimation.panel, value: isSettingsOpen)
+                    .padding(.trailing, isSettingsOpen ? 0 : 16)
 
                 chatContentView(geometry: geometry)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
-                    .animation(VAnimation.panel, value: sidebarExpanded)
                     .overlay {
                         assistantLoadingOverlayIfNeeded
                     }


### PR DESCRIPTION
## Summary
- Removes .animation(VAnimation.panel, value: sidebarExpanded) from chatContentView — was causing layout interpolation during view switches
- Replaces conditional sidebar removal with width-based hide using explicit widths
- Changes HStack spacing to 0 with explicit padding to avoid 16pt discrepancy

Part of plan: scroll-layout-jitter.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
