### PR TITLE
refactor: update all references from deprecated oauth connection commands to unified commands

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -292,24 +292,19 @@ async function runCli(
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("assistant oauth connections token <provider-key>", () => {
+describe("assistant oauth token <provider-key>", () => {
   beforeEach(() => {
     mockWithValidToken = async (_service, cb) => cb("mock-access-token-xyz");
   });
 
   test("prints bare token in human mode", async () => {
-    const { exitCode, stdout } = await runCli([
-      "connections",
-      "token",
-      "integration:twitter",
-    ]);
+    const { exitCode, stdout } = await runCli(["token", "integration:twitter"]);
     expect(exitCode).toBe(0);
     expect(stdout).toBe("mock-access-token-xyz\n");
   });
 
   test("prints JSON in --json mode", async () => {
     const { exitCode, stdout } = await runCli([
-      "connections",
       "token",
       "integration:twitter",
       "--json",
@@ -326,7 +321,7 @@ describe("assistant oauth connections token <provider-key>", () => {
       return cb("tok");
     };
 
-    await runCli(["connections", "token", "integration:twitter"]);
+    await runCli(["token", "integration:twitter"]);
     expect(capturedService).toBe("integration:twitter");
   });
 
@@ -337,11 +332,7 @@ describe("assistant oauth connections token <provider-key>", () => {
       return cb("gmail-token");
     };
 
-    const { exitCode, stdout } = await runCli([
-      "connections",
-      "token",
-      "integration:google",
-    ]);
+    const { exitCode, stdout } = await runCli(["token", "integration:google"]);
     expect(exitCode).toBe(0);
     expect(stdout).toBe("gmail-token\n");
     expect(capturedService).toBe("integration:google");
@@ -355,7 +346,6 @@ describe("assistant oauth connections token <provider-key>", () => {
     };
 
     const { exitCode, stdout } = await runCli([
-      "connections",
       "token",
       "integration:twitter",
       "--json",
@@ -374,7 +364,6 @@ describe("assistant oauth connections token <provider-key>", () => {
     };
 
     const { exitCode, stdout } = await runCli([
-      "connections",
       "token",
       "integration:twitter",
       "--json",
@@ -389,17 +378,13 @@ describe("assistant oauth connections token <provider-key>", () => {
     // Simulate withValidToken refreshing and returning a new token
     mockWithValidToken = async (_service, cb) => cb("refreshed-new-token");
 
-    const { exitCode, stdout } = await runCli([
-      "connections",
-      "token",
-      "integration:twitter",
-    ]);
+    const { exitCode, stdout } = await runCli(["token", "integration:twitter"]);
     expect(exitCode).toBe(0);
     expect(stdout).toBe("refreshed-new-token\n");
   });
 
   test("missing provider-key argument exits non-zero", async () => {
-    const { exitCode } = await runCli(["connections", "token"]);
+    const { exitCode } = await runCli(["token"]);
     expect(exitCode).not.toBe(0);
   });
 });
@@ -763,7 +748,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
 // ping
 // ---------------------------------------------------------------------------
 
-describe("assistant oauth connections ping <provider-key>", () => {
+describe("assistant oauth ping <provider-key>", () => {
   beforeEach(() => {
     mockWithValidToken = async (_service, cb) => cb("mock-access-token-xyz");
   });
@@ -785,7 +770,6 @@ describe("assistant oauth connections ping <provider-key>", () => {
       new Response("{}", { status: 200 })) as unknown as typeof fetch;
     try {
       const { exitCode, stdout } = await runCli([
-        "connections",
         "ping",
         "integration:google",
         "--json",
@@ -802,7 +786,6 @@ describe("assistant oauth connections ping <provider-key>", () => {
   test("exits 1 when provider not found", async () => {
     mockGetProvider = () => undefined;
     const { exitCode, stdout } = await runCli([
-      "connections",
       "ping",
       "integration:unknown",
       "--json",
@@ -825,12 +808,7 @@ describe("assistant oauth connections ping <provider-key>", () => {
       createdAt: Date.now(),
       updatedAt: Date.now(),
     });
-    const { exitCode, stdout } = await runCli([
-      "connections",
-      "ping",
-      "telegram",
-      "--json",
-    ]);
+    const { exitCode, stdout } = await runCli(["ping", "telegram", "--json"]);
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
@@ -855,7 +833,6 @@ describe("assistant oauth connections ping <provider-key>", () => {
       new Response("Forbidden", { status: 403 })) as unknown as typeof fetch;
     try {
       const { exitCode, stdout } = await runCli([
-        "connections",
         "ping",
         "integration:google",
         "--json",
@@ -885,7 +862,6 @@ describe("assistant oauth connections ping <provider-key>", () => {
       updatedAt: Date.now(),
     });
     const { exitCode, stdout } = await runCli([
-      "connections",
       "ping",
       "integration:google",
       "--json",

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -71,6 +71,22 @@ let mockGetProviderBehavior: (
   providerKey: string,
 ) => Record<string, unknown> | undefined = () => undefined;
 let mockGetSecureKey: (account: string) => string | undefined = () => undefined;
+let mockResolveOAuthConnection: (
+  providerKey: string,
+  options?: Record<string, unknown>,
+) => Promise<{
+  request: (req: Record<string, unknown>) => Promise<{
+    status: number;
+    headers: Record<string, string>;
+    body: unknown;
+  }>;
+  withToken: <T>(fn: (token: string) => Promise<T>) => Promise<T>;
+  id: string;
+  providerKey: string;
+  accountInfo: string | null;
+}> = async () => {
+  throw new Error("resolveOAuthConnection not configured in test");
+};
 let mockGetCredentialMetadata: (
   service: string,
   field: string,
@@ -207,9 +223,10 @@ mock.module("../oauth/provider-behaviors.js", () => ({
 // ---------------------------------------------------------------------------
 
 mock.module("../oauth/connection-resolver.js", () => ({
-  resolveOAuthConnection: async () => {
-    throw new Error("resolveOAuthConnection not configured in test");
-  },
+  resolveOAuthConnection: (
+    providerKey: string,
+    options?: Record<string, unknown>,
+  ) => mockResolveOAuthConnection(providerKey, options),
 }));
 
 // ---------------------------------------------------------------------------
@@ -751,6 +768,10 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
 describe("assistant oauth ping <provider-key>", () => {
   beforeEach(() => {
     mockWithValidToken = async (_service, cb) => cb("mock-access-token-xyz");
+    // Reset resolveOAuthConnection to default (unconfigured)
+    mockResolveOAuthConnection = async () => {
+      throw new Error("resolveOAuthConnection not configured in test");
+    };
   });
 
   test("returns ok when ping endpoint returns 200", async () => {
@@ -765,22 +786,22 @@ describe("assistant oauth ping <provider-key>", () => {
       createdAt: Date.now(),
       updatedAt: Date.now(),
     });
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = (async () =>
-      new Response("{}", { status: 200 })) as unknown as typeof fetch;
-    try {
-      const { exitCode, stdout } = await runCli([
-        "ping",
-        "integration:google",
-        "--json",
-      ]);
-      expect(exitCode).toBe(0);
-      const parsed = JSON.parse(stdout);
-      expect(parsed.ok).toBe(true);
-      expect(parsed.status).toBe(200);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    mockResolveOAuthConnection = async () => ({
+      id: "conn-1",
+      providerKey: "integration:google",
+      accountInfo: null,
+      request: async () => ({ status: 200, headers: {}, body: {} }),
+      withToken: async (fn) => fn("mock-access-token-xyz"),
+    });
+    const { exitCode, stdout } = await runCli([
+      "ping",
+      "integration:google",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.status).toBe(200);
   });
 
   test("exits 1 when provider not found", async () => {
@@ -793,7 +814,7 @@ describe("assistant oauth ping <provider-key>", () => {
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
-    expect(parsed.error).toContain("Provider not found");
+    expect(parsed.error).toContain("Unknown provider");
   });
 
   test("exits 1 when no ping URL configured", async () => {
@@ -827,29 +848,25 @@ describe("assistant oauth ping <provider-key>", () => {
       createdAt: Date.now(),
       updatedAt: Date.now(),
     });
-    const originalFetch = globalThis.fetch;
-    // Use 403 (not 401) — 401 now throws inside withValidToken for retry
-    globalThis.fetch = (async () =>
-      new Response("Forbidden", { status: 403 })) as unknown as typeof fetch;
-    try {
-      const { exitCode, stdout } = await runCli([
-        "ping",
-        "integration:google",
-        "--json",
-      ]);
-      expect(exitCode).toBe(1);
-      const parsed = JSON.parse(stdout);
-      expect(parsed.ok).toBe(false);
-      expect(parsed.status).toBe(403);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    mockResolveOAuthConnection = async () => ({
+      id: "conn-1",
+      providerKey: "integration:google",
+      accountInfo: null,
+      request: async () => ({ status: 403, headers: {}, body: "Forbidden" }),
+      withToken: async (fn) => fn("mock-access-token-xyz"),
+    });
+    const { exitCode, stdout } = await runCli([
+      "ping",
+      "integration:google",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.status).toBe(403);
   });
 
-  test("exits 1 when no token exists", async () => {
-    mockWithValidToken = async () => {
-      throw new Error('No access token found for "integration:google".');
-    };
+  test("exits 1 when no connection can be resolved", async () => {
     mockGetProvider = () => ({
       providerKey: "integration:google",
       pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
@@ -861,6 +878,9 @@ describe("assistant oauth ping <provider-key>", () => {
       createdAt: Date.now(),
       updatedAt: Date.now(),
     });
+    mockResolveOAuthConnection = async () => {
+      throw new Error('No access token found for "integration:google".');
+    };
     const { exitCode, stdout } = await runCli([
       "ping",
       "integration:google",

--- a/assistant/src/cli/commands/oauth/index.ts
+++ b/assistant/src/cli/commands/oauth/index.ts
@@ -31,7 +31,7 @@ The oauth command group manages the full OAuth lifecycle:
   request     Make authenticated HTTP requests (curl-like interface)
   providers   Protocol-level configurations (auth URLs, scopes, endpoints)
   apps        Client credentials (client ID / secret pairs)
-  connections Active token grants per provider (token, ping, list, get)
+  connections Active token grants per provider (list, get)
 
 Providers are seeded on startup for built-in integrations. Apps and connections
 are created during the OAuth authorization flow or can be managed manually via
@@ -45,7 +45,6 @@ Examples:
   $ assistant oauth request --provider integration:google /gmail/v1/users/me/messages
   $ assistant oauth request --provider integration:twitter -X POST -d '{"text":"Hello"}' https://api.x.com/2/tweets
   $ assistant oauth token integration:twitter
-  $ assistant oauth connections token integration:twitter
   $ assistant oauth providers list
   $ assistant oauth providers get integration:google`,
   );

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -231,7 +231,7 @@ Arguments (via options):
                         (e.g. "client_secret_post", "client_secret_basic").
   --callback-transport  Transport method for the OAuth callback.
   --ping-url            Optional URL for a lightweight health-check endpoint.
-                        Used by "connections ping" to validate that a stored token
+                        Used by "assistant oauth ping" to validate that a stored token
                         is still functional (e.g. "https://api.example.com/user").
   --display-name        Optional human-readable display name for the provider.
   --description         Optional short description of the provider.


### PR DESCRIPTION
## Summary
- Updates help text in index.ts to remove stale `connections token` example and update description
- Updates providers.ts help text to reference `assistant oauth ping` instead of deprecated `connections ping`
- Rewrites test suites in oauth-cli.test.ts to exercise new unified `token` and `ping` commands

Part of plan: remove-deprecated-oauth-cmds.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
