### PR TITLE
Improve oauth request/token help text to clarify best practices

### DIFF
--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -86,7 +86,7 @@ export function registerRequestCommand(oauth: Command): void {
   oauth
     .command("request <url>")
     .description(
-      "Make an authenticated OAuth request (supports a curl-like interface)",
+      "The recommended way to make an authenticated request to an OAuth provider (supports a curl-like interface)",
     )
     .requiredOption(
       "--provider <key>",
@@ -114,9 +114,13 @@ export function registerRequestCommand(oauth: Command): void {
     .addHelpText(
       "after",
       `
-Make authenticated HTTP requests through an OAuth provider. Resolves the
-OAuth connection automatically (platform-managed or BYO) and injects
-tokens transparently.
+This is the first-class mechanism for making authenticated HTTP requests
+to an OAuth provider. By using this CLI, you follow security best-practices
+regarding how the OAuth token is used. This approach is preferred over retrieving
+the token (using \`assistant oauth token\`) and making the request directly.
+
+This command resolves the OAuth connection automatically (regardless of whether
+the provider's mode is set to "managed" or "your-own") and injects tokens transparently.
 
 URL can be absolute (https://api.twitter.com/2/tweets) or relative (/2/tweets).
 Absolute URLs have their host extracted as a baseUrl override; relative paths

--- a/assistant/src/cli/commands/oauth/token.ts
+++ b/assistant/src/cli/commands/oauth/token.ts
@@ -31,7 +31,7 @@ export function registerTokenCommand(oauth: Command): void {
   oauth
     .command("token <provider>")
     .description(
-      'Print a valid OAuth access token for a provider (only supported for providers with mode set to "your-own")',
+      'An escape hatch to retrieve a valid OAuth access token for a provider whose mode is "your-own" for direct use.',
     )
     .option(
       "--account <account>",
@@ -56,6 +56,12 @@ Options:
                         shown in 'assistant oauth status <provider>'.
   --client-id <id>      Select a specific OAuth app when multiple apps exist
                         for the same provider.
+
+
+This command is discouraged from use and should be used sparingly. Only use
+if you need direct access to the token (i.e. \`assistant oauth request\` is
+insufficient for your use case) and you are comfortable with the potential
+security implications of exposing this token.
 
 Token retrieval is only supported for providers with mode set to "your-own".
 Platform-managed providers handle tokens internally — use


### PR DESCRIPTION
## Summary
- Positioned `oauth request` as the recommended first-class way to make authenticated requests, noting it follows security best practices over raw token retrieval
- Added a discouragement note to `oauth token` help text clarifying it's an escape hatch for when `oauth request` is insufficient, with a security implications callout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
