### PR TITLE
refactor: replace DispatchQueue.main.asyncAfter with Task.sleep in SwiftUI views

### DIFF
--- a/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationFlowView.swift
@@ -413,11 +413,11 @@ struct ChannelVerificationFlowView: View {
                 maxWidth: 360,
                 isFocused: $isDestinationFocused
             )
-            .onAppear {
+            .task {
                 if autoFocus {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                        isDestinationFocused = true
-                    }
+                    try? await Task.sleep(nanoseconds: 100_000_000)
+                    guard !Task.isCancelled else { return }
+                    isDestinationFocused = true
                 }
             }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -125,24 +125,26 @@ struct ComposerView: View {
         .disabled(!isInteractionEnabled)
         .animation(VAnimation.fast, value: isComposerFocused)
         .onAppear {
+            let identity = IdentityInfo.load()
+            avatarSeed = identity?.name ?? "default"
+        }
+        .task {
             // Delay focus slightly so the NSTextView field editor is fully
             // installed before we request first-responder status. Setting
             // @FocusState synchronously during an animated layout pass
             // (e.g. the empty-state fade-in) can give logical focus without
             // rendering the blinking caret.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                composerFocus = isInteractionEnabled
-            }
-            let identity = IdentityInfo.load()
-            avatarSeed = identity?.name ?? "default"
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            guard !Task.isCancelled else { return }
+            composerFocus = isInteractionEnabled
         }
-        .onChange(of: conversationId) {
+        .task(id: conversationId) {
             guard isInteractionEnabled, !hasPendingConfirmation else { return }
             // Same delay: the conversation switch may trigger a view rebuild
             // (new empty state) whose layout isn't settled yet.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                composerFocus = true
-            }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            guard !Task.isCancelled else { return }
+            composerFocus = true
         }
         .onChange(of: currentMode) {
             composerLog.debug("Composer mode: \(String(describing: currentMode))")

--- a/clients/macos/vellum-assistant/Features/MainWindow/ComingAliveOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ComingAliveOverlay.swift
@@ -71,7 +71,9 @@ struct ComingAliveOverlay: View {
         }
 
         // 2. Glow pulse starts slightly after avatar begins
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            guard !Task.isCancelled else { return }
             withAnimation(.easeOut(duration: 0.8)) {
                 glowScale = 1.6
                 glowOpacity = 0.5
@@ -83,7 +85,9 @@ struct ComingAliveOverlay: View {
         }
 
         // 3. Notify completion
-        DispatchQueue.main.asyncAfter(deadline: .now() + completionDelay) {
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: UInt64(completionDelay * 1_000_000_000))
+            guard !Task.isCancelled else { return }
             onComplete()
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -1052,7 +1052,7 @@ private struct PublishedButton: View {
     @Binding var copied: Bool
 
     @State private var isCopyHovered = false
-    @State private var resetTimer: DispatchWorkItem?
+    @State private var resetTask: Task<Void, Never>?
 
     var body: some View {
         HStack(spacing: VSpacing.xs) {
@@ -1067,13 +1067,15 @@ private struct PublishedButton: View {
                 .animation(VAnimation.fast, value: copied)
                 .contentShape(Rectangle())
                 .onTapGesture {
-                    resetTimer?.cancel()
+                    resetTask?.cancel()
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(url, forType: .string)
                     copied = true
-                    let timer = DispatchWorkItem { copied = false }
-                    resetTimer = timer
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: timer)
+                    resetTask = Task { @MainActor in
+                        try? await Task.sleep(nanoseconds: 1_500_000_000)
+                        guard !Task.isCancelled else { return }
+                        copied = false
+                    }
                 }
                 .onHover { hovering in
                     isCopyHovered = hovering

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -119,7 +119,9 @@ struct APIKeyEntryStepView: View {
             withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
                 showContent = true
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 800_000_000)
+                guard !Task.isCancelled else { return }
                 keyFieldFocused = true
             }
         }
@@ -175,7 +177,9 @@ struct APIKeyEntryStepView: View {
                         .vInputChrome()
                         .onTapGesture {
                             isEditing = true
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                            Task { @MainActor in
+                                try? await Task.sleep(nanoseconds: 100_000_000)
+                                guard !Task.isCancelled else { return }
                                 keyFieldFocused = true
                             }
                         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingButton.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingButton.swift
@@ -58,12 +58,12 @@ struct OnboardingButton: View {
                 isHovered = hovering
             }
         }
-        .onAppear {
+        .task {
             if fadeIn {
-                DispatchQueue.main.asyncAfter(deadline: .now() + fadeDelay) {
-                    withAnimation(.easeOut(duration: 0.5)) {
-                        visible = true
-                    }
+                try? await Task.sleep(nanoseconds: UInt64(fadeDelay * 1_000_000_000))
+                guard !Task.isCancelled else { return }
+                withAnimation(.easeOut(duration: 0.5)) {
+                    visible = true
                 }
             } else {
                 visible = true

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -98,7 +98,9 @@ struct OnboardingFlowView: View {
                                             guard !isAdvancingFromWakeUp else { return }
                                             isAdvancingFromWakeUp = true
                                             state.hasHatched = true
-                                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                                            Task { @MainActor in
+                                                try? await Task.sleep(nanoseconds: 300_000_000)
+                                                guard !Task.isCancelled else { return }
                                                 state.advance()
                                             }
                                         },


### PR DESCRIPTION
## Summary
- Replaces asyncAfter with .task{}, .task(id:), or Task{} depending on context
- All post-sleep paths include guard !Task.isCancelled

Part of plan: modern-patterns-cleanup.md (PR 6 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21385" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
