### PR TITLE
refactor: remove `toBareProvider()` and `integration:` stripping from connection resolver

### DIFF
--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -16,7 +16,6 @@ import {
   isManagedMode,
   requirePlatformClient,
   resolveService,
-  toBareProvider,
 } from "./shared.js";
 
 const log = getCliLogger("cli");
@@ -121,7 +120,7 @@ Examples:
             if (!client) return;
 
             // Call the platform's OAuth start endpoint
-            const startPath = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/${encodeURIComponent(toBareProvider(providerKey))}/start/`;
+            const startPath = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/${encodeURIComponent(providerKey)}/start/`;
 
             const body: Record<string, unknown> = {};
             if (opts.scopes && opts.scopes.length > 0) {

--- a/assistant/src/cli/commands/oauth/disconnect.ts
+++ b/assistant/src/cli/commands/oauth/disconnect.ts
@@ -16,7 +16,6 @@ import {
   isManagedMode,
   requirePlatformClient,
   resolveService,
-  toBareProvider,
 } from "./shared.js";
 
 const log = getCliLogger("cli");
@@ -138,7 +137,7 @@ Examples:
               );
               if (matching.length === 0) {
                 writeError(
-                  `No active connection found for "${toBareProvider(providerKey)}" with account "${opts.account}".\n\n` +
+                  `No active connection found for "${providerKey}" with account "${opts.account}".\n\n` +
                     `Run 'assistant oauth status ${provider}' to see connected accounts.`,
                 );
                 return;
@@ -150,7 +149,7 @@ Examples:
               const match = entries.find((c) => c.id === opts.connectionId);
               if (!match) {
                 writeError(
-                  `Connection "${opts.connectionId}" is not an active ${toBareProvider(providerKey)} connection.\n\n` +
+                  `Connection "${opts.connectionId}" is not an active ${providerKey} connection.\n\n` +
                     `Run 'assistant oauth status ${provider}' to see active connections.`,
                 );
                 return;
@@ -161,7 +160,7 @@ Examples:
               // Neither specified — auto-resolve
               if (entries.length === 0) {
                 writeError(
-                  `No active connections found for "${toBareProvider(providerKey)}".\n\n` +
+                  `No active connections found for "${providerKey}".\n\n` +
                     `Run 'assistant oauth status ${provider}' to check connection status.`,
                 );
                 return;
@@ -173,7 +172,7 @@ Examples:
                   account: c.account_label ?? null,
                 }));
                 writeError(
-                  `Multiple active connections for "${toBareProvider(providerKey)}". ` +
+                  `Multiple active connections for "${providerKey}". ` +
                     `Specify which one to disconnect with --account or --connection-id.\n\n` +
                     `Run 'assistant oauth status ${provider}' to see connected accounts and IDs.`,
                   { connections: connectionList },

--- a/assistant/src/cli/commands/oauth/mode.ts
+++ b/assistant/src/cli/commands/oauth/mode.ts
@@ -18,7 +18,6 @@ import {
   fetchActiveConnections,
   getManagedServiceConfigKey,
   resolveService,
-  toBareProvider,
 } from "./shared.js";
 
 /**
@@ -216,8 +215,6 @@ Examples:
         // Best-effort check for active connections on old and new modes
         let oldModeConnections = 0;
         let newModeConnections = 0;
-        const bareProvider = toBareProvider(providerKey);
-
         if (currentMode === "managed") {
           // Old mode was managed — check platform connections
           oldModeConnections = await countManagedConnections(providerKey, cmd);
@@ -235,7 +232,7 @@ Examples:
         // Build hint if there are connections on the old mode but none on the new
         let hint: string | undefined;
         if (oldModeConnections > 0 && newModeConnections === 0) {
-          hint = `No active connections in ${newMode} mode. Run 'assistant oauth connect ${bareProvider}' to connect.`;
+          hint = `No active connections in ${newMode} mode. Run 'assistant oauth connect ${providerKey}' to connect.`;
         }
 
         if (shouldOutputJson(cmd)) {

--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -14,7 +14,7 @@ import {
 } from "../../../oauth/oauth-store.js";
 import { VellumPlatformClient } from "../../../platform/client.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
-import { isManagedMode, resolveService, toBareProvider } from "./shared.js";
+import { isManagedMode, resolveService } from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -233,7 +233,7 @@ Examples:
               const client = await VellumPlatformClient.create();
               if (client && client.platformAssistantId) {
                 const params = new URLSearchParams();
-                params.set("provider", toBareProvider(providerKey));
+                params.set("provider", providerKey);
                 params.set("status", "ACTIVE");
                 params.set("account_identifier", opts.account);
 

--- a/assistant/src/cli/commands/oauth/shared.ts
+++ b/assistant/src/cli/commands/oauth/shared.ts
@@ -32,17 +32,6 @@ export interface PlatformConnectionEntry {
 // ---------------------------------------------------------------------------
 
 /**
- * Extract the bare provider slug (e.g. "google") from either a raw CLI
- * argument or a canonical provider key (e.g. "integration:google").
- * Platform API paths expect the bare slug, not the internal key.
- */
-export function toBareProvider(provider: string): string {
-  return provider.startsWith("integration:")
-    ? provider.slice("integration:".length)
-    : provider;
-}
-
-/**
  * Return the provider's `managedServiceConfigKey` if it exists and is a valid
  * key in `ServicesSchema.shape`, or `null` otherwise. This centralises the
  * lookup so that callers (e.g. `isManagedMode`, `mode.ts`) don't duplicate the
@@ -104,7 +93,7 @@ export async function fetchActiveConnections(
   options?: { silent?: boolean },
 ): Promise<PlatformConnectionEntry[] | null> {
   const params = new URLSearchParams();
-  params.set("provider", toBareProvider(provider));
+  params.set("provider", provider);
   params.set("status", "ACTIVE");
 
   const path = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/connections/?${params.toString()}`;

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -59,11 +59,9 @@ export async function resolveOAuthConnection(
         );
       }
 
-      const providerSlug = providerKey.replace(/^integration:/, "");
-
       const connectionId = await resolvePlatformConnectionId({
         client,
-        provider: providerSlug,
+        provider: providerKey,
         account,
       });
 


### PR DESCRIPTION
## Summary
- Delete `toBareProvider()` function from shared.ts since provider keys are now bare names
- Remove all call sites that stripped the `integration:` prefix before passing to the platform API
- Simplify connection resolver to use provider key directly as the platform slug

Part of plan: simplify-oauth-provider-keys.md (PR 3 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
