### PR TITLE
feat: separate heartbeat conversations into Background sidebar section

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
@@ -49,6 +49,11 @@ struct ConversationModel: Identifiable, Hashable {
         self.forkParent = forkParent
     }
 
+    /// Whether this conversation was created by a background process (heartbeat, etc.).
+    var isBackgroundConversation: Bool {
+        source == "heartbeat"
+    }
+
     /// Whether this conversation was created by a schedule trigger (including one-shot/reminders).
     /// Checks for legacy "reminder" source for conversations created before unification.
     /// Falls back to title prefix when source is nil (HTTP mode).

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
@@ -39,6 +39,7 @@ final class SidebarInteractionState {
     var renameText: String = ""
     var showAllConversations: Bool = false
     var showAllScheduleConversations: Bool = false
+    var showAllBackgroundConversations: Bool = false
     /// Set of schedule group keys (scheduleJobId values) that are currently expanded.
     var expandedScheduleGroups: Set<String> = []
     var showAllApps: Bool = false

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -30,7 +30,11 @@ extension MainWindowView {
     }
 
     var regularConversations: [ConversationModel] {
-        conversationManager.visibleConversations.filter { !$0.isScheduleConversation }
+        conversationManager.visibleConversations.filter { !$0.isScheduleConversation && !$0.isBackgroundConversation }
+    }
+
+    var backgroundConversations: [ConversationModel] {
+        conversationManager.visibleConversations.filter { $0.isBackgroundConversation }
     }
 
     var scheduleConversations: [ConversationModel] {
@@ -45,6 +49,18 @@ extension MainWindowView {
     var displayedScheduleConversations: [ConversationModel] {
         let all = scheduleConversations
         return sidebar.showAllScheduleConversations ? all : Array(all.prefix(3))
+    }
+
+    var displayedBackgroundConversations: [ConversationModel] {
+        let all = backgroundConversations
+        if sidebar.showAllBackgroundConversations { return all }
+        // Auto-expand if any hidden conversation has unread messages.
+        let visible = Array(all.prefix(3))
+        let hidden = all.dropFirst(3)
+        if hidden.contains(where: { $0.hasUnseenLatestAssistantMessage }) {
+            return all
+        }
+        return visible
     }
 
     /// Groups schedule conversations by their scheduleJobId.
@@ -477,6 +493,42 @@ extension MainWindowView {
                                     size: .compact
                                 ) {
                                     withAnimation(VAnimation.fast) { sidebar.showAllScheduleConversations.toggle() }
+                                }
+                                Spacer()
+                            }
+                            .padding(.leading, VSpacing.xs + SidebarLayoutMetrics.iconSlotSize + VSpacing.xs - VSpacing.sm)
+                            .padding(.top, VSpacing.sm)
+                            .padding(.bottom, VSpacing.xs)
+                        }
+                    }
+
+                    if !backgroundConversations.isEmpty {
+                        // Background conversations section
+                        HStack {
+                            Text("Background")
+                                .font(VFont.labelDefault)
+                                .foregroundStyle(VColor.contentTertiary)
+                            Spacer()
+                        }
+                        .padding(.leading, SidebarLayoutMetrics.iconSlotSize)
+                        .padding(.trailing, VSpacing.md)
+                        .padding(.top, SidebarLayoutMetrics.scheduledHeaderTopGap)
+                        .padding(.bottom, SidebarLayoutMetrics.scheduledHeaderBottomGap)
+
+                        ForEach(displayedBackgroundConversations) { conversation in
+                            makeSidebarRow(conversation: conversation)
+                                .equatable()
+                                .padding(.bottom, SidebarLayoutMetrics.listRowGap)
+                        }
+
+                        if backgroundConversations.count > 3 {
+                            HStack {
+                                VButton(
+                                    label: sidebar.showAllBackgroundConversations ? "Show less" : "Show more",
+                                    style: .ghost,
+                                    size: .compact
+                                ) {
+                                    withAnimation(VAnimation.fast) { sidebar.showAllBackgroundConversations.toggle() }
                                 }
                                 Spacer()
                             }


### PR DESCRIPTION
## Summary

- Adds `isBackgroundConversation` computed property to `ConversationModel` (checks `source == "heartbeat"`)
- Filters background conversations out of the regular conversation list into a new "Background" section in the sidebar
- Shows 3 background conversations by default with auto-expand on unread and show more/less toggle, matching the "Scheduled" section pattern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
