### PR TITLE
docs: add AGENTS.md for feature flag conventions

### DIFF
--- a/meta/feature-flags/AGENTS.md
+++ b/meta/feature-flags/AGENTS.md
@@ -1,0 +1,72 @@
+# Feature Flags — Agent Instructions
+
+## Naming Convention
+
+Feature flag keys are **simple kebab-case strings** with no prefix or suffix:
+
+```
+"browser"
+"email-channel"
+"ces-tools"
+"conversation-starters"
+```
+
+The `id` and `key` fields in `feature-flag-registry.json` **must match** and both use kebab-case. macOS-scope flags follow the same convention:
+
+```
+"user-hosted-enabled"
+"mobile-pairing"
+"quick-input"
+```
+
+**Do not** use a `feature_flags.` prefix, `.enabled` suffix, or snake_case. The old canonical format (`feature_flags.<id>.enabled` / `snake_case_key`) is being retired.
+
+## Adding a New Flag
+
+1. Add an entry to `meta/feature-flags/feature-flag-registry.json` with matching `id` and `key`:
+
+   ```json
+   {
+     "id": "my-new-flag",
+     "scope": "assistant",
+     "key": "my-new-flag",
+     "label": "My New Flag",
+     "description": "What this flag controls",
+     "defaultEnabled": false
+   }
+   ```
+
+2. Run the sync script to copy the registry into bundled locations:
+
+   ```bash
+   bun run meta/feature-flags/sync-bundled-copies.ts
+   ```
+
+## Creating a Feature Gate
+
+Define a constant using the flag's `id` directly and a predicate function that delegates to the resolver:
+
+```typescript
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../config/schema.js";
+
+const MY_FLAG = "my-flag" as const;
+
+export function isMyFlagEnabled(config: AssistantConfig): boolean {
+  return isAssistantFeatureFlagEnabled(MY_FLAG, config);
+}
+```
+
+## Skill Feature-Flag Gating
+
+A skill's SKILL.md frontmatter `featureFlag` field should reference the flag `id` directly:
+
+```yaml
+featureFlag: my-new-flag
+```
+
+Skills without a `featureFlag` field are always available. Skills that declare one are gated at six independent enforcement points — when the flag is OFF the skill is unavailable everywhere.
+
+## Auth Scopes Are Unrelated
+
+The OAuth/API scopes `feature_flags.read` and `feature_flags.write` control access to the feature-flag management API. They are **not** flag keys and should not be modified when adding or renaming flags.


### PR DESCRIPTION
## Summary
- Creates meta/feature-flags/AGENTS.md documenting the simplified kebab-case naming convention for feature flags
- Documents how to add new flags, create feature gates, and use skill frontmatter featureFlag field

Part of plan: simplify-feature-flag-names.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
