### PR TITLE
fix: CTA button not disappearing — bottom detection blocked by early return

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -804,21 +804,23 @@ struct MessageListView: View {
                 // A 0.5pt dead-zone prevents floating-point rounding differences
                 // between render passes from triggering continuous @State mutations
                 // (scrollViewportHeight) which would create a runaway render loop.
+                // --- Viewport height update ---
                 let decision = PreferenceGeometryFilter.evaluate(
                     newValue: newState.visibleRectHeight,
                     previous: scrollViewportHeight,
                     deadZone: 0.5
                 )
-                guard case .accept(let accepted) = decision else { return }
-                os_signpost(.begin, log: PerfSignposts.log, name: "viewportHeightChanged")
-                if scrollViewportHeight != accepted {
-                    scrollViewportHeight = accepted
-                    scrollCoordinator.currentScrollViewportHeight = accepted
+                if case .accept(let accepted) = decision {
+                    os_signpost(.begin, log: PerfSignposts.log, name: "viewportHeightChanged")
+                    if scrollViewportHeight != accepted {
+                        scrollViewportHeight = accepted
+                        scrollCoordinator.currentScrollViewportHeight = accepted
+                    }
+                    os_signpost(.end, log: PerfSignposts.log, name: "viewportHeightChanged")
                 }
-                os_signpost(.end, log: PerfSignposts.log, name: "viewportHeightChanged")
 
                 // --- Bottom detection ---
-                // 20pt threshold accounts for the avatar inset and trailing padding.
+                // Always runs regardless of viewport dead-zone filter above.
                 let distanceFromBottom = newState.contentHeight - newState.contentOffsetY - newState.visibleRectHeight
                 let nowAtBottom = distanceFromBottom.isFinite && distanceFromBottom <= 20
                 if scrollCoordinator.isAtBottom != nowAtBottom {


### PR DESCRIPTION
## Summary
- The viewport height dead-zone guard used `guard ... else { return }` which blocked the bottom detection code from running on most scroll events
- Changed to `if case .accept` so viewport update and bottom detection are independent
- Bottom detection now runs on every scroll geometry change, not just when viewport height changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
