### PR TITLE
fix: stop 60s watchdog from killing extended thinking responses

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1868,7 +1868,7 @@ extension ChatViewModel {
             switch msg.phase {
             case "thinking":
                 isThinking = true
-                isSending = true
+                isSending = false
             case "streaming", "tool_running":
                 isThinking = false
             case "idle":


### PR DESCRIPTION
## Summary
- The `isSending` watchdog (60s timeout) was being restarted when the daemon acknowledged thinking, causing it to fire during long extended-thinking responses and force-reset the entire UI state to idle
- Changed `isSending = true` → `isSending = false` in the `"thinking"` activity state handler — once the daemon is thinking, the message has been received and the watchdog is no longer needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
