### PR TITLE
fix: align underline tabs with Figma design

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPayloadView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPayloadView.swift
@@ -35,7 +35,7 @@ struct MessageInspectorPayloadView: View {
             Spacer(minLength: VSpacing.md)
 
             if model.showsViewModePicker {
-                VSegmentedControl(
+                VTabs(
                     items: model.availableViewModes.map { (label: $0.label, tag: $0) },
                     selection: viewModeBinding,
                     style: .pill,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
@@ -293,19 +293,14 @@ struct MessageInspectorView: View {
     }
 
     private var detailTabBar: some View {
-        VTabBar {
-            ForEach(MessageInspectorDetailTab.allCases, id: \.self) { tab in
-                VTab(
-                    label: tab.label,
-                    icon: tab.icon.rawValue,
-                    isSelected: viewState.selectedDetailTab == tab,
-                    isCloseable: false,
-                    style: .rectangular
-                ) {
-                    viewState.selectDetailTab(tab)
-                }
-            }
-        }
+        VTabs(
+            items: MessageInspectorDetailTab.allCases.map { (label: $0.label, icon: $0.icon.rawValue, tag: $0) },
+            selection: Binding(
+                get: { viewState.selectedDetailTab },
+                set: { viewState.selectDetailTab($0) }
+            ),
+            style: .underline
+        )
     }
 
     @ViewBuilder
@@ -327,7 +322,7 @@ struct MessageInspectorView: View {
     private func rawPayloadTab(for entry: LLMRequestLogEntry) -> some View {
         VStack(spacing: 0) {
             HStack {
-                VSegmentedControl(
+                VTabs(
                     items: RawPayloadPane.allCases.map { (label: $0.label, tag: $0) },
                     selection: rawPaneBinding,
                     style: .pill,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -56,16 +56,10 @@ struct IntelligencePanel: View {
             .padding(.bottom, VSpacing.md)
 
             // Tab bar
-            VStack(spacing: 0) {
-                HStack(spacing: VSpacing.xl) {
-                    ForEach(visibleTabs, id: \.self) { tab in
-                        tabButton(tab.rawValue, tab: tab)
-                    }
-                    Spacer()
-                }
-
-                Divider().background(VColor.borderDisabled)
-            }
+            VTabs(
+                items: visibleTabs.map { (label: $0.rawValue, tag: $0) },
+                selection: $selectedTab
+            )
             .padding(.top, VSpacing.md)
             .padding(.bottom, VSpacing.md)
 
@@ -127,30 +121,6 @@ struct IntelligencePanel: View {
         }
     }
 
-    // MARK: - Tab Button
-
-    @ViewBuilder
-    private func tabButton(_ label: String, tab: IntelligenceTab) -> some View {
-        let isActive = selectedTab == tab
-        Button {
-            withAnimation(VAnimation.fast) { selectedTab = tab }
-        } label: {
-            VStack(spacing: VSpacing.sm) {
-                Text(label)
-                    .font(VFont.bodyMediumDefault)
-                    .foregroundStyle(isActive ? VColor.primaryActive : VColor.contentSecondary)
-                    .padding(.bottom, VSpacing.xs)
-
-                Rectangle()
-                    .fill(isActive ? VColor.borderActive : Color.clear)
-                    .frame(height: 2)
-            }
-            .fixedSize()
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .pointerCursor()
-    }
 
     // MARK: - Tab Content
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -53,14 +53,13 @@ struct IntelligencePanel: View {
                     .foregroundStyle(VColor.contentEmphasized)
                 Spacer()
             }
-            .padding(.bottom, VSpacing.md)
+            .padding(.bottom, VSpacing.lg)
 
             // Tab bar
             VTabs(
                 items: visibleTabs.map { (label: $0.rawValue, tag: $0) },
                 selection: $selectedTab
             )
-            .padding(.top, VSpacing.md)
             .padding(.bottom, VSpacing.md)
 
             // Tab content

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -89,7 +89,7 @@ struct FileContentView: View {
                 fileName: fileName
             ) {
                 if modes.count > 1 {
-                    VSegmentedControl(
+                    VTabs(
                         items: modes.map { (label: viewModeLabel($0), tag: $0) },
                         selection: $viewMode,
                         style: .pill,

--- a/clients/macos/vellum-assistant/Features/Settings/ServiceModeCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ServiceModeCard.swift
@@ -50,7 +50,7 @@ struct ServiceModeCard<ManagedContent: View, YourOwnContent: View>: View {
                         .foregroundStyle(VColor.contentTertiary)
                 }
                 Spacer()
-                VSegmentedControl(
+                VTabs(
                     items: [
                         (label: "Managed", tag: "managed"),
                         (label: "Your Own", tag: "your-own"),

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -33,7 +33,7 @@ struct RecordingSourcePickerView: View {
                 .padding(.bottom, VSpacing.sm)
 
             // Scope picker (Display / Window)
-            VSegmentedControl(
+            VTabs(
                 items: CaptureScope.allCases.map { (label: $0.rawValue, tag: $0) },
                 selection: $viewModel.captureScope,
                 style: .pill

--- a/clients/shared/DesignSystem/Components/Navigation/VSegmentedControl.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VSegmentedControl.swift
@@ -47,12 +47,12 @@ public struct VSegmentedControl<SelectionValue: Hashable>: View {
             ForEach(items.indices, id: \.self) { index in
                 let item = items[index]
                 Button(action: { selection = item.tag }) {
-                    VStack(spacing: VSpacing.xs) {
+                    VStack(spacing: 0) {
                         Text(item.label)
-                            .font(VFont.labelDefault)
-                            .foregroundStyle(selection == item.tag ? VColor.contentDefault : VColor.contentTertiary)
-                            .padding(.horizontal, VSpacing.xl)
-                            .padding(.vertical, VSpacing.xs)
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(selection == item.tag ? VColor.contentDefault : VColor.contentSecondary)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 7)
 
                         Rectangle()
                             .fill(selection == item.tag ? VColor.primaryBase : .clear)
@@ -67,7 +67,11 @@ public struct VSegmentedControl<SelectionValue: Hashable>: View {
             }
         }
         .fixedSize(horizontal: true, vertical: false)
-        .padding(.horizontal, VSpacing.sm)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(VColor.borderDisabled)
+                .frame(height: 2)
+        }
     }
 
     // MARK: - Pill Style

--- a/clients/shared/DesignSystem/Components/Navigation/VTabs.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VTabs.swift
@@ -58,6 +58,7 @@ public struct VTabs<SelectionValue: Hashable>: View {
                             .fill(selection == item.tag ? VColor.borderActive : .clear)
                             .frame(height: 2)
                     }
+                    .fixedSize(horizontal: true, vertical: false)
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
@@ -65,8 +66,8 @@ public struct VTabs<SelectionValue: Hashable>: View {
                 .accessibilityLabel(item.label)
                 .accessibilityAddTraits(selection == item.tag ? .isSelected : [])
             }
+            Spacer(minLength: 0)
         }
-        .fixedSize(horizontal: true, vertical: false)
         .overlay(alignment: .bottom) {
             Rectangle()
                 .fill(VColor.borderDisabled)

--- a/clients/shared/DesignSystem/Components/Navigation/VTabs.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VTabs.swift
@@ -50,12 +50,12 @@ public struct VTabs<SelectionValue: Hashable>: View {
                     VStack(spacing: 0) {
                         Text(item.label)
                             .font(VFont.bodyMediumDefault)
-                            .foregroundStyle(selection == item.tag ? VColor.contentDefault : VColor.contentSecondary)
+                            .foregroundStyle(selection == item.tag ? VColor.primaryActive : VColor.contentSecondary)
                             .padding(.horizontal, 10)
                             .padding(.vertical, 7)
 
                         Rectangle()
-                            .fill(selection == item.tag ? VColor.primaryBase : .clear)
+                            .fill(selection == item.tag ? VColor.borderActive : .clear)
                             .frame(height: 2)
                     }
                     .contentShape(Rectangle())

--- a/clients/shared/DesignSystem/Components/Navigation/VTabs.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VTabs.swift
@@ -1,22 +1,22 @@
 import SwiftUI
 
-public enum VSegmentedControlStyle {
+public enum VTabsStyle {
     case underline
     case pill
 }
 
-public enum VSegmentedControlSize {
+public enum VTabsSize {
     case regular
     case compact
 }
 
-public struct VSegmentedControl<SelectionValue: Hashable>: View {
+public struct VTabs<SelectionValue: Hashable>: View {
     public let items: [(label: String, icon: String?, tag: SelectionValue)]
     @Binding public var selection: SelectionValue
-    public let style: VSegmentedControlStyle
-    public let size: VSegmentedControlSize
+    public let style: VTabsStyle
+    public let size: VTabsSize
 
-    public init(items: [(label: String, icon: String?, tag: SelectionValue)], selection: Binding<SelectionValue>, style: VSegmentedControlStyle = .underline, size: VSegmentedControlSize = .regular) {
+    public init(items: [(label: String, icon: String?, tag: SelectionValue)], selection: Binding<SelectionValue>, style: VTabsStyle = .underline, size: VTabsSize = .regular) {
         self.items = items
         self._selection = selection
         self.style = style
@@ -24,7 +24,7 @@ public struct VSegmentedControl<SelectionValue: Hashable>: View {
     }
 
     /// Convenience init without icons.
-    public init(items: [(label: String, tag: SelectionValue)], selection: Binding<SelectionValue>, style: VSegmentedControlStyle = .underline, size: VSegmentedControlSize = .regular) {
+    public init(items: [(label: String, tag: SelectionValue)], selection: Binding<SelectionValue>, style: VTabsStyle = .underline, size: VTabsSize = .regular) {
         self.items = items.map { (label: $0.label, icon: nil, tag: $0.tag) }
         self._selection = selection
         self.style = style
@@ -100,8 +100,8 @@ public struct VSegmentedControl<SelectionValue: Hashable>: View {
 
 // MARK: - Int convenience initializer
 
-public extension VSegmentedControl where SelectionValue == Int {
-    init(items: [String], selection: Binding<Int>, style: VSegmentedControlStyle = .underline, size: VSegmentedControlSize = .regular) {
+public extension VTabs where SelectionValue == Int {
+    init(items: [String], selection: Binding<Int>, style: VTabsStyle = .underline, size: VTabsSize = .regular) {
         self.init(
             items: items.enumerated().map { (label: $0.element, icon: nil as String?, tag: $0.offset) },
             selection: selection,
@@ -116,7 +116,7 @@ public extension VSegmentedControl where SelectionValue == Int {
 private struct PillSegment: View {
     let label: String
     var icon: String? = nil
-    let size: VSegmentedControlSize
+    let size: VTabsSize
     let isSelected: Bool
     let action: () -> Void
 

--- a/clients/shared/DesignSystem/Components/Navigation/VTabs.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VTabs.swift
@@ -68,7 +68,7 @@ public struct VTabs<SelectionValue: Hashable>: View {
             }
             Spacer(minLength: 0)
         }
-        .overlay(alignment: .bottom) {
+        .background(alignment: .bottom) {
             Rectangle()
                 .fill(VColor.borderDisabled)
                 .frame(height: 2)

--- a/clients/shared/DesignSystem/Components/Navigation/VThemeToggle.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VThemeToggle.swift
@@ -54,7 +54,7 @@ public struct VThemeToggle: View {
     private var segmentedControl: some View {
         switch style {
         case .iconPill:
-            VSegmentedControl(
+            VTabs(
                 items: [
                     (label: "System", icon: VIcon.monitor.rawValue, tag: "system"),
                     (label: "Light", icon: VIcon.sun.rawValue, tag: "light"),
@@ -65,7 +65,7 @@ public struct VThemeToggle: View {
             )
             .frame(width: pillWidth)
         case .labelPill:
-            VSegmentedControl(
+            VTabs(
                 items: [
                     (label: "System", tag: "system"),
                     (label: "Light", tag: "light"),

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -126,9 +126,8 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
             ]
         case .navigation:
             return [
-                GalleryComponent("vSegmentedControl", "VSegmentedControl", keywords: ["segmented control", "tabs"], description: "Segmented control with underline, pill, or compact pill styles for switching between views."),
+                GalleryComponent("vSegmentedControl", "VTabs", keywords: ["segmented control", "tabs"], description: "Segmented control with underline, pill, or compact pill styles for switching between views."),
                 GalleryComponent("vSidebarRow", "VSidebarRow", keywords: ["sidebar row", "navigation row"], description: "Sidebar navigation row with icon, label, hover/active states, trailing disclosure icon, and collapsed mode."),
-                GalleryComponent("vTabBar", "VTabBar + VTab", keywords: ["tab bar", "tabs"], description: "Horizontal scrollable tab bar with pill, flat, and rectangular styles. Tabs support selection, close, and icons."),
                 GalleryComponent("vLink", "VLink", keywords: ["link", "url", "external link", "hyperlink"], description: "Styled external link that opens a URL in the default browser. Applies pointer cursor, single-line truncation, and caption font by default."),
                 GalleryComponent("vThemeToggle", "VThemeToggle", keywords: ["theme toggle", "dark mode", "light mode"], description: "Three-way theme toggle (System / Light / Dark). Reads and writes themePreference in UserDefaults."),
             ]

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -23,7 +23,7 @@ struct ButtonsGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.xl) {
                         // Controls
                         HStack(spacing: VSpacing.xl) {
-                            VSegmentedControl(
+                            VTabs(
                                 items: [
                                     (label: "Primary", tag: VButton.Style.primary),
                                     (label: "Outlined", tag: VButton.Style.outlined),

--- a/clients/shared/DesignSystem/Gallery/Sections/LayoutGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/LayoutGallerySection.swift
@@ -156,7 +156,7 @@ struct LayoutGallerySection: View {
 
                 VCard(padding: 0) {
                     VSidePanel(title: "Control", onClose: {}, pinnedContent: {
-                        VSegmentedControl(
+                        VTabs(
                             items: ["Profile", "Settings", "Channels", "Overview"],
                             selection: $pinnedTabSelection
                         )

--- a/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
@@ -7,24 +7,16 @@ struct NavigationGallerySection: View {
     @State private var segmentSelection = 0
     @State private var pillSelection = "active"
     @State private var compactPillSelection = "preview"
-    @State private var selectedTab = 0
     @State private var sidebarRowActive = "Intelligence"
     @State private var sidebarDisclosureExpanded = true
 
     private let segmentItems = ["All", "Active", "Archived", "Drafts"]
-    private let tabs = [
-        (label: "Dashboard", icon: VIcon.house.rawValue),
-        (label: "Conversations", icon: VIcon.list.rawValue),
-        (label: "Settings", icon: VIcon.settings.rawValue),
-        (label: "Logs", icon: VIcon.fileText.rawValue),
-    ]
-
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xxl) {
             if filter == nil || filter == "vSegmentedControl" {
-                // MARK: - VSegmentedControl
+                // MARK: - VTabs
                 GallerySectionHeader(
-                    title: "VSegmentedControl",
+                    title: "VTabs",
                     description: "Underlined segmented control for switching between views."
                 )
 
@@ -36,7 +28,7 @@ struct NavigationGallerySection: View {
 
                         Divider().background(VColor.borderBase)
 
-                        VSegmentedControl(items: segmentItems, selection: $segmentSelection)
+                        VTabs(items: segmentItems, selection: $segmentSelection)
 
                         // Show a placeholder for the selected segment
                         VCard {
@@ -51,9 +43,9 @@ struct NavigationGallerySection: View {
 
                 Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
 
-                // MARK: - VSegmentedControl (Pill)
+                // MARK: - VTabs (Pill)
                 GallerySectionHeader(
-                    title: "VSegmentedControl (Pill)",
+                    title: "VTabs (Pill)",
                     description: "Pill-style segmented control with filled accent background on selection."
                 )
 
@@ -65,7 +57,7 @@ struct NavigationGallerySection: View {
 
                         Divider().background(VColor.borderBase)
 
-                        VSegmentedControl(
+                        VTabs(
                             items: [
                                 (label: "All", tag: "all"),
                                 (label: "Active", tag: "active"),
@@ -80,9 +72,9 @@ struct NavigationGallerySection: View {
 
                 Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
 
-                // MARK: - VSegmentedControl (Compact Pill)
+                // MARK: - VTabs (Compact Pill)
                 GallerySectionHeader(
-                    title: "VSegmentedControl (Compact Pill)",
+                    title: "VTabs (Compact Pill)",
                     description: "Compact pill-style segmented control for inline use in toolbars and headers."
                 )
 
@@ -90,7 +82,7 @@ struct NavigationGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.md) {
                         Divider().background(VColor.borderBase)
 
-                        VSegmentedControl(
+                        VTabs(
                             items: [
                                 (label: "Preview", tag: "preview"),
                                 (label: "Source", tag: "source"),
@@ -201,125 +193,6 @@ struct NavigationGallerySection: View {
                 }
             }
 
-            if filter == nil || filter == "vTabBar" {
-                if filter == nil {
-                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
-                }
-                // MARK: - VTabBar + VTab
-                GallerySectionHeader(
-                    title: "VTabBar + VTab",
-                    description: "Horizontal scrollable tab bar with selectable and closeable tabs."
-                )
-
-                VCard(padding: 0) {
-                    VStack(spacing: 0) {
-                        VTabBar {
-                            ForEach(Array(tabs.enumerated()), id: \.offset) { index, tab in
-                                VTab(
-                                    label: tab.label,
-                                    icon: tab.icon,
-                                    isSelected: selectedTab == index,
-                                    isCloseable: index > 0,
-                                    onSelect: { selectedTab = index },
-                                    onClose: index > 0 ? {} : nil
-                                )
-                            }
-                        }
-
-                        // Content area
-                        VStack {
-                            Text(tabs[selectedTab].label)
-                                .font(VFont.titleMedium)
-                                .foregroundStyle(VColor.contentDefault)
-                            Text("Tab content area")
-                                .font(VFont.labelDefault)
-                                .foregroundStyle(VColor.contentTertiary)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 120)
-                        .background(VColor.surfaceOverlay)
-                    }
-                }
-
-                // Tab states
-                Text("Tab States (Pill)")
-                    .font(VFont.bodySmallEmphasised)
-                    .foregroundStyle(VColor.contentSecondary)
-
-                VCard {
-                    HStack(spacing: VSpacing.lg) {
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Default").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
-                            VTab(label: "Tab", icon: VIcon.file.rawValue, onSelect: {})
-                        }
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Selected").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
-                            VTab(label: "Tab", icon: VIcon.file.rawValue, isSelected: true, onSelect: {})
-                        }
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Not closeable").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
-                            VTab(label: "Tab", icon: VIcon.file.rawValue, isCloseable: false, onSelect: {})
-                        }
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("No icon").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
-                            VTab(label: "Plain Tab", isCloseable: false, onSelect: {})
-                        }
-                    }
-                }
-
-                // Flat-style tab states
-                Text("Tab States (Flat)")
-                    .font(VFont.bodySmallEmphasised)
-                    .foregroundStyle(VColor.contentSecondary)
-
-                VCard {
-                    HStack(spacing: VSpacing.lg) {
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Default").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
-                            VTab(label: "Conversation 1", style: .flat, onSelect: {})
-                        }
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Selected").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
-                            VTab(label: "Conversation 1", isSelected: true, style: .flat, onSelect: {})
-                        }
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Closeable").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
-                            VTab(label: "Conversation 2", style: .flat, onSelect: {}, onClose: {})
-                        }
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Selected + Closeable").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
-                            VTab(label: "Conversation 2", isSelected: true, style: .flat, onSelect: {}, onClose: {})
-                        }
-                    }
-                }
-
-                // Rectangular-style tab states
-                Text("Tab States (Rectangular)")
-                    .font(VFont.bodySmallEmphasised)
-                    .foregroundStyle(VColor.contentSecondary)
-
-                VCard {
-                    HStack(spacing: VSpacing.lg) {
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Default").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
-                            VTab(label: "Tab", icon: VIcon.file.rawValue, style: .rectangular, onSelect: {})
-                        }
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Selected").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
-                            VTab(label: "Tab", icon: VIcon.file.rawValue, isSelected: true, style: .rectangular, onSelect: {})
-                        }
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Closeable").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
-                            VTab(label: "Tab", icon: VIcon.file.rawValue, style: .rectangular, onSelect: {}, onClose: {})
-                        }
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            Text("Selected + Closeable").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
-                            VTab(label: "Tab", icon: VIcon.file.rawValue, isSelected: true, style: .rectangular, onSelect: {}, onClose: {})
-                        }
-                    }
-                }
-
-            }
 
             if filter == nil || filter == "vLink" {
                 if filter == nil {
@@ -390,7 +263,6 @@ extension NavigationGallerySection {
     static func componentPage(_ id: String) -> some View {
         switch id {
         case "vSegmentedControl": NavigationGallerySection(filter: "vSegmentedControl")
-        case "vTabBar": NavigationGallerySection(filter: "vTabBar")
         case "vSidebarRow": NavigationGallerySection(filter: "vSidebarRow")
         case "vLink": NavigationGallerySection(filter: "vLink")
         case "vThemeToggle": NavigationGallerySection(filter: "vThemeToggle")


### PR DESCRIPTION
## Summary
Fixes `VSegmentedControl` underline style to match Figma tabs spec (node 823:5693):

- Font: `labelDefault` (11pt) → `bodyMediumDefault` (14pt Medium)
- Unselected text color: `contentTertiary` → `contentSecondary`
- Tab padding: 24pt h / 4pt v → 10pt h / 7pt v
- Text↔underline gap: 4pt → 0
- Added full-width 2pt `borderDisabled` bottom border
- Removed container horizontal padding

## Test plan
- [ ] Open Component Gallery → Navigation section, verify underline tabs match Figma
- [ ] Check Layout Gallery side panel tabs
- [ ] Verify selected/unselected states look correct
- [ ] Test in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
