### PR TITLE
feat: simplify feature flag keys to kebab-case in registry and gateway

### DIFF
--- a/gateway/src/__tests__/feature-flags-route.test.ts
+++ b/gateway/src/__tests__/feature-flags-route.test.ts
@@ -33,7 +33,7 @@ const TEST_REGISTRY = {
     {
       id: "browser",
       scope: "assistant",
-      key: "feature_flags.browser.enabled",
+      key: "browser",
       label: "Browser",
       description: "Browser skill",
       defaultEnabled: true,
@@ -41,7 +41,7 @@ const TEST_REGISTRY = {
     {
       id: "contacts",
       scope: "assistant",
-      key: "feature_flags.contacts.enabled",
+      key: "contacts",
       label: "Contacts",
       description: "Contacts management",
       defaultEnabled: false,
@@ -49,7 +49,7 @@ const TEST_REGISTRY = {
     {
       id: "user-hosted-enabled",
       scope: "macos",
-      key: "user_hosted_enabled",
+      key: "user-hosted-enabled",
       label: "User Hosted Enabled",
       description: "Enable user-hosted onboarding flow",
       defaultEnabled: false,
@@ -128,14 +128,12 @@ describe("GET /v1/feature-flags handler", () => {
       expect(typeof flag.enabled).toBe("boolean");
       expect(typeof flag.defaultEnabled).toBe("boolean");
       expect(typeof flag.description).toBe("string");
-      expect(flag.key).toMatch(
-        /^feature_flags\.[a-z0-9][a-z0-9._-]*\.enabled$/,
-      );
+      expect(flag.key).toMatch(/^[a-z0-9][a-z0-9-]*$/);
     }
 
     // Check a specific known flag
     const browserFlag = body.flags.find(
-      (f: { key: string }) => f.key === "feature_flags.browser.enabled",
+      (f: { key: string }) => f.key === "browser",
     );
     expect(browserFlag).toBeDefined();
     expect(browserFlag.defaultEnabled).toBe(true);
@@ -160,7 +158,7 @@ describe("GET /v1/feature-flags handler", () => {
 
     // Verify specific labels
     const browserFlag2 = body.flags.find(
-      (f: { key: string }) => f.key === "feature_flags.browser.enabled",
+      (f: { key: string }) => f.key === "browser",
     );
     expect(browserFlag2).toBeDefined();
     expect(browserFlag2.label).toBe("Browser");
@@ -177,7 +175,7 @@ describe("GET /v1/feature-flags handler", () => {
 
     // The macos-scope flag should not appear
     const macosFlag = body.flags.find(
-      (f: { key: string }) => f.key === "user_hosted_enabled",
+      (f: { key: string }) => f.key === "user-hosted-enabled",
     );
     expect(macosFlag).toBeUndefined();
   });
@@ -209,7 +207,7 @@ describe("GET /v1/feature-flags handler", () => {
       JSON.stringify({
         version: 1,
         values: {
-          "feature_flags.browser.enabled": false,
+          browser: false,
         },
       }),
     );
@@ -224,7 +222,7 @@ describe("GET /v1/feature-flags handler", () => {
     const body = await res.json();
 
     const browserFlag = body.flags.find(
-      (f: { key: string }) => f.key === "feature_flags.browser.enabled",
+      (f: { key: string }) => f.key === "browser",
     );
     expect(browserFlag).toBeDefined();
     expect(browserFlag.enabled).toBe(false); // overridden from default true
@@ -238,7 +236,7 @@ describe("GET /v1/feature-flags handler", () => {
       JSON.stringify({
         version: 1,
         values: {
-          "feature_flags.browser.enabled": "no",
+          browser: "no",
         },
       }),
     );
@@ -256,7 +254,7 @@ describe("GET /v1/feature-flags handler", () => {
     // invalid "no" string is dropped and the flag falls back to its
     // registry default (true).
     const browserFlag = body.flags.find(
-      (f: { key: string }) => f.key === "feature_flags.browser.enabled",
+      (f: { key: string }) => f.key === "browser",
     );
     expect(browserFlag).toBeDefined();
     expect(browserFlag.enabled).toBe(true);
@@ -270,7 +268,7 @@ describe("GET /v1/feature-flags handler", () => {
       JSON.stringify({
         version: 1,
         values: {
-          "feature_flags.contacts.enabled": true,
+          contacts: true,
         },
       }),
     );
@@ -291,7 +289,7 @@ describe("GET /v1/feature-flags handler", () => {
     const body = await res.json();
 
     const contactsFlag = body.flags.find(
-      (f: { key: string }) => f.key === "feature_flags.contacts.enabled",
+      (f: { key: string }) => f.key === "contacts",
     );
     expect(contactsFlag).toBeDefined();
     // Remote value (true) overrides registry default (false)
@@ -305,7 +303,7 @@ describe("GET /v1/feature-flags handler", () => {
       JSON.stringify({
         version: 1,
         values: {
-          "feature_flags.contacts.enabled": true,
+          contacts: true,
         },
       }),
     );
@@ -317,7 +315,7 @@ describe("GET /v1/feature-flags handler", () => {
       JSON.stringify({
         version: 1,
         values: {
-          "feature_flags.contacts.enabled": false,
+          contacts: false,
         },
       }),
     );
@@ -332,7 +330,7 @@ describe("GET /v1/feature-flags handler", () => {
     const body = await res.json();
 
     const contactsFlag = body.flags.find(
-      (f: { key: string }) => f.key === "feature_flags.contacts.enabled",
+      (f: { key: string }) => f.key === "contacts",
     );
     expect(contactsFlag).toBeDefined();
     // Local override (false) takes precedence over remote (true)
@@ -362,7 +360,7 @@ describe("GET /v1/feature-flags handler", () => {
 
     // contacts has defaultEnabled: false in registry
     const contactsFlag = body.flags.find(
-      (f: { key: string }) => f.key === "feature_flags.contacts.enabled",
+      (f: { key: string }) => f.key === "contacts",
     );
     expect(contactsFlag).toBeDefined();
     expect(contactsFlag.enabled).toBe(false);
@@ -370,7 +368,7 @@ describe("GET /v1/feature-flags handler", () => {
 
     // browser has defaultEnabled: true in registry
     const browserFlag = body.flags.find(
-      (f: { key: string }) => f.key === "feature_flags.browser.enabled",
+      (f: { key: string }) => f.key === "browser",
     );
     expect(browserFlag).toBeDefined();
     expect(browserFlag.enabled).toBe(true);
@@ -382,28 +380,25 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
   test("writes to feature-flags.json store", async () => {
     const handler = createFeatureFlagsPatchHandler();
     const res = await handler(
-      new Request(
-        "http://gateway.test/v1/feature-flags/feature_flags.browser.enabled",
-        {
-          method: "PATCH",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ enabled: false }),
-        },
-      ),
-      "feature_flags.browser.enabled",
+      new Request("http://gateway.test/v1/feature-flags/browser", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: false }),
+      }),
+      "browser",
     );
 
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual({
-      key: "feature_flags.browser.enabled",
+      key: "browser",
       enabled: false,
     });
 
     // Verify persistence to the feature-flags.json store
     clearFeatureFlagStoreCache();
     const persisted = readPersistedFeatureFlags();
-    expect(persisted["feature_flags.browser.enabled"]).toBe(false);
+    expect(persisted["browser"]).toBe(false);
   });
 
   test("preserves existing persisted flags when writing", async () => {
@@ -413,7 +408,7 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
       JSON.stringify({
         version: 1,
         values: {
-          "feature_flags.contacts.enabled": true,
+          contacts: true,
         },
       }),
     );
@@ -421,22 +416,19 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
 
     const handler = createFeatureFlagsPatchHandler();
     await handler(
-      new Request(
-        "http://gateway.test/v1/feature-flags/feature_flags.browser.enabled",
-        {
-          method: "PATCH",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ enabled: true }),
-        },
-      ),
-      "feature_flags.browser.enabled",
+      new Request("http://gateway.test/v1/feature-flags/browser", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: true }),
+      }),
+      "browser",
     );
 
     // Both old and new values should be persisted
     clearFeatureFlagStoreCache();
     const persisted = readPersistedFeatureFlags();
-    expect(persisted["feature_flags.contacts.enabled"]).toBe(true);
-    expect(persisted["feature_flags.browser.enabled"]).toBe(true);
+    expect(persisted["contacts"]).toBe(true);
+    expect(persisted["browser"]).toBe(true);
   });
 
   test("creates feature-flags.json and directories when they do not exist", async () => {
@@ -445,15 +437,12 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
 
     const handler = createFeatureFlagsPatchHandler();
     const res = await handler(
-      new Request(
-        "http://gateway.test/v1/feature-flags/feature_flags.browser.enabled",
-        {
-          method: "PATCH",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ enabled: true }),
-        },
-      ),
-      "feature_flags.browser.enabled",
+      new Request("http://gateway.test/v1/feature-flags/browser", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: true }),
+      }),
+      "browser",
     );
 
     expect(res.status).toBe(200);
@@ -461,7 +450,7 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
 
     clearFeatureFlagStoreCache();
     const persisted = readPersistedFeatureFlags();
-    expect(persisted["feature_flags.browser.enabled"]).toBe(true);
+    expect(persisted["browser"]).toBe(true);
   });
 
   // Validation tests
@@ -506,17 +495,16 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     }
   });
 
-  test("rejects key not matching feature_flags.<id>.enabled format", async () => {
+  test("rejects key not matching simple kebab-case format", async () => {
     const handler = createFeatureFlagsPatchHandler();
 
     const invalidKeys = [
       "random.key",
-      "feature_flags.enabled",
-      "feature_flags..enabled",
-      "feature_flags.UPPERCASE.enabled",
-      "feature_flags.browser.disabled",
-      "other.browser.enabled",
-      "feature_flags.browser.enabled.extra",
+      "UPPERCASE",
+      "has_underscore",
+      "has.dot",
+      "INVALID!",
+      "-starts-with-dash",
     ];
 
     for (const key of invalidKeys) {
@@ -539,15 +527,12 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     const handler = createFeatureFlagsPatchHandler();
 
     const res = await handler(
-      new Request(
-        "http://gateway.test/v1/feature-flags/feature_flags.totally-unknown-flag.enabled",
-        {
-          method: "PATCH",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ enabled: true }),
-        },
-      ),
-      "feature_flags.totally-unknown-flag.enabled",
+      new Request("http://gateway.test/v1/feature-flags/totally-unknown-flag", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: true }),
+      }),
+      "totally-unknown-flag",
     );
 
     expect(res.status).toBe(400);
@@ -555,13 +540,10 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     expect(body.error).toContain("not declared");
   });
 
-  test("accepts valid declared feature_flags.* key formats", async () => {
+  test("accepts valid declared kebab-case key formats", async () => {
     const handler = createFeatureFlagsPatchHandler();
 
-    const validKeys = [
-      "feature_flags.browser.enabled",
-      "feature_flags.contacts.enabled",
-    ];
+    const validKeys = ["browser", "contacts"];
 
     for (const key of validKeys) {
       clearFeatureFlagStoreCache();
@@ -584,15 +566,12 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     const invalidValues = ["true", 1, null, undefined];
     for (const value of invalidValues) {
       const res = await handler(
-        new Request(
-          "http://gateway.test/v1/feature-flags/feature_flags.browser.enabled",
-          {
-            method: "PATCH",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify({ enabled: value }),
-          },
-        ),
-        "feature_flags.browser.enabled",
+        new Request("http://gateway.test/v1/feature-flags/browser", {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ enabled: value }),
+        }),
+        "browser",
       );
 
       expect(res.status).toBe(400);
@@ -604,15 +583,12 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
   test("rejects invalid JSON body", async () => {
     const handler = createFeatureFlagsPatchHandler();
     const res = await handler(
-      new Request(
-        "http://gateway.test/v1/feature-flags/feature_flags.browser.enabled",
-        {
-          method: "PATCH",
-          headers: { "content-type": "application/json" },
-          body: "not json",
-        },
-      ),
-      "feature_flags.browser.enabled",
+      new Request("http://gateway.test/v1/feature-flags/browser", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: "not json",
+      }),
+      "browser",
     );
 
     expect(res.status).toBe(400);
@@ -623,13 +599,10 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
   test("rejects missing body", async () => {
     const handler = createFeatureFlagsPatchHandler();
     const res = await handler(
-      new Request(
-        "http://gateway.test/v1/feature-flags/feature_flags.browser.enabled",
-        {
-          method: "PATCH",
-        },
-      ),
-      "feature_flags.browser.enabled",
+      new Request("http://gateway.test/v1/feature-flags/browser", {
+        method: "PATCH",
+      }),
+      "browser",
     );
 
     expect(res.status).toBe(400);
@@ -641,30 +614,27 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
       featureFlagStorePath,
       JSON.stringify({
         version: 1,
-        values: { "feature_flags.contacts.enabled": true },
+        values: { contacts: true },
       }),
     );
     clearFeatureFlagStoreCache();
 
     const handler = createFeatureFlagsPatchHandler();
     await handler(
-      new Request(
-        "http://gateway.test/v1/feature-flags/feature_flags.browser.enabled",
-        {
-          method: "PATCH",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ enabled: false }),
-        },
-      ),
-      "feature_flags.browser.enabled",
+      new Request("http://gateway.test/v1/feature-flags/browser", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: false }),
+      }),
+      "browser",
     );
 
     // Verify the file is valid JSON and contains all expected data
     const raw = readFileSync(featureFlagStorePath, "utf-8");
     const data = JSON.parse(raw);
     expect(data.version).toBe(1);
-    expect(data.values["feature_flags.contacts.enabled"]).toBe(true);
-    expect(data.values["feature_flags.browser.enabled"]).toBe(false);
+    expect(data.values["contacts"]).toBe(true);
+    expect(data.values["browser"]).toBe(false);
 
     // Verify no temp files left behind
     const { readdirSync } = await import("node:fs");
@@ -677,10 +647,7 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     const handler = createFeatureFlagsPatchHandler();
 
     // Fire multiple concurrent PATCH requests at the same time
-    const flagKeys = [
-      "feature_flags.browser.enabled",
-      "feature_flags.contacts.enabled",
-    ];
+    const flagKeys = ["browser", "contacts"];
 
     const results = await Promise.all(
       flagKeys.map((key) =>

--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -110,7 +110,7 @@ describe("RemoteFeatureFlagSync", () => {
   test("fetches and caches flags on successful response", async () => {
     fetchMock = mock(async () =>
       Response.json({
-        flags: { "feature_flags.browser.enabled": true },
+        flags: { browser: true },
       }),
     );
 
@@ -122,14 +122,14 @@ describe("RemoteFeatureFlagSync", () => {
 
     clearRemoteFeatureFlagStoreCache();
     const cached = readRemoteFeatureFlags();
-    expect(cached).toEqual({ "feature_flags.browser.enabled": true });
+    expect(cached).toEqual({ browser: true });
   });
 
   test("preserves cached flags on non-OK response", async () => {
     // First, seed cached flags with a successful fetch
     fetchMock = mock(async () =>
       Response.json({
-        flags: { "feature_flags.browser.enabled": true },
+        flags: { browser: true },
       }),
     );
 
@@ -139,7 +139,7 @@ describe("RemoteFeatureFlagSync", () => {
 
     clearRemoteFeatureFlagStoreCache();
     expect(readRemoteFeatureFlags()).toEqual({
-      "feature_flags.browser.enabled": true,
+      browser: true,
     });
 
     // Now simulate a non-OK response — cached flags should be preserved
@@ -155,14 +155,14 @@ describe("RemoteFeatureFlagSync", () => {
 
     clearRemoteFeatureFlagStoreCache();
     const cached = readRemoteFeatureFlags();
-    expect(cached).toEqual({ "feature_flags.browser.enabled": true });
+    expect(cached).toEqual({ browser: true });
   });
 
   test("preserves cached flags on network error", async () => {
     // First, seed cached flags with a successful fetch
     fetchMock = mock(async () =>
       Response.json({
-        flags: { "feature_flags.browser.enabled": true },
+        flags: { browser: true },
       }),
     );
 
@@ -172,7 +172,7 @@ describe("RemoteFeatureFlagSync", () => {
 
     clearRemoteFeatureFlagStoreCache();
     expect(readRemoteFeatureFlags()).toEqual({
-      "feature_flags.browser.enabled": true,
+      browser: true,
     });
 
     // Now simulate a network error — cached flags should be preserved
@@ -189,7 +189,7 @@ describe("RemoteFeatureFlagSync", () => {
 
     clearRemoteFeatureFlagStoreCache();
     const cached = readRemoteFeatureFlags();
-    expect(cached).toEqual({ "feature_flags.browser.enabled": true });
+    expect(cached).toEqual({ browser: true });
   });
 
   test("sends correct auth header", async () => {
@@ -230,10 +230,10 @@ describe("RemoteFeatureFlagSync", () => {
     fetchMock = mock(async () =>
       Response.json({
         flags: {
-          "feature_flags.browser.enabled": true,
-          "feature_flags.contacts.enabled": "yes" as unknown,
-          "feature_flags.other.enabled": 1 as unknown,
-          "feature_flags.valid.enabled": false,
+          browser: true,
+          contacts: "yes" as unknown,
+          other: 1 as unknown,
+          valid: false,
         },
       }),
     );
@@ -245,8 +245,8 @@ describe("RemoteFeatureFlagSync", () => {
     clearRemoteFeatureFlagStoreCache();
     const cached = readRemoteFeatureFlags();
     expect(cached).toEqual({
-      "feature_flags.browser.enabled": true,
-      "feature_flags.valid.enabled": false,
+      browser: true,
+      valid: false,
     });
   });
 
@@ -254,7 +254,7 @@ describe("RemoteFeatureFlagSync", () => {
     // First, seed cached flags with a successful fetch
     fetchMock = mock(async () =>
       Response.json({
-        flags: { "feature_flags.browser.enabled": true },
+        flags: { browser: true },
       }),
     );
 
@@ -264,7 +264,7 @@ describe("RemoteFeatureFlagSync", () => {
 
     clearRemoteFeatureFlagStoreCache();
     expect(readRemoteFeatureFlags()).toEqual({
-      "feature_flags.browser.enabled": true,
+      browser: true,
     });
 
     // Now simulate a response with missing flags field — cached flags should be preserved
@@ -276,6 +276,6 @@ describe("RemoteFeatureFlagSync", () => {
 
     clearRemoteFeatureFlagStoreCache();
     const cached = readRemoteFeatureFlags();
-    expect(cached).toEqual({ "feature_flags.browser.enabled": true });
+    expect(cached).toEqual({ browser: true });
   });
 });

--- a/gateway/src/http/routes/feature-flags.ts
+++ b/gateway/src/http/routes/feature-flags.ts
@@ -12,11 +12,9 @@ import { getLogger } from "../../logger.js";
 const log = getLogger("feature-flags");
 
 /**
- * Only allow keys matching `feature_flags.<flagId>.enabled` for the canonical format.
- * The flagId segment must be a non-empty string of lowercase alphanumeric chars,
- * dots, hyphens, and underscores.
+ * Only allow simple kebab-case keys (e.g., "browser", "ces-tools").
  */
-const ALLOWED_KEY_RE = /^feature_flags\.[a-z0-9][a-z0-9._-]*\.enabled$/;
+const ALLOWED_KEY_RE = /^[a-z0-9][a-z0-9-]*$/;
 
 export type FeatureFlagEntry = {
   key: string;
@@ -73,7 +71,7 @@ export function createFeatureFlagsPatchHandler() {
       return Response.json(
         {
           error:
-            "Invalid flag key format. Must match: feature_flags.<flagId>.enabled",
+            "Invalid flag key format. Must be a simple kebab-case string (e.g., 'browser', 'ces-tools')",
         },
         { status: 400 },
       );

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -4,7 +4,7 @@
     {
       "id": "browser",
       "scope": "assistant",
-      "key": "feature_flags.browser.enabled",
+      "key": "browser",
       "label": "Browser",
       "description": "Enable browser skill prerequisites section in the system prompt",
       "defaultEnabled": true
@@ -12,7 +12,7 @@
     {
       "id": "user-hosted-enabled",
       "scope": "macos",
-      "key": "user_hosted_enabled",
+      "key": "user-hosted-enabled",
       "label": "User Hosted Enabled",
       "description": "Enable user-hosted onboarding flow",
       "defaultEnabled": false
@@ -20,7 +20,7 @@
     {
       "id": "platform-hosted-enabled",
       "scope": "macos",
-      "key": "platform_hosted_enabled",
+      "key": "platform-hosted-enabled",
       "label": "Platform Hosted Assistants",
       "description": "Enable the Vellum Cloud hosting option on the Hosting screen",
       "defaultEnabled": false
@@ -28,7 +28,7 @@
     {
       "id": "contacts",
       "scope": "assistant",
-      "key": "feature_flags.contacts.enabled",
+      "key": "contacts",
       "label": "Contacts",
       "description": "Show the Contacts tab in Settings for viewing and managing contacts",
       "defaultEnabled": true
@@ -36,7 +36,7 @@
     {
       "id": "email-channel",
       "scope": "assistant",
-      "key": "feature_flags.email-channel.enabled",
+      "key": "email-channel",
       "label": "Email Channel",
       "description": "Enable the entire email integration: email CLI commands, email channel, sequences, email readiness probes, invite adapters, and the email-setup skill",
       "defaultEnabled": false
@@ -44,7 +44,7 @@
     {
       "id": "app-builder-multifile",
       "scope": "assistant",
-      "key": "feature_flags.app-builder-multifile.enabled",
+      "key": "app-builder-multifile",
       "label": "App Builder Multi-file",
       "description": "Enable multi-file TSX app creation with esbuild compilation instead of single-HTML apps",
       "defaultEnabled": false
@@ -52,7 +52,7 @@
     {
       "id": "mobile-pairing",
       "scope": "macos",
-      "key": "mobile_pairing_enabled",
+      "key": "mobile-pairing",
       "label": "Mobile Pairing",
       "description": "Show the Mobile (iOS) pairing card in Settings > Account",
       "defaultEnabled": false
@@ -60,7 +60,7 @@
     {
       "id": "settings-developer-nav",
       "scope": "assistant",
-      "key": "feature_flags.settings-developer-nav.enabled",
+      "key": "settings-developer-nav",
       "label": "Settings Developer Nav",
       "description": "Control Developer nav visibility in macOS settings",
       "defaultEnabled": true
@@ -68,7 +68,7 @@
     {
       "id": "developer-menu-items",
       "scope": "macos",
-      "key": "developer_menu_items_enabled",
+      "key": "developer-menu-items",
       "label": "Developer Menu Items",
       "description": "Show Component Gallery and Replay Onboarding in the menu bar",
       "defaultEnabled": false
@@ -76,7 +76,7 @@
     {
       "id": "ces-tools",
       "scope": "assistant",
-      "key": "feature_flags.ces-tools.enabled",
+      "key": "ces-tools",
       "label": "CES Tool Exposure",
       "description": "Register Credential Execution Service tools (credential-grant, credential-revoke, credential-list) in the agent loop",
       "defaultEnabled": false
@@ -84,7 +84,7 @@
     {
       "id": "ces-shell-lockdown",
       "scope": "assistant",
-      "key": "feature_flags.ces-shell-lockdown.enabled",
+      "key": "ces-shell-lockdown",
       "label": "CES Shell Lockdown",
       "description": "Enforce untrusted-agent shell lockdown when CES credentials are active, restricting direct shell access to credentialed services",
       "defaultEnabled": false
@@ -92,7 +92,7 @@
     {
       "id": "ces-secure-install",
       "scope": "assistant",
-      "key": "feature_flags.ces-secure-install.enabled",
+      "key": "ces-secure-install",
       "label": "CES Secure Command Installation",
       "description": "Enable secure tool/command installation via CES instead of direct shell execution for untrusted agents",
       "defaultEnabled": false
@@ -100,7 +100,7 @@
     {
       "id": "ces-grant-audit",
       "scope": "assistant",
-      "key": "feature_flags.ces-grant-audit.enabled",
+      "key": "ces-grant-audit",
       "label": "CES Grant & Audit Inspection",
       "description": "Surface credential grant and audit inspection endpoints for reviewing active grants and access logs",
       "defaultEnabled": false
@@ -108,7 +108,7 @@
     {
       "id": "ces-managed-sidecar",
       "scope": "assistant",
-      "key": "feature_flags.ces-managed-sidecar.enabled",
+      "key": "ces-managed-sidecar",
       "label": "CES Managed Sidecar Transport",
       "description": "Use managed sidecar transport for CES communication when running in a containerized environment",
       "defaultEnabled": true
@@ -116,7 +116,7 @@
     {
       "id": "ces-credential-backend",
       "scope": "assistant",
-      "key": "feature_flags.ces-credential-backend.enabled",
+      "key": "ces-credential-backend",
       "label": "CES Credential Backend",
       "description": "Route credential reads and writes through the CES process instead of accessing the encrypted store directly",
       "defaultEnabled": true
@@ -124,7 +124,7 @@
     {
       "id": "settings-billing",
       "scope": "macos",
-      "key": "settings_billing_enabled",
+      "key": "settings-billing",
       "label": "Billing Settings Tab",
       "description": "Show the Billing tab in Settings when signed in, displaying credits balance and top-up",
       "defaultEnabled": true
@@ -132,7 +132,7 @@
     {
       "id": "managed-sign-in",
       "scope": "macos",
-      "key": "managed_sign_in_enabled",
+      "key": "managed-sign-in",
       "label": "Managed Sign In",
       "description": "Enable managed (organization-hosted) sign-in flow in the onboarding experience",
       "defaultEnabled": true
@@ -140,7 +140,7 @@
     {
       "id": "integration-twitter",
       "scope": "assistant",
-      "key": "feature_flags.integration-twitter.enabled",
+      "key": "integration-twitter",
       "label": "Twitter / X Integration",
       "description": "Enable the Twitter / X OAuth setup skill for connecting to the Twitter API",
       "defaultEnabled": false
@@ -148,7 +148,7 @@
     {
       "id": "integration-github",
       "scope": "assistant",
-      "key": "feature_flags.integration-github.enabled",
+      "key": "integration-github",
       "label": "GitHub Integration",
       "description": "Enable the GitHub OAuth setup skill for connecting to GitHub",
       "defaultEnabled": false
@@ -156,7 +156,7 @@
     {
       "id": "integration-linear",
       "scope": "assistant",
-      "key": "feature_flags.integration-linear.enabled",
+      "key": "integration-linear",
       "label": "Linear Integration",
       "description": "Enable the Linear OAuth setup skill for connecting to Linear",
       "defaultEnabled": false
@@ -164,7 +164,7 @@
     {
       "id": "integration-spotify",
       "scope": "assistant",
-      "key": "feature_flags.integration-spotify.enabled",
+      "key": "integration-spotify",
       "label": "Spotify Integration",
       "description": "Enable the Spotify OAuth setup skill for connecting to the Spotify API",
       "defaultEnabled": false
@@ -172,7 +172,7 @@
     {
       "id": "integration-todoist",
       "scope": "assistant",
-      "key": "feature_flags.integration-todoist.enabled",
+      "key": "integration-todoist",
       "label": "Todoist Integration",
       "description": "Enable the Todoist OAuth setup skill for connecting to Todoist",
       "defaultEnabled": false
@@ -180,7 +180,7 @@
     {
       "id": "integration-discord",
       "scope": "assistant",
-      "key": "feature_flags.integration-discord.enabled",
+      "key": "integration-discord",
       "label": "Discord Integration",
       "description": "Enable the Discord OAuth setup skill for connecting to Discord",
       "defaultEnabled": false
@@ -188,7 +188,7 @@
     {
       "id": "integration-dropbox",
       "scope": "assistant",
-      "key": "feature_flags.integration-dropbox.enabled",
+      "key": "integration-dropbox",
       "label": "Dropbox Integration",
       "description": "Enable the Dropbox OAuth setup skill for connecting to Dropbox",
       "defaultEnabled": false
@@ -196,7 +196,7 @@
     {
       "id": "integration-asana",
       "scope": "assistant",
-      "key": "feature_flags.integration-asana.enabled",
+      "key": "integration-asana",
       "label": "Asana Integration",
       "description": "Enable the Asana OAuth setup skill for connecting to Asana",
       "defaultEnabled": false
@@ -204,7 +204,7 @@
     {
       "id": "integration-airtable",
       "scope": "assistant",
-      "key": "feature_flags.integration-airtable.enabled",
+      "key": "integration-airtable",
       "label": "Airtable Integration",
       "description": "Enable the Airtable OAuth setup skill for connecting to Airtable",
       "defaultEnabled": false
@@ -212,7 +212,7 @@
     {
       "id": "integration-hubspot",
       "scope": "assistant",
-      "key": "feature_flags.integration-hubspot.enabled",
+      "key": "integration-hubspot",
       "label": "HubSpot Integration",
       "description": "Enable the HubSpot OAuth setup skill for connecting to HubSpot CRM",
       "defaultEnabled": false
@@ -220,7 +220,7 @@
     {
       "id": "integration-figma",
       "scope": "assistant",
-      "key": "feature_flags.integration-figma.enabled",
+      "key": "integration-figma",
       "label": "Figma Integration",
       "description": "Enable the Figma OAuth setup skill for connecting to Figma",
       "defaultEnabled": false
@@ -228,7 +228,7 @@
     {
       "id": "integration-notion",
       "scope": "assistant",
-      "key": "feature_flags.integration-notion.enabled",
+      "key": "integration-notion",
       "label": "Notion Integration",
       "description": "Enable the Notion setup skill for connecting to Notion",
       "defaultEnabled": false
@@ -236,7 +236,7 @@
     {
       "id": "conversation-starters",
       "scope": "assistant",
-      "key": "feature_flags.conversation-starters.enabled",
+      "key": "conversation-starters",
       "label": "Recommended Starts",
       "description": "Show a curated row of recommended starting actions on the empty conversation page, ordered by relevance as confident first-click options",
       "defaultEnabled": true
@@ -244,7 +244,7 @@
     {
       "id": "deploy-to-vercel",
       "scope": "assistant",
-      "key": "feature_flags.deploy-to-vercel.enabled",
+      "key": "deploy-to-vercel",
       "label": "Deploy to Vercel",
       "description": "Enable the Deploy to Vercel / Publish option in the app workspace header share menu",
       "defaultEnabled": false
@@ -252,7 +252,7 @@
     {
       "id": "managed-google-oauth",
       "scope": "assistant",
-      "key": "feature_flags.managed-google-oauth.enabled",
+      "key": "managed-google-oauth",
       "label": "Managed Google OAuth",
       "description": "Show the Google OAuth service card in Models & Services settings",
       "defaultEnabled": false
@@ -260,7 +260,7 @@
     {
       "id": "settings-embedding-provider",
       "scope": "assistant",
-      "key": "feature_flags.settings-embedding-provider.enabled",
+      "key": "settings-embedding-provider",
       "label": "Embedding Provider Settings",
       "description": "Show the Embedding service card in Models & Services settings",
       "defaultEnabled": false
@@ -268,7 +268,7 @@
     {
       "id": "settings-schedules",
       "scope": "assistant",
-      "key": "feature_flags.settings-schedules.enabled",
+      "key": "settings-schedules",
       "label": "Schedules Settings Tab",
       "description": "Show the Schedules tab in Settings for viewing and managing schedules",
       "defaultEnabled": false
@@ -276,7 +276,7 @@
     {
       "id": "quick-input",
       "scope": "macos",
-      "key": "quick_input_enabled",
+      "key": "quick-input",
       "label": "Quick Input",
       "description": "Enable the Quick Input popover on right-click of the menu bar icon",
       "defaultEnabled": false
@@ -284,7 +284,7 @@
     {
       "id": "expand-completed-steps",
       "scope": "macos",
-      "key": "expand_completed_steps",
+      "key": "expand-completed-steps",
       "label": "Expand Completed Steps",
       "description": "Auto-expand completed tool call step groups instead of showing them collapsed",
       "defaultEnabled": false
@@ -292,7 +292,7 @@
     {
       "id": "inline-skill-commands",
       "scope": "assistant",
-      "key": "feature_flags.inline-skill-commands.enabled",
+      "key": "inline-skill-commands",
       "label": "Inline Skill Command Expansion",
       "description": "Enable secure inline skill command expansion via !`command` syntax, with version-pinned approval and sandboxed execution at skill load time",
       "defaultEnabled": true
@@ -300,7 +300,7 @@
     {
       "id": "channel-voice-transcription",
       "scope": "assistant",
-      "key": "feature_flags.channel-voice-transcription.enabled",
+      "key": "channel-voice-transcription",
       "label": "Channel Voice Transcription",
       "description": "Auto-transcribe voice/audio messages received from channels (Telegram, WhatsApp) before processing",
       "defaultEnabled": true
@@ -308,7 +308,7 @@
     {
       "id": "sounds",
       "scope": "assistant",
-      "key": "feature_flags.sounds.enabled",
+      "key": "sounds",
       "label": "Sounds",
       "description": "Enable the Sounds tab in Settings and all app sound playback (event sounds, random ambient sounds)",
       "defaultEnabled": true
@@ -316,7 +316,7 @@
     {
       "id": "message-tts",
       "scope": "assistant",
-      "key": "feature_flags.message-tts.enabled",
+      "key": "message-tts",
       "label": "Message Text-to-Speech",
       "description": "Show a speaker button on assistant messages to generate and play the message as audio via Fish Audio TTS",
       "defaultEnabled": false
@@ -324,7 +324,7 @@
     {
       "id": "backward-releases",
       "scope": "assistant",
-      "key": "feature_flags.backward-releases.enabled",
+      "key": "backward-releases",
       "label": "Backward Releases",
       "description": "Show older versions in the version picker, allowing rollback to previous releases",
       "defaultEnabled": true
@@ -332,7 +332,7 @@
     {
       "id": "show-background-conversations",
       "scope": "assistant",
-      "key": "feature_flags.show-background-conversations.enabled",
+      "key": "show-background-conversations",
       "label": "Show Background Conversations",
       "description": "Include background conversations (heartbeat, tasks) in the sidebar conversation list",
       "defaultEnabled": false


### PR DESCRIPTION
## Summary
- Updates all feature flag registry keys to simple kebab-case format (e.g., 'browser' instead of 'feature_flags.browser.enabled')
- Updates macOS-scope flags from snake_case to kebab-case
- Updates gateway ALLOWED_KEY_RE validation and all gateway tests

Part of plan: simplify-feature-flag-names.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
