### PR TITLE
fix: wire Slack thread context hints through to LLM [JARVIS-355]

### DIFF
--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -61,6 +61,12 @@ mock.module("../prompts/system-prompt.js", () => ({
   buildSystemPrompt: mockBuildSystemPrompt,
 }));
 
+mock.module("../prompts/persona-resolver.js", () => ({
+  resolveGuardianPersona: () => null,
+  resolveChannelPersona: () => null,
+  resolveUserPersona: () => null,
+}));
+
 // ---------------------------------------------------------------------------
 // Imports (after mocks)
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -245,6 +245,7 @@ export interface AgentLoopConversationContext {
   trustContext?: TrustContext;
   assistantId?: string;
   voiceCallControlPrompt?: string;
+  transportHints?: string[];
 
   readonly coreToolNames: Set<string>;
   allowedToolNames?: Set<string>;
@@ -748,6 +749,7 @@ export async function runAgentLoopImpl(
       temporalContext,
       nowScratchpad,
       voiceCallControlPrompt: ctx.voiceCallControlPrompt ?? null,
+      transportHints: ctx.transportHints ?? null,
       isNonInteractive: !isInteractiveResolved,
     } as const;
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1000,6 +1000,23 @@ export function stripInterfaceTurnContext(messages: Message[]): Message[] {
   ]);
 }
 
+// ---------------------------------------------------------------------------
+// Transport hints injection (e.g. Slack thread context from the gateway)
+// ---------------------------------------------------------------------------
+
+function injectTransportHints(message: Message, hints: string[]): Message {
+  const block = `<transport_hints>\n${hints.join("\n")}\n</transport_hints>`;
+  return {
+    ...message,
+    content: [{ type: "text", text: block }, ...message.content],
+  };
+}
+
+/** Strip `<transport_hints>` blocks injected by `injectTransportHints`. */
+export function stripTransportHints(messages: Message[]): Message[] {
+  return stripUserTextBlocksByPrefix(messages, ["<transport_hints>"]);
+}
+
 /** Prefixes stripped by the pipeline (order doesn't matter — single pass). */
 const RUNTIME_INJECTION_PREFIXES = [
   "<channel_capabilities>",
@@ -1018,6 +1035,7 @@ const RUNTIME_INJECTION_PREFIXES = [
   "<active_dynamic_page>",
   "<non_interactive_context>",
   "<now_scratchpad>",
+  "<transport_hints>",
 ];
 
 /**
@@ -1064,6 +1082,7 @@ export function applyRuntimeInjections(
     voiceCallControlPrompt?: string | null;
     nowScratchpad?: string | null;
     isNonInteractive?: boolean;
+    transportHints?: string[] | null;
     mode?: InjectionMode;
   },
 ): Message[] {
@@ -1161,6 +1180,16 @@ export function applyRuntimeInjections(
       result = [
         ...result.slice(0, -1),
         injectInboundActorContext(userTail, options.inboundActorContext),
+      ];
+    }
+  }
+
+  if (options.transportHints && options.transportHints.length > 0) {
+    const userTail = result[result.length - 1];
+    if (userTail && userTail.role === "user") {
+      result = [
+        ...result.slice(0, -1),
+        injectTransportHints(userTail, options.transportHints),
       ];
     }
   }

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1184,7 +1184,11 @@ export function applyRuntimeInjections(
     }
   }
 
-  if (options.transportHints && options.transportHints.length > 0) {
+  if (
+    mode === "full" &&
+    options.transportHints &&
+    options.transportHints.length > 0
+  ) {
     const userTail = result[result.length - 1];
     if (userTail && userTail.role === "user") {
       result = [

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -187,6 +187,7 @@ export class Conversation {
   /** @internal */ authContext?: AuthContext;
   /** @internal */ loadedHistoryTrustClass?: TrustClass;
   /** @internal */ voiceCallControlPrompt?: string;
+  /** @internal */ transportHints?: string[];
   /** @internal */ assistantId?: string;
   /** @internal */ commandIntent?: {
     type: string;
@@ -890,6 +891,10 @@ export class Conversation {
 
   setVoiceCallControlPrompt(prompt: string | null): void {
     this.voiceCallControlPrompt = prompt ?? undefined;
+  }
+
+  setTransportHints(hints: string[] | undefined): void {
+    this.transportHints = hints;
   }
 
   setAssistantId(assistantId: string | null): void {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -319,7 +319,7 @@ export class DaemonServer {
   }
 
   private applyTransportMetadata(
-    _conversation: Conversation,
+    conversation: Conversation,
     options: ConversationCreateOptions | undefined,
   ): void {
     const transport = options?.transport;
@@ -328,6 +328,7 @@ export class DaemonServer {
       { channelId: transport.channelId },
       "Transport metadata received",
     );
+    conversation.setTransportHints(transport.hints);
   }
 
   constructor() {


### PR DESCRIPTION
## Summary
- PR #21302 added thread context fetching in the gateway but `applyTransportMetadata()` in `server.ts` silently dropped the `transport.hints` payload — the thread context never reached the LLM
- This wires the hints through: `server.ts` stores them on the Conversation, the agent loop passes them to `applyRuntimeInjections`, and a new `<transport_hints>` injection block delivers them to the model
- 4 files changed, minimal touch — the gateway-side fetch from #21302 is now actually consumed

## Test plan
- [ ] Manual: mention bot in a Slack thread reply → verify it now understands the parent message content
- [ ] Verify `<transport_hints>` block appears in model input when thread context is present
- [ ] Verify no `<transport_hints>` block when there's no thread context (e.g. DM or non-thread message)
- [ ] TypeScript compiles clean

Closes JARVIS-355

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
