### PR TITLE
Insert inlineResponseHandledRequestIds before sending confirmation POST to prevent dedup race

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2636,6 +2636,7 @@ public final class ChatViewModel: ObservableObject {
     /// Respond to a tool confirmation request displayed inline in the chat.
     public func respondToConfirmation(requestId: String, decision: String) {
         markConfirmationInFlight(requestId: requestId, decision: decision)
+        inlineResponseHandledRequestIds.insert(requestId)
         Task {
             let success = await performConfirmationResponse(
                 requestId: requestId, decision: decision, selectedPattern: nil, selectedScope: nil
@@ -2653,6 +2654,7 @@ public final class ChatViewModel: ObservableObject {
     /// fallback actually went through.
     public func respondToAlwaysAllow(requestId: String, selectedPattern: String, selectedScope: String, decision: String = "always_allow") {
         markConfirmationInFlight(requestId: requestId, decision: decision)
+        inlineResponseHandledRequestIds.insert(requestId)
         Task {
             let success = await interactionClient.sendConfirmationResponse(
                 requestId: requestId, decision: decision, selectedPattern: selectedPattern, selectedScope: selectedScope


### PR DESCRIPTION
## Summary
- Move inlineResponseHandledRequestIds.insert(requestId) before the async Task in respondToConfirmation and respondToAlwaysAllow
- Prevents race where confirmationStateChanged SSE event arrives before POST response, bypassing the dedup check
- Keep the redundant insert in performConfirmationResponse as a safety net (idempotent)

Part of plan: confirm-response-debug-logging.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
