### PR TITLE
fix: update VModal to match Figma modal spec

### DIFF
--- a/clients/shared/DesignSystem/Components/Layout/VModal.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VModal.swift
@@ -109,10 +109,10 @@ public struct VModal<Content: View, Footer: View>: View {
             }
         }
         .frame(maxHeight: screenMaxHeight)
-        .background(VColor.surfaceOverlay)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .background(VColor.surfaceLift)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .overlay(
-            RoundedRectangle(cornerRadius: VRadius.md)
+            RoundedRectangle(cornerRadius: VRadius.lg)
                 .stroke(VColor.borderBase, lineWidth: 1)
         )
     }
@@ -127,7 +127,7 @@ public struct VModal<Content: View, Footer: View>: View {
             }
             if let subtitle {
                 Text(subtitle)
-                    .font(VFont.bodyMediumLighter)
+                    .font(VFont.bodyMediumDefault)
                     .foregroundStyle(VColor.contentSecondary)
             }
         }


### PR DESCRIPTION
## Summary
- Background: `surfaceOverlay` → `surfaceLift` (white in light mode, black in dark mode) per Figma design
- Corner radius: `VRadius.md` (8pt) → `VRadius.lg` (12pt)
- Subtitle font: `bodyMediumLighter` (weight 300) → `bodyMediumDefault` (weight 500)

All VModal consumers (AppIconPicker, MemoryCreate/Detail, PairingQR, TrustRuleForm, BundleConfirmation, SkillDelete) inherit these changes automatically.

Part 1 of modal consolidation — follow-up PRs will address ad-hoc sheets and button positioning.

## Test plan
- [ ] Open any VModal-based sheet (e.g. Change Icon on an app card, New Memory, Trust Rules)
- [ ] Verify background is white (light mode) / black (dark mode)
- [ ] Verify corner radius is 12pt (visually rounder than before)
- [ ] Toggle dark mode and confirm both themes render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
