### PR TITLE
perf: consolidate scroll geometry handlers to reduce per-frame callback overhead

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -88,12 +88,13 @@ struct PrecomputedCacheKey: Equatable {
 }
 
 /// Lightweight snapshot of scroll geometry for the onScrollGeometryChange
-/// handler. Captures only the values needed for scroll-direction and
-/// scrollable-content detection.
-private struct ScrollDetectionState: Equatable {
+/// handler. Captures values needed for scroll-direction detection,
+/// scrollable-content detection, and viewport height tracking.
+private struct ScrollGeometrySnapshot: Equatable {
     let contentOffsetY: CGFloat
     let contentHeight: CGFloat
     let containerHeight: CGFloat
+    let visibleRectHeight: CGFloat
 }
 
 struct MessageListView: View {
@@ -774,13 +775,15 @@ struct MessageListView: View {
                     scrollCoordinator.handleScrollToBottom()
                 }
             }
-            .onScrollGeometryChange(for: ScrollDetectionState.self) { geometry in
-                ScrollDetectionState(
+            .onScrollGeometryChange(for: ScrollGeometrySnapshot.self) { geometry in
+                ScrollGeometrySnapshot(
                     contentOffsetY: geometry.contentOffset.y,
                     contentHeight: geometry.contentSize.height,
-                    containerHeight: geometry.containerSize.height
+                    containerHeight: geometry.containerSize.height,
+                    visibleRectHeight: geometry.visibleRect.height
                 )
             } action: { _, newState in
+                // --- Scroll direction detection ---
                 let tracking = scrollCoordinator.scrollTracking
                 let isScrollable = newState.contentHeight > newState.containerHeight
                 let isScrollingUp = newState.contentOffsetY < tracking.lastScrollContentOffsetY
@@ -794,17 +797,14 @@ struct MessageListView: View {
                 if scrollPhase == .interacting && isScrollingUp && isScrollable {
                     scrollCoordinator.handleScrollUp()
                 }
-            }
-            .scrollIndicators(.automatic)
-            .onScrollGeometryChange(for: CGFloat.self) { geo in
-                geo.visibleRect.height
-            } action: { _, newHeight in
+
+                // --- Viewport height update ---
                 // Filter non-finite viewport heights and sub-pixel jitter.
                 // A 0.5pt dead-zone prevents floating-point rounding differences
                 // between render passes from triggering continuous @State mutations
                 // (scrollViewportHeight) which would create a runaway render loop.
                 let decision = PreferenceGeometryFilter.evaluate(
-                    newValue: newHeight,
+                    newValue: newState.visibleRectHeight,
                     previous: scrollViewportHeight,
                     deadZone: 0.5
                 )
@@ -816,6 +816,7 @@ struct MessageListView: View {
                 )
                 os_signpost(.end, log: PerfSignposts.log, name: "viewportHeightChanged")
             }
+            .scrollIndicators(.automatic)
             .onScrollGeometryChange(for: CGFloat.self) { geo in
                 // Distance from bottom: how far the visible rect's bottom edge
                 // is from the content bottom. Replaces the AnchorMinYKey preference


### PR DESCRIPTION
## Summary
- Merges ScrollDetectionState and viewport height handlers into single onScrollGeometryChange
- Creates ScrollGeometrySnapshot struct combining all fields
- Keeps distance-from-bottom as separate handler
- Result: 2 handlers instead of 3

Part of plan: scroll-layout-jitter.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
