### PR TITLE
fix: TimelineView build error — mismatched schedule types

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineAudioAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineAudioAttachmentView.swift
@@ -175,7 +175,7 @@ struct InlineAudioAttachmentView: View {
     }
 
     private var progressBar: some View {
-        TimelineView(isPlaying ? .periodic(from: .now, by: 0.1) : .everyMinute) { _ in
+        TimelineView(.periodic(from: .now, by: isPlaying ? 0.1 : 60)) { _ in
             GeometryReader { geo in
                 let dur = currentDuration
                 let prog = currentProgress
@@ -204,7 +204,7 @@ struct InlineAudioAttachmentView: View {
     }
 
     private var timeDisplay: some View {
-        TimelineView(isPlaying ? .periodic(from: .now, by: 0.1) : .everyMinute) { _ in
+        TimelineView(.periodic(from: .now, by: isPlaying ? 0.1 : 60)) { _ in
             let dur = currentDuration
             let prog = currentProgress
             Group {


### PR DESCRIPTION
## Summary
- `.periodic` and `.everyMinute` are different TimelineSchedule types, can't use ternary
- Uses `.periodic(from: .now, by: isPlaying ? 0.1 : 60)` — same type, effectively paused when idle
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
