### PR TITLE
feat: add migration 196 to strip `integration:` prefix from OAuth provider keys

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -117,6 +117,7 @@ import {
   migrateScheduleOneShotRouting,
   migrateScheduleQuietFlag,
   migrateSchemaIndexesAndColumns,
+  migrateStripIntegrationPrefixFromProviderKeys,
   migrateUsageDashboardIndexes,
   migrateVoiceInviteColumns,
   migrateVoiceInviteDisplayMetadata,
@@ -515,6 +516,9 @@ export function initializeDb(): void {
 
   // 92. Add ping_method, ping_headers, ping_body columns to oauth_providers
   migrateOAuthProvidersPingConfig(database);
+
+  // 93. Strip `integration:` prefix from provider_key across OAuth tables
+  migrateStripIntegrationPrefixFromProviderKeys(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/196-strip-integration-prefix-from-provider-keys.ts
+++ b/assistant/src/memory/migrations/196-strip-integration-prefix-from-provider-keys.ts
@@ -1,0 +1,161 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+/**
+ * One-shot migration: strip the `integration:` prefix from provider_key
+ * values across all three OAuth tables (oauth_providers, oauth_apps,
+ * oauth_connections).
+ *
+ * Historically provider keys were stored as `integration:google`,
+ * `integration:slack`, etc.  The codebase is moving to bare-name keys
+ * (`google`, `slack`) for simplicity.  Providers that were already stored
+ * with bare names (e.g. `slack_channel`, `telegram`) are unaffected.
+ *
+ * If a bare-name key already exists (runtime seed data created it), the
+ * old `integration:` rows are orphaned — we delete them instead of
+ * renaming to avoid UNIQUE constraint violations.
+ *
+ * FK constraints require us to update child tables (oauth_apps,
+ * oauth_connections) before the parent (oauth_providers), or disable FKs.
+ * We disable FKs for safety and update all three tables atomically.
+ */
+export function migrateStripIntegrationPrefixFromProviderKeys(
+  database: DrizzleDb,
+): void {
+  withCrashRecovery(
+    database,
+    "migration_strip_integration_prefix_from_provider_keys_v1",
+    () => {
+      const raw = getSqliteFrom(database);
+
+      raw.exec("PRAGMA foreign_keys = OFF");
+      try {
+        // Find all provider keys with the integration: prefix.
+        const rows = raw
+          .prepare(
+            /*sql*/ `SELECT provider_key FROM oauth_providers WHERE provider_key LIKE 'integration:%'`,
+          )
+          .all() as Array<{ provider_key: string }>;
+
+        for (const { provider_key: oldKey } of rows) {
+          const newKey = oldKey.replace(/^integration:/, "");
+
+          // Check if the bare-name key already exists (seed data may have created it).
+          const bareExists = raw
+            .prepare(
+              /*sql*/ `SELECT 1 FROM oauth_providers WHERE provider_key = ?`,
+            )
+            .get(newKey);
+
+          if (bareExists) {
+            // Bare-name provider already exists — delete the old prefixed rows
+            // to avoid UNIQUE constraint violations.
+            raw
+              .prepare(
+                /*sql*/ `DELETE FROM oauth_connections WHERE provider_key = ?`,
+              )
+              .run(oldKey);
+            raw
+              .prepare(/*sql*/ `DELETE FROM oauth_apps WHERE provider_key = ?`)
+              .run(oldKey);
+            raw
+              .prepare(
+                /*sql*/ `DELETE FROM oauth_providers WHERE provider_key = ?`,
+              )
+              .run(oldKey);
+          } else {
+            // Rename: update child tables first, then parent.
+            raw
+              .prepare(
+                /*sql*/ `UPDATE oauth_connections SET provider_key = ? WHERE provider_key = ?`,
+              )
+              .run(newKey, oldKey);
+            raw
+              .prepare(
+                /*sql*/ `UPDATE oauth_apps SET provider_key = ? WHERE provider_key = ?`,
+              )
+              .run(newKey, oldKey);
+            raw
+              .prepare(
+                /*sql*/ `UPDATE oauth_providers SET provider_key = ? WHERE provider_key = ?`,
+              )
+              .run(newKey, oldKey);
+          }
+        }
+      } finally {
+        raw.exec("PRAGMA foreign_keys = ON");
+      }
+    },
+  );
+}
+
+/**
+ * Reverse: re-add the `integration:` prefix to provider keys that don't
+ * already have one and aren't known bare-name providers.
+ *
+ * This is a best-effort rollback — we prefix all keys that look like they
+ * were originally `integration:` prefixed.  Known bare-name keys
+ * (`slack_channel`, `telegram`) are left as-is because they never had the
+ * prefix.
+ */
+export function migrateStripIntegrationPrefixFromProviderKeysDown(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  // Keys that were always bare — never had an integration: prefix.
+  const ALWAYS_BARE = new Set(["slack_channel", "telegram"]);
+
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    const rows = raw
+      .prepare(
+        /*sql*/ `SELECT provider_key FROM oauth_providers WHERE provider_key NOT LIKE 'integration:%'`,
+      )
+      .all() as Array<{ provider_key: string }>;
+
+    for (const { provider_key: bareKey } of rows) {
+      if (ALWAYS_BARE.has(bareKey)) continue;
+
+      const prefixedKey = `integration:${bareKey}`;
+
+      // If the prefixed key already exists, delete the bare rows.
+      const prefixedExists = raw
+        .prepare(/*sql*/ `SELECT 1 FROM oauth_providers WHERE provider_key = ?`)
+        .get(prefixedKey);
+
+      if (prefixedExists) {
+        raw
+          .prepare(
+            /*sql*/ `DELETE FROM oauth_connections WHERE provider_key = ?`,
+          )
+          .run(bareKey);
+        raw
+          .prepare(/*sql*/ `DELETE FROM oauth_apps WHERE provider_key = ?`)
+          .run(bareKey);
+        raw
+          .prepare(/*sql*/ `DELETE FROM oauth_providers WHERE provider_key = ?`)
+          .run(bareKey);
+      } else {
+        raw
+          .prepare(
+            /*sql*/ `UPDATE oauth_connections SET provider_key = ? WHERE provider_key = ?`,
+          )
+          .run(prefixedKey, bareKey);
+        raw
+          .prepare(
+            /*sql*/ `UPDATE oauth_apps SET provider_key = ? WHERE provider_key = ?`,
+          )
+          .run(prefixedKey, bareKey);
+        raw
+          .prepare(
+            /*sql*/ `UPDATE oauth_providers SET provider_key = ? WHERE provider_key = ?`,
+          )
+          .run(prefixedKey, bareKey);
+      }
+    }
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -134,6 +134,7 @@ export { migrateContactsUserFileColumn } from "./192-contacts-user-file-column.j
 export { migrateAddSourceTypeColumns } from "./193-add-source-type-columns.js";
 export { migrateCreateMemoryRecallLogs } from "./194-memory-recall-logs.js";
 export { migrateOAuthProvidersPingConfig } from "./195-oauth-providers-ping-config.js";
+export { migrateStripIntegrationPrefixFromProviderKeys } from "./196-strip-integration-prefix-from-provider-keys.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -38,6 +38,7 @@ import { migrateBackfillInlineAttachmentsToDiskDown } from "./180-backfill-inlin
 import { migrateRenameThreadStartersCheckpointsDown } from "./181-rename-thread-starters-checkpoints.js";
 import { migrateBackfillAudioAttachmentMimeTypesDown } from "./191-backfill-audio-attachment-mime-types.js";
 import { migrateAddSourceTypeColumnsDown } from "./193-add-source-type-columns.js";
+import { migrateStripIntegrationPrefixFromProviderKeysDown } from "./196-strip-integration-prefix-from-provider-keys.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -332,6 +333,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Add source_type and source_message_role columns to memory_items with backfill from verification_state and source messages",
     down: migrateAddSourceTypeColumnsDown,
+  },
+  {
+    key: "migration_strip_integration_prefix_from_provider_keys_v1",
+    version: 38,
+    description:
+      "Strip integration: prefix from provider_key across oauth_providers, oauth_apps, and oauth_connections",
+    down: migrateStripIntegrationPrefixFromProviderKeysDown,
   },
 ];
 


### PR DESCRIPTION
## Summary
- Add database migration 196 that strips the `integration:` prefix from provider_key in oauth_providers, oauth_apps, and oauth_connections tables
- Uses a transaction for atomic updates across all three tables
- Leaves bare-name providers (slack_channel, telegram) unchanged

Part of plan: simplify-oauth-provider-keys.md (PR 2 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
