### PR TITLE
refactor: update all assistant feature flag keys to simple kebab-case

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flag-guard.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flag-guard.test.ts
@@ -7,11 +7,11 @@ import { describe, expect, test } from "bun:test";
  * Guard tests for assistant feature flags.
  *
  * 1. Key format validation: ensure production code uses the canonical
- *    `feature_flags.<flagId>.enabled` format, not the legacy
- *    `skills.<id>.enabled` format.
+ *    simple kebab-case format (e.g., "browser", "ces-tools"), not the
+ *    legacy `skills.<id>.enabled` format.
  *
  * 2. Declaration coverage: ensure all assistant-scope flag keys in the
- *    unified registry conform to the canonical format.
+ *    unified registry conform to the simple kebab-case format.
  *
  * See AGENTS.md "Assistant Feature Flags" for the full convention.
  */
@@ -53,7 +53,7 @@ function loadRegistry(): Registry {
   return JSON.parse(raw);
 }
 
-const CANONICAL_KEY_RE = /^feature_flags\.[a-z0-9][a-z0-9._-]*\.enabled$/;
+const CANONICAL_KEY_RE = /^[a-z0-9][a-z0-9-]*$/;
 
 /**
  * Files allowed to contain the legacy `skills.<id>.enabled` key format.
@@ -126,13 +126,13 @@ describe("assistant feature flag guard", () => {
     if (violations.length > 0) {
       const message = [
         "Found production files using the legacy `skills.<id>.enabled` key format.",
-        "New code must use the canonical format: `feature_flags.<id>.enabled`.",
+        'New code must use the canonical simple kebab-case format (e.g., "browser", "ces-tools").',
         'See AGENTS.md "Assistant Feature Flags" for the convention.',
         "",
         "Violations:",
         ...violations.map((f) => `  - ${f}`),
         "",
-        "To fix: replace `skills.<id>.enabled` with `feature_flags.<id>.enabled`.",
+        "To fix: replace `skills.<id>.enabled` with the simple kebab-case format.",
         "If backward-compat access is genuinely needed, add to LEGACY_KEY_ALLOWLIST in assistant-feature-flag-guard.test.ts.",
       ].join("\n");
 
@@ -144,7 +144,7 @@ describe("assistant feature flag guard", () => {
   // Test: unified registry key format (assistant-scope only)
   // ---------------------------------------------------------------------------
 
-  test("all assistant-scope keys in the unified registry use the canonical feature_flags.<id>.enabled format", () => {
+  test("all assistant-scope keys in the unified registry use the canonical simple kebab-case format", () => {
     const registry = loadRegistry();
     const assistantFlags = registry.flags.filter(
       (f) => f.scope === "assistant",
@@ -156,7 +156,7 @@ describe("assistant feature flag guard", () => {
     if (violations.length > 0) {
       const message = [
         "Found assistant-scope keys in the unified registry that do not match the canonical format.",
-        "Expected format: feature_flags.<flagId>.enabled",
+        'Expected format: simple kebab-case (e.g., "browser", "ces-tools")',
         "",
         "Violations:",
         ...violations.map((k) => `  - ${k}`),

--- a/assistant/src/__tests__/assistant-feature-flag-guardrails.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flag-guardrails.test.ts
@@ -1,8 +1,8 @@
 /**
  * Guard tests for assistant feature flag conventions:
  *
- * 1. Key format: all feature flag keys used in production code must follow the
- *    canonical `feature_flags.<flag_id>.enabled` format. Any remaining
+ * 1. Key format: all feature flag keys used in production code must use
+ *    simple kebab-case format (e.g., "browser", "ces-tools"). Any remaining
  *    `skills.<id>.enabled` usage outside of migration/backward-compat code is
  *    flagged — including template literal forms like `skills.${skillId}.enabled`.
  *
@@ -10,11 +10,6 @@
  *    `isAssistantFeatureFlagEnabled('<key>', ...)` in production code must be
  *    declared in the unified registry. This keeps flag usage declarative while
  *    allowing skills to exist without corresponding feature flags.
- *
- * 3. Indirect key coverage: all `feature_flags.<id>.enabled` string literals
- *    anywhere in production code (maps, constants, variables, etc.) must be
- *    declared in the unified registry. This catches indirect key patterns that
- *    Guard 2 would miss, such as flag keys stored in lookup maps or constants.
  */
 
 import { execSync } from "node:child_process";
@@ -196,82 +191,6 @@ describe("assistant feature flag declaration coverage guard", () => {
         ...undeclared.map((k) => `  - ${k}`),
         "",
         'To fix: add the missing key(s) to the unified registry with scope "assistant".',
-      ].join("\n");
-
-      expect(undeclared, message).toEqual([]);
-    }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Guard 3: Indirect key coverage — flag key literals anywhere in production code
-// ---------------------------------------------------------------------------
-
-describe("assistant feature flag indirect key coverage guard", () => {
-  test("all feature_flags.<id>.enabled string literals in production code are declared in the unified registry", () => {
-    const repoRoot = getRepoRoot();
-
-    // Load the unified registry and extract all declared keys (any scope)
-    const registry = loadRegistry();
-    const declaredKeys = new Set(registry.flags.map((f) => f.key));
-
-    // Search for any string literal matching the canonical key pattern
-    // in production .ts files under assistant/src/ and gateway/src/.
-    // This catches keys in maps, constants, variables, or any other
-    // indirect patterns that Guard 2 would miss.
-    let grepOutput = "";
-    try {
-      grepOutput = execSync(
-        `git grep -nE "feature_flags\\.[a-z0-9_-]+\\.enabled\\b" -- 'assistant/src/**/*.ts' 'gateway/src/**/*.ts'`,
-        { encoding: "utf-8", cwd: repoRoot },
-      ).trim();
-    } catch (err) {
-      // Exit code 1 means no matches — happy path
-      if ((err as { status?: number }).status === 1) {
-        return;
-      }
-      throw err;
-    }
-
-    const keyPattern = /feature_flags\.[a-z0-9_-]+\.enabled\b/g;
-    const undeclared: string[] = [];
-
-    for (const line of grepOutput.split("\n")) {
-      if (!line) continue;
-
-      // Format: "file:line:content"
-      const colonIdx = line.indexOf(":");
-      if (colonIdx === -1) continue;
-      const filePath = line.slice(0, colonIdx);
-
-      // Skip test files and persisted-data migration files (they reference retired flag keys by design)
-      if (isTestFile(filePath)) continue;
-      if (
-        filePath.includes("/workspace/migrations/") ||
-        filePath.includes("/memory/migrations/")
-      )
-        continue;
-
-      // Extract all key occurrences from this line
-      const content = line.slice(colonIdx + 1);
-      for (const match of content.matchAll(keyPattern)) {
-        const key = match[0];
-        if (!declaredKeys.has(key)) {
-          undeclared.push(`${filePath}: ${key}`);
-        }
-      }
-    }
-
-    if (undeclared.length > 0) {
-      const message = [
-        "Found feature_flags.<id>.enabled string literals in production code that are NOT declared in the unified registry.",
-        "This catches indirect flag key usage (maps, constants, variables) that the direct-call guard misses.",
-        `Registry: meta/feature-flags/feature-flag-registry.json`,
-        "",
-        "Undeclared keys:",
-        ...undeclared.map((k) => `  - ${k}`),
-        "",
-        "To fix: add the missing key(s) to the unified registry, or remove the stale reference.",
       ].join("\n");
 
       expect(undeclared, message).toEqual([]);

--- a/assistant/src/cli/commands/credential-execution.ts
+++ b/assistant/src/cli/commands/credential-execution.ts
@@ -46,8 +46,7 @@ function ensureGrantAuditEnabled(cmd: Command): boolean {
 
   writeOutput(cmd, {
     ok: false,
-    error:
-      "CES grant/audit inspection is disabled (feature_flags.ces-grant-audit.enabled is off)",
+    error: "CES grant/audit inspection is disabled (ces-grant-audit is off)",
   });
   process.exitCode = 1;
   return false;

--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -14,7 +14,7 @@
  *   4. `true`                                     (for undeclared keys)
  *
  * Key format:
- *   Canonical:  `feature_flags.<id>.enabled`
+ *   Canonical:  simple kebab-case string (e.g., "browser", "ces-tools")
  */
 
 import { existsSync, readFileSync } from "node:fs";

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-create.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-create.ts
@@ -13,7 +13,7 @@ export async function run(
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const multifileEnabled = isAssistantFeatureFlagEnabled(
-    "feature_flags.app-builder-multifile.enabled",
+    "app-builder-multifile",
     getConfig(),
   );
   const createInput: AppCreateInput = {

--- a/assistant/src/config/skill-state.ts
+++ b/assistant/src/config/skill-state.ts
@@ -17,9 +17,7 @@ export interface ResolvedSkill {
 export function skillFlagKey(
   skill: Pick<SkillSummary, "featureFlag">,
 ): string | undefined {
-  return skill.featureFlag
-    ? `feature_flags.${skill.featureFlag}.enabled`
-    : undefined;
+  return skill.featureFlag || undefined;
 }
 
 export function resolveSkillStates(

--- a/assistant/src/credential-execution/feature-gates.ts
+++ b/assistant/src/credential-execution/feature-gates.ts
@@ -5,8 +5,8 @@
  * All checks delegate to the unified feature-flag resolver so that
  * config overrides and registry defaults are respected uniformly.
  *
- * Flag keys follow the canonical `feature_flags.<id>.enabled` format
- * and are declared in `meta/feature-flags/feature-flag-registry.json`.
+ * Flag keys use simple kebab-case format (e.g., "ces-tools") and are
+ * declared in `meta/feature-flags/feature-flag-registry.json`.
  */
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
@@ -17,27 +17,23 @@ import type { AssistantConfig } from "../config/schema.js";
 // ---------------------------------------------------------------------------
 
 /** Gate for CES tool registration (credential-grant, credential-revoke, credential-list). */
-export const CES_TOOLS_FLAG_KEY = "feature_flags.ces-tools.enabled" as const;
+export const CES_TOOLS_FLAG_KEY = "ces-tools" as const;
 
 /** Gate for untrusted-agent shell lockdown when CES credentials are active. */
-export const CES_SHELL_LOCKDOWN_FLAG_KEY =
-  "feature_flags.ces-shell-lockdown.enabled" as const;
+export const CES_SHELL_LOCKDOWN_FLAG_KEY = "ces-shell-lockdown" as const;
 
 /** Gate for secure tool/command installation via CES. */
-export const CES_SECURE_INSTALL_FLAG_KEY =
-  "feature_flags.ces-secure-install.enabled" as const;
+export const CES_SECURE_INSTALL_FLAG_KEY = "ces-secure-install" as const;
 
 /** Gate for credential grant and audit inspection surfaces. */
-export const CES_GRANT_AUDIT_FLAG_KEY =
-  "feature_flags.ces-grant-audit.enabled" as const;
+export const CES_GRANT_AUDIT_FLAG_KEY = "ces-grant-audit" as const;
 
 /** Gate for managed sidecar transport in containerized environments. */
-export const CES_MANAGED_SIDECAR_FLAG_KEY =
-  "feature_flags.ces-managed-sidecar.enabled" as const;
+export const CES_MANAGED_SIDECAR_FLAG_KEY = "ces-managed-sidecar" as const;
 
 /** Gate for routing credential reads/writes through the CES process. */
 export const CES_CREDENTIAL_BACKEND_FLAG_KEY =
-  "feature_flags.ces-credential-backend.enabled" as const;
+  "ces-credential-backend" as const;
 
 // ---------------------------------------------------------------------------
 // Public API — predicate functions
@@ -84,8 +80,5 @@ export function isCesManagedSidecarEnabled(config: AssistantConfig): boolean {
 export function isCesCredentialBackendEnabled(
   config: AssistantConfig,
 ): boolean {
-  return isAssistantFeatureFlagEnabled(
-    CES_CREDENTIAL_BACKEND_FLAG_KEY,
-    config,
-  );
+  return isAssistantFeatureFlagEnabled(CES_CREDENTIAL_BACKEND_FLAG_KEY, config);
 }

--- a/assistant/src/email/feature-gate.ts
+++ b/assistant/src/email/feature-gate.ts
@@ -5,15 +5,15 @@
  * Delegates to the unified feature-flag resolver so that config overrides
  * and registry defaults are respected uniformly.
  *
- * The flag key follows the canonical `feature_flags.<id>.enabled` format
- * and is declared in `meta/feature-flags/feature-flag-registry.json`.
+ * The flag key uses simple kebab-case format and is declared in
+ * `meta/feature-flags/feature-flag-registry.json`.
  */
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import type { AssistantConfig } from "../config/schema.js";
 
 /** Gate for the entire email integration. */
-export const EMAIL_FLAG_KEY = "feature_flags.email-channel.enabled" as const;
+export const EMAIL_FLAG_KEY = "email-channel" as const;
 
 /**
  * Whether the email integration is enabled.

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -444,7 +444,7 @@ async function buildCommandCandidates(
       // through to the permissive skill_load:* allow rule.
       const config = getConfig();
       const inlineEnabled = isAssistantFeatureFlagEnabled(
-        "feature_flags.inline-skill-commands.enabled",
+        "inline-skill-commands",
         config,
       );
 
@@ -1107,7 +1107,7 @@ function skillLoadAllowlistStrategy(
     // Check whether this is a dynamic (inline-command) skill load
     const config = getConfig();
     const inlineEnabled = isAssistantFeatureFlagEnabled(
-      "feature_flags.inline-skill-commands.enabled",
+      "inline-skill-commands",
       config,
     );
 

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -1029,7 +1029,7 @@ export class RuntimeHttpServer {
           const limit = Number(url.searchParams.get("limit") ?? 50);
           const offset = Number(url.searchParams.get("offset") ?? 0);
           const includeBackground = isAssistantFeatureFlagEnabled(
-            "feature_flags.show-background-conversations.enabled",
+            "show-background-conversations",
             getConfig(),
           );
           const conversations = listConversations(

--- a/assistant/src/runtime/routes/inbound-stages/transcribe-audio.ts
+++ b/assistant/src/runtime/routes/inbound-stages/transcribe-audio.ts
@@ -15,8 +15,7 @@ import { getLogger } from "../../../util/logger.js";
 
 const log = getLogger("transcribe-audio");
 
-const VOICE_TRANSCRIPTION_FLAG_KEY =
-  "feature_flags.channel-voice-transcription.enabled" as const;
+const VOICE_TRANSCRIPTION_FLAG_KEY = "channel-voice-transcription" as const;
 
 /** Timeout for the entire transcription pipeline (all attachments). */
 const TRANSCRIPTION_TIMEOUT_MS = 30_000;

--- a/assistant/src/runtime/routes/tts-routes.ts
+++ b/assistant/src/runtime/routes/tts-routes.ts
@@ -3,7 +3,7 @@
  *
  * POST /v1/messages/:id/tts?conversationId=... — synthesize message text to audio
  *
- * Gated behind the `feature_flags.message-tts.enabled` assistant feature flag.
+ * Gated behind the `message-tts` assistant feature flag.
  * Uses Fish Audio for synthesis when configured.
  */
 
@@ -18,7 +18,7 @@ import type { RouteDefinition } from "../http-router.js";
 
 const log = getLogger("tts-routes");
 
-const MESSAGE_TTS_FLAG = "feature_flags.message-tts.enabled" as const;
+const MESSAGE_TTS_FLAG = "message-tts" as const;
 
 // ---------------------------------------------------------------------------
 // Route definitions

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -30,7 +30,7 @@ import { registerTool } from "../registry.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 
 /** Canonical feature flag key for inline skill command expansion. */
-const INLINE_COMMANDS_FLAG_KEY = "feature_flags.inline-skill-commands.enabled";
+const INLINE_COMMANDS_FLAG_KEY = "inline-skill-commands";
 
 /** Skill sources eligible for inline command expansion in v1. */
 const INLINE_COMMAND_ELIGIBLE_SOURCES = new Set([

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -89,7 +89,7 @@ export const explicitTools: Tool[] = [
 
 // ── CES tools (feature-flag gated) ──────────────────────────────────
 // Credential Execution Service tools are only registered when the
-// CES feature flag (`feature_flags.ces-tools.enabled`) is enabled.
+// CES feature flag (`ces-tools`) is enabled.
 // This list is intentionally separate from `explicitTools` so that
 // initializeTools() in registry.ts can conditionally include them.
 


### PR DESCRIPTION
## Summary
- Updates all assistant feature gate constants and inline flag key references to simple kebab-case format
- Simplifies skillFlagKey to return the featureFlag value directly (no more feature_flags.*.enabled wrapping)
- Updates guard tests: new CANONICAL_KEY_RE for kebab-case, removes Guard 3 (indirect key coverage)
- Updates doc comments across feature-gates, email gate, TTS routes, and assistant-feature-flags

Part of plan: simplify-feature-flag-names.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
