### PR TITLE
fix: include `managedModeSupported` in all oauth mode set responses

### DIFF
--- a/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
@@ -475,6 +475,7 @@ describe("assistant oauth mode", () => {
       expect(parsed.provider).toBe("integration:google");
       expect(parsed.mode).toBe("managed");
       expect(parsed.changed).toBe(false);
+      expect(parsed.managedModeSupported).toBe(true);
     });
 
     test("switch managed -> your-own with active managed connections and no BYO connections includes hint", async () => {
@@ -514,6 +515,7 @@ describe("assistant oauth mode", () => {
       expect(parsed.provider).toBe("integration:google");
       expect(parsed.mode).toBe("your-own");
       expect(parsed.changed).toBe(true);
+      expect(parsed.managedModeSupported).toBe(true);
       expect(parsed.hint).toContain("No active connections");
       expect(parsed.hint).toContain("your-own");
       expect(parsed.hint).toContain("connect");
@@ -556,6 +558,7 @@ describe("assistant oauth mode", () => {
       expect(parsed.provider).toBe("integration:google");
       expect(parsed.mode).toBe("managed");
       expect(parsed.changed).toBe(true);
+      expect(parsed.managedModeSupported).toBe(true);
       expect(parsed.hint).toContain("No active connections");
       expect(parsed.hint).toContain("managed");
       expect(parsed.hint).toContain("connect");
@@ -602,6 +605,7 @@ describe("assistant oauth mode", () => {
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
       expect(parsed.changed).toBe(true);
+      expect(parsed.managedModeSupported).toBe(true);
       expect(parsed.hint).toBeUndefined();
     });
 
@@ -634,6 +638,7 @@ describe("assistant oauth mode", () => {
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
       expect(parsed.changed).toBe(true);
+      expect(parsed.managedModeSupported).toBe(true);
       expect(parsed.hint).toBeUndefined();
     });
 

--- a/assistant/src/cli/commands/oauth/mode.ts
+++ b/assistant/src/cli/commands/oauth/mode.ts
@@ -200,6 +200,7 @@ Examples:
               provider: providerKey,
               mode: newMode,
               changed: false,
+              managedModeSupported: true,
             });
           } else {
             log.info(`${providerKey} is already set to ${newMode}`);
@@ -243,6 +244,7 @@ Examples:
             provider: providerKey,
             mode: newMode,
             changed: true,
+            managedModeSupported: true,
           };
           if (hint) result.hint = hint;
           writeOutput(cmd, result);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-mode-command.md.

**Gap:** Inconsistent managedModeSupported field in JSON responses
**What was expected:** managedModeSupported should be in all response shapes
**What was found:** Set-mode paths for same-mode no-op and mode-changed did not include it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
