### PR TITLE
fix: update remaining assistant test files to use kebab-case feature flag keys

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flag-guardrails.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flag-guardrails.test.ts
@@ -110,8 +110,8 @@ describe("assistant feature flag key format guard", () => {
     if (violations.length > 0) {
       const message = [
         "Found production TypeScript files using legacy `skills.<id>.enabled` key format.",
-        "Use the canonical `feature_flags.<id>.enabled` format instead.",
-        "Call `isAssistantFeatureFlagEnabled(`feature_flags.${skillId}.enabled`, config)` to check skill flags.",
+        "Use simple kebab-case keys instead (e.g., `contacts`, `browser`).",
+        "Call `isAssistantFeatureFlagEnabled(skillId, config)` to check skill flags.",
         "",
         "Violations:",
         ...violations.map((f) => `  - ${f}`),
@@ -144,7 +144,7 @@ describe("assistant feature flag declaration coverage guard", () => {
     // multiline regex so that calls split across lines are still caught:
     //
     //   isAssistantFeatureFlagEnabled(
-    //     'feature_flags.foo.enabled',
+    //     'browser',
     //     config,
     //   )
     //

--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -45,7 +45,7 @@ let currentConfig: Record<string, unknown> = {
 };
 
 const DECLARED_FLAG_ID = "contacts";
-const DECLARED_FLAG_KEY = `feature_flags.${DECLARED_FLAG_ID}.enabled`;
+const DECLARED_FLAG_KEY = DECLARED_FLAG_ID;
 const DECLARED_SKILL_ID = "contacts";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -201,7 +201,7 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
 
     _setOverridesForTesting({
       [DECLARED_FLAG_KEY]: false,
-      "feature_flags.browser.enabled": true,
+      browser: true,
     });
 
     currentConfig = {
@@ -286,7 +286,7 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
 
     _setOverridesForTesting({
       [DECLARED_FLAG_KEY]: false,
-      "feature_flags.email-channel.enabled": false,
+      "email-channel": false,
     });
 
     currentConfig = {
@@ -356,7 +356,7 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
       "browser",
     );
 
-    _setOverridesForTesting({ "feature_flags.browser.enabled": false });
+    _setOverridesForTesting({ browser: false });
 
     currentConfig = {
       services: {
@@ -478,21 +478,14 @@ describe("isAssistantFeatureFlagEnabled", () => {
   test("unknown flag defaults to true when no persisted override", () => {
     const config = {} as any;
 
-    expect(
-      isAssistantFeatureFlagEnabled(
-        "feature_flags.unknown-skill.enabled",
-        config,
-      ),
-    ).toBe(true);
+    expect(isAssistantFeatureFlagEnabled("unknown-skill", config)).toBe(true);
   });
 
   test("undeclared flag respects persisted override", () => {
-    _setOverridesForTesting({ "feature_flags.browser.enabled": false });
+    _setOverridesForTesting({ browser: false });
     const config = {} as any;
 
-    expect(
-      isAssistantFeatureFlagEnabled("feature_flags.browser.enabled", config),
-    ).toBe(false);
+    expect(isAssistantFeatureFlagEnabled("browser", config)).toBe(false);
   });
 });
 

--- a/assistant/src/__tests__/browser-skill-endstate.test.ts
+++ b/assistant/src/__tests__/browser-skill-endstate.test.ts
@@ -39,7 +39,7 @@ describe("browser skill migration end-state", () => {
   beforeAll(async () => {
     __resetRegistryForTesting();
     _setOverridesForTesting({
-      "feature_flags.browser.enabled": true,
+      browser: true,
     });
     await initializeTools();
   });

--- a/assistant/src/__tests__/credential-execution-feature-gates.test.ts
+++ b/assistant/src/__tests__/credential-execution-feature-gates.test.ts
@@ -94,8 +94,8 @@ const ALL_CES_PREDICATES = [
 
 describe("CES flag key format", () => {
   for (const key of ALL_CES_FLAG_KEYS) {
-    test(`${key} uses canonical feature_flags.<id>.enabled format`, () => {
-      expect(key).toMatch(/^feature_flags\.[a-z0-9][a-z0-9_-]*\.enabled$/);
+    test(`${key} uses simple kebab-case format`, () => {
+      expect(key).toMatch(/^[a-z0-9][a-z0-9-]*$/);
     });
   }
 });
@@ -177,9 +177,7 @@ describe("CES flags do not affect unrelated flags", () => {
     const config = makeConfig();
 
     // browser defaults to true in the registry and should stay true
-    expect(
-      isAssistantFeatureFlagEnabled("feature_flags.browser.enabled", config),
-    ).toBe(true);
+    expect(isAssistantFeatureFlagEnabled("browser", config)).toBe(true);
   });
 
   test("enabling all CES flags does not change contacts flag (defaultEnabled: true)", () => {
@@ -191,8 +189,6 @@ describe("CES flags do not affect unrelated flags", () => {
     const config = makeConfig();
 
     // contacts defaults to true in the registry and should stay true
-    expect(
-      isAssistantFeatureFlagEnabled("feature_flags.contacts.enabled", config),
-    ).toBe(true);
+    expect(isAssistantFeatureFlagEnabled("contacts", config)).toBe(true);
   });
 });

--- a/assistant/src/__tests__/credential-execution-managed-contract.test.ts
+++ b/assistant/src/__tests__/credential-execution-managed-contract.test.ts
@@ -453,7 +453,7 @@ describe("feature-flag rollback safety", () => {
 
   test("managed sidecar flag can be explicitly enabled", () => {
     _setOverridesForTesting({
-      "feature_flags.ces-managed-sidecar.enabled": true,
+      "ces-managed-sidecar": true,
     });
     const config = makeConfig();
     expect(isCesManagedSidecarEnabled(config)).toBe(true);
@@ -461,7 +461,7 @@ describe("feature-flag rollback safety", () => {
 
   test("managed sidecar flag can be explicitly disabled", () => {
     _setOverridesForTesting({
-      "feature_flags.ces-managed-sidecar.enabled": false,
+      "ces-managed-sidecar": false,
     });
     const config = makeConfig();
     expect(isCesManagedSidecarEnabled(config)).toBe(false);
@@ -469,7 +469,7 @@ describe("feature-flag rollback safety", () => {
 
   test("enabling managed sidecar does not enable CES tools", () => {
     _setOverridesForTesting({
-      "feature_flags.ces-managed-sidecar.enabled": true,
+      "ces-managed-sidecar": true,
     });
     const config = makeConfig();
     // CES tools flag should remain independently controlled
@@ -478,8 +478,8 @@ describe("feature-flag rollback safety", () => {
 
   test("disabling managed sidecar does not affect other CES flags", () => {
     _setOverridesForTesting({
-      "feature_flags.ces-managed-sidecar.enabled": false,
-      "feature_flags.ces-tools.enabled": true,
+      "ces-managed-sidecar": false,
+      "ces-tools": true,
     });
     const config = makeConfig();
     expect(isCesToolsEnabled(config)).toBe(true);
@@ -493,7 +493,7 @@ describe("feature-flag rollback safety", () => {
 describe("process manager config wiring", () => {
   test("CesProcessManagerConfig accepts assistantConfig for flag gating", () => {
     _setOverridesForTesting({
-      "feature_flags.ces-managed-sidecar.enabled": true,
+      "ces-managed-sidecar": true,
     });
     const config: CesProcessManagerConfig = {
       assistantConfig: makeConfig(),
@@ -511,7 +511,7 @@ describe("process manager config wiring", () => {
 
   test("when flag is off, managed discovery is skipped", () => {
     _setOverridesForTesting({
-      "feature_flags.ces-managed-sidecar.enabled": false,
+      "ces-managed-sidecar": false,
     });
     const config: CesProcessManagerConfig = {
       assistantConfig: makeConfig(),
@@ -528,7 +528,7 @@ describe("process manager config wiring", () => {
 describe("non-CES internal consumers intact when flag is off", () => {
   test("existing non-agent flows are unaffected by managed sidecar flag", () => {
     _setOverridesForTesting({
-      "feature_flags.ces-managed-sidecar.enabled": false,
+      "ces-managed-sidecar": false,
     });
     const config = makeConfig();
     expect(isCesManagedSidecarEnabled(config)).toBe(false);

--- a/assistant/src/__tests__/inline-skill-load-permissions.test.ts
+++ b/assistant/src/__tests__/inline-skill-load-permissions.test.ts
@@ -2,7 +2,7 @@
  * Tests for inline-command skill load permission handling.
  *
  * When a skill contains inline command expansions (!\`...\`) and the
- * feature_flags.inline-skill-commands.enabled flag is on, the permission
+ * inline-skill-commands flag is on, the permission
  * system must:
  *
  * 1. Emit skill_load_dynamic:<id>@<hash> / skill_load_dynamic:<id> candidates
@@ -117,7 +117,7 @@ describe("inline-command skill_load permissions", () => {
     testConfig.permissions = { mode: "workspace" };
     testConfig.skills = { load: { extraDirs: [] } };
     _setOverridesForTesting({
-      "feature_flags.inline-skill-commands.enabled": true,
+      "inline-skill-commands": true,
     });
     try {
       rmSync(join(testDir, "protected", "trust.json"));
@@ -351,7 +351,7 @@ describe("inline-command skill_load permissions", () => {
 
       // Disable the feature flag
       _setOverridesForTesting({
-        "feature_flags.inline-skill-commands.enabled": false,
+        "inline-skill-commands": false,
       });
 
       const result = await check(

--- a/assistant/src/__tests__/skill-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags-integration.test.ts
@@ -137,7 +137,7 @@ describe("frontmatter feature-flag integration", () => {
     expect(skill!.featureFlag).toBe("contacts");
 
     const key = skillFlagKey(skill!);
-    expect(key).toBe("feature_flags.contacts.enabled");
+    expect(key).toBe("contacts");
   });
 
   test("skillFlagKey returns undefined for skill without feature-flag", () => {
@@ -162,7 +162,7 @@ describe("frontmatter feature-flag integration", () => {
 
   test("resolveSkillStates includes skill with featureFlag when flag is ON", () => {
     _setOverridesForTesting({
-      "feature_flags.contacts.enabled": true,
+      contacts: true,
     });
     const skill = buildSkillSummary("contacts", SKILL_MD_WITH_FLAG)!;
     const config = makeConfig();
@@ -176,7 +176,7 @@ describe("frontmatter feature-flag integration", () => {
     const skill = buildSkillSummary("plain-skill", SKILL_MD_WITHOUT_FLAG)!;
     // Even with an explicit false override for this skill ID, it should pass through
     _setOverridesForTesting({
-      "feature_flags.plain-skill.enabled": false,
+      "plain-skill": false,
     });
     const config = makeConfig();
 
@@ -200,7 +200,7 @@ describe("frontmatter feature-flag integration", () => {
 
     // Step 3: Derive the flag key
     const key = skillFlagKey(skill);
-    expect(key).toBe("feature_flags.contacts.enabled");
+    expect(key).toBe("contacts");
 
     // Step 4: Check flag state — "contacts" has defaultEnabled: true in registry
     const configDefault = makeConfig();

--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -17,7 +17,7 @@ const TEST_DIR = join(
 let currentConfig: Record<string, unknown> = {};
 
 const DECLARED_SKILL_ID = "contacts";
-const DECLARED_FLAG_KEY = "feature_flags.contacts.enabled";
+const DECLARED_FLAG_KEY = "contacts";
 
 const platformOverrides: Record<string, (...args: unknown[]) => unknown> = {
   getRootDir: () => TEST_DIR,

--- a/assistant/src/__tests__/skill-memory.test.ts
+++ b/assistant/src/__tests__/skill-memory.test.ts
@@ -472,8 +472,7 @@ describe("seedCatalogSkillMemories", () => {
     mockResolveCatalog = async () => skills;
 
     // Disable the feature flag for the flagged skill
-    mockIsFeatureFlagEnabled = (key: string) =>
-      key !== "feature_flags.my_gated_feature.enabled";
+    mockIsFeatureFlagEnabled = (key: string) => key !== "my_gated_feature";
 
     await seedCatalogSkillMemories();
 
@@ -519,8 +518,7 @@ describe("seedCatalogSkillMemories", () => {
     expect(beforeItems.every((i) => i.status === "active")).toBe(true);
 
     // Now disable the flag — the flagged skill should be pruned
-    mockIsFeatureFlagEnabled = (key: string) =>
-      key !== "feature_flags.my_gated_feature.enabled";
+    mockIsFeatureFlagEnabled = (key: string) => key !== "my_gated_feature";
     await seedCatalogSkillMemories();
 
     const afterItems = db

--- a/assistant/src/__tests__/skill-projection-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-projection-feature-flag.test.ts
@@ -22,7 +22,7 @@ let mockSkillRefCount: Map<string, number> = new Map();
 
 let currentConfig: Record<string, unknown> = {};
 const DECLARED_SKILL_ID = "contacts";
-const DECLARED_FLAG_KEY = "feature_flags.contacts.enabled";
+const DECLARED_FLAG_KEY = "contacts";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -40,9 +40,7 @@ mock.module("../config/loader.js", () => ({
 
 mock.module("../config/skill-state.js", () => ({
   skillFlagKey: (skill: { featureFlag?: string }) =>
-    skill.featureFlag
-      ? `feature_flags.${skill.featureFlag}.enabled`
-      : undefined,
+    skill.featureFlag || undefined,
 }));
 
 // Mock assistant-feature-flags to avoid loading the real module (which

--- a/assistant/src/__tests__/vellum-self-knowledge-inline-command.test.ts
+++ b/assistant/src/__tests__/vellum-self-knowledge-inline-command.test.ts
@@ -226,7 +226,7 @@ describe("vellum-self-knowledge inline command expansion", () => {
 
     // Enable the feature flag via protected directory override
     _setOverridesForTesting({
-      "feature_flags.inline-skill-commands.enabled": true,
+      "inline-skill-commands": true,
     });
     testConfig.skills = { load: { extraDirs: [] } };
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for simplify-feature-flag-names.md.

- Updates 10 assistant test files that still used old feature_flags.<id>.enabled format
- Updates Guard 1 error message in assistant-feature-flag-guardrails.test.ts to reference kebab-case
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
