### PR TITLE
test: update credential-watcher and index tests for generic CredentialChangeEvent

### DIFF
--- a/gateway/src/__tests__/credential-reader.test.ts
+++ b/gateway/src/__tests__/credential-reader.test.ts
@@ -26,6 +26,8 @@ mock.module("../logger.js", () => ({
 import {
   readCredential,
   readTelegramCredentials,
+  readServiceCredentials,
+  type ServiceCredentialSpec,
 } from "../credential-reader.js";
 
 // ---------------------------------------------------------------------------
@@ -271,6 +273,115 @@ describe("v1 encrypted store backward compatibility", () => {
 
     const result = await readCredential(credentialKey("test", "key"));
     expect(result).toBe("v1-secret-value");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: generic readServiceCredentials
+// ---------------------------------------------------------------------------
+
+describe("readServiceCredentials", () => {
+  const telegramSpec: ServiceCredentialSpec = {
+    service: "telegram",
+    requiredFields: ["bot_token", "webhook_secret"],
+  };
+
+  test("returns correct Record<string, string> for a valid spec", async () => {
+    writeMetadata([
+      { service: "telegram", field: "bot_token" },
+      { service: "telegram", field: "webhook_secret" },
+    ]);
+
+    writeEncryptedStore({
+      [credentialKey("telegram", "bot_token")]: "my-bot-token",
+      [credentialKey("telegram", "webhook_secret")]: "my-webhook-secret",
+    });
+
+    const result = await readServiceCredentials(telegramSpec);
+    expect(result).toEqual({
+      bot_token: "my-bot-token",
+      webhook_secret: "my-webhook-secret",
+    });
+  });
+
+  test("returns null when metadata is missing", async () => {
+    // No metadata file written at all
+    const result = await readServiceCredentials(telegramSpec);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when metadata has no entries for the service", async () => {
+    writeMetadata([{ service: "github", field: "token" }]);
+
+    const result = await readServiceCredentials(telegramSpec);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when metadata exists but encrypted values cannot be read", async () => {
+    writeMetadata([
+      { service: "telegram", field: "bot_token" },
+      { service: "telegram", field: "webhook_secret" },
+    ]);
+    // No encrypted store written — secrets are unreadable
+
+    const result = await readServiceCredentials(telegramSpec);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when only some required fields exist in metadata", async () => {
+    writeMetadata([
+      { service: "telegram", field: "bot_token" },
+      // webhook_secret is missing from metadata
+    ]);
+
+    writeEncryptedStore({
+      [credentialKey("telegram", "bot_token")]: "my-bot-token",
+      [credentialKey("telegram", "webhook_secret")]: "my-webhook-secret",
+    });
+
+    const result = await readServiceCredentials(telegramSpec);
+    expect(result).toBeNull();
+  });
+
+  test("works for a hypothetical new service spec (extensibility)", async () => {
+    const customSpec: ServiceCredentialSpec = {
+      service: "test_service",
+      requiredFields: ["api_key", "secret"],
+    };
+
+    writeMetadata([
+      { service: "test_service", field: "api_key" },
+      { service: "test_service", field: "secret" },
+    ]);
+
+    writeEncryptedStore({
+      [credentialKey("test_service", "api_key")]: "custom-api-key",
+      [credentialKey("test_service", "secret")]: "custom-secret",
+    });
+
+    const result = await readServiceCredentials(customSpec);
+    expect(result).toEqual({
+      api_key: "custom-api-key",
+      secret: "custom-secret",
+    });
+  });
+
+  test("works with v2 encrypted store", async () => {
+    writeMetadata([
+      { service: "telegram", field: "bot_token" },
+      { service: "telegram", field: "webhook_secret" },
+    ]);
+
+    writeEncryptedStoreV2({
+      [credentialKey("telegram", "bot_token")]: "v2-bot-token",
+      [credentialKey("telegram", "webhook_secret")]: "v2-webhook-secret",
+    });
+
+    const result = await readServiceCredentials(telegramSpec);
+    expect(result).toEqual({
+      bot_token: "v2-bot-token",
+      webhook_secret: "v2-webhook-secret",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Update credential-watcher test assertions to use map-based event shape (credentials Map + changedServices Set)
- Add tests for readServiceCredentials generic function including extensibility test
- Preserve existing per-service reader tests for backward compatibility

Part of plan: generic-credential-framework.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
