### PR TITLE
fix: use consistent provider field format in disconnect.ts JSON output

### DIFF
--- a/assistant/src/cli/commands/oauth/disconnect.ts
+++ b/assistant/src/cli/commands/oauth/disconnect.ts
@@ -202,7 +202,7 @@ Examples:
 
             const result: Record<string, unknown> = {
               ok: true,
-              provider: toBareProvider(providerKey),
+              provider: providerKey,
               connectionId,
             };
             if (accountLabel) result.account = accountLabel;
@@ -210,7 +210,7 @@ Examples:
 
             if (!jsonMode) {
               log.info(
-                `Disconnected ${toBareProvider(providerKey)} connection ${connectionId}`,
+                `Disconnected ${providerKey} connection ${connectionId}`,
               );
             }
           } else {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for unified-oauth-cli.md.

**Gap:** Inconsistent provider field format in disconnect.ts
**What was expected:** Consistent provider format across connect/disconnect/status
**What was found:** Managed path used toBareProvider(providerKey) while BYO used providerKey
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
