### PR TITLE
fix: update btw-routes test for persona params

### DIFF
--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -304,7 +304,9 @@ describe("POST /v1/btw", () => {
     // System prompt built by buildSystemPrompt({ excludeBootstrap: true })
     expect(systemPrompt).toBe(MOCK_SYSTEM_PROMPT);
     expect(mockBuildSystemPrompt).toHaveBeenCalledWith({
+      channelPersona: null,
       excludeBootstrap: true,
+      userPersona: null,
     });
 
     // Options: tool_choice must be "none"


### PR DESCRIPTION
## Summary
- Update `btw-routes.test.ts` to expect `channelPersona: null` and `userPersona: null` in the `buildSystemPrompt` call assertion, matching the implementation change from #21470.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23529674721/job/68490488217
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
