### PR TITLE
fix: add WebP to avatar upload allowed file types

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarCustomizationPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarCustomizationPanel.swift
@@ -104,7 +104,7 @@ struct AvatarCustomizationPanel: View {
         let panel = NSOpenPanel()
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
-        panel.allowedContentTypes = [.png, .jpeg, .gif, .heic]
+        panel.allowedContentTypes = [.png, .jpeg, .webP, .gif, .heic]
         panel.message = "Choose a profile picture"
 
         guard panel.runModal() == .OK, let url = panel.url,

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarManagementSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarManagementSheet.swift
@@ -81,7 +81,7 @@ struct AvatarManagementSheet: View {
                 actionRow(
                     icon: "photo",
                     label: "Upload Image",
-                    subtitle: "Choose a PNG or JPEG from your Mac"
+                    subtitle: "Choose an image from your Mac"
                 ) {
                     pickImage()
                 }
@@ -329,7 +329,7 @@ struct AvatarManagementSheet: View {
         let panel = NSOpenPanel()
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
-        panel.allowedContentTypes = [.png, .jpeg, .gif, .heic]
+        panel.allowedContentTypes = [.png, .jpeg, .webP, .gif, .heic]
         panel.message = "Choose a profile picture"
 
         guard panel.runModal() == .OK, let url = panel.url,


### PR DESCRIPTION
## Summary
- Add `.webP` to `allowedContentTypes` in both `AvatarManagementSheet` and `AvatarCustomizationPanel` file pickers
- Update subtitle from "Choose a PNG or JPEG from your Mac" to "Choose an image from your Mac" since we now support PNG, JPEG, WebP, GIF, and HEIC

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
