### PR TITLE
feat: add `assistant oauth mode` command for getting/setting OAuth mode

### DIFF
--- a/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
@@ -1,0 +1,644 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockGetProvider: (
+  key: string,
+) => Record<string, unknown> | undefined = () => undefined;
+
+let mockListActiveConnectionsByProvider: (
+  providerKey: string,
+) => Array<Record<string, unknown>> = () => [];
+
+let mockGetManagedServiceConfigKey: (key: string) => string | null = () => null;
+
+let mockPlatformClientResult: Record<string, unknown> | null = null;
+let mockPlatformFetchResults: Array<{
+  ok: boolean;
+  status: number;
+  body: unknown;
+}> = [];
+let mockPlatformFetchCallIndex = 0;
+
+let mockRawConfig: Record<string, unknown> = {};
+let mockSaveRawConfigCalls: Array<Record<string, unknown>> = [];
+let mockSetNestedValueCalls: Array<{
+  obj: Record<string, unknown>;
+  path: string;
+  value: unknown;
+}> = [];
+
+let mockConfigServices: Record<string, unknown> = {};
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../../config/loader.js", () => ({
+  getConfig: () => ({ services: mockConfigServices }),
+  loadRawConfig: () => mockRawConfig,
+  saveRawConfig: (config: Record<string, unknown>) => {
+    mockSaveRawConfigCalls.push(structuredClone(config));
+  },
+  setNestedValue: (
+    obj: Record<string, unknown>,
+    path: string,
+    value: unknown,
+  ) => {
+    mockSetNestedValueCalls.push({ obj, path, value });
+    // Actually set the value so the mock raw config is mutated
+    const keys = path.split(".");
+    let current: Record<string, unknown> = obj;
+    for (let i = 0; i < keys.length - 1; i++) {
+      const key = keys[i];
+      if (current[key] == null || typeof current[key] !== "object") {
+        current[key] = {};
+      }
+      current = current[key] as Record<string, unknown>;
+    }
+    current[keys[keys.length - 1]] = value;
+  },
+  API_KEY_PROVIDERS: [],
+}));
+
+mock.module("../../../../oauth/oauth-store.js", () => ({
+  getProvider: (key: string) => mockGetProvider(key),
+  listActiveConnectionsByProvider: (providerKey: string) =>
+    mockListActiveConnectionsByProvider(providerKey),
+  listConnections: () => [],
+  getConnection: () => undefined,
+  getConnectionByProvider: () => undefined,
+  getActiveConnection: () => undefined,
+  disconnectOAuthProvider: async () => "not-found" as const,
+  upsertApp: async () => ({}),
+  getApp: () => undefined,
+  getAppByProviderAndClientId: () => undefined,
+  getMostRecentAppByProvider: () => undefined,
+  listApps: () => [],
+  deleteApp: async () => false,
+  listProviders: () => [],
+  registerProvider: () => ({}),
+  seedProviders: () => {},
+  isProviderConnected: () => false,
+  createConnection: () => ({}),
+  updateConnection: () => ({}),
+  deleteConnection: () => false,
+}));
+
+mock.module("../../../../oauth/provider-behaviors.js", () => ({
+  resolveService: (service: string) => {
+    const aliases: Record<string, string> = {
+      gmail: "integration:google",
+      google: "integration:google",
+      slack: "integration:slack",
+    };
+    if (aliases[service]) return aliases[service];
+    if (!service.includes(":")) return `integration:${service}`;
+    return service;
+  },
+  getProviderBehavior: () => undefined,
+}));
+
+mock.module("../../../../platform/client.js", () => ({
+  VellumPlatformClient: {
+    create: async () => mockPlatformClientResult,
+  },
+}));
+
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+mock.module("../../../lib/daemon-credential-client.js", () => ({
+  getSecureKeyViaDaemon: async () => undefined,
+  deleteSecureKeyViaDaemon: async () => "not-found" as const,
+}));
+
+// Mock shared.js helpers
+mock.module("../shared.js", () => ({
+  resolveService: (service: string) => {
+    const aliases: Record<string, string> = {
+      gmail: "integration:google",
+      google: "integration:google",
+      slack: "integration:slack",
+    };
+    if (aliases[service]) return aliases[service];
+    if (!service.includes(":")) return `integration:${service}`;
+    return service;
+  },
+  isManagedMode: () => false,
+  getManagedServiceConfigKey: (key: string) =>
+    mockGetManagedServiceConfigKey(key),
+  requirePlatformClient: async (_cmd: Command) => {
+    if (
+      !mockPlatformClientResult ||
+      !(mockPlatformClientResult as Record<string, unknown>).platformAssistantId
+    ) {
+      process.exitCode = 1;
+      process.stdout.write(
+        JSON.stringify({
+          ok: false,
+          error:
+            "Platform prerequisites not met (not logged in or missing assistant ID)",
+        }) + "\n",
+      );
+      return null;
+    }
+    return {
+      platformAssistantId: (mockPlatformClientResult as Record<string, unknown>)
+        .platformAssistantId,
+      fetch: async (): Promise<Response> => {
+        const idx = mockPlatformFetchCallIndex++;
+        const result = mockPlatformFetchResults[idx] ?? {
+          ok: false,
+          status: 500,
+          body: "mock not configured",
+        };
+        return {
+          ok: result.ok,
+          status: result.status,
+          json: async () => result.body,
+          text: async () =>
+            typeof result.body === "string"
+              ? result.body
+              : JSON.stringify(result.body),
+        } as unknown as Response;
+      },
+    };
+  },
+  fetchActiveConnections: async (
+    _client: Record<string, unknown>,
+    _provider: string,
+    _cmd: Command,
+    _options?: { silent?: boolean },
+  ): Promise<Array<Record<string, unknown>> | null> => {
+    const idx = mockPlatformFetchCallIndex++;
+    const result = mockPlatformFetchResults[idx];
+    if (!result) return [];
+    if (!result.ok) return null;
+    return result.body as Array<Record<string, unknown>>;
+  },
+  toBareProvider: (provider: string): string =>
+    provider.startsWith("integration:")
+      ? provider.slice("integration:".length)
+      : provider,
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+const { registerModeCommand } = await import("../mode.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((chunk: unknown) => {
+    stderrChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.option("--json", "JSON output");
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerModeCommand(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return {
+    exitCode,
+    stdout: stdoutChunks.join(""),
+    stderr: stderrChunks.join(""),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth mode", () => {
+  beforeEach(() => {
+    mockGetProvider = () => undefined;
+    mockListActiveConnectionsByProvider = () => [];
+    mockGetManagedServiceConfigKey = () => null;
+    mockPlatformClientResult = null;
+    mockPlatformFetchResults = [];
+    mockPlatformFetchCallIndex = 0;
+    mockRawConfig = {};
+    mockSaveRawConfigCalls = [];
+    mockSetNestedValueCalls = [];
+    mockConfigServices = {};
+    process.exitCode = 0;
+  });
+
+  // =========================================================================
+  // Get mode
+  // =========================================================================
+
+  describe("get mode", () => {
+    test("unknown provider returns error", async () => {
+      mockGetProvider = () => undefined;
+
+      const { exitCode, stdout } = await runCommand([
+        "mode",
+        "nonexistent",
+        "--json",
+      ]);
+      expect(exitCode).toBe(1);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("Unknown provider");
+      expect(parsed.error).toContain("providers list");
+    });
+
+    test("provider alias resolution: gmail resolves to integration:google", async () => {
+      let capturedProviderKey: string | undefined;
+
+      mockGetProvider = (key: string) => {
+        capturedProviderKey = key;
+        return {
+          providerKey: key,
+          managedServiceConfigKey: "google-oauth",
+        };
+      };
+      mockGetManagedServiceConfigKey = () => "google-oauth";
+      mockConfigServices = {
+        "google-oauth": { mode: "managed" },
+      };
+
+      await runCommand(["mode", "gmail", "--json"]);
+      expect(capturedProviderKey).toBe("integration:google");
+    });
+
+    test("provider without managedServiceConfigKey returns your-own with managedModeSupported: false", async () => {
+      mockGetProvider = () => ({
+        providerKey: "integration:slack",
+        managedServiceConfigKey: null,
+      });
+      mockGetManagedServiceConfigKey = () => null;
+
+      const { exitCode, stdout } = await runCommand([
+        "mode",
+        "slack",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.provider).toBe("integration:slack");
+      expect(parsed.mode).toBe("your-own");
+      expect(parsed.managedModeSupported).toBe(false);
+    });
+
+    test("provider in managed mode returns mode: managed with managedModeSupported: true", async () => {
+      mockGetProvider = () => ({
+        providerKey: "integration:google",
+        managedServiceConfigKey: "google-oauth",
+      });
+      mockGetManagedServiceConfigKey = () => "google-oauth";
+      mockConfigServices = {
+        "google-oauth": { mode: "managed" },
+      };
+
+      const { exitCode, stdout } = await runCommand([
+        "mode",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.mode).toBe("managed");
+      expect(parsed.managedModeSupported).toBe(true);
+    });
+
+    test("provider in your-own mode returns mode: your-own with managedModeSupported: true", async () => {
+      mockGetProvider = () => ({
+        providerKey: "integration:google",
+        managedServiceConfigKey: "google-oauth",
+      });
+      mockGetManagedServiceConfigKey = () => "google-oauth";
+      mockConfigServices = {
+        "google-oauth": { mode: "your-own" },
+      };
+
+      const { exitCode, stdout } = await runCommand([
+        "mode",
+        "google",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.mode).toBe("your-own");
+      expect(parsed.managedModeSupported).toBe(true);
+    });
+  });
+
+  // =========================================================================
+  // Set mode
+  // =========================================================================
+
+  describe("set mode", () => {
+    test("invalid mode value returns error listing valid values", async () => {
+      mockGetProvider = () => ({
+        providerKey: "integration:google",
+        managedServiceConfigKey: "google-oauth",
+      });
+      mockGetManagedServiceConfigKey = () => "google-oauth";
+
+      const { exitCode, stdout } = await runCommand([
+        "mode",
+        "google",
+        "--set",
+        "invalid",
+        "--json",
+      ]);
+      expect(exitCode).toBe(1);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("invalid");
+      expect(parsed.error).toContain("managed");
+      expect(parsed.error).toContain("your-own");
+    });
+
+    test("provider without managedServiceConfigKey returns error about managed mode not available", async () => {
+      mockGetProvider = () => ({
+        providerKey: "integration:slack",
+        managedServiceConfigKey: null,
+      });
+      mockGetManagedServiceConfigKey = () => null;
+
+      const { exitCode, stdout } = await runCommand([
+        "mode",
+        "slack",
+        "--set",
+        "managed",
+        "--json",
+      ]);
+      expect(exitCode).toBe(1);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("Managed mode is not available");
+      expect(parsed.error).toContain("integration:slack");
+    });
+
+    test("set to same mode returns changed: false", async () => {
+      mockGetProvider = () => ({
+        providerKey: "integration:google",
+        managedServiceConfigKey: "google-oauth",
+      });
+      mockGetManagedServiceConfigKey = () => "google-oauth";
+      mockConfigServices = {
+        "google-oauth": { mode: "managed" },
+      };
+
+      const { exitCode, stdout } = await runCommand([
+        "mode",
+        "google",
+        "--set",
+        "managed",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.mode).toBe("managed");
+      expect(parsed.changed).toBe(false);
+    });
+
+    test("switch managed -> your-own with active managed connections and no BYO connections includes hint", async () => {
+      mockGetProvider = () => ({
+        providerKey: "integration:google",
+        managedServiceConfigKey: "google-oauth",
+      });
+      mockGetManagedServiceConfigKey = () => "google-oauth";
+      mockConfigServices = {
+        "google-oauth": { mode: "managed" },
+      };
+      mockRawConfig = { services: { "google-oauth": { mode: "managed" } } };
+
+      // Platform has active connections (old mode = managed)
+      mockPlatformClientResult = { platformAssistantId: "asst-123" };
+      mockPlatformFetchResults = [
+        {
+          ok: true,
+          status: 200,
+          body: [{ id: "conn-1", account_label: "user@gmail.com" }],
+        },
+      ];
+
+      // No BYO connections (new mode = your-own)
+      mockListActiveConnectionsByProvider = () => [];
+
+      const { exitCode, stdout } = await runCommand([
+        "mode",
+        "google",
+        "--set",
+        "your-own",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.mode).toBe("your-own");
+      expect(parsed.changed).toBe(true);
+      expect(parsed.hint).toContain("No active connections");
+      expect(parsed.hint).toContain("your-own");
+      expect(parsed.hint).toContain("connect");
+    });
+
+    test("switch your-own -> managed with active BYO connections and no managed connections includes hint", async () => {
+      mockGetProvider = () => ({
+        providerKey: "integration:google",
+        managedServiceConfigKey: "google-oauth",
+      });
+      mockGetManagedServiceConfigKey = () => "google-oauth";
+      mockConfigServices = {
+        "google-oauth": { mode: "your-own" },
+      };
+      mockRawConfig = { services: { "google-oauth": { mode: "your-own" } } };
+
+      // BYO has active connections (old mode = your-own)
+      mockListActiveConnectionsByProvider = () => [
+        {
+          id: "conn-local-1",
+          providerKey: "integration:google",
+          status: "active",
+        },
+      ];
+
+      // Platform has no connections (new mode = managed)
+      mockPlatformClientResult = { platformAssistantId: "asst-123" };
+      mockPlatformFetchResults = [{ ok: true, status: 200, body: [] }];
+
+      const { exitCode, stdout } = await runCommand([
+        "mode",
+        "google",
+        "--set",
+        "managed",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.mode).toBe("managed");
+      expect(parsed.changed).toBe(true);
+      expect(parsed.hint).toContain("No active connections");
+      expect(parsed.hint).toContain("managed");
+      expect(parsed.hint).toContain("connect");
+    });
+
+    test("switch mode with connections on both sides has no hint", async () => {
+      mockGetProvider = () => ({
+        providerKey: "integration:google",
+        managedServiceConfigKey: "google-oauth",
+      });
+      mockGetManagedServiceConfigKey = () => "google-oauth";
+      mockConfigServices = {
+        "google-oauth": { mode: "managed" },
+      };
+      mockRawConfig = { services: { "google-oauth": { mode: "managed" } } };
+
+      // Platform has active connections (old mode = managed)
+      mockPlatformClientResult = { platformAssistantId: "asst-123" };
+      mockPlatformFetchResults = [
+        {
+          ok: true,
+          status: 200,
+          body: [{ id: "conn-1", account_label: "user@gmail.com" }],
+        },
+      ];
+
+      // BYO also has connections (new mode = your-own)
+      mockListActiveConnectionsByProvider = () => [
+        {
+          id: "conn-local-1",
+          providerKey: "integration:google",
+          status: "active",
+        },
+      ];
+
+      const { exitCode, stdout } = await runCommand([
+        "mode",
+        "google",
+        "--set",
+        "your-own",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.changed).toBe(true);
+      expect(parsed.hint).toBeUndefined();
+    });
+
+    test("switch mode with no connections on either side has no hint", async () => {
+      mockGetProvider = () => ({
+        providerKey: "integration:google",
+        managedServiceConfigKey: "google-oauth",
+      });
+      mockGetManagedServiceConfigKey = () => "google-oauth";
+      mockConfigServices = {
+        "google-oauth": { mode: "managed" },
+      };
+      mockRawConfig = { services: { "google-oauth": { mode: "managed" } } };
+
+      // No platform connections
+      mockPlatformClientResult = { platformAssistantId: "asst-123" };
+      mockPlatformFetchResults = [{ ok: true, status: 200, body: [] }];
+
+      // No BYO connections
+      mockListActiveConnectionsByProvider = () => [];
+
+      const { exitCode, stdout } = await runCommand([
+        "mode",
+        "google",
+        "--set",
+        "your-own",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.changed).toBe(true);
+      expect(parsed.hint).toBeUndefined();
+    });
+
+    test("saveRawConfig is called with the correct nested path", async () => {
+      mockGetProvider = () => ({
+        providerKey: "integration:google",
+        managedServiceConfigKey: "google-oauth",
+      });
+      mockGetManagedServiceConfigKey = () => "google-oauth";
+      mockConfigServices = {
+        "google-oauth": { mode: "managed" },
+      };
+      mockRawConfig = { services: { "google-oauth": { mode: "managed" } } };
+
+      // No platform client — skip connection checking
+      mockPlatformClientResult = null;
+      mockListActiveConnectionsByProvider = () => [];
+
+      await runCommand(["mode", "google", "--set", "your-own", "--json"]);
+
+      // Verify setNestedValue was called with correct path and value
+      expect(mockSetNestedValueCalls.length).toBeGreaterThanOrEqual(1);
+      const setCall = mockSetNestedValueCalls[0];
+      expect(setCall.path).toBe("services.google-oauth.mode");
+      expect(setCall.value).toBe("your-own");
+
+      // Verify saveRawConfig was called
+      expect(mockSaveRawConfigCalls.length).toBe(1);
+    });
+  });
+});

--- a/assistant/src/cli/commands/oauth/index.ts
+++ b/assistant/src/cli/commands/oauth/index.ts
@@ -4,6 +4,7 @@ import { registerAppCommands } from "./apps.js";
 import { registerConnectCommand } from "./connect.js";
 import { registerConnectionCommands } from "./connections.js";
 import { registerDisconnectCommand } from "./disconnect.js";
+import { registerModeCommand } from "./mode.js";
 import { registerPingCommand } from "./ping.js";
 import { registerProviderCommands } from "./providers.js";
 import { registerRequestCommand } from "./request.js";
@@ -24,6 +25,7 @@ The oauth command group manages the full OAuth lifecycle:
   connect     Initiate an OAuth flow for a provider (managed or BYO)
   disconnect  Disconnect an OAuth provider
   status      Show OAuth connection status for a provider
+  mode        Get or set OAuth mode (managed vs your-own) for a provider
   token       Print a valid OAuth access token (BYO providers only)
   ping        Verify an OAuth token is valid by hitting the provider's health-check endpoint
   request     Make authenticated HTTP requests (curl-like interface)
@@ -89,6 +91,12 @@ Examples:
   // ---------------------------------------------------------------------------
 
   registerStatusCommand(oauth);
+
+  // ---------------------------------------------------------------------------
+  // mode — get or set OAuth mode (managed vs your-own) for a provider
+  // ---------------------------------------------------------------------------
+
+  registerModeCommand(oauth);
 
   // ---------------------------------------------------------------------------
   // ping — unified ping command (auto-detects managed vs BYO)

--- a/assistant/src/cli/commands/oauth/mode.ts
+++ b/assistant/src/cli/commands/oauth/mode.ts
@@ -1,0 +1,242 @@
+import type { Command } from "commander";
+
+import {
+  getConfig,
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "../../../config/loader.js";
+import type { Services } from "../../../config/schemas/services.js";
+import {
+  getProvider,
+  listActiveConnectionsByProvider,
+} from "../../../oauth/oauth-store.js";
+import { VellumPlatformClient } from "../../../platform/client.js";
+import { getCliLogger } from "../../logger.js";
+import { shouldOutputJson, writeOutput } from "../../output.js";
+import {
+  fetchActiveConnections,
+  getManagedServiceConfigKey,
+  resolveService,
+  toBareProvider,
+} from "./shared.js";
+
+/**
+ * Best-effort helper to count active platform connections for a provider.
+ * Returns 0 if the platform client cannot be created or the fetch fails.
+ *
+ * Uses `VellumPlatformClient.create()` directly (instead of the error-writing
+ * `requirePlatformClient`) so that a missing platform session doesn't pollute
+ * command output or set a non-zero exit code.
+ */
+async function countManagedConnections(
+  providerKey: string,
+  cmd: Command,
+): Promise<number> {
+  try {
+    const client = await VellumPlatformClient.create();
+    if (!client || !client.platformAssistantId) return 0;
+    const entries = await fetchActiveConnections(client, providerKey, cmd, {
+      silent: true,
+    });
+    return entries?.length ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+const log = getCliLogger("cli");
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+export function registerModeCommand(oauth: Command): void {
+  oauth
+    .command("mode <provider>")
+    .description("Get or set the OAuth mode for a provider")
+    .option(
+      "--set <mode>",
+      'Set the mode to "managed" (platform-handled credentials) or "your-own" (bring-your-own client ID and secret). Omit to show the current mode.',
+    )
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  provider   Provider key, alias, or ID (e.g. google, integration:google).
+             Run "assistant oauth providers list" to see available providers.
+
+Options:
+  --set <mode>   Set the mode to "managed" (platform-handled credentials) or
+                 "your-own" (bring-your-own client ID and secret). Omit to
+                 show the current mode.
+
+Modes:
+  managed    OAuth credentials are managed by the Vellum platform. The
+             assistant connects via a platform-hosted authorization flow.
+             No local client ID or secret is needed.
+  your-own   You supply your own OAuth app credentials (client ID and
+             secret). The assistant runs the OAuth flow locally.
+
+Examples:
+  $ assistant oauth mode google
+  $ assistant oauth mode google --set your-own
+  $ assistant oauth mode google --set managed`,
+    )
+    .action(async (provider: string, opts: { set?: string }, cmd: Command) => {
+      try {
+        // -----------------------------------------------------------------
+        // Resolve + validate provider
+        // -----------------------------------------------------------------
+        const providerKey = resolveService(provider);
+        const providerRow = getProvider(providerKey);
+
+        if (!providerRow) {
+          writeOutput(cmd, {
+            ok: false,
+            error:
+              `Unknown provider "${provider}". ` +
+              `Run 'assistant oauth providers list' to see available providers.`,
+          });
+          process.exitCode = 1;
+          return;
+        }
+
+        const managedKey = getManagedServiceConfigKey(providerKey);
+
+        // -----------------------------------------------------------------
+        // GET mode (no --set flag)
+        // -----------------------------------------------------------------
+        if (opts.set === undefined) {
+          if (managedKey === null) {
+            // Provider has no managedServiceConfigKey
+            if (shouldOutputJson(cmd)) {
+              writeOutput(cmd, {
+                ok: true,
+                provider: providerKey,
+                mode: "your-own",
+                managedModeSupported: false,
+              });
+            } else {
+              log.info(
+                `${providerKey} mode: your-own (managed mode not available for this provider)`,
+              );
+            }
+            return;
+          }
+
+          // Provider supports managed mode — read current config value
+          const services: Services = getConfig().services;
+          const currentMode = services[managedKey as keyof Services].mode;
+
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, {
+              ok: true,
+              provider: providerKey,
+              mode: currentMode,
+              managedModeSupported: true,
+            });
+          } else {
+            log.info(`${providerKey} mode: ${currentMode}`);
+          }
+          return;
+        }
+
+        // -----------------------------------------------------------------
+        // SET mode (--set flag present)
+        // -----------------------------------------------------------------
+        const newMode = opts.set;
+
+        // Validate mode value
+        if (newMode !== "managed" && newMode !== "your-own") {
+          writeOutput(cmd, {
+            ok: false,
+            error: `Invalid mode "${newMode}". Valid values are "managed" or "your-own".`,
+          });
+          process.exitCode = 1;
+          return;
+        }
+
+        // Validate provider supports managed mode
+        if (managedKey === null) {
+          writeOutput(cmd, {
+            ok: false,
+            error:
+              `Managed mode is not available for ${providerKey}. ` +
+              `Only providers with platform-managed OAuth support can be switched to managed mode.`,
+          });
+          process.exitCode = 1;
+          return;
+        }
+
+        // Read current mode
+        const services: Services = getConfig().services;
+        const currentMode = services[managedKey as keyof Services].mode;
+
+        // Same mode — no-op
+        if (currentMode === newMode) {
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, {
+              ok: true,
+              provider: providerKey,
+              mode: newMode,
+              changed: false,
+            });
+          } else {
+            log.info(`${providerKey} is already set to ${newMode}`);
+          }
+          return;
+        }
+
+        // Write the new mode
+        const raw = loadRawConfig();
+        setNestedValue(raw, `services.${managedKey}.mode`, newMode);
+        saveRawConfig(raw);
+
+        // Best-effort check for active connections on old and new modes
+        let oldModeConnections = 0;
+        let newModeConnections = 0;
+        const bareProvider = toBareProvider(providerKey);
+
+        if (currentMode === "managed") {
+          // Old mode was managed — check platform connections
+          oldModeConnections = await countManagedConnections(providerKey, cmd);
+          // New mode is your-own — check local connections
+          newModeConnections =
+            listActiveConnectionsByProvider(providerKey).length;
+        } else {
+          // Old mode was your-own — check local connections
+          oldModeConnections =
+            listActiveConnectionsByProvider(providerKey).length;
+          // New mode is managed — check platform connections
+          newModeConnections = await countManagedConnections(providerKey, cmd);
+        }
+
+        // Build hint if there are connections on the old mode but none on the new
+        let hint: string | undefined;
+        if (oldModeConnections > 0 && newModeConnections === 0) {
+          hint = `No active connections in ${newMode} mode. Run 'assistant oauth connect ${bareProvider}' to connect.`;
+        }
+
+        if (shouldOutputJson(cmd)) {
+          const result: Record<string, unknown> = {
+            ok: true,
+            provider: providerKey,
+            mode: newMode,
+            changed: true,
+          };
+          if (hint) result.hint = hint;
+          writeOutput(cmd, result);
+        } else {
+          log.info(`${providerKey} mode changed to ${newMode}`);
+          if (hint) {
+            process.stderr.write(hint + "\n");
+          }
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        writeOutput(cmd, { ok: false, error: message });
+        process.exitCode = 1;
+      }
+    });
+}

--- a/assistant/src/cli/commands/oauth/shared.ts
+++ b/assistant/src/cli/commands/oauth/shared.ts
@@ -59,13 +59,25 @@ export function toBareProvider(provider: string): string {
 }
 
 /**
+ * Return the provider's `managedServiceConfigKey` if it exists and is a valid
+ * key in `ServicesSchema.shape`, or `null` otherwise. This centralises the
+ * lookup so that callers (e.g. `isManagedMode`, `mode.ts`) don't duplicate the
+ * validation.
+ */
+export function getManagedServiceConfigKey(providerKey: string): string | null {
+  const provider = getProvider(providerKey);
+  const managedKey = provider?.managedServiceConfigKey;
+  if (!managedKey || !(managedKey in ServicesSchema.shape)) return null;
+  return managedKey;
+}
+
+/**
  * Determine whether a provider is running in platform-managed mode.
  * Returns false if config is unavailable (e.g. in test environments).
  */
 export function isManagedMode(providerKey: string): boolean {
-  const provider = getProvider(providerKey);
-  const managedKey = provider?.managedServiceConfigKey;
-  if (!managedKey || !(managedKey in ServicesSchema.shape)) return false;
+  const managedKey = getManagedServiceConfigKey(providerKey);
+  if (!managedKey) return false;
   try {
     const services: Services = getConfig().services;
     return services[managedKey as keyof Services].mode === "managed";


### PR DESCRIPTION
## Summary
- Adds `assistant oauth mode <provider>` command that gets or sets the OAuth mode (managed vs your-own) for a given provider
- Extracts `getManagedServiceConfigKey` helper in shared.ts, refactors `isManagedMode` to use it
- Includes connection-aware hint when switching modes (warns if no connections exist in the new mode)
- Comprehensive test suite covering get/set, validation, alias resolution, and connection hints

Part of plan: oauth-mode-command.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
