### PR TITLE
refactor: remove unused printDeprecationWarning and fix stale index comment

### DIFF
--- a/assistant/src/cli/commands/oauth/__tests__/ping.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/ping.test.ts
@@ -118,7 +118,6 @@ mock.module("../shared.js", () => ({
     provider.startsWith("integration:")
       ? provider.slice("integration:".length)
       : provider,
-  printDeprecationWarning: () => {},
 }));
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/cli/commands/oauth/__tests__/token.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/token.test.ts
@@ -109,7 +109,6 @@ mock.module("../shared.js", () => ({
     return service;
   },
   isManagedMode: (key: string) => mockIsManagedMode(key),
-  printDeprecationWarning: () => {},
   toBareProvider: (provider: string): string =>
     provider.startsWith("integration:")
       ? provider.slice("integration:".length)

--- a/assistant/src/cli/commands/oauth/index.ts
+++ b/assistant/src/cli/commands/oauth/index.ts
@@ -62,7 +62,7 @@ Examples:
   registerAppCommands(oauth);
 
   // ---------------------------------------------------------------------------
-  // connections — subcommand group (includes token)
+  // connections — subcommand group (list, get)
   // ---------------------------------------------------------------------------
 
   registerConnectionCommands(oauth);

--- a/assistant/src/cli/commands/oauth/shared.ts
+++ b/assistant/src/cli/commands/oauth/shared.ts
@@ -8,7 +8,7 @@ import {
 import { getProvider } from "../../../oauth/oauth-store.js";
 import { resolveService } from "../../../oauth/provider-behaviors.js";
 import { VellumPlatformClient } from "../../../platform/client.js";
-import { shouldOutputJson, writeOutput } from "../../output.js";
+import { writeOutput } from "../../output.js";
 
 // ---------------------------------------------------------------------------
 // Re-exports
@@ -30,22 +30,6 @@ export interface PlatformConnectionEntry {
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Print a deprecation warning to stderr for renamed commands. Skipped in JSON
- * mode so machine-parseable output is not polluted.
- */
-export function printDeprecationWarning(
-  oldCmd: string,
-  newCmd: string,
-  cmd: Command,
-): void {
-  if (!shouldOutputJson(cmd)) {
-    process.stderr.write(
-      `Warning: '${oldCmd}' is deprecated. Use '${newCmd}' instead.\n`,
-    );
-  }
-}
 
 /**
  * Extract the bare provider slug (e.g. "google") from either a raw CLI


### PR DESCRIPTION
## Summary
- Remove the unused `printDeprecationWarning` function from shared.ts and its test mocks
- Clean up the unused `shouldOutputJson` import
- Fix stale comment in index.ts (`includes token` → `list, get`)

Part of plan: oauth-cli-review-cleanup.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
