### PR TITLE
Fix stop button for in-flight tasks

### DIFF
--- a/assistant/src/__tests__/host-bash-proxy.test.ts
+++ b/assistant/src/__tests__/host-bash-proxy.test.ts
@@ -215,6 +215,29 @@ describe("HostBashProxy", () => {
       expect(proxy.hasPendingRequest(requestId)).toBe(false);
     });
 
+    test("sends host_bash_cancel to client on abort", async () => {
+      setup();
+
+      const controller = new AbortController();
+      const resultPromise = proxy.request(
+        { command: "echo hello" },
+        "session-1",
+        controller.signal,
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+
+      controller.abort();
+      await resultPromise;
+
+      // Second message should be the cancel
+      expect(sentMessages).toHaveLength(2);
+      const cancelMsg = sentMessages[1] as Record<string, unknown>;
+      expect(cancelMsg.type).toBe("host_bash_cancel");
+      expect(cancelMsg.requestId).toBe(requestId);
+    });
+
     test("returns immediately if signal already aborted", async () => {
       setup();
 
@@ -271,6 +294,62 @@ describe("HostBashProxy", () => {
       expect(proxy.hasPendingRequest(requestId)).toBe(false);
       // The promise should reject since dispose rejects pending
       expect(resultPromise).rejects.toThrow("Host bash proxy disposed");
+    });
+
+    test("sends host_bash_cancel for each pending request on dispose", () => {
+      setup();
+
+      const p1 = proxy.request({ command: "echo a" }, "session-1");
+      const p2 = proxy.request({ command: "echo b" }, "session-1");
+      p1.catch(() => {}); // Expected rejection on dispose
+      p2.catch(() => {}); // Expected rejection on dispose
+
+      const requestIds = (sentMessages as Array<Record<string, unknown>>).map(
+        (m) => m.requestId as string,
+      );
+      expect(requestIds).toHaveLength(2);
+
+      proxy.dispose();
+
+      // After the 2 request messages, dispose should have sent 2 cancel messages
+      const cancelMessages = sentMessages
+        .slice(2)
+        .filter(
+          (m) => (m as Record<string, unknown>).type === "host_bash_cancel",
+        ) as Array<Record<string, unknown>>;
+      expect(cancelMessages).toHaveLength(2);
+      expect(cancelMessages.map((m) => m.requestId)).toContain(requestIds[0]);
+      expect(cancelMessages.map((m) => m.requestId)).toContain(requestIds[1]);
+    });
+  });
+
+  describe("late resolve after abort", () => {
+    test("resolve is a no-op after abort (entry already deleted)", async () => {
+      setup();
+
+      const controller = new AbortController();
+      const resultPromise = proxy.request(
+        { command: "echo hello" },
+        "session-1",
+        controller.signal,
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+
+      controller.abort();
+      const result = await resultPromise;
+      expect(result.content).toContain("Aborted");
+
+      // Late resolve should be silently ignored (no throw, no double-resolve)
+      proxy.resolve(requestId, {
+        stdout: "late",
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      });
+
+      expect(proxy.hasPendingRequest(requestId)).toBe(false);
     });
   });
 

--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -187,6 +187,32 @@ describe("HostCuProxy", () => {
       expect(proxy.hasPendingRequest(requestId)).toBe(false);
     });
 
+    test("sends host_cu_cancel to client on abort", async () => {
+      setup();
+
+      const controller = new AbortController();
+      const resultPromise = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+        undefined,
+        controller.signal,
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+
+      controller.abort();
+      await resultPromise;
+
+      // Second message should be the cancel
+      expect(sentMessages).toHaveLength(2);
+      const cancelMsg = sentMessages[1] as Record<string, unknown>;
+      expect(cancelMsg.type).toBe("host_cu_cancel");
+      expect(cancelMsg.requestId).toBe(requestId);
+    });
+
     test("returns immediately if signal already aborted", async () => {
       setup();
 
@@ -683,6 +709,70 @@ describe("HostCuProxy", () => {
 
       expect(proxy.hasPendingRequest(requestId)).toBe(false);
       await expect(resultPromise).rejects.toThrow("Host CU proxy disposed");
+    });
+
+    test("sends host_cu_cancel for each pending request on dispose", () => {
+      setup();
+
+      const p1 = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+      );
+      const p2 = proxy.request(
+        "computer_use_type_text",
+        { text: "hello" },
+        "session-1",
+        2,
+      );
+      p1.catch(() => {}); // Expected rejection on dispose
+      p2.catch(() => {}); // Expected rejection on dispose
+
+      const requestIds = (sentMessages as Array<Record<string, unknown>>).map(
+        (m) => m.requestId as string,
+      );
+      expect(requestIds).toHaveLength(2);
+
+      proxy.dispose();
+
+      // After the 2 request messages, dispose should have sent 2 cancel messages
+      const cancelMessages = sentMessages
+        .slice(2)
+        .filter(
+          (m) => (m as Record<string, unknown>).type === "host_cu_cancel",
+        ) as Array<Record<string, unknown>>;
+      expect(cancelMessages).toHaveLength(2);
+      expect(cancelMessages.map((m) => m.requestId)).toContain(requestIds[0]);
+      expect(cancelMessages.map((m) => m.requestId)).toContain(requestIds[1]);
+    });
+  });
+
+  describe("late resolve after abort", () => {
+    test("resolve is a no-op after abort (entry already deleted)", async () => {
+      setup();
+
+      const controller = new AbortController();
+      const resultPromise = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+        undefined,
+        controller.signal,
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+
+      controller.abort();
+      const result = await resultPromise;
+      expect(result.content).toContain("Aborted");
+
+      // Late resolve should be silently ignored (no throw, no double-resolve)
+      proxy.resolve(requestId, { axTree: "late response" });
+
+      expect(proxy.hasPendingRequest(requestId)).toBe(false);
     });
   });
 

--- a/assistant/src/__tests__/host-file-proxy.test.ts
+++ b/assistant/src/__tests__/host-file-proxy.test.ts
@@ -184,6 +184,32 @@ describe("HostFileProxy", () => {
       expect(proxy.hasPendingRequest(requestId)).toBe(false);
     });
 
+    test("sends host_file_cancel to client on abort", async () => {
+      setup();
+
+      const controller = new AbortController();
+      const resultPromise = proxy.request(
+        {
+          operation: "read",
+          path: "/tmp/test.txt",
+        },
+        "session-1",
+        controller.signal,
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+
+      controller.abort();
+      await resultPromise;
+
+      // Second message should be the cancel
+      expect(sentMessages).toHaveLength(2);
+      const cancelMsg = sentMessages[1] as Record<string, unknown>;
+      expect(cancelMsg.type).toBe("host_file_cancel");
+      expect(cancelMsg.requestId).toBe(requestId);
+    });
+
     test("returns immediately if signal already aborted", async () => {
       setup();
 
@@ -246,6 +272,69 @@ describe("HostFileProxy", () => {
 
       expect(proxy.hasPendingRequest(requestId)).toBe(false);
       expect(resultPromise).rejects.toThrow("Host file proxy disposed");
+    });
+
+    test("sends host_file_cancel for each pending request on dispose", () => {
+      setup();
+
+      const p1 = proxy.request(
+        { operation: "read", path: "/tmp/a.txt" },
+        "session-1",
+      );
+      const p2 = proxy.request(
+        { operation: "read", path: "/tmp/b.txt" },
+        "session-1",
+      );
+      p1.catch(() => {}); // Expected rejection on dispose
+      p2.catch(() => {}); // Expected rejection on dispose
+
+      const requestIds = (sentMessages as Array<Record<string, unknown>>).map(
+        (m) => m.requestId as string,
+      );
+      expect(requestIds).toHaveLength(2);
+
+      proxy.dispose();
+
+      // After the 2 request messages, dispose should have sent 2 cancel messages
+      const cancelMessages = sentMessages
+        .slice(2)
+        .filter(
+          (m) => (m as Record<string, unknown>).type === "host_file_cancel",
+        ) as Array<Record<string, unknown>>;
+      expect(cancelMessages).toHaveLength(2);
+      expect(cancelMessages.map((m) => m.requestId)).toContain(requestIds[0]);
+      expect(cancelMessages.map((m) => m.requestId)).toContain(requestIds[1]);
+    });
+  });
+
+  describe("late resolve after abort", () => {
+    test("resolve is a no-op after abort (entry already deleted)", async () => {
+      setup();
+
+      const controller = new AbortController();
+      const resultPromise = proxy.request(
+        {
+          operation: "read",
+          path: "/tmp/test.txt",
+        },
+        "session-1",
+        controller.signal,
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+
+      controller.abort();
+      const result = await resultPromise;
+      expect(result.content).toBe("Aborted");
+
+      // Late resolve should be silently ignored (no throw, no double-resolve)
+      proxy.resolve(requestId, {
+        content: "late response",
+        isError: false,
+      });
+
+      expect(proxy.hasPendingRequest(requestId)).toBe(false);
     });
   });
 

--- a/assistant/src/__tests__/mcp-abort-signal.test.ts
+++ b/assistant/src/__tests__/mcp-abort-signal.test.ts
@@ -50,7 +50,7 @@ describe("MCP AbortSignal threading", () => {
 
       expect(callToolSpy).toHaveBeenCalledTimes(1);
       const [_params, _resultSchema, options] = callToolSpy.mock.calls[0];
-      expect(options).toEqual({ signal: undefined });
+      expect(options).toBeUndefined();
     });
 
     test("already-aborted signal causes the SDK call to reject", async () => {

--- a/assistant/src/__tests__/mcp-abort-signal.test.ts
+++ b/assistant/src/__tests__/mcp-abort-signal.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, jest, mock, test } from "bun:test";
+
+// Mock secure-keys so McpOAuthProvider doesn't try to access the credential store
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: jest.fn().mockResolvedValue(null),
+  setSecureKeyAsync: jest.fn().mockResolvedValue(true),
+  deleteSecureKeyAsync: jest.fn().mockResolvedValue("deleted"),
+}));
+
+const { McpClient } = await import("../mcp/client.js");
+const { McpServerManager } = await import("../mcp/manager.js");
+const { createMcpTool } = await import("../tools/mcp/mcp-tool-factory.js");
+
+describe("MCP AbortSignal threading", () => {
+  describe("McpClient.callTool", () => {
+    test("forwards signal to the SDK client.callTool options", async () => {
+      const client = new McpClient("test-server");
+
+      const callToolSpy = jest.fn().mockResolvedValue({
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      });
+
+      // Monkey-patch to mark as connected and capture callTool args
+      (client as any).connected = true;
+      (client as any).client = { callTool: callToolSpy };
+
+      const ac = new AbortController();
+      await client.callTool("my-tool", { foo: "bar" }, ac.signal);
+
+      expect(callToolSpy).toHaveBeenCalledTimes(1);
+      const [params, resultSchema, options] = callToolSpy.mock.calls[0];
+      expect(params).toEqual({ name: "my-tool", arguments: { foo: "bar" } });
+      expect(resultSchema).toBeUndefined();
+      expect(options).toEqual({ signal: ac.signal });
+    });
+
+    test("passes undefined signal cleanly (no regression)", async () => {
+      const client = new McpClient("test-server");
+
+      const callToolSpy = jest.fn().mockResolvedValue({
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      });
+
+      (client as any).connected = true;
+      (client as any).client = { callTool: callToolSpy };
+
+      await client.callTool("my-tool", { foo: "bar" });
+
+      expect(callToolSpy).toHaveBeenCalledTimes(1);
+      const [_params, _resultSchema, options] = callToolSpy.mock.calls[0];
+      expect(options).toEqual({ signal: undefined });
+    });
+
+    test("already-aborted signal causes the SDK call to reject", async () => {
+      const client = new McpClient("test-server");
+
+      const callToolSpy = jest
+        .fn()
+        .mockImplementation((_p: any, _r: any, opts: any) => {
+          if (opts?.signal?.aborted) {
+            return Promise.reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            );
+          }
+          return Promise.resolve({
+            content: [{ type: "text", text: "ok" }],
+            isError: false,
+          });
+        });
+
+      (client as any).connected = true;
+      (client as any).client = { callTool: callToolSpy };
+
+      const ac = new AbortController();
+      ac.abort();
+
+      await expect(client.callTool("my-tool", {}, ac.signal)).rejects.toThrow(
+        "The operation was aborted.",
+      );
+    });
+  });
+
+  describe("McpServerManager.callTool", () => {
+    test("forwards signal to the underlying McpClient.callTool", async () => {
+      const manager = new McpServerManager();
+
+      const callToolSpy = jest.fn().mockResolvedValue({
+        content: "result",
+        isError: false,
+      });
+
+      const fakeClient = { callTool: callToolSpy, serverId: "test-server" };
+      (manager as any).clients.set("test-server", fakeClient);
+
+      const ac = new AbortController();
+      await manager.callTool("test-server", "my-tool", { x: 1 }, ac.signal);
+
+      expect(callToolSpy).toHaveBeenCalledWith("my-tool", { x: 1 }, ac.signal);
+    });
+
+    test("passes undefined signal when not provided", async () => {
+      const manager = new McpServerManager();
+
+      const callToolSpy = jest.fn().mockResolvedValue({
+        content: "result",
+        isError: false,
+      });
+
+      const fakeClient = { callTool: callToolSpy, serverId: "test-server" };
+      (manager as any).clients.set("test-server", fakeClient);
+
+      await manager.callTool("test-server", "my-tool", { x: 1 });
+
+      expect(callToolSpy).toHaveBeenCalledWith("my-tool", { x: 1 }, undefined);
+    });
+  });
+
+  describe("createMcpTool execute", () => {
+    test("threads context.signal through manager.callTool", async () => {
+      const callToolSpy = jest.fn().mockResolvedValue({
+        content: "tool result",
+        isError: false,
+      });
+
+      const fakeManager = { callTool: callToolSpy } as any;
+
+      const tool = createMcpTool(
+        {
+          name: "my-tool",
+          description: "A test tool",
+          inputSchema: { type: "object", properties: {} },
+        },
+        "test-server",
+        {
+          transport: { type: "stdio", command: "echo", args: [] },
+          enabled: true,
+          defaultRiskLevel: "high",
+          maxTools: 100,
+        },
+        fakeManager,
+      );
+
+      const ac = new AbortController();
+      await tool.execute(
+        { someArg: "value" },
+        {
+          workingDir: "/tmp",
+          conversationId: "conv-1",
+          signal: ac.signal,
+          trustClass: "guardian",
+        },
+      );
+
+      expect(callToolSpy).toHaveBeenCalledWith(
+        "test-server",
+        "my-tool",
+        { someArg: "value" },
+        ac.signal,
+      );
+    });
+
+    test("passes undefined signal when context has no signal", async () => {
+      const callToolSpy = jest.fn().mockResolvedValue({
+        content: "tool result",
+        isError: false,
+      });
+
+      const fakeManager = { callTool: callToolSpy } as any;
+
+      const tool = createMcpTool(
+        {
+          name: "my-tool",
+          description: "A test tool",
+          inputSchema: { type: "object", properties: {} },
+        },
+        "test-server",
+        {
+          transport: { type: "stdio", command: "echo", args: [] },
+          enabled: true,
+          defaultRiskLevel: "high",
+          maxTools: 100,
+        },
+        fakeManager,
+      );
+
+      await tool.execute(
+        { someArg: "value" },
+        {
+          workingDir: "/tmp",
+          conversationId: "conv-1",
+          trustClass: "guardian",
+        },
+      );
+
+      expect(callToolSpy).toHaveBeenCalledWith(
+        "test-server",
+        "my-tool",
+        { someArg: "value" },
+        undefined,
+      );
+    });
+  });
+});

--- a/assistant/src/daemon/host-bash-proxy.ts
+++ b/assistant/src/daemon/host-bash-proxy.ts
@@ -86,10 +86,14 @@ export class HostBashProxy {
             clearTimeout(timer);
             this.pending.delete(requestId);
             this.onInternalResolve?.(requestId);
-            this.sendToClient({
-              type: "host_bash_cancel",
-              requestId,
-            } as ServerMessage);
+            try {
+              this.sendToClient({
+                type: "host_bash_cancel",
+                requestId,
+              } as ServerMessage);
+            } catch {
+              // Best-effort cancel notification — connection may already be closed.
+            }
             resolve(formatShellOutput("", "Aborted", null, false, 0));
           }
         };
@@ -148,10 +152,14 @@ export class HostBashProxy {
     for (const [requestId, entry] of this.pending) {
       clearTimeout(entry.timer);
       this.onInternalResolve?.(requestId);
-      this.sendToClient({
-        type: "host_bash_cancel",
-        requestId,
-      } as ServerMessage);
+      try {
+        this.sendToClient({
+          type: "host_bash_cancel",
+          requestId,
+        } as ServerMessage);
+      } catch {
+        // Best-effort cancel notification — connection may already be closed.
+      }
       entry.reject(
         new AssistantError(
           "Host bash proxy disposed",

--- a/assistant/src/daemon/host-bash-proxy.ts
+++ b/assistant/src/daemon/host-bash-proxy.ts
@@ -86,6 +86,10 @@ export class HostBashProxy {
             clearTimeout(timer);
             this.pending.delete(requestId);
             this.onInternalResolve?.(requestId);
+            this.sendToClient({
+              type: "host_bash_cancel",
+              requestId,
+            } as ServerMessage);
             resolve(formatShellOutput("", "Aborted", null, false, 0));
           }
         };
@@ -144,6 +148,10 @@ export class HostBashProxy {
     for (const [requestId, entry] of this.pending) {
       clearTimeout(entry.timer);
       this.onInternalResolve?.(requestId);
+      this.sendToClient({
+        type: "host_bash_cancel",
+        requestId,
+      } as ServerMessage);
       entry.reject(
         new AssistantError(
           "Host bash proxy disposed",

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -170,6 +170,10 @@ export class HostCuProxy {
             clearTimeout(timer);
             this.pending.delete(requestId);
             this.onInternalResolve?.(requestId);
+            this.sendToClient({
+              type: "host_cu_cancel",
+              requestId,
+            } as ServerMessage);
             resolve({ content: "Aborted", isError: true });
           }
         };
@@ -381,6 +385,7 @@ export class HostCuProxy {
     for (const [requestId, entry] of this.pending) {
       clearTimeout(entry.timer);
       this.onInternalResolve?.(requestId);
+      this.sendToClient({ type: "host_cu_cancel", requestId } as ServerMessage);
       entry.reject(
         new AssistantError("Host CU proxy disposed", ErrorCode.INTERNAL_ERROR),
       );

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -170,10 +170,14 @@ export class HostCuProxy {
             clearTimeout(timer);
             this.pending.delete(requestId);
             this.onInternalResolve?.(requestId);
-            this.sendToClient({
-              type: "host_cu_cancel",
-              requestId,
-            } as ServerMessage);
+            try {
+              this.sendToClient({
+                type: "host_cu_cancel",
+                requestId,
+              } as ServerMessage);
+            } catch {
+              // Best-effort cancel notification — connection may already be closed.
+            }
             resolve({ content: "Aborted", isError: true });
           }
         };
@@ -385,7 +389,14 @@ export class HostCuProxy {
     for (const [requestId, entry] of this.pending) {
       clearTimeout(entry.timer);
       this.onInternalResolve?.(requestId);
-      this.sendToClient({ type: "host_cu_cancel", requestId } as ServerMessage);
+      try {
+        this.sendToClient({
+          type: "host_cu_cancel",
+          requestId,
+        } as ServerMessage);
+      } catch {
+        // Best-effort cancel notification — connection may already be closed.
+      }
       entry.reject(
         new AssistantError("Host CU proxy disposed", ErrorCode.INTERNAL_ERROR),
       );

--- a/assistant/src/daemon/host-file-proxy.ts
+++ b/assistant/src/daemon/host-file-proxy.ts
@@ -82,6 +82,10 @@ export class HostFileProxy {
             clearTimeout(timer);
             this.pending.delete(requestId);
             this.onInternalResolve?.(requestId);
+            this.sendToClient({
+              type: "host_file_cancel",
+              requestId,
+            } as ServerMessage);
             resolve({ content: "Aborted", isError: true });
           }
         };
@@ -123,6 +127,10 @@ export class HostFileProxy {
     for (const [requestId, entry] of this.pending) {
       clearTimeout(entry.timer);
       this.onInternalResolve?.(requestId);
+      this.sendToClient({
+        type: "host_file_cancel",
+        requestId,
+      } as ServerMessage);
       entry.reject(
         new AssistantError(
           "Host file proxy disposed",

--- a/assistant/src/daemon/host-file-proxy.ts
+++ b/assistant/src/daemon/host-file-proxy.ts
@@ -82,10 +82,14 @@ export class HostFileProxy {
             clearTimeout(timer);
             this.pending.delete(requestId);
             this.onInternalResolve?.(requestId);
-            this.sendToClient({
-              type: "host_file_cancel",
-              requestId,
-            } as ServerMessage);
+            try {
+              this.sendToClient({
+                type: "host_file_cancel",
+                requestId,
+              } as ServerMessage);
+            } catch {
+              // Best-effort cancel notification — connection may already be closed.
+            }
             resolve({ content: "Aborted", isError: true });
           }
         };
@@ -127,10 +131,14 @@ export class HostFileProxy {
     for (const [requestId, entry] of this.pending) {
       clearTimeout(entry.timer);
       this.onInternalResolve?.(requestId);
-      this.sendToClient({
-        type: "host_file_cancel",
-        requestId,
-      } as ServerMessage);
+      try {
+        this.sendToClient({
+          type: "host_file_cancel",
+          requestId,
+        } as ServerMessage);
+      } catch {
+        // Best-effort cancel notification — connection may already be closed.
+      }
       entry.reject(
         new AssistantError(
           "Host file proxy disposed",

--- a/assistant/src/daemon/message-types/host-bash.ts
+++ b/assistant/src/daemon/message-types/host-bash.ts
@@ -15,6 +15,11 @@ export interface HostBashRequest {
   env?: Record<string, string>;
 }
 
+export interface HostBashCancelRequest {
+  type: "host_bash_cancel";
+  requestId: string;
+}
+
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
-export type _HostBashServerMessages = HostBashRequest;
+export type _HostBashServerMessages = HostBashRequest | HostBashCancelRequest;

--- a/assistant/src/daemon/message-types/host-cu.ts
+++ b/assistant/src/daemon/message-types/host-cu.ts
@@ -14,6 +14,11 @@ export interface HostCuRequest {
   reasoning?: string;
 }
 
+export interface HostCuCancelRequest {
+  type: "host_cu_cancel";
+  requestId: string;
+}
+
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
-export type _HostCuServerMessages = HostCuRequest;
+export type _HostCuServerMessages = HostCuRequest | HostCuCancelRequest;

--- a/assistant/src/daemon/message-types/host-file.ts
+++ b/assistant/src/daemon/message-types/host-file.ts
@@ -39,6 +39,11 @@ export type HostFileRequest =
   | HostFileWriteRequest
   | HostFileEditRequest;
 
+export interface HostFileCancelRequest {
+  type: "host_file_cancel";
+  requestId: string;
+}
+
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
-export type _HostFileServerMessages = HostFileRequest;
+export type _HostFileServerMessages = HostFileRequest | HostFileCancelRequest;

--- a/assistant/src/mcp/client.ts
+++ b/assistant/src/mcp/client.ts
@@ -159,12 +159,17 @@ export class McpClient {
   async callTool(
     name: string,
     args: Record<string, unknown>,
+    signal?: AbortSignal,
   ): Promise<McpCallResult> {
     if (!this.connected) {
       throw new Error(`MCP client "${this.serverId}" is not connected`);
     }
 
-    const result = await this.client.callTool({ name, arguments: args });
+    const result = await this.client.callTool(
+      { name, arguments: args },
+      undefined,
+      { signal },
+    );
     const isError = result.isError === true;
 
     // Handle structuredContent if present

--- a/assistant/src/mcp/client.ts
+++ b/assistant/src/mcp/client.ts
@@ -168,7 +168,7 @@ export class McpClient {
     const result = await this.client.callTool(
       { name, arguments: args },
       undefined,
-      { signal },
+      signal ? { signal } : undefined,
     );
     const isError = result.isError === true;
 

--- a/assistant/src/mcp/manager.ts
+++ b/assistant/src/mcp/manager.ts
@@ -127,12 +127,13 @@ export class McpServerManager {
     serverId: string,
     toolName: string,
     args: Record<string, unknown>,
+    signal?: AbortSignal,
   ) {
     const client = this.clients.get(serverId);
     if (!client) {
       throw new Error(`MCP server "${serverId}" not found`);
     }
-    return client.callTool(toolName, args);
+    return client.callTool(toolName, args, signal);
   }
 
   getClient(serverId: string): McpClient | undefined {

--- a/assistant/src/signals/bash.ts
+++ b/assistant/src/signals/bash.ts
@@ -138,11 +138,16 @@ export function handleBashSignal(filename: string): void {
   const child = spawn("bash", ["-c", command], {
     cwd: getWorkspaceDir(),
     stdio: ["ignore", "pipe", "pipe"],
+    detached: true,
   });
 
   const timer = setTimeout(() => {
     timedOut = true;
-    child.kill("SIGKILL");
+    try {
+      process.kill(-child.pid!, "SIGKILL");
+    } catch {
+      // Process group may have already exited.
+    }
   }, effectiveTimeout);
 
   child.stdout.on("data", (data: Buffer) => {

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -204,20 +204,33 @@ class HostShellTool implements Tool {
         cwd: workingDir,
         env: hostEnv,
         stdio: ["ignore", "pipe", "pipe"],
+        detached: true,
       });
 
       const timer = setTimeout(() => {
         timedOut = true;
-        child.kill("SIGKILL");
+        try {
+          process.kill(-child.pid!, "SIGKILL");
+        } catch {
+          // Process group may have already exited.
+        }
       }, timeoutMs);
 
       // Cooperative cancellation via AbortSignal
       const onAbort = () => {
-        child.kill("SIGKILL");
+        try {
+          process.kill(-child.pid!, "SIGKILL");
+        } catch {
+          // Process group may have already exited.
+        }
       };
       if (context.signal) {
         if (context.signal.aborted) {
-          child.kill("SIGKILL");
+          try {
+            process.kill(-child.pid!, "SIGKILL");
+          } catch {
+            // Process group may have already exited.
+          }
         } else {
           context.signal.addEventListener("abort", onAbort, { once: true });
         }

--- a/assistant/src/tools/mcp/mcp-tool-factory.ts
+++ b/assistant/src/tools/mcp/mcp-tool-factory.ts
@@ -62,7 +62,7 @@ export function createMcpTool(
 
     async execute(
       input: Record<string, unknown>,
-      _context: ToolContext,
+      context: ToolContext,
     ): Promise<ToolExecutionResult> {
       try {
         // Strip injected activity before sending to MCP server
@@ -77,6 +77,7 @@ export function createMcpTool(
           serverId,
           metadata.name,
           forwardInput,
+          context.signal,
         );
         return {
           content: result.content,

--- a/assistant/src/tools/skills/sandbox-runner.ts
+++ b/assistant/src/tools/skills/sandbox-runner.ts
@@ -159,20 +159,33 @@ function spawnRunner(
       cwd: runDir,
       env,
       stdio: ["ignore", "pipe", "pipe"],
+      detached: true,
     });
 
     const timer = setTimeout(() => {
       timedOut = true;
-      child.kill("SIGKILL");
+      try {
+        process.kill(-child.pid!, "SIGKILL");
+      } catch {
+        // Process group may have already exited.
+      }
     }, timeoutMs);
 
     // Cooperative cancellation via AbortSignal
     const onAbort = () => {
-      child.kill("SIGKILL");
+      try {
+        process.kill(-child.pid!, "SIGKILL");
+      } catch {
+        // Process group may have already exited.
+      }
     };
     if (context.signal) {
       if (context.signal.aborted) {
-        child.kill("SIGKILL");
+        try {
+          process.kill(-child.pid!, "SIGKILL");
+        } catch {
+          // Process group may have already exited.
+        }
       } else {
         context.signal.addEventListener("abort", onAbort, { once: true });
       }

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -329,20 +329,33 @@ class ShellTool implements Tool {
         cwd: context.workingDir,
         env,
         stdio: ["ignore", "pipe", "pipe"],
+        detached: true,
       });
 
       const timer = setTimeout(() => {
         timedOut = true;
-        child.kill("SIGKILL");
+        try {
+          process.kill(-child.pid!, "SIGKILL");
+        } catch {
+          // Process group may have already exited.
+        }
       }, timeoutMs);
 
       // Cooperative cancellation via AbortSignal
       const onAbort = () => {
-        child.kill("SIGKILL");
+        try {
+          process.kill(-child.pid!, "SIGKILL");
+        } catch {
+          // Process group may have already exited.
+        }
       };
       if (context.signal) {
         if (context.signal.aborted) {
-          child.kill("SIGKILL");
+          try {
+            process.kill(-child.pid!, "SIGKILL");
+          } catch {
+            // Process group may have already exited.
+          }
         } else {
           context.signal.addEventListener("abort", onAbort, { once: true });
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -366,8 +366,10 @@ extension AppDelegate {
         HostToolExecutor.markCancelled(requestId)
         if let task = inFlightCuTasks.removeValue(forKey: requestId) {
             task.cancel()
-            dismissHostCuOverlay()
         }
+        // Always dismiss — the task may have already completed and removed
+        // itself from inFlightCuTasks, but the overlay can still be visible.
+        dismissHostCuOverlay()
         log.info("Cancelling host CU — requestId=\(requestId, privacy: .public)")
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -284,13 +284,20 @@ extension AppDelegate {
                     let task = Task { @MainActor in
                         defer { self.inFlightCuTasks.removeValue(forKey: msg.requestId) }
 
-                        guard !Task.isCancelled else { return }
+                        guard !Task.isCancelled else {
+                            HostCuActionRunner.clearSession(msg.conversationId)
+                            return
+                        }
                         let result = await HostCuActionRunner.perform(msg, overlayProxy: proxy)
 
-                        guard !Task.isCancelled else { return }
+                        guard !Task.isCancelled else {
+                            HostCuActionRunner.clearSession(msg.conversationId)
+                            return
+                        }
 
                         // Suppress stale POST if cancelled
                         if HostToolExecutor.isCancelledAndConsume(msg.requestId) {
+                            HostCuActionRunner.clearSession(msg.conversationId)
                             log.debug("Host CU result suppressed (cancelled) — requestId=\(msg.requestId, privacy: .public)")
                             return
                         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -359,8 +359,8 @@ extension AppDelegate {
         HostToolExecutor.markCancelled(requestId)
         if let task = inFlightCuTasks.removeValue(forKey: requestId) {
             task.cancel()
+            dismissHostCuOverlay()
         }
-        dismissHostCuOverlay()
         log.info("Cancelling host CU — requestId=\(requestId, privacy: .public)")
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -281,10 +281,29 @@ extension AppDelegate {
                     HostToolExecutor.executeHostFileRequest(msg)
                 case .hostCuRequest(let msg):
                     let proxy = self.getOrCreateHostCuOverlay(conversationId: msg.conversationId, request: msg)
-                    Task { @MainActor in
+                    let task = Task { @MainActor in
+                        defer { self.inFlightCuTasks.removeValue(forKey: msg.requestId) }
+
+                        guard !Task.isCancelled else { return }
                         let result = await HostCuActionRunner.perform(msg, overlayProxy: proxy)
+
+                        guard !Task.isCancelled else { return }
+
+                        // Suppress stale POST if cancelled
+                        if HostToolExecutor.isCancelledAndConsume(msg.requestId) {
+                            log.debug("Host CU result suppressed (cancelled) — requestId=\(msg.requestId, privacy: .public)")
+                            return
+                        }
                         _ = await HostProxyClient().postCuResult(result)
                     }
+                    self.inFlightCuTasks[msg.requestId] = task
+
+                case .hostBashCancel(let msg):
+                    HostToolExecutor.cancelHostBashRequest(msg.requestId)
+                case .hostFileCancel(let msg):
+                    HostToolExecutor.cancelHostFileRequest(msg.requestId)
+                case .hostCuCancel(let msg):
+                    self.cancelHostCuRequest(msg.requestId)
 
                 // Signing identity
                 case .signBundlePayload(let msg):
@@ -330,6 +349,19 @@ extension AppDelegate {
                 }
             }
         }
+    }
+
+    // MARK: - Host CU Cancel
+
+    /// Cancel an in-flight host CU request: mark it cancelled, cancel the
+    /// Swift Task, and dismiss the overlay.
+    func cancelHostCuRequest(_ requestId: String) {
+        HostToolExecutor.markCancelled(requestId)
+        if let task = inFlightCuTasks.removeValue(forKey: requestId) {
+            task.cancel()
+        }
+        dismissHostCuOverlay()
+        log.info("Cancelling host CU — requestId=\(requestId, privacy: .public)")
     }
 
     // MARK: - Signing Identity

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -41,6 +41,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var hostCuOverlayCleanupTask: Task<Void, Never>?
     /// Combine subscriptions for host CU overlay state observation.
     var hostCuOverlayCancellables = Set<AnyCancellable>()
+    /// In-flight CU tasks keyed by request ID, for cancel support.
+    var inFlightCuTasks: [String: Task<Void, Never>] = [:]
     var isStartingSession = false
     var startSessionTask: Task<Void, Never>?
     var voiceInput: VoiceInputManager?

--- a/clients/shared/Network/HostToolExecutor.swift
+++ b/clients/shared/Network/HostToolExecutor.swift
@@ -22,7 +22,7 @@ public enum HostToolExecutor {
     #endif
 
     /// Mark a request ID as cancelled and sweep stale entries (>30s old).
-    static func markCancelled(_ requestId: String) {
+    public static func markCancelled(_ requestId: String) {
         lock.withLock {
             let now = Date()
             cancelledRequestIds[requestId] = now
@@ -33,7 +33,7 @@ public enum HostToolExecutor {
 
     /// Check if a request ID was cancelled. If found, removes it (consume-once)
     /// and returns `true`. Returns `false` if not cancelled.
-    static func isCancelledAndConsume(_ requestId: String) -> Bool {
+    public static func isCancelledAndConsume(_ requestId: String) -> Bool {
         lock.withLock {
             if cancelledRequestIds.removeValue(forKey: requestId) != nil {
                 return true

--- a/clients/shared/Network/HostToolExecutor.swift
+++ b/clients/shared/Network/HostToolExecutor.swift
@@ -7,6 +7,41 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 /// These run locally on macOS and post results back via `HostProxyClient`.
 public enum HostToolExecutor {
 
+    // MARK: - Cancelled Request Tracking
+
+    /// Lock guarding `cancelledRequestIds` and `runningProcesses`.
+    private static let lock = NSLock()
+
+    /// Request IDs that have been cancelled, with timestamps for TTL cleanup.
+    /// Entries older than 30 seconds are swept on each `markCancelled` call.
+    private static var cancelledRequestIds: [String: Date] = [:]
+
+    #if os(macOS)
+    /// Currently running bash processes keyed by request ID.
+    private static var runningProcesses: [String: Process] = [:]
+    #endif
+
+    /// Mark a request ID as cancelled and sweep stale entries (>30s old).
+    static func markCancelled(_ requestId: String) {
+        lock.withLock {
+            let now = Date()
+            cancelledRequestIds[requestId] = now
+            // Sweep entries older than 30 seconds
+            cancelledRequestIds = cancelledRequestIds.filter { now.timeIntervalSince($0.value) < 30 }
+        }
+    }
+
+    /// Check if a request ID was cancelled. If found, removes it (consume-once)
+    /// and returns `true`. Returns `false` if not cancelled.
+    static func isCancelledAndConsume(_ requestId: String) -> Bool {
+        lock.withLock {
+            if cancelledRequestIds.removeValue(forKey: requestId) != nil {
+                return true
+            }
+            return false
+        }
+    }
+
     // MARK: - Host Bash Execution
 
     #if os(macOS)
@@ -16,6 +51,12 @@ public enum HostToolExecutor {
     @MainActor
     public static func executeHostBashRequest(_ request: HostBashRequest) {
         Task.detached {
+            // If already cancelled before we start, skip entirely
+            if isCancelledAndConsume(request.requestId) {
+                log.debug("Host bash skipped (pre-cancelled) — requestId=\(request.requestId, privacy: .public)")
+                return
+            }
+
             let defaultTimeout: Double = 120
             let timeout = request.timeoutSeconds ?? defaultTimeout
 
@@ -94,6 +135,9 @@ public enum HostToolExecutor {
                 pipeGroup.leave()
             }
 
+            // Register the process so cancel can terminate it
+            lock.withLock { runningProcesses[request.requestId] = process }
+
             do {
                 try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
                     process.terminationHandler = { _ in
@@ -111,6 +155,7 @@ public enum HostToolExecutor {
                     }
                 }
             } catch {
+                lock.withLock { runningProcesses.removeValue(forKey: request.requestId) }
                 timerSource.cancel()
                 log.error("Failed to launch host bash process: \(error.localizedDescription)")
                 let result = HostBashResultPayload(
@@ -120,9 +165,12 @@ public enum HostToolExecutor {
                     exitCode: nil,
                     timedOut: false
                 )
-                _ = await HostProxyClient().postBashResult(result)
+                if !isCancelledAndConsume(request.requestId) {
+                    _ = await HostProxyClient().postBashResult(result)
+                }
                 return
             }
+            lock.withLock { runningProcesses.removeValue(forKey: request.requestId) }
             timerSource.cancel()
 
             let stdout = String(data: stdoutBox.value, encoding: .utf8) ?? ""
@@ -139,7 +187,32 @@ public enum HostToolExecutor {
             )
 
             log.debug("Host bash completed — requestId=\(request.requestId, privacy: .public) exitCode=\(exitCode) timedOut=\(timedOut)")
+
+            // Suppress stale POST if cancelled while running
+            if isCancelledAndConsume(request.requestId) {
+                log.debug("Host bash result suppressed (cancelled) — requestId=\(request.requestId, privacy: .public)")
+                return
+            }
             _ = await HostProxyClient().postBashResult(result)
+        }
+    }
+
+    /// Cancel an in-flight host bash request: mark it cancelled and terminate
+    /// the running process (SIGTERM, then SIGKILL after 2s).
+    public static func cancelHostBashRequest(_ requestId: String) {
+        markCancelled(requestId)
+        let process: Process? = lock.withLock { runningProcesses[requestId] }
+        guard let process else { return }
+        log.info("Cancelling host bash — requestId=\(requestId, privacy: .public)")
+        if process.isRunning {
+            process.terminate()
+            DispatchQueue.global().asyncAfter(deadline: .now() + 2) { [process] in
+                // SIGKILL if still alive after grace period — check liveness first
+                // to avoid killing a reused PID if the process already exited.
+                if process.isRunning {
+                    kill(process.processIdentifier, SIGKILL)
+                }
+            }
         }
     }
     #endif
@@ -152,6 +225,13 @@ public enum HostToolExecutor {
     @MainActor
     public static func executeHostFileRequest(_ request: HostFileRequest) {
         Task.detached {
+            // Check cancellation BEFORE performing the file operation to prevent
+            // cancelled requests from mutating the filesystem.
+            if isCancelledAndConsume(request.requestId) {
+                log.debug("Host file skipped (pre-cancelled) — requestId=\(request.requestId, privacy: .public)")
+                return
+            }
+
             let result: HostFileResultPayload
 
             do {
@@ -208,8 +288,22 @@ public enum HostToolExecutor {
             }
 
             log.debug("Host file completed — requestId=\(request.requestId, privacy: .public) op=\(request.operation, privacy: .public) isError=\(result.isError)")
+
+            // Suppress stale POST if cancelled
+            if isCancelledAndConsume(request.requestId) {
+                log.debug("Host file result suppressed (cancelled) — requestId=\(request.requestId, privacy: .public)")
+                return
+            }
             _ = await HostProxyClient().postFileResult(result)
         }
+    }
+
+    /// Cancel an in-flight host file request. File operations are synchronous
+    /// and short-lived so there is no process to kill — we just mark it
+    /// cancelled so the result POST is suppressed.
+    public static func cancelHostFileRequest(_ requestId: String) {
+        markCancelled(requestId)
+        log.info("Cancelling host file — requestId=\(requestId, privacy: .public)")
     }
 
     // MARK: - File Operations

--- a/clients/shared/Network/HostToolExecutor.swift
+++ b/clients/shared/Network/HostToolExecutor.swift
@@ -143,6 +143,9 @@ public enum HostToolExecutor {
             if isCancelledAndConsume(request.requestId) {
                 lock.withLock { runningProcesses.removeValue(forKey: request.requestId) }
                 timerSource.cancel()
+                // Close write ends so the readDataToEndOfFile() GCD blocks can finish
+                try? stdoutPipe.fileHandleForWriting.close()
+                try? stderrPipe.fileHandleForWriting.close()
                 log.debug("Host bash cancelled before launch — requestId=\(request.requestId, privacy: .public)")
                 return
             }

--- a/clients/shared/Network/HostToolExecutor.swift
+++ b/clients/shared/Network/HostToolExecutor.swift
@@ -138,6 +138,15 @@ public enum HostToolExecutor {
             // Register the process so cancel can terminate it
             lock.withLock { runningProcesses[request.requestId] = process }
 
+            // Re-check cancellation after registration — a cancel may have
+            // arrived between the initial check and the store above.
+            if isCancelledAndConsume(request.requestId) {
+                lock.withLock { runningProcesses.removeValue(forKey: request.requestId) }
+                timerSource.cancel()
+                log.debug("Host bash cancelled before launch — requestId=\(request.requestId, privacy: .public)")
+                return
+            }
+
             do {
                 try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
                     process.terminationHandler = { _ in

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1389,6 +1389,13 @@ public struct HostBashRequest: Decodable, Sendable {
     }
 }
 
+/// Cancellation signal from the daemon telling the client to abort an in-flight
+/// host bash execution identified by `requestId`.
+public struct HostBashCancelRequest: Decodable, Sendable {
+    public let type: String
+    public let requestId: String
+}
+
 /// Payload posted back to the daemon with the result of a host bash execution.
 public struct HostBashResultPayload: Codable, Sendable {
     public let requestId: String
@@ -1444,6 +1451,13 @@ public struct HostFileRequest: Decodable, Sendable {
     }
 }
 
+/// Cancellation signal from the daemon telling the client to abort an in-flight
+/// host file operation identified by `requestId`.
+public struct HostFileCancelRequest: Decodable, Sendable {
+    public let type: String
+    public let requestId: String
+}
+
 /// Payload posted back to the daemon with the result of a host file operation.
 public struct HostFileResultPayload: Codable, Sendable {
     public let requestId: String
@@ -1480,6 +1494,13 @@ public struct HostCuRequest: Decodable, Sendable {
         case stepNumber
         case reasoning
     }
+}
+
+/// Cancellation signal from the daemon telling the client to abort an in-flight
+/// host computer-use action identified by `requestId`.
+public struct HostCuCancelRequest: Decodable, Sendable {
+    public let type: String
+    public let requestId: String
 }
 
 /// Payload posted back to the daemon with the result of a host CU action execution.
@@ -2150,8 +2171,11 @@ public enum ServerMessage: Decodable, Sendable {
     case tokenRotated(TokenRotatedMessage)
     case identityChanged(IdentityChanged)
     case hostBashRequest(HostBashRequest)
+    case hostBashCancel(HostBashCancelRequest)
     case hostFileRequest(HostFileRequest)
+    case hostFileCancel(HostFileCancelRequest)
     case hostCuRequest(HostCuRequest)
+    case hostCuCancel(HostCuCancelRequest)
     case usageUpdate(UsageUpdate)
     case serviceGroupUpdateStarting(ServiceGroupUpdateStartingMessage)
     case serviceGroupUpdateProgress(ServiceGroupUpdateProgressMessage)
@@ -2579,12 +2603,21 @@ public enum ServerMessage: Decodable, Sendable {
         case "host_bash_request":
             let message = try HostBashRequest(from: decoder)
             self = .hostBashRequest(message)
+        case "host_bash_cancel":
+            let message = try HostBashCancelRequest(from: decoder)
+            self = .hostBashCancel(message)
         case "host_file_request":
             let message = try HostFileRequest(from: decoder)
             self = .hostFileRequest(message)
+        case "host_file_cancel":
+            let message = try HostFileCancelRequest(from: decoder)
+            self = .hostFileCancel(message)
         case "host_cu_request":
             let message = try HostCuRequest(from: decoder)
             self = .hostCuRequest(message)
+        case "host_cu_cancel":
+            let message = try HostCuCancelRequest(from: decoder)
+            self = .hostCuCancel(message)
         case "usage_update":
             let message = try UsageUpdate(from: decoder)
             self = .usageUpdate(message)


### PR DESCRIPTION
## Summary
When the user presses the stop button while the assistant is executing a task, host-proxied tool execution (bash, file, CU) now actually terminates on the macOS client. Previously, the daemon resolved its pending promise but never notified the Swift client to kill the running process. Additionally, MCP tool calls are now cancellable via AbortSignal, and child process groups are properly cleaned up on macOS.

## Changes
- **Wire protocol**: Added `host_bash_cancel`, `host_file_cancel`, `host_cu_cancel` message types to daemon TypeScript and Swift `MessageTypes`
- **Daemon proxies**: All three proxies (bash, file, CU) now send cancel messages when AbortSignal fires in `onAbort` and `dispose()`
- **Swift client**: Handles cancel messages — kills bash processes (SIGTERM → SIGKILL), cancels CU tasks, dismisses overlays, and suppresses stale result POSTs with TTL-based tracking and consume-on-read pattern
- **MCP tools**: Threaded AbortSignal through `mcp-tool-factory` → `manager` → `client` → SDK `callTool()` options for cooperative cancellation
- **Process groups**: Tool child processes spawn with `detached: true` and use `process.kill(-pid, SIGKILL)` for reliable grandchild cleanup (with try/catch for ESRCH)

## Milestone PRs (merged into feature branch)
- #21269: M1 — Wire protocol cancel message types
- #21370: M2 — Daemon proxies send cancel on abort
- #21374: M3 — Swift client handles cancel, kills work, suppresses stale POSTs
- #21271: M4 — Thread AbortSignal into MCP tool calls
- #21270: M5 — Process group kill for grandchild cleanup

## Project issue
Closes #21263

## Test plan
- [ ] Press stop during a long-running bash command — verify process is killed on macOS host
- [ ] Press stop during an MCP tool call — verify the call is aborted
- [ ] Press stop during a file write operation — verify the write is prevented
- [ ] Press stop during CU action — verify overlay is dismissed
- [ ] Verify no stale result POSTs reach the daemon after cancel
- [ ] Run `bun test src/__tests__/host-bash-proxy.test.ts src/__tests__/host-file-proxy.test.ts src/__tests__/host-cu-proxy.test.ts src/__tests__/mcp-abort-signal.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
