### PR TITLE
fix: tighten history fetch retry — dedup, graduated delays, cancellation cleanup

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -112,6 +112,8 @@ final class ConversationRestorer {
         guard let viewModel = delegate.chatViewModel(for: localId) else { return }
         guard !viewModel.isHistoryLoaded else { return }
 
+        // Skip if a fetch is already in flight for this conversation.
+        guard pendingHistoryByConversationId[conversationId] == nil else { return }
         pendingHistoryByConversationId[conversationId] = localId
 
         // Wire up the "load more" callback so the view model can request
@@ -120,9 +122,10 @@ final class ConversationRestorer {
             self?.requestPaginatedHistory(conversationId: conversationId, beforeTimestamp: beforeTimestamp)
         }
 
+        let retryDelays: [UInt64] = [500_000_000, 2_000_000_000] // 0.5s, then 2s
         Task { [weak self] in
             guard let self else { return }
-            let maxAttempts = 3
+            let maxAttempts = retryDelays.count + 1
             for attempt in 1...maxAttempts {
                 let response = await self.conversationHistoryClient.fetchHistory(conversationId: conversationId, limit: 50, beforeTimestamp: nil, mode: "light", maxTextChars: nil, maxToolResultChars: 1000)
                 if let response {
@@ -130,12 +133,16 @@ final class ConversationRestorer {
                     return
                 }
                 if attempt < maxAttempts {
-                    log.warning("History fetch attempt \(attempt) of \(maxAttempts) for conversation \(conversationId) failed, retrying in 1 second...")
-                    try? await Task.sleep(nanoseconds: 1_000_000_000)
-                    guard !Task.isCancelled else { return }
+                    let delay = retryDelays[attempt - 1]
+                    log.warning("History fetch attempt \(attempt) of \(maxAttempts) for conversation \(conversationId) failed, retrying in \(Double(delay) / 1_000_000_000)s...")
+                    try? await Task.sleep(nanoseconds: delay)
+                    guard !Task.isCancelled else {
+                        self.pendingHistoryByConversationId.removeValue(forKey: conversationId)
+                        return
+                    }
                 }
             }
-            log.warning("All \(maxAttempts) history fetch attempts failed for conversation \(conversationId)")
+            log.error("All \(maxAttempts) history fetch attempts failed for conversation \(conversationId)")
             self.pendingHistoryByConversationId.removeValue(forKey: conversationId)
         }
     }


### PR DESCRIPTION
## Summary
- Add in-flight guard to prevent duplicate concurrent fetch Tasks from the `selectConversation` feedback loop
- Graduate retry delays (0.5s then 2s) instead of uniform 1s — first retry covers startup race, second covers slow daemon warmup, without compounding 15s timeout waits for large conversations
- Clean up `pendingHistoryByConversationId` on the Task cancellation path (was a resource leak)
- Log final failure at `.error` level (permanently stuck conversation is an error, not a warning)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
