### PR TITLE
M2: Daemon proxies send cancel on abort

### DIFF
--- a/assistant/src/__tests__/host-bash-proxy.test.ts
+++ b/assistant/src/__tests__/host-bash-proxy.test.ts
@@ -215,6 +215,29 @@ describe("HostBashProxy", () => {
       expect(proxy.hasPendingRequest(requestId)).toBe(false);
     });
 
+    test("sends host_bash_cancel to client on abort", async () => {
+      setup();
+
+      const controller = new AbortController();
+      const resultPromise = proxy.request(
+        { command: "echo hello" },
+        "session-1",
+        controller.signal,
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+
+      controller.abort();
+      await resultPromise;
+
+      // Second message should be the cancel
+      expect(sentMessages).toHaveLength(2);
+      const cancelMsg = sentMessages[1] as Record<string, unknown>;
+      expect(cancelMsg.type).toBe("host_bash_cancel");
+      expect(cancelMsg.requestId).toBe(requestId);
+    });
+
     test("returns immediately if signal already aborted", async () => {
       setup();
 
@@ -271,6 +294,62 @@ describe("HostBashProxy", () => {
       expect(proxy.hasPendingRequest(requestId)).toBe(false);
       // The promise should reject since dispose rejects pending
       expect(resultPromise).rejects.toThrow("Host bash proxy disposed");
+    });
+
+    test("sends host_bash_cancel for each pending request on dispose", () => {
+      setup();
+
+      const p1 = proxy.request({ command: "echo a" }, "session-1");
+      const p2 = proxy.request({ command: "echo b" }, "session-1");
+      p1.catch(() => {}); // Expected rejection on dispose
+      p2.catch(() => {}); // Expected rejection on dispose
+
+      const requestIds = (sentMessages as Array<Record<string, unknown>>).map(
+        (m) => m.requestId as string,
+      );
+      expect(requestIds).toHaveLength(2);
+
+      proxy.dispose();
+
+      // After the 2 request messages, dispose should have sent 2 cancel messages
+      const cancelMessages = sentMessages
+        .slice(2)
+        .filter(
+          (m) => (m as Record<string, unknown>).type === "host_bash_cancel",
+        ) as Array<Record<string, unknown>>;
+      expect(cancelMessages).toHaveLength(2);
+      expect(cancelMessages.map((m) => m.requestId)).toContain(requestIds[0]);
+      expect(cancelMessages.map((m) => m.requestId)).toContain(requestIds[1]);
+    });
+  });
+
+  describe("late resolve after abort", () => {
+    test("resolve is a no-op after abort (entry already deleted)", async () => {
+      setup();
+
+      const controller = new AbortController();
+      const resultPromise = proxy.request(
+        { command: "echo hello" },
+        "session-1",
+        controller.signal,
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+
+      controller.abort();
+      const result = await resultPromise;
+      expect(result.content).toContain("Aborted");
+
+      // Late resolve should be silently ignored (no throw, no double-resolve)
+      proxy.resolve(requestId, {
+        stdout: "late",
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      });
+
+      expect(proxy.hasPendingRequest(requestId)).toBe(false);
     });
   });
 

--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -187,6 +187,32 @@ describe("HostCuProxy", () => {
       expect(proxy.hasPendingRequest(requestId)).toBe(false);
     });
 
+    test("sends host_cu_cancel to client on abort", async () => {
+      setup();
+
+      const controller = new AbortController();
+      const resultPromise = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+        undefined,
+        controller.signal,
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+
+      controller.abort();
+      await resultPromise;
+
+      // Second message should be the cancel
+      expect(sentMessages).toHaveLength(2);
+      const cancelMsg = sentMessages[1] as Record<string, unknown>;
+      expect(cancelMsg.type).toBe("host_cu_cancel");
+      expect(cancelMsg.requestId).toBe(requestId);
+    });
+
     test("returns immediately if signal already aborted", async () => {
       setup();
 
@@ -683,6 +709,70 @@ describe("HostCuProxy", () => {
 
       expect(proxy.hasPendingRequest(requestId)).toBe(false);
       await expect(resultPromise).rejects.toThrow("Host CU proxy disposed");
+    });
+
+    test("sends host_cu_cancel for each pending request on dispose", () => {
+      setup();
+
+      const p1 = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+      );
+      const p2 = proxy.request(
+        "computer_use_type_text",
+        { text: "hello" },
+        "session-1",
+        2,
+      );
+      p1.catch(() => {}); // Expected rejection on dispose
+      p2.catch(() => {}); // Expected rejection on dispose
+
+      const requestIds = (sentMessages as Array<Record<string, unknown>>).map(
+        (m) => m.requestId as string,
+      );
+      expect(requestIds).toHaveLength(2);
+
+      proxy.dispose();
+
+      // After the 2 request messages, dispose should have sent 2 cancel messages
+      const cancelMessages = sentMessages
+        .slice(2)
+        .filter(
+          (m) => (m as Record<string, unknown>).type === "host_cu_cancel",
+        ) as Array<Record<string, unknown>>;
+      expect(cancelMessages).toHaveLength(2);
+      expect(cancelMessages.map((m) => m.requestId)).toContain(requestIds[0]);
+      expect(cancelMessages.map((m) => m.requestId)).toContain(requestIds[1]);
+    });
+  });
+
+  describe("late resolve after abort", () => {
+    test("resolve is a no-op after abort (entry already deleted)", async () => {
+      setup();
+
+      const controller = new AbortController();
+      const resultPromise = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+        undefined,
+        controller.signal,
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+
+      controller.abort();
+      const result = await resultPromise;
+      expect(result.content).toContain("Aborted");
+
+      // Late resolve should be silently ignored (no throw, no double-resolve)
+      proxy.resolve(requestId, { axTree: "late response" });
+
+      expect(proxy.hasPendingRequest(requestId)).toBe(false);
     });
   });
 

--- a/assistant/src/__tests__/host-file-proxy.test.ts
+++ b/assistant/src/__tests__/host-file-proxy.test.ts
@@ -184,6 +184,32 @@ describe("HostFileProxy", () => {
       expect(proxy.hasPendingRequest(requestId)).toBe(false);
     });
 
+    test("sends host_file_cancel to client on abort", async () => {
+      setup();
+
+      const controller = new AbortController();
+      const resultPromise = proxy.request(
+        {
+          operation: "read",
+          path: "/tmp/test.txt",
+        },
+        "session-1",
+        controller.signal,
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+
+      controller.abort();
+      await resultPromise;
+
+      // Second message should be the cancel
+      expect(sentMessages).toHaveLength(2);
+      const cancelMsg = sentMessages[1] as Record<string, unknown>;
+      expect(cancelMsg.type).toBe("host_file_cancel");
+      expect(cancelMsg.requestId).toBe(requestId);
+    });
+
     test("returns immediately if signal already aborted", async () => {
       setup();
 
@@ -246,6 +272,69 @@ describe("HostFileProxy", () => {
 
       expect(proxy.hasPendingRequest(requestId)).toBe(false);
       expect(resultPromise).rejects.toThrow("Host file proxy disposed");
+    });
+
+    test("sends host_file_cancel for each pending request on dispose", () => {
+      setup();
+
+      const p1 = proxy.request(
+        { operation: "read", path: "/tmp/a.txt" },
+        "session-1",
+      );
+      const p2 = proxy.request(
+        { operation: "read", path: "/tmp/b.txt" },
+        "session-1",
+      );
+      p1.catch(() => {}); // Expected rejection on dispose
+      p2.catch(() => {}); // Expected rejection on dispose
+
+      const requestIds = (sentMessages as Array<Record<string, unknown>>).map(
+        (m) => m.requestId as string,
+      );
+      expect(requestIds).toHaveLength(2);
+
+      proxy.dispose();
+
+      // After the 2 request messages, dispose should have sent 2 cancel messages
+      const cancelMessages = sentMessages
+        .slice(2)
+        .filter(
+          (m) => (m as Record<string, unknown>).type === "host_file_cancel",
+        ) as Array<Record<string, unknown>>;
+      expect(cancelMessages).toHaveLength(2);
+      expect(cancelMessages.map((m) => m.requestId)).toContain(requestIds[0]);
+      expect(cancelMessages.map((m) => m.requestId)).toContain(requestIds[1]);
+    });
+  });
+
+  describe("late resolve after abort", () => {
+    test("resolve is a no-op after abort (entry already deleted)", async () => {
+      setup();
+
+      const controller = new AbortController();
+      const resultPromise = proxy.request(
+        {
+          operation: "read",
+          path: "/tmp/test.txt",
+        },
+        "session-1",
+        controller.signal,
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+
+      controller.abort();
+      const result = await resultPromise;
+      expect(result.content).toBe("Aborted");
+
+      // Late resolve should be silently ignored (no throw, no double-resolve)
+      proxy.resolve(requestId, {
+        content: "late response",
+        isError: false,
+      });
+
+      expect(proxy.hasPendingRequest(requestId)).toBe(false);
     });
   });
 

--- a/assistant/src/daemon/host-bash-proxy.ts
+++ b/assistant/src/daemon/host-bash-proxy.ts
@@ -86,6 +86,10 @@ export class HostBashProxy {
             clearTimeout(timer);
             this.pending.delete(requestId);
             this.onInternalResolve?.(requestId);
+            this.sendToClient({
+              type: "host_bash_cancel",
+              requestId,
+            } as ServerMessage);
             resolve(formatShellOutput("", "Aborted", null, false, 0));
           }
         };
@@ -144,6 +148,10 @@ export class HostBashProxy {
     for (const [requestId, entry] of this.pending) {
       clearTimeout(entry.timer);
       this.onInternalResolve?.(requestId);
+      this.sendToClient({
+        type: "host_bash_cancel",
+        requestId,
+      } as ServerMessage);
       entry.reject(
         new AssistantError(
           "Host bash proxy disposed",

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -170,6 +170,10 @@ export class HostCuProxy {
             clearTimeout(timer);
             this.pending.delete(requestId);
             this.onInternalResolve?.(requestId);
+            this.sendToClient({
+              type: "host_cu_cancel",
+              requestId,
+            } as ServerMessage);
             resolve({ content: "Aborted", isError: true });
           }
         };
@@ -381,6 +385,7 @@ export class HostCuProxy {
     for (const [requestId, entry] of this.pending) {
       clearTimeout(entry.timer);
       this.onInternalResolve?.(requestId);
+      this.sendToClient({ type: "host_cu_cancel", requestId } as ServerMessage);
       entry.reject(
         new AssistantError("Host CU proxy disposed", ErrorCode.INTERNAL_ERROR),
       );

--- a/assistant/src/daemon/host-file-proxy.ts
+++ b/assistant/src/daemon/host-file-proxy.ts
@@ -82,6 +82,10 @@ export class HostFileProxy {
             clearTimeout(timer);
             this.pending.delete(requestId);
             this.onInternalResolve?.(requestId);
+            this.sendToClient({
+              type: "host_file_cancel",
+              requestId,
+            } as ServerMessage);
             resolve({ content: "Aborted", isError: true });
           }
         };
@@ -123,6 +127,10 @@ export class HostFileProxy {
     for (const [requestId, entry] of this.pending) {
       clearTimeout(entry.timer);
       this.onInternalResolve?.(requestId);
+      this.sendToClient({
+        type: "host_file_cancel",
+        requestId,
+      } as ServerMessage);
       entry.reject(
         new AssistantError(
           "Host file proxy disposed",


### PR DESCRIPTION
## Summary
- When the daemon aborts an in-flight host proxy request (bash, file, or CU) via AbortSignal or dispose(), it now sends a cancel message (`host_bash_cancel`, `host_file_cancel`, `host_cu_cancel`) to the Swift client
- The client can then kill the running process and suppress the stale result POST

Part of #21263.

## Changes
- `assistant/src/daemon/host-bash-proxy.ts` — send `host_bash_cancel` in `onAbort` and `dispose()`
- `assistant/src/daemon/host-file-proxy.ts` — send `host_file_cancel` in `onAbort` and `dispose()`
- `assistant/src/daemon/host-cu-proxy.ts` — send `host_cu_cancel` in `onAbort` and `dispose()`
- `assistant/src/__tests__/host-bash-proxy.test.ts` — tests for cancel on abort, cancel on dispose, late-resolve no-op
- `assistant/src/__tests__/host-file-proxy.test.ts` — same test coverage
- `assistant/src/__tests__/host-cu-proxy.test.ts` — same test coverage

## Test plan
- [x] `bun test src/__tests__/host-bash-proxy.test.ts` — 20 pass
- [x] `bun test src/__tests__/host-file-proxy.test.ts` — 19 pass
- [x] `bun test src/__tests__/host-cu-proxy.test.ts` — 39 pass
- [x] `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
