### PR TITLE
fix: add discovery hint to apps get --client-id option

### DIFF
--- a/assistant/src/cli/commands/oauth/apps.ts
+++ b/assistant/src/cli/commands/oauth/apps.ts
@@ -104,7 +104,7 @@ Examples:
     )
     .option(
       "--client-id <id>",
-      "OAuth client ID (requires --provider). The client ID registered with the OAuth provider's developer console.",
+      "OAuth client ID (requires --provider). Find registered client IDs via 'assistant oauth apps list'.",
     )
     .addHelpText(
       "after",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-cli-review-cleanup.md.

**Gap:** apps get --client-id missing discovery hint
**What was expected:** The --client-id option should include a CLI discovery hint
**What was found:** Description only mentioned developer console, not 'assistant oauth apps list'
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
