### PR TITLE
refactor: remove deprecated `connections token` and `connections ping` subcommands

### DIFF
--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -8,31 +8,10 @@ import {
 import {
   getConnection,
   getConnectionByProvider,
-  getProvider,
   listConnections,
 } from "../../../oauth/oauth-store.js";
-import { withValidToken } from "../../../security/token-manager.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
-import { printDeprecationWarning } from "./shared.js";
-
-// ---------------------------------------------------------------------------
-// CES shell lockdown guard
-// ---------------------------------------------------------------------------
-
-/**
- * Returns true when the current process is running inside an untrusted shell
- * (CES shell lockdown active). CLI commands that reveal raw tokens must
- * check this and fail deterministically.
- */
-function isUntrustedShell(): boolean {
-  return process.env.VELLUM_UNTRUSTED_SHELL === "1";
-}
-
-/** Error message for commands blocked by CES shell lockdown. */
-const UNTRUSTED_SHELL_ERROR =
-  "This command is not available in untrusted shell mode. " +
-  "Raw token access is restricted when running under CES shell lockdown.";
 
 const log = getCliLogger("cli");
 
@@ -121,9 +100,7 @@ Examples:
   $ assistant oauth connections list --client-id abc123
   $ assistant oauth connections get --id <uuid>
   $ assistant oauth connections get --provider integration:google
-  $ assistant oauth connections get --provider integration:google --client-id abc123
-  $ assistant oauth connections token integration:twitter
-  $ assistant oauth connections ping integration:google`,
+  $ assistant oauth connections get --provider integration:google --client-id abc123`,
   );
 
   // ---------------------------------------------------------------------------
@@ -258,205 +235,6 @@ At least --id or --provider must be specified.`,
           }
 
           writeOutput(cmd, formatConnectionRow(row));
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          writeOutput(cmd, { ok: false, error: message });
-          process.exitCode = 1;
-        }
-      },
-    );
-
-  // ---------------------------------------------------------------------------
-  // connections token <provider-key>
-  // ---------------------------------------------------------------------------
-
-  connections
-    .command("token <provider-key>", { hidden: true })
-    .description(
-      "Print a valid OAuth access token for a provider, refreshing if expired",
-    )
-    .option(
-      "--client-id <id>",
-      "Filter by OAuth client ID when multiple apps exist for the provider",
-    )
-    .addHelpText(
-      "after",
-      `
-Arguments:
-  provider-key   Provider key (e.g. integration:google, integration:twitter)
-
-Returns a valid OAuth access token for the given provider. If the stored token
-is expired or near-expiry, it is refreshed automatically before being returned.
-
-In human mode, prints the bare token to stdout (suitable for shell substitution).
-In JSON mode (--json), prints {"ok": true, "token": "..."}.
-
-Exits with code 1 if no access token exists or refresh fails.
-
-Examples:
-  $ assistant oauth connections token integration:twitter
-  $ assistant oauth connections token integration:google --json
-  $ assistant oauth connections token integration:google --client-id abc123`,
-    )
-    .action(
-      async (
-        providerKey: string,
-        opts: { clientId?: string },
-        cmd: Command,
-      ) => {
-        try {
-          printDeprecationWarning(
-            "assistant oauth connections token",
-            "assistant oauth token",
-            cmd,
-          );
-
-          // CES shell lockdown: deny raw token reveal in untrusted shells.
-          if (isUntrustedShell()) {
-            writeOutput(cmd, { ok: false, error: UNTRUSTED_SHELL_ERROR });
-            process.exitCode = 1;
-            return;
-          }
-
-          const token = await withValidToken(
-            providerKey,
-            async (t) => t,
-            opts.clientId,
-          );
-          if (shouldOutputJson(cmd)) {
-            writeOutput(cmd, { ok: true, token });
-          } else {
-            process.stdout.write(token + "\n");
-          }
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          writeOutput(cmd, { ok: false, error: message });
-          process.exitCode = 1;
-        }
-      },
-    );
-
-  // ---------------------------------------------------------------------------
-  // connections ping <provider-key>
-  // ---------------------------------------------------------------------------
-
-  connections
-    .command("ping <provider-key>", { hidden: true })
-    .description(
-      "Verify that a stored OAuth token is still valid by hitting the provider's health-check endpoint",
-    )
-    .option(
-      "--client-id <id>",
-      "Filter by OAuth client ID when multiple apps exist for the provider",
-    )
-    .addHelpText(
-      "after",
-      `
-Arguments:
-  provider-key   Provider key (e.g. integration:google, integration:twitter)
-
-Fetches a valid access token (refreshing if needed) and sends a GET request
-to the provider's configured ping URL. Reports success (HTTP 2xx) or failure.
-
-The ping URL is set per-provider in seed data or via "providers register --ping-url".
-If no ping URL is configured for the provider, exits with an error.
-
-Examples:
-  $ assistant oauth connections ping integration:google
-  $ assistant oauth connections ping integration:twitter --json
-  $ assistant oauth connections ping integration:google --client-id abc123`,
-    )
-    .action(
-      async (
-        providerKey: string,
-        opts: { clientId?: string },
-        cmd: Command,
-      ) => {
-        try {
-          printDeprecationWarning(
-            "assistant oauth connections ping",
-            "assistant oauth ping",
-            cmd,
-          );
-
-          const provider = getProvider(providerKey);
-          if (!provider) {
-            writeOutput(cmd, {
-              ok: false,
-              error: `Provider not found: ${providerKey}`,
-            });
-            process.exitCode = 1;
-            return;
-          }
-
-          if (!provider.pingUrl) {
-            writeOutput(cmd, {
-              ok: false,
-              error: `No ping URL configured for "${providerKey}"`,
-            });
-            process.exitCode = 1;
-            return;
-          }
-
-          const pingUrl = provider.pingUrl;
-
-          const PING_TIMEOUT_MS = 15_000;
-
-          const result = await withValidToken(
-            providerKey,
-            async (token) => {
-              const controller = new AbortController();
-              const timer = setTimeout(
-                () => controller.abort(),
-                PING_TIMEOUT_MS,
-              );
-              try {
-                const res = await fetch(pingUrl, {
-                  method: "GET",
-                  headers: { Authorization: `Bearer ${token}` },
-                  signal: controller.signal,
-                });
-
-                if (res.status === 401) {
-                  const err = new Error(
-                    `Ping returned HTTP 401 from ${pingUrl}`,
-                  );
-                  (err as unknown as { status: number }).status = 401;
-                  throw err;
-                }
-
-                return { status: res.status, ok: res.ok };
-              } finally {
-                clearTimeout(timer);
-              }
-            },
-            opts.clientId,
-          );
-
-          if (result.ok) {
-            if (shouldOutputJson(cmd)) {
-              writeOutput(cmd, {
-                ok: true,
-                provider: providerKey,
-                status: result.status,
-              });
-            } else {
-              log.info(`${providerKey}: OK (HTTP ${result.status})`);
-              writeOutput(cmd, {
-                ok: true,
-                provider: providerKey,
-                status: result.status,
-              });
-            }
-          } else {
-            writeOutput(cmd, {
-              ok: false,
-              provider: providerKey,
-              status: result.status,
-              error: `Ping failed with HTTP ${result.status}`,
-            });
-            process.exitCode = 1;
-          }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           writeOutput(cmd, { ok: false, error: message });


### PR DESCRIPTION
## Summary
- Removes deprecated `connections token` and `connections ping` subcommands from connections.ts
- Cleans up unused imports, helpers, and constants (isUntrustedShell, UNTRUSTED_SHELL_ERROR, withValidToken, printDeprecationWarning)
- Updates parent connections command help text to remove token/ping examples
- `connections list` and `connections get` remain functional

Part of plan: remove-deprecated-oauth-cmds.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
