### PR TITLE
fix: introduce BottomVisibilityPolicy with hysteresis to prevent anchorIsVisible toggle jitter

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/BottomVisibilityPolicy.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/BottomVisibilityPolicy.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Centralizes the bottom-visibility decision with hysteresis to prevent
+/// rapid `anchorIsVisible` toggling during scroll.
+///
+/// The enter/leave thresholds create a 10pt dead zone (20–30pt) where the
+/// visibility state is sticky — it stays in whichever state it was already in.
+/// This prevents the "Scroll to latest" button from flickering when the user
+/// scrolls near the bottom boundary.
+enum BottomVisibilityPolicy {
+    /// Threshold to ENTER visible state (must be ≤ this to become visible)
+    static let enterThreshold: CGFloat = 20
+    /// Threshold to LEAVE visible state (must be > this to become invisible)
+    static let leaveThreshold: CGFloat = 30
+
+    /// Returns the new visibility state given the current state and distance.
+    static func evaluate(currentlyVisible: Bool, distanceFromBottom: CGFloat) -> Bool {
+        if currentlyVisible {
+            return distanceFromBottom >= -leaveThreshold && distanceFromBottom <= leaveThreshold
+        } else {
+            return distanceFromBottom >= -enterThreshold && distanceFromBottom <= enterThreshold
+        }
+    }
+
+    /// Whether the user is close enough to bottom for auto-reattach on idle,
+    /// independent of the hysteresis state. Used by onScrollPhaseChange to
+    /// re-tether when the user stops scrolling near the bottom.
+    static func isNearEnoughForReattach(distanceFromBottom: CGFloat) -> Bool {
+        distanceFromBottom >= -leaveThreshold && distanceFromBottom <= leaveThreshold
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
@@ -206,7 +206,10 @@ final class MessageListScrollCoordinator: ObservableObject {
     /// distance is at most 20pt.
     func updateAnchor(distanceFromBottom: CGFloat, viewportHeight: CGFloat) {
         anchorLastMinY = distanceFromBottom
-        let newVisible = distanceFromBottom >= -20 && distanceFromBottom <= 20
+        let newVisible = BottomVisibilityPolicy.evaluate(
+            currentlyVisible: anchorIsVisible,
+            distanceFromBottom: distanceFromBottom
+        )
         if anchorIsVisible != newVisible { anchorIsVisible = newVisible }
     }
 
@@ -222,7 +225,10 @@ final class MessageListScrollCoordinator: ObservableObject {
         // evaluates to false, incorrectly flipping anchorIsVisible to false and
         // flashing the "Scroll to latest" button on short conversations.
         guard anchorLastMinY.isFinite else { return true }
-        let newVisible = anchorLastMinY >= -20 && anchorLastMinY <= 20
+        let newVisible = BottomVisibilityPolicy.evaluate(
+            currentlyVisible: anchorIsVisible,
+            distanceFromBottom: anchorLastMinY
+        )
         if anchorIsVisible != newVisible { anchorIsVisible = newVisible }
         return true
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -760,12 +760,14 @@ struct MessageListView: View {
             })
             .onScrollPhaseChange { oldPhase, newPhase in
                 scrollPhase = newPhase
-                if newPhase == .idle && oldPhase != .idle && scrollCoordinator.anchorIsVisible {
+                if newPhase == .idle && oldPhase != .idle
+                    && BottomVisibilityPolicy.isNearEnoughForReattach(
+                        distanceFromBottom: scrollCoordinator.anchorLastMinY
+                    ) {
                     // User finished scrolling and ended up near the bottom — re-tether.
-                    // Uses anchorIsVisible (geometry-derived) instead of isNearBottom
-                    // to break the circular dependency: isNearBottom is only set by
-                    // handleScrollToBottom(), so checking it here would prevent
-                    // users from re-tethering by scrolling back to the bottom.
+                    // Uses distance-based check instead of anchorIsVisible to avoid
+                    // hysteresis dead zone: a user at 21-30pt who is currently invisible
+                    // should still reattach when they stop scrolling.
                     scrollCoordinator.handleScrollToBottom()
                 }
             }
@@ -861,9 +863,7 @@ struct MessageListView: View {
                     .padding(.bottom, ConversationAvatarFollower.verticalOffset)
             }
             .overlay(alignment: .bottom) {
-                if !isNearBottom && !scrollCoordinator.anchorIsVisible
-                    && scrollCoordinator.anchorLastMinY > 20
-                {
+                if !isNearBottom && !scrollCoordinator.anchorIsVisible {
                     Button(action: {
                         os_signpost(.event, log: PerfSignposts.log, name: "scrollToLatestPressed")
                         scrollCoordinator.hasReceivedScrollEvent = true

--- a/clients/macos/vellum-assistantTests/BottomVisibilityPolicyTests.swift
+++ b/clients/macos/vellum-assistantTests/BottomVisibilityPolicyTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Testing
+@testable import VellumAssistantLib
+
+@Suite("BottomVisibilityPolicy")
+struct BottomVisibilityPolicyTests {
+
+    @Test("enters visible state when distance ≤ enterThreshold (20pt)")
+    func testEnterVisibleFromInvisible() {
+        // Currently invisible — should enter visible at exactly 20pt
+        #expect(BottomVisibilityPolicy.evaluate(currentlyVisible: false, distanceFromBottom: 20) == true)
+        #expect(BottomVisibilityPolicy.evaluate(currentlyVisible: false, distanceFromBottom: 15) == true)
+        #expect(BottomVisibilityPolicy.evaluate(currentlyVisible: false, distanceFromBottom: 0) == true)
+        // Should NOT enter visible above enterThreshold
+        #expect(BottomVisibilityPolicy.evaluate(currentlyVisible: false, distanceFromBottom: 21) == false)
+        #expect(BottomVisibilityPolicy.evaluate(currentlyVisible: false, distanceFromBottom: 25) == false)
+    }
+
+    @Test("leaves visible state when distance > leaveThreshold (30pt)")
+    func testLeaveVisibleFromVisible() {
+        // Currently visible — should stay visible up to 30pt
+        #expect(BottomVisibilityPolicy.evaluate(currentlyVisible: true, distanceFromBottom: 30) == true)
+        #expect(BottomVisibilityPolicy.evaluate(currentlyVisible: true, distanceFromBottom: 25) == true)
+        #expect(BottomVisibilityPolicy.evaluate(currentlyVisible: true, distanceFromBottom: 0) == true)
+        // Should leave visible above leaveThreshold
+        #expect(BottomVisibilityPolicy.evaluate(currentlyVisible: true, distanceFromBottom: 31) == false)
+        #expect(BottomVisibilityPolicy.evaluate(currentlyVisible: true, distanceFromBottom: 50) == false)
+    }
+
+    @Test("hysteresis gap: state is sticky in 20-30pt band")
+    func testHysteresisGap() {
+        // At 25pt: if currently visible, stays visible
+        #expect(BottomVisibilityPolicy.evaluate(currentlyVisible: true, distanceFromBottom: 25) == true)
+        // At 25pt: if currently invisible, stays invisible
+        #expect(BottomVisibilityPolicy.evaluate(currentlyVisible: false, distanceFromBottom: 25) == false)
+
+        // At 20pt boundary: invisible → visible (enters)
+        #expect(BottomVisibilityPolicy.evaluate(currentlyVisible: false, distanceFromBottom: 20) == true)
+        // At 30pt boundary: visible → still visible (hasn't left yet)
+        #expect(BottomVisibilityPolicy.evaluate(currentlyVisible: true, distanceFromBottom: 30) == true)
+    }
+
+    @Test("handles negative distances correctly")
+    func testNegativeDistances() {
+        // Negative distances within thresholds (content overscrolled past bottom)
+        #expect(BottomVisibilityPolicy.evaluate(currentlyVisible: false, distanceFromBottom: -15) == true)
+        #expect(BottomVisibilityPolicy.evaluate(currentlyVisible: false, distanceFromBottom: -20) == true)
+        #expect(BottomVisibilityPolicy.evaluate(currentlyVisible: false, distanceFromBottom: -21) == false)
+        #expect(BottomVisibilityPolicy.evaluate(currentlyVisible: true, distanceFromBottom: -25) == true)
+        #expect(BottomVisibilityPolicy.evaluate(currentlyVisible: true, distanceFromBottom: -30) == true)
+        #expect(BottomVisibilityPolicy.evaluate(currentlyVisible: true, distanceFromBottom: -31) == false)
+    }
+
+    @Test("boundary oscillation around 25pt causes at most 1 state change")
+    func testBoundaryOscillation() {
+        // Simulate rapid oscillation around 25pt starting from visible
+        var isVisible = true
+        var stateChanges = 0
+        let distances: [CGFloat] = [25, 24, 26, 25, 23, 27, 25, 24, 26, 25]
+
+        for distance in distances {
+            let newVisible = BottomVisibilityPolicy.evaluate(
+                currentlyVisible: isVisible,
+                distanceFromBottom: distance
+            )
+            if newVisible != isVisible {
+                stateChanges += 1
+                isVisible = newVisible
+            }
+        }
+
+        // All distances are in the 20-30pt hysteresis band, so starting from
+        // visible the state should never change (stays visible the whole time).
+        #expect(stateChanges <= 1)
+    }
+
+    @Test("invisible at 25pt after scrolling past 30pt: anchorIsVisible is false, isNearEnoughForReattach is true")
+    func testInvisibleScrollBackTo25WhileDetached() {
+        // Sequence: visible → scroll past 30 → invisible → scroll back to 25
+        var isVisible = true
+
+        // Step 1: at 0pt, visible
+        isVisible = BottomVisibilityPolicy.evaluate(currentlyVisible: isVisible, distanceFromBottom: 0)
+        #expect(isVisible == true)
+
+        // Step 2: scroll past 30pt → becomes invisible
+        isVisible = BottomVisibilityPolicy.evaluate(currentlyVisible: isVisible, distanceFromBottom: 35)
+        #expect(isVisible == false)
+
+        // Step 3: scroll back to 25pt — still invisible due to hysteresis
+        isVisible = BottomVisibilityPolicy.evaluate(currentlyVisible: isVisible, distanceFromBottom: 25)
+        #expect(isVisible == false)
+
+        // But isNearEnoughForReattach says yes (within leaveThreshold of 30pt)
+        #expect(BottomVisibilityPolicy.isNearEnoughForReattach(distanceFromBottom: 25) == true)
+
+        // CTA condition: !isNearBottom && !anchorIsVisible → would show the button
+        // (isNearBottom would be false since we haven't reattached)
+        let isNearBottom = false // not reattached yet
+        let ctaVisible = !isNearBottom && !isVisible
+        #expect(ctaVisible == true)
+    }
+
+    @Test("after idle reattach at 25pt, CTA disappears")
+    func testInvisibleScrollBackTo25ThenIdle() {
+        // Setup: same as above — invisible at 25pt
+        var isVisible = true
+        isVisible = BottomVisibilityPolicy.evaluate(currentlyVisible: isVisible, distanceFromBottom: 0)
+        isVisible = BottomVisibilityPolicy.evaluate(currentlyVisible: isVisible, distanceFromBottom: 35)
+        isVisible = BottomVisibilityPolicy.evaluate(currentlyVisible: isVisible, distanceFromBottom: 25)
+        #expect(isVisible == false)
+
+        // Pre-idle state: CTA visible, reattach pending
+        let preIdleIsNearBottom = false
+        let preIdleCta = !preIdleIsNearBottom && !isVisible
+        #expect(preIdleCta == true)
+        #expect(BottomVisibilityPolicy.isNearEnoughForReattach(distanceFromBottom: 25) == true)
+
+        // Simulate idle reattach: handleScrollToBottom() fires, sets isNearBottom = true
+        // and scrolls to 0, making anchorIsVisible = true
+        let postIdleIsNearBottom = true
+        isVisible = BottomVisibilityPolicy.evaluate(currentlyVisible: isVisible, distanceFromBottom: 0)
+        #expect(isVisible == true)
+
+        // Post-idle state: CTA hidden
+        let postIdleCta = !postIdleIsNearBottom && !isVisible
+        #expect(postIdleCta == false)
+    }
+}


### PR DESCRIPTION
## Summary
- Introduces BottomVisibilityPolicy with 20/30pt hysteresis to prevent rapid anchorIsVisible toggling during scroll
- Fixes reattach-on-idle to use distance-based check (isNearEnoughForReattach) instead of anchorIsVisible
- Simplifies CTA button condition — no hardcoded threshold, no dead zone
- Adds 7 regression tests including invisible-path scenario

Part of plan: scroll-layout-jitter.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21359" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
