### PR TITLE
fix: right-align modal buttons in TrustRuleForm and BundleConfirmation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
@@ -231,8 +231,6 @@ private struct TrustRuleFormView: View {
                 Text(existingRule != nil ? "Edit Trust Rule" : "Add Trust Rule")
                     .font(.headline)
                 Spacer()
-                Button("Cancel") { dismiss() }
-                    .keyboardShortcut(.cancelAction)
             }
             .padding()
 
@@ -262,6 +260,8 @@ private struct TrustRuleFormView: View {
 
             HStack {
                 Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
                 Button("Save") {
                     save()
                 }

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationView.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationView.swift
@@ -19,7 +19,7 @@ struct BundleConfirmationView: View {
             }
         }
         .frame(width: 480, height: 400)
-        .background(VColor.surfaceOverlay)
+        .background(VColor.surfaceLift)
     }
 
     // MARK: - Main Confirmation Content
@@ -216,12 +216,12 @@ struct BundleConfirmationView: View {
     // MARK: - Footer
 
     private var footerSection: some View {
-        HStack(spacing: VSpacing.md) {
+        HStack(spacing: VSpacing.sm) {
+            Spacer()
+
             VButton(label: "Cancel", style: .outlined) {
                 viewModel.cancel()
             }
-
-            Spacer()
 
             if viewModel.isTampered {
                 tamperedInstallButton


### PR DESCRIPTION
## Summary
- **TrustRuleFormView:** Moved Cancel from top-right header to bottom footer, right-aligned next to Save (Cancel → Save order per Figma spec)
- **BundleConfirmationView:** Moved Cancel from left side to right-aligned next to Install (Cancel → Install), 8pt gap
- **BundleConfirmationView:** Background `surfaceOverlay` → `surfaceLift`

Part 3 of modal consolidation. All other VModal-based footers (AppIconPicker, MemoryCreate, MemoryDetail, PairingQR, OAuth) were already correctly right-aligned.

## Test plan
- [ ] Open Trust Rules → Add Rule, verify Cancel and Save are bottom-right
- [ ] Open a shared app bundle, verify Cancel and Install are bottom-right
- [ ] Verify BundleConfirmation background is white (light) / black (dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
