### PR TITLE
fix: schedule-triggered task conversations missing from sidebar

### DIFF
--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -188,13 +188,19 @@ async function runScheduleOnce(
         );
         const { runTask } = await import("../tasks/task-runner.js");
         const result = await runTask(
-          { taskId, workingDir: process.cwd(), source: "schedule" },
+          { taskId, workingDir: process.cwd(), source: "schedule", scheduleJobId: job.id },
           processMessage as (
             conversationId: string,
             message: string,
             taskRunId: string,
           ) => Promise<void>,
         );
+
+        onScheduleConversationCreated?.({
+          conversationId: result.conversationId,
+          scheduleJobId: job.id,
+          title: result.status === "failed" ? `${job.name}: Error` : job.name,
+        });
 
         // Track the schedule run using the task's conversation
         const runId = createScheduleRun(job.id, result.conversationId);

--- a/assistant/src/tasks/task-runner.ts
+++ b/assistant/src/tasks/task-runner.ts
@@ -19,6 +19,8 @@ export interface TaskRunOptions {
   approvedTools?: string[];
   /** Conversation source to propagate to the created conversation (e.g. 'schedule' when triggered by a schedule). */
   source?: string;
+  /** Schedule job ID to associate with the conversation. Set when the task is triggered by a schedule. */
+  scheduleJobId?: string;
 }
 
 export interface TaskRunResult {
@@ -58,8 +60,12 @@ export async function runTask(
 
   const run = createTaskRun(task.id);
   const conversation = bootstrapConversation({
-    conversationType: "background",
+    // Schedule-triggered tasks use "standard" so they appear in the sidebar's
+    // Scheduled section; non-schedule tasks use "background" to stay out of
+    // the main conversation list.
+    conversationType: opts.source === "schedule" ? undefined : "background",
     source: opts.source,
+    scheduleJobId: opts.scheduleJobId,
     origin: "task",
     systemHint: `Task: ${task.title}`,
   });


### PR DESCRIPTION
## Summary
- When a schedule fires a task via `run_task:<id>`, the task runner hardcoded `conversationType: "background"` — causing these conversations to be filtered out of the conversation list API when `show-background-conversations` is disabled (the default). Now uses `"standard"` when the source is `"schedule"`.
- The scheduler never called `onScheduleConversationCreated` for task-based schedules, so the client received no SSE notification. Now broadcasts the event after task completion.
- The scheduler never passed `scheduleJobId` to the task runner, so conversations couldn't be grouped by schedule in the sidebar. Added `scheduleJobId` to `TaskRunOptions`.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
