### PR TITLE
Add logging to confirmationStateChanged handler for dedup and notification cleanup paths

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1850,8 +1850,11 @@ extension ChatViewModel {
                 // for this requestId, skip the duplicate call; otherwise forward
                 // so externally-resolved confirmations still dismiss notifications.
                 if inlineResponseHandledRequestIds.remove(msg.requestId) == nil {
+                    log.info("[confirm-flow] confirmationStateChanged: forwarding to notification cleanup (not in handledSet): requestId=\(msg.requestId, privacy: .public) state=\(msg.state, privacy: .public)")
                     let decisionString = msg.state == "approved" ? "allow" : "deny"
                     onInlineConfirmationResponse?(msg.requestId, decisionString)
+                } else {
+                    log.info("[confirm-flow] confirmationStateChanged: skipped notification cleanup (already in handledSet): requestId=\(msg.requestId, privacy: .public) state=\(msg.state, privacy: .public)")
                 }
             }
 


### PR DESCRIPTION
## Summary
- Add [confirm-flow] tagged logging to the confirmationStateChanged dedup check
- Logs whether each terminal-state event forwards to notification cleanup or is skipped (already in handledSet)
- No logging for 'pending' state transitions to avoid noise

Part of plan: confirm-response-debug-logging.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
