### PR TITLE
fix: add discovery hints and actionable errors to oauth providers commands

### DIFF
--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -175,7 +175,7 @@ Examples:
         if (!row) {
           writeOutput(cmd, {
             ok: false,
-            error: `Provider not found: ${providerKey}`,
+            error: `Provider not found: "${providerKey}". Run 'assistant oauth providers list' to see all registered providers. To register a custom provider, run 'assistant oauth providers register --help'.`,
           });
           process.exitCode = 1;
           return;
@@ -196,7 +196,10 @@ Examples:
   providers
     .command("register")
     .description("Register a new OAuth provider configuration")
-    .requiredOption("--provider-key <key>", "Provider key")
+    .requiredOption(
+      "--provider-key <key>",
+      "Unique provider key (e.g. \"integration:custom-service\"). Must not collide with an existing key from 'assistant oauth providers list'.",
+    )
     .requiredOption("--auth-url <url>", "Authorization endpoint URL")
     .requiredOption("--token-url <url>", "Token endpoint URL")
     .option("--base-url <url>", "API base URL")


### PR DESCRIPTION
## Summary
- Make `providers get` error message actionable with references to `providers list` and `providers register --help`
- Add format guidance and collision check hint to `providers register --provider-key` help text

Part of plan: oauth-cli-review-cleanup.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
