### PR TITLE
fix: update skill-memory.ts and skills.ts to use kebab-case flag keys

### DIFF
--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -223,9 +223,7 @@ mock.module("../config/assistant-feature-flags.js", () => ({
 
 mock.module("../config/skill-state.js", () => ({
   skillFlagKey: (skill: { featureFlag?: string }) =>
-    skill.featureFlag
-      ? `feature_flags.${skill.featureFlag}.enabled`
-      : undefined,
+    skill.featureFlag || undefined,
 }));
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/skill-projection.benchmark.test.ts
+++ b/assistant/src/__tests__/skill-projection.benchmark.test.ts
@@ -66,9 +66,7 @@ mock.module("../config/skills.js", () => ({
 // only needs skillFlagKey and doesn't exercise resolveSkillStates.
 mock.module("../config/skill-state.js", () => ({
   skillFlagKey: (skill: { featureFlag?: string }) =>
-    skill.featureFlag
-      ? `feature_flags.${skill.featureFlag}.enabled`
-      : undefined,
+    skill.featureFlag || undefined,
   resolveSkillStates: () => [],
 }));
 

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -928,13 +928,11 @@ function applyFeatureGatedSections(body: string): string {
   let result = body;
 
   result = result.replace(mainRe, (_match, flagId: string, content: string) => {
-    const key = `feature_flags.${flagId}.enabled`;
-    return isAssistantFeatureFlagEnabled(key, config) ? content : "";
+    return isAssistantFeatureFlagEnabled(flagId, config) ? content : "";
   });
 
   result = result.replace(altRe, (_match, flagId: string, content: string) => {
-    const key = `feature_flags.${flagId}.enabled`;
-    return isAssistantFeatureFlagEnabled(key, config) ? "" : content;
+    return isAssistantFeatureFlagEnabled(flagId, config) ? "" : content;
   });
 
   return result;

--- a/assistant/src/skills/skill-memory.ts
+++ b/assistant/src/skills/skill-memory.ts
@@ -183,8 +183,7 @@ export async function seedCatalogSkillMemories(): Promise<void> {
       // Skip skills whose feature flag is disabled
       const flagId = entry.metadata?.vellum?.["feature-flag"];
       if (flagId) {
-        const flagKey = `feature_flags.${flagId}.enabled`;
-        if (!isAssistantFeatureFlagEnabled(flagKey, config)) {
+        if (!isAssistantFeatureFlagEnabled(flagId, config)) {
           continue;
         }
       }


### PR DESCRIPTION
## Summary
- Fixes `skill-memory.ts` and `skills.ts` which still constructed old-format keys via template literals (`feature_flags.${flagId}.enabled`)
- Updates two test mocks (`conversation-skill-tools.test.ts`, `skill-projection.benchmark.test.ts`) that replicated the old `skillFlagKey` behavior
- Root cause of the CI test failure on the feature branch

Part of plan: simplify-feature-flag-names.md (fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
