### PR TITLE
feat: deprecate old OAuth connect/disconnect/status commands, update top-level help

### DIFF
--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -31,6 +31,7 @@ import {
 } from "../../lib/daemon-credential-client.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
+import { printDeprecationWarning } from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // CES shell lockdown guard
@@ -477,7 +478,7 @@ Examples:
   // ---------------------------------------------------------------------------
 
   connections
-    .command("disconnect <provider-key>")
+    .command("disconnect <provider-key>", { hidden: true })
     .description(
       "Disconnect an OAuth integration and remove all associated credentials",
     )
@@ -510,6 +511,11 @@ Examples:
         cmd: Command,
       ) => {
         try {
+          printDeprecationWarning(
+            "assistant oauth connections disconnect",
+            "assistant oauth disconnect",
+            cmd,
+          );
           assertMetadataWritable();
 
           let cleanedUp = false;
@@ -574,7 +580,7 @@ Examples:
   // ---------------------------------------------------------------------------
 
   connections
-    .command("connect <provider-key>")
+    .command("connect <provider-key>", { hidden: true })
     .description("Initiate an OAuth2 authorization flow for a provider")
     .option(
       "--client-id <id>",
@@ -621,6 +627,11 @@ Examples:
         cmd: Command,
       ) => {
         try {
+          printDeprecationWarning(
+            "assistant oauth connections connect",
+            "assistant oauth connect",
+            cmd,
+          );
           // a. Resolve service alias
           const resolvedServiceKey = resolveService(providerKey);
 

--- a/assistant/src/cli/commands/oauth/index.ts
+++ b/assistant/src/cli/commands/oauth/index.ts
@@ -20,28 +20,28 @@ export function registerOAuthCommand(program: Command): void {
     `
 The oauth command group manages the full OAuth lifecycle:
 
+  connect     Initiate an OAuth flow for a provider (managed or BYO)
+  disconnect  Disconnect an OAuth provider
+  status      Show OAuth connection status for a provider
+  request     Make authenticated HTTP requests (curl-like interface)
   providers   Protocol-level configurations (auth URLs, scopes, endpoints)
   apps        Client credentials (client ID / secret pairs)
-  connections Active token grants per provider (list, get, token, disconnect)
-  platform    Platform-managed OAuth provider status and connections
-  request     Make authenticated HTTP requests (curl-like interface)
-  connect     Initiate an OAuth flow (auto-detects managed vs BYO mode)
-  disconnect  Disconnect a provider and remove credentials (auto-detects mode)
-  status      Show connection status for a provider (auto-detects mode)
+  connections Active token grants per provider (deprecated)
+  platform    Platform-managed OAuth provider status and connections (deprecated)
 
 Providers are seeded on startup for built-in integrations. Apps and connections
 are created during the OAuth authorization flow or can be managed manually via
 their respective subcommands.
 
 Examples:
+  $ assistant oauth connect google --open-browser
+  $ assistant oauth status google
+  $ assistant oauth disconnect google
   $ assistant oauth request --provider integration:google /gmail/v1/users/me/messages
   $ assistant oauth request --provider integration:twitter -X POST -d '{"text":"Hello"}' https://api.x.com/2/tweets
   $ assistant oauth connections token integration:twitter
-  $ assistant oauth connections list
-  $ assistant oauth connections get --provider integration:google
   $ assistant oauth providers list
-  $ assistant oauth providers get integration:google
-  $ assistant oauth providers register --provider-key custom:myapi --auth-url https://example.com/auth --token-url https://example.com/token`,
+  $ assistant oauth providers get integration:google`,
   );
 
   // ---------------------------------------------------------------------------

--- a/assistant/src/cli/commands/oauth/platform.ts
+++ b/assistant/src/cli/commands/oauth/platform.ts
@@ -11,6 +11,7 @@ import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 import {
   fetchActiveConnections,
+  printDeprecationWarning,
   requirePlatformClient,
   toBareProvider,
 } from "./shared.js";
@@ -105,7 +106,7 @@ export function registerPlatformCommands(oauth: Command): void {
 
 function registerStatusCommand(platform: Command): void {
   platform
-    .command("status <provider>")
+    .command("status <provider>", { hidden: true })
     .description(
       "Check whether a provider supports managed OAuth and list the user's active connections",
     )
@@ -130,6 +131,11 @@ Examples:
         cmd: Command,
       ) => {
         try {
+          printDeprecationWarning(
+            "assistant oauth platform status",
+            "assistant oauth status",
+            cmd,
+          );
           const providerKey = toProviderKey(provider);
           const providerRow = getProvider(providerKey);
 
@@ -224,7 +230,7 @@ Examples:
 
 function registerConnectCommand(platform: Command): void {
   platform
-    .command("connect <provider>")
+    .command("connect <provider>", { hidden: true })
     .description(
       "Initiate a platform-managed OAuth flow for a provider and open the browser",
     )
@@ -261,6 +267,11 @@ Examples:
     .action(
       async (provider: string, opts: { scopes?: string[] }, cmd: Command) => {
         try {
+          printDeprecationWarning(
+            "assistant oauth platform connect",
+            "assistant oauth connect",
+            cmd,
+          );
           if (!requireManagedProvider(provider, cmd)) return;
 
           const client = await requirePlatformClient(cmd);
@@ -333,7 +344,7 @@ Examples:
 
 function registerDisconnectCommand(platform: Command): void {
   platform
-    .command("disconnect <provider>")
+    .command("disconnect <provider>", { hidden: true })
     .description(
       "Disconnect a platform-managed OAuth connection for a provider",
     )
@@ -367,6 +378,11 @@ Examples:
         cmd: Command,
       ) => {
         try {
+          printDeprecationWarning(
+            "assistant oauth platform disconnect",
+            "assistant oauth disconnect",
+            cmd,
+          );
           if (!requireManagedCapableProvider(provider, cmd)) return;
 
           const client = await requirePlatformClient(cmd);

--- a/assistant/src/cli/commands/oauth/shared.ts
+++ b/assistant/src/cli/commands/oauth/shared.ts
@@ -8,7 +8,7 @@ import {
 import { getProvider } from "../../../oauth/oauth-store.js";
 import { resolveService } from "../../../oauth/provider-behaviors.js";
 import { VellumPlatformClient } from "../../../platform/client.js";
-import { writeOutput } from "../../output.js";
+import { shouldOutputJson, writeOutput } from "../../output.js";
 
 // ---------------------------------------------------------------------------
 // Re-exports
@@ -30,6 +30,22 @@ export interface PlatformConnectionEntry {
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Print a deprecation warning to stderr for renamed commands. Skipped in JSON
+ * mode so machine-parseable output is not polluted.
+ */
+export function printDeprecationWarning(
+  oldCmd: string,
+  newCmd: string,
+  cmd: Command,
+): void {
+  if (!shouldOutputJson(cmd)) {
+    process.stderr.write(
+      `Warning: '${oldCmd}' is deprecated. Use '${newCmd}' instead.\n`,
+    );
+  }
+}
 
 /**
  * Extract the bare provider slug (e.g. "google") from either a raw CLI


### PR DESCRIPTION
## Summary
- Add deprecation warnings (stderr) to old `connections connect`, `connections disconnect`, `platform connect`, `platform disconnect`, and `platform status` commands
- Hide deprecated commands from `--help` output via `{ hidden: true }` option
- Update top-level `oauth --help` to prominently list new unified commands (connect, disconnect, status)
- Deprecation warnings suppressed in JSON mode to avoid breaking machine parsing

Part of plan: unified-oauth-cli.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
