### PR TITLE
fix: preserve query parameters from ping URLs in oauth ping command

### DIFF
--- a/assistant/src/cli/commands/oauth/ping.ts
+++ b/assistant/src/cli/commands/oauth/ping.ts
@@ -99,6 +99,12 @@ Examples:
           const baseUrl = `${parsed.protocol}//${parsed.host}`;
           const path = parsed.pathname;
 
+          // Preserve query parameters from the configured ping URL
+          const query: Record<string, string> = {};
+          for (const [key, value] of parsed.searchParams) {
+            query[key] = value;
+          }
+
           // -----------------------------------------------------------------
           // 4. Resolve connection (auto-detects managed vs BYO)
           // -----------------------------------------------------------------
@@ -140,6 +146,7 @@ Examples:
             method: "GET",
             path,
             baseUrl,
+            ...(Object.keys(query).length > 0 ? { query } : {}),
           });
 
           // -----------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-ping-token.md.

**Gap:** oauth ping drops query parameters from ping URLs
**What was expected:** Query parameters in provider ping URLs should be preserved
**What was found:** Only pathname was extracted, silently dropping query params (e.g. HubSpot's ?limit=1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
