### PR TITLE
docs: update OAuth CLI help text to use bare provider names

### DIFF
--- a/assistant/src/cli/commands/oauth/apps.ts
+++ b/assistant/src/cli/commands/oauth/apps.ts
@@ -48,8 +48,8 @@ a provider with a mode of "your-own" set.
 Examples:
   $ assistant oauth apps list
   $ assistant oauth apps get --id <uuid>
-  $ assistant oauth apps get --provider integration:google
-  $ assistant oauth apps upsert --provider integration:google --client-id abc123
+  $ assistant oauth apps get --provider google
+  $ assistant oauth apps upsert --provider google --client-id abc123
   $ assistant oauth apps delete <id>`,
   );
 
@@ -101,7 +101,7 @@ Examples:
     .option("--id <id>", "App ID (UUID) from 'assistant oauth apps list'")
     .option(
       "--provider <key>",
-      "Provider key (e.g. integration:google) from 'assistant oauth providers list'",
+      "Provider key (e.g. google) from 'assistant oauth providers list'",
     )
     .option(
       "--client-id <id>",
@@ -116,10 +116,10 @@ Three lookup modes are supported:
      $ assistant oauth apps get --id <uuid>
 
   2. By provider + client ID (exact match):
-     $ assistant oauth apps get --provider integration:google --client-id abc123
+     $ assistant oauth apps get --provider google --client-id abc123
 
   3. By provider only (returns the most recently created app):
-     $ assistant oauth apps get --provider integration:google
+     $ assistant oauth apps get --provider google
 
 At least --id or --provider must be specified.`,
     )
@@ -179,7 +179,7 @@ At least --id or --provider must be specified.`,
     .description("Create or return an existing OAuth app registration")
     .requiredOption(
       "--provider <key>",
-      "Provider key (e.g. integration:google) from 'assistant oauth providers list'",
+      "Provider key (e.g. google) from 'assistant oauth providers list'",
     )
     .requiredOption(
       "--client-id <id>",
@@ -208,16 +208,16 @@ existing credential in the store via --client-secret-credential-path. These two
 options are mutually exclusive — providing both is an error.
 
 The --client-secret-credential-path accepts two formats:
-  1. Full credential path: "credential/integration:google/client_secret"
-  2. Short name (service:field): "integration:google:client_secret"
+  1. Full credential path: "credential/google/client_secret"
+  2. Short name (service:field): "google:client_secret"
      Resolved via the metadata store by splitting on the last colon.
 
 Examples:
-  $ assistant oauth apps upsert --provider integration:google --client-id abc123
-  $ assistant oauth apps upsert --provider integration:slack --client-id def456 --client-secret s3cret
-  $ assistant oauth apps upsert --provider integration:slack --client-id def456 --client-secret-credential-path "credential/integration:slack/client_secret"
-  $ assistant oauth apps upsert --provider integration:slack --client-id def456 --client-secret-credential-path "integration:slack:client_secret"
-  $ assistant oauth apps upsert --provider integration:google --client-id abc123 --json`,
+  $ assistant oauth apps upsert --provider google --client-id abc123
+  $ assistant oauth apps upsert --provider slack --client-id def456 --client-secret s3cret
+  $ assistant oauth apps upsert --provider slack --client-id def456 --client-secret-credential-path "credential/slack/client_secret"
+  $ assistant oauth apps upsert --provider slack --client-id def456 --client-secret-credential-path "slack:client_secret"
+  $ assistant oauth apps upsert --provider google --client-id abc123 --json`,
     )
     .action(
       async (

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -41,9 +41,8 @@ export function registerConnectCommand(oauth: Command): void {
       "after",
       `
 Arguments:
-  provider   Provider key, alias, or ID from 'assistant oauth providers list'.
-             Accepts canonical keys (e.g. integration:google), aliases (e.g.
-             gmail), or bare provider names (e.g. google).
+  provider   Provider name (e.g. google, slack, gmail).
+             Run 'assistant oauth providers list' to see available providers.
 
 Options:
   --scopes <scopes...>   Scopes to request for the authorization. In managed
@@ -61,7 +60,7 @@ Options:
 Examples:
   $ assistant oauth connect google
   $ assistant oauth connect gmail --open-browser
-  $ assistant oauth connect integration:google --scopes https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/calendar.events
+  $ assistant oauth connect google --scopes https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/calendar.events
   $ assistant oauth connect google --client-id abc123 --open-browser`,
     )
     .action(

--- a/assistant/src/cli/commands/oauth/disconnect.ts
+++ b/assistant/src/cli/commands/oauth/disconnect.ts
@@ -40,7 +40,7 @@ export function registerDisconnectCommand(oauth: Command): void {
       "after",
       `
 Arguments:
-  provider   Provider name or key (e.g. google, integration:google, gmail).
+  provider   Provider name (e.g. google, slack, gmail).
              Run 'assistant oauth providers list' to see available providers.
 
 Options:

--- a/assistant/src/cli/commands/oauth/index.ts
+++ b/assistant/src/cli/commands/oauth/index.ts
@@ -36,13 +36,13 @@ You can define entirely new oauth providers to integrate with even if they do no
 
 Examples:
   assistant oauth providers list
-  assistant oauth providers get integration:google
-  assistant oauth mode integration:google --set=managed
-  assistant oauth connect integration:google --open-browser
-  assistant oauth status integration:google
-  assistant oauth ping integration:google
-  assistant oauth request --provider integration:google /gmail/v1/users/me/messages
-  assistant oauth disconnect integration:google`,
+  assistant oauth providers get google
+  assistant oauth mode google --set=managed
+  assistant oauth connect google --open-browser
+  assistant oauth status google
+  assistant oauth ping google
+  assistant oauth request --provider google /gmail/v1/users/me/messages
+  assistant oauth disconnect google`,
   );
 
   // ---------------------------------------------------------------------------

--- a/assistant/src/cli/commands/oauth/mode.ts
+++ b/assistant/src/cli/commands/oauth/mode.ts
@@ -63,7 +63,7 @@ export function registerModeCommand(oauth: Command): void {
       "after",
       `
 Arguments:
-  provider   Provider key, alias, or ID (e.g. google, integration:google).
+  provider   Provider name (e.g. google, slack).
              Run "assistant oauth providers list" to see available providers.
 
 Options:

--- a/assistant/src/cli/commands/oauth/ping.ts
+++ b/assistant/src/cli/commands/oauth/ping.ts
@@ -27,9 +27,8 @@ export function registerPingCommand(oauth: Command): void {
       "after",
       `
 Arguments:
-  provider   Provider key, alias, or provider ID from 'assistant oauth providers list'.
-             Accepts canonical keys (e.g. integration:google), aliases (e.g.
-             gmail), or bare provider names (e.g. google).
+  provider   Provider name (e.g. google, slack).
+             Run 'assistant oauth providers list' to see available providers.
 
 Options:
   --account <account>   Account identifier (e.g. email) to disambiguate when
@@ -40,7 +39,7 @@ Options:
 
 Examples:
   $ assistant oauth ping google
-  $ assistant oauth ping integration:google --json
+  $ assistant oauth ping google --json
   $ assistant oauth ping google --account user@example.com`,
     )
     .action(

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -83,7 +83,7 @@ authorization URL, token URL, default scopes, and other endpoint details.
 They are seeded on startup for built-in integrations (e.g. Google, Slack,
 GitHub) but can also be registered dynamically via the "register" subcommand.
 
-Each provider is identified by a provider key (e.g. "integration:google").`,
+Each provider is identified by a provider key (e.g. "google").`,
   );
 
   // ---------------------------------------------------------------------------
@@ -159,7 +159,7 @@ Examples:
       "after",
       `
 Arguments:
-  provider-key   The full provider key (e.g. "integration:google").
+  provider-key   Provider key (e.g. "google").
                  Must match the key used during registration or seeding.
 
 Returns the full provider configuration including auth URL, token URL,
@@ -167,8 +167,8 @@ default scopes, scope policy, and extra parameters. Exits with code 1
 if the provider key is not found.
 
 Examples:
-  $ assistant oauth providers get integration:google
-  $ assistant oauth providers get integration:twitter --json`,
+  $ assistant oauth providers get google
+  $ assistant oauth providers get twitter --json`,
     )
     .action((providerKey: string, _opts: unknown, cmd: Command) => {
       try {

--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -88,10 +88,7 @@ export function registerRequestCommand(oauth: Command): void {
     .description(
       "The recommended way to make an authenticated request to an OAuth provider (supports a curl-like interface)",
     )
-    .requiredOption(
-      "--provider <key>",
-      "Provider key (e.g. integration:google) or alias (e.g. gmail)",
-    )
+    .requiredOption("--provider <key>", "Provider name (e.g. google, slack)")
     .option("-X, --request <method>", "HTTP method (default: GET)")
     .option(
       "-H, --header <header>",
@@ -130,11 +127,11 @@ Note: The Authorization header is set automatically. User-supplied
 -H "Authorization: ..." will be overridden by the OAuth bearer token.
 
 Examples:
-  $ assistant oauth request --provider integration:twitter https://api.x.com/2/tweets
+  $ assistant oauth request --provider twitter https://api.x.com/2/tweets
   $ assistant oauth request --provider gmail /gmail/v1/users/me/messages -G
-  $ assistant oauth request --provider integration:twitter -X POST -d '{"text":"Hello"}' https://api.x.com/2/tweets
-  $ assistant oauth request --provider integration:google -d @body.json https://www.googleapis.com/calendar/v3/calendars
-  $ assistant oauth request --provider integration:slack -H "Content-Type: application/json" -d '{"channel":"C123"}' /api/chat.postMessage --json`,
+  $ assistant oauth request --provider twitter -X POST -d '{"text":"Hello"}' https://api.x.com/2/tweets
+  $ assistant oauth request --provider google -d @body.json https://www.googleapis.com/calendar/v3/calendars
+  $ assistant oauth request --provider slack -H "Content-Type: application/json" -d '{"channel":"C123"}' /api/chat.postMessage --json`,
     )
     .action(
       async (

--- a/assistant/src/cli/commands/oauth/status.ts
+++ b/assistant/src/cli/commands/oauth/status.ts
@@ -24,8 +24,7 @@ export function registerStatusCommand(oauth: Command): void {
       "after",
       `
 Arguments:
-  provider   Provider name or key. Accepts bare names (google, slack),
-             canonical keys (integration:google), or aliases (gmail).
+  provider   Provider name (e.g. google, slack).
              Run 'assistant oauth providers list' to see all available providers.
 
 The output includes connection IDs and account identifiers that can be used
@@ -36,7 +35,7 @@ as inputs to other commands:
 
 Examples:
   $ assistant oauth status google
-  $ assistant oauth status integration:google --json`,
+  $ assistant oauth status google --json`,
     )
     .action(
       async (

--- a/assistant/src/cli/commands/oauth/token.ts
+++ b/assistant/src/cli/commands/oauth/token.ts
@@ -45,10 +45,9 @@ export function registerTokenCommand(oauth: Command): void {
       "after",
       `
 Arguments:
-  provider   Provider name or key. Accepts bare names (google, slack),
-             canonical keys (integration:google), aliases (gmail), or
-             provider IDs. Run 'assistant oauth providers list' to see
-             all available providers.
+  provider   Provider name (e.g. google, slack).
+             Run 'assistant oauth providers list' to see all available
+             providers.
 
 Options:
   --account <account>   Select a specific account when multiple connections
@@ -74,7 +73,7 @@ shell (VELLUM_UNTRUSTED_SHELL=1) to prevent token exfiltration.
 
 Examples:
   $ assistant oauth token google
-  $ assistant oauth token integration:twitter --json
+  $ assistant oauth token twitter --json
   $ assistant oauth token google --account user@gmail.com
   $ assistant oauth token google --client-id abc123`,
     )

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1738,7 +1738,7 @@ export function buildSchema(): Record<string, unknown> {
               required: true,
               schema: { type: "string" },
               description:
-                "OAuth provider key to filter by, for example `integration:google`.",
+                "OAuth provider key to filter by, for example `google`.",
             },
           ],
           security: [{ BearerAuth: [] }],


### PR DESCRIPTION
## Summary
- Update all OAuth CLI command help text and examples to use bare provider names (e.g. `google` instead of `integration:google`)
- Remove references to 'canonical keys', 'aliases', and multiple accepted formats
- Update gateway OpenAPI schema description

Part of plan: simplify-oauth-provider-keys.md (PR 7 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
