### PR TITLE
fix: reattach immediately when scrolling to bottom, not just on idle

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -985,8 +985,14 @@ struct MessageListView: View {
                     scrollCoordinator.lastAutoFocusedRequestId = requestId
                 }
             }
-            .onChange(of: scrollPosition.viewID(type: String.self)) { _, newViewID in
+            .onChange(of: scrollPosition.viewID(type: String.self)) { oldViewID, newViewID in
                 scrollCoordinator.updateIsAtBottom(newViewID)
+                // Re-tether immediately when the bottom sentinel scrolls into view,
+                // not just on idle. This makes isNearBottom update in real-time so the
+                // avatar appears and the CTA disappears as the user scrolls down.
+                if newViewID == "scroll-bottom-anchor" && oldViewID != "scroll-bottom-anchor" {
+                    scrollCoordinator.handleScrollToBottom()
+                }
             }
     }
 }


### PR DESCRIPTION
## Summary
- Triggers reattach via `onChange(of: scrollPosition.viewID)` when bottom sentinel becomes visible
- Avatar appears and CTA disappears in real-time while scrolling down, not just on idle
- `onScrollPhaseChange` idle reattach kept as safety fallback
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
