### PR TITLE
fix: treat `--set your-own` as no-op for providers without managed-mode support

### DIFF
--- a/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
@@ -408,7 +408,7 @@ describe("assistant oauth mode", () => {
       expect(parsed.error).toContain("your-own");
     });
 
-    test("provider without managedServiceConfigKey returns error about managed mode not available", async () => {
+    test("provider without managedServiceConfigKey returns error about managed mode not available when --set managed", async () => {
       mockGetProvider = () => ({
         providerKey: "integration:slack",
         managedServiceConfigKey: null,
@@ -427,6 +427,29 @@ describe("assistant oauth mode", () => {
       expect(parsed.ok).toBe(false);
       expect(parsed.error).toContain("Managed mode is not available");
       expect(parsed.error).toContain("integration:slack");
+    });
+
+    test("provider without managedServiceConfigKey treats --set your-own as successful no-op", async () => {
+      mockGetProvider = () => ({
+        providerKey: "integration:slack",
+        managedServiceConfigKey: null,
+      });
+      mockGetManagedServiceConfigKey = () => null;
+
+      const { exitCode, stdout } = await runCommand([
+        "mode",
+        "slack",
+        "--set",
+        "your-own",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.provider).toBe("integration:slack");
+      expect(parsed.mode).toBe("your-own");
+      expect(parsed.changed).toBe(false);
+      expect(parsed.managedModeSupported).toBe(false);
     });
 
     test("set to same mode returns changed: false", async () => {

--- a/assistant/src/cli/commands/oauth/mode.ts
+++ b/assistant/src/cli/commands/oauth/mode.ts
@@ -157,8 +157,27 @@ Examples:
           return;
         }
 
-        // Validate provider supports managed mode
+        // Provider has no managedServiceConfigKey — it is always "your-own"
         if (managedKey === null) {
+          if (newMode === "your-own") {
+            // Already your-own — successful no-op
+            if (shouldOutputJson(cmd)) {
+              writeOutput(cmd, {
+                ok: true,
+                provider: providerKey,
+                mode: "your-own",
+                changed: false,
+                managedModeSupported: false,
+              });
+            } else {
+              log.info(
+                `${providerKey} is already set to your-own (managed mode not available for this provider)`,
+              );
+            }
+            return;
+          }
+
+          // Requesting managed on a provider that doesn't support it
           writeOutput(cmd, {
             ok: false,
             error:


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-mode-command.md.

**Gap:** --set your-own rejected with misleading error for providers without managed-mode support
**What was expected:** Setting your-own on a provider that doesn't support managed mode should be a no-op
**What was found:** The command showed a confusing 'Managed mode is not available' error regardless of which mode was requested
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
