### PR TITLE
refactor: replace GeometryReader with .onGeometryChange in macOS views

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -538,13 +538,11 @@ struct AssistantProgressView: View {
         .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.xs)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(GeometryReader { geo in
-            Color.clear
-                .onAppear { hideInlineChips = geo.size.width < 350 }
-                .onChange(of: geo.size.width) { _, width in
-                    hideInlineChips = width < 350
-                }
-        })
+        .onGeometryChange(for: Bool.self) { proxy in
+            proxy.size.width < 350
+        } action: { shouldHide in
+            hideInlineChips = shouldHide
+        }
     }
 
     // MARK: - Status Icon

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -572,14 +572,11 @@ extension MainWindowView {
                     showConversationSwitcher = false
                 }
                 .pointerCursor()
-                .background(GeometryReader { proxy in
-                    Color.clear.onAppear {
-                        conversationSwitcherTriggerFrame = proxy.frame(in: .named("coreLayout"))
-                    }
-                    .onChange(of: proxy.frame(in: .named("coreLayout"))) { _, newFrame in
-                        conversationSwitcherTriggerFrame = newFrame
-                    }
-                })
+                .onGeometryChange(for: CGRect.self) { proxy in
+                    proxy.frame(in: .named("coreLayout"))
+                } action: { newFrame in
+                    conversationSwitcherTriggerFrame = newFrame
+                }
             }
 
             Spacer()

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -512,14 +512,11 @@ struct MainWindowView: View {
                     onOpenForkParent: { openForkParentConversation() },
                     showDrawer: $showConversationActionsDrawer
                 )
-                .background(GeometryReader { proxy in
-                    Color.clear.onAppear {
-                        conversationTitleFrame = proxy.frame(in: .named("coreLayout"))
-                    }
-                    .onChange(of: proxy.frame(in: .named("coreLayout"))) { _, newFrame in
-                        conversationTitleFrame = newFrame
-                    }
-                })
+                .onGeometryChange(for: CGRect.self) { proxy in
+                    proxy.frame(in: .named("coreLayout"))
+                } action: { newFrame in
+                    conversationTitleFrame = newFrame
+                }
                 // Shift the title right so it centers above the chat content area
                 // (not the full window). Content starts after outer padding (16) +
                 // sidebar + spacing (16), so its center is offset from the window

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -868,12 +868,11 @@ struct DynamicWorkspaceWrapper: View {
                                 VButton(label: "Share", iconOnly: VIcon.share.rawValue, style: .outlined, iconSize: 32, tooltip: "Share") {
                                     showShareDrawer.toggle()
                                 }
-                                .background(GeometryReader { proxy in
-                                    Color.clear.onChange(of: showShareDrawer) { _, _ in
-                                        shareButtonFrame = proxy.frame(in: .named("appPageContainer"))
-                                    }
-                                    .onAppear { shareButtonFrame = proxy.frame(in: .named("appPageContainer")) }
-                                })
+                                .onGeometryChange(for: CGRect.self) { proxy in
+                                    proxy.frame(in: .named("appPageContainer"))
+                                } action: { newFrame in
+                                    shareButtonFrame = newFrame
+                                }
                                 .overlay {
                                     AppSharePanel(
                                         items: sharing.shareFileURL != nil ? [sharing.shareFileURL!] : [],


### PR DESCRIPTION
## Summary
- Replaces GeometryReader-in-background measurement patterns with .onGeometryChange (single-value overload)

Part of plan: modern-patterns-cleanup.md (PR 1 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
