### PR TITLE
feat: use provider pingMethod/pingHeaders/pingBody in oauth ping command

### DIFF
--- a/assistant/src/cli/commands/oauth/__tests__/ping.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/ping.test.ts
@@ -563,6 +563,108 @@ describe("assistant oauth ping", () => {
   });
 
   // =========================================================================
+  // Provider ping config (method / headers / body)
+  // =========================================================================
+
+  test("uses configured pingMethod for POST providers", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:dropbox",
+      pingUrl: "https://api.dropboxapi.com/2/users/get_current_account",
+      pingMethod: "POST",
+      pingHeaders: null,
+      pingBody: null,
+    });
+
+    let capturedRequestArgs: Record<string, unknown> = {};
+    mockResolveOAuthConnectionResult = {
+      request: async (req: unknown) => {
+        capturedRequestArgs = req as Record<string, unknown>;
+        return { status: 200, headers: {}, body: {} };
+      },
+    };
+
+    const { exitCode } = await runCommand(["ping", "dropbox", "--json"]);
+    expect(exitCode).toBe(0);
+    expect(capturedRequestArgs.method).toBe("POST");
+  });
+
+  test("uses configured pingHeaders", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:notion",
+      pingUrl: "https://api.notion.com/v1/users/me",
+      pingMethod: null,
+      pingHeaders: '{"Notion-Version":"2022-06-28"}',
+      pingBody: null,
+    });
+
+    let capturedRequestArgs: Record<string, unknown> = {};
+    mockResolveOAuthConnectionResult = {
+      request: async (req: unknown) => {
+        capturedRequestArgs = req as Record<string, unknown>;
+        return { status: 200, headers: {}, body: {} };
+      },
+    };
+
+    const { exitCode } = await runCommand(["ping", "notion", "--json"]);
+    expect(exitCode).toBe(0);
+    expect(capturedRequestArgs.headers).toEqual({
+      "Notion-Version": "2022-06-28",
+    });
+  });
+
+  test("uses configured pingBody for GraphQL providers", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:linear",
+      pingUrl: "https://api.linear.app/graphql",
+      pingMethod: "POST",
+      pingHeaders: '{"Content-Type":"application/json"}',
+      pingBody: '{"query":"{ viewer { id name email } }"}',
+    });
+
+    let capturedRequestArgs: Record<string, unknown> = {};
+    mockResolveOAuthConnectionResult = {
+      request: async (req: unknown) => {
+        capturedRequestArgs = req as Record<string, unknown>;
+        return { status: 200, headers: {}, body: {} };
+      },
+    };
+
+    const { exitCode } = await runCommand(["ping", "linear", "--json"]);
+    expect(exitCode).toBe(0);
+    expect(capturedRequestArgs.method).toBe("POST");
+    expect(capturedRequestArgs.headers).toEqual({
+      "Content-Type": "application/json",
+    });
+    expect(capturedRequestArgs.body).toEqual({
+      query: "{ viewer { id name email } }",
+    });
+  });
+
+  test("defaults to GET with no extra headers/body when ping config is null", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:google",
+      pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
+      pingMethod: null,
+      pingHeaders: null,
+      pingBody: null,
+    });
+
+    let capturedRequestArgs: Record<string, unknown> = {};
+    mockResolveOAuthConnectionResult = {
+      request: async (req: unknown) => {
+        capturedRequestArgs = req as Record<string, unknown>;
+        return { status: 200, headers: {}, body: {} };
+      },
+    };
+
+    const { exitCode } = await runCommand(["ping", "google", "--json"]);
+    expect(exitCode).toBe(0);
+    expect(capturedRequestArgs.method).toBe("GET");
+    expect(capturedRequestArgs.headers).toBeUndefined();
+    expect(capturedRequestArgs.body).toBeUndefined();
+  });
+
+  // =========================================================================
   // Network failure
   // =========================================================================
 

--- a/assistant/src/cli/commands/oauth/ping.ts
+++ b/assistant/src/cli/commands/oauth/ping.ts
@@ -142,11 +142,27 @@ Examples:
           // -----------------------------------------------------------------
           // 5. Make the ping request
           // -----------------------------------------------------------------
+          const method = (providerRow.pingMethod as string | null) ?? "GET";
+
+          // Parse provider-configured ping headers (JSON string -> Record)
+          const pingHeaders: Record<string, string> = providerRow.pingHeaders
+            ? JSON.parse(providerRow.pingHeaders as string)
+            : {};
+
+          // Parse provider-configured ping body (JSON string -> unknown)
+          const pingBody: unknown = providerRow.pingBody
+            ? JSON.parse(providerRow.pingBody as string)
+            : undefined;
+
           const response = await connection.request({
-            method: "GET",
+            method,
             path,
             baseUrl,
             ...(Object.keys(query).length > 0 ? { query } : {}),
+            ...(Object.keys(pingHeaders).length > 0
+              ? { headers: pingHeaders }
+              : {}),
+            ...(pingBody !== undefined ? { body: pingBody } : {}),
           });
 
           // -----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Update ping command to read pingMethod, pingHeaders, pingBody from provider row instead of hardcoding GET
- Add tests for POST method, custom headers, GraphQL body, and null defaults

Part of plan: extend-oauth-ping-params.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
