### PR TITLE
M3: Swift client handles cancel, kills work, suppresses stale POSTs

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -281,10 +281,29 @@ extension AppDelegate {
                     HostToolExecutor.executeHostFileRequest(msg)
                 case .hostCuRequest(let msg):
                     let proxy = self.getOrCreateHostCuOverlay(conversationId: msg.conversationId, request: msg)
-                    Task { @MainActor in
+                    let task = Task { @MainActor in
+                        defer { self.inFlightCuTasks.removeValue(forKey: msg.requestId) }
+
+                        guard !Task.isCancelled else { return }
                         let result = await HostCuActionRunner.perform(msg, overlayProxy: proxy)
+
+                        guard !Task.isCancelled else { return }
+
+                        // Suppress stale POST if cancelled
+                        if HostToolExecutor.isCancelledAndConsume(msg.requestId) {
+                            log.debug("Host CU result suppressed (cancelled) — requestId=\(msg.requestId, privacy: .public)")
+                            return
+                        }
                         _ = await HostProxyClient().postCuResult(result)
                     }
+                    self.inFlightCuTasks[msg.requestId] = task
+
+                case .hostBashCancel(let msg):
+                    HostToolExecutor.cancelHostBashRequest(msg.requestId)
+                case .hostFileCancel(let msg):
+                    HostToolExecutor.cancelHostFileRequest(msg.requestId)
+                case .hostCuCancel(let msg):
+                    self.cancelHostCuRequest(msg.requestId)
 
                 // Signing identity
                 case .signBundlePayload(let msg):
@@ -330,6 +349,19 @@ extension AppDelegate {
                 }
             }
         }
+    }
+
+    // MARK: - Host CU Cancel
+
+    /// Cancel an in-flight host CU request: mark it cancelled, cancel the
+    /// Swift Task, and dismiss the overlay.
+    func cancelHostCuRequest(_ requestId: String) {
+        HostToolExecutor.markCancelled(requestId)
+        if let task = inFlightCuTasks.removeValue(forKey: requestId) {
+            task.cancel()
+        }
+        dismissHostCuOverlay()
+        log.info("Cancelling host CU — requestId=\(requestId, privacy: .public)")
     }
 
     // MARK: - Signing Identity

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -41,6 +41,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var hostCuOverlayCleanupTask: Task<Void, Never>?
     /// Combine subscriptions for host CU overlay state observation.
     var hostCuOverlayCancellables = Set<AnyCancellable>()
+    /// In-flight CU tasks keyed by request ID, for cancel support.
+    var inFlightCuTasks: [String: Task<Void, Never>] = [:]
     var isStartingSession = false
     var startSessionTask: Task<Void, Never>?
     var voiceInput: VoiceInputManager?

--- a/clients/shared/Network/HostToolExecutor.swift
+++ b/clients/shared/Network/HostToolExecutor.swift
@@ -7,6 +7,41 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 /// These run locally on macOS and post results back via `HostProxyClient`.
 public enum HostToolExecutor {
 
+    // MARK: - Cancelled Request Tracking
+
+    /// Lock guarding `cancelledRequestIds` and `runningProcesses`.
+    private static let lock = NSLock()
+
+    /// Request IDs that have been cancelled, with timestamps for TTL cleanup.
+    /// Entries older than 30 seconds are swept on each `markCancelled` call.
+    private static var cancelledRequestIds: [String: Date] = [:]
+
+    #if os(macOS)
+    /// Currently running bash processes keyed by request ID.
+    private static var runningProcesses: [String: Process] = [:]
+    #endif
+
+    /// Mark a request ID as cancelled and sweep stale entries (>30s old).
+    static func markCancelled(_ requestId: String) {
+        lock.withLock {
+            let now = Date()
+            cancelledRequestIds[requestId] = now
+            // Sweep entries older than 30 seconds
+            cancelledRequestIds = cancelledRequestIds.filter { now.timeIntervalSince($0.value) < 30 }
+        }
+    }
+
+    /// Check if a request ID was cancelled. If found, removes it (consume-once)
+    /// and returns `true`. Returns `false` if not cancelled.
+    static func isCancelledAndConsume(_ requestId: String) -> Bool {
+        lock.withLock {
+            if cancelledRequestIds.removeValue(forKey: requestId) != nil {
+                return true
+            }
+            return false
+        }
+    }
+
     // MARK: - Host Bash Execution
 
     #if os(macOS)
@@ -16,6 +51,12 @@ public enum HostToolExecutor {
     @MainActor
     public static func executeHostBashRequest(_ request: HostBashRequest) {
         Task.detached {
+            // If already cancelled before we start, skip entirely
+            if isCancelledAndConsume(request.requestId) {
+                log.debug("Host bash skipped (pre-cancelled) — requestId=\(request.requestId, privacy: .public)")
+                return
+            }
+
             let defaultTimeout: Double = 120
             let timeout = request.timeoutSeconds ?? defaultTimeout
 
@@ -94,6 +135,9 @@ public enum HostToolExecutor {
                 pipeGroup.leave()
             }
 
+            // Register the process so cancel can terminate it
+            lock.withLock { runningProcesses[request.requestId] = process }
+
             do {
                 try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
                     process.terminationHandler = { _ in
@@ -111,6 +155,7 @@ public enum HostToolExecutor {
                     }
                 }
             } catch {
+                lock.withLock { runningProcesses.removeValue(forKey: request.requestId) }
                 timerSource.cancel()
                 log.error("Failed to launch host bash process: \(error.localizedDescription)")
                 let result = HostBashResultPayload(
@@ -120,9 +165,12 @@ public enum HostToolExecutor {
                     exitCode: nil,
                     timedOut: false
                 )
-                _ = await HostProxyClient().postBashResult(result)
+                if !isCancelledAndConsume(request.requestId) {
+                    _ = await HostProxyClient().postBashResult(result)
+                }
                 return
             }
+            lock.withLock { runningProcesses.removeValue(forKey: request.requestId) }
             timerSource.cancel()
 
             let stdout = String(data: stdoutBox.value, encoding: .utf8) ?? ""
@@ -139,7 +187,30 @@ public enum HostToolExecutor {
             )
 
             log.debug("Host bash completed — requestId=\(request.requestId, privacy: .public) exitCode=\(exitCode) timedOut=\(timedOut)")
+
+            // Suppress stale POST if cancelled while running
+            if isCancelledAndConsume(request.requestId) {
+                log.debug("Host bash result suppressed (cancelled) — requestId=\(request.requestId, privacy: .public)")
+                return
+            }
             _ = await HostProxyClient().postBashResult(result)
+        }
+    }
+
+    /// Cancel an in-flight host bash request: mark it cancelled and terminate
+    /// the running process (SIGTERM, then SIGKILL after 2s).
+    public static func cancelHostBashRequest(_ requestId: String) {
+        markCancelled(requestId)
+        let process: Process? = lock.withLock { runningProcesses[requestId] }
+        guard let process else { return }
+        log.info("Cancelling host bash — requestId=\(requestId, privacy: .public)")
+        if process.isRunning {
+            process.terminate()
+            let pid = process.processIdentifier
+            DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
+                // SIGKILL if still alive after grace period
+                kill(pid, SIGKILL)
+            }
         }
     }
     #endif
@@ -208,8 +279,22 @@ public enum HostToolExecutor {
             }
 
             log.debug("Host file completed — requestId=\(request.requestId, privacy: .public) op=\(request.operation, privacy: .public) isError=\(result.isError)")
+
+            // Suppress stale POST if cancelled
+            if isCancelledAndConsume(request.requestId) {
+                log.debug("Host file result suppressed (cancelled) — requestId=\(request.requestId, privacy: .public)")
+                return
+            }
             _ = await HostProxyClient().postFileResult(result)
         }
+    }
+
+    /// Cancel an in-flight host file request. File operations are synchronous
+    /// and short-lived so there is no process to kill — we just mark it
+    /// cancelled so the result POST is suppressed.
+    public static func cancelHostFileRequest(_ requestId: String) {
+        markCancelled(requestId)
+        log.info("Cancelling host file — requestId=\(requestId, privacy: .public)")
     }
 
     // MARK: - File Operations

--- a/clients/shared/Network/HostToolExecutor.swift
+++ b/clients/shared/Network/HostToolExecutor.swift
@@ -206,10 +206,12 @@ public enum HostToolExecutor {
         log.info("Cancelling host bash — requestId=\(requestId, privacy: .public)")
         if process.isRunning {
             process.terminate()
-            let pid = process.processIdentifier
-            DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
-                // SIGKILL if still alive after grace period
-                kill(pid, SIGKILL)
+            DispatchQueue.global().asyncAfter(deadline: .now() + 2) { [process] in
+                // SIGKILL if still alive after grace period — check liveness first
+                // to avoid killing a reused PID if the process already exited.
+                if process.isRunning {
+                    kill(process.processIdentifier, SIGKILL)
+                }
             }
         }
     }
@@ -223,6 +225,13 @@ public enum HostToolExecutor {
     @MainActor
     public static func executeHostFileRequest(_ request: HostFileRequest) {
         Task.detached {
+            // Check cancellation BEFORE performing the file operation to prevent
+            // cancelled requests from mutating the filesystem.
+            if isCancelledAndConsume(request.requestId) {
+                log.debug("Host file skipped (pre-cancelled) — requestId=\(request.requestId, privacy: .public)")
+                return
+            }
+
             let result: HostFileResultPayload
 
             do {


### PR DESCRIPTION
## Summary
- Adds thread-safe cancelled-request tracking with 30s TTL cleanup to `HostToolExecutor`
- Handles `host_bash_cancel`: terminates running processes (SIGTERM, then SIGKILL after 2s), suppresses stale result POSTs
- Handles `host_file_cancel`: marks cancelled so result POST is suppressed
- Handles `host_cu_cancel`: cancels the Swift Task, marks cancelled, dismisses the CU overlay
- Dispatches `.hostBashCancel`, `.hostFileCancel`, `.hostCuCancel` SSE messages in `startEventSubscription`

Part of #21263.

## Test plan
- [ ] Trigger a long-running bash command via host proxy, then abort the session — verify the process is killed and no result POST is sent
- [ ] Trigger a CU session via host proxy, then abort — verify the overlay is dismissed and no result POST is sent
- [ ] Trigger a file operation and cancel — verify no result POST is sent
- [ ] Verify normal (non-cancelled) operations still complete and POST results as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
