### PR TITLE
feat: add pingMethod/pingHeaders/pingBody to oauth-store and seed providers

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -95,6 +95,7 @@ import {
   migrateOAuthAppsClientSecretPath,
   migrateOAuthProvidersDisplayMetadata,
   migrateOAuthProvidersManagedServiceConfigKey,
+  migrateOAuthProvidersPingConfig,
   migrateOAuthProvidersPingUrl,
   migrateReminderRoutingIntent,
   migrateRemindersToSchedules,
@@ -511,6 +512,9 @@ export function initializeDb(): void {
 
   // 91. Memory recall logs table for inspector memory tab
   migrateCreateMemoryRecallLogs(database);
+
+  // 92. Add ping_method, ping_headers, ping_body columns to oauth_providers
+  migrateOAuthProvidersPingConfig(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -45,11 +45,12 @@ export type OAuthConnectionRow = typeof oauthConnections.$inferSelect;
  * Seed well-known provider profiles into the database. Uses INSERT … ON
  * CONFLICT DO UPDATE so that implementation fields (authUrl, tokenUrl,
  * tokenEndpointAuthMethod, userinfoUrl, extraParams, callbackTransport,
- * pingUrl, managedServiceConfigKey) and display metadata (displayName,
- * description, dashboardUrl, clientIdPlaceholder, requiresClientSecret)
- * propagate to existing installations on every startup, while
- * user-customizable fields (defaultScopes, scopePolicy, baseUrl) are
- * only written on the initial insert.
+ * pingUrl, pingMethod, pingHeaders, pingBody, managedServiceConfigKey)
+ * and display metadata (displayName, description, dashboardUrl,
+ * clientIdPlaceholder, requiresClientSecret) propagate to existing
+ * installations on every startup, while user-customizable fields
+ * (defaultScopes, scopePolicy, baseUrl) are only written on the
+ * initial insert.
  */
 export function seedProviders(
   profiles: Array<{
@@ -59,6 +60,9 @@ export function seedProviders(
     tokenEndpointAuthMethod?: string;
     userinfoUrl?: string;
     pingUrl?: string;
+    pingMethod?: string;
+    pingHeaders?: Record<string, string>;
+    pingBody?: unknown;
     baseUrl?: string;
     defaultScopes: string[];
     scopePolicy: Record<string, unknown>;
@@ -80,6 +84,9 @@ export function seedProviders(
     const tokenEndpointAuthMethod = p.tokenEndpointAuthMethod ?? null;
     const userinfoUrl = p.userinfoUrl ?? null;
     const pingUrl = p.pingUrl ?? null;
+    const pingMethod = p.pingMethod ?? null;
+    const pingHeaders = p.pingHeaders ? JSON.stringify(p.pingHeaders) : null;
+    const pingBody = p.pingBody ? JSON.stringify(p.pingBody) : null;
     const baseUrl = p.baseUrl ?? null;
     const defaultScopes = JSON.stringify(p.defaultScopes);
     const scopePolicy = JSON.stringify(p.scopePolicy);
@@ -105,6 +112,9 @@ export function seedProviders(
         extraParams,
         callbackTransport,
         pingUrl,
+        pingMethod,
+        pingHeaders,
+        pingBody,
         managedServiceConfigKey,
         displayName,
         description,
@@ -124,6 +134,9 @@ export function seedProviders(
           extraParams,
           callbackTransport,
           pingUrl,
+          pingMethod,
+          pingHeaders,
+          pingBody,
           managedServiceConfigKey,
           displayName,
           description,
@@ -164,6 +177,9 @@ export function registerProvider(params: {
   tokenEndpointAuthMethod?: string;
   userinfoUrl?: string;
   pingUrl?: string;
+  pingMethod?: string;
+  pingHeaders?: Record<string, string>;
+  pingBody?: unknown;
   baseUrl?: string;
   defaultScopes: string[];
   scopePolicy: Record<string, unknown>;
@@ -175,9 +191,6 @@ export function registerProvider(params: {
   dashboardUrl?: string;
   clientIdPlaceholder?: string;
   requiresClientSecret?: number;
-  pingMethod?: string;
-  pingHeaders?: string;
-  pingBody?: string;
 }): OAuthProviderRow {
   const db = getDb();
   const now = Date.now();
@@ -200,8 +213,8 @@ export function registerProvider(params: {
     callbackTransport: params.callbackTransport ?? null,
     pingUrl: params.pingUrl ?? null,
     pingMethod: params.pingMethod ?? null,
-    pingHeaders: params.pingHeaders ?? null,
-    pingBody: params.pingBody ?? null,
+    pingHeaders: params.pingHeaders ? JSON.stringify(params.pingHeaders) : null,
+    pingBody: params.pingBody ? JSON.stringify(params.pingBody) : null,
     managedServiceConfigKey: params.managedServiceConfigKey ?? null,
     displayName: params.displayName ?? null,
     description: params.description ?? null,

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -6,7 +6,8 @@ import { seedProviders } from "./oauth-store.js";
  * These values are upserted into the `oauth_providers` SQLite table on
  * every startup. Only Vellum implementation fields (authUrl, tokenUrl,
  * tokenEndpointAuthMethod, userinfoUrl, extraParams, callbackTransport,
- * pingUrl, managedServiceConfigKey) and display metadata (displayName,
+ * pingUrl, pingMethod, pingHeaders, pingBody, managedServiceConfigKey)
+ * and display metadata (displayName,
  * description, dashboardUrl, clientIdPlaceholder, requiresClientSecret)
  * are overwritten on subsequent startups — user-customizable
  * fields (defaultScopes, scopePolicy, baseUrl) are only
@@ -25,6 +26,9 @@ const PROVIDER_SEED_DATA: Record<
     tokenEndpointAuthMethod?: string;
     userinfoUrl?: string;
     pingUrl?: string;
+    pingMethod?: string;
+    pingHeaders?: Record<string, string>;
+    pingBody?: unknown;
     baseUrl?: string;
     defaultScopes: string[];
     scopePolicy: {
@@ -117,6 +121,7 @@ const PROVIDER_SEED_DATA: Record<
     authUrl: "https://api.notion.com/v1/oauth/authorize",
     tokenUrl: "https://api.notion.com/v1/oauth/token",
     pingUrl: "https://api.notion.com/v1/users/me",
+    pingHeaders: { "Notion-Version": "2022-06-28" },
     baseUrl: "https://api.notion.com",
     displayName: "Notion",
     description: "Pages and databases",
@@ -187,6 +192,9 @@ const PROVIDER_SEED_DATA: Record<
     authUrl: "https://linear.app/oauth/authorize",
     tokenUrl: "https://api.linear.app/oauth/token",
     pingUrl: "https://api.linear.app/graphql",
+    pingMethod: "POST",
+    pingHeaders: { "Content-Type": "application/json" },
+    pingBody: { query: "{ viewer { id name email } }" },
     baseUrl: "https://api.linear.app",
     displayName: "Linear",
     description: "Issues and projects",
@@ -280,6 +288,7 @@ const PROVIDER_SEED_DATA: Record<
     authUrl: "https://www.dropbox.com/oauth2/authorize",
     tokenUrl: "https://api.dropboxapi.com/oauth2/token",
     pingUrl: "https://api.dropboxapi.com/2/users/get_current_account",
+    pingMethod: "POST",
     baseUrl: "https://api.dropboxapi.com/2",
     displayName: "Dropbox",
     description: "Files and folders",


### PR DESCRIPTION
## Summary
- Thread pingMethod, pingHeaders, pingBody through seedProviders() and registerProvider() in oauth-store
- Add ping config to seed data: Dropbox (POST), Linear (POST+GraphQL), Notion (Notion-Version header)

Part of plan: extend-oauth-ping-params.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
