### PR TITLE
fix: prevent conversation loading stuck after quit/relaunch

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -122,12 +122,21 @@ final class ConversationRestorer {
 
         Task { [weak self] in
             guard let self else { return }
-            let response = await self.conversationHistoryClient.fetchHistory(conversationId: conversationId, limit: 50, beforeTimestamp: nil, mode: "light", maxTextChars: nil, maxToolResultChars: 1000)
-            if let response {
-                self.handleHistoryResponse(response)
-            } else {
-                self.pendingHistoryByConversationId.removeValue(forKey: conversationId)
+            let maxAttempts = 3
+            for attempt in 1...maxAttempts {
+                let response = await self.conversationHistoryClient.fetchHistory(conversationId: conversationId, limit: 50, beforeTimestamp: nil, mode: "light", maxTextChars: nil, maxToolResultChars: 1000)
+                if let response {
+                    self.handleHistoryResponse(response)
+                    return
+                }
+                if attempt < maxAttempts {
+                    log.warning("History fetch attempt \(attempt) of \(maxAttempts) for conversation \(conversationId) failed, retrying in 1 second...")
+                    try? await Task.sleep(nanoseconds: 1_000_000_000)
+                    guard !Task.isCancelled else { return }
+                }
             }
+            log.warning("All \(maxAttempts) history fetch attempts failed for conversation \(conversationId)")
+            self.pendingHistoryByConversationId.removeValue(forKey: conversationId)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -112,6 +112,8 @@ final class ConversationRestorer {
         guard let viewModel = delegate.chatViewModel(for: localId) else { return }
         guard !viewModel.isHistoryLoaded else { return }
 
+        // Skip if a fetch is already in flight for this conversation.
+        guard pendingHistoryByConversationId[conversationId] == nil else { return }
         pendingHistoryByConversationId[conversationId] = localId
 
         // Wire up the "load more" callback so the view model can request
@@ -120,9 +122,10 @@ final class ConversationRestorer {
             self?.requestPaginatedHistory(conversationId: conversationId, beforeTimestamp: beforeTimestamp)
         }
 
+        let retryDelays: [UInt64] = [500_000_000, 2_000_000_000] // 0.5s, then 2s
         Task { [weak self] in
             guard let self else { return }
-            let maxAttempts = 3
+            let maxAttempts = retryDelays.count + 1
             for attempt in 1...maxAttempts {
                 let response = await self.conversationHistoryClient.fetchHistory(conversationId: conversationId, limit: 50, beforeTimestamp: nil, mode: "light", maxTextChars: nil, maxToolResultChars: 1000)
                 if let response {
@@ -130,12 +133,16 @@ final class ConversationRestorer {
                     return
                 }
                 if attempt < maxAttempts {
-                    log.warning("History fetch attempt \(attempt) of \(maxAttempts) for conversation \(conversationId) failed, retrying in 1 second...")
-                    try? await Task.sleep(nanoseconds: 1_000_000_000)
-                    guard !Task.isCancelled else { return }
+                    let delay = retryDelays[attempt - 1]
+                    log.warning("History fetch attempt \(attempt) of \(maxAttempts) for conversation \(conversationId) failed, retrying in \(Double(delay) / 1_000_000_000)s...")
+                    try? await Task.sleep(nanoseconds: delay)
+                    guard !Task.isCancelled else {
+                        self.pendingHistoryByConversationId.removeValue(forKey: conversationId)
+                        return
+                    }
                 }
             }
-            log.warning("All \(maxAttempts) history fetch attempts failed for conversation \(conversationId)")
+            log.error("All \(maxAttempts) history fetch attempts failed for conversation \(conversationId)")
             self.pendingHistoryByConversationId.removeValue(forKey: conversationId)
         }
     }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -751,7 +751,12 @@ public final class ChatViewModel: ObservableObject {
         "Forking is unavailable in private conversations."
 
     /// Whether this view model has had its history loaded from the daemon.
-    public var isHistoryLoaded: Bool = false
+    public var isHistoryLoaded: Bool = false {
+        didSet {
+            guard oldValue != isHistoryLoaded else { return }
+            scheduleCoalescedPublish()
+        }
+    }
 
     /// True while `populateFromHistory` is actively inserting messages.
     /// Observers can check this to avoid treating the history hydration as new activity.


### PR DESCRIPTION
## Summary
After quit/relaunch, the first conversation gets stuck in a loading skeleton state. Two root causes fixed:
1. `fetchHistory` had no retry mechanism — a single failure left `isHistoryLoaded` false forever
2. `isHistoryLoaded` was not `@Published` on `ChatViewModel`, making view updates dependent on a fragile side-effect chain

## Changes
- **ConversationRestorer.swift**: Added 3-attempt retry loop with 1s delays to `loadHistoryIfNeeded`, matching the existing pattern in `fetchConversationList`
- **ChatViewModel.swift**: Added `didSet` on `isHistoryLoaded` that calls `scheduleCoalescedPublish()` so view updates trigger directly when history loading state changes

## Milestone PRs (merged into feature branch)
- #21456: fix: add retry logic to conversation history fetch on startup
- #21461: fix: make isHistoryLoaded trigger view updates via didSet

## Project issue
Closes #21453

## Test plan
- [ ] Quit and relaunch the app — first conversation should load without getting stuck on the skeleton
- [ ] Switch between conversations — history should load reliably
- [ ] Verify no regressions in conversation loading after daemon reconnect
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
