### PR TITLE
fix: update disconnect test to expect canonical provider key format

### DIFF
--- a/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
@@ -384,7 +384,7 @@ describe("assistant oauth disconnect", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("google");
+      expect(parsed.provider).toBe("integration:google");
       expect(parsed.connectionId).toBe("conn-1");
       expect(parsed.account).toBe("user@gmail.com");
     });


### PR DESCRIPTION
## Summary
Fixes stale test assertion in disconnect.test.ts that expected bare provider name instead of canonical key format after the provider field consistency fix.

**Gap:** disconnect.test.ts managed-mode test expects 'google' but production code outputs 'integration:google'
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
