### PR TITLE
refactor: replace Timer.scheduledTimer with TimelineView for recording HUD elapsed time

### DIFF
--- a/clients/macos/vellum-assistant/Recording/RecordingHUDWindow.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingHUDWindow.swift
@@ -85,14 +85,22 @@ final class RecordingHUDWindow {
 @MainActor
 @Observable
 final class RecordingHUDViewModel {
-    var elapsedSeconds: Int = 0
     var isRecording = true
     var isPaused = false
     var failureMessage: String?
 
-    private var timer: Timer?
+    private var recordingStartTime: Date?
+    private var accumulatedPausedDuration: TimeInterval = 0
+    private var pauseStartTime: Date?
     private let onStop: () -> Void
     private let onPauseResume: ((Bool) -> Void)?
+
+    var elapsedSeconds: Int {
+        guard let start = recordingStartTime else { return 0 }
+        let totalElapsed = Date().timeIntervalSince(start)
+        let paused = accumulatedPausedDuration + (pauseStartTime.map { Date().timeIntervalSince($0) } ?? 0)
+        return max(0, Int(totalElapsed - paused))
+    }
 
     init(onStop: @escaping () -> Void, onPauseResume: ((Bool) -> Void)? = nil) {
         self.onStop = onStop
@@ -101,28 +109,28 @@ final class RecordingHUDViewModel {
     }
 
     func startTimer() {
-        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                self?.elapsedSeconds += 1
-            }
-        }
+        recordingStartTime = Date()
+        accumulatedPausedDuration = 0
+        pauseStartTime = nil
     }
 
     /// Pause the elapsed-time timer (called when recording is paused).
     func pauseTimer() {
-        timer?.invalidate()
-        timer = nil
+        pauseStartTime = Date()
     }
 
     /// Resume the elapsed-time timer (called when recording is resumed).
     func resumeTimer() {
-        guard timer == nil else { return }
-        startTimer()
+        if let pauseStart = pauseStartTime {
+            accumulatedPausedDuration += Date().timeIntervalSince(pauseStart)
+            pauseStartTime = nil
+        }
     }
 
     func stopTimer() {
-        timer?.invalidate()
-        timer = nil
+        recordingStartTime = nil
+        accumulatedPausedDuration = 0
+        pauseStartTime = nil
     }
 
     func stop() {
@@ -175,11 +183,13 @@ struct RecordingHUDView: View {
                         }
                     }
 
-                // Elapsed time (freezes when paused via timer pause)
-                Text(viewModel.formattedTime)
-                    .font(VFont.bodySmallDefault)
-                    .foregroundStyle(viewModel.isPaused ? VColor.contentSecondary : VColor.contentDefault)
-                    .monospacedDigit()
+                // Elapsed time (freezes when paused via computed property)
+                TimelineView(.periodic(from: .now, by: 1)) { _ in
+                    Text(viewModel.formattedTime)
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(viewModel.isPaused ? VColor.contentSecondary : VColor.contentDefault)
+                        .monospacedDigit()
+                }
 
                 if viewModel.isPaused {
                     Text("Paused")


### PR DESCRIPTION
## Summary
- Replaces Timer with TimelineView + computed elapsed time from timestamps
- Properly tracks accumulated paused duration for pause/resume
- resumeTimer() no longer resets elapsed time

Part of plan: modern-patterns-cleanup.md (PR 4 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
