### PR TITLE
feat: rename OAuth provider keys from `integration:X` to `X` in seed data and behaviors

### DIFF
--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -755,8 +755,8 @@ describe("credential_store tool — prompt action", () => {
 describe("credential_store tool — oauth2_connect error paths", () => {
   /** Well-known provider rows returned by the mocked getProvider */
   const wellKnownProviders: Record<string, object> = {
-    "integration:google": {
-      key: "integration:google",
+    google: {
+      key: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: JSON.stringify(["https://mail.google.com/"]),
@@ -764,8 +764,8 @@ describe("credential_store tool — oauth2_connect error paths", () => {
       callbackTransport: "loopback",
       loopbackPort: 8756,
     },
-    "integration:slack": {
-      key: "integration:slack",
+    slack: {
+      key: "slack",
       authUrl: "https://slack.com/oauth/v2/authorize",
       tokenUrl: "https://slack.com/api/oauth.v2.access",
       defaultScopes: JSON.stringify(["channels:read"]),
@@ -880,7 +880,7 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     expect(result.content).toContain("mock-auth-url.example.com");
   });
 
-  test("resolves gmail alias to integration:google", async () => {
+  test("resolves gmail alias to google", async () => {
     // Even with alias resolution, missing client_id should still fail
     const result = await credentialStoreTool.execute(
       {
@@ -895,7 +895,7 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     expect(result.content).toContain("client_id is required");
   });
 
-  test("resolves slack alias to integration:slack", async () => {
+  test("resolves slack to its canonical name", async () => {
     const result = await credentialStoreTool.execute(
       {
         action: "oauth2_connect",
@@ -912,13 +912,13 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     // and store client_secret in the secure store.
     mockGetMostRecentAppByProvider.mockImplementation(() => ({
       id: "test-app-id",
-      providerKey: "integration:google",
+      providerKey: "google",
       clientId: "stored-client-id-123",
       clientSecretCredentialPath: "oauth_app/test-app-id/client_secret",
       createdAt: Date.now(),
     }));
     mockGetProvider.mockImplementation(() => ({
-      key: "integration:google",
+      key: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: JSON.stringify(["https://mail.google.com/"]),
@@ -958,13 +958,10 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     // most-recent-app heuristic) so the secret comes from the correct app.
     mockGetAppByProviderAndClientId.mockImplementation(
       (providerKey: string, cId: string) => {
-        if (
-          providerKey === "integration:google" &&
-          cId === "caller-supplied-client-id"
-        ) {
+        if (providerKey === "google" && cId === "caller-supplied-client-id") {
           return {
             id: "matched-app-id",
-            providerKey: "integration:google",
+            providerKey: "google",
             clientId: "caller-supplied-client-id",
             clientSecretCredentialPath:
               "oauth_app/matched-app-id/client_secret",
@@ -975,7 +972,7 @@ describe("credential_store tool — oauth2_connect error paths", () => {
       },
     );
     mockGetProvider.mockImplementation(() => ({
-      key: "integration:google",
+      key: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: JSON.stringify(["https://mail.google.com/"]),
@@ -1013,13 +1010,13 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     // use getMostRecentAppByProvider (the fallback heuristic).
     mockGetMostRecentAppByProvider.mockImplementation(() => ({
       id: "recent-app-id",
-      providerKey: "integration:google",
+      providerKey: "google",
       clientId: "recent-client-id",
       clientSecretCredentialPath: "oauth_app/recent-app-id/client_secret",
       createdAt: Date.now(),
     }));
     mockGetProvider.mockImplementation(() => ({
-      key: "integration:google",
+      key: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: JSON.stringify(["https://mail.google.com/"]),
@@ -1056,7 +1053,7 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     // report the missing secret error.
     mockGetAppByProviderAndClientId.mockImplementation(() => undefined);
     mockGetProvider.mockImplementation(() => ({
-      key: "integration:google",
+      key: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: JSON.stringify(["https://mail.google.com/"]),
@@ -1087,12 +1084,12 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     // guardrail.
     mockGetMostRecentAppByProvider.mockImplementation(() => ({
       id: "test-app-id-no-secret",
-      providerKey: "integration:google",
+      providerKey: "google",
       clientId: "stored-client-id-456",
       createdAt: Date.now(),
     }));
     mockGetProvider.mockImplementation(() => ({
-      key: "integration:google",
+      key: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: JSON.stringify(["https://mail.google.com/"]),

--- a/assistant/src/__tests__/oauth-provider-profiles.test.ts
+++ b/assistant/src/__tests__/oauth-provider-profiles.test.ts
@@ -10,7 +10,7 @@ describe("oauth provider behaviors", () => {
     const service = resolveService("gmail");
     const behavior = getProviderBehavior(service);
 
-    expect(service).toBe("integration:google");
+    expect(service).toBe("google");
     expect(behavior).toBeDefined();
     expect(behavior?.injectionTemplates).toBeDefined();
     expect(behavior?.injectionTemplates).toHaveLength(3);

--- a/assistant/src/oauth/connect-types.ts
+++ b/assistant/src/oauth/connect-types.ts
@@ -40,7 +40,7 @@ export interface OAuthScopePolicy {
  * templates, skill IDs) and cannot be serialised to a DB row.
  */
 export interface OAuthProviderBehavior {
-  /** Canonical service key (e.g. "integration:twitter"). */
+  /** Canonical service key (e.g. "twitter"). */
   service: string;
   /**
    * Async function that verifies the user's identity after a successful

--- a/assistant/src/oauth/provider-behaviors.ts
+++ b/assistant/src/oauth/provider-behaviors.ts
@@ -16,8 +16,8 @@ import type { OAuthProviderBehavior } from "./connect-types.js";
 // ---------------------------------------------------------------------------
 
 const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
-  "integration:google": {
-    service: "integration:google",
+  google: {
+    service: "google",
     // Google APIs for Gmail/Calendar/Contacts span multiple hosts; register
     // all of them so proxied bash can inject the OAuth bearer token reliably.
     injectionTemplates: [
@@ -71,8 +71,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:slack": {
-    service: "integration:slack",
+  slack: {
+    service: "slack",
     loopbackPort: 17322,
     injectionTemplates: [
       {
@@ -112,8 +112,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:notion": {
-    service: "integration:notion",
+  notion: {
+    service: "notion",
     loopbackPort: 17323,
     injectionTemplates: [
       {
@@ -155,8 +155,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:twitter": {
-    service: "integration:twitter",
+  twitter: {
+    service: "twitter",
     injectionTemplates: [
       {
         hostPattern: "api.x.com",
@@ -189,8 +189,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
       return undefined;
     },
   },
-  "integration:github": {
-    service: "integration:github",
+  github: {
+    service: "github",
     loopbackPort: 17332,
     injectionTemplates: [
       {
@@ -225,8 +225,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:linear": {
-    service: "integration:linear",
+  linear: {
+    service: "linear",
     loopbackPort: 17324,
     injectionTemplates: [
       {
@@ -268,8 +268,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:spotify": {
-    service: "integration:spotify",
+  spotify: {
+    service: "spotify",
     loopbackPort: 17333,
     injectionTemplates: [
       {
@@ -307,8 +307,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:todoist": {
-    service: "integration:todoist",
+  todoist: {
+    service: "todoist",
     loopbackPort: 17325,
     injectionTemplates: [
       {
@@ -350,8 +350,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:discord": {
-    service: "integration:discord",
+  discord: {
+    service: "discord",
     loopbackPort: 17326,
     injectionTemplates: [
       {
@@ -389,8 +389,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:dropbox": {
-    service: "integration:dropbox",
+  dropbox: {
+    service: "dropbox",
     loopbackPort: 17327,
     injectionTemplates: [
       {
@@ -438,8 +438,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:asana": {
-    service: "integration:asana",
+  asana: {
+    service: "asana",
     loopbackPort: 17328,
     injectionTemplates: [
       {
@@ -476,8 +476,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:airtable": {
-    service: "integration:airtable",
+  airtable: {
+    service: "airtable",
     loopbackPort: 17329,
     injectionTemplates: [
       {
@@ -512,8 +512,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:hubspot": {
-    service: "integration:hubspot",
+  hubspot: {
+    service: "hubspot",
     loopbackPort: 17330,
     injectionTemplates: [
       {
@@ -551,8 +551,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:figma": {
-    service: "integration:figma",
+  figma: {
+    service: "figma",
     loopbackPort: 17331,
     injectionTemplates: [
       {
@@ -597,33 +597,12 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
 
 /** Map shorthand aliases to canonical service names. */
 export const SERVICE_ALIASES: Record<string, string> = {
-  gmail: "integration:google",
-  google: "integration:google",
-  slack: "integration:slack",
-  notion: "integration:notion",
-  twitter: "integration:twitter",
-  github: "integration:github",
-  linear: "integration:linear",
-  spotify: "integration:spotify",
-  todoist: "integration:todoist",
-  discord: "integration:discord",
-  dropbox: "integration:dropbox",
-  asana: "integration:asana",
-  airtable: "integration:airtable",
-  hubspot: "integration:hubspot",
-  figma: "integration:figma",
+  gmail: "google",
 };
 
-/**
- * Resolve a service name through aliases, then fall back to `integration:`
- * prefix for providers registered in PROVIDER_BEHAVIORS without a
- * SERVICE_ALIASES entry.
- */
+/** Resolve a service name through aliases. */
 export function resolveService(service: string): string {
-  if (SERVICE_ALIASES[service]) return SERVICE_ALIASES[service];
-  if (!service.includes(":") && PROVIDER_BEHAVIORS[`integration:${service}`])
-    return `integration:${service}`;
-  return service;
+  return SERVICE_ALIASES[service] ?? service;
 }
 
 /** Look up a provider behavior by canonical service name. */

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -46,8 +46,8 @@ const PROVIDER_SEED_DATA: Record<
     requiresClientSecret?: boolean;
   }
 > = {
-  "integration:google": {
-    providerKey: "integration:google",
+  google: {
+    providerKey: "google",
     authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
     tokenUrl: "https://oauth2.googleapis.com/token",
     userinfoUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
@@ -79,8 +79,8 @@ const PROVIDER_SEED_DATA: Record<
     managedServiceConfigKey: "google-oauth",
   },
 
-  "integration:slack": {
-    providerKey: "integration:slack",
+  slack: {
+    providerKey: "slack",
     authUrl: "https://slack.com/oauth/v2/authorize",
     tokenUrl: "https://slack.com/api/oauth.v2.access",
     pingUrl: "https://slack.com/api/auth.test",
@@ -116,8 +116,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:notion": {
-    providerKey: "integration:notion",
+  notion: {
+    providerKey: "notion",
     authUrl: "https://api.notion.com/v1/oauth/authorize",
     tokenUrl: "https://api.notion.com/v1/oauth/token",
     pingUrl: "https://api.notion.com/v1/users/me",
@@ -138,8 +138,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:twitter": {
-    providerKey: "integration:twitter",
+  twitter: {
+    providerKey: "twitter",
     authUrl: "https://twitter.com/i/oauth2/authorize",
     tokenUrl: "https://api.x.com/2/oauth2/token",
     pingUrl: "https://api.x.com/2/users/me",
@@ -163,8 +163,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "gateway",
   },
 
-  "integration:github": {
-    providerKey: "integration:github",
+  github: {
+    providerKey: "github",
     authUrl: "https://github.com/login/oauth/authorize",
     tokenUrl: "https://github.com/login/oauth/access_token",
     pingUrl: "https://api.github.com/user",
@@ -187,8 +187,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:linear": {
-    providerKey: "integration:linear",
+  linear: {
+    providerKey: "linear",
     authUrl: "https://linear.app/oauth/authorize",
     tokenUrl: "https://api.linear.app/oauth/token",
     pingUrl: "https://api.linear.app/graphql",
@@ -210,8 +210,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:spotify": {
-    providerKey: "integration:spotify",
+  spotify: {
+    providerKey: "spotify",
     authUrl: "https://accounts.spotify.com/authorize",
     tokenUrl: "https://accounts.spotify.com/api/token",
     pingUrl: "https://api.spotify.com/v1/me",
@@ -240,8 +240,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:todoist": {
-    providerKey: "integration:todoist",
+  todoist: {
+    providerKey: "todoist",
     authUrl: "https://todoist.com/oauth/authorize",
     tokenUrl: "https://todoist.com/oauth/access_token",
     pingUrl: "https://api.todoist.com/rest/v2/projects",
@@ -259,8 +259,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:discord": {
-    providerKey: "integration:discord",
+  discord: {
+    providerKey: "discord",
     authUrl: "https://discord.com/oauth2/authorize",
     tokenUrl: "https://discord.com/api/v10/oauth2/token",
     pingUrl: "https://discord.com/api/v10/users/@me",
@@ -283,8 +283,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:dropbox": {
-    providerKey: "integration:dropbox",
+  dropbox: {
+    providerKey: "dropbox",
     authUrl: "https://www.dropbox.com/oauth2/authorize",
     tokenUrl: "https://api.dropboxapi.com/oauth2/token",
     pingUrl: "https://api.dropboxapi.com/2/users/get_current_account",
@@ -309,8 +309,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:asana": {
-    providerKey: "integration:asana",
+  asana: {
+    providerKey: "asana",
     authUrl: "https://app.asana.com/-/oauth_authorize",
     tokenUrl: "https://app.asana.com/-/oauth_token",
     pingUrl: "https://app.asana.com/api/1.0/users/me",
@@ -328,8 +328,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:airtable": {
-    providerKey: "integration:airtable",
+  airtable: {
+    providerKey: "airtable",
     authUrl: "https://airtable.com/oauth2/v1/authorize",
     tokenUrl: "https://airtable.com/oauth2/v1/token",
     pingUrl: "https://api.airtable.com/v0/meta/whoami",
@@ -352,8 +352,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:hubspot": {
-    providerKey: "integration:hubspot",
+  hubspot: {
+    providerKey: "hubspot",
     authUrl: "https://app.hubspot.com/oauth/authorize",
     tokenUrl: "https://api.hubapi.com/oauth/v1/token",
     pingUrl: "https://api.hubapi.com/crm/v3/objects/contacts?limit=1",
@@ -380,8 +380,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:figma": {
-    providerKey: "integration:figma",
+  figma: {
+    providerKey: "figma",
     authUrl: "https://www.figma.com/oauth",
     tokenUrl: "https://api.figma.com/v1/oauth/token",
     pingUrl: "https://api.figma.com/v1/me",


### PR DESCRIPTION
## Summary
- Rename all 14 OAuth provider keys from `integration:X` to bare `X` format in seed data and provider behaviors
- Simplify SERVICE_ALIASES to only retain `gmail -> google` alias
- Simplify resolveService() to just alias lookup

Part of plan: simplify-oauth-provider-keys.md (PR 1 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
