### PR TITLE
Add diagnostic logging to confirmation request/response flow in macOS client

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -133,6 +133,7 @@ extension AppDelegate {
                 } else {
                     log.error("Failed to auto-approve confirmation")
                 }
+                log.info("[confirm-flow] CU auto-approved requestId=\(msg.requestId, privacy: .public) tool=\(msg.toolName, privacy: .public)")
                 return
             }
 
@@ -140,11 +141,14 @@ extension AppDelegate {
                 let activeSessionId = mainWindow.conversationManager.activeViewModel?.conversationId
                 let confirmationIsForActiveConversation = msg.conversationId == nil || msg.conversationId == activeSessionId
                 if confirmationIsForActiveConversation {
+                    log.info("[confirm-flow] Skipping notification (app active, inline handles): requestId=\(msg.requestId, privacy: .public) tool=\(msg.toolName, privacy: .public) appActive=\(NSApp.isActive) windowVisible=\(mainWindow.isVisible)")
                     return
                 }
             }
 
+            log.info("[confirm-flow] Posting macOS notification: requestId=\(msg.requestId, privacy: .public) tool=\(msg.toolName, privacy: .public)")
             let decision = await self.toolConfirmationNotificationService.showConfirmation(msg)
+            log.info("[confirm-flow] Notification path resolved: requestId=\(msg.requestId, privacy: .public) decision=\(decision, privacy: .public) isSentinel=\(decision == ToolConfirmationNotificationService.inlineHandledSentinel)")
             guard decision != ToolConfirmationNotificationService.inlineHandledSentinel else {
                 return
             }
@@ -158,7 +162,7 @@ extension AppDelegate {
                     decision: decision
                 )
             } else {
-                log.error("Failed to send confirmation response")
+                log.error("[confirm-flow] Notification-path POST failed: requestId=\(msg.requestId, privacy: .public) decision=\(decision, privacy: .public)")
             }
         }
     }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2635,12 +2635,14 @@ public final class ChatViewModel: ObservableObject {
 
     /// Respond to a tool confirmation request displayed inline in the chat.
     public func respondToConfirmation(requestId: String, decision: String) {
+        log.info("[confirm-flow] respondToConfirmation called: requestId=\(requestId, privacy: .public) decision=\(decision, privacy: .public)")
         markConfirmationInFlight(requestId: requestId, decision: decision)
         Task {
             let success = await performConfirmationResponse(
                 requestId: requestId, decision: decision, selectedPattern: nil, selectedScope: nil
             )
             if !success {
+                log.error("[confirm-flow] respondToConfirmation POST failed (will show error banner): requestId=\(requestId, privacy: .public) decision=\(decision, privacy: .public)")
                 self.revertConfirmationInFlight(requestId: requestId)
                 self.errorText = "Failed to send confirmation response."
             }

--- a/clients/shared/Network/InteractionClient.swift
+++ b/clients/shared/Network/InteractionClient.swift
@@ -32,9 +32,10 @@ public struct InteractionClient: InteractionClientProtocol {
             if let selectedScope { body["selectedScope"] = selectedScope }
 
             let path = try Self.approvalPath(endpoint: "confirm")
+            log.info("[confirm-flow] Sending POST /confirm: requestId=\(requestId, privacy: .public) decision=\(decision, privacy: .public)")
             let response = try await GatewayHTTPClient.post(path: path, json: body, timeout: 10)
             if !response.isSuccess {
-                log.error("sendConfirmationResponse failed (HTTP \(response.statusCode))")
+                log.error("[confirm-flow] POST /confirm failed: requestId=\(requestId, privacy: .public) decision=\(decision, privacy: .public) HTTP \(response.statusCode)")
                 return false
             }
             return true


### PR DESCRIPTION
## Summary
- Add [confirm-flow] tagged logging to AppDelegate confirmation handler (CU auto-approve, inline skip, notification paths)
- Add entry/failure logging to ChatViewModel.respondToConfirmation
- Add pre-POST and failure logging to InteractionClient.sendConfirmationResponse
- All logs use privacy: .public for requestId/decision to ensure visibility in OS logs

Part of plan: confirm-response-debug-logging.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
