### PR TITLE
fix: hide voice mode button behind feature flag (default off)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -414,16 +414,17 @@ struct ComposerView: View {
                     action: onStop
                 )
             } else if inputText.isEmpty && !hasPendingConfirmation {
-                // Live voice button
-                VButton(
-                    label: "Voice mode",
-                    iconOnly: VIcon.audioWaveform.rawValue,
-                    style: .ghost,
-                    iconSize: composerActionButtonSize,
-                    action: { onVoiceModeToggle?() }
-                )
-
-                .vTooltip("Live voice conversation")
+                if onVoiceModeToggle != nil {
+                    // Live voice button
+                    VButton(
+                        label: "Voice mode",
+                        iconOnly: VIcon.audioWaveform.rawValue,
+                        style: .ghost,
+                        iconSize: composerActionButtonSize,
+                        action: { onVoiceModeToggle?() }
+                    )
+                    .vTooltip("Live voice conversation")
+                }
 
                 // Dictate button
                 VButton(
@@ -474,14 +475,15 @@ struct ComposerView: View {
                 .vTooltip(canSend ? "Send" : "Type a message to send")
             } else {
                 // Pending confirmation — show same buttons as empty-input state
-                VButton(
-                    label: "Voice mode",
-                    iconOnly: VIcon.audioWaveform.rawValue,
-                    style: .ghost,
-                    iconSize: composerActionButtonSize,
-                    action: { onVoiceModeToggle?() }
-                )
-
+                if onVoiceModeToggle != nil {
+                    VButton(
+                        label: "Voice mode",
+                        iconOnly: VIcon.audioWaveform.rawValue,
+                        style: .ghost,
+                        iconSize: composerActionButtonSize,
+                        action: { onVoiceModeToggle?() }
+                    )
+                }
 
                 VButton(
                     label: isRecording ? "Stop recording" : "Dictate",

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -383,6 +383,9 @@ extension MainWindowView {
             let isTTSEnabled = assistantFeatureFlagStore.isEnabled(
                 "message-tts"
             )
+            let isVoiceModeEnabled = assistantFeatureFlagStore.isEnabled(
+                "voice-mode"
+            )
             ActiveChatViewWrapper(
                 viewModel: viewModel,
                 windowState: windowState,
@@ -403,9 +406,9 @@ extension MainWindowView {
                 onDictateToggle: {
                     AppDelegate.shared?.voiceInput?.toggleRecording(origin: .chatComposer)
                 },
-                onVoiceModeToggle: {
+                onVoiceModeToggle: isVoiceModeEnabled ? {
                     toggleVoiceMode()
-                },
+                } : nil,
                 conversationId: conversationManager.activeConversationId,
                 anchorMessageId: $conversationManager.pendingAnchorMessageId,
                 highlightedMessageId: $conversationManager.highlightedMessageId

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -336,6 +336,14 @@
       "label": "Show Background Conversations",
       "description": "Include background conversations (heartbeat, tasks) in the sidebar conversation list",
       "defaultEnabled": false
+    },
+    {
+      "id": "voice-mode",
+      "scope": "assistant",
+      "key": "voice-mode",
+      "label": "Voice Mode",
+      "description": "Show the live voice conversation button in the composer",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `voice-mode` feature flag to the registry with scope `assistant` and `defaultEnabled: false`
- Gates the voice mode button in `ComposerView` behind `onVoiceModeToggle != nil` for both empty-input and pending-confirmation states
- `PanelCoordinator` passes `onVoiceModeToggle` as `nil` when the flag is off

Replaces #21502 which had the flag scoped as `macos` — the macOS app's `AssistantFeatureFlagStore` only loads `assistant`-scoped flags, so the old scope caused the flag to be ignored (falling through to `?? true`).

## Test plan
- [ ] Verify voice mode button is hidden by default in the composer
- [ ] Enable `voice-mode` flag and verify the button appears
- [ ] Confirm button behavior in both empty-input and pending-confirmation states

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
