### PR TITLE
feat: unified OAuth CLI commands (connect, disconnect, status)

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -148,6 +148,7 @@ mock.module("../oauth/oauth-store.js", () => ({
   registerProvider: () => ({}),
   seedProviders: () => {},
   getActiveConnection: () => undefined,
+  listActiveConnectionsByProvider: () => [],
   createConnection: () => ({}),
   isProviderConnected: () => false,
   updateConnection: () => ({}),

--- a/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
@@ -1,0 +1,785 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockGetProvider: (
+  key: string,
+) => Record<string, unknown> | undefined = () => undefined;
+
+let mockGetAppByProviderAndClientId: (
+  key: string,
+  clientId: string,
+) => Record<string, unknown> | undefined = () => undefined;
+
+let mockGetMostRecentAppByProvider: (
+  key: string,
+) => Record<string, unknown> | undefined = () => undefined;
+
+let mockOrchestrateOAuthConnect: (
+  opts: Record<string, unknown>,
+) => Promise<Record<string, unknown>> = async () => ({
+  success: true,
+  deferred: false,
+  grantedScopes: [],
+});
+
+let mockGetProviderBehavior: (
+  key: string,
+) => Record<string, unknown> | undefined = () => undefined;
+
+let mockGetSecureKeyViaDaemon: (
+  account: string,
+) => Promise<string | undefined> = async () => undefined;
+
+let mockOpenInBrowserCalls: string[] = [];
+let mockPlatformClientResult: Record<string, unknown> | null = null;
+let mockPlatformFetchResults: Array<{
+  ok: boolean;
+  status: number;
+  body: unknown;
+}> = [];
+let mockPlatformFetchCallIndex = 0;
+
+let mockIsManagedMode: (key: string) => boolean = () => false;
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../../config/loader.js", () => ({
+  getConfig: () => ({ services: {} }),
+  API_KEY_PROVIDERS: [],
+}));
+
+mock.module("../../../../oauth/oauth-store.js", () => ({
+  getProvider: (key: string) => mockGetProvider(key),
+  getAppByProviderAndClientId: (key: string, clientId: string) =>
+    mockGetAppByProviderAndClientId(key, clientId),
+  getMostRecentAppByProvider: (key: string) =>
+    mockGetMostRecentAppByProvider(key),
+  listConnections: () => [],
+  getConnection: () => undefined,
+  getConnectionByProvider: () => undefined,
+  getActiveConnection: () => undefined,
+  listActiveConnectionsByProvider: () => [],
+  disconnectOAuthProvider: async () => "not-found" as const,
+  upsertApp: async () => ({}),
+  getApp: () => undefined,
+  listApps: () => [],
+  deleteApp: async () => false,
+  listProviders: () => [],
+  registerProvider: () => ({}),
+  seedProviders: () => {},
+  isProviderConnected: () => false,
+  createConnection: () => ({}),
+  updateConnection: () => ({}),
+  deleteConnection: () => false,
+}));
+
+mock.module("../../../../oauth/provider-behaviors.js", () => ({
+  resolveService: (service: string) => {
+    const aliases: Record<string, string> = {
+      gmail: "integration:google",
+      google: "integration:google",
+      slack: "integration:slack",
+    };
+    if (aliases[service]) return aliases[service];
+    if (!service.includes(":")) return `integration:${service}`;
+    return service;
+  },
+  getProviderBehavior: (key: string) => mockGetProviderBehavior(key),
+}));
+
+mock.module("../../../../oauth/connect-orchestrator.js", () => ({
+  orchestrateOAuthConnect: (opts: Record<string, unknown>) =>
+    mockOrchestrateOAuthConnect(opts),
+}));
+
+mock.module("../../../../platform/client.js", () => ({
+  VellumPlatformClient: {
+    create: async () => mockPlatformClientResult,
+  },
+}));
+
+mock.module("../../../../util/browser.js", () => ({
+  openInBrowser: (url: string) => {
+    mockOpenInBrowserCalls.push(url);
+  },
+}));
+
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+mock.module("../../../lib/daemon-credential-client.js", () => ({
+  getSecureKeyViaDaemon: (account: string) =>
+    mockGetSecureKeyViaDaemon(account),
+  deleteSecureKeyViaDaemon: async () => "not-found" as const,
+}));
+
+// Mock shared.js helpers to control managed vs BYO mode routing
+mock.module("../shared.js", () => ({
+  resolveService: (service: string) => {
+    const aliases: Record<string, string> = {
+      gmail: "integration:google",
+      google: "integration:google",
+      slack: "integration:slack",
+    };
+    if (aliases[service]) return aliases[service];
+    if (!service.includes(":")) return `integration:${service}`;
+    return service;
+  },
+  isManagedMode: (key: string) => mockIsManagedMode(key),
+  requirePlatformClient: async (_cmd: Command) => {
+    if (
+      !mockPlatformClientResult ||
+      !(mockPlatformClientResult as Record<string, unknown>).platformAssistantId
+    ) {
+      process.exitCode = 1;
+      process.stdout.write(
+        JSON.stringify({
+          ok: false,
+          error:
+            "Platform prerequisites not met (not logged in or missing assistant ID)",
+        }) + "\n",
+      );
+      return null;
+    }
+    return {
+      platformAssistantId: (mockPlatformClientResult as Record<string, unknown>)
+        .platformAssistantId,
+      fetch: async (_path: string, _init?: RequestInit): Promise<Response> => {
+        const idx = mockPlatformFetchCallIndex++;
+        const result = mockPlatformFetchResults[idx] ?? {
+          ok: false,
+          status: 500,
+          body: "mock not configured",
+        };
+        return {
+          ok: result.ok,
+          status: result.status,
+          json: async () => result.body,
+          text: async () =>
+            typeof result.body === "string"
+              ? result.body
+              : JSON.stringify(result.body),
+        } as unknown as Response;
+      },
+    };
+  },
+  fetchActiveConnections: async (
+    _client: Record<string, unknown>,
+    _provider: string,
+    _cmd: Command,
+  ): Promise<Array<Record<string, unknown>> | null> => {
+    const idx = mockPlatformFetchCallIndex++;
+    const result = mockPlatformFetchResults[idx];
+    if (!result) return [];
+    if (!result.ok) return null;
+    return result.body as Array<Record<string, unknown>>;
+  },
+  toBareProvider: (provider: string): string =>
+    provider.startsWith("integration:")
+      ? provider.slice("integration:".length)
+      : provider,
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+const { registerConnectCommand } = await import("../connect.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = (() => true) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.option("--json", "JSON output");
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerConnectCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return { exitCode, stdout: stdoutChunks.join("") };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth connect", () => {
+  beforeEach(() => {
+    mockGetProvider = () => undefined;
+    mockGetAppByProviderAndClientId = () => undefined;
+    mockGetMostRecentAppByProvider = () => undefined;
+    mockOrchestrateOAuthConnect = async () => ({
+      success: true,
+      deferred: false,
+      grantedScopes: [],
+    });
+    mockGetProviderBehavior = () => undefined;
+    mockGetSecureKeyViaDaemon = async () => undefined;
+    mockOpenInBrowserCalls = [];
+    mockPlatformClientResult = null;
+    mockPlatformFetchResults = [];
+    mockPlatformFetchCallIndex = 0;
+    mockIsManagedMode = () => false;
+    process.exitCode = 0;
+  });
+
+  // -------------------------------------------------------------------------
+  // Unknown provider
+  // -------------------------------------------------------------------------
+
+  test("unknown provider returns error with hint", async () => {
+    mockGetProvider = () => undefined;
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "nonexistent",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Unknown provider");
+    expect(parsed.error).toContain("providers list");
+  });
+
+  // -------------------------------------------------------------------------
+  // Provider alias resolution
+  // -------------------------------------------------------------------------
+
+  test("provider alias 'gmail' resolves to integration:google", async () => {
+    let capturedProviderKey: string | undefined;
+
+    mockGetProvider = (key: string) => {
+      capturedProviderKey = key;
+      return {
+        providerKey: key,
+        authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+        tokenUrl: "https://oauth2.googleapis.com/token",
+        managedServiceConfigKey: null,
+      };
+    };
+
+    mockGetMostRecentAppByProvider = () => ({
+      id: "app-1",
+      clientId: "test-id",
+      clientSecretCredentialPath: "oauth_app/app-1/client_secret",
+      providerKey: "integration:google",
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    mockOrchestrateOAuthConnect = async () => ({
+      success: true,
+      deferred: false,
+      grantedScopes: ["read"],
+      accountInfo: "user@example.com",
+    });
+
+    await runCommand(["connect", "gmail", "--json"]);
+    expect(capturedProviderKey).toBe("integration:google");
+  });
+
+  // -------------------------------------------------------------------------
+  // Managed mode: prints connect URL without --open-browser
+  // -------------------------------------------------------------------------
+
+  test("managed mode: prints connect URL without --open-browser", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      managedServiceConfigKey: "google-oauth",
+    });
+    mockIsManagedMode = () => true;
+    mockPlatformClientResult = { platformAssistantId: "asst-123" };
+    mockPlatformFetchResults = [
+      {
+        ok: true,
+        status: 200,
+        body: { connect_url: "https://platform.example.com/oauth/connect" },
+      },
+    ];
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "google",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.deferred).toBe(true);
+    expect(parsed.connectUrl).toBe(
+      "https://platform.example.com/oauth/connect",
+    );
+    expect(parsed.provider).toBe("integration:google");
+  });
+
+  // -------------------------------------------------------------------------
+  // Managed mode with --open-browser: opens browser and polls
+  // -------------------------------------------------------------------------
+
+  test("managed mode with --open-browser: opens browser and polls for new connection", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      managedServiceConfigKey: "google-oauth",
+    });
+    mockIsManagedMode = () => true;
+    mockPlatformClientResult = { platformAssistantId: "asst-123" };
+
+    // First call: /start/ endpoint returns connect_url
+    // Second call: fetchActiveConnections snapshot (before browser)
+    // Third call: fetchActiveConnections poll (new connection found)
+    mockPlatformFetchResults = [
+      {
+        ok: true,
+        status: 200,
+        body: { connect_url: "https://platform.example.com/oauth/connect" },
+      },
+      // Snapshot — empty
+      { ok: true, status: 200, body: [] },
+      // Poll — new connection appeared
+      {
+        ok: true,
+        status: 200,
+        body: [
+          {
+            id: "conn-new",
+            account_label: "user@gmail.com",
+            scopes_granted: ["email"],
+          },
+        ],
+      },
+    ];
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "google",
+      "--open-browser",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.connectionId).toBe("conn-new");
+    expect(parsed.accountLabel).toBe("user@gmail.com");
+    expect(parsed.scopesGranted).toEqual(["email"]);
+    expect(mockOpenInBrowserCalls.length).toBeGreaterThanOrEqual(1);
+    expect(mockOpenInBrowserCalls[0]).toBe(
+      "https://platform.example.com/oauth/connect",
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // BYO mode: prints auth URL without --open-browser (deferred)
+  // -------------------------------------------------------------------------
+
+  test("BYO mode: prints auth URL without --open-browser", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      managedServiceConfigKey: null,
+    });
+    mockIsManagedMode = () => false;
+
+    mockGetMostRecentAppByProvider = () => ({
+      id: "app-1",
+      clientId: "byo-client-id",
+      clientSecretCredentialPath: "oauth_app/app-1/client_secret",
+      providerKey: "integration:google",
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    mockOrchestrateOAuthConnect = async () => ({
+      success: true,
+      deferred: true,
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth?state=abc",
+      state: "abc",
+      service: "integration:google",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "integration:google",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.deferred).toBe(true);
+    expect(parsed.authUrl).toBe(
+      "https://accounts.google.com/o/oauth2/v2/auth?state=abc",
+    );
+    expect(parsed.service).toBe("integration:google");
+  });
+
+  // -------------------------------------------------------------------------
+  // BYO mode with --open-browser: orchestrator called with isInteractive true
+  // -------------------------------------------------------------------------
+
+  test("BYO mode with --open-browser calls orchestrator with isInteractive: true", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      managedServiceConfigKey: null,
+    });
+    mockIsManagedMode = () => false;
+
+    mockGetAppByProviderAndClientId = () => ({
+      id: "app-1",
+      clientId: "test-id",
+      clientSecretCredentialPath: "oauth_app/app-1/client_secret",
+      providerKey: "integration:google",
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    let capturedOpts: Record<string, unknown> | undefined;
+    mockOrchestrateOAuthConnect = async (opts) => {
+      capturedOpts = opts;
+      return {
+        success: true,
+        deferred: false,
+        grantedScopes: ["email"],
+        accountInfo: "user@example.com",
+      };
+    };
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "integration:google",
+      "--client-id",
+      "test-id",
+      "--open-browser",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(capturedOpts).toBeDefined();
+    expect(capturedOpts!.isInteractive).toBe(true);
+    // openUrl should be provided when --open-browser is set
+    expect(typeof capturedOpts!.openUrl).toBe("function");
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.grantedScopes).toEqual(["email"]);
+    expect(parsed.accountInfo).toBe("user@example.com");
+  });
+
+  // -------------------------------------------------------------------------
+  // BYO missing app: error with hint
+  // -------------------------------------------------------------------------
+
+  test("BYO mode: missing app with --client-id returns error with hint", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      managedServiceConfigKey: null,
+    });
+    mockIsManagedMode = () => false;
+    mockGetAppByProviderAndClientId = () => undefined;
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "integration:google",
+      "--client-id",
+      "nonexistent-id",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("nonexistent-id");
+    expect(parsed.error).toContain("apps upsert");
+  });
+
+  // -------------------------------------------------------------------------
+  // BYO mode: no client_id at all
+  // -------------------------------------------------------------------------
+
+  test("BYO mode: no client_id found returns error with hint", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      managedServiceConfigKey: null,
+    });
+    mockIsManagedMode = () => false;
+    mockGetMostRecentAppByProvider = () => undefined;
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "integration:google",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("client_id");
+    expect(parsed.error).toContain("apps upsert");
+  });
+
+  // -------------------------------------------------------------------------
+  // --client-id ignored in managed mode (silent, no error)
+  // -------------------------------------------------------------------------
+
+  test("--client-id is silently ignored in managed mode", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      managedServiceConfigKey: "google-oauth",
+    });
+    mockIsManagedMode = () => true;
+    mockPlatformClientResult = { platformAssistantId: "asst-123" };
+    mockPlatformFetchResults = [
+      {
+        ok: true,
+        status: 200,
+        body: { connect_url: "https://platform.example.com/oauth/connect" },
+      },
+    ];
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "google",
+      "--client-id",
+      "should-be-ignored",
+      "--json",
+    ]);
+    // Should succeed — --client-id does not cause an error in managed mode
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.connectUrl).toBe(
+      "https://platform.example.com/oauth/connect",
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // JSON output format for deferred case (BYO)
+  // -------------------------------------------------------------------------
+
+  test("JSON output for deferred case includes ok, deferred, authUrl, service", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:slack",
+      authUrl: "https://slack.com/oauth/v2/authorize",
+      tokenUrl: "https://slack.com/api/oauth.v2.access",
+      managedServiceConfigKey: null,
+    });
+    mockIsManagedMode = () => false;
+
+    mockGetMostRecentAppByProvider = () => ({
+      id: "app-slack",
+      clientId: "slack-client-id",
+      clientSecretCredentialPath: "oauth_app/app-slack/client_secret",
+      providerKey: "integration:slack",
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    mockOrchestrateOAuthConnect = async () => ({
+      success: true,
+      deferred: true,
+      authUrl: "https://slack.com/oauth/v2/authorize?state=xyz",
+      state: "xyz",
+      service: "integration:slack",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "slack",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toHaveProperty("ok", true);
+    expect(parsed).toHaveProperty("deferred", true);
+    expect(parsed).toHaveProperty("authUrl");
+    expect(parsed).toHaveProperty("service", "integration:slack");
+  });
+
+  // -------------------------------------------------------------------------
+  // JSON output format for completed case (BYO)
+  // -------------------------------------------------------------------------
+
+  test("JSON output for completed case includes ok, grantedScopes, accountInfo", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      managedServiceConfigKey: null,
+    });
+    mockIsManagedMode = () => false;
+
+    mockGetMostRecentAppByProvider = () => ({
+      id: "app-1",
+      clientId: "completed-client-id",
+      clientSecretCredentialPath: "oauth_app/app-1/client_secret",
+      providerKey: "integration:google",
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    mockOrchestrateOAuthConnect = async () => ({
+      success: true,
+      deferred: false,
+      grantedScopes: ["email", "profile"],
+      accountInfo: "test@gmail.com",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "google",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toHaveProperty("ok", true);
+    expect(parsed).toHaveProperty("grantedScopes");
+    expect(parsed.grantedScopes).toEqual(["email", "profile"]);
+    expect(parsed).toHaveProperty("accountInfo", "test@gmail.com");
+    // Should NOT have deferred
+    expect(parsed.deferred).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // BYO mode: client_secret required but missing
+  // -------------------------------------------------------------------------
+
+  test("BYO mode: client_secret required but missing returns error with hint", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      tokenEndpointAuthMethod: "client_secret_post",
+      managedServiceConfigKey: null,
+    });
+    mockIsManagedMode = () => false;
+
+    mockGetMostRecentAppByProvider = () => ({
+      id: "app-1",
+      clientId: "test-id",
+      clientSecretCredentialPath: "oauth_app/app-1/client_secret",
+      providerKey: "integration:google",
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    // No secret stored
+    mockGetSecureKeyViaDaemon = async () => undefined;
+
+    // Provider behavior says secret is required
+    mockGetProviderBehavior = () => ({
+      setup: {
+        requiresClientSecret: true,
+        displayName: "Google",
+        dashboardUrl: "https://console.cloud.google.com",
+        appType: "Desktop app",
+      },
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "integration:google",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("client_secret");
+    expect(parsed.error).toContain("apps upsert");
+  });
+
+  // -------------------------------------------------------------------------
+  // Orchestrator error propagation
+  // -------------------------------------------------------------------------
+
+  test("BYO mode: orchestrator error propagates correctly", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      managedServiceConfigKey: null,
+    });
+    mockIsManagedMode = () => false;
+
+    mockGetMostRecentAppByProvider = () => ({
+      id: "app-1",
+      clientId: "client-id",
+      clientSecretCredentialPath: "oauth_app/app-1/client_secret",
+      providerKey: "integration:google",
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    mockOrchestrateOAuthConnect = async () => ({
+      success: false,
+      error: "Token exchange failed: invalid_grant",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "integration:google",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toBe("Token exchange failed: invalid_grant");
+  });
+});

--- a/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
@@ -1,0 +1,760 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockGetProvider: (
+  key: string,
+) => Record<string, unknown> | undefined = () => undefined;
+
+let mockGetConnection: (
+  id: string,
+) => Record<string, unknown> | undefined = () => undefined;
+
+let mockGetActiveConnection: (
+  providerKey: string,
+  opts?: { account?: string },
+) => Record<string, unknown> | undefined = () => undefined;
+
+let mockListActiveConnectionsByProvider: (
+  providerKey: string,
+) => Array<Record<string, unknown>> = () => [];
+
+let mockDisconnectOAuthProviderResult: "disconnected" | "not-found" | "error" =
+  "disconnected";
+
+let mockDisconnectOAuthProviderCalls: Array<{
+  providerKey: string;
+  account: string | undefined;
+  connectionId: string | undefined;
+}> = [];
+
+let mockDeleteSecureKeyViaDaemonCalls: Array<{
+  type: string;
+  name: string;
+}> = [];
+
+let mockDeleteCredentialMetadataCalls: Array<{
+  service: string;
+  field: string;
+}> = [];
+
+let mockIsManagedMode: (key: string) => boolean = () => false;
+
+let mockPlatformClientResult: Record<string, unknown> | null = null;
+let mockPlatformFetchResults: Array<{
+  ok: boolean;
+  status: number;
+  body: unknown;
+}> = [];
+let mockPlatformFetchCallIndex = 0;
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../../config/loader.js", () => ({
+  getConfig: () => ({ services: {} }),
+  API_KEY_PROVIDERS: [],
+}));
+
+mock.module("../../../../oauth/oauth-store.js", () => ({
+  getProvider: (key: string) => mockGetProvider(key),
+  getConnection: (id: string) => mockGetConnection(id),
+  getActiveConnection: (providerKey: string, opts?: { account?: string }) =>
+    mockGetActiveConnection(providerKey, opts),
+  listActiveConnectionsByProvider: (providerKey: string) =>
+    mockListActiveConnectionsByProvider(providerKey),
+  disconnectOAuthProvider: async (
+    providerKey: string,
+    account?: string,
+    connectionId?: string,
+  ) => {
+    mockDisconnectOAuthProviderCalls.push({
+      providerKey,
+      account,
+      connectionId,
+    });
+    return mockDisconnectOAuthProviderResult;
+  },
+  getConnectionByProvider: () => undefined,
+  listConnections: () => [],
+  upsertApp: async () => ({}),
+  getApp: () => undefined,
+  getAppByProviderAndClientId: () => undefined,
+  getMostRecentAppByProvider: () => undefined,
+  listApps: () => [],
+  deleteApp: async () => false,
+  listProviders: () => [],
+  registerProvider: () => ({}),
+  seedProviders: () => {},
+  isProviderConnected: () => false,
+  createConnection: () => ({}),
+  updateConnection: () => ({}),
+  deleteConnection: () => false,
+}));
+
+mock.module("../../../../oauth/provider-behaviors.js", () => ({
+  resolveService: (service: string) => {
+    const aliases: Record<string, string> = {
+      gmail: "integration:google",
+      google: "integration:google",
+      slack: "integration:slack",
+    };
+    if (aliases[service]) return aliases[service];
+    if (!service.includes(":")) return `integration:${service}`;
+    return service;
+  },
+  getProviderBehavior: () => undefined,
+}));
+
+mock.module("../../../../oauth/connect-orchestrator.js", () => ({
+  orchestrateOAuthConnect: async () => ({
+    success: true,
+    deferred: false,
+    grantedScopes: [],
+  }),
+}));
+
+mock.module("../../../../platform/client.js", () => ({
+  VellumPlatformClient: {
+    create: async () => mockPlatformClientResult,
+  },
+}));
+
+mock.module("../../../../util/browser.js", () => ({
+  openInBrowser: () => {},
+}));
+
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+mock.module("../../../../tools/credentials/metadata-store.js", () => ({
+  deleteCredentialMetadata: (service: string, field: string) => {
+    mockDeleteCredentialMetadataCalls.push({ service, field });
+    return true;
+  },
+  getCredentialMetadata: () => undefined,
+  upsertCredentialMetadata: () => ({}),
+  listCredentialMetadata: () => [],
+  assertMetadataWritable: () => {},
+}));
+
+mock.module("../../../lib/daemon-credential-client.js", () => ({
+  getSecureKeyViaDaemon: async () => undefined,
+  deleteSecureKeyViaDaemon: async (type: string, name: string) => {
+    mockDeleteSecureKeyViaDaemonCalls.push({ type, name });
+    return "deleted" as const;
+  },
+}));
+
+// Mock shared.js helpers to control managed vs BYO mode routing
+mock.module("../shared.js", () => ({
+  resolveService: (service: string) => {
+    const aliases: Record<string, string> = {
+      gmail: "integration:google",
+      google: "integration:google",
+      slack: "integration:slack",
+    };
+    if (aliases[service]) return aliases[service];
+    if (!service.includes(":")) return `integration:${service}`;
+    return service;
+  },
+  isManagedMode: (key: string) => mockIsManagedMode(key),
+  requirePlatformClient: async (_cmd: Command) => {
+    if (
+      !mockPlatformClientResult ||
+      !(mockPlatformClientResult as Record<string, unknown>).platformAssistantId
+    ) {
+      process.exitCode = 1;
+      process.stdout.write(
+        JSON.stringify({
+          ok: false,
+          error:
+            "Platform prerequisites not met (not logged in or missing assistant ID)",
+        }) + "\n",
+      );
+      return null;
+    }
+    return {
+      platformAssistantId: (mockPlatformClientResult as Record<string, unknown>)
+        .platformAssistantId,
+      fetch: async (): Promise<Response> => {
+        const idx = mockPlatformFetchCallIndex++;
+        const result = mockPlatformFetchResults[idx] ?? {
+          ok: false,
+          status: 500,
+          body: "mock not configured",
+        };
+        return {
+          ok: result.ok,
+          status: result.status,
+          json: async () => result.body,
+          text: async () =>
+            typeof result.body === "string"
+              ? result.body
+              : JSON.stringify(result.body),
+        } as unknown as Response;
+      },
+    };
+  },
+  fetchActiveConnections: async (): Promise<Array<
+    Record<string, unknown>
+  > | null> => {
+    const idx = mockPlatformFetchCallIndex++;
+    const result = mockPlatformFetchResults[idx];
+    if (!result) return [];
+    if (!result.ok) return null;
+    return result.body as Array<Record<string, unknown>>;
+  },
+  toBareProvider: (provider: string): string =>
+    provider.startsWith("integration:")
+      ? provider.slice("integration:".length)
+      : provider,
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+const { registerDisconnectCommand } = await import("../disconnect.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = (() => true) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.option("--json", "JSON output");
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerDisconnectCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return { exitCode, stdout: stdoutChunks.join("") };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth disconnect", () => {
+  beforeEach(() => {
+    mockGetProvider = () => undefined;
+    mockGetConnection = () => undefined;
+    mockGetActiveConnection = () => undefined;
+    mockListActiveConnectionsByProvider = () => [];
+    mockDisconnectOAuthProviderResult = "disconnected";
+    mockDisconnectOAuthProviderCalls = [];
+    mockDeleteSecureKeyViaDaemonCalls = [];
+    mockDeleteCredentialMetadataCalls = [];
+    mockIsManagedMode = () => false;
+    mockPlatformClientResult = null;
+    mockPlatformFetchResults = [];
+    mockPlatformFetchCallIndex = 0;
+    process.exitCode = 0;
+  });
+
+  // -------------------------------------------------------------------------
+  // Unknown provider
+  // -------------------------------------------------------------------------
+
+  test("unknown provider returns error with hint", async () => {
+    mockGetProvider = () => undefined;
+
+    const { exitCode, stdout } = await runCommand([
+      "disconnect",
+      "nonexistent",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Unknown provider");
+    expect(parsed.error).toContain("providers list");
+  });
+
+  // -------------------------------------------------------------------------
+  // Both --account and --connection-id → error
+  // -------------------------------------------------------------------------
+
+  test("both --account and --connection-id returns error", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      managedServiceConfigKey: null,
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "disconnect",
+      "google",
+      "--account",
+      "user@example.com",
+      "--connection-id",
+      "conn-123",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Cannot specify both");
+    expect(parsed.error).toContain("--account");
+    expect(parsed.error).toContain("--connection-id");
+  });
+
+  // =========================================================================
+  // Managed mode tests
+  // =========================================================================
+
+  describe("managed mode", () => {
+    beforeEach(() => {
+      mockGetProvider = () => ({
+        providerKey: "integration:google",
+        managedServiceConfigKey: "google-oauth",
+      });
+      mockIsManagedMode = () => true;
+      mockPlatformClientResult = { platformAssistantId: "asst-123" };
+    });
+
+    test("single connection auto-disconnects", async () => {
+      mockPlatformFetchResults = [
+        // fetchActiveConnections returns one connection
+        {
+          ok: true,
+          status: 200,
+          body: [
+            {
+              id: "conn-1",
+              account_label: "user@gmail.com",
+              scopes_granted: ["email"],
+            },
+          ],
+        },
+        // disconnect call succeeds
+        { ok: true, status: 200, body: {} },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.provider).toBe("google");
+      expect(parsed.connectionId).toBe("conn-1");
+      expect(parsed.account).toBe("user@gmail.com");
+    });
+
+    test("multiple connections without flag returns error with connection list", async () => {
+      mockPlatformFetchResults = [
+        {
+          ok: true,
+          status: 200,
+          body: [
+            {
+              id: "conn-1",
+              account_label: "user1@gmail.com",
+              scopes_granted: [],
+            },
+            {
+              id: "conn-2",
+              account_label: "user2@gmail.com",
+              scopes_granted: [],
+            },
+          ],
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(1);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("Multiple active connections");
+      expect(parsed.error).toContain("--account");
+      expect(parsed.error).toContain("--connection-id");
+      expect(parsed.connections).toBeDefined();
+      expect(parsed.connections).toHaveLength(2);
+    });
+
+    test("--account filters correctly", async () => {
+      mockPlatformFetchResults = [
+        {
+          ok: true,
+          status: 200,
+          body: [
+            {
+              id: "conn-1",
+              account_label: "user1@gmail.com",
+              scopes_granted: [],
+            },
+            {
+              id: "conn-2",
+              account_label: "user2@gmail.com",
+              scopes_granted: [],
+            },
+          ],
+        },
+        // disconnect call succeeds
+        { ok: true, status: 200, body: {} },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--account",
+        "user2@gmail.com",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.connectionId).toBe("conn-2");
+      expect(parsed.account).toBe("user2@gmail.com");
+    });
+
+    test("--connection-id validates ownership", async () => {
+      mockPlatformFetchResults = [
+        {
+          ok: true,
+          status: 200,
+          body: [
+            {
+              id: "conn-1",
+              account_label: "user@gmail.com",
+              scopes_granted: [],
+            },
+          ],
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--connection-id",
+        "conn-nonexistent",
+        "--json",
+      ]);
+      expect(exitCode).toBe(1);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("conn-nonexistent");
+      expect(parsed.error).toContain("not an active");
+    });
+
+    test("no connections returns error with hint", async () => {
+      mockPlatformFetchResults = [{ ok: true, status: 200, body: [] }];
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(1);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("No active connections");
+      expect(parsed.error).toContain("status");
+    });
+  });
+
+  // =========================================================================
+  // BYO mode tests
+  // =========================================================================
+
+  describe("BYO mode", () => {
+    beforeEach(() => {
+      mockGetProvider = () => ({
+        providerKey: "integration:google",
+        managedServiceConfigKey: null,
+      });
+      mockIsManagedMode = () => false;
+    });
+
+    test("single connection auto-disconnects", async () => {
+      mockListActiveConnectionsByProvider = () => [
+        {
+          id: "conn-1",
+          providerKey: "integration:google",
+          accountInfo: "user@gmail.com",
+          status: "active",
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.connectionId).toBe("conn-1");
+      expect(parsed.account).toBe("user@gmail.com");
+
+      // Verify disconnectOAuthProvider was called
+      expect(mockDisconnectOAuthProviderCalls).toHaveLength(1);
+      expect(mockDisconnectOAuthProviderCalls[0].providerKey).toBe(
+        "integration:google",
+      );
+      expect(mockDisconnectOAuthProviderCalls[0].connectionId).toBe("conn-1");
+    });
+
+    test("single connection also cleans up legacy credential keys", async () => {
+      mockListActiveConnectionsByProvider = () => [
+        {
+          id: "conn-1",
+          providerKey: "integration:google",
+          accountInfo: "user@gmail.com",
+          status: "active",
+        },
+      ];
+
+      await runCommand(["disconnect", "google", "--json"]);
+
+      // Should have attempted to delete legacy keys
+      const expectedFields = [
+        "access_token",
+        "refresh_token",
+        "client_id",
+        "client_secret",
+      ];
+      expect(mockDeleteSecureKeyViaDaemonCalls.length).toBe(
+        expectedFields.length,
+      );
+      for (const field of expectedFields) {
+        expect(
+          mockDeleteSecureKeyViaDaemonCalls.some(
+            (c) =>
+              c.type === "credential" &&
+              c.name === `integration:google:${field}`,
+          ),
+        ).toBe(true);
+      }
+
+      expect(mockDeleteCredentialMetadataCalls.length).toBe(
+        expectedFields.length,
+      );
+      for (const field of expectedFields) {
+        expect(
+          mockDeleteCredentialMetadataCalls.some(
+            (c) => c.service === "integration:google" && c.field === field,
+          ),
+        ).toBe(true);
+      }
+    });
+
+    test("--account matches accountInfo", async () => {
+      mockGetActiveConnection = (providerKey, opts) => {
+        if (opts?.account === "user@gmail.com") {
+          return {
+            id: "conn-1",
+            providerKey: "integration:google",
+            accountInfo: "user@gmail.com",
+            status: "active",
+          };
+        }
+        return undefined;
+      };
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--account",
+        "user@gmail.com",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.connectionId).toBe("conn-1");
+      expect(parsed.account).toBe("user@gmail.com");
+    });
+
+    test("--account with no match returns error", async () => {
+      mockGetActiveConnection = () => undefined;
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--account",
+        "nonexistent@gmail.com",
+        "--json",
+      ]);
+      expect(exitCode).toBe(1);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("No active connection");
+      expect(parsed.error).toContain("nonexistent@gmail.com");
+    });
+
+    test("--connection-id looks up by ID", async () => {
+      mockGetConnection = (id) => {
+        if (id === "conn-123") {
+          return {
+            id: "conn-123",
+            providerKey: "integration:google",
+            accountInfo: "user@gmail.com",
+            status: "active",
+          };
+        }
+        return undefined;
+      };
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--connection-id",
+        "conn-123",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.connectionId).toBe("conn-123");
+    });
+
+    test("--connection-id with wrong provider returns error", async () => {
+      mockGetConnection = (id) => {
+        if (id === "conn-slack") {
+          return {
+            id: "conn-slack",
+            providerKey: "integration:slack",
+            accountInfo: null,
+            status: "active",
+          };
+        }
+        return undefined;
+      };
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--connection-id",
+        "conn-slack",
+        "--json",
+      ]);
+      expect(exitCode).toBe(1);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("conn-slack");
+      expect(parsed.error).toContain("not an active");
+    });
+
+    test("multiple connections without flags returns error with list", async () => {
+      mockListActiveConnectionsByProvider = () => [
+        {
+          id: "conn-1",
+          providerKey: "integration:google",
+          accountInfo: "user1@gmail.com",
+          status: "active",
+        },
+        {
+          id: "conn-2",
+          providerKey: "integration:google",
+          accountInfo: "user2@gmail.com",
+          status: "active",
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(1);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("Multiple active connections");
+      expect(parsed.error).toContain("--account");
+      expect(parsed.error).toContain("--connection-id");
+      expect(parsed.connections).toBeDefined();
+      expect(parsed.connections).toHaveLength(2);
+    });
+
+    test("no connections returns error with hint", async () => {
+      mockListActiveConnectionsByProvider = () => [];
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(1);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("No active connections");
+      expect(parsed.error).toContain("status");
+    });
+
+    test("disconnect error returns error message", async () => {
+      mockDisconnectOAuthProviderResult = "error";
+      mockListActiveConnectionsByProvider = () => [
+        {
+          id: "conn-1",
+          providerKey: "integration:google",
+          accountInfo: null,
+          status: "active",
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "disconnect",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(1);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("Failed to disconnect");
+    });
+  });
+});

--- a/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
@@ -384,7 +384,7 @@ describe("assistant oauth disconnect", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("google");
+      expect(parsed.provider).toBe("integration:google");
       expect(parsed.connectionId).toBe("conn-1");
       expect(parsed.account).toBe("user@gmail.com");
     });

--- a/assistant/src/cli/commands/oauth/__tests__/status.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/status.test.ts
@@ -1,0 +1,579 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockGetProvider: (
+  key: string,
+) => Record<string, unknown> | undefined = () => undefined;
+
+let mockListConnections: (
+  providerKey: string,
+) => Array<Record<string, unknown>> = () => [];
+
+let mockIsManagedMode: (key: string) => boolean = () => false;
+
+let mockPlatformClientResult: Record<string, unknown> | null = null;
+let mockPlatformFetchResults: Array<{
+  ok: boolean;
+  status: number;
+  body: unknown;
+}> = [];
+let mockPlatformFetchCallIndex = 0;
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../../config/loader.js", () => ({
+  getConfig: () => ({ services: {} }),
+  API_KEY_PROVIDERS: [],
+}));
+
+mock.module("../../../../oauth/oauth-store.js", () => ({
+  getProvider: (key: string) => mockGetProvider(key),
+  listConnections: (providerKey: string) => mockListConnections(providerKey),
+  getConnection: () => undefined,
+  getConnectionByProvider: () => undefined,
+  getActiveConnection: () => undefined,
+  listActiveConnectionsByProvider: () => [],
+  disconnectOAuthProvider: async () => "not-found" as const,
+  upsertApp: async () => ({}),
+  getApp: () => undefined,
+  getAppByProviderAndClientId: () => undefined,
+  getMostRecentAppByProvider: () => undefined,
+  listApps: () => [],
+  deleteApp: async () => false,
+  listProviders: () => [],
+  registerProvider: () => ({}),
+  seedProviders: () => {},
+  isProviderConnected: () => false,
+  createConnection: () => ({}),
+  updateConnection: () => ({}),
+  deleteConnection: () => false,
+}));
+
+mock.module("../../../../oauth/provider-behaviors.js", () => ({
+  resolveService: (service: string) => {
+    const aliases: Record<string, string> = {
+      gmail: "integration:google",
+      google: "integration:google",
+      slack: "integration:slack",
+    };
+    if (aliases[service]) return aliases[service];
+    if (!service.includes(":")) return `integration:${service}`;
+    return service;
+  },
+  getProviderBehavior: () => undefined,
+}));
+
+mock.module("../../../../oauth/connect-orchestrator.js", () => ({
+  orchestrateOAuthConnect: async () => ({
+    success: true,
+    deferred: false,
+    grantedScopes: [],
+  }),
+}));
+
+mock.module("../../../../platform/client.js", () => ({
+  VellumPlatformClient: {
+    create: async () => mockPlatformClientResult,
+  },
+}));
+
+mock.module("../../../../util/browser.js", () => ({
+  openInBrowser: () => {},
+}));
+
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+mock.module("../../../lib/daemon-credential-client.js", () => ({
+  getSecureKeyViaDaemon: async () => undefined,
+  deleteSecureKeyViaDaemon: async () => "not-found" as const,
+}));
+
+// Mock shared.js helpers to control managed vs BYO mode routing
+mock.module("../shared.js", () => ({
+  resolveService: (service: string) => {
+    const aliases: Record<string, string> = {
+      gmail: "integration:google",
+      google: "integration:google",
+      slack: "integration:slack",
+    };
+    if (aliases[service]) return aliases[service];
+    if (!service.includes(":")) return `integration:${service}`;
+    return service;
+  },
+  isManagedMode: (key: string) => mockIsManagedMode(key),
+  requirePlatformClient: async (_cmd: Command) => {
+    if (
+      !mockPlatformClientResult ||
+      !(mockPlatformClientResult as Record<string, unknown>).platformAssistantId
+    ) {
+      process.exitCode = 1;
+      process.stdout.write(
+        JSON.stringify({
+          ok: false,
+          error:
+            "Platform prerequisites not met (not logged in or missing assistant ID)",
+        }) + "\n",
+      );
+      return null;
+    }
+    return {
+      platformAssistantId: (mockPlatformClientResult as Record<string, unknown>)
+        .platformAssistantId,
+      fetch: async (): Promise<Response> => {
+        const idx = mockPlatformFetchCallIndex++;
+        const result = mockPlatformFetchResults[idx] ?? {
+          ok: false,
+          status: 500,
+          body: "mock not configured",
+        };
+        return {
+          ok: result.ok,
+          status: result.status,
+          json: async () => result.body,
+          text: async () =>
+            typeof result.body === "string"
+              ? result.body
+              : JSON.stringify(result.body),
+        } as unknown as Response;
+      },
+    };
+  },
+  fetchActiveConnections: async (): Promise<Array<
+    Record<string, unknown>
+  > | null> => {
+    const idx = mockPlatformFetchCallIndex++;
+    const result = mockPlatformFetchResults[idx];
+    if (!result) return [];
+    if (!result.ok) return null;
+    return result.body as Array<Record<string, unknown>>;
+  },
+  toBareProvider: (provider: string): string =>
+    provider.startsWith("integration:")
+      ? provider.slice("integration:".length)
+      : provider,
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+const { registerStatusCommand } = await import("../status.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = (() => true) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.option("--json", "JSON output");
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerStatusCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return { exitCode, stdout: stdoutChunks.join("") };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth status", () => {
+  beforeEach(() => {
+    mockGetProvider = () => undefined;
+    mockListConnections = () => [];
+    mockIsManagedMode = () => false;
+    mockPlatformClientResult = null;
+    mockPlatformFetchResults = [];
+    mockPlatformFetchCallIndex = 0;
+    process.exitCode = 0;
+  });
+
+  // -------------------------------------------------------------------------
+  // Unknown provider
+  // -------------------------------------------------------------------------
+
+  test("unknown provider returns error", async () => {
+    mockGetProvider = () => undefined;
+
+    const { exitCode, stdout } = await runCommand([
+      "status",
+      "nonexistent",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Unknown provider");
+    expect(parsed.error).toContain("providers list");
+  });
+
+  // =========================================================================
+  // Managed mode tests
+  // =========================================================================
+
+  describe("managed mode", () => {
+    beforeEach(() => {
+      mockGetProvider = () => ({
+        providerKey: "integration:google",
+        managedServiceConfigKey: "google-oauth",
+      });
+      mockIsManagedMode = () => true;
+      mockPlatformClientResult = { platformAssistantId: "asst-123" };
+    });
+
+    test("shows platform connections with account labels", async () => {
+      mockPlatformFetchResults = [
+        {
+          ok: true,
+          status: 200,
+          body: [
+            {
+              id: "conn-1",
+              account_label: "user@gmail.com",
+              scopes_granted: ["email", "calendar"],
+              status: "ACTIVE",
+            },
+            {
+              id: "conn-2",
+              account_label: "work@company.com",
+              scopes_granted: ["email"],
+              status: "ACTIVE",
+            },
+          ],
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "status",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.mode).toBe("managed");
+      expect(parsed.connections).toHaveLength(2);
+
+      // Verify connection structure
+      const conn1 = parsed.connections[0];
+      expect(conn1.id).toBe("conn-1");
+      expect(conn1.account).toBe("user@gmail.com");
+      expect(conn1.grantedScopes).toEqual(["email", "calendar"]);
+      expect(conn1.status).toBe("ACTIVE");
+
+      const conn2 = parsed.connections[1];
+      expect(conn2.id).toBe("conn-2");
+      expect(conn2.account).toBe("work@company.com");
+    });
+
+    test("no connections: empty connections array in JSON", async () => {
+      mockPlatformFetchResults = [{ ok: true, status: 200, body: [] }];
+
+      const { exitCode, stdout } = await runCommand([
+        "status",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.mode).toBe("managed");
+      expect(parsed.connections).toEqual([]);
+    });
+
+    test("no connections: human output hints at connect command", async () => {
+      mockPlatformFetchResults = [{ ok: true, status: 200, body: [] }];
+
+      // Run without --json to test human output path
+      const { exitCode } = await runCommand(["status", "google"]);
+      // Should succeed (info message printed via logger, which is mocked)
+      expect(exitCode).toBe(0);
+    });
+
+    test("JSON output structure matches contract", async () => {
+      mockPlatformFetchResults = [
+        {
+          ok: true,
+          status: 200,
+          body: [
+            {
+              id: "conn-abc",
+              account_label: null,
+              scopes_granted: [],
+              status: "ACTIVE",
+            },
+          ],
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "status",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+
+      // Required top-level fields
+      expect(parsed).toHaveProperty("ok", true);
+      expect(parsed).toHaveProperty("provider");
+      expect(parsed).toHaveProperty("mode", "managed");
+      expect(parsed).toHaveProperty("connections");
+      expect(Array.isArray(parsed.connections)).toBe(true);
+
+      // Required per-connection fields
+      const conn = parsed.connections[0];
+      expect(conn).toHaveProperty("id");
+      expect(conn).toHaveProperty("account");
+      expect(conn).toHaveProperty("grantedScopes");
+      expect(conn).toHaveProperty("status");
+    });
+  });
+
+  // =========================================================================
+  // BYO mode tests
+  // =========================================================================
+
+  describe("BYO mode", () => {
+    beforeEach(() => {
+      mockGetProvider = () => ({
+        providerKey: "integration:google",
+        managedServiceConfigKey: null,
+      });
+      mockIsManagedMode = () => false;
+    });
+
+    test("shows local connections with expiry and refresh info", async () => {
+      const expiresAt = Date.now() + 3600_000; // 1 hour from now
+      mockListConnections = () => [
+        {
+          id: "conn-local-1",
+          providerKey: "integration:google",
+          accountInfo: "localuser@gmail.com",
+          grantedScopes: '["email","profile"]',
+          expiresAt,
+          hasRefreshToken: 1,
+          status: "active",
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "status",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.mode).toBe("byo");
+      expect(parsed.connections).toHaveLength(1);
+
+      const conn = parsed.connections[0];
+      expect(conn.id).toBe("conn-local-1");
+      expect(conn.account).toBe("localuser@gmail.com");
+      expect(conn.grantedScopes).toEqual(["email", "profile"]);
+      expect(conn.expiresAt).toBeTruthy();
+      expect(conn.hasRefreshToken).toBe(true);
+      expect(conn.status).toBe("active");
+    });
+
+    test("shows connection with no refresh token", async () => {
+      mockListConnections = () => [
+        {
+          id: "conn-local-2",
+          providerKey: "integration:google",
+          accountInfo: null,
+          grantedScopes: "[]",
+          expiresAt: null,
+          hasRefreshToken: 0,
+          status: "active",
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "status",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      const conn = parsed.connections[0];
+      expect(conn.account).toBeNull();
+      expect(conn.expiresAt).toBeNull();
+      expect(conn.hasRefreshToken).toBe(false);
+    });
+
+    test("filters to only active connections", async () => {
+      mockListConnections = () => [
+        {
+          id: "conn-active",
+          providerKey: "integration:google",
+          accountInfo: "user@gmail.com",
+          grantedScopes: "[]",
+          expiresAt: null,
+          hasRefreshToken: 0,
+          status: "active",
+        },
+        {
+          id: "conn-revoked",
+          providerKey: "integration:google",
+          accountInfo: "old@gmail.com",
+          grantedScopes: "[]",
+          expiresAt: null,
+          hasRefreshToken: 0,
+          status: "revoked",
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "status",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.connections).toHaveLength(1);
+      expect(parsed.connections[0].id).toBe("conn-active");
+    });
+
+    test("no connections: empty array in JSON output", async () => {
+      mockListConnections = () => [];
+
+      const { exitCode, stdout } = await runCommand([
+        "status",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.mode).toBe("byo");
+      expect(parsed.connections).toEqual([]);
+    });
+
+    test("no connections: human output hints at connect command", async () => {
+      mockListConnections = () => [];
+
+      // Run without --json — the human output path logs via getCliLogger
+      const { exitCode } = await runCommand(["status", "google"]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("JSON output structure matches contract", async () => {
+      mockListConnections = () => [
+        {
+          id: "conn-structure",
+          providerKey: "integration:google",
+          accountInfo: "check@gmail.com",
+          grantedScopes: '["scope1"]',
+          expiresAt: Date.now() + 60_000,
+          hasRefreshToken: 1,
+          status: "active",
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "status",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+
+      // Required top-level fields
+      expect(parsed).toHaveProperty("ok", true);
+      expect(parsed).toHaveProperty("provider");
+      expect(parsed).toHaveProperty("mode", "byo");
+      expect(parsed).toHaveProperty("connections");
+      expect(Array.isArray(parsed.connections)).toBe(true);
+
+      // Required per-connection fields for BYO
+      const conn = parsed.connections[0];
+      expect(conn).toHaveProperty("id");
+      expect(conn).toHaveProperty("account");
+      expect(conn).toHaveProperty("grantedScopes");
+      expect(conn).toHaveProperty("expiresAt");
+      expect(conn).toHaveProperty("hasRefreshToken");
+      expect(conn).toHaveProperty("status");
+    });
+
+    test("handles malformed grantedScopes JSON gracefully", async () => {
+      mockListConnections = () => [
+        {
+          id: "conn-bad-scopes",
+          providerKey: "integration:google",
+          accountInfo: null,
+          grantedScopes: "not-valid-json",
+          expiresAt: null,
+          hasRefreshToken: 0,
+          status: "active",
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "status",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      // Should default to empty array on parse failure
+      expect(parsed.connections[0].grantedScopes).toEqual([]);
+    });
+  });
+});

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -1,0 +1,370 @@
+import type { Command } from "commander";
+
+import { orchestrateOAuthConnect } from "../../../oauth/connect-orchestrator.js";
+import {
+  getAppByProviderAndClientId,
+  getMostRecentAppByProvider,
+  getProvider,
+} from "../../../oauth/oauth-store.js";
+import { getProviderBehavior } from "../../../oauth/provider-behaviors.js";
+import { openInBrowser } from "../../../util/browser.js";
+import { getSecureKeyViaDaemon } from "../../lib/daemon-credential-client.js";
+import { getCliLogger } from "../../logger.js";
+import { shouldOutputJson, writeOutput } from "../../output.js";
+import {
+  fetchActiveConnections,
+  isManagedMode,
+  requirePlatformClient,
+  resolveService,
+  toBareProvider,
+} from "./shared.js";
+
+const log = getCliLogger("cli");
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+export function registerConnectCommand(oauth: Command): void {
+  oauth
+    .command("connect <provider>")
+    .description(
+      "Initiate an OAuth authorization flow for a provider (auto-detects managed vs BYO mode)",
+    )
+    .option("--scopes <scopes...>", "Scopes to request for the authorization")
+    .option(
+      "--open-browser",
+      "Open the auth URL in the browser and wait for completion",
+    )
+    .option("--client-id <id>", "BYO app client ID disambiguation")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  provider   Provider key, alias, or ID from 'assistant oauth providers list'.
+             Accepts canonical keys (e.g. integration:google), aliases (e.g.
+             gmail), or bare provider names (e.g. google).
+
+Options:
+  --scopes <scopes...>   Scopes to request for the authorization. In managed
+                         mode, each scope must be in the provider's allowed set
+                         (use full scope URLs where required). In BYO mode,
+                         scopes are appended to the provider's defaults.
+  --open-browser         Open the authorization URL in your browser and wait
+                         for completion. In managed mode, polls for a new
+                         platform connection. In BYO mode, starts a local
+                         callback server and blocks until the OAuth redirect.
+  --client-id <id>       BYO-only: select a specific OAuth app when multiple
+                         apps exist for the same provider. Ignored for
+                         platform-managed providers.
+
+Mode detection:
+  The command checks the services config to determine whether the provider
+  runs in platform-managed or BYO (bring-your-own credentials) mode.
+
+  Managed mode: Calls the platform /start/ endpoint, returns a connect URL.
+    With --open-browser, opens the URL and polls for a new connection.
+  BYO mode: Resolves local client credentials from the OAuth app store and
+    runs the OAuth2 authorization code flow via the local orchestrator.
+
+Examples:
+  $ assistant oauth connect google
+  $ assistant oauth connect gmail --open-browser
+  $ assistant oauth connect integration:google --scopes https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/calendar.events
+  $ assistant oauth connect google --client-id abc123 --open-browser`,
+    )
+    .action(
+      async (
+        provider: string,
+        opts: {
+          scopes?: string[];
+          openBrowser?: boolean;
+          clientId?: string;
+        },
+        cmd: Command,
+      ) => {
+        const jsonMode = shouldOutputJson(cmd);
+
+        // Helper: write an error and set exit code
+        const writeError = (error: string): void => {
+          writeOutput(cmd, { ok: false, error });
+          process.exitCode = 1;
+        };
+
+        try {
+          // ---------------------------------------------------------------
+          // 1. Resolve provider key
+          // ---------------------------------------------------------------
+          const providerKey = resolveService(provider);
+
+          // ---------------------------------------------------------------
+          // 2. Validate provider exists
+          // ---------------------------------------------------------------
+          const providerRow = getProvider(providerKey);
+          if (!providerRow) {
+            writeError(
+              `Unknown provider "${providerKey}". ` +
+                `Run 'assistant oauth providers list' to see available providers.`,
+            );
+            return;
+          }
+
+          // ---------------------------------------------------------------
+          // 3. Detect mode
+          // ---------------------------------------------------------------
+          const managed = isManagedMode(providerKey);
+
+          if (managed) {
+            // =============================================================
+            // MANAGED PATH
+            // =============================================================
+
+            // Warn about --client-id being ignored in managed mode
+            if (opts.clientId) {
+              log.info(
+                `Warning: --client-id is ignored for platform-managed providers. The platform manages OAuth apps for "${providerKey}".`,
+              );
+            }
+
+            const client = await requirePlatformClient(cmd);
+            if (!client) return;
+
+            // Call the platform's OAuth start endpoint
+            const startPath = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/${encodeURIComponent(toBareProvider(providerKey))}/start/`;
+
+            const body: Record<string, unknown> = {};
+            if (opts.scopes && opts.scopes.length > 0) {
+              body.requested_scopes = opts.scopes;
+            }
+
+            const response = await client.fetch(startPath, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(body),
+            });
+
+            if (!response.ok) {
+              const errorText = await response.text().catch(() => "");
+              writeError(
+                `Platform returned HTTP ${response.status}${errorText ? `: ${errorText}` : ""}`,
+              );
+              return;
+            }
+
+            const result = (await response.json()) as {
+              connect_url?: string;
+            };
+
+            if (!result.connect_url) {
+              writeError(
+                "Platform did not return a connect URL — the OAuth flow could not be started",
+              );
+              return;
+            }
+
+            if (opts.openBrowser) {
+              // Snapshot existing connection IDs before opening browser
+              const snapshotEntries = await fetchActiveConnections(
+                client,
+                providerKey,
+                cmd,
+              );
+              const snapshotIds = new Set(
+                (snapshotEntries ?? []).map((e) => e.id),
+              );
+
+              openInBrowser(result.connect_url);
+
+              if (!jsonMode) {
+                log.info(
+                  `Opening browser to connect ${providerKey}. Waiting for authorization...`,
+                );
+              }
+
+              // Poll for a new connection every 2s for up to 5 minutes
+              const pollIntervalMs = 2000;
+              const timeoutMs = 5 * 60 * 1000;
+              const deadline = Date.now() + timeoutMs;
+              let newConnection: {
+                id: string;
+                account_label?: string;
+                scopes_granted?: string[];
+              } | null = null;
+
+              while (Date.now() < deadline) {
+                await new Promise((r) => setTimeout(r, pollIntervalMs));
+
+                const currentEntries = await fetchActiveConnections(
+                  client,
+                  providerKey,
+                  cmd,
+                );
+                if (!currentEntries) continue;
+
+                const found = currentEntries.find(
+                  (e) => !snapshotIds.has(e.id),
+                );
+                if (found) {
+                  newConnection = found;
+                  break;
+                }
+              }
+
+              if (newConnection) {
+                // Success — new connection found
+                if (jsonMode) {
+                  writeOutput(cmd, {
+                    ok: true,
+                    provider: providerKey,
+                    connectionId: newConnection.id,
+                    accountLabel: newConnection.account_label ?? null,
+                    scopesGranted: newConnection.scopes_granted ?? [],
+                  });
+                } else {
+                  const label = newConnection.account_label
+                    ? ` as ${newConnection.account_label}`
+                    : "";
+                  process.stdout.write(`Connected to ${providerKey}${label}\n`);
+                }
+              } else {
+                // Timeout — authorization may still be in progress
+                if (jsonMode) {
+                  writeOutput(cmd, {
+                    ok: true,
+                    deferred: true,
+                    provider: providerKey,
+                    connectUrl: result.connect_url,
+                    message:
+                      "Authorization may still be in progress. Check with 'assistant oauth status <provider>'.",
+                  });
+                } else {
+                  process.stdout.write(
+                    `Timed out waiting for authorization. It may still be in progress.\n` +
+                      `Check with: assistant oauth status ${providerKey}\n`,
+                  );
+                }
+              }
+            } else {
+              // No --open-browser: output the connect URL
+              if (jsonMode) {
+                writeOutput(cmd, {
+                  ok: true,
+                  deferred: true,
+                  connectUrl: result.connect_url,
+                  provider: providerKey,
+                });
+              } else {
+                process.stdout.write(result.connect_url + "\n");
+              }
+            }
+          } else {
+            // =============================================================
+            // BYO PATH
+            // =============================================================
+
+            // a. Resolve service alias (already done above via resolveService)
+            const resolvedServiceKey = providerKey;
+
+            // b. Resolve client credentials from the DB
+            const dbApp = opts.clientId
+              ? getAppByProviderAndClientId(resolvedServiceKey, opts.clientId)
+              : getMostRecentAppByProvider(resolvedServiceKey);
+
+            let clientId = opts.clientId;
+            let clientSecret: string | undefined;
+
+            if (dbApp) {
+              if (!clientId) clientId = dbApp.clientId;
+              const storedSecret = await getSecureKeyViaDaemon(
+                dbApp.clientSecretCredentialPath,
+              );
+              if (storedSecret) clientSecret = storedSecret;
+            } else if (opts.clientId) {
+              // --client-id was explicitly provided but no matching app exists
+              writeError(
+                `No registered app found for "${resolvedServiceKey}" with client ID "${opts.clientId}". ` +
+                  `Register one with 'assistant oauth apps upsert'.`,
+              );
+              return;
+            }
+
+            // c. Validate client_id exists
+            if (!clientId) {
+              writeError(
+                `No client_id found for "${resolvedServiceKey}". ` +
+                  `Register one with 'assistant oauth apps upsert'.`,
+              );
+              return;
+            }
+
+            // d. Check if client_secret is required but missing
+            if (clientSecret === undefined) {
+              const behavior = getProviderBehavior(resolvedServiceKey);
+
+              const requiresSecret =
+                behavior?.setup?.requiresClientSecret ??
+                !!(
+                  providerRow?.tokenEndpointAuthMethod ||
+                  providerRow?.extraParams
+                );
+
+              if (requiresSecret) {
+                writeError(
+                  `client_secret is required for ${resolvedServiceKey} but not found. ` +
+                    `Store it with 'assistant oauth apps upsert --client-secret'.`,
+                );
+                return;
+              }
+            }
+
+            // e. Call the orchestrator
+            const result = await orchestrateOAuthConnect({
+              service: provider,
+              clientId,
+              clientSecret,
+              isInteractive: !!opts.openBrowser,
+              openUrl: opts.openBrowser ? openInBrowser : undefined,
+              ...(opts.scopes ? { requestedScopes: opts.scopes } : {}),
+            });
+
+            // f. Handle results
+            if (!result.success) {
+              writeError(result.error ?? "OAuth connect failed");
+              return;
+            }
+
+            if (result.deferred) {
+              if (jsonMode) {
+                writeOutput(cmd, {
+                  ok: true,
+                  deferred: true,
+                  authUrl: result.authUrl,
+                  service: result.service,
+                });
+              } else {
+                process.stdout.write(
+                  `\nAuthorize with ${resolvedServiceKey}:\n\n${result.authUrl}\n\nThe connection will complete automatically once you authorize.\n`,
+                );
+              }
+              return;
+            }
+
+            // Interactive mode completed
+            if (jsonMode) {
+              writeOutput(cmd, {
+                ok: true,
+                grantedScopes: result.grantedScopes,
+                accountInfo: result.accountInfo,
+              });
+            } else {
+              const msg = `Connected to ${resolvedServiceKey}${result.accountInfo ? ` as ${result.accountInfo}` : ""}`;
+              process.stdout.write(msg + "\n");
+            }
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          writeError(message);
+        }
+      },
+    );
+}

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -169,9 +169,11 @@ Examples:
                 providerKey,
                 cmd,
               );
-              const snapshotIds = new Set(
-                (snapshotEntries ?? []).map((e) => e.id),
-              );
+              if (!snapshotEntries) {
+                // fetchActiveConnections already wrote the error output
+                return;
+              }
+              const snapshotIds = new Set(snapshotEntries.map((e) => e.id));
 
               openInBrowser(result.connect_url);
 
@@ -198,6 +200,7 @@ Examples:
                   client,
                   providerKey,
                   cmd,
+                  { silent: true },
                 );
                 if (!currentEntries) continue;
 

--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -31,6 +31,7 @@ import {
 } from "../../lib/daemon-credential-client.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
+import { printDeprecationWarning } from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // CES shell lockdown guard
@@ -477,7 +478,7 @@ Examples:
   // ---------------------------------------------------------------------------
 
   connections
-    .command("disconnect <provider-key>")
+    .command("disconnect <provider-key>", { hidden: true })
     .description(
       "Disconnect an OAuth integration and remove all associated credentials",
     )
@@ -510,6 +511,11 @@ Examples:
         cmd: Command,
       ) => {
         try {
+          printDeprecationWarning(
+            "assistant oauth connections disconnect",
+            "assistant oauth disconnect",
+            cmd,
+          );
           assertMetadataWritable();
 
           let cleanedUp = false;
@@ -574,7 +580,7 @@ Examples:
   // ---------------------------------------------------------------------------
 
   connections
-    .command("connect <provider-key>")
+    .command("connect <provider-key>", { hidden: true })
     .description("Initiate an OAuth2 authorization flow for a provider")
     .option(
       "--client-id <id>",
@@ -621,6 +627,11 @@ Examples:
         cmd: Command,
       ) => {
         try {
+          printDeprecationWarning(
+            "assistant oauth connections connect",
+            "assistant oauth connect",
+            cmd,
+          );
           // a. Resolve service alias
           const resolvedServiceKey = resolveService(providerKey);
 

--- a/assistant/src/cli/commands/oauth/disconnect.ts
+++ b/assistant/src/cli/commands/oauth/disconnect.ts
@@ -1,0 +1,333 @@
+import type { Command } from "commander";
+
+import {
+  disconnectOAuthProvider,
+  getActiveConnection,
+  getConnection,
+  getProvider,
+  listActiveConnectionsByProvider,
+} from "../../../oauth/oauth-store.js";
+import { deleteCredentialMetadata } from "../../../tools/credentials/metadata-store.js";
+import { deleteSecureKeyViaDaemon } from "../../lib/daemon-credential-client.js";
+import { getCliLogger } from "../../logger.js";
+import { shouldOutputJson, writeOutput } from "../../output.js";
+import {
+  fetchActiveConnections,
+  isManagedMode,
+  requirePlatformClient,
+  resolveService,
+  toBareProvider,
+} from "./shared.js";
+
+const log = getCliLogger("cli");
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+export function registerDisconnectCommand(oauth: Command): void {
+  oauth
+    .command("disconnect <provider>")
+    .description(
+      "Disconnect an OAuth provider and remove associated credentials (auto-detects managed vs BYO mode)",
+    )
+    .option(
+      "--account <identifier>",
+      "Account identifier to disconnect (e.g. email address)",
+    )
+    .option("--connection-id <id>", "Exact connection ID to disconnect")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  provider   Provider name or key (e.g. google, integration:google, gmail).
+             Run 'assistant oauth providers list' to see available providers.
+
+Options:
+  --account          Recommended way to specify which connection to disconnect.
+                     Works for both managed and BYO modes. Use the account
+                     identifier shown by 'assistant oauth status <provider>'
+                     (e.g. an email address for Google).
+  --connection-id    Exact match on the connection ID shown by
+                     'assistant oauth status <provider>'. Useful when account
+                     labels are ambiguous or absent.
+
+  At most one of --account or --connection-id may be specified.
+
+Disambiguation:
+  When a provider has multiple active connections and neither --account nor
+  --connection-id is given, the command errors with a list of connections
+  (id + account label) and a hint to use --account or --connection-id.
+  Run 'assistant oauth status <provider>' to discover available values.
+
+Examples:
+  $ assistant oauth disconnect google
+  $ assistant oauth disconnect google --account user@gmail.com
+  $ assistant oauth disconnect google --connection-id conn_abc123`,
+    )
+    .action(
+      async (
+        provider: string,
+        opts: { account?: string; connectionId?: string },
+        cmd: Command,
+      ) => {
+        const jsonMode = shouldOutputJson(cmd);
+
+        // Helper: write an error and set exit code
+        const writeError = (
+          error: string,
+          extra?: Record<string, unknown>,
+        ): void => {
+          writeOutput(cmd, { ok: false, error, ...extra });
+          process.exitCode = 1;
+        };
+
+        try {
+          // -------------------------------------------------------------------
+          // 1. Resolve + validate provider
+          // -------------------------------------------------------------------
+          const providerKey = resolveService(provider);
+
+          const providerRow = getProvider(providerKey);
+          if (!providerRow) {
+            writeError(
+              `Unknown provider "${provider}".\n\n` +
+                `Run 'assistant oauth providers list' to see available providers.\n` +
+                `If this is a custom provider, register it first with 'assistant oauth providers register --help'.`,
+            );
+            return;
+          }
+
+          // -------------------------------------------------------------------
+          // 2. Validate mutual exclusivity
+          // -------------------------------------------------------------------
+          if (opts.account && opts.connectionId) {
+            writeError(
+              `Cannot specify both --account and --connection-id. Use one or the other.\n\n` +
+                `Run 'assistant oauth status ${provider}' to see connected accounts and IDs.`,
+            );
+            return;
+          }
+
+          // -------------------------------------------------------------------
+          // 3. Detect mode
+          // -------------------------------------------------------------------
+          const managed = isManagedMode(providerKey);
+
+          if (managed) {
+            // -----------------------------------------------------------------
+            // Managed path
+            // -----------------------------------------------------------------
+            const client = await requirePlatformClient(cmd);
+            if (!client) return;
+
+            const entries = await fetchActiveConnections(
+              client,
+              providerKey,
+              cmd,
+            );
+            if (!entries) return;
+
+            let connectionId: string | undefined;
+            let accountLabel: string | undefined;
+
+            if (opts.account) {
+              // Filter connections by account_label matching the account value
+              const matching = entries.filter(
+                (c) => c.account_label === opts.account,
+              );
+              if (matching.length === 0) {
+                writeError(
+                  `No active connection found for "${toBareProvider(providerKey)}" with account "${opts.account}".\n\n` +
+                    `Run 'assistant oauth status ${provider}' to see connected accounts.`,
+                );
+                return;
+              }
+              connectionId = matching[0].id;
+              accountLabel = matching[0].account_label;
+            } else if (opts.connectionId) {
+              // Verify the supplied ID belongs to this provider
+              const match = entries.find((c) => c.id === opts.connectionId);
+              if (!match) {
+                writeError(
+                  `Connection "${opts.connectionId}" is not an active ${toBareProvider(providerKey)} connection.\n\n` +
+                    `Run 'assistant oauth status ${provider}' to see active connections.`,
+                );
+                return;
+              }
+              connectionId = match.id;
+              accountLabel = match.account_label;
+            } else {
+              // Neither specified — auto-resolve
+              if (entries.length === 0) {
+                writeError(
+                  `No active connections found for "${toBareProvider(providerKey)}".\n\n` +
+                    `Run 'assistant oauth status ${provider}' to check connection status.`,
+                );
+                return;
+              }
+
+              if (entries.length > 1) {
+                const connectionList = entries.map((c) => ({
+                  id: c.id,
+                  account: c.account_label ?? null,
+                }));
+                writeError(
+                  `Multiple active connections for "${toBareProvider(providerKey)}". ` +
+                    `Specify which one to disconnect with --account or --connection-id.\n\n` +
+                    `Run 'assistant oauth status ${provider}' to see connected accounts and IDs.`,
+                  { connections: connectionList },
+                );
+                return;
+              }
+
+              connectionId = entries[0].id;
+              accountLabel = entries[0].account_label;
+            }
+
+            // Call platform /disconnect/ endpoint
+            const disconnectPath = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/connections/${encodeURIComponent(connectionId)}/disconnect/`;
+            const disconnectResponse = await client.fetch(disconnectPath, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+            });
+
+            if (!disconnectResponse.ok) {
+              const errorText = await disconnectResponse.text().catch(() => "");
+              writeError(
+                `Platform returned HTTP ${disconnectResponse.status}${errorText ? `: ${errorText}` : ""}`,
+              );
+              return;
+            }
+
+            const result: Record<string, unknown> = {
+              ok: true,
+              provider: toBareProvider(providerKey),
+              connectionId,
+            };
+            if (accountLabel) result.account = accountLabel;
+            writeOutput(cmd, result);
+
+            if (!jsonMode) {
+              log.info(
+                `Disconnected ${toBareProvider(providerKey)} connection ${connectionId}`,
+              );
+            }
+          } else {
+            // -----------------------------------------------------------------
+            // BYO path
+            // -----------------------------------------------------------------
+            let connectionId: string | undefined;
+            let accountLabel: string | undefined;
+
+            if (opts.account) {
+              const conn = getActiveConnection(providerKey, {
+                account: opts.account,
+              });
+              if (!conn) {
+                writeError(
+                  `No active connection found for "${providerKey}" with account "${opts.account}".\n\n` +
+                    `Run 'assistant oauth status ${provider}' to see connected accounts.`,
+                );
+                return;
+              }
+              connectionId = conn.id;
+              accountLabel = conn.accountInfo ?? undefined;
+            } else if (opts.connectionId) {
+              const conn = getConnection(opts.connectionId);
+              if (!conn || conn.providerKey !== providerKey) {
+                writeError(
+                  `Connection "${opts.connectionId}" is not an active ${providerKey} connection.\n\n` +
+                    `Run 'assistant oauth status ${provider}' to see active connections.`,
+                );
+                return;
+              }
+              connectionId = conn.id;
+              accountLabel = conn.accountInfo ?? undefined;
+            } else {
+              // Neither specified — auto-resolve
+              const active = listActiveConnectionsByProvider(providerKey);
+
+              if (active.length === 0) {
+                writeError(
+                  `No active connections found for "${providerKey}".\n\n` +
+                    `Run 'assistant oauth status ${provider}' to check connection status.`,
+                );
+                return;
+              }
+
+              if (active.length > 1) {
+                const connectionList = active.map((c) => ({
+                  id: c.id,
+                  account: c.accountInfo ?? null,
+                }));
+                writeError(
+                  `Multiple active connections for "${providerKey}". ` +
+                    `Specify which one to disconnect with --account or --connection-id.\n\n` +
+                    `Run 'assistant oauth status ${provider}' to see connected accounts and IDs.`,
+                  { connections: connectionList },
+                );
+                return;
+              }
+
+              connectionId = active[0].id;
+              accountLabel = active[0].accountInfo ?? undefined;
+            }
+
+            // Disconnect the OAuth connection (tokens + connection row)
+            const oauthResult = await disconnectOAuthProvider(
+              providerKey,
+              undefined,
+              connectionId,
+            );
+            if (oauthResult === "error") {
+              writeError(
+                `Failed to disconnect OAuth provider "${providerKey}" — please try again.`,
+              );
+              return;
+            }
+
+            // Clean up legacy credential keys
+            const legacyFields = [
+              "access_token",
+              "refresh_token",
+              "client_id",
+              "client_secret",
+            ];
+            for (const field of legacyFields) {
+              try {
+                await deleteSecureKeyViaDaemon(
+                  "credential",
+                  `${providerKey}:${field}`,
+                );
+              } catch {
+                // Best-effort cleanup — ignore failures
+              }
+              try {
+                deleteCredentialMetadata(providerKey, field);
+              } catch {
+                // Best-effort cleanup — ignore failures
+              }
+            }
+
+            const result: Record<string, unknown> = {
+              ok: true,
+              provider: providerKey,
+              connectionId,
+            };
+            if (accountLabel) result.account = accountLabel;
+            writeOutput(cmd, result);
+
+            if (!jsonMode) {
+              log.info(
+                `Disconnected ${providerKey} connection ${connectionId}`,
+              );
+            }
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          writeError(message);
+        }
+      },
+    );
+}

--- a/assistant/src/cli/commands/oauth/disconnect.ts
+++ b/assistant/src/cli/commands/oauth/disconnect.ts
@@ -202,7 +202,7 @@ Examples:
 
             const result: Record<string, unknown> = {
               ok: true,
-              provider: toBareProvider(providerKey),
+              provider: providerKey,
               connectionId,
             };
             if (accountLabel) result.account = accountLabel;
@@ -210,7 +210,7 @@ Examples:
 
             if (!jsonMode) {
               log.info(
-                `Disconnected ${toBareProvider(providerKey)} connection ${connectionId}`,
+                `Disconnected ${providerKey} connection ${connectionId}`,
               );
             }
           } else {

--- a/assistant/src/cli/commands/oauth/index.ts
+++ b/assistant/src/cli/commands/oauth/index.ts
@@ -20,28 +20,28 @@ export function registerOAuthCommand(program: Command): void {
     `
 The oauth command group manages the full OAuth lifecycle:
 
+  connect     Initiate an OAuth flow for a provider (managed or BYO)
+  disconnect  Disconnect an OAuth provider
+  status      Show OAuth connection status for a provider
+  request     Make authenticated HTTP requests (curl-like interface)
   providers   Protocol-level configurations (auth URLs, scopes, endpoints)
   apps        Client credentials (client ID / secret pairs)
-  connections Active token grants per provider (list, get, token, disconnect)
-  platform    Platform-managed OAuth provider status and connections
-  request     Make authenticated HTTP requests (curl-like interface)
-  connect     Initiate an OAuth flow (auto-detects managed vs BYO mode)
-  disconnect  Disconnect a provider and remove credentials (auto-detects mode)
-  status      Show connection status for a provider (auto-detects mode)
+  connections Active token grants per provider (deprecated)
+  platform    Platform-managed OAuth provider status and connections (deprecated)
 
 Providers are seeded on startup for built-in integrations. Apps and connections
 are created during the OAuth authorization flow or can be managed manually via
 their respective subcommands.
 
 Examples:
+  $ assistant oauth connect google --open-browser
+  $ assistant oauth status google
+  $ assistant oauth disconnect google
   $ assistant oauth request --provider integration:google /gmail/v1/users/me/messages
   $ assistant oauth request --provider integration:twitter -X POST -d '{"text":"Hello"}' https://api.x.com/2/tweets
   $ assistant oauth connections token integration:twitter
-  $ assistant oauth connections list
-  $ assistant oauth connections get --provider integration:google
   $ assistant oauth providers list
-  $ assistant oauth providers get integration:google
-  $ assistant oauth providers register --provider-key custom:myapi --auth-url https://example.com/auth --token-url https://example.com/token`,
+  $ assistant oauth providers get integration:google`,
   );
 
   // ---------------------------------------------------------------------------

--- a/assistant/src/cli/commands/oauth/index.ts
+++ b/assistant/src/cli/commands/oauth/index.ts
@@ -3,6 +3,7 @@ import type { Command } from "commander";
 import { registerAppCommands } from "./apps.js";
 import { registerConnectCommand } from "./connect.js";
 import { registerConnectionCommands } from "./connections.js";
+import { registerDisconnectCommand } from "./disconnect.js";
 import { registerPlatformCommands } from "./platform.js";
 import { registerProviderCommands } from "./providers.js";
 import { registerRequestCommand } from "./request.js";
@@ -25,6 +26,7 @@ The oauth command group manages the full OAuth lifecycle:
   platform    Platform-managed OAuth provider status and connections
   request     Make authenticated HTTP requests (curl-like interface)
   connect     Initiate an OAuth flow (auto-detects managed vs BYO mode)
+  disconnect  Disconnect a provider and remove credentials (auto-detects mode)
   status      Show connection status for a provider (auto-detects mode)
 
 Providers are seeded on startup for built-in integrations. Apps and connections
@@ -77,6 +79,12 @@ Examples:
   // ---------------------------------------------------------------------------
 
   registerConnectCommand(oauth);
+
+  // ---------------------------------------------------------------------------
+  // disconnect — unified disconnect with auto-detected managed/BYO routing
+  // ---------------------------------------------------------------------------
+
+  registerDisconnectCommand(oauth);
 
   // ---------------------------------------------------------------------------
   // status — unified connection status (auto-detects managed vs BYO)

--- a/assistant/src/cli/commands/oauth/index.ts
+++ b/assistant/src/cli/commands/oauth/index.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 
 import { registerAppCommands } from "./apps.js";
+import { registerConnectCommand } from "./connect.js";
 import { registerConnectionCommands } from "./connections.js";
 import { registerPlatformCommands } from "./platform.js";
 import { registerProviderCommands } from "./providers.js";
@@ -23,6 +24,7 @@ The oauth command group manages the full OAuth lifecycle:
   connections Active token grants per provider (list, get, token, disconnect)
   platform    Platform-managed OAuth provider status and connections
   request     Make authenticated HTTP requests (curl-like interface)
+  connect     Initiate an OAuth flow (auto-detects managed vs BYO mode)
   status      Show connection status for a provider (auto-detects mode)
 
 Providers are seeded on startup for built-in integrations. Apps and connections
@@ -69,6 +71,12 @@ Examples:
   // ---------------------------------------------------------------------------
 
   registerRequestCommand(oauth);
+
+  // ---------------------------------------------------------------------------
+  // connect — unified connect command (auto-detects managed vs BYO)
+  // ---------------------------------------------------------------------------
+
+  registerConnectCommand(oauth);
 
   // ---------------------------------------------------------------------------
   // status — unified connection status (auto-detects managed vs BYO)

--- a/assistant/src/cli/commands/oauth/index.ts
+++ b/assistant/src/cli/commands/oauth/index.ts
@@ -5,6 +5,7 @@ import { registerConnectionCommands } from "./connections.js";
 import { registerPlatformCommands } from "./platform.js";
 import { registerProviderCommands } from "./providers.js";
 import { registerRequestCommand } from "./request.js";
+import { registerStatusCommand } from "./status.js";
 
 export function registerOAuthCommand(program: Command): void {
   const oauth = program
@@ -22,6 +23,7 @@ The oauth command group manages the full OAuth lifecycle:
   connections Active token grants per provider (list, get, token, disconnect)
   platform    Platform-managed OAuth provider status and connections
   request     Make authenticated HTTP requests (curl-like interface)
+  status      Show connection status for a provider (auto-detects mode)
 
 Providers are seeded on startup for built-in integrations. Apps and connections
 are created during the OAuth authorization flow or can be managed manually via
@@ -67,4 +69,10 @@ Examples:
   // ---------------------------------------------------------------------------
 
   registerRequestCommand(oauth);
+
+  // ---------------------------------------------------------------------------
+  // status — unified connection status (auto-detects managed vs BYO)
+  // ---------------------------------------------------------------------------
+
+  registerStatusCommand(oauth);
 }

--- a/assistant/src/cli/commands/oauth/platform.ts
+++ b/assistant/src/cli/commands/oauth/platform.ts
@@ -6,26 +6,19 @@ import {
   ServicesSchema,
 } from "../../../config/schemas/services.js";
 import { getProvider } from "../../../oauth/oauth-store.js";
-import { VellumPlatformClient } from "../../../platform/client.js";
 import { openInBrowser } from "../../../util/browser.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
+import {
+  fetchActiveConnections,
+  requirePlatformClient,
+  toBareProvider,
+} from "./shared.js";
 
 const log = getCliLogger("cli");
 
 // ---------------------------------------------------------------------------
-// Shared types
-// ---------------------------------------------------------------------------
-
-interface PlatformConnectionEntry {
-  id: string;
-  account_label?: string;
-  scopes_granted?: string[];
-  status?: string;
-}
-
-// ---------------------------------------------------------------------------
-// Shared helpers
+// Platform-specific helpers
 // ---------------------------------------------------------------------------
 
 /**
@@ -36,17 +29,6 @@ function toProviderKey(provider: string): string {
   return provider.startsWith("integration:")
     ? provider
     : `integration:${provider}`;
-}
-
-/**
- * Extract the bare provider slug (e.g. "google") from either a raw CLI
- * argument or a canonical provider key (e.g. "integration:google").
- * Platform API paths expect the bare slug, not the internal key.
- */
-function toBareProvider(provider: string): string {
-  return provider.startsWith("integration:")
-    ? provider.slice("integration:".length)
-    : provider;
 }
 
 /**
@@ -99,60 +81,6 @@ function requireManagedProvider(provider: string, cmd: Command): string | null {
   }
 
   return managedKey;
-}
-
-/**
- * Create an authenticated platform client, or write an error and return null.
- */
-async function requirePlatformClient(
-  cmd: Command,
-): Promise<VellumPlatformClient | null> {
-  const client = await VellumPlatformClient.create();
-  if (!client || !client.platformAssistantId) {
-    writeOutput(cmd, {
-      ok: false,
-      error:
-        "Platform prerequisites not met (not logged in or missing assistant ID)",
-    });
-    process.exitCode = 1;
-    return null;
-  }
-  return client;
-}
-
-/**
- * Fetch active platform connections for a provider. Returns the parsed entries
- * or writes an error and returns null.
- */
-async function fetchActiveConnections(
-  client: VellumPlatformClient,
-  provider: string,
-  cmd: Command,
-): Promise<PlatformConnectionEntry[] | null> {
-  const params = new URLSearchParams();
-  params.set("provider", toBareProvider(provider));
-  params.set("status", "ACTIVE");
-
-  const path = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/connections/?${params.toString()}`;
-  const response = await client.fetch(path);
-
-  if (!response.ok) {
-    writeOutput(cmd, {
-      ok: false,
-      error: `Platform returned HTTP ${response.status}`,
-    });
-    process.exitCode = 1;
-    return null;
-  }
-
-  const body = (await response.json()) as unknown;
-
-  // The platform returns either a flat array or a {results: [...]} wrapper.
-  return (
-    Array.isArray(body)
-      ? body
-      : ((body as Record<string, unknown>).results ?? [])
-  ) as PlatformConnectionEntry[];
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/cli/commands/oauth/platform.ts
+++ b/assistant/src/cli/commands/oauth/platform.ts
@@ -11,6 +11,7 @@ import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 import {
   fetchActiveConnections,
+  printDeprecationWarning,
   requirePlatformClient,
   toBareProvider,
 } from "./shared.js";
@@ -105,7 +106,7 @@ export function registerPlatformCommands(oauth: Command): void {
 
 function registerStatusCommand(platform: Command): void {
   platform
-    .command("status <provider>")
+    .command("status <provider>", { hidden: true })
     .description(
       "Check whether a provider supports managed OAuth and list the user's active connections",
     )
@@ -130,6 +131,11 @@ Examples:
         cmd: Command,
       ) => {
         try {
+          printDeprecationWarning(
+            "assistant oauth platform status",
+            "assistant oauth status",
+            cmd,
+          );
           const providerKey = toProviderKey(provider);
           const providerRow = getProvider(providerKey);
 
@@ -224,7 +230,7 @@ Examples:
 
 function registerConnectCommand(platform: Command): void {
   platform
-    .command("connect <provider>")
+    .command("connect <provider>", { hidden: true })
     .description(
       "Initiate a platform-managed OAuth flow for a provider and open the browser",
     )
@@ -261,6 +267,11 @@ Examples:
     .action(
       async (provider: string, opts: { scopes?: string[] }, cmd: Command) => {
         try {
+          printDeprecationWarning(
+            "assistant oauth platform connect",
+            "assistant oauth connect",
+            cmd,
+          );
           if (!requireManagedProvider(provider, cmd)) return;
 
           const client = await requirePlatformClient(cmd);
@@ -333,7 +344,7 @@ Examples:
 
 function registerDisconnectCommand(platform: Command): void {
   platform
-    .command("disconnect <provider>")
+    .command("disconnect <provider>", { hidden: true })
     .description(
       "Disconnect a platform-managed OAuth connection for a provider",
     )
@@ -367,6 +378,11 @@ Examples:
         cmd: Command,
       ) => {
         try {
+          printDeprecationWarning(
+            "assistant oauth platform disconnect",
+            "assistant oauth disconnect",
+            cmd,
+          );
           if (!requireManagedCapableProvider(provider, cmd)) return;
 
           const client = await requirePlatformClient(cmd);

--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -2,11 +2,6 @@ import { readFileSync, writeFileSync } from "node:fs";
 
 import type { Command } from "commander";
 
-import { getConfig } from "../../../config/loader.js";
-import {
-  type Services,
-  ServicesSchema,
-} from "../../../config/schemas/services.js";
 import type { OAuthConnectionRequest } from "../../../oauth/connection.js";
 import {
   resolveOAuthConnection,
@@ -17,9 +12,9 @@ import {
   getAppByProviderAndClientId,
   getProvider,
 } from "../../../oauth/oauth-store.js";
-import { resolveService } from "../../../oauth/provider-behaviors.js";
 import { VellumPlatformClient } from "../../../platform/client.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
+import { isManagedMode, resolveService, toBareProvider } from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -81,31 +76,6 @@ function readBodyData(data: string): unknown {
   }
 
   return tryJsonParse(data);
-}
-
-/**
- * Determine whether a provider is running in platform-managed mode.
- * Returns false if config is unavailable (e.g. in test environments).
- */
-function isManagedMode(providerKey: string): boolean {
-  const provider = getProvider(providerKey);
-  const managedKey = provider?.managedServiceConfigKey;
-  if (!managedKey || !(managedKey in ServicesSchema.shape)) return false;
-  try {
-    const services: Services = getConfig().services;
-    return services[managedKey as keyof Services].mode === "managed";
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Normalize a bare provider name into the canonical provider key.
- */
-function toBareProvider(provider: string): string {
-  return provider.startsWith("integration:")
-    ? provider.slice("integration:".length)
-    : provider;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -247,8 +247,8 @@ Examples:
                   if (connections.length === 0) {
                     writeError(
                       `Error: No active platform connection found for "${providerKey}" with account "${opts.account}".\n\n` +
-                        `Run 'assistant oauth platform status ${providerKey}' to see connected accounts for this provider.\n` +
-                        `To connect a new account, run 'assistant oauth platform connect --help'.`,
+                        `Run 'assistant oauth status ${providerKey}' to see connected accounts for this provider.\n` +
+                        `To connect a new account, run 'assistant oauth connect --help'.`,
                     );
                     return;
                   }
@@ -266,8 +266,8 @@ Examples:
               if (!conn) {
                 writeError(
                   `Error: No active OAuth connection found for "${providerKey}" with account "${opts.account}"${opts.clientId ? ` and client ID "${opts.clientId}"` : ""}.\n\n` +
-                    `Run 'assistant oauth connections list' to see active connections.\n` +
-                    `To connect a new account, run 'assistant oauth connections connect --help'.`,
+                    `Run 'assistant oauth status ${providerKey}' to see active connections.\n` +
+                    `To connect a new account, run 'assistant oauth connect --help'.`,
                 );
                 return;
               }
@@ -434,14 +434,14 @@ Examples:
             if (managed) {
               writeError(
                 `Error: ${resolveMessage}\n\n` +
-                  `Run 'assistant oauth platform status ${providerKey}' to check connection status.\n` +
-                  `To connect, run 'assistant oauth platform connect --help'.`,
+                  `Run 'assistant oauth status ${providerKey}' to check connection status.\n` +
+                  `To connect, run 'assistant oauth connect --help'.`,
               );
             } else {
               writeError(
                 `Error: ${resolveMessage}\n\n` +
-                  `Run 'assistant oauth connections list' to see active connections.\n` +
-                  `To connect, run 'assistant oauth connections connect --help'.`,
+                  `Run 'assistant oauth status ${providerKey}' to see active connections.\n` +
+                  `To connect, run 'assistant oauth connect --help'.`,
               );
             }
             return;
@@ -473,13 +473,13 @@ Examples:
             if (managed) {
               authHint =
                 `Hint: Request returned HTTP ${response.status}. The OAuth token may be expired or revoked.\n\n` +
-                `Run 'assistant oauth platform status ${providerKey}' to check connection health.\n` +
-                `To reconnect, run 'assistant oauth platform connect --help'.`;
+                `Run 'assistant oauth status ${providerKey}' to check connection health.\n` +
+                `To reconnect, run 'assistant oauth connect --help'.`;
             } else {
               authHint =
                 `Hint: Request returned HTTP ${response.status}. The OAuth token may be expired or revoked.\n\n` +
-                `Run 'assistant oauth connections list --provider ${providerKey}' to check connection status.\n` +
-                `To reconnect, run 'assistant oauth connections connect --help'.`;
+                `Run 'assistant oauth status ${providerKey}' to check connection status.\n` +
+                `To reconnect, run 'assistant oauth connect --help'.`;
             }
             writeInfo(authHint);
           }
@@ -555,11 +555,11 @@ Examples:
             const managed = isManagedMode(providerKey);
             const authHint = managed
               ? `Hint: Request returned HTTP ${errStatus}. The OAuth token may be expired or revoked.\n\n` +
-                `Run 'assistant oauth platform status ${providerKey}' to check connection health.\n` +
-                `To reconnect, run 'assistant oauth platform connect --help'.`
+                `Run 'assistant oauth status ${providerKey}' to check connection health.\n` +
+                `To reconnect, run 'assistant oauth connect --help'.`
               : `Hint: Request returned HTTP ${errStatus}. The OAuth token may be expired or revoked.\n\n` +
-                `Run 'assistant oauth connections list --provider ${providerKey}' to check connection status.\n` +
-                `To reconnect, run 'assistant oauth connections connect --help'.`;
+                `Run 'assistant oauth status ${providerKey}' to check connection status.\n` +
+                `To reconnect, run 'assistant oauth connect --help'.`;
 
             writeError(`Error: ${message}`, authHint);
             writeInfo(authHint);

--- a/assistant/src/cli/commands/oauth/shared.ts
+++ b/assistant/src/cli/commands/oauth/shared.ts
@@ -8,7 +8,7 @@ import {
 import { getProvider } from "../../../oauth/oauth-store.js";
 import { resolveService } from "../../../oauth/provider-behaviors.js";
 import { VellumPlatformClient } from "../../../platform/client.js";
-import { writeOutput } from "../../output.js";
+import { shouldOutputJson, writeOutput } from "../../output.js";
 
 // ---------------------------------------------------------------------------
 // Re-exports
@@ -30,6 +30,22 @@ export interface PlatformConnectionEntry {
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Print a deprecation warning to stderr for renamed commands. Skipped in JSON
+ * mode so machine-parseable output is not polluted.
+ */
+export function printDeprecationWarning(
+  oldCmd: string,
+  newCmd: string,
+  cmd: Command,
+): void {
+  if (!shouldOutputJson(cmd)) {
+    process.stderr.write(
+      `Warning: '${oldCmd}' is deprecated. Use '${newCmd}' instead.\n`,
+    );
+  }
+}
 
 /**
  * Extract the bare provider slug (e.g. "google") from either a raw CLI

--- a/assistant/src/cli/commands/oauth/shared.ts
+++ b/assistant/src/cli/commands/oauth/shared.ts
@@ -1,0 +1,113 @@
+import type { Command } from "commander";
+
+import { getConfig } from "../../../config/loader.js";
+import {
+  type Services,
+  ServicesSchema,
+} from "../../../config/schemas/services.js";
+import { getProvider } from "../../../oauth/oauth-store.js";
+import { resolveService } from "../../../oauth/provider-behaviors.js";
+import { VellumPlatformClient } from "../../../platform/client.js";
+import { writeOutput } from "../../output.js";
+
+// ---------------------------------------------------------------------------
+// Re-exports
+// ---------------------------------------------------------------------------
+
+export { resolveService };
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+export interface PlatformConnectionEntry {
+  id: string;
+  account_label?: string;
+  scopes_granted?: string[];
+  status?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the bare provider slug (e.g. "google") from either a raw CLI
+ * argument or a canonical provider key (e.g. "integration:google").
+ * Platform API paths expect the bare slug, not the internal key.
+ */
+export function toBareProvider(provider: string): string {
+  return provider.startsWith("integration:")
+    ? provider.slice("integration:".length)
+    : provider;
+}
+
+/**
+ * Determine whether a provider is running in platform-managed mode.
+ * Returns false if config is unavailable (e.g. in test environments).
+ */
+export function isManagedMode(providerKey: string): boolean {
+  const provider = getProvider(providerKey);
+  const managedKey = provider?.managedServiceConfigKey;
+  if (!managedKey || !(managedKey in ServicesSchema.shape)) return false;
+  try {
+    const services: Services = getConfig().services;
+    return services[managedKey as keyof Services].mode === "managed";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Create an authenticated platform client, or write an error and return null.
+ */
+export async function requirePlatformClient(
+  cmd: Command,
+): Promise<VellumPlatformClient | null> {
+  const client = await VellumPlatformClient.create();
+  if (!client || !client.platformAssistantId) {
+    writeOutput(cmd, {
+      ok: false,
+      error:
+        "Platform prerequisites not met (not logged in or missing assistant ID)",
+    });
+    process.exitCode = 1;
+    return null;
+  }
+  return client;
+}
+
+/**
+ * Fetch active platform connections for a provider. Returns the parsed entries
+ * or writes an error and returns null.
+ */
+export async function fetchActiveConnections(
+  client: VellumPlatformClient,
+  provider: string,
+  cmd: Command,
+): Promise<PlatformConnectionEntry[] | null> {
+  const params = new URLSearchParams();
+  params.set("provider", toBareProvider(provider));
+  params.set("status", "ACTIVE");
+
+  const path = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/connections/?${params.toString()}`;
+  const response = await client.fetch(path);
+
+  if (!response.ok) {
+    writeOutput(cmd, {
+      ok: false,
+      error: `Platform returned HTTP ${response.status}`,
+    });
+    process.exitCode = 1;
+    return null;
+  }
+
+  const body = (await response.json()) as unknown;
+
+  // The platform returns either a flat array or a {results: [...]} wrapper.
+  return (
+    Array.isArray(body)
+      ? body
+      : ((body as Record<string, unknown>).results ?? [])
+  ) as PlatformConnectionEntry[];
+}

--- a/assistant/src/cli/commands/oauth/shared.ts
+++ b/assistant/src/cli/commands/oauth/shared.ts
@@ -96,11 +96,16 @@ export async function requirePlatformClient(
 /**
  * Fetch active platform connections for a provider. Returns the parsed entries
  * or writes an error and returns null.
+ *
+ * When `silent` is true the helper returns null on HTTP errors without writing
+ * any output — useful inside polling loops where transient failures should be
+ * quietly retried rather than emitting multiple error lines.
  */
 export async function fetchActiveConnections(
   client: VellumPlatformClient,
   provider: string,
   cmd: Command,
+  options?: { silent?: boolean },
 ): Promise<PlatformConnectionEntry[] | null> {
   const params = new URLSearchParams();
   params.set("provider", toBareProvider(provider));
@@ -110,11 +115,13 @@ export async function fetchActiveConnections(
   const response = await client.fetch(path);
 
   if (!response.ok) {
-    writeOutput(cmd, {
-      ok: false,
-      error: `Platform returned HTTP ${response.status}`,
-    });
-    process.exitCode = 1;
+    if (!options?.silent) {
+      writeOutput(cmd, {
+        ok: false,
+        error: `Platform returned HTTP ${response.status}`,
+      });
+      process.exitCode = 1;
+    }
     return null;
   }
 

--- a/assistant/src/cli/commands/oauth/status.ts
+++ b/assistant/src/cli/commands/oauth/status.ts
@@ -1,0 +1,202 @@
+import type { Command } from "commander";
+
+import { getProvider, listConnections } from "../../../oauth/oauth-store.js";
+import { getCliLogger } from "../../logger.js";
+import { shouldOutputJson, writeOutput } from "../../output.js";
+import {
+  fetchActiveConnections,
+  isManagedMode,
+  requirePlatformClient,
+  resolveService,
+} from "./shared.js";
+
+const log = getCliLogger("cli");
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+export function registerStatusCommand(oauth: Command): void {
+  oauth
+    .command("status <provider>")
+    .description(
+      "Show OAuth connection status for a provider (auto-detects managed vs BYO mode)",
+    )
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  provider   Provider name or key. Accepts bare names (google, slack),
+             canonical keys (integration:google), or aliases (gmail).
+             Run 'assistant oauth providers list' to see all available providers.
+
+The output includes connection IDs and account identifiers that can be used
+as inputs to other commands:
+  - 'assistant oauth disconnect <provider>' to remove a connection
+  - 'assistant oauth request --provider <provider> --account <account>' to
+    make authenticated requests as a specific account
+
+Mode detection:
+  The command automatically detects whether the provider is configured in
+  platform-managed mode or bring-your-own (BYO) mode based on the assistant's
+  services config. Managed mode delegates OAuth to the Vellum platform; BYO
+  mode uses locally stored tokens.
+
+Examples:
+  $ assistant oauth status google
+  $ assistant oauth status integration:google --json`,
+    )
+    .action(
+      async (
+        provider: string,
+        _opts: Record<string, unknown>,
+        cmd: Command,
+      ) => {
+        try {
+          // -----------------------------------------------------------------
+          // Resolve + validate provider
+          // -----------------------------------------------------------------
+          const providerKey = resolveService(provider);
+          const providerRow = getProvider(providerKey);
+
+          if (!providerRow) {
+            writeOutput(cmd, {
+              ok: false,
+              error:
+                `Unknown provider "${provider}". ` +
+                `Run 'assistant oauth providers list' to see available providers.`,
+            });
+            process.exitCode = 1;
+            return;
+          }
+
+          // -----------------------------------------------------------------
+          // Detect mode
+          // -----------------------------------------------------------------
+          const managed = isManagedMode(providerKey);
+
+          if (managed) {
+            // ---------------------------------------------------------------
+            // Managed path
+            // ---------------------------------------------------------------
+            const client = await requirePlatformClient(cmd);
+            if (!client) return;
+
+            const rawEntries = await fetchActiveConnections(
+              client,
+              providerKey,
+              cmd,
+            );
+            if (!rawEntries) return;
+
+            const connections = rawEntries.map((c) => ({
+              id: c.id,
+              account: c.account_label ?? null,
+              grantedScopes: c.scopes_granted ?? [],
+              status: c.status ?? "ACTIVE",
+            }));
+
+            if (shouldOutputJson(cmd)) {
+              writeOutput(cmd, {
+                ok: true,
+                provider: providerKey,
+                mode: "managed",
+                connections,
+              });
+              return;
+            }
+
+            // Human output
+            if (connections.length === 0) {
+              log.info(
+                `No active connections for ${providerKey}. Connect with 'assistant oauth connect ${providerKey}'.`,
+              );
+              return;
+            }
+
+            log.info(`Provider: ${providerKey} (managed)`);
+            log.info(`${connections.length} active connection(s):`);
+            for (const c of connections) {
+              const scopes =
+                c.grantedScopes.length > 0
+                  ? `[${c.grantedScopes.join(", ")}]`
+                  : "[]";
+              log.info(
+                `  \u2022 ${c.id}  ${c.account ?? "(no account)"}  ${scopes}  ${c.status}`,
+              );
+            }
+          } else {
+            // ---------------------------------------------------------------
+            // BYO path
+            // ---------------------------------------------------------------
+            const allConnections = listConnections(providerKey);
+            const activeRows = allConnections.filter(
+              (r) => r.status === "active",
+            );
+
+            const connections = activeRows.map((r) => {
+              let grantedScopes: string[] = [];
+              try {
+                grantedScopes = r.grantedScopes
+                  ? JSON.parse(r.grantedScopes)
+                  : [];
+              } catch {
+                // Malformed JSON — default to empty
+              }
+
+              return {
+                id: r.id,
+                account: r.accountInfo ?? null,
+                grantedScopes,
+                expiresAt: r.expiresAt
+                  ? new Date(r.expiresAt).toISOString()
+                  : null,
+                hasRefreshToken: r.hasRefreshToken === 1,
+                status: r.status,
+              };
+            });
+
+            if (shouldOutputJson(cmd)) {
+              writeOutput(cmd, {
+                ok: true,
+                provider: providerKey,
+                mode: "byo",
+                connections,
+              });
+              return;
+            }
+
+            // Human output
+            if (connections.length === 0) {
+              log.info(
+                `No active connections for ${providerKey}. Connect with 'assistant oauth connect ${providerKey}'.`,
+              );
+              return;
+            }
+
+            log.info(`Provider: ${providerKey} (byo)`);
+            log.info(`${connections.length} active connection(s):`);
+            for (const c of connections) {
+              const scopes =
+                c.grantedScopes.length > 0
+                  ? `[${c.grantedScopes.join(", ")}]`
+                  : "[]";
+              const expires = c.expiresAt
+                ? `expires ${c.expiresAt}`
+                : "no expiry";
+              const refresh = c.hasRefreshToken
+                ? "refresh: yes"
+                : "refresh: no";
+              log.info(
+                `  \u2022 ${c.id}  ${c.account ?? "(no account)"}  ${scopes}  ${expires}  ${refresh}`,
+              );
+            }
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          writeOutput(cmd, { ok: false, error: message });
+          process.exitCode = 1;
+        }
+      },
+    );
+}


### PR DESCRIPTION
## Summary
Add three unified top-level OAuth CLI commands that auto-detect managed vs BYO mode and route transparently, following the pattern established by `oauth request`. Old commands are preserved but hidden with deprecation warnings.

- `assistant oauth connect <provider>` — initiate OAuth flow (managed or BYO)
- `assistant oauth disconnect <provider>` — disconnect a provider
- `assistant oauth status <provider>` — show connection status

## PRs merged into feature branch
- #21375: refactor: extract shared OAuth CLI helpers into `oauth/shared.ts`
- #21376: feat: add unified `oauth status` command
- #21378: feat: add unified `oauth connect` command
- #21377: feat: add unified `oauth disconnect` command
- #21388: feat: deprecate old connect/disconnect/status commands, update help
- #21392: test: add tests for unified oauth connect, disconnect, and status commands

## Fix PRs
- #21396: fix: update request.ts error hints to reference unified commands
- #21397: fix: prevent multiple JSON outputs in managed-mode connect polling loop
- #21398: fix: use consistent provider field format in disconnect.ts JSON output
- #21401: fix: update disconnect test to expect canonical provider key format

## Self-review result
PASS after 2 remediation rounds (3 gaps found and fixed in round 1, 1 stale test assertion fixed in round 2)

Part of plan: unified-oauth-cli.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
