### PR TITLE
refactor: update macOS Swift client to use simple kebab-case feature flag keys

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -328,7 +328,7 @@ extension AppDelegate {
             return
         }
         if (event.type == .rightMouseUp || event.modifierFlags.contains(.control)),
-           MacOSClientFeatureFlagManager.shared.isEnabled("quick_input_enabled") {
+           MacOSClientFeatureFlagManager.shared.isEnabled("quick-input") {
             toggleQuickInput()
         } else {
             showStatusMenu()
@@ -377,7 +377,7 @@ extension AppDelegate {
         newChatItem.image = VIcon.messageCirclePlus.nsImage(size: 16)
         menu.addItem(newChatItem)
 
-        if MacOSClientFeatureFlagManager.shared.isEnabled("developer_menu_items_enabled") {
+        if MacOSClientFeatureFlagManager.shared.isEnabled("developer-menu-items") {
             menu.addItem(NSMenuItem.separator())
 
             let onboardingItem = NSMenuItem(title: "Replay Onboarding", action: #selector(replayOnboarding), keyEquivalent: "")

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -199,7 +199,7 @@ struct AssistantProgressView: View {
         let derived = _derived.wrappedValue
         let isComplete = derived.hasTools && derived.allComplete
         let isDenied = derived.hasDeniedToolCalls && derived.hasTools && !derived.allComplete
-        let expandFlag = MacOSClientFeatureFlagManager.shared.isEnabled("expand_completed_steps")
+        let expandFlag = MacOSClientFeatureFlagManager.shared.isEnabled("expand-completed-steps")
         let shouldAutoExpand = (isComplete || isDenied) && expandFlag
         _isExpanded = State(initialValue: shouldAutoExpand || derived.hasPendingConfirmation)
     }
@@ -374,7 +374,7 @@ struct AssistantProgressView: View {
     }
 
     private func handlePhaseChange(_ newPhase: ProgressPhase) {
-        let expandFlag = MacOSClientFeatureFlagManager.shared.isEnabled("expand_completed_steps")
+        let expandFlag = MacOSClientFeatureFlagManager.shared.isEnabled("expand-completed-steps")
         ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
             kind: .progressCardTransition,
             reason: "phase_change:\(newPhase) group=\(derived.groupId) phase=\(newPhase) expand_flag=\(expandFlag) completed=\(derived.completedToolCount)/\(derived.totalToolCount) denied=\(derived.deniedCount) pending_confirm=\(derived.hasPendingConfirmation) rehydrate=\(onRehydrate != nil)",
@@ -387,7 +387,7 @@ struct AssistantProgressView: View {
         // Auto-expand when a step group completes, if the flag is enabled
         if (newPhase == .complete || newPhase == .denied),
            !isExpanded,
-           MacOSClientFeatureFlagManager.shared.isEnabled("expand_completed_steps")
+           MacOSClientFeatureFlagManager.shared.isEnabled("expand-completed-steps")
         {
             ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
                 kind: .progressCardTransition,
@@ -438,7 +438,7 @@ struct AssistantProgressView: View {
         // expanded groups don't render with empty details.
         if !isExpanded,
            (phase == .complete || phase == .denied),
-           MacOSClientFeatureFlagManager.shared.isEnabled("expand_completed_steps")
+           MacOSClientFeatureFlagManager.shared.isEnabled("expand-completed-steps")
         {
             ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
                 kind: .progressCardTransition,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -121,7 +121,7 @@ struct SettingsPanel: View {
     @State private var bootstrapGeneration: Int = 0
     @AppStorage("connectedOrganizationId") private var connectedOrgId: String?
     private static let schedulesFeatureFlagKey = "feature_flags.settings-schedules.enabled"
-    private static let billingFeatureFlagKey = "settings_billing_enabled"
+    private static let billingFeatureFlagKey = "settings-billing"
     private static let developerFeatureFlagKey = "feature_flags.settings-developer-nav.enabled"
     private static let googleOAuthFeatureFlagKey = "feature_flags.managed-google-oauth.enabled"
     private static let embeddingProviderFeatureFlagKey = "feature_flags.settings-embedding-provider.enabled"

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -19,7 +19,7 @@ struct DrawerMenuView: View {
     private var isBillingVisible: Bool {
         let _ = bootstrapGeneration  // Force recomputation when bootstrap completes
         return authManager.isAuthenticated &&
-        MacOSClientFeatureFlagManager.shared.isEnabled("settings_billing_enabled") &&
+        MacOSClientFeatureFlagManager.shared.isEnabled("settings-billing") &&
         connectedOrgId != nil
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -11,11 +11,11 @@ struct APIKeyStepView: View {
     @State private var showContent = false
 
     private var userHostedEnabled: Bool {
-        MacOSClientFeatureFlagManager.shared.isEnabled("user_hosted_enabled")
+        MacOSClientFeatureFlagManager.shared.isEnabled("user-hosted-enabled")
     }
 
     private var platformHostedEnabled: Bool {
-        MacOSClientFeatureFlagManager.shared.isEnabled("platform_hosted_enabled")
+        MacOSClientFeatureFlagManager.shared.isEnabled("platform-hosted-enabled")
     }
 
     var body: some View {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -26,7 +26,7 @@ struct OnboardingFlowView: View {
     }()
 
     private var managedSignInEnabled: Bool {
-        MacOSClientFeatureFlagManager.shared.isEnabled("managed_sign_in_enabled")
+        MacOSClientFeatureFlagManager.shared.isEnabled("managed-sign-in")
     }
 
     private var maxOnboardingStep: Int {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -73,7 +73,7 @@ struct SettingsGeneralTab: View {
                     healthzLoaded: healthzLoaded
                 )
             }
-            if MacOSClientFeatureFlagManager.shared.isEnabled("mobile_pairing_enabled") {
+            if MacOSClientFeatureFlagManager.shared.isEnabled("mobile-pairing") {
                 mobilePairingCard
             }
             SettingsAppearanceTab(store: store)

--- a/clients/shared/Utilities/MacOSClientFeatureFlagManager.swift
+++ b/clients/shared/Utilities/MacOSClientFeatureFlagManager.swift
@@ -62,7 +62,7 @@ public final class MacOSClientFeatureFlagManager: @unchecked Sendable {
         }
     }
 
-    /// Check whether a flag is enabled by its key (e.g. "user_hosted_enabled").
+    /// Check whether a flag is enabled by its key (e.g. "user-hosted-enabled").
     /// Resolution order: override (env var / .env file / UserDefaults) -> registry defaultEnabled -> false.
     public func isEnabled(_ key: String) -> Bool {
         lock.lock()


### PR DESCRIPTION
## Summary
- Updates all macOS Swift client feature flag key references from snake_case to kebab-case
- Covers APIKeyStepView, OnboardingFlowView, AppDelegate+MenuBar, SettingsGeneralTab, AssistantProgressView, SettingsPanel, DrawerMenuView
- Updates MacOSClientFeatureFlagManager doc comment

Part of plan: simplify-feature-flag-names.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
