### PR TITLE
fix: move CU auto-approve log inside success branch

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -130,10 +130,10 @@ extension AppDelegate {
                         requestId: msg.requestId,
                         decision: "allow"
                     )
+                    log.info("[confirm-flow] CU auto-approved requestId=\(msg.requestId, privacy: .public) tool=\(msg.toolName, privacy: .public)")
                 } else {
                     log.error("Failed to auto-approve confirmation")
                 }
-                log.info("[confirm-flow] CU auto-approved requestId=\(msg.requestId, privacy: .public) tool=\(msg.toolName, privacy: .public)")
                 return
             }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for confirm-response-debug-logging.md.

**Gap:** CU auto-approve log message fires unconditionally
**What was expected:** The log should only fire on actual success
**What was found:** Log was placed after the if/else block, firing regardless of POST result
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
