### PR TITLE
fix: crash on macOS 26 — use let for non-observed class properties in MainWindowView

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -9,8 +9,8 @@ extension Notification.Name {
 
 struct MainWindowView: View {
     @ObservedObject var conversationManager: ConversationManager
-    var appListManager: AppListManager
-    var zoomManager: ZoomManager
+    let appListManager: AppListManager
+    let zoomManager: ZoomManager
     /// Plain `let` instead of `@ObservedObject` so SwiftUI doesn't observe
     /// TraceStore mutations when the DebugPanel isn't visible. DebugPanel
     /// itself uses `@ObservedObject` and is only instantiated when shown.
@@ -51,7 +51,7 @@ struct MainWindowView: View {
     let ambientAgent: AmbientAgent
     let settingsStore: SettingsStore
     let authManager: AuthManager
-    var documentManager: DocumentManager
+    let documentManager: DocumentManager
     let onMicrophoneToggle: () -> Void
     @ObservedObject var voiceModeManager: VoiceModeManager
     @ObservedObject var updateManager: UpdateManager
@@ -1287,7 +1287,7 @@ struct MainWindowView: View {
 /// the correct conversation's ViewModel — even if the user switches conversations while a
 /// toast is visible.
 private struct ErrorToastOverlay: View {
-    var errorManager: ChatErrorManager
+    let errorManager: ChatErrorManager
     let onOpenModelsAndServices: () -> Void
     let onRetryConversationError: () -> Void
     let onCopyDebugInfo: () -> Void


### PR DESCRIPTION
## Summary
- App crashes immediately on launch on macOS 26 (Tahoe) with `EXC_BAD_ACCESS (SIGSEGV)` in `outlined init with copy of MainWindowView`
- Root cause: #21305 (`e1c6baf82`) changed `@ObservedObject var` → plain `var` for `appListManager`, `zoomManager`, `documentManager`, and `errorManager`. On macOS 26, SwiftUI's struct copying triggers a use-after-free on mutable class references
- Fix: change `var` → `let` for these properties — preserves the intent of removing unnecessary observation while keeping references safe during struct copies

## Test plan
- [ ] Build and launch on macOS 26 — app should no longer crash on startup
- [ ] Verify no regressions on macOS 15

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
