### PR TITLE
refactor: replace 60fps Timer with TimelineView for hatching progress animation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -25,8 +25,10 @@ struct HatchingStepView: View {
         state.hatchAvatarColor ?? .allCases[0]
     }
     @State private var completionTask: Task<Void, Never>?
-    @State private var progressTimer: Timer?
+    @State private var isAnimatingProgress: Bool = false
     @State private var progressStartTime: CFAbsoluteTime?
+    @State private var completionTime: Date?
+    @State private var progressAtCompletion: Double?
 
     var body: some View {
         VStack(spacing: VSpacing.lg) {
@@ -75,21 +77,28 @@ struct HatchingStepView: View {
             // appears, so .onChange(of: hatchStepLabel) never fires. Start the
             // progress timer eagerly when the label is already present.
             if state.hatchStepLabel != nil {
-                startProgressTimer()
+                progressStartTime = CFAbsoluteTimeGetCurrent()
+                isAnimatingProgress = true
             }
         }
         .onDisappear {
             completionTask?.cancel()
-            stopProgressTimer()
+            isAnimatingProgress = false
         }
         .onChange(of: state.hatchStepLabel) { oldLabel, newLabel in
             if oldLabel == nil, newLabel != nil {
-                startProgressTimer()
+                progressStartTime = CFAbsoluteTimeGetCurrent()
+                isAnimatingProgress = true
             }
         }
         .onChange(of: state.hatchCompleted) { _, completed in
             if completed {
                 characterAwake = true
+                // Capture state for the completion ramp animation
+                if completionTime == nil {
+                    progressAtCompletion = progressValue(at: Date())
+                    completionTime = Date()
+                }
             }
         }
         .onChange(of: state.hatchFailed) { _, failed in
@@ -185,14 +194,17 @@ struct HatchingStepView: View {
     // MARK: - Progress Bar
 
     private var showProgressBar: Bool {
-        !state.hatchFailed && !state.hatchCompleted && !isCustomHardware && state.hatchStepLabel != nil
+        !state.hatchFailed && !isCustomHardware && state.hatchStepLabel != nil
+            && (!state.hatchCompleted || isAnimatingProgress)
     }
 
     private var progressSection: some View {
         VStack(spacing: VSpacing.xs) {
-            ProgressView(value: state.hatchProgressDisplay)
-                .progressViewStyle(.linear)
-                .frame(maxWidth: 240)
+            TimelineView(.animation) { context in
+                ProgressView(value: progressValue(at: context.date))
+                    .progressViewStyle(.linear)
+                    .frame(maxWidth: 240)
+            }
             if let label = state.hatchStepLabel {
                 Text(label)
                     .font(VFont.bodySmallDefault)
@@ -281,7 +293,7 @@ struct HatchingStepView: View {
         }
     }
 
-    // MARK: - Progress Timer
+    // MARK: - Progress Calculation
 
     /// Estimated hatch duration per hosting mode, used to pace the progress bar.
     /// The bar uses an asymptotic curve so it never stalls even if the actual
@@ -295,48 +307,37 @@ struct HatchingStepView: View {
         }
     }
 
-    private func startProgressTimer() {
-        progressStartTime = CFAbsoluteTimeGetCurrent()
-        progressTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { _ in
-            Task { @MainActor in
-                updateProgressDisplay()
+    /// Computes the progress bar value for the given point in time.
+    /// Called from within `TimelineView(.animation)` so it runs at display refresh rate.
+    private func progressValue(at date: Date) -> Double {
+        guard state.hatchStepLabel != nil, let startTime = progressStartTime else { return 0 }
+
+        if state.hatchCompleted, let compTime = completionTime, let baseProgress = progressAtCompletion {
+            // Ease-out ramp from current position to 100%
+            let timeSinceCompletion = date.timeIntervalSince(compTime)
+            let rampProgress = min(1.0, 1.0 - exp(-timeSinceCompletion * 3.0))
+            let value = baseProgress + (1.0 - baseProgress) * rampProgress
+            if value >= 0.999 {
+                // Stop the animation once the ramp is effectively complete
+                Task { @MainActor in
+                    isAnimatingProgress = false
+                }
+                return 1.0
             }
-        }
-    }
-
-    private func stopProgressTimer() {
-        progressTimer?.invalidate()
-        progressTimer = nil
-    }
-
-    private func updateProgressDisplay() {
-        guard state.hatchStepLabel != nil, let startTime = progressStartTime else { return }
-
-        let current = state.hatchProgressDisplay
-
-        if state.hatchCompleted {
-            // Animate to 100%
-            let diff = 1.0 - current
-            if diff > 0.001 {
-                state.hatchProgressDisplay = current + diff * 0.15
-            } else {
-                state.hatchProgressDisplay = 1.0
-                stopProgressTimer()
-            }
-            return
+            return value
         }
 
         if state.hatchFailed {
-            stopProgressTimer()
-            return
+            // Freeze at the last computed asymptotic value
+            let elapsed = CFAbsoluteTimeGetCurrent() - startTime
+            return 0.95 * (1.0 - exp(-elapsed / estimatedDuration))
         }
 
         // Asymptotic time-based progress: 0.95 * (1 - e^(-t/estimated))
         // Never reaches 95% no matter how long — always appears to be moving.
         // estimatedDuration controls the pace: at 1x estimate the bar is ~60%.
         let elapsed = CFAbsoluteTimeGetCurrent() - startTime
-        let timeProgress = 0.95 * (1.0 - exp(-elapsed / estimatedDuration))
-        state.hatchProgressDisplay = timeProgress
+        return 0.95 * (1.0 - exp(-elapsed / estimatedDuration))
     }
 
     // MARK: - Hatching / Pairing


### PR DESCRIPTION
## Summary
- Replaces 60fps Timer with TimelineView(.animation) for display-rate-adaptive animation
- Updates showProgressBar to stay visible during completion ramp
- Preserves completion ease-out ramp to 100%

Part of plan: modern-patterns-cleanup.md (PR 5 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
