### PR TITLE
docs: remove --client-id from oauth connect commands in skill docs

### DIFF
--- a/skills/airtable-oauth-setup/SKILL.md
+++ b/skills/airtable-oauth-setup/SKILL.md
@@ -136,10 +136,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:airtable --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    )
+    assistant oauth connect integration:airtable
 ```
 
 ---

--- a/skills/airtable-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/airtable-oauth-setup/references/path-b-manual-setup.md
@@ -122,10 +122,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:airtable --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    )
+    assistant oauth connect integration:airtable
 ```
 
 Send the returned auth URL to the user. Tell them to click **Grant access** on the Airtable consent page.

--- a/skills/asana-oauth-setup/SKILL.md
+++ b/skills/asana-oauth-setup/SKILL.md
@@ -120,10 +120,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:asana --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    )
+    assistant oauth connect integration:asana
 ```
 
 ---

--- a/skills/asana-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/asana-oauth-setup/references/path-b-manual-setup.md
@@ -110,10 +110,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:asana --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    )
+    assistant oauth connect integration:asana
 ```
 
 Send the returned auth URL to the user. Tell them to click **Allow** on the Asana consent page.

--- a/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
+++ b/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
@@ -158,10 +158,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect <provider-key> --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    )
+    assistant oauth connect <provider-key>
 ```
 
 The command prints an authorization URL. Send it to the user. Wait for completion.

--- a/skills/discord-oauth-setup/SKILL.md
+++ b/skills/discord-oauth-setup/SKILL.md
@@ -141,10 +141,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:discord --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    ) --scopes identify guilds guilds.members.read messages.read
+    assistant oauth connect integration:discord --scopes identify guilds guilds.members.read messages.read
 ```
 
 ---

--- a/skills/discord-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/discord-oauth-setup/references/path-b-manual-setup.md
@@ -120,10 +120,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:discord --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    ) --scopes identify guilds guilds.members.read messages.read
+    assistant oauth connect integration:discord --scopes identify guilds guilds.members.read messages.read
 ```
 
 Send the returned auth URL to the user. Tell them to click **Authorize** on the Discord consent page.

--- a/skills/dropbox-oauth-setup/SKILL.md
+++ b/skills/dropbox-oauth-setup/SKILL.md
@@ -160,10 +160,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:dropbox --client-id $(cat <<'EOF'
-    <app-key>
-    EOF
-    )
+    assistant oauth connect integration:dropbox
 ```
 
 ---

--- a/skills/dropbox-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/dropbox-oauth-setup/references/path-b-manual-setup.md
@@ -124,10 +124,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:dropbox --client-id $(cat <<'EOF'
-    <app-key>
-    EOF
-    )
+    assistant oauth connect integration:dropbox
 ```
 
 Send the returned auth URL to the user. Tell them to click **Allow** on the Dropbox consent page.

--- a/skills/figma-oauth-setup/SKILL.md
+++ b/skills/figma-oauth-setup/SKILL.md
@@ -141,10 +141,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:figma --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    )
+    assistant oauth connect integration:figma
 ```
 
 After authorization completes, verify the connection:

--- a/skills/figma-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/figma-oauth-setup/references/path-b-manual-setup.md
@@ -113,10 +113,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:figma --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    )
+    assistant oauth connect integration:figma
 ```
 
 Send the returned auth URL to the user. Tell them to click **Allow access** on the Figma consent page.

--- a/skills/github-oauth-setup/SKILL.md
+++ b/skills/github-oauth-setup/SKILL.md
@@ -147,10 +147,7 @@ These scopes are passed during the authorization step below.
 ```
 bash:
   command: |
-    assistant oauth connect integration:github --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    ) --scopes repo read:user notifications
+    assistant oauth connect integration:github --scopes repo read:user notifications
 ```
 
 **Milestone (7 of 8):** "Authorization complete - let's verify it works."

--- a/skills/github-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/github-oauth-setup/references/path-b-manual-setup.md
@@ -101,10 +101,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:github --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    ) --scopes repo read:user notifications
+    assistant oauth connect integration:github --scopes repo read:user notifications
 ```
 
 Send the returned auth URL to the user. Tell them to click **Authorize** on the GitHub consent page.

--- a/skills/hubspot-oauth-setup/SKILL.md
+++ b/skills/hubspot-oauth-setup/SKILL.md
@@ -150,10 +150,7 @@ Then authorize:
 ```
 bash:
   command: |
-    assistant oauth connect integration:hubspot --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    )
+    assistant oauth connect integration:hubspot
 ```
 
 **Milestone (9 of 10):** "Credentials saved and authorized - let's verify."

--- a/skills/hubspot-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/hubspot-oauth-setup/references/path-b-manual-setup.md
@@ -124,10 +124,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:hubspot --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    )
+    assistant oauth connect integration:hubspot
 ```
 
 Send the returned auth URL to the user. Tell them to select their HubSpot account and click **Grant access** on the consent page.

--- a/skills/linear-oauth-setup/SKILL.md
+++ b/skills/linear-oauth-setup/SKILL.md
@@ -137,10 +137,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:linear --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    )
+    assistant oauth connect integration:linear
 ```
 
 ---

--- a/skills/linear-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/linear-oauth-setup/references/path-b-manual-setup.md
@@ -95,10 +95,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:linear --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    )
+    assistant oauth connect integration:linear
 ```
 
 Send the returned auth URL to the user. Tell them to click **Authorize** on the Linear consent page.

--- a/skills/notion-oauth-setup/references/path-b-public-oauth.md
+++ b/skills/notion-oauth-setup/references/path-b-public-oauth.md
@@ -82,10 +82,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:notion --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    )
+    assistant oauth connect integration:notion
 ```
 
 ### Step 5: Verify Connection

--- a/skills/oauth-setup/SKILL.md
+++ b/skills/oauth-setup/SKILL.md
@@ -175,10 +175,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect <provider-key> --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    )
+    assistant oauth connect <provider-key>
 ```
 
 If the service shows an "unverified app" or consent warning, tell the user how to proceed.

--- a/skills/spotify-oauth-setup/SKILL.md
+++ b/skills/spotify-oauth-setup/SKILL.md
@@ -134,10 +134,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:spotify --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    )
+    assistant oauth connect integration:spotify
 ```
 
 The scopes requested will include:

--- a/skills/spotify-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/spotify-oauth-setup/references/path-b-manual-setup.md
@@ -101,10 +101,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:spotify --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    )
+    assistant oauth connect integration:spotify
 ```
 
 Send the returned auth URL to the user. Tell them to click **Agree** on the Spotify consent page.

--- a/skills/todoist-oauth-setup/SKILL.md
+++ b/skills/todoist-oauth-setup/SKILL.md
@@ -108,10 +108,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:todoist --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    )
+    assistant oauth connect integration:todoist
 ```
 
 ---

--- a/skills/todoist-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/todoist-oauth-setup/references/path-b-manual-setup.md
@@ -108,10 +108,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:todoist --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    )
+    assistant oauth connect integration:todoist
 ```
 
 Send the returned auth URL to the user. Tell them to click **Agree** on the Todoist consent page.

--- a/skills/twitter-oauth-setup/SKILL.md
+++ b/skills/twitter-oauth-setup/SKILL.md
@@ -183,10 +183,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:twitter --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    )
+    assistant oauth connect integration:twitter
 ```
 
 ---

--- a/skills/twitter-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/twitter-oauth-setup/references/path-b-manual-setup.md
@@ -121,10 +121,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:twitter --client-id $(cat <<'EOF'
-    <client-id>
-    EOF
-    )
+    assistant oauth connect integration:twitter
 ```
 
 Send the returned auth URL to the user. Tell them to review the permissions and click **Authorize app**.


### PR DESCRIPTION
## Summary
- Remove `--client-id` heredoc block from `oauth connect` commands in all skill markdown files
- The unified `oauth connect` command auto-resolves client credentials, making `--client-id` unnecessary
- Leave `oauth connections token` and `oauth apps upsert` commands unchanged (they still need `--client-id`)

Part of plan: remove-deprecated-oauth-cli.md (follow-up)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
