### PR TITLE
refactor: replace DispatchQueue.main.asyncAfter with Task.sleep in service classes

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -244,7 +244,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         // Apply immediately, and again after a short delay to catch SwiftUI
         // resetting the title after applicationDidFinishLaunching returns.
         applyMenuBarTitlePatch()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            guard !Task.isCancelled else { return }
             self?.applyMenuBarTitlePatch()
         }
     }
@@ -260,8 +262,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// with delays (same pattern as Help menu and app-name patching).
     func installFileMenuDelegate() {
         installFileMenuDelegateOnce()
-        for delay in [0.1, 0.5, 1.0] {
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+        for delay: UInt64 in [100_000_000, 500_000_000, 1_000_000_000] {
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: delay)
+                guard !Task.isCancelled else { return }
                 self?.installFileMenuDelegateOnce()
             }
         }
@@ -317,7 +321,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             if let existing = others.first {
                 log.info("[singleInstance] Another instance (pid \(existing.processIdentifier)) detected — activating it and terminating self")
                 existing.activate()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 300_000_000)
+                    guard !Task.isCancelled else { return }
                     NSApp.terminate(nil)
                 }
                 return

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputWindow.swift
@@ -164,7 +164,9 @@ final class QuickInputWindow {
                 if let conversationId = self?.textModel.selectedConversationId {
                     self?.onSelectConversation?(conversationId)
                     // Small delay so the conversation switches before we send the message
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    Task { @MainActor [weak self] in
+                        try? await Task.sleep(nanoseconds: 100_000_000)
+                        guard !Task.isCancelled else { return }
                         self?.onSubmitToConversation?(message, self?.attachedImageData)
                     }
                 } else {

--- a/clients/macos/vellum-assistant/Features/Sharing/ShareSheetHelper.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/ShareSheetHelper.swift
@@ -69,7 +69,9 @@ struct AppSharePanel: NSViewRepresentable {
                 onDismiss()
                 return
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: 50_000_000)
+                guard !Task.isCancelled else { return }
                 self?.presentWhenReady(nsView: nsView, attempt: attempt + 1, onDismiss: onDismiss)
             }
         }

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -889,7 +889,9 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             guard let onSnapshotCaptured else { return }
             logPhase("captureSnapshotAfterMorph:start")
             hasCapturedSnapshot = false
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: 500_000_000)
+                guard !Task.isCancelled else { return }
                 guard let self, self.morphGeneration == generation else { return }
                 self.logPhase("captureSnapshotAfterMorph:takeSnapshot")
                 self.captureSnapshot { [weak self] base64 in
@@ -1040,7 +1042,9 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             if !hasCapturedSnapshot, let onSnapshotCaptured {
                 hasCapturedSnapshot = true
                 logPhase("onSnapshotCaptured:scheduled")
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+                Task { @MainActor [weak self] in
+                    try? await Task.sleep(nanoseconds: 1_500_000_000)
+                    guard !Task.isCancelled else { return }
                     self?.logPhase("onSnapshotCaptured:takeSnapshot")
                     self?.captureSnapshot { base64 in
                         if let base64 {

--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -145,7 +145,9 @@ final class SecretPromptManager {
             dismissPrompt(requestId: requestId)
         } else if success {
             // Save: delay dismiss so "Saved" confirmation is visible
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: 1_500_000_000)
+                guard !Task.isCancelled else { return }
                 self?.dismissPrompt(requestId: requestId)
             }
         }

--- a/clients/macos/vellum-assistant/Features/Voice/DictationOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationOverlayWindow.swift
@@ -115,7 +115,9 @@ final class DictationOverlayWindow {
 
     func showDoneAndDismiss() {
         show(state: .done)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 800_000_000)
+            guard !Task.isCancelled else { return }
             self?.dismiss()
         }
     }

--- a/clients/macos/vellum-assistant/Features/Voice/DictationTextInserter.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationTextInserter.swift
@@ -33,7 +33,9 @@ final class DictationTextInserter {
 
         // Restore clipboard after delay
         let itemsToRestore = savedItems
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 500_000_000)
+            guard !Task.isCancelled else { return }
             restorePasteboardItems(itemsToRestore, to: NSPasteboard.general)
         }
 

--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -169,7 +169,9 @@ private final class VTooltipTrackerView: NSView {
         ) { _ in
             // Brief delay so tracking-area recalculation settles before
             // we accept mouseEntered again.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 300_000_000)
+                guard !Task.isCancelled else { return }
                 Self.isScrolling = false
             }
         }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -750,7 +750,9 @@ extension ChatViewModel {
                 let hadCodePreview = messages[index].streamingCodePreview != nil
                 if hadCodePreview {
                     let msgId = existingId
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [weak self] in
+                    Task { @MainActor [weak self] in
+                        try? await Task.sleep(nanoseconds: 5_000_000_000)
+                        guard !Task.isCancelled else { return }
                         guard let self,
                               let idx = self.messages.firstIndex(where: { $0.id == msgId }) else { return }
                         self.messages[idx].streamingCodePreview = nil

--- a/clients/shared/Features/Chat/MarkdownRenderer.swift
+++ b/clients/shared/Features/Chat/MarkdownRenderer.swift
@@ -57,7 +57,9 @@ private struct CodeBlockView: View {
         UIPasteboard.general.string = code
         #endif
         showCopied = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            guard !Task.isCancelled else { return }
             showCopied = false
         }
     }


### PR DESCRIPTION
## Summary
- Replaces asyncAfter with Task.sleep in service/manager classes
- SettingsStore explicitly excluded (uses cancelable DispatchWorkItem)
- All post-sleep paths include guard !Task.isCancelled

Part of plan: modern-patterns-cleanup.md (PR 7 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
