### PR TITLE
fix: remove backdrop overlays from modals

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -193,38 +193,22 @@ struct IdentityPanel: View {
                 .padding(.trailing, 0)
             }
             .animation(.spring(response: 0.4, dampingFraction: 0.8), value: isFullscreen)
-            .overlay {
-                VColor.auxBlack.opacity(viewingFilePath != nil ? 0.4 : 0)
-                    .ignoresSafeArea()
-                    .allowsHitTesting(viewingFilePath != nil)
-                    .onTapGesture { viewingFilePath = nil }
-
+            .sheet(isPresented: Binding(
+                get: { viewingFilePath != nil },
+                set: { if !$0 { viewingFilePath = nil } }
+            )) {
                 if let path = viewingFilePath {
                     WorkspaceFileSheet(filePath: path, onClose: { viewingFilePath = nil })
                         .frame(width: 600, height: 500)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
-                        .shadow(color: VColor.auxBlack.opacity(0.5), radius: 20, y: 8)
-                        .transition(.opacity.combined(with: .scale(scale: 0.95)))
                 }
             }
-            .animation(VAnimation.standard, value: viewingFilePath != nil)
-            .overlay {
-                VColor.auxBlack.opacity(showAvatarSheet ? 0.4 : 0)
-                    .ignoresSafeArea()
-                    .allowsHitTesting(showAvatarSheet)
-                    .onTapGesture { showAvatarSheet = false }
-
-                if showAvatarSheet {
-                    AvatarManagementSheet(
-                        onClose: { showAvatarSheet = false }
-                    )
-                    .frame(width: 360)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .shadow(color: VColor.auxBlack.opacity(0.5), radius: 20, y: 8)
-                    .transition(.opacity.combined(with: .scale(scale: 0.95)))
-                }
+            .sheet(isPresented: $showAvatarSheet) {
+                AvatarManagementSheet(
+                    onClose: { showAvatarSheet = false }
+                )
+                .frame(width: 360)
+                .fixedSize(horizontal: false, vertical: true)
             }
-            .animation(VAnimation.standard, value: showAvatarSheet)
             .onAppear {
                 identity = IdentityInfo.load()
                 metadata = AssistantMetadata.load()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -108,25 +108,13 @@ struct MemoriesPanel: View {
             searchDebounceTask?.cancel()
             searchDebounceTask = nil
         }
-        .overlay {
-            if let item = selectedItem {
-                VColor.auxBlack.opacity(0.3)
-                    .ignoresSafeArea()
-                    .onTapGesture {
-                        withAnimation(VAnimation.fast) { selectedItem = nil }
-                    }
-
-                MemoryItemDetailSheet(
-                    item: item,
-                    store: store,
-                    onDismiss: {
-                        withAnimation(VAnimation.fast) { selectedItem = nil }
-                    }
-                )
-                .transition(.opacity.combined(with: .scale(scale: 0.97)))
-            }
+        .sheet(item: $selectedItem) { item in
+            MemoryItemDetailSheet(
+                item: item,
+                store: store,
+                onDismiss: { selectedItem = nil }
+            )
         }
-        .animation(VAnimation.fast, value: selectedItem?.id)
         .sheet(isPresented: $showCreateSheet) {
             MemoryItemCreateSheet(
                 store: store,


### PR DESCRIPTION
## Summary
- **MemoriesPanel:** Converted memory detail from `.overlay` (with 30% black backdrop) to `.sheet(item:)`, matching the create memory sheet
- **IdentityPanel:** Converted workspace file viewer and avatar management from `.overlay` (with 40% black backdrop) to `.sheet` presentations
- No modal should dim the rest of the app with a backdrop overlay — all modals now use native `.sheet` presentation

## Test plan
- [ ] Open a memory item — should open as a sheet (no backdrop dimming)
- [ ] Create a new memory — should open as a sheet at the same level
- [ ] Open workspace file viewer from Identity panel — should open as sheet
- [ ] Open avatar management from Identity panel — should open as sheet
- [ ] Verify all sheets dismiss correctly (close button, click outside)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
