### PR TITLE
refactor: update all hardcoded `integration:X` provider key references to bare names

### DIFF
--- a/assistant/src/__tests__/integration-status.test.ts
+++ b/assistant/src/__tests__/integration-status.test.ts
@@ -56,8 +56,8 @@ describe("integration-status", () => {
     });
 
     test("returns all connected when all keys are set", async () => {
-      setOAuthConnected("integration:google");
-      setOAuthConnected("integration:slack");
+      setOAuthConnected("google");
+      setOAuthConnected("slack");
       mockTwilioAccountSid = "sid";
       secureKeyValues.set(credentialKey("twilio", "auth_token"), "auth");
       setOAuthConnected("telegram");
@@ -129,8 +129,8 @@ describe("integration-status", () => {
     });
 
     test("all connected", async () => {
-      setOAuthConnected("integration:google");
-      setOAuthConnected("integration:slack");
+      setOAuthConnected("google");
+      setOAuthConnected("slack");
       mockTwilioAccountSid = "sid";
       secureKeyValues.set(credentialKey("twilio", "auth_token"), "auth");
       setOAuthConnected("telegram");
@@ -163,7 +163,7 @@ describe("integration-status", () => {
     });
 
     test("email category checks Gmail", async () => {
-      setOAuthConnected("integration:google");
+      setOAuthConnected("google");
       expect(await hasCapability("email")).toBe(true);
     });
   });

--- a/assistant/src/__tests__/slack-messaging-token-resolution.test.ts
+++ b/assistant/src/__tests__/slack-messaging-token-resolution.test.ts
@@ -117,12 +117,12 @@ describe("Slack messaging token resolution", () => {
       expect(await slackProvider.isConnected!()).toBe(true);
     });
 
-    test("returns true when only integration:slack has active OAuth connection (backwards compat)", async () => {
+    test("returns true when only slack has active OAuth connection (backwards compat)", async () => {
       // No bot token
       getSecureKeyAsyncMock.mockImplementation(async () => null);
       // But OAuth provider is connected
       isProviderConnectedMock.mockImplementation(async (service: string) =>
-        service === "integration:slack" ? true : false,
+        service === "slack" ? true : false,
       );
 
       expect(await slackProvider.isConnected!()).toBe(true);
@@ -160,7 +160,7 @@ describe("Slack messaging token resolution", () => {
       expect(result).toBe("xoxb-token-only");
     });
 
-    test("returns OAuthConnection when only OAuth integration:slack credentials exist (backwards compat)", async () => {
+    test("returns OAuthConnection when only OAuth slack credentials exist (backwards compat)", async () => {
       getSecureKeyAsyncMock.mockImplementation(async () => null);
       const oauthConn = {
         accessToken: "xoxp-oauth-token",
@@ -169,16 +169,15 @@ describe("Slack messaging token resolution", () => {
 
       const result = await slackProvider.resolveConnection!();
       expect(result).toBe(oauthConn);
-      expect(resolveOAuthConnectionMock).toHaveBeenCalledWith(
-        "integration:slack",
-        { account: undefined },
-      );
+      expect(resolveOAuthConnectionMock).toHaveBeenCalledWith("slack", {
+        account: undefined,
+      });
     });
 
     test("throws when no credentials exist at all (no Socket Mode, no OAuth)", async () => {
       getSecureKeyAsyncMock.mockImplementation(async () => null);
       resolveOAuthConnectionMock.mockImplementation(async () => {
-        throw new Error("No OAuth connection found for integration:slack");
+        throw new Error("No OAuth connection found for slack");
       });
 
       await expect(slackProvider.resolveConnection!()).rejects.toThrow(
@@ -247,10 +246,9 @@ describe("Slack messaging token resolution", () => {
 
       const result = await getProviderConnection(gmailMessagingProvider);
       expect(result).toBe(oauthConn);
-      expect(resolveOAuthConnectionMock).toHaveBeenCalledWith(
-        "integration:google",
-        { account: undefined },
-      );
+      expect(resolveOAuthConnectionMock).toHaveBeenCalledWith("google", {
+        account: undefined,
+      });
     });
   });
 
@@ -264,7 +262,7 @@ describe("Slack messaging token resolution", () => {
       );
       // Gmail connected via OAuth
       isProviderConnectedMock.mockImplementation(async (service: string) =>
-        service === "integration:google" ? true : false,
+        service === "google" ? true : false,
       );
 
       await expect(resolveProvider()).rejects.toThrow(
@@ -285,7 +283,7 @@ describe("Slack messaging token resolution", () => {
     test("auto-selects Gmail when it is the only connected provider (no Slack credentials)", async () => {
       getSecureKeyAsyncMock.mockImplementation(async () => null);
       isProviderConnectedMock.mockImplementation(async (service: string) =>
-        service === "integration:google" ? true : false,
+        service === "google" ? true : false,
       );
 
       const provider = await resolveProvider();

--- a/assistant/src/__tests__/slack-share-routes.test.ts
+++ b/assistant/src/__tests__/slack-share-routes.test.ts
@@ -111,7 +111,7 @@ describe("handleListSlackChannels", () => {
   });
 
   test("returns channels sorted by type then name", async () => {
-    connectionByProvider["integration:slack"] = { id: "conn-slack-1" };
+    connectionByProvider["slack"] = { id: "conn-slack-1" };
     secureKeyValues.set(
       "oauth_connection/conn-slack-1/access_token",
       "xoxb-test",
@@ -192,7 +192,7 @@ describe("handleShareToSlackChannel", () => {
   });
 
   test("returns 400 for malformed JSON", async () => {
-    connectionByProvider["integration:slack"] = { id: "conn-slack-1" };
+    connectionByProvider["slack"] = { id: "conn-slack-1" };
     secureKeyValues.set(
       "oauth_connection/conn-slack-1/access_token",
       "xoxb-test",
@@ -207,7 +207,7 @@ describe("handleShareToSlackChannel", () => {
   });
 
   test("returns 400 when missing required fields", async () => {
-    connectionByProvider["integration:slack"] = { id: "conn-slack-1" };
+    connectionByProvider["slack"] = { id: "conn-slack-1" };
     secureKeyValues.set(
       "oauth_connection/conn-slack-1/access_token",
       "xoxb-test",
@@ -220,7 +220,7 @@ describe("handleShareToSlackChannel", () => {
   });
 
   test("returns 404 when app not found", async () => {
-    connectionByProvider["integration:slack"] = { id: "conn-slack-1" };
+    connectionByProvider["slack"] = { id: "conn-slack-1" };
     secureKeyValues.set(
       "oauth_connection/conn-slack-1/access_token",
       "xoxb-test",
@@ -232,7 +232,7 @@ describe("handleShareToSlackChannel", () => {
   });
 
   test("posts message and returns success", async () => {
-    connectionByProvider["integration:slack"] = { id: "conn-slack-1" };
+    connectionByProvider["slack"] = { id: "conn-slack-1" };
     secureKeyValues.set(
       "oauth_connection/conn-slack-1/access_token",
       "xoxb-test",

--- a/assistant/src/config/bundled-skills/contacts/tools/google-contacts.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/google-contacts.ts
@@ -44,7 +44,7 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     switch (action) {

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
@@ -35,7 +35,7 @@ export async function run(
     }
 
     try {
-      const connection = await resolveOAuthConnection("integration:google", {
+      const connection = await resolveOAuthConnection("google", {
         account,
       });
       const allMessageIds: string[] = [];
@@ -106,7 +106,7 @@ export async function run(
   } else if (messageId) {
     // Single message path
     try {
-      const connection = await resolveOAuthConnection("integration:google", {
+      const connection = await resolveOAuthConnection("google", {
         account,
       });
       await modifyMessage(connection, messageId, { removeLabelIds: ["INBOX"] });
@@ -126,7 +126,7 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     if (messageIds.length === 1) {

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-attachments.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-attachments.ts
@@ -57,7 +57,7 @@ export async function run(
 
   if (action === "list") {
     try {
-      const connection = await resolveOAuthConnection("integration:google", {
+      const connection = await resolveOAuthConnection("google", {
         account,
       });
       const message = await getMessage(connection, messageId, "full");
@@ -81,7 +81,7 @@ export async function run(
     if (!filename) return err("filename is required for download.");
 
     try {
-      const connection = await resolveOAuthConnection("integration:google", {
+      const connection = await resolveOAuthConnection("google", {
         account,
       });
       const attachment = await getAttachment(

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-draft.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-draft.ts
@@ -23,7 +23,7 @@ export async function run(
   if (!body) return err("body is required.");
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     const draft = await createDraft(

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-filters.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-filters.ts
@@ -26,7 +26,7 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     switch (action) {

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-follow-up.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-follow-up.ts
@@ -38,7 +38,7 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     switch (action) {

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-forward.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-forward.ts
@@ -76,7 +76,7 @@ export async function run(
   if (!forwardTo) return err("to is required.");
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     const message = await getMessage(connection, messageId, "full");

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-label.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-label.ts
@@ -21,7 +21,7 @@ export async function run(
 
   if (messageIds && messageIds.length > 0) {
     try {
-      const connection = await resolveOAuthConnection("integration:google", {
+      const connection = await resolveOAuthConnection("google", {
         account,
       });
       await batchModifyMessages(connection, messageIds, {
@@ -36,7 +36,7 @@ export async function run(
 
   if (messageId) {
     try {
-      const connection = await resolveOAuthConnection("integration:google", {
+      const connection = await resolveOAuthConnection("google", {
         account,
       });
       await modifyMessage(connection, messageId, {

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
@@ -56,7 +56,7 @@ export async function run(
   const query = `in:inbox -has:unsubscribe newer_than:${timeRange}`;
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     // Pipeline: fire metadata fetches for each page of IDs as they arrive

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-send-draft.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-send-draft.ts
@@ -15,7 +15,7 @@ export async function run(
   if (!draftId) return err("draft_id is required.");
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     const msg = await sendDraft(connection, draftId);

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
@@ -58,7 +58,7 @@ export async function run(
   const inputPageToken = input.page_token as string | undefined;
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     // Pipeline: fire metadata fetches for each page of IDs as they arrive,

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-trash.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-trash.ts
@@ -18,7 +18,7 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     await trashMessage(connection, messageId);

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
@@ -32,7 +32,7 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     const message = await getMessage(connection, messageId, "metadata", [

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-vacation.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-vacation.ts
@@ -22,7 +22,7 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     switch (action) {

--- a/assistant/src/config/bundled-skills/google-calendar/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/shared.ts
@@ -13,5 +13,5 @@ export function ok(content: string): ToolExecutionResult {
 export async function getCalendarConnection(
   account?: string,
 ): Promise<OAuthConnection> {
-  return resolveOAuthConnection("integration:google", { account });
+  return resolveOAuthConnection("google", { account });
 }

--- a/assistant/src/messaging/providers/gmail/adapter.ts
+++ b/assistant/src/messaging/providers/gmail/adapter.ts
@@ -86,7 +86,7 @@ function mapGmailMessage(msg: GmailMessage): Message {
 export const gmailMessagingProvider: MessagingProvider = {
   id: "gmail",
   displayName: "Gmail",
-  credentialService: "integration:google",
+  credentialService: "google",
   capabilities: new Set([
     "threads",
     "labels",

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -113,7 +113,7 @@ function mapSearchMatch(match: SlackSearchMatch): Message {
 export const slackProvider: MessagingProvider = {
   id: "slack",
   displayName: "Slack",
-  credentialService: "integration:slack",
+  credentialService: "slack",
   capabilities: new Set(["reactions", "threads", "leave_channel"]),
 
   async isConnected(): Promise<boolean> {
@@ -124,8 +124,8 @@ export const slackProvider: MessagingProvider = {
       credentialKey("slack_channel", "bot_token"),
     );
     if (botToken) return true;
-    // Preserve existing OAuth path (integration:slack) for backwards compat.
-    return isProviderConnected("integration:slack");
+    // Preserve existing OAuth path for backwards compat.
+    return isProviderConnected("slack");
   },
 
   async resolveConnection(account?: string): Promise<OAuthConnection | string> {
@@ -135,8 +135,8 @@ export const slackProvider: MessagingProvider = {
       credentialKey("slack_channel", "bot_token"),
     );
     if (botToken) return botToken;
-    // Preserve existing OAuth path (integration:slack) for backwards compat.
-    return resolveOAuthConnection("integration:slack", { account });
+    // Preserve existing OAuth path for backwards compat.
+    return resolveOAuthConnection("slack", { account });
   },
 
   async testConnection(

--- a/assistant/src/runtime/routes/integrations/slack/share.ts
+++ b/assistant/src/runtime/routes/integrations/slack/share.ts
@@ -28,7 +28,7 @@ const log = getLogger("slack-share");
  * Resolve the Slack bot token from the OAuth connection store.
  */
 async function resolveSlackToken(): Promise<string | undefined> {
-  const conn = getConnectionByProvider("integration:slack");
+  const conn = getConnectionByProvider("slack");
   return conn
     ? await getSecureKeyAsync(`oauth_connection/${conn.id}/access_token`)
     : undefined;

--- a/assistant/src/schedule/integration-status.ts
+++ b/assistant/src/schedule/integration-status.ts
@@ -15,12 +15,12 @@ const INTEGRATION_PROBES: IntegrationProbe[] = [
   {
     name: "Gmail",
     category: "email",
-    isConnected: () => isProviderConnected("integration:google"),
+    isConnected: () => isProviderConnected("google"),
   },
   {
     name: "Slack",
     category: "messaging",
-    isConnected: () => isProviderConnected("integration:slack"),
+    isConnected: () => isProviderConnected("slack"),
   },
   {
     name: "Twilio",

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -35,16 +35,13 @@ import { getSecureKeyAsync, setSecureKeyAsync } from "./secure-keys.js";
 
 const log = getLogger("token-manager");
 
-const MESSAGING_SERVICES = new Set(["integration:google", "integration:slack"]);
+const MESSAGING_SERVICES = new Set(["google", "slack"]);
 
 function recoveryHint(service: string): string {
-  const shortName = service.startsWith("integration:")
-    ? service.slice("integration:".length)
-    : service;
   if (MESSAGING_SERVICES.has(service)) {
-    return ` Reconnect ${shortName} — follow the Error Recovery steps in the messaging skill. Do not present options or explain the error to the user.`;
+    return ` Reconnect ${service} — follow the Error Recovery steps in the messaging skill. Do not present options or explain the error to the user.`;
   }
-  return ` Re-authorization required for ${shortName}. Do not present options or explain the error to the user.`;
+  return ` Re-authorization required for ${service}. Do not present options or explain the error to the user.`;
 }
 
 // ── Shared circuit breaker & deduplication instances ──────────────────

--- a/assistant/src/tools/credentials/post-connect-hooks.ts
+++ b/assistant/src/tools/credentials/post-connect-hooks.ts
@@ -48,7 +48,7 @@ async function slackWelcomeDM(ctx: PostConnectHookContext): Promise<void> {
 // ---------------------------------------------------------------------------
 
 const POST_CONNECT_HOOKS: Record<string, PostConnectHook> = {
-  "integration:slack": slackWelcomeDM,
+  slack: slackWelcomeDM,
 };
 
 /**

--- a/assistant/src/watcher/providers/github.ts
+++ b/assistant/src/watcher/providers/github.ts
@@ -6,7 +6,7 @@
  * start from "now" and don't replay historical notifications.
  *
  * The credential service expects a GitHub Personal Access Token (or fine-grained
- * token) stored under `integration:github`. The token needs at minimum the
+ * token) stored under `github`. The token needs at minimum the
  * `notifications` scope (classic) or Notification read permission (fine-grained).
  */
 
@@ -117,7 +117,7 @@ async function fetchNotificationsPage(
 export const githubProvider: WatcherProvider = {
   id: "github",
   displayName: "GitHub",
-  requiredCredentialService: "integration:github",
+  requiredCredentialService: "github",
 
   async getInitialWatermark(_credentialService: string): Promise<string> {
     // Start from "now" so we don't replay all existing notifications

--- a/assistant/src/watcher/providers/gmail.ts
+++ b/assistant/src/watcher/providers/gmail.ts
@@ -115,7 +115,7 @@ class HistoryExpiredError extends Error {
 export const gmailProvider: WatcherProvider = {
   id: "gmail",
   displayName: "Gmail",
-  requiredCredentialService: "integration:google",
+  requiredCredentialService: "google",
 
   async getInitialWatermark(credentialService: string): Promise<string> {
     const connection = await resolveOAuthConnection(credentialService);

--- a/assistant/src/watcher/providers/google-calendar.ts
+++ b/assistant/src/watcher/providers/google-calendar.ts
@@ -25,7 +25,7 @@ import type {
 const log = getLogger("watcher:google-calendar");
 
 /** The credential service — calendar shares OAuth tokens with Gmail. */
-const CREDENTIAL_SERVICE = "integration:google";
+const CREDENTIAL_SERVICE = "google";
 
 function eventToItem(event: CalendarEvent, eventType: string): WatcherItem {
   const start = event.start?.dateTime ?? event.start?.date ?? "";

--- a/assistant/src/watcher/providers/linear.ts
+++ b/assistant/src/watcher/providers/linear.ts
@@ -9,7 +9,7 @@
  * for issues assigned to the authenticated user.
  *
  * The credential service expects a Linear API key (personal or OAuth access token)
- * stored under `integration:linear`. The token only needs read access to notifications
+ * stored under `linear`. The token only needs read access to notifications
  * and issues.
  */
 
@@ -495,7 +495,7 @@ function issueToStatusChangeItem(
 export const linearProvider: WatcherProvider = {
   id: "linear",
   displayName: "Linear",
-  requiredCredentialService: "integration:linear",
+  requiredCredentialService: "linear",
 
   async getInitialWatermark(_credentialService: string): Promise<string> {
     // Start from "now" so we don't replay all existing notifications

--- a/packages/credential-storage/src/index.ts
+++ b/packages/credential-storage/src/index.ts
@@ -98,7 +98,7 @@ export interface SecureKeyBackend {
 export interface OAuthConnectionRecord {
   /** Unique identifier for this connection. */
   id: string;
-  /** Provider key (e.g. "integration:google", "integration:slack"). */
+  /** Provider key (e.g. "google", "slack"). */
   providerKey: string;
   /** Account identifier (e.g. email address). */
   accountInfo: string | null;


### PR DESCRIPTION
## Summary
- Update ~26 files with hardcoded `integration:X` provider key references to use bare names
- Covers token-manager, messaging adapters, watcher providers, bundled skill tools, runtime routes
- Simplifies token-manager recoveryHint() to remove prefix stripping logic

Part of plan: simplify-oauth-provider-keys.md (PR 5 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
