### PR TITLE
perf: move scroll detection @State to non-reactive ScrollTrackingState

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -59,6 +59,18 @@ extension EnvironmentValues {
     var lastKnownLastMessageStreaming: Bool = false
     /// Cached count of incomplete tool calls across all messages.
     var lastKnownIncompleteToolCallCount: Int = 0
+
+    // MARK: - Scroll Geometry (non-reactive, updated every scroll tick)
+
+    /// Content height from scroll geometry, used to guard against false
+    /// detaches on short conversations that can't scroll.
+    var scrollContentHeight: CGFloat = 0
+    /// Container (viewport) height from scroll geometry, used alongside
+    /// scrollContentHeight to determine if content is scrollable.
+    var scrollContainerHeight: CGFloat = 0
+    /// Last content offset Y observed by onScrollGeometryChange, used to
+    /// determine scroll direction (increasing offset = scrolling toward older content).
+    var lastScrollContentOffsetY: CGFloat = 0
 }
 
 /// Lightweight key that captures all inputs to `precomputedState`.
@@ -169,15 +181,6 @@ struct MessageListView: View {
     /// Only `.interacting` (direct user gesture) triggers detach — `.decelerating`
     /// (momentum/inertia) is intentionally ignored.
     @State private var scrollPhase: ScrollPhase = .idle
-    /// Last content offset Y observed by onScrollGeometryChange, used to
-    /// determine scroll direction (increasing offset = scrolling toward older content).
-    @State private var lastScrollContentOffsetY: CGFloat = 0
-    /// Content height from scroll geometry, used to guard against false
-    /// detaches on short conversations that can't scroll.
-    @State private var scrollContentHeight: CGFloat = 0
-    /// Container (viewport) height from scroll geometry, used alongside
-    /// scrollContentHeight to determine if content is scrollable.
-    @State private var scrollContainerHeight: CGFloat = 0
 
     /// The subset of messages actually shown, honoring the pagination window.
     /// Uses the shared `ChatVisibleMessageFilter` so hidden automated messages
@@ -776,11 +779,12 @@ struct MessageListView: View {
                     containerHeight: geometry.containerSize.height
                 )
             } action: { _, newState in
+                let tracking = scrollCoordinator.scrollTracking
                 let isScrollable = newState.contentHeight > newState.containerHeight
-                let isScrollingUp = newState.contentOffsetY < lastScrollContentOffsetY
-                scrollContentHeight = newState.contentHeight
-                scrollContainerHeight = newState.containerHeight
-                lastScrollContentOffsetY = newState.contentOffsetY
+                let isScrollingUp = newState.contentOffsetY < tracking.lastScrollContentOffsetY
+                tracking.scrollContentHeight = newState.contentHeight
+                tracking.scrollContainerHeight = newState.containerHeight
+                tracking.lastScrollContentOffsetY = newState.contentOffsetY
 
                 // Only detach on direct user gesture (interacting), not momentum.
                 // Only detach when content is scrollable (prevents false detaches


### PR DESCRIPTION
## Summary
- Moves scrollContentHeight, scrollContainerHeight, lastScrollContentOffsetY from @State to non-reactive ScrollTrackingState
- Eliminates per-frame @State mutations during scroll that triggered unnecessary view re-evaluations

Part of plan: scroll-layout-jitter.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
