### PR TITLE
fix: default Google OAuth service mode to "your-own" instead of "managed"

### DIFF
--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -47,7 +47,7 @@ export const WebSearchServiceSchema = BaseServiceSchema.extend({
 export type WebSearchService = z.infer<typeof WebSearchServiceSchema>;
 
 export const GoogleOAuthServiceSchema = BaseServiceSchema.extend({
-  mode: ServiceModeSchema.default("managed"),
+  mode: ServiceModeSchema.default("your-own"),
 });
 export type GoogleOAuthService = z.infer<typeof GoogleOAuthServiceSchema>;
 


### PR DESCRIPTION
## Summary

- Changed the default mode for `GoogleOAuthServiceSchema` from `"managed"` to `"your-own"` in `assistant/src/config/schemas/services.ts`
- The `managed-google-oauth` feature flag (defaultEnabled: false) only gates the Settings UI card visibility, not the backend connection resolution logic. The schema default of `"managed"` caused all users to route through the platform proxy, leading to Gmail API 404s, broken OAuth redirects, and repeated login prompts
- With this fix, Google OAuth defaults to BYO mode like every other service; managed mode only activates when explicitly enabled through the Settings UI

## Original prompt
Fix: default Google OAuth service mode to "your-own" instead of "managed". The managed-google-oauth feature flag only gates the Settings UI card, but the schema default of "managed" causes all users to route through the platform proxy, leading to Gmail API 404s and broken OAuth redirect flows.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
