### PR TITLE
fix: update request.ts error hints to reference unified OAuth commands

### DIFF
--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -247,8 +247,8 @@ Examples:
                   if (connections.length === 0) {
                     writeError(
                       `Error: No active platform connection found for "${providerKey}" with account "${opts.account}".\n\n` +
-                        `Run 'assistant oauth platform status ${providerKey}' to see connected accounts for this provider.\n` +
-                        `To connect a new account, run 'assistant oauth platform connect --help'.`,
+                        `Run 'assistant oauth status ${providerKey}' to see connected accounts for this provider.\n` +
+                        `To connect a new account, run 'assistant oauth connect --help'.`,
                     );
                     return;
                   }
@@ -266,8 +266,8 @@ Examples:
               if (!conn) {
                 writeError(
                   `Error: No active OAuth connection found for "${providerKey}" with account "${opts.account}"${opts.clientId ? ` and client ID "${opts.clientId}"` : ""}.\n\n` +
-                    `Run 'assistant oauth connections list' to see active connections.\n` +
-                    `To connect a new account, run 'assistant oauth connections connect --help'.`,
+                    `Run 'assistant oauth status ${providerKey}' to see active connections.\n` +
+                    `To connect a new account, run 'assistant oauth connect --help'.`,
                 );
                 return;
               }
@@ -434,14 +434,14 @@ Examples:
             if (managed) {
               writeError(
                 `Error: ${resolveMessage}\n\n` +
-                  `Run 'assistant oauth platform status ${providerKey}' to check connection status.\n` +
-                  `To connect, run 'assistant oauth platform connect --help'.`,
+                  `Run 'assistant oauth status ${providerKey}' to check connection status.\n` +
+                  `To connect, run 'assistant oauth connect --help'.`,
               );
             } else {
               writeError(
                 `Error: ${resolveMessage}\n\n` +
-                  `Run 'assistant oauth connections list' to see active connections.\n` +
-                  `To connect, run 'assistant oauth connections connect --help'.`,
+                  `Run 'assistant oauth status ${providerKey}' to see active connections.\n` +
+                  `To connect, run 'assistant oauth connect --help'.`,
               );
             }
             return;
@@ -473,13 +473,13 @@ Examples:
             if (managed) {
               authHint =
                 `Hint: Request returned HTTP ${response.status}. The OAuth token may be expired or revoked.\n\n` +
-                `Run 'assistant oauth platform status ${providerKey}' to check connection health.\n` +
-                `To reconnect, run 'assistant oauth platform connect --help'.`;
+                `Run 'assistant oauth status ${providerKey}' to check connection health.\n` +
+                `To reconnect, run 'assistant oauth connect --help'.`;
             } else {
               authHint =
                 `Hint: Request returned HTTP ${response.status}. The OAuth token may be expired or revoked.\n\n` +
-                `Run 'assistant oauth connections list --provider ${providerKey}' to check connection status.\n` +
-                `To reconnect, run 'assistant oauth connections connect --help'.`;
+                `Run 'assistant oauth status ${providerKey}' to check connection status.\n` +
+                `To reconnect, run 'assistant oauth connect --help'.`;
             }
             writeInfo(authHint);
           }
@@ -555,11 +555,11 @@ Examples:
             const managed = isManagedMode(providerKey);
             const authHint = managed
               ? `Hint: Request returned HTTP ${errStatus}. The OAuth token may be expired or revoked.\n\n` +
-                `Run 'assistant oauth platform status ${providerKey}' to check connection health.\n` +
-                `To reconnect, run 'assistant oauth platform connect --help'.`
+                `Run 'assistant oauth status ${providerKey}' to check connection health.\n` +
+                `To reconnect, run 'assistant oauth connect --help'.`
               : `Hint: Request returned HTTP ${errStatus}. The OAuth token may be expired or revoked.\n\n` +
-                `Run 'assistant oauth connections list --provider ${providerKey}' to check connection status.\n` +
-                `To reconnect, run 'assistant oauth connections connect --help'.`;
+                `Run 'assistant oauth status ${providerKey}' to check connection status.\n` +
+                `To reconnect, run 'assistant oauth connect --help'.`;
 
             writeError(`Error: ${message}`, authHint);
             writeInfo(authHint);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for unified-oauth-cli.md.

**Gap:** request.ts error hints reference deprecated commands
**What was expected:** Error messages should point to unified oauth connect/status/disconnect commands
**What was found:** Still references deprecated oauth platform/connections commands
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
