### PR TITLE
fix: standardize ad-hoc progress sheets

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -230,8 +230,9 @@ struct SettingsDeveloperTab: View {
                     .font(VFont.labelDefault)
                     .foregroundStyle(VColor.contentTertiary)
             }
-            .padding(VSpacing.xxl)
+            .padding(VSpacing.lg)
             .frame(minWidth: 260)
+            .background(VColor.surfaceLift)
             .interactiveDismissDisabled()
         }
         .sheet(isPresented: $isRetiring) {
@@ -246,8 +247,9 @@ struct SettingsDeveloperTab: View {
                     .font(VFont.labelDefault)
                     .foregroundStyle(VColor.contentTertiary)
             }
-            .padding(VSpacing.xxl)
+            .padding(VSpacing.lg)
             .frame(minWidth: 260)
+            .background(VColor.surfaceLift)
             .interactiveDismissDisabled()
         }
         .sheet(isPresented: $showingEnvVars) {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -130,8 +130,9 @@ struct SettingsGeneralTab: View {
                         .foregroundStyle(VColor.contentTertiary)
                 }
             }
-            .padding(VSpacing.xxl)
+            .padding(VSpacing.lg)
             .frame(minWidth: 260)
+            .background(VColor.surfaceLift)
             .interactiveDismissDisabled(!dockerOperationTimedOut)
             .onAppear {
                 dockerOperationTimedOut = false


### PR DESCRIPTION
## Summary
- Docker operation, restart, and retire progress sheets now use 16pt padding (`VSpacing.lg`) instead of 24pt
- Added `surfaceLift` background to all three progress sheets
- These sheets were the only ones bypassing VModal with raw VStack layouts

Part 2 of modal consolidation (depends on PR #21484 for VModal changes).

## Test plan
- [ ] Trigger Docker update in Settings → General and verify progress sheet styling
- [ ] Trigger restart in Settings → Developer and verify progress sheet styling
- [ ] Verify sheets display correctly in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
