### PR TITLE
fix: correct command paths in CLI AGENTS.md discovery table and error example

### DIFF
--- a/assistant/src/cli/AGENTS.md
+++ b/assistant/src/cli/AGENTS.md
@@ -79,12 +79,12 @@ users and AI agents have no way to know what to pass.
 
 Common discovery patterns:
 
-| Argument type | Discovery command                                              |
-| ------------- | -------------------------------------------------------------- |
-| Provider key  | `assistant providers list`                                     |
-| Connection ID | `assistant connections list` or `assistant connections status` |
-| OAuth app ID  | `assistant oauth apps list`                                    |
-| Contact ID    | `assistant contacts list`                                      |
+| Argument type | Discovery command                                                         |
+| ------------- | ------------------------------------------------------------------------- |
+| Provider key  | `assistant oauth providers list`                                          |
+| Connection ID | `assistant oauth connections list` or `assistant oauth status <provider>` |
+| OAuth app ID  | `assistant oauth apps list`                                               |
+| Contact ID    | `assistant contacts list`                                                 |
 
 ### Error Messages
 
@@ -104,7 +104,7 @@ throw new Error("Connection not found");
 
 ```ts
 throw new Error(
-  `Connection "${id}" not found. Run 'assistant connections list' to see available connections.`,
+  `Connection "${id}" not found. Run 'assistant oauth connections list' to see available connections.`,
 );
 ```
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-cli-review-cleanup.md.

**Gap:** AGENTS.md has incorrect command paths
**What was expected:** Discovery table and error example should use full command paths with oauth namespace
**What was found:** Lines 84-85 and 107 referenced commands without the oauth prefix
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
