### PR TITLE
docs: replace curl-based OAuth verification with assistant oauth ping

### DIFF
--- a/skills/airtable-oauth-setup/SKILL.md
+++ b/skills/airtable-oauth-setup/SKILL.md
@@ -148,7 +148,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth token integration:airtable)" "https://api.airtable.com/v0/meta/whoami" | python3 -m json.tool
+    assistant oauth ping integration:airtable
 ```
 
 **On success:** "Airtable is connected! You can now ask me to read and update records in your Airtable bases."

--- a/skills/asana-oauth-setup/SKILL.md
+++ b/skills/asana-oauth-setup/SKILL.md
@@ -132,7 +132,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth token integration:asana)" "https://app.asana.com/api/1.0/users/me" | python3 -m json.tool
+    assistant oauth ping integration:asana
 ```
 
 **On success:** "Asana is connected! You can now ask me to check your Asana tasks, create projects, manage assignments, and track your work."

--- a/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
+++ b/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
@@ -174,7 +174,7 @@ If a ping URL is available:
 ```
 bash:
   command: |
-    curl -H "Authorization: Bearer $(assistant oauth token <provider-key>)" "<provider-ping-url>"
+    assistant oauth ping <provider-key>
 ```
 
 ---

--- a/skills/discord-oauth-setup/SKILL.md
+++ b/skills/discord-oauth-setup/SKILL.md
@@ -153,7 +153,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth token integration:discord)" "https://discord.com/api/v10/users/@me" | python3 -m json.tool
+    assistant oauth ping integration:discord
 ```
 
 **On success:** "Discord is connected! You can now ask me to check your Discord servers, read messages, and look up server members."

--- a/skills/dropbox-oauth-setup/SKILL.md
+++ b/skills/dropbox-oauth-setup/SKILL.md
@@ -172,7 +172,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -X POST -H "Authorization: Bearer $(assistant oauth token integration:dropbox)" "https://api.dropboxapi.com/2/users/get_current_account" | python3 -m json.tool
+    assistant oauth ping integration:dropbox
 ```
 
 **On success:** "Dropbox is connected! You can now ask me to read files, upload documents, and browse your Dropbox."

--- a/skills/figma-oauth-setup/SKILL.md
+++ b/skills/figma-oauth-setup/SKILL.md
@@ -149,7 +149,7 @@ After authorization completes, verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth token integration:figma)" "https://api.figma.com/v1/me" | python3 -m json.tool
+    assistant oauth ping integration:figma
 ```
 
 **On success:** "Figma is connected! You can now ask me to browse your design files, inspect components, and post comments."

--- a/skills/github-oauth-setup/SKILL.md
+++ b/skills/github-oauth-setup/SKILL.md
@@ -161,7 +161,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth token integration:github)" "https://api.github.com/user" | python3 -m json.tool
+    assistant oauth ping integration:github
 ```
 
 **On success:** "GitHub is connected! You can now ask me to check your repositories, notifications, pull requests, and issues."

--- a/skills/hubspot-oauth-setup/SKILL.md
+++ b/skills/hubspot-oauth-setup/SKILL.md
@@ -164,7 +164,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth token integration:hubspot)" "https://api.hubapi.com/crm/v3/objects/contacts?limit=1" | python3 -m json.tool
+    assistant oauth ping integration:hubspot
 ```
 
 **On success:** "HubSpot is connected! You can now ask me to look up contacts, manage deals, and browse company records in your HubSpot CRM."

--- a/skills/linear-oauth-setup/SKILL.md
+++ b/skills/linear-oauth-setup/SKILL.md
@@ -149,7 +149,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $(assistant oauth token integration:linear)" -d '{"query":"{ viewer { id name email } }"}' "https://api.linear.app/graphql" | python3 -m json.tool
+    assistant oauth ping integration:linear
 ```
 
 **On success:** "Linear is connected! You can now ask me to create issues, check your assignments, search across projects, and manage your Linear workflow."

--- a/skills/notion-oauth-setup/references/path-b-public-oauth.md
+++ b/skills/notion-oauth-setup/references/path-b-public-oauth.md
@@ -90,5 +90,5 @@ bash:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth token integration:notion)" "https://api.notion.com/v1/users/me" -H "Notion-Version: 2022-06-28"
+    assistant oauth ping integration:notion
 ```

--- a/skills/oauth-setup/SKILL.md
+++ b/skills/oauth-setup/SKILL.md
@@ -189,7 +189,7 @@ If a ping URL is available, verify:
 ```
 bash:
   command: |
-    curl -H "Authorization: Bearer $(assistant oauth token <provider-key>)" "<provider-ping-url>"
+    assistant oauth ping <provider-key>
 ```
 
 **On success:** "**{setup.displayName} is connected!** You're all set."

--- a/skills/spotify-oauth-setup/SKILL.md
+++ b/skills/spotify-oauth-setup/SKILL.md
@@ -158,7 +158,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth token integration:spotify)" "https://api.spotify.com/v1/me" | python3 -m json.tool
+    assistant oauth ping integration:spotify
 ```
 
 **On success:** "Spotify is connected! You can now ask me to control playback, manage your playlists, check what's playing, and browse your library."

--- a/skills/todoist-oauth-setup/SKILL.md
+++ b/skills/todoist-oauth-setup/SKILL.md
@@ -120,7 +120,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth token integration:todoist)" "https://api.todoist.com/rest/v2/projects" | python3 -m json.tool
+    assistant oauth ping integration:todoist
 ```
 
 **On success:** "Todoist is connected! You can now ask me to manage your tasks, create projects, and organize your to-do lists."

--- a/skills/twitter-oauth-setup/SKILL.md
+++ b/skills/twitter-oauth-setup/SKILL.md
@@ -195,7 +195,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth token integration:twitter)" "https://api.x.com/2/users/me" | python3 -m json.tool
+    assistant oauth ping integration:twitter
 ```
 
 **On success:** "Twitter is connected! You can now ask me to read your timeline, post tweets, and check your profile."


### PR DESCRIPTION
## Summary
- Replaced raw `curl -H "Authorization: Bearer $(assistant oauth token ...)" <url> | python3 -m json.tool` commands with `assistant oauth ping <provider>` across 14 skill files
- Covers all provider-specific OAuth setup skills (GitHub, Linear, Notion, Spotify, etc.) plus the generic `oauth-setup` and `collaborative-oauth-flow` skills
- The `assistant oauth ping` command handles token resolution, request formatting, and response validation internally

## Original prompt
Simplify verification sections across all skills in `skills/` that use raw `curl` commands with OAuth bearer tokens for ping/verification. Replace those curl-based verification blocks with the new `assistant oauth ping` CLI command instead. Look for patterns like `curl -H "Authorization: Bearer $(assistant oauth token <provider>)" "<url>"` and replace them with the appropriate `assistant oauth ping <provider>` command.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
