### PR TITLE
fix: prevent multiple JSON outputs in managed-mode connect polling loop

### DIFF
--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -169,9 +169,11 @@ Examples:
                 providerKey,
                 cmd,
               );
-              const snapshotIds = new Set(
-                (snapshotEntries ?? []).map((e) => e.id),
-              );
+              if (!snapshotEntries) {
+                // fetchActiveConnections already wrote the error output
+                return;
+              }
+              const snapshotIds = new Set(snapshotEntries.map((e) => e.id));
 
               openInBrowser(result.connect_url);
 
@@ -198,6 +200,7 @@ Examples:
                   client,
                   providerKey,
                   cmd,
+                  { silent: true },
                 );
                 if (!currentEntries) continue;
 

--- a/assistant/src/cli/commands/oauth/shared.ts
+++ b/assistant/src/cli/commands/oauth/shared.ts
@@ -96,11 +96,16 @@ export async function requirePlatformClient(
 /**
  * Fetch active platform connections for a provider. Returns the parsed entries
  * or writes an error and returns null.
+ *
+ * When `silent` is true the helper returns null on HTTP errors without writing
+ * any output — useful inside polling loops where transient failures should be
+ * quietly retried rather than emitting multiple error lines.
  */
 export async function fetchActiveConnections(
   client: VellumPlatformClient,
   provider: string,
   cmd: Command,
+  options?: { silent?: boolean },
 ): Promise<PlatformConnectionEntry[] | null> {
   const params = new URLSearchParams();
   params.set("provider", toBareProvider(provider));
@@ -110,11 +115,13 @@ export async function fetchActiveConnections(
   const response = await client.fetch(path);
 
   if (!response.ok) {
-    writeOutput(cmd, {
-      ok: false,
-      error: `Platform returned HTTP ${response.status}`,
-    });
-    process.exitCode = 1;
+    if (!options?.silent) {
+      writeOutput(cmd, {
+        ok: false,
+        error: `Platform returned HTTP ${response.status}`,
+      });
+      process.exitCode = 1;
+    }
     return null;
   }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for unified-oauth-cli.md.

**Gap:** Managed-mode polling loop can emit multiple JSON outputs
**What was expected:** Single JSON output line in --json mode
**What was found:** fetchActiveConnections writes error output on HTTP failures, polling loop continues and may emit additional error lines

**Fix:**
1. Pre-loop snapshot: if fetchActiveConnections returns null, return immediately (error already emitted by the shared helper).
2. Polling loop: pass `{ silent: true }` to fetchActiveConnections so transient HTTP failures are silently retried without emitting error output. This ensures at most one JSON line is written to stdout.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
