### PR TITLE
fix: add retry logic to conversation history fetch on startup

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -122,12 +122,21 @@ final class ConversationRestorer {
 
         Task { [weak self] in
             guard let self else { return }
-            let response = await self.conversationHistoryClient.fetchHistory(conversationId: conversationId, limit: 50, beforeTimestamp: nil, mode: "light", maxTextChars: nil, maxToolResultChars: 1000)
-            if let response {
-                self.handleHistoryResponse(response)
-            } else {
-                self.pendingHistoryByConversationId.removeValue(forKey: conversationId)
+            let maxAttempts = 3
+            for attempt in 1...maxAttempts {
+                let response = await self.conversationHistoryClient.fetchHistory(conversationId: conversationId, limit: 50, beforeTimestamp: nil, mode: "light", maxTextChars: nil, maxToolResultChars: 1000)
+                if let response {
+                    self.handleHistoryResponse(response)
+                    return
+                }
+                if attempt < maxAttempts {
+                    log.warning("History fetch attempt \(attempt) of \(maxAttempts) for conversation \(conversationId) failed, retrying in 1 second...")
+                    try? await Task.sleep(nanoseconds: 1_000_000_000)
+                    guard !Task.isCancelled else { return }
+                }
             }
+            log.warning("All \(maxAttempts) history fetch attempts failed for conversation \(conversationId)")
+            self.pendingHistoryByConversationId.removeValue(forKey: conversationId)
         }
     }
 


### PR DESCRIPTION
## Summary
- Add 3-attempt retry loop with 1s delays to `loadHistoryIfNeeded` in `ConversationRestorer.swift`
- Matches the existing retry pattern in `fetchConversationList()`
- Fixes first conversation getting stuck loading after quit/relaunch

Part of #21453. Closes #21454.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
