### PR TITLE
feat: show last ran and next scheduled time on heartbeat card

### DIFF
--- a/assistant/src/daemon/message-types/schedules.ts
+++ b/assistant/src/daemon/message-types/schedules.ts
@@ -98,6 +98,7 @@ export interface HeartbeatConfigResponse {
   activeHoursStart: number | null;
   activeHoursEnd: number | null;
   nextRunAt: number | null;
+  lastRunAt: number | null;
   success: boolean;
   error?: string;
 }

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -29,20 +29,34 @@ export class HeartbeatService {
   private readonly deps: HeartbeatDeps;
   private timer: ReturnType<typeof setInterval> | null = null;
   private activeRun: Promise<void> | null = null;
+  private _lastRunAt: number | null = null;
+  private _nextRunAt: number | null = null;
 
   constructor(deps: HeartbeatDeps) {
     this.deps = deps;
+  }
+
+  /** Epoch-ms timestamp of the last completed heartbeat run. */
+  get lastRunAt(): number | null {
+    return this._lastRunAt;
+  }
+
+  /** Epoch-ms timestamp of the next scheduled heartbeat run. */
+  get nextRunAt(): number | null {
+    return this._nextRunAt;
   }
 
   start(): void {
     const config = getConfig().heartbeat;
     if (!config.enabled) {
       log.info("Heartbeat disabled by config");
+      this._nextRunAt = null;
       return;
     }
     if (this.timer) return;
 
     log.info({ intervalMs: config.intervalMs }, "Heartbeat service started");
+    this.scheduleNextRun(config.intervalMs);
     this.timer = setInterval(() => {
       this.runOnce().catch((err) => {
         log.error({ err }, "Heartbeat runOnce failed");
@@ -56,6 +70,7 @@ export class HeartbeatService {
       clearInterval(this.timer);
       this.timer = null;
     }
+    this._nextRunAt = null;
     this.start();
   }
 
@@ -64,6 +79,7 @@ export class HeartbeatService {
       clearInterval(this.timer);
       this.timer = null;
     }
+    this._nextRunAt = null;
     if (this.activeRun) {
       let timerId: ReturnType<typeof setTimeout>;
       const timeout = new Promise<void>((resolve) => {
@@ -120,8 +136,14 @@ export class HeartbeatService {
       await run;
     } finally {
       this.activeRun = null;
+      this._lastRunAt = Date.now();
+      this.scheduleNextRun(getConfig().heartbeat.intervalMs);
     }
     return true;
+  }
+
+  private scheduleNextRun(intervalMs: number): void {
+    this._nextRunAt = Date.now() + intervalMs;
   }
 
   private async executeRun(): Promise<void> {

--- a/assistant/src/runtime/routes/heartbeat-routes.ts
+++ b/assistant/src/runtime/routes/heartbeat-routes.ts
@@ -23,19 +23,25 @@ const log = getLogger("heartbeat-routes");
 // Handlers
 // ---------------------------------------------------------------------------
 
-function handleGetConfig(): Response {
+function handleGetConfig(
+  heartbeatService?: HeartbeatService,
+): Response {
   const config = getConfig().heartbeat;
   return Response.json({
     enabled: config.enabled,
     intervalMs: config.intervalMs,
     activeHoursStart: config.activeHoursStart ?? null,
     activeHoursEnd: config.activeHoursEnd ?? null,
-    nextRunAt: null, // TODO: track next run time in HeartbeatService
+    nextRunAt: heartbeatService?.nextRunAt ?? null,
+    lastRunAt: heartbeatService?.lastRunAt ?? null,
     success: true,
   });
 }
 
-function handleUpdateConfig(body: Record<string, unknown>): Response {
+function handleUpdateConfig(
+  body: Record<string, unknown>,
+  heartbeatService?: HeartbeatService,
+): Response {
   const config = getConfig();
   const heartbeat = { ...config.heartbeat };
 
@@ -63,7 +69,8 @@ function handleUpdateConfig(body: Record<string, unknown>): Response {
     intervalMs: heartbeat.intervalMs,
     activeHoursStart: heartbeat.activeHoursStart ?? null,
     activeHoursEnd: heartbeat.activeHoursEnd ?? null,
-    nextRunAt: null,
+    nextRunAt: heartbeatService?.nextRunAt ?? null,
+    lastRunAt: heartbeatService?.lastRunAt ?? null,
     success: true,
   });
 }
@@ -147,7 +154,7 @@ export function heartbeatRouteDefinitions(deps: {
       endpoint: "heartbeat/config",
       method: "GET",
       policyKey: "heartbeat",
-      handler: () => handleGetConfig(),
+      handler: () => handleGetConfig(deps.getHeartbeatService?.()),
     },
     {
       endpoint: "heartbeat/config",
@@ -162,7 +169,10 @@ export function heartbeatRouteDefinitions(deps: {
             400,
           );
         }
-        return handleUpdateConfig(body as Record<string, unknown>);
+        return handleUpdateConfig(
+          body as Record<string, unknown>,
+          deps.getHeartbeatService?.(),
+        );
       },
     },
     {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsSchedulesTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsSchedulesTab.swift
@@ -472,8 +472,13 @@ struct SettingsSchedulesTab: View {
                             .font(VFont.bodyMediumDefault)
                             .foregroundStyle(VColor.contentDefault)
                     }
+                    if let lastRun = config.lastRunAt, let formatted = formatEpochMs(lastRun) {
+                        Text("Last ran \(formatted)")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                    }
                     if let nextRun = config.nextRunAt, let formatted = formatEpochMs(nextRun) {
-                        Text("Next run: \(formatted)")
+                        Text("Next run \(formatted)")
                             .font(VFont.labelDefault)
                             .foregroundStyle(VColor.contentTertiary)
                     }

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -1875,16 +1875,18 @@ public struct HeartbeatConfigResponse: Codable, Sendable {
     public let activeHoursStart: Double?
     public let activeHoursEnd: Double?
     public let nextRunAt: Int?
+    public let lastRunAt: Int?
     public let success: Bool
     public let error: String?
 
-    public init(type: String, enabled: Bool, intervalMs: Double, activeHoursStart: Double?, activeHoursEnd: Double?, nextRunAt: Int?, success: Bool, error: String? = nil) {
+    public init(type: String, enabled: Bool, intervalMs: Double, activeHoursStart: Double?, activeHoursEnd: Double?, nextRunAt: Int?, lastRunAt: Int? = nil, success: Bool, error: String? = nil) {
         self.type = type
         self.enabled = enabled
         self.intervalMs = intervalMs
         self.activeHoursStart = activeHoursStart
         self.activeHoursEnd = activeHoursEnd
         self.nextRunAt = nextRunAt
+        self.lastRunAt = lastRunAt
         self.success = success
         self.error = error
     }


### PR DESCRIPTION
## Summary
- Track `lastRunAt` and `nextRunAt` timestamps in `HeartbeatService` and return them from the heartbeat config API endpoint
- Display "Last ran" and "Next run" with relative timestamps on the heartbeat settings card in the macOS app
- Add `lastRunAt` field to `HeartbeatConfigResponse` in both TypeScript message types and Swift generated types

## Original prompt
This should show when the last heartbeat ran and when the next one is scheduled to run
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
