### PR TITLE
fix: Scroll to latest button stays visible after scrolling to bottom

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -771,7 +771,8 @@ struct MessageListView: View {
             })
             .onScrollPhaseChange { oldPhase, newPhase in
                 scrollPhase = newPhase
-                if newPhase == .idle && oldPhase != .idle && scrollCoordinator.isAtBottom {
+                if newPhase == .idle && oldPhase != .idle
+                    && scrollPosition.viewID(type: String.self) == "scroll-bottom-anchor" {
                     // User finished scrolling and ended up at the bottom — re-tether.
                     scrollCoordinator.handleScrollToBottom()
                 }
@@ -834,7 +835,7 @@ struct MessageListView: View {
                     .padding(.bottom, ConversationAvatarFollower.verticalOffset)
             }
             .overlay(alignment: .bottom) {
-                if !isNearBottom && !scrollCoordinator.isAtBottom {
+                if !isNearBottom && scrollPosition.viewID(type: String.self) != "scroll-bottom-anchor" {
                     Button(action: {
                         os_signpost(.event, log: PerfSignposts.log, name: "scrollToLatestPressed")
                         scrollCoordinator.hasReceivedScrollEvent = true


### PR DESCRIPTION
## Summary
- CTA button and reattach-on-idle now read `scrollPosition.viewID` directly instead of `scrollCoordinator.isAtBottom` (non-reactive plain var)
- Button disappears immediately when user scrolls to bottom
- Avatar reappears when user reaches bottom (reattach fires correctly)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
