### PR TITLE
fix: reset heartbeat timer on guardian message

### DIFF
--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -329,6 +329,41 @@ describe("HeartbeatService", () => {
     expect(alerterCalls[0].body).toBe("DB locked");
   });
 
+  test("resetTimer() pushes nextRunAt forward", () => {
+    const service = createService();
+    service.start();
+
+    const firstNextRunAt = service.nextRunAt;
+    expect(firstNextRunAt).not.toBeNull();
+
+    // Simulate some time passing, then reset
+    const before = Date.now();
+    service.resetTimer();
+    const afterReset = service.nextRunAt;
+
+    expect(afterReset).not.toBeNull();
+    // The new nextRunAt should be >= the interval from now
+    expect(afterReset!).toBeGreaterThanOrEqual(before + mockConfig.heartbeat.intervalMs);
+    service.stop();
+  });
+
+  test("resetTimer() is a no-op when heartbeat is not running", () => {
+    const service = createService();
+    // Don't call start() — heartbeat not running
+    expect(service.nextRunAt).toBeNull();
+    service.resetTimer();
+    expect(service.nextRunAt).toBeNull();
+  });
+
+  test("resetTimer() is a no-op when heartbeat is disabled", () => {
+    mockConfig.heartbeat.enabled = false;
+    const service = createService();
+    service.start();
+    expect(service.nextRunAt).toBeNull();
+    service.resetTimer();
+    expect(service.nextRunAt).toBeNull();
+  });
+
   test("cleanup", () => {
     try {
       rmSync(testWorkspaceDir, { recursive: true, force: true });

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -74,6 +74,23 @@ export class HeartbeatService {
     this.start();
   }
 
+  /**
+   * Reset the heartbeat timer so the next run is a full interval from now.
+   * Called when the guardian sends a message — no need for a heartbeat shortly
+   * after an active conversation.
+   */
+  resetTimer(): void {
+    if (!this.timer) return;
+    const config = getConfig().heartbeat;
+    clearInterval(this.timer);
+    this.scheduleNextRun(config.intervalMs);
+    this.timer = setInterval(() => {
+      this.runOnce().catch((err) => {
+        log.error({ err }, "Heartbeat runOnce failed");
+      });
+    }, config.intervalMs);
+  }
+
   async stop(): Promise<void> {
     if (this.timer) {
       clearInterval(this.timer);

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -1176,6 +1176,7 @@ export class RuntimeHttpServer {
         approvalConversationGenerator: this.approvalConversationGenerator,
         suggestionCache: this.suggestionCache,
         suggestionInFlight: this.suggestionInFlight,
+        getHeartbeatService: this.getHeartbeatService,
       }),
       ...globalSearchRouteDefinitions(),
       ...approvalRouteDefinitions(),
@@ -1238,6 +1239,7 @@ export class RuntimeHttpServer {
         guardianActionCopyGenerator: this.guardianActionCopyGenerator,
         guardianFollowUpConversationGenerator:
           this.guardianFollowUpConversationGenerator,
+        getHeartbeatService: this.getHeartbeatService,
       }),
       ...callRouteDefinitions({ assistantId }),
 

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -8,6 +8,7 @@
  * - channel-guardian-routes.ts — guardian approval interception, expiry sweep
  */
 
+import type { HeartbeatService } from "../../heartbeat/heartbeat-service.js";
 import type { RouteDefinition } from "../http-router.js";
 import type {
   ApprovalConversationGenerator,
@@ -53,6 +54,7 @@ export function channelRouteDefinitions(deps: {
   approvalConversationGenerator?: ApprovalConversationGenerator;
   guardianActionCopyGenerator?: GuardianActionCopyGenerator;
   guardianFollowUpConversationGenerator?: GuardianFollowUpConversationGenerator;
+  getHeartbeatService?: () => HeartbeatService | undefined;
 }): RouteDefinition[] {
   return [
     {
@@ -73,6 +75,7 @@ export function channelRouteDefinitions(deps: {
           deps.approvalConversationGenerator,
           deps.guardianActionCopyGenerator,
           deps.guardianFollowUpConversationGenerator,
+          deps.getHeartbeatService?.(),
         ),
     },
     {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -55,6 +55,7 @@ import {
   getOrCreateConversation,
 } from "../../memory/conversation-key-store.js";
 import { searchConversations } from "../../memory/conversation-queries.js";
+import type { HeartbeatService } from "../../heartbeat/heartbeat-service.js";
 import { getConfiguredProvider } from "../../providers/provider-send-message.js";
 import type { Provider } from "../../providers/types.js";
 import { checkIngressForSecrets } from "../../security/secret-ingress.js";
@@ -628,6 +629,7 @@ export async function handleSendMessage(
   deps: {
     sendMessageDeps?: SendMessageDeps;
     approvalConversationGenerator?: ApprovalConversationGenerator;
+    heartbeatService?: HeartbeatService;
   },
   authContext: AuthContext,
 ): Promise<Response> {
@@ -730,6 +732,10 @@ export async function handleSendMessage(
       503,
     );
   }
+
+  // Desktop messages are always from the guardian — reset the heartbeat
+  // timer so the next heartbeat is a full interval after this interaction.
+  deps.heartbeatService?.resetTimer();
 
   const conversationType =
     body.conversationType === "private" ? ("private" as const) : undefined;
@@ -1482,6 +1488,7 @@ export function conversationRouteDefinitions(deps: {
   approvalConversationGenerator?: ApprovalConversationGenerator;
   suggestionCache: Map<string, string>;
   suggestionInFlight: Map<string, Promise<string | null>>;
+  getHeartbeatService?: () => HeartbeatService | undefined;
 }): RouteDefinition[] {
   return [
     {
@@ -1498,6 +1505,7 @@ export function conversationRouteDefinitions(deps: {
           {
             sendMessageDeps: deps.sendMessageDeps,
             approvalConversationGenerator: deps.approvalConversationGenerator,
+            heartbeatService: deps.getHeartbeatService?.(),
           },
           authContext,
         ),

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -5,6 +5,7 @@
  * invite token redemption.
  */
 import { getChannelPermissionProfile } from "../../channels/permission-profiles.js";
+import type { HeartbeatService } from "../../heartbeat/heartbeat-service.js";
 import {
   CHANNEL_IDS,
   INTERFACE_IDS,
@@ -58,6 +59,7 @@ export async function handleChannelInbound(
   approvalConversationGenerator?: ApprovalConversationGenerator,
   _guardianActionCopyGenerator?: GuardianActionCopyGenerator,
   _guardianFollowUpConversationGenerator?: GuardianFollowUpConversationGenerator,
+  heartbeatService?: HeartbeatService,
 ): Promise<Response> {
   // Gateway-origin proof is enforced by route-policy middleware (svc_gateway
   // principal type required) before this handler runs. The exchange JWT
@@ -671,6 +673,12 @@ export async function handleChannelInbound(
         "Channel message blocked at ingress: contains secrets",
       );
     } else {
+      // Guardian messages reset the heartbeat timer so the next heartbeat
+      // fires a full interval after this interaction.
+      if (trustCtx.trustClass === "guardian") {
+        heartbeatService?.resetTimer();
+      }
+
       // Fire-and-forget: process the message and deliver the reply in the background.
       // The HTTP response returns immediately so the gateway webhook is not blocked.
       // The onEvent callback in processMessage registers pending interactions, and


### PR DESCRIPTION
## Summary
- Added `resetTimer()` method to `HeartbeatService` that clears and restarts the interval timer, pushing the next heartbeat to a full interval from now
- Desktop path (`handleSendMessage`): always resets the timer since desktop messages are always from the guardian
- Channel path (`handleChannelInbound`): resets the timer only when `trustClass === "guardian"` and the message enters the agent loop

## Original prompt
When the guardian sends a message, it should reset the heartbeat timer back to the beginning so the first heartbeat is <interval> after the last guardian message
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
