### PR TITLE
feat: add generic `readServiceCredentials` reader in credential-reader.ts

### DIFF
--- a/gateway/src/credential-reader.ts
+++ b/gateway/src/credential-reader.ts
@@ -209,9 +209,7 @@ const CES_HTTP_TIMEOUT_MS = 5_000;
  * Returns `undefined` if the env vars are not set, the CES is unreachable,
  * or the credential doesn't exist (404).
  */
-async function readCesCredential(
-  account: string,
-): Promise<string | undefined> {
+async function readCesCredential(account: string): Promise<string | undefined> {
   const baseUrl = process.env.CES_CREDENTIAL_URL?.trim();
   if (!baseUrl) return undefined;
 
@@ -279,6 +277,62 @@ export async function readCredential(
 
   // Encrypted file fallback
   return readEncryptedCredential(account);
+}
+
+export type ServiceCredentialSpec = {
+  /** Service name as it appears in metadata.json (e.g., "telegram", "slack_channel") */
+  service: string;
+  /** Field names required for this service (e.g., ["bot_token", "webhook_secret"]) */
+  requiredFields: readonly string[];
+};
+
+/**
+ * Generic credential reader that checks metadata for the given service and
+ * reads the required fields from the encrypted store.
+ *
+ * Returns a `Record<string, string>` mapping field names to their values if
+ * all required fields are present in metadata and readable from the store.
+ * Returns `null` if metadata is missing, any required field is absent from
+ * metadata, or any secret value can't be read.
+ */
+export async function readServiceCredentials(
+  spec: ServiceCredentialSpec,
+): Promise<Record<string, string> | null> {
+  try {
+    const metadataPath = getMetadataPath();
+    if (!existsSync(metadataPath)) return null;
+
+    const raw = readFileSync(metadataPath, "utf-8");
+    const data = JSON.parse(raw);
+    if (!data || !Array.isArray(data.credentials)) return null;
+
+    // Check that all required fields exist in metadata
+    for (const field of spec.requiredFields) {
+      const found = data.credentials.some(
+        (c: { service?: string; field?: string }) =>
+          c.service === spec.service && c.field === field,
+      );
+      if (!found) return null;
+    }
+
+    // Read each credential from the store
+    const result: Record<string, string> = {};
+    for (const field of spec.requiredFields) {
+      const value = await readCredential(credentialKey(spec.service, field));
+      if (!value) {
+        log.warn(
+          `${spec.service} credential metadata exists but secrets could not be read`,
+        );
+        return null;
+      }
+      result[field] = value;
+    }
+
+    return result;
+  } catch (err) {
+    log.debug({ err }, `Failed to read ${spec.service} credentials`);
+    return null;
+  }
 }
 
 export type TelegramCredentials = {


### PR DESCRIPTION
## Summary
- Add new `ServiceCredentialSpec` type and generic `readServiceCredentials` function
- Consolidates the metadata-reading + credential-fetching pattern used by all per-service readers
- No changes to existing per-service functions (backward compatible)

Part of plan: generic-credential-framework.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
