### PR TITLE
refactor: clean up deprecated marker from connections help text

### DIFF
--- a/assistant/src/cli/commands/oauth/index.ts
+++ b/assistant/src/cli/commands/oauth/index.ts
@@ -29,7 +29,7 @@ The oauth command group manages the full OAuth lifecycle:
   request     Make authenticated HTTP requests (curl-like interface)
   providers   Protocol-level configurations (auth URLs, scopes, endpoints)
   apps        Client credentials (client ID / secret pairs)
-  connections Active token grants per provider (deprecated)
+  connections Active token grants per provider (token, ping, list, get)
 
 Providers are seeded on startup for built-in integrations. Apps and connections
 are created during the OAuth authorization flow or can be managed manually via


### PR DESCRIPTION
## Summary
- Update connections help text in `index.ts`: remove `(deprecated)` marker, list active subcommands `(token, ping, list, get)`
- `printDeprecationWarning` in `shared.ts` was NOT removed because it still has active callers: `connections token` and `connections ping` use it to warn users about the deprecated aliases (pointing them to the top-level `oauth token` and `oauth ping` commands)

Part of plan: remove-deprecated-oauth-cli.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
