### PR TITLE
docs: switch Dropbox, Linear, Notion skills back to assistant oauth ping

### DIFF
--- a/skills/dropbox-oauth-setup/SKILL.md
+++ b/skills/dropbox-oauth-setup/SKILL.md
@@ -172,7 +172,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -X POST -H "Authorization: Bearer $(assistant oauth token integration:dropbox)" "https://api.dropboxapi.com/2/users/get_current_account" | python3 -m json.tool
+    assistant oauth ping integration:dropbox
 ```
 
 **On success:** "Dropbox is connected! You can now ask me to read files, upload documents, and browse your Dropbox."

--- a/skills/linear-oauth-setup/SKILL.md
+++ b/skills/linear-oauth-setup/SKILL.md
@@ -149,7 +149,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $(assistant oauth token integration:linear)" -d '{"query":"{ viewer { id name email } }"}' "https://api.linear.app/graphql" | python3 -m json.tool
+    assistant oauth ping integration:linear
 ```
 
 **On success:** "Linear is connected! You can now ask me to create issues, check your assignments, search across projects, and manage your Linear workflow."

--- a/skills/notion-oauth-setup/references/path-b-public-oauth.md
+++ b/skills/notion-oauth-setup/references/path-b-public-oauth.md
@@ -90,5 +90,5 @@ bash:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth token integration:notion)" "https://api.notion.com/v1/users/me" -H "Notion-Version: 2022-06-28"
+    assistant oauth ping integration:notion
 ```


### PR DESCRIPTION
## Summary
- Replace curl-based verification commands with assistant oauth ping for Dropbox, Linear, and Notion
- Now that the ping command supports configurable method, headers, and body, all OAuth skills use the same verification pattern

Part of plan: extend-oauth-ping-params.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
