### PR TITLE
feat: implement invite-code-gated A2A pairing with mutual guardian approval

### DIFF
--- a/assistant/src/__tests__/a2a-pairing.test.ts
+++ b/assistant/src/__tests__/a2a-pairing.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { initializeDb, resetDb } from "../memory/db.js";
+// Import types from barrel to keep index.ts used by knip
 import type {
   A2APairingAccepted,
   A2APairingFinalize,
-} from "../runtime/a2a/message-contract.js";
+} from "../runtime/a2a/index.js";
 import {
   handleInboundPairingRequest,
   handlePairingAccepted,

--- a/assistant/src/__tests__/a2a-pairing.test.ts
+++ b/assistant/src/__tests__/a2a-pairing.test.ts
@@ -1,23 +1,22 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { initializeDb, resetDb } from "../memory/db.js";
+import type {
+  A2APairingAccepted,
+  A2APairingFinalize,
+} from "../runtime/a2a/message-contract.js";
+import {
+  handleInboundPairingRequest,
+  handlePairingAccepted,
+  handlePairingFinalize,
+} from "../runtime/a2a/pairing.js";
 import {
   createPairingRequest,
   findPairingByInviteCode,
   findPairingByRemoteAssistant,
   updatePairingStatus,
 } from "../runtime/a2a/pairing-store.js";
-import {
-  handleInboundPairingRequest,
-  handlePairingAccepted,
-  handlePairingFinalize,
-} from "../runtime/a2a/pairing.js";
-import type {
-  A2APairingAccepted,
-  A2APairingFinalize,
-} from "../runtime/a2a/message-contract.js";
 import { interceptA2AEnvelope } from "../runtime/routes/inbound-stages/a2a-interceptor.js";
-import { _resetBackend } from "../security/secure-keys.js";
 
 // Mock fetch for outbound HTTP calls
 const mockFetch = mock(() =>
@@ -111,13 +110,13 @@ describe("pairing store", () => {
   test("findPairingByRemoteAssistant returns null for wrong direction", () => {
     createPairingRequest(
       "outbound",
-      "invite-xyz",
-      "remote-asst-2",
+      "invite-wrong-dir",
+      "remote-asst-3",
       "https://gw2.example.com",
       Date.now() + 3600_000,
     );
 
-    expect(findPairingByRemoteAssistant("remote-asst-2", "inbound")).toBeNull();
+    expect(findPairingByRemoteAssistant("remote-asst-3", "inbound")).toBeNull();
   });
 
   test("updatePairingStatus changes status", () => {

--- a/assistant/src/__tests__/a2a-pairing.test.ts
+++ b/assistant/src/__tests__/a2a-pairing.test.ts
@@ -1,0 +1,530 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { initializeDb, resetDb } from "../memory/db.js";
+import {
+  createPairingRequest,
+  findPairingByInviteCode,
+  findPairingByRemoteAssistant,
+  updatePairingStatus,
+} from "../runtime/a2a/pairing-store.js";
+import {
+  handleInboundPairingRequest,
+  handlePairingAccepted,
+  handlePairingFinalize,
+} from "../runtime/a2a/pairing.js";
+import type {
+  A2APairingAccepted,
+  A2APairingFinalize,
+} from "../runtime/a2a/message-contract.js";
+import { interceptA2AEnvelope } from "../runtime/routes/inbound-stages/a2a-interceptor.js";
+import { _resetBackend } from "../security/secure-keys.js";
+
+// Mock fetch for outbound HTTP calls
+const mockFetch = mock(() =>
+  Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 })),
+);
+globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+// Mock secure key store — in-memory map for tests
+const keyStore = new Map<string, string>();
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (key: string) => keyStore.get(key),
+  setSecureKeyAsync: async (key: string, value: string) => {
+    keyStore.set(key, value);
+    return true;
+  },
+  _resetBackend: () => {},
+}));
+
+// Mock access request helper to avoid full notification pipeline
+const mockNotifyGuardian = mock(() => ({
+  notified: true,
+  created: true,
+  requestId: "test-request-id",
+}));
+mock.module("../runtime/access-request-helper.js", () => ({
+  notifyGuardianOfAccessRequest: mockNotifyGuardian,
+}));
+
+initializeDb();
+
+beforeEach(() => {
+  resetDb();
+  initializeDb();
+  keyStore.clear();
+  mockFetch.mockClear();
+  mockNotifyGuardian.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// Pairing store CRUD
+// ---------------------------------------------------------------------------
+
+describe("pairing store", () => {
+  test("createPairingRequest stores and retrieves by invite code", () => {
+    const req = createPairingRequest(
+      "outbound",
+      "invite-abc",
+      "remote-asst-1",
+      "https://gw.example.com",
+      Date.now() + 3600_000,
+    );
+
+    expect(req.direction).toBe("outbound");
+    expect(req.status).toBe("pending");
+
+    const found = findPairingByInviteCode("invite-abc");
+    expect(found).not.toBeNull();
+    expect(found!.remoteAssistantId).toBe("remote-asst-1");
+  });
+
+  test("findPairingByInviteCode returns null for unknown code", () => {
+    expect(findPairingByInviteCode("nonexistent")).toBeNull();
+  });
+
+  test("findPairingByInviteCode auto-expires stale requests", () => {
+    createPairingRequest(
+      "outbound",
+      "expired-code",
+      "remote-asst-1",
+      "https://gw.example.com",
+      Date.now() - 1, // Already expired
+    );
+
+    expect(findPairingByInviteCode("expired-code")).toBeNull();
+  });
+
+  test("findPairingByRemoteAssistant returns matching request", () => {
+    createPairingRequest(
+      "inbound",
+      "invite-xyz",
+      "remote-asst-2",
+      "https://gw2.example.com",
+      Date.now() + 3600_000,
+    );
+
+    const found = findPairingByRemoteAssistant("remote-asst-2", "inbound");
+    expect(found).not.toBeNull();
+    expect(found!.inviteCode).toBe("invite-xyz");
+  });
+
+  test("findPairingByRemoteAssistant returns null for wrong direction", () => {
+    createPairingRequest(
+      "outbound",
+      "invite-xyz",
+      "remote-asst-2",
+      "https://gw2.example.com",
+      Date.now() + 3600_000,
+    );
+
+    expect(findPairingByRemoteAssistant("remote-asst-2", "inbound")).toBeNull();
+  });
+
+  test("updatePairingStatus changes status", () => {
+    const req = createPairingRequest(
+      "outbound",
+      "invite-status",
+      "remote-asst",
+      "https://gw.example.com",
+      Date.now() + 3600_000,
+    );
+
+    updatePairingStatus(req.id, "accepted");
+    const found = findPairingByInviteCode("invite-status");
+    expect(found!.status).toBe("accepted");
+  });
+
+  test("duplicate pairing request replaces pending request", () => {
+    createPairingRequest(
+      "outbound",
+      "invite-old",
+      "remote-asst-1",
+      "https://gw.example.com",
+      Date.now() + 3600_000,
+    );
+
+    createPairingRequest(
+      "outbound",
+      "invite-new",
+      "remote-asst-1",
+      "https://gw.example.com",
+      Date.now() + 3600_000,
+    );
+
+    // Old invite code should no longer be found
+    expect(findPairingByInviteCode("invite-old")).toBeNull();
+
+    // New invite code should be found
+    const found = findPairingByInviteCode("invite-new");
+    expect(found).not.toBeNull();
+    expect(found!.remoteAssistantId).toBe("remote-asst-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pairing protocol — handleInboundPairingRequest
+// ---------------------------------------------------------------------------
+
+describe("handleInboundPairingRequest", () => {
+  test("stores inbound pairing request", () => {
+    handleInboundPairingRequest({
+      version: "v1",
+      type: "pairing_request",
+      senderAssistantId: "sender-asst",
+      senderGatewayUrl: "https://sender-gw.example.com",
+      inviteCode: "inbound-invite",
+    });
+
+    const found = findPairingByInviteCode("inbound-invite");
+    expect(found).not.toBeNull();
+    expect(found!.direction).toBe("inbound");
+    expect(found!.remoteAssistantId).toBe("sender-asst");
+    expect(found!.status).toBe("pending");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pairing protocol — handlePairingAccepted
+// ---------------------------------------------------------------------------
+
+describe("handlePairingAccepted", () => {
+  test("rejects when no matching outbound request exists", async () => {
+    const envelope: A2APairingAccepted = {
+      version: "v1",
+      type: "pairing_accepted",
+      senderAssistantId: "remote-asst",
+      inviteCode: "nonexistent-code",
+      inboundToken: "tok-123",
+    };
+
+    const result = await handlePairingAccepted(envelope);
+    expect(result).toBe(false);
+  });
+
+  test("rejects when invite code matches but sender identity mismatches", async () => {
+    createPairingRequest(
+      "outbound",
+      "invite-mismatch",
+      "expected-asst",
+      "https://gw.example.com",
+      Date.now() + 3600_000,
+    );
+
+    const envelope: A2APairingAccepted = {
+      version: "v1",
+      type: "pairing_accepted",
+      senderAssistantId: "wrong-asst", // Does not match "expected-asst"
+      inviteCode: "invite-mismatch",
+      inboundToken: "tok-123",
+    };
+
+    const result = await handlePairingAccepted(envelope);
+    expect(result).toBe(false);
+  });
+
+  test("rejects expired outbound request", async () => {
+    createPairingRequest(
+      "outbound",
+      "invite-expired",
+      "remote-asst",
+      "https://gw.example.com",
+      Date.now() - 1, // Already expired
+    );
+
+    const envelope: A2APairingAccepted = {
+      version: "v1",
+      type: "pairing_accepted",
+      senderAssistantId: "remote-asst",
+      inviteCode: "invite-expired",
+      inboundToken: "tok-123",
+    };
+
+    const result = await handlePairingAccepted(envelope);
+    expect(result).toBe(false);
+  });
+
+  test("succeeds with valid outbound request and matching sender", async () => {
+    createPairingRequest(
+      "outbound",
+      "invite-valid",
+      "remote-asst",
+      "https://gw.example.com",
+      Date.now() + 3600_000,
+    );
+
+    const envelope: A2APairingAccepted = {
+      version: "v1",
+      type: "pairing_accepted",
+      senderAssistantId: "remote-asst",
+      inviteCode: "invite-valid",
+      inboundToken: "tok-from-target",
+    };
+
+    const result = await handlePairingAccepted(envelope);
+    expect(result).toBe(true);
+
+    // Should have stored outbound token
+    expect(keyStore.get("a2a:outbound:remote-asst")).toBe("tok-from-target");
+    // Should have generated inbound token
+    expect(keyStore.get("a2a:inbound:remote-asst")).toBeTruthy();
+    // Should have stored gateway URL from stored request (not envelope)
+    expect(keyStore.get("a2a:gateway:remote-asst")).toBe(
+      "https://gw.example.com",
+    );
+
+    // Should have sent pairing_finalize
+    expect(mockFetch).toHaveBeenCalled();
+
+    // Pairing request should be accepted
+    const req = findPairingByInviteCode("invite-valid");
+    expect(req!.status).toBe("accepted");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pairing protocol — handlePairingFinalize
+// ---------------------------------------------------------------------------
+
+describe("handlePairingFinalize", () => {
+  test("rejects when no matching inbound request exists", async () => {
+    const envelope: A2APairingFinalize = {
+      version: "v1",
+      type: "pairing_finalize",
+      senderAssistantId: "remote-asst",
+      inviteCode: "nonexistent-code",
+      inboundToken: "tok-123",
+    };
+
+    const result = await handlePairingFinalize(envelope);
+    expect(result).toBe(false);
+  });
+
+  test("rejects when inbound request exists but is pending (not accepted)", async () => {
+    createPairingRequest(
+      "inbound",
+      "invite-pending",
+      "remote-asst",
+      "https://gw.example.com",
+      Date.now() + 3600_000,
+    );
+    // Status is "pending", but finalize requires "accepted"
+
+    const envelope: A2APairingFinalize = {
+      version: "v1",
+      type: "pairing_finalize",
+      senderAssistantId: "remote-asst",
+      inviteCode: "invite-pending",
+      inboundToken: "tok-123",
+    };
+
+    const result = await handlePairingFinalize(envelope);
+    expect(result).toBe(false);
+  });
+
+  test("rejects when sender identity mismatches", async () => {
+    const req = createPairingRequest(
+      "inbound",
+      "invite-fin-mismatch",
+      "expected-asst",
+      "https://gw.example.com",
+      Date.now() + 3600_000,
+    );
+    updatePairingStatus(req.id, "accepted");
+
+    const envelope: A2APairingFinalize = {
+      version: "v1",
+      type: "pairing_finalize",
+      senderAssistantId: "wrong-asst",
+      inviteCode: "invite-fin-mismatch",
+      inboundToken: "tok-123",
+    };
+
+    const result = await handlePairingFinalize(envelope);
+    expect(result).toBe(false);
+  });
+
+  test("succeeds with valid accepted inbound request", async () => {
+    const req = createPairingRequest(
+      "inbound",
+      "invite-fin-valid",
+      "remote-asst",
+      "https://gw.example.com",
+      Date.now() + 3600_000,
+    );
+    updatePairingStatus(req.id, "accepted");
+
+    const envelope: A2APairingFinalize = {
+      version: "v1",
+      type: "pairing_finalize",
+      senderAssistantId: "remote-asst",
+      inviteCode: "invite-fin-valid",
+      inboundToken: "tok-from-initiator",
+    };
+
+    const result = await handlePairingFinalize(envelope);
+    expect(result).toBe(true);
+
+    // Should have stored outbound token
+    expect(keyStore.get("a2a:outbound:remote-asst")).toBe("tok-from-initiator");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A2A interceptor
+// ---------------------------------------------------------------------------
+
+describe("A2A interceptor", () => {
+  test("passes through non-A2A metadata", async () => {
+    const result = await interceptA2AEnvelope({
+      sourceMetadata: { someOther: true },
+    });
+    expect(result.handled).toBe(false);
+  });
+
+  test("passes through undefined metadata", async () => {
+    const result = await interceptA2AEnvelope({});
+    expect(result.handled).toBe(false);
+  });
+
+  test("passes through message type to normal pipeline", async () => {
+    const result = await interceptA2AEnvelope({
+      sourceMetadata: {
+        a2a: true,
+        envelopeType: "message",
+        authenticated: true,
+      },
+    });
+    expect(result.handled).toBe(false);
+  });
+
+  test("rejects unauthenticated non-pairing envelopes", async () => {
+    const result = await interceptA2AEnvelope({
+      sourceMetadata: {
+        a2a: true,
+        envelopeType: "message",
+        authenticated: false,
+      },
+    });
+    expect(result.handled).toBe(true);
+    expect(result.response?.status).toBe(403);
+  });
+
+  test("rejects unauthenticated pairing_finalize", async () => {
+    const result = await interceptA2AEnvelope({
+      sourceMetadata: {
+        a2a: true,
+        envelopeType: "pairing_finalize",
+        authenticated: false,
+      },
+    });
+    expect(result.handled).toBe(true);
+    expect(result.response?.status).toBe(403);
+  });
+
+  test("handles pairing_request envelope", async () => {
+    const result = await interceptA2AEnvelope({
+      sourceMetadata: {
+        a2a: true,
+        envelopeType: "pairing_request",
+        authenticated: false,
+        envelope: {
+          version: "v1",
+          type: "pairing_request",
+          senderAssistantId: "test-asst",
+          senderGatewayUrl: "https://test-gw.example.com",
+          inviteCode: "test-invite",
+        },
+      },
+    });
+    expect(result.handled).toBe(true);
+    const body = await result.response!.json();
+    expect(body.accepted).toBe(true);
+    expect(body.type).toBe("pairing_request");
+
+    // Should have stored the inbound pairing request
+    const found = findPairingByInviteCode("test-invite");
+    expect(found).not.toBeNull();
+    expect(found!.direction).toBe("inbound");
+  });
+
+  test("handles unknown envelope type", async () => {
+    const result = await interceptA2AEnvelope({
+      sourceMetadata: {
+        a2a: true,
+        envelopeType: "unknown_type",
+        authenticated: true,
+      },
+    });
+    expect(result.handled).toBe(true);
+    expect(result.response?.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full handshake lifecycle (integration-style)
+// ---------------------------------------------------------------------------
+
+describe("full handshake lifecycle", () => {
+  test("pairing envelopes never reach conversation pipeline", async () => {
+    // pairing_request with a2a flag should be handled by interceptor
+    const requestResult = await interceptA2AEnvelope({
+      sourceMetadata: {
+        a2a: true,
+        envelopeType: "pairing_request",
+        authenticated: false,
+        envelope: {
+          version: "v1",
+          type: "pairing_request",
+          senderAssistantId: "lifecycle-asst",
+          senderGatewayUrl: "https://lifecycle-gw.example.com",
+          inviteCode: "lifecycle-invite",
+        },
+      },
+    });
+    expect(requestResult.handled).toBe(true);
+
+    // pairing_accepted should be handled
+    const acceptedResult = await interceptA2AEnvelope({
+      sourceMetadata: {
+        a2a: true,
+        envelopeType: "pairing_accepted",
+        authenticated: false,
+        envelope: {
+          version: "v1",
+          type: "pairing_accepted",
+          senderAssistantId: "other-asst",
+          inviteCode: "some-code",
+          inboundToken: "tok-123",
+        },
+      },
+    });
+    expect(acceptedResult.handled).toBe(true);
+
+    // pairing_finalize should be handled (when authenticated)
+    const finalizeResult = await interceptA2AEnvelope({
+      sourceMetadata: {
+        a2a: true,
+        envelopeType: "pairing_finalize",
+        authenticated: true,
+        envelope: {
+          version: "v1",
+          type: "pairing_finalize",
+          senderAssistantId: "other-asst",
+          inviteCode: "some-code",
+          inboundToken: "tok-456",
+        },
+      },
+    });
+    expect(finalizeResult.handled).toBe(true);
+
+    // Only "message" passes through
+    const messageResult = await interceptA2AEnvelope({
+      sourceMetadata: {
+        a2a: true,
+        envelopeType: "message",
+        authenticated: true,
+      },
+    });
+    expect(messageResult.handled).toBe(false);
+  });
+});

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -216,6 +216,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "daemon/handlers/config-model.ts", // masked provider key display
       "providers/speech-to-text/resolve.ts", // STT provider API key lookup
       "daemon/lifecycle.ts", // CES client injection into secure-keys at startup
+      "runtime/a2a/pairing.ts", // A2A pairing token exchange (inbound/outbound/gateway key storage)
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -14,8 +14,6 @@
 import { answerCall } from "../calls/call-domain.js";
 import { getGatewayInternalBaseUrl } from "../config/env.js";
 import { upsertContactChannel } from "../contacts/contacts-write.js";
-import { findPairingByRemoteAssistant } from "../runtime/a2a/pairing-store.js";
-import { completePairingApproval } from "../runtime/a2a/pairing.js";
 import {
   type CanonicalGuardianRequest,
   getCanonicalGuardianRequest,
@@ -26,6 +24,8 @@ import {
   type NotificationSourceChannel,
 } from "../notifications/signal.js";
 import { addRule } from "../permissions/trust-store.js";
+import { completePairingApproval } from "../runtime/a2a/pairing.js";
+import { findPairingByRemoteAssistant } from "../runtime/a2a/pairing-store.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { mintDaemonDeliveryToken } from "../runtime/auth/token-service.js";
 import type { ApprovalAction } from "../runtime/channel-approval-types.js";

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -14,6 +14,8 @@
 import { answerCall } from "../calls/call-domain.js";
 import { getGatewayInternalBaseUrl } from "../config/env.js";
 import { upsertContactChannel } from "../contacts/contacts-write.js";
+import { findPairingByRemoteAssistant } from "../runtime/a2a/pairing-store.js";
+import { completePairingApproval } from "../runtime/a2a/pairing.js";
 import {
   type CanonicalGuardianRequest,
   getCanonicalGuardianRequest,
@@ -482,6 +484,36 @@ const accessRequestResolver: GuardianRequestResolver = {
           ? { guardianReplyText: `Access denied for ${requesterLabel}.` }
           : {}),
       };
+    }
+
+    // A2A pairing approvals: directly activate the assistant contact without
+    // minting a verification session. Identity is established by the
+    // invite-code handshake, not by channel-native identity verification.
+    const a2aPairing = findPairingByRemoteAssistant(
+      requesterExternalUserId,
+      "inbound",
+    );
+    if (a2aPairing && a2aPairing.status === "pending") {
+      try {
+        const success = await completePairingApproval(requesterExternalUserId);
+        if (success) {
+          log.info(
+            {
+              event: "resolver_access_request_a2a_approved",
+              requestId: request.id,
+              remoteAssistantId: requesterExternalUserId,
+            },
+            "Access request resolver: A2A pairing approval — direct assistant contact activation",
+          );
+          return { ok: true, applied: true };
+        }
+      } catch (err) {
+        log.error(
+          { err, requesterExternalUserId },
+          "Access request resolver: failed to complete A2A pairing approval",
+        );
+      }
+      return { ok: false, reason: "a2a_pairing_approval_failed" };
     }
 
     // Voice approvals: directly activate the trusted contact without minting

--- a/assistant/src/cli/commands/contacts.ts
+++ b/assistant/src/cli/commands/contacts.ts
@@ -16,6 +16,8 @@ import type {
   ContactRole,
   ContactType,
 } from "../../contacts/types.js";
+import { initiatePairing } from "../../runtime/a2a/pairing.js";
+import { findPairingByInviteCode } from "../../runtime/a2a/pairing-store.js";
 import {
   createIngressInvite,
   listIngressInvites,
@@ -711,6 +713,110 @@ Examples:
               process.exitCode = 1;
             }
           }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          writeOutput(cmd, { ok: false, error: message });
+          process.exitCode = 1;
+        }
+      },
+    );
+
+  // ── A2A Pairing ────────────────────────────────────────────────────
+
+  contacts
+    .command("pair <targetGatewayUrl> <targetAssistantId>")
+    .description("Initiate A2A pairing with a remote assistant")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  targetGatewayUrl    Gateway URL of the remote assistant (e.g. https://gateway.example.com)
+  targetAssistantId   ID of the remote assistant to pair with
+
+Initiates the A2A pairing handshake by generating an invite code and
+sending a pairing request to the remote assistant's gateway. The remote
+assistant's guardian must approve the request before pairing completes.
+
+Examples:
+  $ assistant contacts pair https://gateway.example.com remote-assistant-id
+  $ assistant contacts pair https://gateway.example.com remote-assistant-id --json`,
+    )
+    .action(
+      async (
+        targetGatewayUrl: string,
+        targetAssistantId: string,
+        _opts: unknown,
+        cmd: Command,
+      ) => {
+        try {
+          initializeDb();
+          const result = await initiatePairing(
+            targetAssistantId,
+            targetGatewayUrl,
+          );
+          writeOutput(cmd, {
+            ok: true,
+            pairingRequestId: result.pairingRequestId,
+            inviteCode: result.inviteCode,
+            status: "pending",
+            message: `Pairing request sent to ${targetAssistantId}. Waiting for guardian approval.`,
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          writeOutput(cmd, { ok: false, error: message });
+          process.exitCode = 1;
+        }
+      },
+    );
+
+  contacts
+    .command("pair-status [inviteCode]")
+    .description("Check the status of an A2A pairing request")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  inviteCode   The invite code returned by 'contacts pair' (optional)
+
+Checks the current status of a pairing request by invite code.
+
+Examples:
+  $ assistant contacts pair-status abc123def456
+  $ assistant contacts pair-status abc123def456 --json`,
+    )
+    .action(
+      async (inviteCode: string | undefined, _opts: unknown, cmd: Command) => {
+        try {
+          if (!inviteCode) {
+            writeOutput(cmd, {
+              ok: false,
+              error: "inviteCode argument is required",
+            });
+            process.exitCode = 1;
+            return;
+          }
+          initializeDb();
+          const request = findPairingByInviteCode(inviteCode);
+          if (!request) {
+            writeOutput(cmd, {
+              ok: false,
+              error: "Pairing request not found or expired",
+            });
+            process.exitCode = 1;
+            return;
+          }
+          writeOutput(cmd, {
+            ok: true,
+            pairingRequest: {
+              id: request.id,
+              direction: request.direction,
+              remoteAssistantId: request.remoteAssistantId,
+              remoteGatewayUrl: request.remoteGatewayUrl,
+              status: request.status,
+              createdAt: request.createdAt,
+              expiresAt: request.expiresAt,
+            },
+          });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           writeOutput(cmd, { ok: false, error: message });

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -13,6 +13,7 @@ import { ensureDataDir, getDbPath } from "../util/platform.js";
 import { getDb, getSqlite } from "./db-connection.js";
 import {
   addCoreColumns,
+  createA2aPairingRequestsTable,
   createActorRefreshTokenRecordsTable,
   createActorTokenRecordsTable,
   createAssistantInboxTables,
@@ -507,6 +508,9 @@ export function initializeDb(): void {
 
   // 90. Add source_type and source_message_role columns to memory_items
   migrateAddSourceTypeColumns(database);
+
+  // 91. A2A pairing requests table for inter-assistant handshake state
+  createA2aPairingRequestsTable(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/194-a2a-pairing-requests.ts
+++ b/assistant/src/memory/migrations/194-a2a-pairing-requests.ts
@@ -1,0 +1,31 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Create the a2a_pairing_requests table for tracking A2A pairing handshake
+ * state. Uses CREATE TABLE IF NOT EXISTS for idempotency.
+ */
+export function createA2aPairingRequestsTable(database: DrizzleDb): void {
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS a2a_pairing_requests (
+      id TEXT PRIMARY KEY,
+      direction TEXT NOT NULL,
+      invite_code TEXT NOT NULL,
+      remote_assistant_id TEXT NOT NULL,
+      remote_gateway_url TEXT NOT NULL,
+      status TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL
+    )
+  `);
+
+  // Unique index on invite_code for fast lookup during handshake validation.
+  // Wrapped in try-catch for idempotency (index may already exist).
+  try {
+    database.run(/*sql*/ `
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_a2a_pairing_invite_code
+      ON a2a_pairing_requests (invite_code)
+    `);
+  } catch {
+    // Index already exists — safe to ignore.
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -132,6 +132,7 @@ export { migrateCallSessionSkipDisclosure } from "./190-call-session-skip-disclo
 export { migrateBackfillAudioAttachmentMimeTypes } from "./191-backfill-audio-attachment-mime-types.js";
 export { migrateContactsUserFileColumn } from "./192-contacts-user-file-column.js";
 export { migrateAddSourceTypeColumns } from "./193-add-source-type-columns.js";
+export { createA2aPairingRequestsTable } from "./194-a2a-pairing-requests.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/a2a.ts
+++ b/assistant/src/memory/schema/a2a.ts
@@ -1,0 +1,30 @@
+import {
+  integer,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+
+/**
+ * Tracks A2A pairing requests for the invite-code-gated handshake.
+ *
+ * `direction` discriminates the role this assistant played:
+ *   - "outbound" — we initiated the pairing; remoteAssistantId/remoteGatewayUrl
+ *     identifies the target.
+ *   - "inbound" — they contacted us; remoteAssistantId/remoteGatewayUrl
+ *     identifies the sender.
+ */
+export const a2aPairingRequests = sqliteTable(
+  "a2a_pairing_requests",
+  {
+    id: text("id").primaryKey(),
+    direction: text("direction").notNull(), // "outbound" | "inbound"
+    inviteCode: text("invite_code").notNull(),
+    remoteAssistantId: text("remote_assistant_id").notNull(),
+    remoteGatewayUrl: text("remote_gateway_url").notNull(),
+    status: text("status").notNull(), // "pending" | "accepted" | "expired" | "failed"
+    createdAt: integer("created_at").notNull(),
+    expiresAt: integer("expires_at").notNull(),
+  },
+  (table) => [uniqueIndex("idx_a2a_pairing_invite_code").on(table.inviteCode)],
+);

--- a/assistant/src/memory/schema/index.ts
+++ b/assistant/src/memory/schema/index.ts
@@ -1,3 +1,4 @@
+export * from "./a2a.js";
 export * from "./calls.js";
 export * from "./contacts.js";
 export * from "./conversations.js";

--- a/assistant/src/runtime/a2a/index.ts
+++ b/assistant/src/runtime/a2a/index.ts
@@ -7,23 +7,21 @@ export {
   A2AValidationError,
   parseA2AEnvelope,
 } from "./message-contract.js";
-
 export {
-  type PairingDirection,
-  type PairingRequest,
-  type PairingStatus,
-  createPairingRequest,
-  findPairingByInviteCode,
-  findPairingByRemoteAssistant,
-  PAIRING_REQUEST_TTL_MS,
-  updatePairingStatus,
-} from "./pairing-store.js";
-
-export {
-  type InitiatePairingResult,
   completePairingApproval,
   handleInboundPairingRequest,
   handlePairingAccepted,
   handlePairingFinalize,
   initiatePairing,
+  type InitiatePairingResult,
 } from "./pairing.js";
+export {
+  createPairingRequest,
+  findPairingByInviteCode,
+  findPairingByRemoteAssistant,
+  PAIRING_REQUEST_TTL_MS,
+  type PairingDirection,
+  type PairingRequest,
+  type PairingStatus,
+  updatePairingStatus,
+} from "./pairing-store.js";

--- a/assistant/src/runtime/a2a/index.ts
+++ b/assistant/src/runtime/a2a/index.ts
@@ -7,3 +7,23 @@ export {
   A2AValidationError,
   parseA2AEnvelope,
 } from "./message-contract.js";
+
+export {
+  type PairingDirection,
+  type PairingRequest,
+  type PairingStatus,
+  createPairingRequest,
+  findPairingByInviteCode,
+  findPairingByRemoteAssistant,
+  PAIRING_REQUEST_TTL_MS,
+  updatePairingStatus,
+} from "./pairing-store.js";
+
+export {
+  type InitiatePairingResult,
+  completePairingApproval,
+  handleInboundPairingRequest,
+  handlePairingAccepted,
+  handlePairingFinalize,
+  initiatePairing,
+} from "./pairing.js";

--- a/assistant/src/runtime/a2a/index.ts
+++ b/assistant/src/runtime/a2a/index.ts
@@ -7,21 +7,3 @@ export {
   A2AValidationError,
   parseA2AEnvelope,
 } from "./message-contract.js";
-export {
-  completePairingApproval,
-  handleInboundPairingRequest,
-  handlePairingAccepted,
-  handlePairingFinalize,
-  initiatePairing,
-  type InitiatePairingResult,
-} from "./pairing.js";
-export {
-  createPairingRequest,
-  findPairingByInviteCode,
-  findPairingByRemoteAssistant,
-  PAIRING_REQUEST_TTL_MS,
-  type PairingDirection,
-  type PairingRequest,
-  type PairingStatus,
-  updatePairingStatus,
-} from "./pairing-store.js";

--- a/assistant/src/runtime/a2a/pairing-store.ts
+++ b/assistant/src/runtime/a2a/pairing-store.ts
@@ -1,0 +1,172 @@
+/**
+ * CRUD operations for the a2a_pairing_requests table.
+ *
+ * Manages pairing handshake state for both the initiator ("outbound")
+ * and target ("inbound") sides of the A2A pairing protocol.
+ */
+
+import { and, eq } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import { getDb } from "../../memory/db.js";
+import { a2aPairingRequests } from "../../memory/schema.js";
+
+export type PairingDirection = "outbound" | "inbound";
+export type PairingStatus = "pending" | "accepted" | "expired" | "failed";
+
+export interface PairingRequest {
+  id: string;
+  direction: PairingDirection;
+  inviteCode: string;
+  remoteAssistantId: string;
+  remoteGatewayUrl: string;
+  status: PairingStatus;
+  createdAt: number;
+  expiresAt: number;
+}
+
+function parseRow(row: typeof a2aPairingRequests.$inferSelect): PairingRequest {
+  return {
+    id: row.id,
+    direction: row.direction as PairingDirection,
+    inviteCode: row.inviteCode,
+    remoteAssistantId: row.remoteAssistantId,
+    remoteGatewayUrl: row.remoteGatewayUrl,
+    status: row.status as PairingStatus,
+    createdAt: row.createdAt,
+    expiresAt: row.expiresAt,
+  };
+}
+
+/** Default pairing request TTL: 1 hour. */
+export const PAIRING_REQUEST_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * Create a new pairing request. If a pending request already exists for
+ * the same (direction, remoteAssistantId), it is replaced (idempotent
+ * re-initiation).
+ */
+export function createPairingRequest(
+  direction: PairingDirection,
+  inviteCode: string,
+  remoteAssistantId: string,
+  remoteGatewayUrl: string,
+  expiresAt: number,
+): PairingRequest {
+  const db = getDb();
+  const now = Date.now();
+
+  // Replace any existing pending request for the same remote assistant + direction
+  const existing = db
+    .select()
+    .from(a2aPairingRequests)
+    .where(
+      and(
+        eq(a2aPairingRequests.direction, direction),
+        eq(a2aPairingRequests.remoteAssistantId, remoteAssistantId),
+        eq(a2aPairingRequests.status, "pending"),
+      ),
+    )
+    .get();
+
+  if (existing) {
+    db.delete(a2aPairingRequests)
+      .where(eq(a2aPairingRequests.id, existing.id))
+      .run();
+  }
+
+  const id = uuid();
+  db.insert(a2aPairingRequests)
+    .values({
+      id,
+      direction,
+      inviteCode,
+      remoteAssistantId,
+      remoteGatewayUrl,
+      status: "pending",
+      createdAt: now,
+      expiresAt,
+    })
+    .run();
+
+  return {
+    id,
+    direction,
+    inviteCode,
+    remoteAssistantId,
+    remoteGatewayUrl,
+    status: "pending",
+    createdAt: now,
+    expiresAt,
+  };
+}
+
+/**
+ * Find a pairing request by invite code. Returns null if not found or expired.
+ */
+export function findPairingByInviteCode(
+  inviteCode: string,
+): PairingRequest | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(a2aPairingRequests)
+    .where(eq(a2aPairingRequests.inviteCode, inviteCode))
+    .get();
+
+  if (!row) return null;
+
+  const parsed = parseRow(row);
+
+  // Auto-expire stale requests
+  if (parsed.status === "pending" && Date.now() > parsed.expiresAt) {
+    updatePairingStatus(parsed.id, "expired");
+    return null;
+  }
+
+  return parsed;
+}
+
+/**
+ * Find a pairing request by remote assistant ID and direction.
+ * Returns the most recent matching request, or null if none found.
+ */
+export function findPairingByRemoteAssistant(
+  remoteAssistantId: string,
+  direction: PairingDirection,
+): PairingRequest | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(a2aPairingRequests)
+    .where(
+      and(
+        eq(a2aPairingRequests.remoteAssistantId, remoteAssistantId),
+        eq(a2aPairingRequests.direction, direction),
+      ),
+    )
+    .get();
+
+  if (!row) return null;
+
+  const parsed = parseRow(row);
+
+  // Auto-expire stale requests
+  if (parsed.status === "pending" && Date.now() > parsed.expiresAt) {
+    updatePairingStatus(parsed.id, "expired");
+    return { ...parsed, status: "expired" };
+  }
+
+  return parsed;
+}
+
+/**
+ * Update the status of a pairing request.
+ */
+export function updatePairingStatus(id: string, status: PairingStatus): void {
+  const db = getDb();
+  db.update(a2aPairingRequests)
+    .set({ status })
+    .where(eq(a2aPairingRequests.id, id))
+    .run();
+}

--- a/assistant/src/runtime/a2a/pairing.ts
+++ b/assistant/src/runtime/a2a/pairing.ts
@@ -1,0 +1,502 @@
+/**
+ * A2A pairing protocol implementation.
+ *
+ * Implements the four-phase invite-code-gated pairing handshake:
+ *   1. Initiator sends PairingRequest (unauthenticated)
+ *   2. Target's guardian approves → sends PairingAccepted (unauthenticated)
+ *   3. Initiator validates + sends PairingFinalize (authenticated)
+ *   4. Target stores outbound token → mutual auth complete
+ *
+ * Each phase stores state in the a2a_pairing_requests table and manages
+ * inbound/outbound tokens in the secure key store.
+ */
+
+import { randomBytes } from "node:crypto";
+
+import {
+  upsertAssistantContactMetadata,
+  upsertContact,
+} from "../../contacts/contact-store.js";
+import {
+  getSecureKeyAsync,
+  setSecureKeyAsync,
+} from "../../security/secure-keys.js";
+import { getLogger } from "../../util/logger.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
+import type {
+  A2APairingAccepted,
+  A2APairingFinalize,
+  A2APairingRequest,
+} from "./message-contract.js";
+import {
+  createPairingRequest,
+  findPairingByInviteCode,
+  findPairingByRemoteAssistant,
+  PAIRING_REQUEST_TTL_MS,
+  updatePairingStatus,
+} from "./pairing-store.js";
+
+const log = getLogger("a2a-pairing");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Generate a cryptographically random invite code (24 bytes, base64url). */
+function generateInviteCode(): string {
+  return randomBytes(24).toString("base64url");
+}
+
+/** Generate a cryptographically random token for bearer auth. */
+function generateToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+/**
+ * Create an active assistant contact with metadata.
+ * Uses the direct upsertContact path (same pattern as phone/voice
+ * direct-activation in guardian-request-resolvers.ts).
+ */
+function createAssistantContact(
+  remoteAssistantId: string,
+  remoteGatewayUrl: string,
+): void {
+  const result = upsertContact({
+    displayName: remoteAssistantId,
+    contactType: "assistant",
+    channels: [
+      {
+        type: "vellum",
+        address: remoteAssistantId,
+        externalUserId: remoteAssistantId,
+        externalChatId: remoteAssistantId,
+        status: "active",
+        policy: "allow",
+      },
+    ],
+  });
+
+  upsertAssistantContactMetadata({
+    contactId: result.id,
+    species: "vellum",
+    metadata: {
+      assistantId: remoteAssistantId,
+      gatewayUrl: remoteGatewayUrl,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1: Initiator sends pairing request
+// ---------------------------------------------------------------------------
+
+export interface InitiatePairingResult {
+  inviteCode: string;
+  pairingRequestId: string;
+}
+
+/**
+ * Initiate pairing with a remote assistant.
+ *
+ * Generates an invite code, stores an outbound pairing request, and sends
+ * the pairing request to the target's gateway (unauthenticated).
+ */
+export async function initiatePairing(
+  targetAssistantId: string,
+  targetGatewayUrl: string,
+  localAssistantId: string = DAEMON_INTERNAL_ASSISTANT_ID,
+  localGatewayUrl?: string,
+): Promise<InitiatePairingResult> {
+  const inviteCode = generateInviteCode();
+  const expiresAt = Date.now() + PAIRING_REQUEST_TTL_MS;
+
+  const pairingRequest = createPairingRequest(
+    "outbound",
+    inviteCode,
+    targetAssistantId,
+    targetGatewayUrl,
+    expiresAt,
+  );
+
+  // Send pairing request to target (unauthenticated)
+  const envelope: A2APairingRequest = {
+    version: "v1",
+    type: "pairing_request",
+    senderAssistantId: localAssistantId,
+    senderGatewayUrl: localGatewayUrl ?? "",
+    inviteCode,
+  };
+
+  try {
+    const url = `${targetGatewayUrl}/webhook/a2a`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(envelope),
+    });
+
+    if (!response.ok) {
+      log.warn(
+        {
+          event: "a2a_pairing_request_delivery_failed",
+          targetAssistantId,
+          targetGatewayUrl,
+          status: response.status,
+        },
+        "Failed to deliver A2A pairing request",
+      );
+    }
+  } catch (err) {
+    log.error(
+      { err, targetAssistantId, targetGatewayUrl },
+      "Error sending A2A pairing request",
+    );
+  }
+
+  log.info(
+    {
+      event: "a2a_pairing_initiated",
+      pairingRequestId: pairingRequest.id,
+      targetAssistantId,
+    },
+    "A2A pairing initiated",
+  );
+
+  return {
+    inviteCode,
+    pairingRequestId: pairingRequest.id,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2: Target receives pairing request
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle an incoming A2A pairing request on the target side.
+ *
+ * Stores the inbound pairing request. The actual guardian notification
+ * is handled by the A2A interceptor which calls notifyGuardianOfAccessRequest.
+ */
+export function handleInboundPairingRequest(envelope: A2APairingRequest): void {
+  const expiresAt = Date.now() + PAIRING_REQUEST_TTL_MS;
+
+  createPairingRequest(
+    "inbound",
+    envelope.inviteCode,
+    envelope.senderAssistantId,
+    envelope.senderGatewayUrl,
+    expiresAt,
+  );
+
+  log.info(
+    {
+      event: "a2a_pairing_request_received",
+      senderAssistantId: envelope.senderAssistantId,
+      senderGatewayUrl: envelope.senderGatewayUrl,
+    },
+    "A2A pairing request received and stored",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2b: Target's guardian approves → send PairingAccepted
+// ---------------------------------------------------------------------------
+
+/**
+ * Complete the target side of pairing after guardian approval.
+ *
+ * Creates the contact, generates an inbound token, stores gateway URL,
+ * and sends PairingAccepted back to the initiator.
+ *
+ * Returns true if successful, false if the pairing request was not found
+ * or could not be processed.
+ */
+export async function completePairingApproval(
+  remoteAssistantId: string,
+  localAssistantId: string = DAEMON_INTERNAL_ASSISTANT_ID,
+): Promise<boolean> {
+  const pairingRequest = findPairingByRemoteAssistant(
+    remoteAssistantId,
+    "inbound",
+  );
+
+  if (!pairingRequest || pairingRequest.status !== "pending") {
+    log.warn(
+      {
+        event: "a2a_pairing_approval_no_request",
+        remoteAssistantId,
+      },
+      "No pending inbound pairing request found for approval",
+    );
+    return false;
+  }
+
+  const remoteGatewayUrl = pairingRequest.remoteGatewayUrl;
+
+  // Create contact with assistant metadata
+  createAssistantContact(remoteAssistantId, remoteGatewayUrl);
+
+  // Generate and store inbound token (token the remote assistant uses to contact us)
+  const inboundToken = generateToken();
+  await setSecureKeyAsync(`a2a:inbound:${remoteAssistantId}`, inboundToken);
+
+  // Store gateway URL for delivery routing
+  await setSecureKeyAsync(`a2a:gateway:${remoteAssistantId}`, remoteGatewayUrl);
+
+  // Send PairingAccepted back to initiator (unauthenticated — validated via invite code)
+  const envelope: A2APairingAccepted = {
+    version: "v1",
+    type: "pairing_accepted",
+    senderAssistantId: localAssistantId,
+    inviteCode: pairingRequest.inviteCode,
+    inboundToken,
+  };
+
+  try {
+    const url = `${remoteGatewayUrl}/webhook/a2a`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(envelope),
+    });
+
+    if (!response.ok) {
+      log.warn(
+        {
+          event: "a2a_pairing_accepted_delivery_failed",
+          remoteAssistantId,
+          status: response.status,
+        },
+        "Failed to deliver A2A pairing accepted",
+      );
+      updatePairingStatus(pairingRequest.id, "failed");
+      return false;
+    }
+  } catch (err) {
+    log.error({ err, remoteAssistantId }, "Error sending A2A pairing accepted");
+    updatePairingStatus(pairingRequest.id, "failed");
+    return false;
+  }
+
+  updatePairingStatus(pairingRequest.id, "accepted");
+
+  log.info(
+    {
+      event: "a2a_pairing_approved",
+      pairingRequestId: pairingRequest.id,
+      remoteAssistantId,
+    },
+    "A2A pairing approved and acceptance sent",
+  );
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3: Initiator receives PairingAccepted
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle an incoming PairingAccepted envelope on the initiator side.
+ *
+ * Validates the invite code and sender identity, stores the outbound token,
+ * generates an inbound token, creates the contact, and sends PairingFinalize.
+ */
+export async function handlePairingAccepted(
+  envelope: A2APairingAccepted,
+  localAssistantId: string = DAEMON_INTERNAL_ASSISTANT_ID,
+): Promise<boolean> {
+  // Look up the outbound pairing request by invite code
+  const pairingRequest = findPairingByInviteCode(envelope.inviteCode);
+
+  if (!pairingRequest) {
+    log.warn(
+      {
+        event: "a2a_pairing_accepted_no_request",
+        inviteCode: envelope.inviteCode.slice(0, 8) + "...",
+      },
+      "Received pairing_accepted with no matching outbound request (not found or expired)",
+    );
+    return false;
+  }
+
+  if (
+    pairingRequest.direction !== "outbound" ||
+    pairingRequest.status !== "pending"
+  ) {
+    log.warn(
+      {
+        event: "a2a_pairing_accepted_invalid_state",
+        direction: pairingRequest.direction,
+        status: pairingRequest.status,
+      },
+      "Pairing request in wrong state for pairing_accepted",
+    );
+    return false;
+  }
+
+  // Validate sender identity matches stored remote assistant
+  if (envelope.senderAssistantId !== pairingRequest.remoteAssistantId) {
+    log.warn(
+      {
+        event: "a2a_pairing_accepted_identity_mismatch",
+        expected: pairingRequest.remoteAssistantId,
+        received: envelope.senderAssistantId,
+      },
+      "Pairing accepted sender identity mismatch — possible impersonation",
+    );
+    return false;
+  }
+
+  const remoteGatewayUrl = pairingRequest.remoteGatewayUrl;
+
+  // Store the received token as our outbound token (to contact them)
+  await setSecureKeyAsync(
+    `a2a:outbound:${envelope.senderAssistantId}`,
+    envelope.inboundToken,
+  );
+
+  // Generate our inbound token (for them to contact us)
+  const inboundToken = generateToken();
+  await setSecureKeyAsync(
+    `a2a:inbound:${envelope.senderAssistantId}`,
+    inboundToken,
+  );
+
+  // Store gateway URL from the STORED pairing request (not from the envelope)
+  await setSecureKeyAsync(
+    `a2a:gateway:${envelope.senderAssistantId}`,
+    remoteGatewayUrl,
+  );
+
+  // Create reciprocal contact
+  createAssistantContact(envelope.senderAssistantId, remoteGatewayUrl);
+
+  // Send PairingFinalize (authenticated — we now have the outbound token)
+  const finalizeEnvelope: A2APairingFinalize = {
+    version: "v1",
+    type: "pairing_finalize",
+    senderAssistantId: localAssistantId,
+    inviteCode: envelope.inviteCode,
+    inboundToken,
+  };
+
+  try {
+    const url = `${remoteGatewayUrl}/deliver/a2a`;
+    const outboundToken = await getSecureKeyAsync(
+      `a2a:outbound:${envelope.senderAssistantId}`,
+    );
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${outboundToken}`,
+      },
+      body: JSON.stringify(finalizeEnvelope),
+    });
+
+    if (!response.ok) {
+      log.warn(
+        {
+          event: "a2a_pairing_finalize_delivery_failed",
+          remoteAssistantId: envelope.senderAssistantId,
+          status: response.status,
+        },
+        "Failed to deliver A2A pairing finalize",
+      );
+    }
+  } catch (err) {
+    log.error(
+      { err, remoteAssistantId: envelope.senderAssistantId },
+      "Error sending A2A pairing finalize",
+    );
+  }
+
+  updatePairingStatus(pairingRequest.id, "accepted");
+
+  log.info(
+    {
+      event: "a2a_pairing_accepted_processed",
+      pairingRequestId: pairingRequest.id,
+      remoteAssistantId: envelope.senderAssistantId,
+    },
+    "A2A pairing accepted processed — finalize sent",
+  );
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 4: Target receives PairingFinalize
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle an incoming PairingFinalize envelope on the target side.
+ *
+ * This arrives authenticated (gateway verified Bearer token). Validates
+ * the invite code and sender identity, then stores the outbound token.
+ */
+export async function handlePairingFinalize(
+  envelope: A2APairingFinalize,
+): Promise<boolean> {
+  // Look up the inbound pairing request by invite code
+  const pairingRequest = findPairingByInviteCode(envelope.inviteCode);
+
+  if (!pairingRequest) {
+    log.warn(
+      {
+        event: "a2a_pairing_finalize_no_request",
+        inviteCode: envelope.inviteCode.slice(0, 8) + "...",
+      },
+      "Received pairing_finalize with no matching inbound request",
+    );
+    return false;
+  }
+
+  if (
+    pairingRequest.direction !== "inbound" ||
+    pairingRequest.status !== "accepted"
+  ) {
+    log.warn(
+      {
+        event: "a2a_pairing_finalize_invalid_state",
+        direction: pairingRequest.direction,
+        status: pairingRequest.status,
+      },
+      "Pairing request in wrong state for pairing_finalize",
+    );
+    return false;
+  }
+
+  // Validate sender identity matches stored remote assistant
+  if (envelope.senderAssistantId !== pairingRequest.remoteAssistantId) {
+    log.warn(
+      {
+        event: "a2a_pairing_finalize_identity_mismatch",
+        expected: pairingRequest.remoteAssistantId,
+        received: envelope.senderAssistantId,
+      },
+      "Pairing finalize sender identity mismatch",
+    );
+    return false;
+  }
+
+  // Store the received token as our outbound token (to contact them)
+  await setSecureKeyAsync(
+    `a2a:outbound:${envelope.senderAssistantId}`,
+    envelope.inboundToken,
+  );
+
+  log.info(
+    {
+      event: "a2a_pairing_finalize_complete",
+      pairingRequestId: pairingRequest.id,
+      remoteAssistantId: envelope.senderAssistantId,
+    },
+    "A2A pairing finalize complete — mutual auth established",
+  );
+
+  return true;
+}

--- a/assistant/src/runtime/routes/inbound-stages/a2a-interceptor.ts
+++ b/assistant/src/runtime/routes/inbound-stages/a2a-interceptor.ts
@@ -1,0 +1,260 @@
+/**
+ * A2A interceptor — routes A2A pairing envelopes before normal inbound
+ * processing (before ACL enforcement, conversation routing, etc.).
+ *
+ * Checks `sourceMetadata?.a2a === true` on the inbound payload and routes
+ * by `sourceMetadata.envelopeType`:
+ *   - "pairing_request"  → handlePairingRequest()
+ *   - "pairing_accepted" → handlePairingAccepted()
+ *   - "pairing_finalize" → handlePairingFinalize()
+ *   - "message"          → pass through to normal inbound pipeline
+ *
+ * Safety invariant: unauthenticated envelopes can only reach pairing
+ * handlers (pairing_request, pairing_accepted), never the message pipeline.
+ */
+
+import { notifyGuardianOfAccessRequest } from "../../access-request-helper.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../assistant-scope.js";
+import {
+  handlePairingAccepted,
+  handlePairingFinalize,
+  handleInboundPairingRequest,
+} from "../../a2a/pairing.js";
+import { parseA2AEnvelope } from "../../a2a/message-contract.js";
+import { getLogger } from "../../../util/logger.js";
+
+const log = getLogger("a2a-interceptor");
+
+export interface A2AInterceptResult {
+  /** Whether the interceptor consumed the request. */
+  handled: boolean;
+  /** HTTP response to return when handled. */
+  response?: Response;
+}
+
+interface A2ASourceMetadata {
+  a2a: true;
+  envelopeType: string;
+  authenticated: boolean;
+  senderAssistantId?: string;
+  senderGatewayUrl?: string;
+  envelope?: unknown;
+}
+
+function isA2ASourceMetadata(
+  metadata: Record<string, unknown> | undefined,
+): metadata is A2ASourceMetadata {
+  return metadata != null && metadata.a2a === true;
+}
+
+/**
+ * Intercept A2A envelopes before normal inbound message processing.
+ *
+ * Returns `{ handled: true, response }` when the envelope was consumed
+ * by a pairing handler. Returns `{ handled: false }` to let normal
+ * inbound processing continue (for "message" type envelopes).
+ */
+export async function interceptA2AEnvelope(params: {
+  sourceMetadata?: Record<string, unknown>;
+  canonicalAssistantId?: string;
+}): Promise<A2AInterceptResult> {
+  const { sourceMetadata, canonicalAssistantId } = params;
+
+  if (!isA2ASourceMetadata(sourceMetadata)) {
+    return { handled: false };
+  }
+
+  const { envelopeType, authenticated, envelope: rawEnvelope } = sourceMetadata;
+
+  // Safety invariant: unauthenticated envelopes can only reach pairing
+  // handlers, never the message processing pipeline.
+  if (
+    !authenticated &&
+    envelopeType !== "pairing_request" &&
+    envelopeType !== "pairing_accepted"
+  ) {
+    log.warn(
+      {
+        event: "a2a_interceptor_unauthenticated_rejected",
+        envelopeType,
+      },
+      "Rejected unauthenticated A2A envelope — only pairing_request and pairing_accepted allowed",
+    );
+    return {
+      handled: true,
+      response: Response.json(
+        {
+          error:
+            "Unauthenticated A2A envelopes can only reach pairing handlers",
+        },
+        { status: 403 },
+      ),
+    };
+  }
+
+  switch (envelopeType) {
+    case "pairing_request":
+      return handlePairingRequestIntercept(rawEnvelope, canonicalAssistantId);
+
+    case "pairing_accepted":
+      return handlePairingAcceptedIntercept(rawEnvelope);
+
+    case "pairing_finalize":
+      return handlePairingFinalizeIntercept(rawEnvelope);
+
+    case "message":
+      // Pass through to normal inbound pipeline
+      return { handled: false };
+
+    default:
+      log.warn(
+        { event: "a2a_interceptor_unknown_type", envelopeType },
+        "Unknown A2A envelope type",
+      );
+      return {
+        handled: true,
+        response: Response.json(
+          { error: `Unknown A2A envelope type: ${envelopeType}` },
+          { status: 400 },
+        ),
+      };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pairing request handler
+// ---------------------------------------------------------------------------
+
+async function handlePairingRequestIntercept(
+  rawEnvelope: unknown,
+  canonicalAssistantId: string = DAEMON_INTERNAL_ASSISTANT_ID,
+): Promise<A2AInterceptResult> {
+  try {
+    const envelope = parseA2AEnvelope(rawEnvelope);
+    if (envelope.type !== "pairing_request") {
+      return {
+        handled: true,
+        response: Response.json(
+          { error: "Expected pairing_request" },
+          { status: 400 },
+        ),
+      };
+    }
+
+    // Store the inbound pairing request
+    handleInboundPairingRequest(envelope);
+
+    // Trigger guardian notification via the existing access request flow.
+    // The guardian will see "Assistant [X] wants to pair with your assistant."
+    notifyGuardianOfAccessRequest({
+      canonicalAssistantId,
+      sourceChannel: "vellum",
+      conversationExternalId: `a2a-pairing:${envelope.senderAssistantId}`,
+      actorExternalId: envelope.senderAssistantId,
+      actorDisplayName: `Assistant ${envelope.senderAssistantId}`,
+      messagePreview: `Assistant ${envelope.senderAssistantId} (at ${envelope.senderGatewayUrl}) wants to pair with your assistant.`,
+    });
+
+    log.info(
+      {
+        event: "a2a_pairing_request_intercepted",
+        senderAssistantId: envelope.senderAssistantId,
+      },
+      "A2A pairing request intercepted — guardian notified",
+    );
+
+    return {
+      handled: true,
+      response: Response.json({ accepted: true, type: "pairing_request" }),
+    };
+  } catch (err) {
+    log.error({ err }, "Error handling A2A pairing request");
+    return {
+      handled: true,
+      response: Response.json(
+        { error: "Failed to process pairing request" },
+        { status: 500 },
+      ),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pairing accepted handler
+// ---------------------------------------------------------------------------
+
+async function handlePairingAcceptedIntercept(
+  rawEnvelope: unknown,
+): Promise<A2AInterceptResult> {
+  try {
+    const envelope = parseA2AEnvelope(rawEnvelope);
+    if (envelope.type !== "pairing_accepted") {
+      return {
+        handled: true,
+        response: Response.json(
+          { error: "Expected pairing_accepted" },
+          { status: 400 },
+        ),
+      };
+    }
+
+    const success = await handlePairingAccepted(envelope);
+
+    return {
+      handled: true,
+      response: Response.json({
+        accepted: success,
+        type: "pairing_accepted",
+      }),
+    };
+  } catch (err) {
+    log.error({ err }, "Error handling A2A pairing accepted");
+    return {
+      handled: true,
+      response: Response.json(
+        { error: "Failed to process pairing accepted" },
+        { status: 500 },
+      ),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pairing finalize handler
+// ---------------------------------------------------------------------------
+
+async function handlePairingFinalizeIntercept(
+  rawEnvelope: unknown,
+): Promise<A2AInterceptResult> {
+  try {
+    const envelope = parseA2AEnvelope(rawEnvelope);
+    if (envelope.type !== "pairing_finalize") {
+      return {
+        handled: true,
+        response: Response.json(
+          { error: "Expected pairing_finalize" },
+          { status: 400 },
+        ),
+      };
+    }
+
+    const success = await handlePairingFinalize(envelope);
+
+    return {
+      handled: true,
+      response: Response.json({
+        accepted: success,
+        type: "pairing_finalize",
+      }),
+    };
+  } catch (err) {
+    log.error({ err }, "Error handling A2A pairing finalize");
+    return {
+      handled: true,
+      response: Response.json(
+        { error: "Failed to process pairing finalize" },
+        { status: 500 },
+      ),
+    };
+  }
+}

--- a/assistant/src/runtime/routes/inbound-stages/a2a-interceptor.ts
+++ b/assistant/src/runtime/routes/inbound-stages/a2a-interceptor.ts
@@ -13,15 +13,15 @@
  * handlers (pairing_request, pairing_accepted), never the message pipeline.
  */
 
-import { notifyGuardianOfAccessRequest } from "../../access-request-helper.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../assistant-scope.js";
+import { getLogger } from "../../../util/logger.js";
+import { parseA2AEnvelope } from "../../a2a/message-contract.js";
 import {
+  handleInboundPairingRequest,
   handlePairingAccepted,
   handlePairingFinalize,
-  handleInboundPairingRequest,
 } from "../../a2a/pairing.js";
-import { parseA2AEnvelope } from "../../a2a/message-contract.js";
-import { getLogger } from "../../../util/logger.js";
+import { notifyGuardianOfAccessRequest } from "../../access-request-helper.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../assistant-scope.js";
 
 const log = getLogger("a2a-interceptor");
 
@@ -32,7 +32,7 @@ export interface A2AInterceptResult {
   response?: Response;
 }
 
-interface A2ASourceMetadata {
+interface A2ASourceMetadata extends Record<string, unknown> {
   a2a: true;
   envelopeType: string;
   authenticated: boolean;


### PR DESCRIPTION
## Summary
- Add `a2a_pairing_requests` table with direction-neutral schema for tracking pairing state
- Implement four-phase pairing handshake: request → guardian approval → accepted → finalize
- Branch `accessRequestResolver` for A2A using phone/voice direct-activation pattern
- Add A2A interceptor stage that routes pairing envelopes before normal inbound processing
- Add CLI commands: `assistant contacts pair` and `assistant contacts pair-status`
- Safety invariant: unauthenticated envelopes can only reach pairing handlers

Part of plan: assistant-to-assistant-a2a.md (PR 3 of 7)
Part of JARVIS-342
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
