### PR TITLE
fix: add discovery hints and actionable errors to oauth apps commands

### DIFF
--- a/assistant/src/cli/commands/oauth/apps.ts
+++ b/assistant/src/cli/commands/oauth/apps.ts
@@ -97,9 +97,15 @@ Examples:
     .description(
       "Look up an OAuth app by ID, provider + client-id, or provider",
     )
-    .option("--id <id>", "App ID (UUID)")
-    .option("--provider <key>", "Provider key (e.g. integration:google)")
-    .option("--client-id <id>", "OAuth client ID (requires --provider)")
+    .option("--id <id>", "App ID (UUID) from 'assistant oauth apps list'")
+    .option(
+      "--provider <key>",
+      "Provider key (e.g. integration:google) from 'assistant oauth providers list'",
+    )
+    .option(
+      "--client-id <id>",
+      "OAuth client ID (requires --provider). The client ID registered with the OAuth provider's developer console.",
+    )
     .addHelpText(
       "after",
       `
@@ -133,14 +139,23 @@ At least --id or --provider must be specified.`,
           } else {
             writeOutput(cmd, {
               ok: false,
-              error: "Provide --id, --provider, or --provider + --client-id",
+              error:
+                "Provide --id, --provider, or --provider + --client-id. Run 'assistant oauth apps list' to see all registered apps.",
             });
             process.exitCode = 1;
             return;
           }
 
           if (!row) {
-            writeOutput(cmd, { ok: false, error: "App not found" });
+            const lookup = opts.id
+              ? `id=${opts.id}`
+              : opts.provider && opts.clientId
+                ? `provider=${opts.provider}, clientId=${opts.clientId}`
+                : `provider=${opts.provider}`;
+            writeOutput(cmd, {
+              ok: false,
+              error: `No app found for ${lookup}. Run 'assistant oauth apps list' to see registered apps, or 'assistant oauth apps upsert --help' to register a new one.`,
+            });
             process.exitCode = 1;
             return;
           }
@@ -163,9 +178,12 @@ At least --id or --provider must be specified.`,
     .description("Create or return an existing OAuth app registration")
     .requiredOption(
       "--provider <key>",
-      "Provider key (e.g. integration:google)",
+      "Provider key (e.g. integration:google) from 'assistant oauth providers list'",
     )
-    .requiredOption("--client-id <id>", "OAuth client ID")
+    .requiredOption(
+      "--client-id <id>",
+      "OAuth client ID from the provider's developer console",
+    )
     .option(
       "--client-secret <secret>",
       "OAuth client secret (stored in credential store)",
@@ -293,7 +311,7 @@ Examples:
         if (!deleted) {
           writeOutput(cmd, {
             ok: false,
-            error: `App not found: ${id}`,
+            error: `App not found: ${id}. Run 'assistant oauth apps list' to see registered apps and their IDs.`,
           });
           process.exitCode = 1;
           return;


### PR DESCRIPTION
## Summary
- Add discovery command references to option help text for `apps get` and `apps upsert`
- Make error messages actionable in `apps get` and `apps delete` with specific CLI commands

Part of plan: oauth-cli-review-cleanup.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
