### PR TITLE
fix: update skill docs to reference unified oauth token and ping commands

### DIFF
--- a/skills/airtable-oauth-setup/SKILL.md
+++ b/skills/airtable-oauth-setup/SKILL.md
@@ -151,7 +151,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:airtable --client-id $(cat <<'EOF'
+    curl -s -H "Authorization: Bearer $(assistant oauth token integration:airtable --client-id $(cat <<'EOF'
     <client-id>
     EOF
     ))" "https://api.airtable.com/v0/meta/whoami" | python3 -m json.tool

--- a/skills/asana-oauth-setup/SKILL.md
+++ b/skills/asana-oauth-setup/SKILL.md
@@ -135,7 +135,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:asana --client-id $(cat <<'EOF'
+    curl -s -H "Authorization: Bearer $(assistant oauth token integration:asana --client-id $(cat <<'EOF'
     <client-id>
     EOF
     ))" "https://app.asana.com/api/1.0/users/me" | python3 -m json.tool

--- a/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
+++ b/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
@@ -177,7 +177,7 @@ If a ping URL is available:
 ```
 bash:
   command: |
-    curl -H "Authorization: Bearer $(assistant oauth connections token <provider-key> --client-id $(cat <<'EOF'
+    curl -H "Authorization: Bearer $(assistant oauth token <provider-key> --client-id $(cat <<'EOF'
     <client-id>
     EOF
     ))" "<provider-ping-url>"

--- a/skills/discord-oauth-setup/SKILL.md
+++ b/skills/discord-oauth-setup/SKILL.md
@@ -156,7 +156,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:discord --client-id $(cat <<'EOF'
+    curl -s -H "Authorization: Bearer $(assistant oauth token integration:discord --client-id $(cat <<'EOF'
     <client-id>
     EOF
     ))" "https://discord.com/api/v10/users/@me" | python3 -m json.tool

--- a/skills/dropbox-oauth-setup/SKILL.md
+++ b/skills/dropbox-oauth-setup/SKILL.md
@@ -175,7 +175,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -X POST -H "Authorization: Bearer $(assistant oauth connections token integration:dropbox --client-id $(cat <<'EOF'
+    curl -s -X POST -H "Authorization: Bearer $(assistant oauth token integration:dropbox --client-id $(cat <<'EOF'
     <app-key>
     EOF
     ))" "https://api.dropboxapi.com/2/users/get_current_account" | python3 -m json.tool

--- a/skills/figma-oauth-setup/SKILL.md
+++ b/skills/figma-oauth-setup/SKILL.md
@@ -152,7 +152,7 @@ After authorization completes, verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:figma --client-id $(cat <<'EOF'
+    curl -s -H "Authorization: Bearer $(assistant oauth token integration:figma --client-id $(cat <<'EOF'
     <client-id>
     EOF
     ))" "https://api.figma.com/v1/me" | python3 -m json.tool

--- a/skills/github-oauth-setup/SKILL.md
+++ b/skills/github-oauth-setup/SKILL.md
@@ -164,7 +164,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:github --client-id $(cat <<'EOF'
+    curl -s -H "Authorization: Bearer $(assistant oauth token integration:github --client-id $(cat <<'EOF'
     <client-id>
     EOF
     ))" "https://api.github.com/user" | python3 -m json.tool

--- a/skills/hubspot-oauth-setup/SKILL.md
+++ b/skills/hubspot-oauth-setup/SKILL.md
@@ -167,7 +167,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:hubspot --client-id $(cat <<'EOF'
+    curl -s -H "Authorization: Bearer $(assistant oauth token integration:hubspot --client-id $(cat <<'EOF'
     <client-id>
     EOF
     ))" "https://api.hubapi.com/crm/v3/objects/contacts?limit=1" | python3 -m json.tool

--- a/skills/linear-oauth-setup/SKILL.md
+++ b/skills/linear-oauth-setup/SKILL.md
@@ -152,7 +152,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $(assistant oauth connections token integration:linear --client-id $(cat <<'EOF'
+    curl -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $(assistant oauth token integration:linear --client-id $(cat <<'EOF'
     <client-id>
     EOF
     ))" -d '{"query":"{ viewer { id name email } }"}' "https://api.linear.app/graphql" | python3 -m json.tool

--- a/skills/notion-oauth-setup/references/path-b-public-oauth.md
+++ b/skills/notion-oauth-setup/references/path-b-public-oauth.md
@@ -93,7 +93,7 @@ bash:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:notion --client-id $(cat <<'EOF'
+    curl -s -H "Authorization: Bearer $(assistant oauth token integration:notion --client-id $(cat <<'EOF'
     <client-id>
     EOF
     ))" "https://api.notion.com/v1/users/me" -H "Notion-Version: 2022-06-28"

--- a/skills/oauth-setup/SKILL.md
+++ b/skills/oauth-setup/SKILL.md
@@ -192,7 +192,7 @@ If a ping URL is available, verify:
 ```
 bash:
   command: |
-    curl -H "Authorization: Bearer $(assistant oauth connections token <provider-key> --client-id $(cat <<'EOF'
+    curl -H "Authorization: Bearer $(assistant oauth token <provider-key> --client-id $(cat <<'EOF'
     <client-id>
     EOF
     ))" "<provider-ping-url>"

--- a/skills/spotify-oauth-setup/SKILL.md
+++ b/skills/spotify-oauth-setup/SKILL.md
@@ -161,7 +161,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:spotify --client-id $(cat <<'EOF'
+    curl -s -H "Authorization: Bearer $(assistant oauth token integration:spotify --client-id $(cat <<'EOF'
     <client-id>
     EOF
     ))" "https://api.spotify.com/v1/me" | python3 -m json.tool

--- a/skills/todoist-oauth-setup/SKILL.md
+++ b/skills/todoist-oauth-setup/SKILL.md
@@ -123,7 +123,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:todoist --client-id $(cat <<'EOF'
+    curl -s -H "Authorization: Bearer $(assistant oauth token integration:todoist --client-id $(cat <<'EOF'
     <client-id>
     EOF
     ))" "https://api.todoist.com/rest/v2/projects" | python3 -m json.tool

--- a/skills/twitter-oauth-setup/SKILL.md
+++ b/skills/twitter-oauth-setup/SKILL.md
@@ -198,7 +198,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:twitter --client-id $(cat <<'EOF'
+    curl -s -H "Authorization: Bearer $(assistant oauth token integration:twitter --client-id $(cat <<'EOF'
     <client-id>
     EOF
     ))" "https://api.x.com/2/users/me" | python3 -m json.tool


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-ping-token.md.

**Gap:** Skill documentation still references deprecated connections token/ping commands
**What was expected:** Skills should reference new unified commands
**What was found:** 13+ SKILL.md files still use deprecated assistant oauth connections token
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
