### PR TITLE
fix: remove dead cancellation guards, add pauseTimer idempotency

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -246,7 +246,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         applyMenuBarTitlePatch()
         Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 100_000_000)
-            guard !Task.isCancelled else { return }
             self?.applyMenuBarTitlePatch()
         }
     }
@@ -265,7 +264,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         for delay: UInt64 in [100_000_000, 500_000_000, 1_000_000_000] {
             Task { @MainActor [weak self] in
                 try? await Task.sleep(nanoseconds: delay)
-                guard !Task.isCancelled else { return }
                 self?.installFileMenuDelegateOnce()
             }
         }
@@ -323,7 +321,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 existing.activate()
                 Task { @MainActor in
                     try? await Task.sleep(nanoseconds: 300_000_000)
-                    guard !Task.isCancelled else { return }
                     NSApp.terminate(nil)
                 }
                 return

--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -147,7 +147,6 @@ final class SecretPromptManager {
             // Save: delay dismiss so "Saved" confirmation is visible
             Task { @MainActor [weak self] in
                 try? await Task.sleep(nanoseconds: 1_500_000_000)
-                guard !Task.isCancelled else { return }
                 self?.dismissPrompt(requestId: requestId)
             }
         }

--- a/clients/macos/vellum-assistant/Features/Voice/DictationOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationOverlayWindow.swift
@@ -117,7 +117,6 @@ final class DictationOverlayWindow {
         show(state: .done)
         Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 800_000_000)
-            guard !Task.isCancelled else { return }
             self?.dismiss()
         }
     }

--- a/clients/macos/vellum-assistant/Features/Voice/DictationTextInserter.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationTextInserter.swift
@@ -35,7 +35,6 @@ final class DictationTextInserter {
         let itemsToRestore = savedItems
         Task { @MainActor in
             try? await Task.sleep(nanoseconds: 500_000_000)
-            guard !Task.isCancelled else { return }
             restorePasteboardItems(itemsToRestore, to: NSPasteboard.general)
         }
 

--- a/clients/macos/vellum-assistant/Recording/RecordingHUDWindow.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingHUDWindow.swift
@@ -116,6 +116,7 @@ final class RecordingHUDViewModel {
 
     /// Pause the elapsed-time timer (called when recording is paused).
     func pauseTimer() {
+        guard pauseStartTime == nil else { return }
         pauseStartTime = Date()
     }
 

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -752,7 +752,6 @@ extension ChatViewModel {
                     let msgId = existingId
                     Task { @MainActor [weak self] in
                         try? await Task.sleep(nanoseconds: 5_000_000_000)
-                        guard !Task.isCancelled else { return }
                         guard let self,
                               let idx = self.messages.firstIndex(where: { $0.id == msgId }) else { return }
                         self.messages[idx].streamingCodePreview = nil


### PR DESCRIPTION
## Summary
- Removes misleading `guard !Task.isCancelled` from 5 fire-and-forget Tasks (never stored, guard was dead code)
- Adds idempotency guard to RecordingHUD `pauseTimer()`

Part of plan: modern-patterns-cleanup.md (review fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
