### PR TITLE
docs: update skill documentation to use unified OAuth commands

### DIFF
--- a/assistant/src/config/bundled-skills/_shared/CLI_RETRIEVAL_PATTERN.md
+++ b/assistant/src/config/bundled-skills/_shared/CLI_RETRIEVAL_PATTERN.md
@@ -6,7 +6,7 @@ For account and auth workflows, prefer documented `assistant` CLI commands over
 any generic account registry:
 
 - `assistant credentials list` for discovering stored credential handles
-- `assistant oauth connections list` for discovering OAuth connection handles
+- `assistant oauth status <provider>` for discovering OAuth connection handles
 - `assistant credentials set ...` for storing new credentials
 - `assistant mcp auth <name>` when an MCP server needs browser login
 - `assistant platform status` for platform-linked deployment/auth context

--- a/skills/airtable-oauth-setup/SKILL.md
+++ b/skills/airtable-oauth-setup/SKILL.md
@@ -136,7 +136,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:airtable --client-id $(cat <<'EOF'
+    assistant oauth connect integration:airtable --client-id $(cat <<'EOF'
     <client-id>
     EOF
     )

--- a/skills/airtable-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/airtable-oauth-setup/references/path-b-manual-setup.md
@@ -122,7 +122,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:airtable --client-id $(cat <<'EOF'
+    assistant oauth connect integration:airtable --client-id $(cat <<'EOF'
     <client-id>
     EOF
     )

--- a/skills/asana-oauth-setup/SKILL.md
+++ b/skills/asana-oauth-setup/SKILL.md
@@ -120,7 +120,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:asana --client-id $(cat <<'EOF'
+    assistant oauth connect integration:asana --client-id $(cat <<'EOF'
     <client-id>
     EOF
     )

--- a/skills/asana-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/asana-oauth-setup/references/path-b-manual-setup.md
@@ -110,7 +110,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:asana --client-id $(cat <<'EOF'
+    assistant oauth connect integration:asana --client-id $(cat <<'EOF'
     <client-id>
     EOF
     )

--- a/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
+++ b/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
@@ -158,7 +158,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect <provider-key> --client-id $(cat <<'EOF'
+    assistant oauth connect <provider-key> --client-id $(cat <<'EOF'
     <client-id>
     EOF
     )

--- a/skills/discord-oauth-setup/SKILL.md
+++ b/skills/discord-oauth-setup/SKILL.md
@@ -141,7 +141,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:discord --client-id $(cat <<'EOF'
+    assistant oauth connect integration:discord --client-id $(cat <<'EOF'
     <client-id>
     EOF
     ) --scopes identify guilds guilds.members.read messages.read

--- a/skills/discord-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/discord-oauth-setup/references/path-b-manual-setup.md
@@ -120,7 +120,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:discord --client-id $(cat <<'EOF'
+    assistant oauth connect integration:discord --client-id $(cat <<'EOF'
     <client-id>
     EOF
     ) --scopes identify guilds guilds.members.read messages.read

--- a/skills/dropbox-oauth-setup/SKILL.md
+++ b/skills/dropbox-oauth-setup/SKILL.md
@@ -160,7 +160,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:dropbox --client-id $(cat <<'EOF'
+    assistant oauth connect integration:dropbox --client-id $(cat <<'EOF'
     <app-key>
     EOF
     )

--- a/skills/dropbox-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/dropbox-oauth-setup/references/path-b-manual-setup.md
@@ -124,7 +124,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:dropbox --client-id $(cat <<'EOF'
+    assistant oauth connect integration:dropbox --client-id $(cat <<'EOF'
     <app-key>
     EOF
     )

--- a/skills/figma-oauth-setup/SKILL.md
+++ b/skills/figma-oauth-setup/SKILL.md
@@ -141,7 +141,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:figma --client-id $(cat <<'EOF'
+    assistant oauth connect integration:figma --client-id $(cat <<'EOF'
     <client-id>
     EOF
     )

--- a/skills/figma-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/figma-oauth-setup/references/path-b-manual-setup.md
@@ -113,7 +113,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:figma --client-id $(cat <<'EOF'
+    assistant oauth connect integration:figma --client-id $(cat <<'EOF'
     <client-id>
     EOF
     )

--- a/skills/github-oauth-setup/SKILL.md
+++ b/skills/github-oauth-setup/SKILL.md
@@ -147,7 +147,7 @@ These scopes are passed during the authorization step below.
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:github --client-id $(cat <<'EOF'
+    assistant oauth connect integration:github --client-id $(cat <<'EOF'
     <client-id>
     EOF
     ) --scopes repo read:user notifications

--- a/skills/github-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/github-oauth-setup/references/path-b-manual-setup.md
@@ -101,7 +101,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:github --client-id $(cat <<'EOF'
+    assistant oauth connect integration:github --client-id $(cat <<'EOF'
     <client-id>
     EOF
     ) --scopes repo read:user notifications

--- a/skills/hubspot-oauth-setup/SKILL.md
+++ b/skills/hubspot-oauth-setup/SKILL.md
@@ -150,7 +150,7 @@ Then authorize:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:hubspot --client-id $(cat <<'EOF'
+    assistant oauth connect integration:hubspot --client-id $(cat <<'EOF'
     <client-id>
     EOF
     )

--- a/skills/hubspot-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/hubspot-oauth-setup/references/path-b-manual-setup.md
@@ -124,7 +124,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:hubspot --client-id $(cat <<'EOF'
+    assistant oauth connect integration:hubspot --client-id $(cat <<'EOF'
     <client-id>
     EOF
     )

--- a/skills/linear-oauth-setup/SKILL.md
+++ b/skills/linear-oauth-setup/SKILL.md
@@ -137,7 +137,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:linear --client-id $(cat <<'EOF'
+    assistant oauth connect integration:linear --client-id $(cat <<'EOF'
     <client-id>
     EOF
     )

--- a/skills/linear-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/linear-oauth-setup/references/path-b-manual-setup.md
@@ -95,7 +95,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:linear --client-id $(cat <<'EOF'
+    assistant oauth connect integration:linear --client-id $(cat <<'EOF'
     <client-id>
     EOF
     )

--- a/skills/notion-oauth-setup/references/path-b-public-oauth.md
+++ b/skills/notion-oauth-setup/references/path-b-public-oauth.md
@@ -82,7 +82,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:notion --client-id $(cat <<'EOF'
+    assistant oauth connect integration:notion --client-id $(cat <<'EOF'
     <client-id>
     EOF
     )

--- a/skills/oauth-setup/SKILL.md
+++ b/skills/oauth-setup/SKILL.md
@@ -175,7 +175,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect <provider-key> --client-id $(cat <<'EOF'
+    assistant oauth connect <provider-key> --client-id $(cat <<'EOF'
     <client-id>
     EOF
     )

--- a/skills/spotify-oauth-setup/SKILL.md
+++ b/skills/spotify-oauth-setup/SKILL.md
@@ -134,7 +134,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:spotify --client-id $(cat <<'EOF'
+    assistant oauth connect integration:spotify --client-id $(cat <<'EOF'
     <client-id>
     EOF
     )

--- a/skills/spotify-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/spotify-oauth-setup/references/path-b-manual-setup.md
@@ -101,7 +101,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:spotify --client-id $(cat <<'EOF'
+    assistant oauth connect integration:spotify --client-id $(cat <<'EOF'
     <client-id>
     EOF
     )

--- a/skills/todoist-oauth-setup/SKILL.md
+++ b/skills/todoist-oauth-setup/SKILL.md
@@ -108,7 +108,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:todoist --client-id $(cat <<'EOF'
+    assistant oauth connect integration:todoist --client-id $(cat <<'EOF'
     <client-id>
     EOF
     )

--- a/skills/todoist-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/todoist-oauth-setup/references/path-b-manual-setup.md
@@ -108,7 +108,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:todoist --client-id $(cat <<'EOF'
+    assistant oauth connect integration:todoist --client-id $(cat <<'EOF'
     <client-id>
     EOF
     )

--- a/skills/twitter-oauth-setup/SKILL.md
+++ b/skills/twitter-oauth-setup/SKILL.md
@@ -183,7 +183,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:twitter --client-id $(cat <<'EOF'
+    assistant oauth connect integration:twitter --client-id $(cat <<'EOF'
     <client-id>
     EOF
     )

--- a/skills/twitter-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/twitter-oauth-setup/references/path-b-manual-setup.md
@@ -121,7 +121,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:twitter --client-id $(cat <<'EOF'
+    assistant oauth connect integration:twitter --client-id $(cat <<'EOF'
     <client-id>
     EOF
     )


### PR DESCRIPTION
## Summary
- Update 25 skill markdown files to replace `oauth connections connect` with `oauth connect`
- Update CLI_RETRIEVAL_PATTERN.md to reference `oauth status` instead of `oauth connections list`
- Leave `oauth connections token` references unchanged (not deprecated)

Part of plan: remove-deprecated-oauth-cli.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
