### PR TITLE
refactor: extract shared OAuth CLI helpers into `oauth/shared.ts`

### DIFF
--- a/assistant/src/cli/commands/oauth/platform.ts
+++ b/assistant/src/cli/commands/oauth/platform.ts
@@ -6,26 +6,19 @@ import {
   ServicesSchema,
 } from "../../../config/schemas/services.js";
 import { getProvider } from "../../../oauth/oauth-store.js";
-import { VellumPlatformClient } from "../../../platform/client.js";
 import { openInBrowser } from "../../../util/browser.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
+import {
+  fetchActiveConnections,
+  requirePlatformClient,
+  toBareProvider,
+} from "./shared.js";
 
 const log = getCliLogger("cli");
 
 // ---------------------------------------------------------------------------
-// Shared types
-// ---------------------------------------------------------------------------
-
-interface PlatformConnectionEntry {
-  id: string;
-  account_label?: string;
-  scopes_granted?: string[];
-  status?: string;
-}
-
-// ---------------------------------------------------------------------------
-// Shared helpers
+// Platform-specific helpers
 // ---------------------------------------------------------------------------
 
 /**
@@ -36,17 +29,6 @@ function toProviderKey(provider: string): string {
   return provider.startsWith("integration:")
     ? provider
     : `integration:${provider}`;
-}
-
-/**
- * Extract the bare provider slug (e.g. "google") from either a raw CLI
- * argument or a canonical provider key (e.g. "integration:google").
- * Platform API paths expect the bare slug, not the internal key.
- */
-function toBareProvider(provider: string): string {
-  return provider.startsWith("integration:")
-    ? provider.slice("integration:".length)
-    : provider;
 }
 
 /**
@@ -99,60 +81,6 @@ function requireManagedProvider(provider: string, cmd: Command): string | null {
   }
 
   return managedKey;
-}
-
-/**
- * Create an authenticated platform client, or write an error and return null.
- */
-async function requirePlatformClient(
-  cmd: Command,
-): Promise<VellumPlatformClient | null> {
-  const client = await VellumPlatformClient.create();
-  if (!client || !client.platformAssistantId) {
-    writeOutput(cmd, {
-      ok: false,
-      error:
-        "Platform prerequisites not met (not logged in or missing assistant ID)",
-    });
-    process.exitCode = 1;
-    return null;
-  }
-  return client;
-}
-
-/**
- * Fetch active platform connections for a provider. Returns the parsed entries
- * or writes an error and returns null.
- */
-async function fetchActiveConnections(
-  client: VellumPlatformClient,
-  provider: string,
-  cmd: Command,
-): Promise<PlatformConnectionEntry[] | null> {
-  const params = new URLSearchParams();
-  params.set("provider", toBareProvider(provider));
-  params.set("status", "ACTIVE");
-
-  const path = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/connections/?${params.toString()}`;
-  const response = await client.fetch(path);
-
-  if (!response.ok) {
-    writeOutput(cmd, {
-      ok: false,
-      error: `Platform returned HTTP ${response.status}`,
-    });
-    process.exitCode = 1;
-    return null;
-  }
-
-  const body = (await response.json()) as unknown;
-
-  // The platform returns either a flat array or a {results: [...]} wrapper.
-  return (
-    Array.isArray(body)
-      ? body
-      : ((body as Record<string, unknown>).results ?? [])
-  ) as PlatformConnectionEntry[];
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -2,11 +2,6 @@ import { readFileSync, writeFileSync } from "node:fs";
 
 import type { Command } from "commander";
 
-import { getConfig } from "../../../config/loader.js";
-import {
-  type Services,
-  ServicesSchema,
-} from "../../../config/schemas/services.js";
 import type { OAuthConnectionRequest } from "../../../oauth/connection.js";
 import {
   resolveOAuthConnection,
@@ -17,9 +12,9 @@ import {
   getAppByProviderAndClientId,
   getProvider,
 } from "../../../oauth/oauth-store.js";
-import { resolveService } from "../../../oauth/provider-behaviors.js";
 import { VellumPlatformClient } from "../../../platform/client.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
+import { isManagedMode, resolveService, toBareProvider } from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -81,31 +76,6 @@ function readBodyData(data: string): unknown {
   }
 
   return tryJsonParse(data);
-}
-
-/**
- * Determine whether a provider is running in platform-managed mode.
- * Returns false if config is unavailable (e.g. in test environments).
- */
-function isManagedMode(providerKey: string): boolean {
-  const provider = getProvider(providerKey);
-  const managedKey = provider?.managedServiceConfigKey;
-  if (!managedKey || !(managedKey in ServicesSchema.shape)) return false;
-  try {
-    const services: Services = getConfig().services;
-    return services[managedKey as keyof Services].mode === "managed";
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Normalize a bare provider name into the canonical provider key.
- */
-function toBareProvider(provider: string): string {
-  return provider.startsWith("integration:")
-    ? provider.slice("integration:".length)
-    : provider;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/cli/commands/oauth/shared.ts
+++ b/assistant/src/cli/commands/oauth/shared.ts
@@ -1,0 +1,113 @@
+import type { Command } from "commander";
+
+import { getConfig } from "../../../config/loader.js";
+import {
+  type Services,
+  ServicesSchema,
+} from "../../../config/schemas/services.js";
+import { getProvider } from "../../../oauth/oauth-store.js";
+import { resolveService } from "../../../oauth/provider-behaviors.js";
+import { VellumPlatformClient } from "../../../platform/client.js";
+import { writeOutput } from "../../output.js";
+
+// ---------------------------------------------------------------------------
+// Re-exports
+// ---------------------------------------------------------------------------
+
+export { resolveService };
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+export interface PlatformConnectionEntry {
+  id: string;
+  account_label?: string;
+  scopes_granted?: string[];
+  status?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the bare provider slug (e.g. "google") from either a raw CLI
+ * argument or a canonical provider key (e.g. "integration:google").
+ * Platform API paths expect the bare slug, not the internal key.
+ */
+export function toBareProvider(provider: string): string {
+  return provider.startsWith("integration:")
+    ? provider.slice("integration:".length)
+    : provider;
+}
+
+/**
+ * Determine whether a provider is running in platform-managed mode.
+ * Returns false if config is unavailable (e.g. in test environments).
+ */
+export function isManagedMode(providerKey: string): boolean {
+  const provider = getProvider(providerKey);
+  const managedKey = provider?.managedServiceConfigKey;
+  if (!managedKey || !(managedKey in ServicesSchema.shape)) return false;
+  try {
+    const services: Services = getConfig().services;
+    return services[managedKey as keyof Services].mode === "managed";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Create an authenticated platform client, or write an error and return null.
+ */
+export async function requirePlatformClient(
+  cmd: Command,
+): Promise<VellumPlatformClient | null> {
+  const client = await VellumPlatformClient.create();
+  if (!client || !client.platformAssistantId) {
+    writeOutput(cmd, {
+      ok: false,
+      error:
+        "Platform prerequisites not met (not logged in or missing assistant ID)",
+    });
+    process.exitCode = 1;
+    return null;
+  }
+  return client;
+}
+
+/**
+ * Fetch active platform connections for a provider. Returns the parsed entries
+ * or writes an error and returns null.
+ */
+export async function fetchActiveConnections(
+  client: VellumPlatformClient,
+  provider: string,
+  cmd: Command,
+): Promise<PlatformConnectionEntry[] | null> {
+  const params = new URLSearchParams();
+  params.set("provider", toBareProvider(provider));
+  params.set("status", "ACTIVE");
+
+  const path = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/connections/?${params.toString()}`;
+  const response = await client.fetch(path);
+
+  if (!response.ok) {
+    writeOutput(cmd, {
+      ok: false,
+      error: `Platform returned HTTP ${response.status}`,
+    });
+    process.exitCode = 1;
+    return null;
+  }
+
+  const body = (await response.json()) as unknown;
+
+  // The platform returns either a flat array or a {results: [...]} wrapper.
+  return (
+    Array.isArray(body)
+      ? body
+      : ((body as Record<string, unknown>).results ?? [])
+  ) as PlatformConnectionEntry[];
+}


### PR DESCRIPTION
## Summary
- Extract duplicated helpers (toBareProvider, isManagedMode, requirePlatformClient, fetchActiveConnections, PlatformConnectionEntry) into a new shared.ts module
- Update platform.ts and request.ts to import from shared.ts instead of defining locally
- Pure refactor — no behavioral changes

Part of plan: unified-oauth-cli.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
