### PR TITLE
refactor: replace GeometryReader with .onGeometryChange for compact layout detection

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -258,19 +258,18 @@ public struct ToolConfirmationBubble: View {
         .padding(VSpacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
-            GeometryReader { geo in
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .fill(VColor.surfaceOverlay)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.md)
-                            .stroke(VColor.borderBase, lineWidth: 0.5)
-                    )
-                    .onAppear { useCompactConfirmationLayout = geo.size.width < 450 }
-                    .onChange(of: geo.size.width) { _, width in
-                        useCompactConfirmationLayout = width < 450
-                    }
-            }
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.surfaceOverlay)
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(VColor.borderBase, lineWidth: 0.5)
+                )
         )
+        .onGeometryChange(for: Bool.self) { proxy in
+            proxy.size.width < 450
+        } action: { isCompact in
+            useCompactConfirmationLayout = isCompact
+        }
         .onAppear {
             if isKeyboardActive {
                 #if os(macOS)


### PR DESCRIPTION
## Summary
- Replaces GeometryReader width detection with .onGeometryChange(for: Bool.self) in ToolConfirmationBubble
- Uses single-value action overload for iOS 17 compatibility

Part of plan: modern-patterns-cleanup.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
