### PR TITLE
Fix btw-routes test: mock persona-resolver to avoid contacts table query

### DIFF
--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -61,6 +61,12 @@ mock.module("../prompts/system-prompt.js", () => ({
   buildSystemPrompt: mockBuildSystemPrompt,
 }));
 
+mock.module("../prompts/persona-resolver.js", () => ({
+  resolveGuardianPersona: () => null,
+  resolveChannelPersona: () => null,
+  resolveUserPersona: () => null,
+}));
+
 // ---------------------------------------------------------------------------
 // Imports (after mocks)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The `btw-routes` handler now calls `resolveGuardianPersona()` which queries the `contacts` table via `findGuardianForChannel()`. The test DB doesn't have this table, causing `SQLiteError: no such table: contacts`.

Fix: mock `persona-resolver.js` to return `null` for all persona functions, isolating the test from DB dependencies.

## Test plan
- [x] `btw-routes.test.ts` — 11/11 pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
