### PR TITLE
Add confirmation flow diagnostic logging and fix dedup race

### DIFF
--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -71,6 +71,10 @@ export async function handleConfirm(
   // pending interaction — the client can retry with corrected values.
   const peeked = pendingInteractions.get(requestId);
   if (!peeked) {
+    log.warn(
+      { requestId, decision },
+      "Confirmation POST for unknown requestId (already consumed or never registered)",
+    );
     return httpError(
       "NOT_FOUND",
       "No pending interaction found for this requestId",
@@ -130,6 +134,16 @@ export async function handleConfirm(
 
   // Validation passed — consume the pending interaction.
   const interaction = pendingInteractions.resolve(requestId)!;
+
+  log.info(
+    {
+      requestId,
+      decision,
+      toolName: interaction.confirmationDetails?.toolName,
+      conversationId: interaction.conversationId,
+    },
+    "Confirmation resolved via HTTP",
+  );
 
   // ACP permissions: resolve directly without a Conversation object.
   if (interaction.directResolve) {

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -133,6 +133,7 @@ extension AppDelegate {
                 } else {
                     log.error("Failed to auto-approve confirmation")
                 }
+                log.info("[confirm-flow] CU auto-approved requestId=\(msg.requestId, privacy: .public) tool=\(msg.toolName, privacy: .public)")
                 return
             }
 
@@ -140,11 +141,14 @@ extension AppDelegate {
                 let activeSessionId = mainWindow.conversationManager.activeViewModel?.conversationId
                 let confirmationIsForActiveConversation = msg.conversationId == nil || msg.conversationId == activeSessionId
                 if confirmationIsForActiveConversation {
+                    log.info("[confirm-flow] Skipping notification (app active, inline handles): requestId=\(msg.requestId, privacy: .public) tool=\(msg.toolName, privacy: .public) appActive=\(NSApp.isActive) windowVisible=\(mainWindow.isVisible)")
                     return
                 }
             }
 
+            log.info("[confirm-flow] Posting macOS notification: requestId=\(msg.requestId, privacy: .public) tool=\(msg.toolName, privacy: .public)")
             let decision = await self.toolConfirmationNotificationService.showConfirmation(msg)
+            log.info("[confirm-flow] Notification path resolved: requestId=\(msg.requestId, privacy: .public) decision=\(decision, privacy: .public) isSentinel=\(decision == ToolConfirmationNotificationService.inlineHandledSentinel)")
             guard decision != ToolConfirmationNotificationService.inlineHandledSentinel else {
                 return
             }
@@ -158,7 +162,7 @@ extension AppDelegate {
                     decision: decision
                 )
             } else {
-                log.error("Failed to send confirmation response")
+                log.error("[confirm-flow] Notification-path POST failed: requestId=\(msg.requestId, privacy: .public) decision=\(decision, privacy: .public)")
             }
         }
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -130,10 +130,10 @@ extension AppDelegate {
                         requestId: msg.requestId,
                         decision: "allow"
                     )
+                    log.info("[confirm-flow] CU auto-approved requestId=\(msg.requestId, privacy: .public) tool=\(msg.toolName, privacy: .public)")
                 } else {
                     log.error("Failed to auto-approve confirmation")
                 }
-                log.info("[confirm-flow] CU auto-approved requestId=\(msg.requestId, privacy: .public) tool=\(msg.toolName, privacy: .public)")
                 return
             }
 

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1850,8 +1850,11 @@ extension ChatViewModel {
                 // for this requestId, skip the duplicate call; otherwise forward
                 // so externally-resolved confirmations still dismiss notifications.
                 if inlineResponseHandledRequestIds.remove(msg.requestId) == nil {
+                    log.info("[confirm-flow] confirmationStateChanged: forwarding to notification cleanup (not in handledSet): requestId=\(msg.requestId, privacy: .public) state=\(msg.state, privacy: .public)")
                     let decisionString = msg.state == "approved" ? "allow" : "deny"
                     onInlineConfirmationResponse?(msg.requestId, decisionString)
+                } else {
+                    log.info("[confirm-flow] confirmationStateChanged: skipped notification cleanup (already in handledSet): requestId=\(msg.requestId, privacy: .public) state=\(msg.state, privacy: .public)")
                 }
             }
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2645,6 +2645,7 @@ public final class ChatViewModel: ObservableObject {
             if !success {
                 log.error("[confirm-flow] respondToConfirmation POST failed (will show error banner): requestId=\(requestId, privacy: .public) decision=\(decision, privacy: .public)")
                 self.revertConfirmationInFlight(requestId: requestId)
+                self.inlineResponseHandledRequestIds.remove(requestId)
                 self.errorText = "Failed to send confirmation response."
             }
         }
@@ -2668,6 +2669,7 @@ public final class ChatViewModel: ObservableObject {
                 )
                 if !fallbackSuccess {
                     self.revertConfirmationInFlight(requestId: requestId)
+                    self.inlineResponseHandledRequestIds.remove(requestId)
                 }
                 if fallbackSuccess {
                     self.errorText = "Preference could not be saved. This action was allowed once."

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2635,6 +2635,7 @@ public final class ChatViewModel: ObservableObject {
 
     /// Respond to a tool confirmation request displayed inline in the chat.
     public func respondToConfirmation(requestId: String, decision: String) {
+        log.info("[confirm-flow] respondToConfirmation called: requestId=\(requestId, privacy: .public) decision=\(decision, privacy: .public)")
         markConfirmationInFlight(requestId: requestId, decision: decision)
         inlineResponseHandledRequestIds.insert(requestId)
         Task {
@@ -2642,6 +2643,7 @@ public final class ChatViewModel: ObservableObject {
                 requestId: requestId, decision: decision, selectedPattern: nil, selectedScope: nil
             )
             if !success {
+                log.error("[confirm-flow] respondToConfirmation POST failed (will show error banner): requestId=\(requestId, privacy: .public) decision=\(decision, privacy: .public)")
                 self.revertConfirmationInFlight(requestId: requestId)
                 self.errorText = "Failed to send confirmation response."
             }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2636,6 +2636,7 @@ public final class ChatViewModel: ObservableObject {
     /// Respond to a tool confirmation request displayed inline in the chat.
     public func respondToConfirmation(requestId: String, decision: String) {
         markConfirmationInFlight(requestId: requestId, decision: decision)
+        inlineResponseHandledRequestIds.insert(requestId)
         Task {
             let success = await performConfirmationResponse(
                 requestId: requestId, decision: decision, selectedPattern: nil, selectedScope: nil
@@ -2653,6 +2654,7 @@ public final class ChatViewModel: ObservableObject {
     /// fallback actually went through.
     public func respondToAlwaysAllow(requestId: String, selectedPattern: String, selectedScope: String, decision: String = "always_allow") {
         markConfirmationInFlight(requestId: requestId, decision: decision)
+        inlineResponseHandledRequestIds.insert(requestId)
         Task {
             let success = await interactionClient.sendConfirmationResponse(
                 requestId: requestId, decision: decision, selectedPattern: selectedPattern, selectedScope: selectedScope

--- a/clients/shared/Network/InteractionClient.swift
+++ b/clients/shared/Network/InteractionClient.swift
@@ -32,9 +32,10 @@ public struct InteractionClient: InteractionClientProtocol {
             if let selectedScope { body["selectedScope"] = selectedScope }
 
             let path = try Self.approvalPath(endpoint: "confirm")
+            log.info("[confirm-flow] Sending POST /confirm: requestId=\(requestId, privacy: .public) decision=\(decision, privacy: .public)")
             let response = try await GatewayHTTPClient.post(path: path, json: body, timeout: 10)
             if !response.isSuccess {
-                log.error("sendConfirmationResponse failed (HTTP \(response.statusCode))")
+                log.error("[confirm-flow] POST /confirm failed: requestId=\(requestId, privacy: .public) decision=\(decision, privacy: .public) HTTP \(response.statusCode)")
                 return false
             }
             return true


### PR DESCRIPTION
## Summary
Adds targeted diagnostic logging to the confirmation request/response flow (both daemon and macOS client) to make "Failed to send confirmation response" errors trivially debuggable in future feedback reports. Also fixes a real race condition in the `inlineResponseHandledRequestIds` dedup logic where the SSE event could arrive before the POST response.

## PRs merged into feature branch
- #21497: Add structured logging to POST /v1/confirm for success and 404 paths
- #21498: Insert inlineResponseHandledRequestIds before sending confirmation POST to prevent dedup race
- #21499: Add logging to confirmationStateChanged handler for dedup and notification cleanup paths
- #21500: Add diagnostic logging to confirmation request/response flow in macOS client

Part of plan: confirm-response-debug-logging.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
