### PR TITLE
fix: make isHistoryLoaded trigger view updates via didSet

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -751,7 +751,12 @@ public final class ChatViewModel: ObservableObject {
         "Forking is unavailable in private conversations."
 
     /// Whether this view model has had its history loaded from the daemon.
-    public var isHistoryLoaded: Bool = false
+    public var isHistoryLoaded: Bool = false {
+        didSet {
+            guard oldValue != isHistoryLoaded else { return }
+            scheduleCoalescedPublish()
+        }
+    }
 
     /// True while `populateFromHistory` is actively inserting messages.
     /// Observers can check this to avoid treating the history hydration as new activity.


### PR DESCRIPTION
## Summary
- Add `didSet` to `ChatViewModel.isHistoryLoaded` that calls `scheduleCoalescedPublish()`
- Ensures view updates happen directly when `isHistoryLoaded` changes, rather than relying on `messages` changes as a side-effect trigger
- Guards against redundant publishes when value doesn't actually change

Part of #21453. Closes #21455.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
