### PR TITLE
fix: revert OAuth ping for Dropbox, Linear, and Notion to curl commands

### DIFF
--- a/skills/dropbox-oauth-setup/SKILL.md
+++ b/skills/dropbox-oauth-setup/SKILL.md
@@ -172,7 +172,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:dropbox
+    curl -s -X POST -H "Authorization: Bearer $(assistant oauth token integration:dropbox)" "https://api.dropboxapi.com/2/users/get_current_account" | python3 -m json.tool
 ```
 
 **On success:** "Dropbox is connected! You can now ask me to read files, upload documents, and browse your Dropbox."

--- a/skills/linear-oauth-setup/SKILL.md
+++ b/skills/linear-oauth-setup/SKILL.md
@@ -149,7 +149,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:linear
+    curl -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $(assistant oauth token integration:linear)" -d '{"query":"{ viewer { id name email } }"}' "https://api.linear.app/graphql" | python3 -m json.tool
 ```
 
 **On success:** "Linear is connected! You can now ask me to create issues, check your assignments, search across projects, and manage your Linear workflow."

--- a/skills/notion-oauth-setup/references/path-b-public-oauth.md
+++ b/skills/notion-oauth-setup/references/path-b-public-oauth.md
@@ -90,5 +90,5 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth ping integration:notion
+    curl -s -H "Authorization: Bearer $(assistant oauth token integration:notion)" "https://api.notion.com/v1/users/me" -H "Notion-Version: 2022-06-28"
 ```


### PR DESCRIPTION
## Summary
- Reverted Dropbox, Linear, and Notion OAuth verification steps back to curl commands (from `assistant oauth ping`)
- `assistant oauth ping` hardcodes GET but Dropbox needs POST, Linear needs POST+GraphQL body, and Notion needs a `Notion-Version` header
- Addresses review feedback from #21440

## Original prompt
Revert the verification commands for Dropbox, Linear, and Notion OAuth setup skills back to their original curl-based commands, since `assistant oauth ping` only supports GET requests and these three providers need special handling.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
