### PR TITLE
fix: update remaining Swift files to use kebab-case feature flag keys

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -6,7 +6,7 @@ import UniformTypeIdentifiers
 
 extension MainWindowView {
     fileprivate static let conversationStartersFeatureFlagKey =
-        "feature_flags.conversation-starters.enabled"
+        "conversation-starters"
 
     // MARK: - Config-Driven Slot Rendering
 
@@ -378,10 +378,10 @@ extension MainWindowView {
                 Self.conversationStartersFeatureFlagKey
             )
             let showInspectButton = assistantFeatureFlagStore.isEnabled(
-                "feature_flags.settings-developer-nav.enabled"
+                "settings-developer-nav"
             )
             let isTTSEnabled = assistantFeatureFlagStore.isEnabled(
-                "feature_flags.message-tts.enabled"
+                "message-tts"
             )
             ActiveChatViewWrapper(
                 viewModel: viewModel,
@@ -811,7 +811,7 @@ struct DynamicWorkspaceWrapper: View {
     @State private var shareButtonFrame: CGRect = .zero
     @State private var isDeployToVercelEnabled = false
 
-    private static let deployToVercelFlagKey = "feature_flags.deploy-to-vercel.enabled"
+    private static let deployToVercelFlagKey = "deploy-to-vercel"
 
     /// Corner radius for the WKWebView clipping container — no rounding needed since the
     /// outer page container handles corner rounding.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -18,8 +18,8 @@ struct IntelligencePanel: View {
     @State private var cachedAssistantName: String = AssistantDisplayName.resolve(IdentityInfo.load()?.name, fallback: "Your Assistant")
     @State private var isContactsEnabled: Bool = false
     @State private var isEmailEnabled: Bool = false
-    private static let contactsFeatureFlagKey = "feature_flags.contacts.enabled"
-    private static let emailFeatureFlagKey = "feature_flags.email-channel.enabled"
+    private static let contactsFeatureFlagKey = "contacts"
+    private static let emailFeatureFlagKey = "email-channel"
 
     init(onClose: @escaping () -> Void, onInvokeSkill: ((SkillInfo) -> Void)? = nil, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient? = nil, store: SettingsStore? = nil, conversationManager: ConversationManager? = nil, showToast: ((String, ToastInfo.Style) -> Void)? = nil, initialTab: String? = nil, pendingMemoryId: Binding<String?> = .constant(nil)) {
         self.onClose = onClose

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -120,12 +120,12 @@ struct SettingsPanel: View {
     @State private var devUnlockMonitor: Any?
     @State private var bootstrapGeneration: Int = 0
     @AppStorage("connectedOrganizationId") private var connectedOrgId: String?
-    private static let schedulesFeatureFlagKey = "feature_flags.settings-schedules.enabled"
+    private static let schedulesFeatureFlagKey = "settings-schedules"
     private static let billingFeatureFlagKey = "settings_billing_enabled"
-    private static let developerFeatureFlagKey = "feature_flags.settings-developer-nav.enabled"
-    private static let googleOAuthFeatureFlagKey = "feature_flags.managed-google-oauth.enabled"
-    private static let embeddingProviderFeatureFlagKey = "feature_flags.settings-embedding-provider.enabled"
-    private static let soundsFeatureFlagKey = "feature_flags.sounds.enabled"
+    private static let developerFeatureFlagKey = "settings-developer-nav"
+    private static let googleOAuthFeatureFlagKey = "managed-google-oauth"
+    private static let embeddingProviderFeatureFlagKey = "settings-embedding-provider"
+    private static let soundsFeatureFlagKey = "sounds"
 
     var body: some View {
         VStack(spacing: 0) {

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -369,7 +369,7 @@ struct AssistantUpgradeSection: View {
         .task { await loadReleases() }
         .task {
             if let flags = try? await featureFlagClient.getFeatureFlags() {
-                backwardReleasesEnabled = flags.first(where: { $0.key == "feature_flags.backward-releases.enabled" })?.enabled ?? false
+                backwardReleasesEnabled = flags.first(where: { $0.key == "backward-releases" })?.enabled ?? false
             }
         }
         .onChange(of: currentVersion) { _, _ in

--- a/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
+++ b/clients/macos/vellum-assistant/Features/Sounds/SoundManager.swift
@@ -137,7 +137,7 @@ final class SoundManager {
 
     /// Plays the sound associated with the given event, respecting global and per-event toggles.
     func play(_ event: SoundEvent) {
-        guard AssistantFeatureFlagResolver.isEnabled("feature_flags.sounds.enabled") else { return }
+        guard AssistantFeatureFlagResolver.isEnabled("sounds") else { return }
         guard config.globalEnabled else { return }
 
         let eventConfig = config.config(for: event)

--- a/clients/macos/vellum-assistantTests/AssistantFeatureFlagResolverTests.swift
+++ b/clients/macos/vellum-assistantTests/AssistantFeatureFlagResolverTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import VellumAssistantShared
 
 final class AssistantFeatureFlagResolverTests: XCTestCase {
-    private let conversationStartersKey = "feature_flags.conversation-starters.enabled"
+    private let conversationStartersKey = "conversation-starters"
 
     private func makeRegistry(defaultEnabled: Bool) -> FeatureFlagRegistry {
         FeatureFlagRegistry(
@@ -78,7 +78,7 @@ final class AssistantFeatureFlagResolverTests: XCTestCase {
             persistedFlags: persistedFlags,
             registryDefaults: registryDefaults
         )
-        let enabled = resolved["feature_flags.unknown.enabled"] ?? true
+        let enabled = resolved["unknown"] ?? true
 
         XCTAssertTrue(enabled)
     }

--- a/clients/macos/vellum-assistantTests/AssistantProgressViewLoggingTests.swift
+++ b/clients/macos/vellum-assistantTests/AssistantProgressViewLoggingTests.swift
@@ -31,7 +31,7 @@ struct AssistantProgressViewLoggingTests {
     }
 
     /// Simulates the auto-expand diagnostic that `onAppear` would emit for a
-    /// completed step group when the `expand_completed_steps` flag is enabled.
+    /// completed step group when the `expand-completed-steps` flag is enabled.
     ///
     /// This mirrors the exact recording logic in AssistantProgressView.onAppear
     /// so that test assertions stay tightly coupled to production behavior.

--- a/clients/shared/Network/FeatureFlagClient.swift
+++ b/clients/shared/Network/FeatureFlagClient.swift
@@ -32,17 +32,10 @@ public struct AssistantFeatureFlag: Decodable, Identifiable, Sendable {
     }
 
     /// Derive a human-readable name from the flag key.
-    /// e.g. "feature_flags.browser.enabled" -> "Browser"
+    /// e.g. "settings-developer-nav" -> "Settings Developer Nav"
     public var displayName: String {
         if let label = label { return label }
-        var name = key
-        if name.hasPrefix("feature_flags.") {
-            name = String(name.dropFirst("feature_flags.".count))
-        }
-        if name.hasSuffix(".enabled") {
-            name = String(name.dropLast(".enabled".count))
-        }
-        return name
+        return key
             .replacingOccurrences(of: "_", with: " ")
             .replacingOccurrences(of: "-", with: " ")
             .replacingOccurrences(of: ".", with: " ")


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for simplify-feature-flag-names.md.

- Updates 5 Swift production files that still used old feature_flags.<id>.enabled format for assistant-scope flags
- Removes dead code in FeatureFlagClient.displayName that stripped old prefix/suffix
- Updates Swift test files to use new kebab-case keys
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
