### PR TITLE
fix: include per-user persona in BTW side-chain greeting generation

### DIFF
--- a/assistant/src/runtime/btw-sidechain.ts
+++ b/assistant/src/runtime/btw-sidechain.ts
@@ -33,6 +33,8 @@ export interface RunBtwSidechainParams {
   signal?: AbortSignal;
   timeoutMs?: number;
   onEvent?: (event: ProviderEvent) => void;
+  userPersona?: string | null;
+  channelPersona?: string | null;
 }
 
 export interface RunBtwSidechainResult {
@@ -64,7 +66,11 @@ export async function runBtwSidechain(
     params.systemPrompt ??
     (params.conversation?.hasSystemPromptOverride
       ? params.conversation.systemPrompt
-      : buildSystemPrompt({ excludeBootstrap: true }));
+      : buildSystemPrompt({
+          excludeBootstrap: true,
+          userPersona: params.userPersona,
+          channelPersona: params.channelPersona,
+        }));
 
   const { signal: timeoutSignal, cleanup } = createTimeout(
     params.timeoutMs ?? 30_000,

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -15,6 +15,10 @@
 import { existsSync, readFileSync } from "node:fs";
 
 import { getConversationByKey } from "../../memory/conversation-key-store.js";
+import {
+  resolveChannelPersona,
+  resolveGuardianPersona,
+} from "../../prompts/persona-resolver.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspacePromptPath } from "../../util/platform.js";
 import type { AuthContext } from "../auth/types.js";
@@ -144,10 +148,14 @@ async function handleBtw(
       (async () => {
         try {
           const isIntroRequest = conversationKey === IDENTITY_INTRO_KEY;
+          const userPersona = resolveGuardianPersona();
+          const channelPersona = resolveChannelPersona(undefined);
           const result = await runBtwSidechain({
             content: trimmedContent,
             conversation,
             signal: req.signal,
+            userPersona,
+            channelPersona,
             onEvent: (event) => {
               if (event.type === "text_delta") {
                 controller.enqueue(


### PR DESCRIPTION
## Summary
- BTW side-chain greeting generation was building its system prompt via `buildSystemPrompt({ excludeBootstrap: true })` without any persona options, so per-user persona files (e.g. `sidd.md`) were ignored
- Added `userPersona`/`channelPersona` params to `RunBtwSidechainParams` and passed them through to `buildSystemPrompt()` in the fallback path
- Resolved persona in `btw-routes.ts` via `resolveGuardianPersona()` and `resolveChannelPersona()` before calling `runBtwSidechain()`

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
