### PR TITLE
fix: clean up inlineResponseHandledRequestIds on confirmation POST failure

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2645,6 +2645,7 @@ public final class ChatViewModel: ObservableObject {
             if !success {
                 log.error("[confirm-flow] respondToConfirmation POST failed (will show error banner): requestId=\(requestId, privacy: .public) decision=\(decision, privacy: .public)")
                 self.revertConfirmationInFlight(requestId: requestId)
+                self.inlineResponseHandledRequestIds.remove(requestId)
                 self.errorText = "Failed to send confirmation response."
             }
         }
@@ -2668,6 +2669,7 @@ public final class ChatViewModel: ObservableObject {
                 )
                 if !fallbackSuccess {
                     self.revertConfirmationInFlight(requestId: requestId)
+                    self.inlineResponseHandledRequestIds.remove(requestId)
                 }
                 if fallbackSuccess {
                     self.errorText = "Preference could not be saved. This action was allowed once."


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for confirm-response-debug-logging.md.

**Gap:** inlineResponseHandledRequestIds not cleaned up on POST failure
**What was expected:** When respondToConfirmation or respondToAlwaysAllow POST fails, the requestId should be removed from inlineResponseHandledRequestIds
**What was found:** The requestId was inserted before the Task but not removed on failure, causing confirmationStateChanged to skip notification cleanup
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
