### PR TITLE
test: update assistant tests to use simple kebab-case feature flag keys

### DIFF
--- a/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
+++ b/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
@@ -84,7 +84,7 @@ describe("Dynamic Skill Authoring Workflow moved to tool descriptions", () => {
   beforeEach(() => {
     mkdirSync(TEST_DIR, { recursive: true });
     _setOverridesForTesting({
-      "feature_flags.browser.enabled": true,
+      browser: true,
     });
   });
 

--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -850,7 +850,7 @@ describe("host_bash — proxy delegation", () => {
     const { _setOverridesForTesting } =
       await import("../config/assistant-feature-flags.js");
     _setOverridesForTesting({
-      "feature_flags.ces-shell-lockdown.enabled": true,
+      "ces-shell-lockdown": true,
     });
 
     try {

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
 });
 
 const DECLARED_FLAG_ID = "contacts";
-const DECLARED_FLAG_KEY = `feature_flags.${DECLARED_FLAG_ID}.enabled`;
+const DECLARED_FLAG_KEY = DECLARED_FLAG_ID;
 const DECLARED_SKILL_ID = "contacts";
 // ---------------------------------------------------------------------------
 // Helpers
@@ -71,9 +71,7 @@ function makeSkill(
 
 describe("skillFlagKey", () => {
   test("returns canonical key when featureFlag is present", () => {
-    expect(skillFlagKey({ featureFlag: "my-flag" })).toBe(
-      "feature_flags.my-flag.enabled",
-    );
+    expect(skillFlagKey({ featureFlag: "my-flag" })).toBe("my-flag");
   });
 
   test("returns undefined when featureFlag is undefined", () => {
@@ -132,9 +130,7 @@ describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
 describe("isAssistantFeatureFlagEnabled", () => {
   test("returns true for unknown flags (open by default)", () => {
     const config = makeConfig();
-    expect(
-      isAssistantFeatureFlagEnabled("feature_flags.unknown.enabled", config),
-    ).toBe(true);
+    expect(isAssistantFeatureFlagEnabled("unknown", config)).toBe(true);
   });
 
   test("file-based override overrides registry default", () => {
@@ -152,19 +148,15 @@ describe("isAssistantFeatureFlagEnabled", () => {
   });
 
   test("respects persisted overrides for undeclared keys", () => {
-    _setOverridesForTesting({ "feature_flags.browser.enabled": false });
+    _setOverridesForTesting({ browser: false });
     const config = makeConfig();
-    expect(
-      isAssistantFeatureFlagEnabled("feature_flags.browser.enabled", config),
-    ).toBe(false);
+    expect(isAssistantFeatureFlagEnabled("browser", config)).toBe(false);
   });
 
   test("declared keys with no persisted override use registry default", () => {
     const config = makeConfig();
     // browser is declared in the registry with defaultEnabled: true
-    expect(
-      isAssistantFeatureFlagEnabled("feature_flags.browser.enabled", config),
-    ).toBe(true);
+    expect(isAssistantFeatureFlagEnabled("browser", config)).toBe(true);
   });
 });
 
@@ -176,7 +168,7 @@ describe("resolveSkillStates with feature flags", () => {
   test("flag OFF skill does not appear in resolved list", () => {
     _setOverridesForTesting({
       [DECLARED_FLAG_KEY]: false,
-      "feature_flags.browser.enabled": true,
+      browser: true,
     });
     const catalog = [
       makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID),
@@ -194,7 +186,7 @@ describe("resolveSkillStates with feature flags", () => {
   test("flag ON skill appears normally", () => {
     _setOverridesForTesting({
       [DECLARED_FLAG_KEY]: true,
-      "feature_flags.browser.enabled": true,
+      browser: true,
     });
     const catalog = [
       makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID),
@@ -259,8 +251,8 @@ describe("resolveSkillStates with feature flags", () => {
   test("multiple skills with mixed flags — persisted overrides respected", () => {
     _setOverridesForTesting({
       [DECLARED_FLAG_KEY]: false,
-      "feature_flags.browser.enabled": true,
-      "feature_flags.deploy.enabled": false,
+      browser: true,
+      deploy: false,
     });
     const catalog = [
       makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID),
@@ -319,7 +311,7 @@ describe("resolveSkillStates with frontmatter featureFlag", () => {
     // setting feature_flags.my-skill.enabled = false has no effect
     // when the skill itself does not declare a featureFlag.
     _setOverridesForTesting({
-      "feature_flags.my-skill.enabled": false,
+      "my-skill": false,
     });
     const catalog = [makeSkill("my-skill")];
     const config = makeConfig();

--- a/assistant/src/__tests__/skill-load-inline-command.test.ts
+++ b/assistant/src/__tests__/skill-load-inline-command.test.ts
@@ -212,7 +212,7 @@ describe("skill_load inline command expansion", () => {
 
     // Enable the feature flag
     _setOverridesForTesting({
-      "feature_flags.inline-skill-commands.enabled": true,
+      "inline-skill-commands": true,
     });
     testConfig.skills = { load: { extraDirs: [] } };
   });
@@ -313,7 +313,7 @@ describe("skill_load inline command expansion", () => {
   describe("feature flag disabled", () => {
     test("returns error when flag is off and skill has inline commands", async () => {
       _setOverridesForTesting({
-        "feature_flags.inline-skill-commands.enabled": false,
+        "inline-skill-commands": false,
       });
 
       writeSkill(
@@ -334,7 +334,7 @@ describe("skill_load inline command expansion", () => {
 
     test("plain skill still loads when flag is off", async () => {
       _setOverridesForTesting({
-        "feature_flags.inline-skill-commands.enabled": false,
+        "inline-skill-commands": false,
       });
 
       writeSkill(

--- a/assistant/src/__tests__/skill-load-inline-includes.test.ts
+++ b/assistant/src/__tests__/skill-load-inline-includes.test.ts
@@ -222,7 +222,7 @@ describe("skill_load inline command expansion for included skills", () => {
 
     // Enable the feature flag
     _setOverridesForTesting({
-      "feature_flags.inline-skill-commands.enabled": true,
+      "inline-skill-commands": true,
     });
     testConfig.skills = { load: { extraDirs: [] } };
   });
@@ -572,7 +572,7 @@ describe("skill_load inline command expansion for included skills", () => {
   describe("feature flag disabled for included skills", () => {
     test("skill_load returns error when child has inline commands and flag is off", async () => {
       _setOverridesForTesting({
-        "feature_flags.inline-skill-commands.enabled": false,
+        "inline-skill-commands": false,
       });
 
       writeSkill(


### PR DESCRIPTION
## Summary
- Updates all assistant test files to use simple kebab-case feature flag keys in override maps and assertions
- Covers skill-feature-flags, skill-load-inline-command, host-shell-tool, skill-load-inline-includes, and dynamic-skill-workflow-prompt tests

Part of plan: simplify-feature-flag-names.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
