### PR TITLE
test: add tests for unified oauth connect, disconnect, and status commands

### DIFF
--- a/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
@@ -1,0 +1,785 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockGetProvider: (
+  key: string,
+) => Record<string, unknown> | undefined = () => undefined;
+
+let mockGetAppByProviderAndClientId: (
+  key: string,
+  clientId: string,
+) => Record<string, unknown> | undefined = () => undefined;
+
+let mockGetMostRecentAppByProvider: (
+  key: string,
+) => Record<string, unknown> | undefined = () => undefined;
+
+let mockOrchestrateOAuthConnect: (
+  opts: Record<string, unknown>,
+) => Promise<Record<string, unknown>> = async () => ({
+  success: true,
+  deferred: false,
+  grantedScopes: [],
+});
+
+let mockGetProviderBehavior: (
+  key: string,
+) => Record<string, unknown> | undefined = () => undefined;
+
+let mockGetSecureKeyViaDaemon: (
+  account: string,
+) => Promise<string | undefined> = async () => undefined;
+
+let mockOpenInBrowserCalls: string[] = [];
+let mockPlatformClientResult: Record<string, unknown> | null = null;
+let mockPlatformFetchResults: Array<{
+  ok: boolean;
+  status: number;
+  body: unknown;
+}> = [];
+let mockPlatformFetchCallIndex = 0;
+
+let mockIsManagedMode: (key: string) => boolean = () => false;
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../../config/loader.js", () => ({
+  getConfig: () => ({ services: {} }),
+  API_KEY_PROVIDERS: [],
+}));
+
+mock.module("../../../../oauth/oauth-store.js", () => ({
+  getProvider: (key: string) => mockGetProvider(key),
+  getAppByProviderAndClientId: (key: string, clientId: string) =>
+    mockGetAppByProviderAndClientId(key, clientId),
+  getMostRecentAppByProvider: (key: string) =>
+    mockGetMostRecentAppByProvider(key),
+  listConnections: () => [],
+  getConnection: () => undefined,
+  getConnectionByProvider: () => undefined,
+  getActiveConnection: () => undefined,
+  listActiveConnectionsByProvider: () => [],
+  disconnectOAuthProvider: async () => "not-found" as const,
+  upsertApp: async () => ({}),
+  getApp: () => undefined,
+  listApps: () => [],
+  deleteApp: async () => false,
+  listProviders: () => [],
+  registerProvider: () => ({}),
+  seedProviders: () => {},
+  isProviderConnected: () => false,
+  createConnection: () => ({}),
+  updateConnection: () => ({}),
+  deleteConnection: () => false,
+}));
+
+mock.module("../../../../oauth/provider-behaviors.js", () => ({
+  resolveService: (service: string) => {
+    const aliases: Record<string, string> = {
+      gmail: "integration:google",
+      google: "integration:google",
+      slack: "integration:slack",
+    };
+    if (aliases[service]) return aliases[service];
+    if (!service.includes(":")) return `integration:${service}`;
+    return service;
+  },
+  getProviderBehavior: (key: string) => mockGetProviderBehavior(key),
+}));
+
+mock.module("../../../../oauth/connect-orchestrator.js", () => ({
+  orchestrateOAuthConnect: (opts: Record<string, unknown>) =>
+    mockOrchestrateOAuthConnect(opts),
+}));
+
+mock.module("../../../../platform/client.js", () => ({
+  VellumPlatformClient: {
+    create: async () => mockPlatformClientResult,
+  },
+}));
+
+mock.module("../../../../util/browser.js", () => ({
+  openInBrowser: (url: string) => {
+    mockOpenInBrowserCalls.push(url);
+  },
+}));
+
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+mock.module("../../../lib/daemon-credential-client.js", () => ({
+  getSecureKeyViaDaemon: (account: string) =>
+    mockGetSecureKeyViaDaemon(account),
+  deleteSecureKeyViaDaemon: async () => "not-found" as const,
+}));
+
+// Mock shared.js helpers to control managed vs BYO mode routing
+mock.module("../shared.js", () => ({
+  resolveService: (service: string) => {
+    const aliases: Record<string, string> = {
+      gmail: "integration:google",
+      google: "integration:google",
+      slack: "integration:slack",
+    };
+    if (aliases[service]) return aliases[service];
+    if (!service.includes(":")) return `integration:${service}`;
+    return service;
+  },
+  isManagedMode: (key: string) => mockIsManagedMode(key),
+  requirePlatformClient: async (_cmd: Command) => {
+    if (
+      !mockPlatformClientResult ||
+      !(mockPlatformClientResult as Record<string, unknown>).platformAssistantId
+    ) {
+      process.exitCode = 1;
+      process.stdout.write(
+        JSON.stringify({
+          ok: false,
+          error:
+            "Platform prerequisites not met (not logged in or missing assistant ID)",
+        }) + "\n",
+      );
+      return null;
+    }
+    return {
+      platformAssistantId: (mockPlatformClientResult as Record<string, unknown>)
+        .platformAssistantId,
+      fetch: async (_path: string, _init?: RequestInit): Promise<Response> => {
+        const idx = mockPlatformFetchCallIndex++;
+        const result = mockPlatformFetchResults[idx] ?? {
+          ok: false,
+          status: 500,
+          body: "mock not configured",
+        };
+        return {
+          ok: result.ok,
+          status: result.status,
+          json: async () => result.body,
+          text: async () =>
+            typeof result.body === "string"
+              ? result.body
+              : JSON.stringify(result.body),
+        } as unknown as Response;
+      },
+    };
+  },
+  fetchActiveConnections: async (
+    _client: Record<string, unknown>,
+    _provider: string,
+    _cmd: Command,
+  ): Promise<Array<Record<string, unknown>> | null> => {
+    const idx = mockPlatformFetchCallIndex++;
+    const result = mockPlatformFetchResults[idx];
+    if (!result) return [];
+    if (!result.ok) return null;
+    return result.body as Array<Record<string, unknown>>;
+  },
+  toBareProvider: (provider: string): string =>
+    provider.startsWith("integration:")
+      ? provider.slice("integration:".length)
+      : provider,
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+const { registerConnectCommand } = await import("../connect.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = (() => true) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.option("--json", "JSON output");
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerConnectCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return { exitCode, stdout: stdoutChunks.join("") };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth connect", () => {
+  beforeEach(() => {
+    mockGetProvider = () => undefined;
+    mockGetAppByProviderAndClientId = () => undefined;
+    mockGetMostRecentAppByProvider = () => undefined;
+    mockOrchestrateOAuthConnect = async () => ({
+      success: true,
+      deferred: false,
+      grantedScopes: [],
+    });
+    mockGetProviderBehavior = () => undefined;
+    mockGetSecureKeyViaDaemon = async () => undefined;
+    mockOpenInBrowserCalls = [];
+    mockPlatformClientResult = null;
+    mockPlatformFetchResults = [];
+    mockPlatformFetchCallIndex = 0;
+    mockIsManagedMode = () => false;
+    process.exitCode = 0;
+  });
+
+  // -------------------------------------------------------------------------
+  // Unknown provider
+  // -------------------------------------------------------------------------
+
+  test("unknown provider returns error with hint", async () => {
+    mockGetProvider = () => undefined;
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "nonexistent",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Unknown provider");
+    expect(parsed.error).toContain("providers list");
+  });
+
+  // -------------------------------------------------------------------------
+  // Provider alias resolution
+  // -------------------------------------------------------------------------
+
+  test("provider alias 'gmail' resolves to integration:google", async () => {
+    let capturedProviderKey: string | undefined;
+
+    mockGetProvider = (key: string) => {
+      capturedProviderKey = key;
+      return {
+        providerKey: key,
+        authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+        tokenUrl: "https://oauth2.googleapis.com/token",
+        managedServiceConfigKey: null,
+      };
+    };
+
+    mockGetMostRecentAppByProvider = () => ({
+      id: "app-1",
+      clientId: "test-id",
+      clientSecretCredentialPath: "oauth_app/app-1/client_secret",
+      providerKey: "integration:google",
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    mockOrchestrateOAuthConnect = async () => ({
+      success: true,
+      deferred: false,
+      grantedScopes: ["read"],
+      accountInfo: "user@example.com",
+    });
+
+    await runCommand(["connect", "gmail", "--json"]);
+    expect(capturedProviderKey).toBe("integration:google");
+  });
+
+  // -------------------------------------------------------------------------
+  // Managed mode: prints connect URL without --open-browser
+  // -------------------------------------------------------------------------
+
+  test("managed mode: prints connect URL without --open-browser", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      managedServiceConfigKey: "google-oauth",
+    });
+    mockIsManagedMode = () => true;
+    mockPlatformClientResult = { platformAssistantId: "asst-123" };
+    mockPlatformFetchResults = [
+      {
+        ok: true,
+        status: 200,
+        body: { connect_url: "https://platform.example.com/oauth/connect" },
+      },
+    ];
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "google",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.deferred).toBe(true);
+    expect(parsed.connectUrl).toBe(
+      "https://platform.example.com/oauth/connect",
+    );
+    expect(parsed.provider).toBe("integration:google");
+  });
+
+  // -------------------------------------------------------------------------
+  // Managed mode with --open-browser: opens browser and polls
+  // -------------------------------------------------------------------------
+
+  test("managed mode with --open-browser: opens browser and polls for new connection", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      managedServiceConfigKey: "google-oauth",
+    });
+    mockIsManagedMode = () => true;
+    mockPlatformClientResult = { platformAssistantId: "asst-123" };
+
+    // First call: /start/ endpoint returns connect_url
+    // Second call: fetchActiveConnections snapshot (before browser)
+    // Third call: fetchActiveConnections poll (new connection found)
+    mockPlatformFetchResults = [
+      {
+        ok: true,
+        status: 200,
+        body: { connect_url: "https://platform.example.com/oauth/connect" },
+      },
+      // Snapshot — empty
+      { ok: true, status: 200, body: [] },
+      // Poll — new connection appeared
+      {
+        ok: true,
+        status: 200,
+        body: [
+          {
+            id: "conn-new",
+            account_label: "user@gmail.com",
+            scopes_granted: ["email"],
+          },
+        ],
+      },
+    ];
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "google",
+      "--open-browser",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.connectionId).toBe("conn-new");
+    expect(parsed.accountLabel).toBe("user@gmail.com");
+    expect(parsed.scopesGranted).toEqual(["email"]);
+    expect(mockOpenInBrowserCalls.length).toBeGreaterThanOrEqual(1);
+    expect(mockOpenInBrowserCalls[0]).toBe(
+      "https://platform.example.com/oauth/connect",
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // BYO mode: prints auth URL without --open-browser (deferred)
+  // -------------------------------------------------------------------------
+
+  test("BYO mode: prints auth URL without --open-browser", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      managedServiceConfigKey: null,
+    });
+    mockIsManagedMode = () => false;
+
+    mockGetMostRecentAppByProvider = () => ({
+      id: "app-1",
+      clientId: "byo-client-id",
+      clientSecretCredentialPath: "oauth_app/app-1/client_secret",
+      providerKey: "integration:google",
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    mockOrchestrateOAuthConnect = async () => ({
+      success: true,
+      deferred: true,
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth?state=abc",
+      state: "abc",
+      service: "integration:google",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "integration:google",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.deferred).toBe(true);
+    expect(parsed.authUrl).toBe(
+      "https://accounts.google.com/o/oauth2/v2/auth?state=abc",
+    );
+    expect(parsed.service).toBe("integration:google");
+  });
+
+  // -------------------------------------------------------------------------
+  // BYO mode with --open-browser: orchestrator called with isInteractive true
+  // -------------------------------------------------------------------------
+
+  test("BYO mode with --open-browser calls orchestrator with isInteractive: true", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      managedServiceConfigKey: null,
+    });
+    mockIsManagedMode = () => false;
+
+    mockGetAppByProviderAndClientId = () => ({
+      id: "app-1",
+      clientId: "test-id",
+      clientSecretCredentialPath: "oauth_app/app-1/client_secret",
+      providerKey: "integration:google",
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    let capturedOpts: Record<string, unknown> | undefined;
+    mockOrchestrateOAuthConnect = async (opts) => {
+      capturedOpts = opts;
+      return {
+        success: true,
+        deferred: false,
+        grantedScopes: ["email"],
+        accountInfo: "user@example.com",
+      };
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "integration:google",
+      "--client-id",
+      "test-id",
+      "--open-browser",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(capturedOpts).toBeDefined();
+    expect(capturedOpts!.isInteractive).toBe(true);
+    // openUrl should be provided when --open-browser is set
+    expect(typeof capturedOpts!.openUrl).toBe("function");
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.grantedScopes).toEqual(["email"]);
+    expect(parsed.accountInfo).toBe("user@example.com");
+  });
+
+  // -------------------------------------------------------------------------
+  // BYO missing app: error with hint
+  // -------------------------------------------------------------------------
+
+  test("BYO mode: missing app with --client-id returns error with hint", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      managedServiceConfigKey: null,
+    });
+    mockIsManagedMode = () => false;
+    mockGetAppByProviderAndClientId = () => undefined;
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "integration:google",
+      "--client-id",
+      "nonexistent-id",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("nonexistent-id");
+    expect(parsed.error).toContain("apps upsert");
+  });
+
+  // -------------------------------------------------------------------------
+  // BYO mode: no client_id at all
+  // -------------------------------------------------------------------------
+
+  test("BYO mode: no client_id found returns error with hint", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      managedServiceConfigKey: null,
+    });
+    mockIsManagedMode = () => false;
+    mockGetMostRecentAppByProvider = () => undefined;
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "integration:google",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("client_id");
+    expect(parsed.error).toContain("apps upsert");
+  });
+
+  // -------------------------------------------------------------------------
+  // --client-id ignored in managed mode (silent, no error)
+  // -------------------------------------------------------------------------
+
+  test("--client-id is silently ignored in managed mode", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      managedServiceConfigKey: "google-oauth",
+    });
+    mockIsManagedMode = () => true;
+    mockPlatformClientResult = { platformAssistantId: "asst-123" };
+    mockPlatformFetchResults = [
+      {
+        ok: true,
+        status: 200,
+        body: { connect_url: "https://platform.example.com/oauth/connect" },
+      },
+    ];
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "google",
+      "--client-id",
+      "should-be-ignored",
+      "--json",
+    ]);
+    // Should succeed — --client-id does not cause an error in managed mode
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.connectUrl).toBe(
+      "https://platform.example.com/oauth/connect",
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // JSON output format for deferred case (BYO)
+  // -------------------------------------------------------------------------
+
+  test("JSON output for deferred case includes ok, deferred, authUrl, service", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:slack",
+      authUrl: "https://slack.com/oauth/v2/authorize",
+      tokenUrl: "https://slack.com/api/oauth.v2.access",
+      managedServiceConfigKey: null,
+    });
+    mockIsManagedMode = () => false;
+
+    mockGetMostRecentAppByProvider = () => ({
+      id: "app-slack",
+      clientId: "slack-client-id",
+      clientSecretCredentialPath: "oauth_app/app-slack/client_secret",
+      providerKey: "integration:slack",
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    mockOrchestrateOAuthConnect = async () => ({
+      success: true,
+      deferred: true,
+      authUrl: "https://slack.com/oauth/v2/authorize?state=xyz",
+      state: "xyz",
+      service: "integration:slack",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "slack",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toHaveProperty("ok", true);
+    expect(parsed).toHaveProperty("deferred", true);
+    expect(parsed).toHaveProperty("authUrl");
+    expect(parsed).toHaveProperty("service", "integration:slack");
+  });
+
+  // -------------------------------------------------------------------------
+  // JSON output format for completed case (BYO)
+  // -------------------------------------------------------------------------
+
+  test("JSON output for completed case includes ok, grantedScopes, accountInfo", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      managedServiceConfigKey: null,
+    });
+    mockIsManagedMode = () => false;
+
+    mockGetMostRecentAppByProvider = () => ({
+      id: "app-1",
+      clientId: "completed-client-id",
+      clientSecretCredentialPath: "oauth_app/app-1/client_secret",
+      providerKey: "integration:google",
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    mockOrchestrateOAuthConnect = async () => ({
+      success: true,
+      deferred: false,
+      grantedScopes: ["email", "profile"],
+      accountInfo: "test@gmail.com",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "google",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toHaveProperty("ok", true);
+    expect(parsed).toHaveProperty("grantedScopes");
+    expect(parsed.grantedScopes).toEqual(["email", "profile"]);
+    expect(parsed).toHaveProperty("accountInfo", "test@gmail.com");
+    // Should NOT have deferred
+    expect(parsed.deferred).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // BYO mode: client_secret required but missing
+  // -------------------------------------------------------------------------
+
+  test("BYO mode: client_secret required but missing returns error with hint", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      tokenEndpointAuthMethod: "client_secret_post",
+      managedServiceConfigKey: null,
+    });
+    mockIsManagedMode = () => false;
+
+    mockGetMostRecentAppByProvider = () => ({
+      id: "app-1",
+      clientId: "test-id",
+      clientSecretCredentialPath: "oauth_app/app-1/client_secret",
+      providerKey: "integration:google",
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    // No secret stored
+    mockGetSecureKeyViaDaemon = async () => undefined;
+
+    // Provider behavior says secret is required
+    mockGetProviderBehavior = () => ({
+      setup: {
+        requiresClientSecret: true,
+        displayName: "Google",
+        dashboardUrl: "https://console.cloud.google.com",
+        appType: "Desktop app",
+      },
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "integration:google",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("client_secret");
+    expect(parsed.error).toContain("apps upsert");
+  });
+
+  // -------------------------------------------------------------------------
+  // Orchestrator error propagation
+  // -------------------------------------------------------------------------
+
+  test("BYO mode: orchestrator error propagates correctly", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      managedServiceConfigKey: null,
+    });
+    mockIsManagedMode = () => false;
+
+    mockGetMostRecentAppByProvider = () => ({
+      id: "app-1",
+      clientId: "client-id",
+      clientSecretCredentialPath: "oauth_app/app-1/client_secret",
+      providerKey: "integration:google",
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    mockOrchestrateOAuthConnect = async () => ({
+      success: false,
+      error: "Token exchange failed: invalid_grant",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "integration:google",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toBe("Token exchange failed: invalid_grant");
+  });
+});

--- a/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
@@ -1,0 +1,760 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockGetProvider: (
+  key: string,
+) => Record<string, unknown> | undefined = () => undefined;
+
+let mockGetConnection: (
+  id: string,
+) => Record<string, unknown> | undefined = () => undefined;
+
+let mockGetActiveConnection: (
+  providerKey: string,
+  opts?: { account?: string },
+) => Record<string, unknown> | undefined = () => undefined;
+
+let mockListActiveConnectionsByProvider: (
+  providerKey: string,
+) => Array<Record<string, unknown>> = () => [];
+
+let mockDisconnectOAuthProviderResult: "disconnected" | "not-found" | "error" =
+  "disconnected";
+
+let mockDisconnectOAuthProviderCalls: Array<{
+  providerKey: string;
+  account: string | undefined;
+  connectionId: string | undefined;
+}> = [];
+
+let mockDeleteSecureKeyViaDaemonCalls: Array<{
+  type: string;
+  name: string;
+}> = [];
+
+let mockDeleteCredentialMetadataCalls: Array<{
+  service: string;
+  field: string;
+}> = [];
+
+let mockIsManagedMode: (key: string) => boolean = () => false;
+
+let mockPlatformClientResult: Record<string, unknown> | null = null;
+let mockPlatformFetchResults: Array<{
+  ok: boolean;
+  status: number;
+  body: unknown;
+}> = [];
+let mockPlatformFetchCallIndex = 0;
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../../config/loader.js", () => ({
+  getConfig: () => ({ services: {} }),
+  API_KEY_PROVIDERS: [],
+}));
+
+mock.module("../../../../oauth/oauth-store.js", () => ({
+  getProvider: (key: string) => mockGetProvider(key),
+  getConnection: (id: string) => mockGetConnection(id),
+  getActiveConnection: (providerKey: string, opts?: { account?: string }) =>
+    mockGetActiveConnection(providerKey, opts),
+  listActiveConnectionsByProvider: (providerKey: string) =>
+    mockListActiveConnectionsByProvider(providerKey),
+  disconnectOAuthProvider: async (
+    providerKey: string,
+    account?: string,
+    connectionId?: string,
+  ) => {
+    mockDisconnectOAuthProviderCalls.push({
+      providerKey,
+      account,
+      connectionId,
+    });
+    return mockDisconnectOAuthProviderResult;
+  },
+  getConnectionByProvider: () => undefined,
+  listConnections: () => [],
+  upsertApp: async () => ({}),
+  getApp: () => undefined,
+  getAppByProviderAndClientId: () => undefined,
+  getMostRecentAppByProvider: () => undefined,
+  listApps: () => [],
+  deleteApp: async () => false,
+  listProviders: () => [],
+  registerProvider: () => ({}),
+  seedProviders: () => {},
+  isProviderConnected: () => false,
+  createConnection: () => ({}),
+  updateConnection: () => ({}),
+  deleteConnection: () => false,
+}));
+
+mock.module("../../../../oauth/provider-behaviors.js", () => ({
+  resolveService: (service: string) => {
+    const aliases: Record<string, string> = {
+      gmail: "integration:google",
+      google: "integration:google",
+      slack: "integration:slack",
+    };
+    if (aliases[service]) return aliases[service];
+    if (!service.includes(":")) return `integration:${service}`;
+    return service;
+  },
+  getProviderBehavior: () => undefined,
+}));
+
+mock.module("../../../../oauth/connect-orchestrator.js", () => ({
+  orchestrateOAuthConnect: async () => ({
+    success: true,
+    deferred: false,
+    grantedScopes: [],
+  }),
+}));
+
+mock.module("../../../../platform/client.js", () => ({
+  VellumPlatformClient: {
+    create: async () => mockPlatformClientResult,
+  },
+}));
+
+mock.module("../../../../util/browser.js", () => ({
+  openInBrowser: () => {},
+}));
+
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+mock.module("../../../../tools/credentials/metadata-store.js", () => ({
+  deleteCredentialMetadata: (service: string, field: string) => {
+    mockDeleteCredentialMetadataCalls.push({ service, field });
+    return true;
+  },
+  getCredentialMetadata: () => undefined,
+  upsertCredentialMetadata: () => ({}),
+  listCredentialMetadata: () => [],
+  assertMetadataWritable: () => {},
+}));
+
+mock.module("../../../lib/daemon-credential-client.js", () => ({
+  getSecureKeyViaDaemon: async () => undefined,
+  deleteSecureKeyViaDaemon: async (type: string, name: string) => {
+    mockDeleteSecureKeyViaDaemonCalls.push({ type, name });
+    return "deleted" as const;
+  },
+}));
+
+// Mock shared.js helpers to control managed vs BYO mode routing
+mock.module("../shared.js", () => ({
+  resolveService: (service: string) => {
+    const aliases: Record<string, string> = {
+      gmail: "integration:google",
+      google: "integration:google",
+      slack: "integration:slack",
+    };
+    if (aliases[service]) return aliases[service];
+    if (!service.includes(":")) return `integration:${service}`;
+    return service;
+  },
+  isManagedMode: (key: string) => mockIsManagedMode(key),
+  requirePlatformClient: async (_cmd: Command) => {
+    if (
+      !mockPlatformClientResult ||
+      !(mockPlatformClientResult as Record<string, unknown>).platformAssistantId
+    ) {
+      process.exitCode = 1;
+      process.stdout.write(
+        JSON.stringify({
+          ok: false,
+          error:
+            "Platform prerequisites not met (not logged in or missing assistant ID)",
+        }) + "\n",
+      );
+      return null;
+    }
+    return {
+      platformAssistantId: (mockPlatformClientResult as Record<string, unknown>)
+        .platformAssistantId,
+      fetch: async (): Promise<Response> => {
+        const idx = mockPlatformFetchCallIndex++;
+        const result = mockPlatformFetchResults[idx] ?? {
+          ok: false,
+          status: 500,
+          body: "mock not configured",
+        };
+        return {
+          ok: result.ok,
+          status: result.status,
+          json: async () => result.body,
+          text: async () =>
+            typeof result.body === "string"
+              ? result.body
+              : JSON.stringify(result.body),
+        } as unknown as Response;
+      },
+    };
+  },
+  fetchActiveConnections: async (): Promise<Array<
+    Record<string, unknown>
+  > | null> => {
+    const idx = mockPlatformFetchCallIndex++;
+    const result = mockPlatformFetchResults[idx];
+    if (!result) return [];
+    if (!result.ok) return null;
+    return result.body as Array<Record<string, unknown>>;
+  },
+  toBareProvider: (provider: string): string =>
+    provider.startsWith("integration:")
+      ? provider.slice("integration:".length)
+      : provider,
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+const { registerDisconnectCommand } = await import("../disconnect.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = (() => true) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.option("--json", "JSON output");
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerDisconnectCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return { exitCode, stdout: stdoutChunks.join("") };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth disconnect", () => {
+  beforeEach(() => {
+    mockGetProvider = () => undefined;
+    mockGetConnection = () => undefined;
+    mockGetActiveConnection = () => undefined;
+    mockListActiveConnectionsByProvider = () => [];
+    mockDisconnectOAuthProviderResult = "disconnected";
+    mockDisconnectOAuthProviderCalls = [];
+    mockDeleteSecureKeyViaDaemonCalls = [];
+    mockDeleteCredentialMetadataCalls = [];
+    mockIsManagedMode = () => false;
+    mockPlatformClientResult = null;
+    mockPlatformFetchResults = [];
+    mockPlatformFetchCallIndex = 0;
+    process.exitCode = 0;
+  });
+
+  // -------------------------------------------------------------------------
+  // Unknown provider
+  // -------------------------------------------------------------------------
+
+  test("unknown provider returns error with hint", async () => {
+    mockGetProvider = () => undefined;
+
+    const { exitCode, stdout } = await runCommand([
+      "disconnect",
+      "nonexistent",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Unknown provider");
+    expect(parsed.error).toContain("providers list");
+  });
+
+  // -------------------------------------------------------------------------
+  // Both --account and --connection-id → error
+  // -------------------------------------------------------------------------
+
+  test("both --account and --connection-id returns error", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      managedServiceConfigKey: null,
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "disconnect",
+      "google",
+      "--account",
+      "user@example.com",
+      "--connection-id",
+      "conn-123",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Cannot specify both");
+    expect(parsed.error).toContain("--account");
+    expect(parsed.error).toContain("--connection-id");
+  });
+
+  // =========================================================================
+  // Managed mode tests
+  // =========================================================================
+
+  describe("managed mode", () => {
+    beforeEach(() => {
+      mockGetProvider = () => ({
+        providerKey: "integration:google",
+        managedServiceConfigKey: "google-oauth",
+      });
+      mockIsManagedMode = () => true;
+      mockPlatformClientResult = { platformAssistantId: "asst-123" };
+    });
+
+    test("single connection auto-disconnects", async () => {
+      mockPlatformFetchResults = [
+        // fetchActiveConnections returns one connection
+        {
+          ok: true,
+          status: 200,
+          body: [
+            {
+              id: "conn-1",
+              account_label: "user@gmail.com",
+              scopes_granted: ["email"],
+            },
+          ],
+        },
+        // disconnect call succeeds
+        { ok: true, status: 200, body: {} },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.provider).toBe("google");
+      expect(parsed.connectionId).toBe("conn-1");
+      expect(parsed.account).toBe("user@gmail.com");
+    });
+
+    test("multiple connections without flag returns error with connection list", async () => {
+      mockPlatformFetchResults = [
+        {
+          ok: true,
+          status: 200,
+          body: [
+            {
+              id: "conn-1",
+              account_label: "user1@gmail.com",
+              scopes_granted: [],
+            },
+            {
+              id: "conn-2",
+              account_label: "user2@gmail.com",
+              scopes_granted: [],
+            },
+          ],
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(1);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("Multiple active connections");
+      expect(parsed.error).toContain("--account");
+      expect(parsed.error).toContain("--connection-id");
+      expect(parsed.connections).toBeDefined();
+      expect(parsed.connections).toHaveLength(2);
+    });
+
+    test("--account filters correctly", async () => {
+      mockPlatformFetchResults = [
+        {
+          ok: true,
+          status: 200,
+          body: [
+            {
+              id: "conn-1",
+              account_label: "user1@gmail.com",
+              scopes_granted: [],
+            },
+            {
+              id: "conn-2",
+              account_label: "user2@gmail.com",
+              scopes_granted: [],
+            },
+          ],
+        },
+        // disconnect call succeeds
+        { ok: true, status: 200, body: {} },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--account",
+        "user2@gmail.com",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.connectionId).toBe("conn-2");
+      expect(parsed.account).toBe("user2@gmail.com");
+    });
+
+    test("--connection-id validates ownership", async () => {
+      mockPlatformFetchResults = [
+        {
+          ok: true,
+          status: 200,
+          body: [
+            {
+              id: "conn-1",
+              account_label: "user@gmail.com",
+              scopes_granted: [],
+            },
+          ],
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--connection-id",
+        "conn-nonexistent",
+        "--json",
+      ]);
+      expect(exitCode).toBe(1);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("conn-nonexistent");
+      expect(parsed.error).toContain("not an active");
+    });
+
+    test("no connections returns error with hint", async () => {
+      mockPlatformFetchResults = [{ ok: true, status: 200, body: [] }];
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(1);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("No active connections");
+      expect(parsed.error).toContain("status");
+    });
+  });
+
+  // =========================================================================
+  // BYO mode tests
+  // =========================================================================
+
+  describe("BYO mode", () => {
+    beforeEach(() => {
+      mockGetProvider = () => ({
+        providerKey: "integration:google",
+        managedServiceConfigKey: null,
+      });
+      mockIsManagedMode = () => false;
+    });
+
+    test("single connection auto-disconnects", async () => {
+      mockListActiveConnectionsByProvider = () => [
+        {
+          id: "conn-1",
+          providerKey: "integration:google",
+          accountInfo: "user@gmail.com",
+          status: "active",
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.connectionId).toBe("conn-1");
+      expect(parsed.account).toBe("user@gmail.com");
+
+      // Verify disconnectOAuthProvider was called
+      expect(mockDisconnectOAuthProviderCalls).toHaveLength(1);
+      expect(mockDisconnectOAuthProviderCalls[0].providerKey).toBe(
+        "integration:google",
+      );
+      expect(mockDisconnectOAuthProviderCalls[0].connectionId).toBe("conn-1");
+    });
+
+    test("single connection also cleans up legacy credential keys", async () => {
+      mockListActiveConnectionsByProvider = () => [
+        {
+          id: "conn-1",
+          providerKey: "integration:google",
+          accountInfo: "user@gmail.com",
+          status: "active",
+        },
+      ];
+
+      await runCommand(["disconnect", "google", "--json"]);
+
+      // Should have attempted to delete legacy keys
+      const expectedFields = [
+        "access_token",
+        "refresh_token",
+        "client_id",
+        "client_secret",
+      ];
+      expect(mockDeleteSecureKeyViaDaemonCalls.length).toBe(
+        expectedFields.length,
+      );
+      for (const field of expectedFields) {
+        expect(
+          mockDeleteSecureKeyViaDaemonCalls.some(
+            (c) =>
+              c.type === "credential" &&
+              c.name === `integration:google:${field}`,
+          ),
+        ).toBe(true);
+      }
+
+      expect(mockDeleteCredentialMetadataCalls.length).toBe(
+        expectedFields.length,
+      );
+      for (const field of expectedFields) {
+        expect(
+          mockDeleteCredentialMetadataCalls.some(
+            (c) => c.service === "integration:google" && c.field === field,
+          ),
+        ).toBe(true);
+      }
+    });
+
+    test("--account matches accountInfo", async () => {
+      mockGetActiveConnection = (providerKey, opts) => {
+        if (opts?.account === "user@gmail.com") {
+          return {
+            id: "conn-1",
+            providerKey: "integration:google",
+            accountInfo: "user@gmail.com",
+            status: "active",
+          };
+        }
+        return undefined;
+      };
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--account",
+        "user@gmail.com",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.connectionId).toBe("conn-1");
+      expect(parsed.account).toBe("user@gmail.com");
+    });
+
+    test("--account with no match returns error", async () => {
+      mockGetActiveConnection = () => undefined;
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--account",
+        "nonexistent@gmail.com",
+        "--json",
+      ]);
+      expect(exitCode).toBe(1);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("No active connection");
+      expect(parsed.error).toContain("nonexistent@gmail.com");
+    });
+
+    test("--connection-id looks up by ID", async () => {
+      mockGetConnection = (id) => {
+        if (id === "conn-123") {
+          return {
+            id: "conn-123",
+            providerKey: "integration:google",
+            accountInfo: "user@gmail.com",
+            status: "active",
+          };
+        }
+        return undefined;
+      };
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--connection-id",
+        "conn-123",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.connectionId).toBe("conn-123");
+    });
+
+    test("--connection-id with wrong provider returns error", async () => {
+      mockGetConnection = (id) => {
+        if (id === "conn-slack") {
+          return {
+            id: "conn-slack",
+            providerKey: "integration:slack",
+            accountInfo: null,
+            status: "active",
+          };
+        }
+        return undefined;
+      };
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--connection-id",
+        "conn-slack",
+        "--json",
+      ]);
+      expect(exitCode).toBe(1);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("conn-slack");
+      expect(parsed.error).toContain("not an active");
+    });
+
+    test("multiple connections without flags returns error with list", async () => {
+      mockListActiveConnectionsByProvider = () => [
+        {
+          id: "conn-1",
+          providerKey: "integration:google",
+          accountInfo: "user1@gmail.com",
+          status: "active",
+        },
+        {
+          id: "conn-2",
+          providerKey: "integration:google",
+          accountInfo: "user2@gmail.com",
+          status: "active",
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(1);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("Multiple active connections");
+      expect(parsed.error).toContain("--account");
+      expect(parsed.error).toContain("--connection-id");
+      expect(parsed.connections).toBeDefined();
+      expect(parsed.connections).toHaveLength(2);
+    });
+
+    test("no connections returns error with hint", async () => {
+      mockListActiveConnectionsByProvider = () => [];
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(1);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("No active connections");
+      expect(parsed.error).toContain("status");
+    });
+
+    test("disconnect error returns error message", async () => {
+      mockDisconnectOAuthProviderResult = "error";
+      mockListActiveConnectionsByProvider = () => [
+        {
+          id: "conn-1",
+          providerKey: "integration:google",
+          accountInfo: null,
+          status: "active",
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(1);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("Failed to disconnect");
+    });
+  });
+});

--- a/assistant/src/cli/commands/oauth/__tests__/status.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/status.test.ts
@@ -1,0 +1,579 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockGetProvider: (
+  key: string,
+) => Record<string, unknown> | undefined = () => undefined;
+
+let mockListConnections: (
+  providerKey: string,
+) => Array<Record<string, unknown>> = () => [];
+
+let mockIsManagedMode: (key: string) => boolean = () => false;
+
+let mockPlatformClientResult: Record<string, unknown> | null = null;
+let mockPlatformFetchResults: Array<{
+  ok: boolean;
+  status: number;
+  body: unknown;
+}> = [];
+let mockPlatformFetchCallIndex = 0;
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../../config/loader.js", () => ({
+  getConfig: () => ({ services: {} }),
+  API_KEY_PROVIDERS: [],
+}));
+
+mock.module("../../../../oauth/oauth-store.js", () => ({
+  getProvider: (key: string) => mockGetProvider(key),
+  listConnections: (providerKey: string) => mockListConnections(providerKey),
+  getConnection: () => undefined,
+  getConnectionByProvider: () => undefined,
+  getActiveConnection: () => undefined,
+  listActiveConnectionsByProvider: () => [],
+  disconnectOAuthProvider: async () => "not-found" as const,
+  upsertApp: async () => ({}),
+  getApp: () => undefined,
+  getAppByProviderAndClientId: () => undefined,
+  getMostRecentAppByProvider: () => undefined,
+  listApps: () => [],
+  deleteApp: async () => false,
+  listProviders: () => [],
+  registerProvider: () => ({}),
+  seedProviders: () => {},
+  isProviderConnected: () => false,
+  createConnection: () => ({}),
+  updateConnection: () => ({}),
+  deleteConnection: () => false,
+}));
+
+mock.module("../../../../oauth/provider-behaviors.js", () => ({
+  resolveService: (service: string) => {
+    const aliases: Record<string, string> = {
+      gmail: "integration:google",
+      google: "integration:google",
+      slack: "integration:slack",
+    };
+    if (aliases[service]) return aliases[service];
+    if (!service.includes(":")) return `integration:${service}`;
+    return service;
+  },
+  getProviderBehavior: () => undefined,
+}));
+
+mock.module("../../../../oauth/connect-orchestrator.js", () => ({
+  orchestrateOAuthConnect: async () => ({
+    success: true,
+    deferred: false,
+    grantedScopes: [],
+  }),
+}));
+
+mock.module("../../../../platform/client.js", () => ({
+  VellumPlatformClient: {
+    create: async () => mockPlatformClientResult,
+  },
+}));
+
+mock.module("../../../../util/browser.js", () => ({
+  openInBrowser: () => {},
+}));
+
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+mock.module("../../../lib/daemon-credential-client.js", () => ({
+  getSecureKeyViaDaemon: async () => undefined,
+  deleteSecureKeyViaDaemon: async () => "not-found" as const,
+}));
+
+// Mock shared.js helpers to control managed vs BYO mode routing
+mock.module("../shared.js", () => ({
+  resolveService: (service: string) => {
+    const aliases: Record<string, string> = {
+      gmail: "integration:google",
+      google: "integration:google",
+      slack: "integration:slack",
+    };
+    if (aliases[service]) return aliases[service];
+    if (!service.includes(":")) return `integration:${service}`;
+    return service;
+  },
+  isManagedMode: (key: string) => mockIsManagedMode(key),
+  requirePlatformClient: async (_cmd: Command) => {
+    if (
+      !mockPlatformClientResult ||
+      !(mockPlatformClientResult as Record<string, unknown>).platformAssistantId
+    ) {
+      process.exitCode = 1;
+      process.stdout.write(
+        JSON.stringify({
+          ok: false,
+          error:
+            "Platform prerequisites not met (not logged in or missing assistant ID)",
+        }) + "\n",
+      );
+      return null;
+    }
+    return {
+      platformAssistantId: (mockPlatformClientResult as Record<string, unknown>)
+        .platformAssistantId,
+      fetch: async (): Promise<Response> => {
+        const idx = mockPlatformFetchCallIndex++;
+        const result = mockPlatformFetchResults[idx] ?? {
+          ok: false,
+          status: 500,
+          body: "mock not configured",
+        };
+        return {
+          ok: result.ok,
+          status: result.status,
+          json: async () => result.body,
+          text: async () =>
+            typeof result.body === "string"
+              ? result.body
+              : JSON.stringify(result.body),
+        } as unknown as Response;
+      },
+    };
+  },
+  fetchActiveConnections: async (): Promise<Array<
+    Record<string, unknown>
+  > | null> => {
+    const idx = mockPlatformFetchCallIndex++;
+    const result = mockPlatformFetchResults[idx];
+    if (!result) return [];
+    if (!result.ok) return null;
+    return result.body as Array<Record<string, unknown>>;
+  },
+  toBareProvider: (provider: string): string =>
+    provider.startsWith("integration:")
+      ? provider.slice("integration:".length)
+      : provider,
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+const { registerStatusCommand } = await import("../status.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = (() => true) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.option("--json", "JSON output");
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerStatusCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return { exitCode, stdout: stdoutChunks.join("") };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth status", () => {
+  beforeEach(() => {
+    mockGetProvider = () => undefined;
+    mockListConnections = () => [];
+    mockIsManagedMode = () => false;
+    mockPlatformClientResult = null;
+    mockPlatformFetchResults = [];
+    mockPlatformFetchCallIndex = 0;
+    process.exitCode = 0;
+  });
+
+  // -------------------------------------------------------------------------
+  // Unknown provider
+  // -------------------------------------------------------------------------
+
+  test("unknown provider returns error", async () => {
+    mockGetProvider = () => undefined;
+
+    const { exitCode, stdout } = await runCommand([
+      "status",
+      "nonexistent",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Unknown provider");
+    expect(parsed.error).toContain("providers list");
+  });
+
+  // =========================================================================
+  // Managed mode tests
+  // =========================================================================
+
+  describe("managed mode", () => {
+    beforeEach(() => {
+      mockGetProvider = () => ({
+        providerKey: "integration:google",
+        managedServiceConfigKey: "google-oauth",
+      });
+      mockIsManagedMode = () => true;
+      mockPlatformClientResult = { platformAssistantId: "asst-123" };
+    });
+
+    test("shows platform connections with account labels", async () => {
+      mockPlatformFetchResults = [
+        {
+          ok: true,
+          status: 200,
+          body: [
+            {
+              id: "conn-1",
+              account_label: "user@gmail.com",
+              scopes_granted: ["email", "calendar"],
+              status: "ACTIVE",
+            },
+            {
+              id: "conn-2",
+              account_label: "work@company.com",
+              scopes_granted: ["email"],
+              status: "ACTIVE",
+            },
+          ],
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "status",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.mode).toBe("managed");
+      expect(parsed.connections).toHaveLength(2);
+
+      // Verify connection structure
+      const conn1 = parsed.connections[0];
+      expect(conn1.id).toBe("conn-1");
+      expect(conn1.account).toBe("user@gmail.com");
+      expect(conn1.grantedScopes).toEqual(["email", "calendar"]);
+      expect(conn1.status).toBe("ACTIVE");
+
+      const conn2 = parsed.connections[1];
+      expect(conn2.id).toBe("conn-2");
+      expect(conn2.account).toBe("work@company.com");
+    });
+
+    test("no connections: empty connections array in JSON", async () => {
+      mockPlatformFetchResults = [{ ok: true, status: 200, body: [] }];
+
+      const { exitCode, stdout } = await runCommand([
+        "status",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.mode).toBe("managed");
+      expect(parsed.connections).toEqual([]);
+    });
+
+    test("no connections: human output hints at connect command", async () => {
+      mockPlatformFetchResults = [{ ok: true, status: 200, body: [] }];
+
+      // Run without --json to test human output path
+      const { exitCode } = await runCommand(["status", "google"]);
+      // Should succeed (info message printed via logger, which is mocked)
+      expect(exitCode).toBe(0);
+    });
+
+    test("JSON output structure matches contract", async () => {
+      mockPlatformFetchResults = [
+        {
+          ok: true,
+          status: 200,
+          body: [
+            {
+              id: "conn-abc",
+              account_label: null,
+              scopes_granted: [],
+              status: "ACTIVE",
+            },
+          ],
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "status",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+
+      // Required top-level fields
+      expect(parsed).toHaveProperty("ok", true);
+      expect(parsed).toHaveProperty("provider");
+      expect(parsed).toHaveProperty("mode", "managed");
+      expect(parsed).toHaveProperty("connections");
+      expect(Array.isArray(parsed.connections)).toBe(true);
+
+      // Required per-connection fields
+      const conn = parsed.connections[0];
+      expect(conn).toHaveProperty("id");
+      expect(conn).toHaveProperty("account");
+      expect(conn).toHaveProperty("grantedScopes");
+      expect(conn).toHaveProperty("status");
+    });
+  });
+
+  // =========================================================================
+  // BYO mode tests
+  // =========================================================================
+
+  describe("BYO mode", () => {
+    beforeEach(() => {
+      mockGetProvider = () => ({
+        providerKey: "integration:google",
+        managedServiceConfigKey: null,
+      });
+      mockIsManagedMode = () => false;
+    });
+
+    test("shows local connections with expiry and refresh info", async () => {
+      const expiresAt = Date.now() + 3600_000; // 1 hour from now
+      mockListConnections = () => [
+        {
+          id: "conn-local-1",
+          providerKey: "integration:google",
+          accountInfo: "localuser@gmail.com",
+          grantedScopes: '["email","profile"]',
+          expiresAt,
+          hasRefreshToken: 1,
+          status: "active",
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "status",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.mode).toBe("byo");
+      expect(parsed.connections).toHaveLength(1);
+
+      const conn = parsed.connections[0];
+      expect(conn.id).toBe("conn-local-1");
+      expect(conn.account).toBe("localuser@gmail.com");
+      expect(conn.grantedScopes).toEqual(["email", "profile"]);
+      expect(conn.expiresAt).toBeTruthy();
+      expect(conn.hasRefreshToken).toBe(true);
+      expect(conn.status).toBe("active");
+    });
+
+    test("shows connection with no refresh token", async () => {
+      mockListConnections = () => [
+        {
+          id: "conn-local-2",
+          providerKey: "integration:google",
+          accountInfo: null,
+          grantedScopes: "[]",
+          expiresAt: null,
+          hasRefreshToken: 0,
+          status: "active",
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "status",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      const conn = parsed.connections[0];
+      expect(conn.account).toBeNull();
+      expect(conn.expiresAt).toBeNull();
+      expect(conn.hasRefreshToken).toBe(false);
+    });
+
+    test("filters to only active connections", async () => {
+      mockListConnections = () => [
+        {
+          id: "conn-active",
+          providerKey: "integration:google",
+          accountInfo: "user@gmail.com",
+          grantedScopes: "[]",
+          expiresAt: null,
+          hasRefreshToken: 0,
+          status: "active",
+        },
+        {
+          id: "conn-revoked",
+          providerKey: "integration:google",
+          accountInfo: "old@gmail.com",
+          grantedScopes: "[]",
+          expiresAt: null,
+          hasRefreshToken: 0,
+          status: "revoked",
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "status",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.connections).toHaveLength(1);
+      expect(parsed.connections[0].id).toBe("conn-active");
+    });
+
+    test("no connections: empty array in JSON output", async () => {
+      mockListConnections = () => [];
+
+      const { exitCode, stdout } = await runCommand([
+        "status",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.mode).toBe("byo");
+      expect(parsed.connections).toEqual([]);
+    });
+
+    test("no connections: human output hints at connect command", async () => {
+      mockListConnections = () => [];
+
+      // Run without --json — the human output path logs via getCliLogger
+      const { exitCode } = await runCommand(["status", "google"]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("JSON output structure matches contract", async () => {
+      mockListConnections = () => [
+        {
+          id: "conn-structure",
+          providerKey: "integration:google",
+          accountInfo: "check@gmail.com",
+          grantedScopes: '["scope1"]',
+          expiresAt: Date.now() + 60_000,
+          hasRefreshToken: 1,
+          status: "active",
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "status",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+
+      // Required top-level fields
+      expect(parsed).toHaveProperty("ok", true);
+      expect(parsed).toHaveProperty("provider");
+      expect(parsed).toHaveProperty("mode", "byo");
+      expect(parsed).toHaveProperty("connections");
+      expect(Array.isArray(parsed.connections)).toBe(true);
+
+      // Required per-connection fields for BYO
+      const conn = parsed.connections[0];
+      expect(conn).toHaveProperty("id");
+      expect(conn).toHaveProperty("account");
+      expect(conn).toHaveProperty("grantedScopes");
+      expect(conn).toHaveProperty("expiresAt");
+      expect(conn).toHaveProperty("hasRefreshToken");
+      expect(conn).toHaveProperty("status");
+    });
+
+    test("handles malformed grantedScopes JSON gracefully", async () => {
+      mockListConnections = () => [
+        {
+          id: "conn-bad-scopes",
+          providerKey: "integration:google",
+          accountInfo: null,
+          grantedScopes: "not-valid-json",
+          expiresAt: null,
+          hasRefreshToken: 0,
+          status: "active",
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "status",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      // Should default to empty array on parse failure
+      expect(parsed.connections[0].grantedScopes).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive test suites for the three new unified OAuth CLI commands
- Tests cover both managed (platform) and BYO code paths
- Tests verify error messages contain actionable hints pointing to discovery commands
- Tests verify JSON output structure matches the documented contract

Part of plan: unified-oauth-cli.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
