### PR TITLE
fix: CTA button not disappearing when user manually scrolls to bottom

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
@@ -75,10 +75,11 @@ final class MessageListScrollCoordinator: ObservableObject {
     /// the view-owned `ScrollPosition` binding.
     var scrollTo: ((_ id: any Hashable, _ anchor: UnitPoint?) -> Void)?
 
-    /// Returns `true` when the bottom sentinel is the current scroll position
-    /// target — i.e., the user is at the bottom of the conversation.
-    /// Replaces the former distance-from-bottom math and `BottomVisibilityPolicy`.
-    var isAtBottom: Bool = true
+    /// Returns `true` when the user is within 20pt of the conversation bottom.
+    /// Computed from scroll geometry in the onScrollGeometryChange handler.
+    /// @Published so the "Scroll to latest" CTA button and avatar visibility
+    /// react immediately when the user scrolls to/from the bottom.
+    @Published var isAtBottom: Bool = true
 
     // MARK: - Reactive State (@Published)
 
@@ -194,13 +195,6 @@ final class MessageListScrollCoordinator: ObservableObject {
     // MARK: - Bottom Detection
 
     /// Updates `isAtBottom` based on the current scroll position's view ID.
-    /// Called from the view's `.onChange(of: scrollPosition.viewID)` handler.
-    /// The bottom sentinel has ID "scroll-bottom-anchor"; when the scroll
-    /// position's viewID matches, the user is at the bottom.
-    func updateIsAtBottom(_ viewID: String?) {
-        isAtBottom = viewID == "scroll-bottom-anchor"
-    }
-
     // MARK: - Suppression Management
 
     /// Adds a suppression reason and schedules its automatic timeout.

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -818,10 +818,7 @@ struct MessageListView: View {
                 os_signpost(.end, log: PerfSignposts.log, name: "viewportHeightChanged")
 
                 // --- Bottom detection ---
-                // Compute distance from bottom using the geometry we already have.
-                // This is more reliable than scrollPosition.viewID which can miss
-                // the 1pt sentinel view. A 20pt threshold accounts for the avatar
-                // inset and any trailing padding.
+                // 20pt threshold accounts for the avatar inset and trailing padding.
                 let distanceFromBottom = newState.contentHeight - newState.contentOffsetY - newState.visibleRectHeight
                 let nowAtBottom = distanceFromBottom.isFinite && distanceFromBottom <= 20
                 if scrollCoordinator.isAtBottom != nowAtBottom {
@@ -998,9 +995,6 @@ struct MessageListView: View {
                     scrollCoordinator.lastAutoFocusedRequestId = requestId
                 }
             }
-            // Bottom detection is now handled by the onScrollGeometryChange handler above
-            // (distance-from-bottom ≤ 20pt check), which is more reliable than
-            // scrollPosition.viewID for the 1pt sentinel view.
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -771,8 +771,7 @@ struct MessageListView: View {
             })
             .onScrollPhaseChange { oldPhase, newPhase in
                 scrollPhase = newPhase
-                if newPhase == .idle && oldPhase != .idle
-                    && scrollPosition.viewID(type: String.self) == "scroll-bottom-anchor" {
+                if newPhase == .idle && oldPhase != .idle && scrollCoordinator.isAtBottom {
                     // User finished scrolling and ended up at the bottom — re-tether.
                     scrollCoordinator.handleScrollToBottom()
                 }
@@ -817,6 +816,20 @@ struct MessageListView: View {
                     scrollCoordinator.currentScrollViewportHeight = accepted
                 }
                 os_signpost(.end, log: PerfSignposts.log, name: "viewportHeightChanged")
+
+                // --- Bottom detection ---
+                // Compute distance from bottom using the geometry we already have.
+                // This is more reliable than scrollPosition.viewID which can miss
+                // the 1pt sentinel view. A 20pt threshold accounts for the avatar
+                // inset and any trailing padding.
+                let distanceFromBottom = newState.contentHeight - newState.contentOffsetY - newState.visibleRectHeight
+                let nowAtBottom = distanceFromBottom.isFinite && distanceFromBottom <= 20
+                if scrollCoordinator.isAtBottom != nowAtBottom {
+                    scrollCoordinator.isAtBottom = nowAtBottom
+                    if nowAtBottom {
+                        scrollCoordinator.handleScrollToBottom()
+                    }
+                }
             }
             .scrollIndicators(.automatic)
             .onPreferenceChange(PaginationSentinelMinYKey.self) { sentinelMinY in
@@ -835,7 +848,7 @@ struct MessageListView: View {
                     .padding(.bottom, ConversationAvatarFollower.verticalOffset)
             }
             .overlay(alignment: .bottom) {
-                if !isNearBottom && scrollPosition.viewID(type: String.self) != "scroll-bottom-anchor" {
+                if !isNearBottom && !scrollCoordinator.isAtBottom {
                     Button(action: {
                         os_signpost(.event, log: PerfSignposts.log, name: "scrollToLatestPressed")
                         scrollCoordinator.hasReceivedScrollEvent = true
@@ -985,15 +998,9 @@ struct MessageListView: View {
                     scrollCoordinator.lastAutoFocusedRequestId = requestId
                 }
             }
-            .onChange(of: scrollPosition.viewID(type: String.self)) { oldViewID, newViewID in
-                scrollCoordinator.updateIsAtBottom(newViewID)
-                // Re-tether immediately when the bottom sentinel scrolls into view,
-                // not just on idle. This makes isNearBottom update in real-time so the
-                // avatar appears and the CTA disappears as the user scrolls down.
-                if newViewID == "scroll-bottom-anchor" && oldViewID != "scroll-bottom-anchor" {
-                    scrollCoordinator.handleScrollToBottom()
-                }
-            }
+            // Bottom detection is now handled by the onScrollGeometryChange handler above
+            // (distance-from-bottom ≤ 20pt check), which is more reliable than
+            // scrollPosition.viewID for the 1pt sentinel view.
     }
 }
 


### PR DESCRIPTION
## Summary
- Computes isAtBottom from scroll geometry (distance ≤ 20pt) instead of scrollPosition.viewID
- Made isAtBottom @Published so CTA button and avatar react immediately
- Removed unreliable onChange(of: scrollPosition.viewID) handler
- CTA disappears and avatar appears in real-time as user scrolls down
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
