### PR TITLE
fix: use consistent assistant prefix in connections ping deprecation warning

### DIFF
--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -373,7 +373,11 @@ Examples:
         cmd: Command,
       ) => {
         try {
-          printDeprecationWarning("oauth connections ping", "oauth ping", cmd);
+          printDeprecationWarning(
+            "assistant oauth connections ping",
+            "assistant oauth ping",
+            cmd,
+          );
 
           const provider = getProvider(providerKey);
           if (!provider) {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-ping-token.md.

**Gap:** Inconsistent deprecation warning prefix for connections ping
**What was expected:** All deprecation warnings should use the assistant prefix consistently
**What was found:** connections ping used 'oauth connections ping' while others used 'assistant oauth connections ...'
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
