### PR TITLE
Add structured logging to POST /v1/confirm for success and 404 paths

### DIFF
--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -71,6 +71,10 @@ export async function handleConfirm(
   // pending interaction — the client can retry with corrected values.
   const peeked = pendingInteractions.get(requestId);
   if (!peeked) {
+    log.warn(
+      { requestId, decision },
+      "Confirmation POST for unknown requestId (already consumed or never registered)",
+    );
     return httpError(
       "NOT_FOUND",
       "No pending interaction found for this requestId",
@@ -130,6 +134,16 @@ export async function handleConfirm(
 
   // Validation passed — consume the pending interaction.
   const interaction = pendingInteractions.resolve(requestId)!;
+
+  log.info(
+    {
+      requestId,
+      decision,
+      toolName: interaction.confirmationDetails?.toolName,
+      conversationId: interaction.conversationId,
+    },
+    "Confirmation resolved via HTTP",
+  );
 
   // ACP permissions: resolve directly without a Conversation object.
   if (interaction.directResolve) {


### PR DESCRIPTION
## Summary
- Add log.info on successful confirmation resolution with requestId, decision, toolName, conversationId
- Add log.warn on 404 path when requestId is not found (already consumed or never registered)
- Both are low-noise since confirmations are infrequent user-initiated actions

Part of plan: confirm-response-debug-logging.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
