### PR TITLE
Simplify OAuth provider keys: remove `integration:` prefix

### DIFF
--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -144,7 +144,7 @@ sequenceDiagram
 
     Note over UI,API: Tool Execution Flow
     Tool->>TokenMgr: withValidToken("gmail", callback)
-    TokenMgr->>Store: getConnectionByProvider("integration:google")
+    TokenMgr->>Store: getConnectionByProvider("google")
     TokenMgr->>Vault: getSecureKeyAsync("oauth_connection/{conn.id}/access_token")
     TokenMgr->>Store: check oauth_connections.expires_at
     alt Token expired
@@ -221,7 +221,7 @@ The OAuth extensibility layer makes adding a new OAuth provider a declarative op
 
 Protocol fields (`authUrl`, `tokenUrl`, `defaultScopes`, `scopePolicy`, `callbackTransport`) are stored in the `oauth_providers` database table rather than in code.
 
-Registered providers: `integration:google`, `integration:slack`, `integration:notion`. Short aliases (e.g. `gmail`, `slack`) are resolved via `resolveService()`.
+Registered providers: `google`, `slack`, `notion`. The `gmail` alias resolves to the `google` provider.
 
 ### Scope Policy Engine
 

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -483,13 +483,9 @@ describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store"
   });
 
   test("upsertCredentialMetadata does not accept oauth2ClientSecret or other OAuth fields", () => {
-    const record = upsertCredentialMetadata(
-      "integration:google",
-      "access_token",
-      {
-        allowedTools: ["api_request"],
-      },
-    );
+    const record = upsertCredentialMetadata("google", "access_token", {
+      allowedTools: ["api_request"],
+    });
     expect("oauth2ClientSecret" in record).toBe(false);
     expect("oauth2TokenUrl" in record).toBe(false);
     expect("oauth2ClientId" in record).toBe(false);
@@ -497,14 +493,14 @@ describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store"
 
   test("client secret is read from secure store, not metadata", async () => {
     await setSecureKeyAsync(
-      credentialKey("integration:google", "client_secret"),
+      credentialKey("google", "client_secret"),
       "my-secret",
     );
-    upsertCredentialMetadata("integration:google", "access_token", {
+    upsertCredentialMetadata("google", "access_token", {
       allowedTools: ["api_request"],
     });
 
-    const meta = getCredentialMetadata("integration:google", "access_token");
+    const meta = getCredentialMetadata("google", "access_token");
     expect(meta).toBeDefined();
     expect("oauth2ClientSecret" in meta!).toBe(false);
     // OAuth-specific fields are no longer in metadata (v5)
@@ -513,9 +509,7 @@ describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store"
 
     // Secret is in secure store
     expect(
-      await getSecureKeyAsync(
-        credentialKey("integration:google", "client_secret"),
-      ),
+      await getSecureKeyAsync(credentialKey("google", "client_secret")),
     ).toBe("my-secret");
   });
 
@@ -525,7 +519,7 @@ describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store"
       credentials: [
         {
           credentialId: "cred-v2-secret",
-          service: "integration:google",
+          service: "google",
           field: "access_token",
           allowedTools: [],
           allowedDomains: [],
@@ -543,7 +537,7 @@ describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store"
       "utf-8",
     );
 
-    const meta = getCredentialMetadata("integration:google", "access_token");
+    const meta = getCredentialMetadata("google", "access_token");
     expect(meta).toBeDefined();
     expect("oauth2ClientSecret" in meta!).toBe(false);
 

--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -755,8 +755,8 @@ describe("credential_store tool — prompt action", () => {
 describe("credential_store tool — oauth2_connect error paths", () => {
   /** Well-known provider rows returned by the mocked getProvider */
   const wellKnownProviders: Record<string, object> = {
-    "integration:google": {
-      key: "integration:google",
+    google: {
+      key: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: JSON.stringify(["https://mail.google.com/"]),
@@ -764,8 +764,8 @@ describe("credential_store tool — oauth2_connect error paths", () => {
       callbackTransport: "loopback",
       loopbackPort: 8756,
     },
-    "integration:slack": {
-      key: "integration:slack",
+    slack: {
+      key: "slack",
       authUrl: "https://slack.com/oauth/v2/authorize",
       tokenUrl: "https://slack.com/api/oauth.v2.access",
       defaultScopes: JSON.stringify(["channels:read"]),
@@ -880,7 +880,7 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     expect(result.content).toContain("mock-auth-url.example.com");
   });
 
-  test("resolves gmail alias to integration:google", async () => {
+  test("resolves gmail alias to google", async () => {
     // Even with alias resolution, missing client_id should still fail
     const result = await credentialStoreTool.execute(
       {
@@ -895,7 +895,7 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     expect(result.content).toContain("client_id is required");
   });
 
-  test("resolves slack alias to integration:slack", async () => {
+  test("resolves slack to its canonical name", async () => {
     const result = await credentialStoreTool.execute(
       {
         action: "oauth2_connect",
@@ -912,13 +912,13 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     // and store client_secret in the secure store.
     mockGetMostRecentAppByProvider.mockImplementation(() => ({
       id: "test-app-id",
-      providerKey: "integration:google",
+      providerKey: "google",
       clientId: "stored-client-id-123",
       clientSecretCredentialPath: "oauth_app/test-app-id/client_secret",
       createdAt: Date.now(),
     }));
     mockGetProvider.mockImplementation(() => ({
-      key: "integration:google",
+      key: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: JSON.stringify(["https://mail.google.com/"]),
@@ -958,13 +958,10 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     // most-recent-app heuristic) so the secret comes from the correct app.
     mockGetAppByProviderAndClientId.mockImplementation(
       (providerKey: string, cId: string) => {
-        if (
-          providerKey === "integration:google" &&
-          cId === "caller-supplied-client-id"
-        ) {
+        if (providerKey === "google" && cId === "caller-supplied-client-id") {
           return {
             id: "matched-app-id",
-            providerKey: "integration:google",
+            providerKey: "google",
             clientId: "caller-supplied-client-id",
             clientSecretCredentialPath:
               "oauth_app/matched-app-id/client_secret",
@@ -975,7 +972,7 @@ describe("credential_store tool — oauth2_connect error paths", () => {
       },
     );
     mockGetProvider.mockImplementation(() => ({
-      key: "integration:google",
+      key: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: JSON.stringify(["https://mail.google.com/"]),
@@ -1013,13 +1010,13 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     // use getMostRecentAppByProvider (the fallback heuristic).
     mockGetMostRecentAppByProvider.mockImplementation(() => ({
       id: "recent-app-id",
-      providerKey: "integration:google",
+      providerKey: "google",
       clientId: "recent-client-id",
       clientSecretCredentialPath: "oauth_app/recent-app-id/client_secret",
       createdAt: Date.now(),
     }));
     mockGetProvider.mockImplementation(() => ({
-      key: "integration:google",
+      key: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: JSON.stringify(["https://mail.google.com/"]),
@@ -1056,7 +1053,7 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     // report the missing secret error.
     mockGetAppByProviderAndClientId.mockImplementation(() => undefined);
     mockGetProvider.mockImplementation(() => ({
-      key: "integration:google",
+      key: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: JSON.stringify(["https://mail.google.com/"]),
@@ -1087,12 +1084,12 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     // guardrail.
     mockGetMostRecentAppByProvider.mockImplementation(() => ({
       id: "test-app-id-no-secret",
-      providerKey: "integration:google",
+      providerKey: "google",
       clientId: "stored-client-id-456",
       createdAt: Date.now(),
     }));
     mockGetProvider.mockImplementation(() => ({
-      key: "integration:google",
+      key: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: JSON.stringify(["https://mail.google.com/"]),

--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -736,7 +736,7 @@ describe("credential_store tool", () => {
       await credentialStoreTool.execute(
         {
           action: "store",
-          service: "integration:google",
+          service: "google",
           field: "api_key",
           value: "test-value",
         },
@@ -744,9 +744,9 @@ describe("credential_store tool", () => {
       );
 
       // Simulate an active OAuth connection for this service
-      mockConnections.set("integration:google", {
+      mockConnections.set("google", {
         id: "conn-gmail",
-        providerKey: "integration:google",
+        providerKey: "google",
         oauthAppId: "app-gmail",
         expiresAt: Date.now() + 3600_000,
       });
@@ -754,7 +754,7 @@ describe("credential_store tool", () => {
       const result = await credentialStoreTool.execute(
         {
           action: "delete",
-          service: "integration:google",
+          service: "google",
           field: "api_key",
         },
         _ctx,
@@ -764,9 +764,7 @@ describe("credential_store tool", () => {
       expect(result.content).toContain("Deleted credential");
       // Verify disconnectOAuthProvider was called with the service name
       expect(mockDisconnectOAuthProvider).toHaveBeenCalledTimes(1);
-      expect(mockDisconnectOAuthProvider).toHaveBeenCalledWith(
-        "integration:google",
-      );
+      expect(mockDisconnectOAuthProvider).toHaveBeenCalledWith("google");
     });
   });
 
@@ -1354,7 +1352,7 @@ describe("withValidToken refresh deduplication", () => {
   }
 
   test("3 concurrent 401 refreshes for the same service call doRefresh exactly once", async () => {
-    await setupService("integration:google");
+    await setupService("google");
 
     let resolveRefresh!: (value: {
       accessToken: string;
@@ -1378,9 +1376,9 @@ describe("withValidToken refresh deduplication", () => {
 
     // Launch 3 concurrent withValidToken calls — all will get a non-expired
     // token first, call the callback, get a 401, and then try to refresh.
-    const p1 = withValidToken("integration:google", callback);
-    const p2 = withValidToken("integration:google", callback);
-    const p3 = withValidToken("integration:google", callback);
+    const p1 = withValidToken("google", callback);
+    const p2 = withValidToken("google", callback);
+    const p3 = withValidToken("google", callback);
 
     // Let the event loop tick so all 3 calls enter the 401 retry path
     await new Promise((r) => setTimeout(r, 10));
@@ -1402,8 +1400,8 @@ describe("withValidToken refresh deduplication", () => {
   });
 
   test("concurrent refreshes for different services proceed independently", async () => {
-    await setupService("integration:google");
-    await setupService("integration:slack");
+    await setupService("google");
+    await setupService("slack");
 
     let resolveGmail!: (value: {
       accessToken: string;
@@ -1447,8 +1445,8 @@ describe("withValidToken refresh deduplication", () => {
       return `slack-${token}`;
     };
 
-    const p1 = withValidToken("integration:google", gmailCallback);
-    const p2 = withValidToken("integration:slack", slackCallback);
+    const p1 = withValidToken("google", gmailCallback);
+    const p2 = withValidToken("slack", slackCallback);
 
     await new Promise((r) => setTimeout(r, 10));
 
@@ -1466,7 +1464,7 @@ describe("withValidToken refresh deduplication", () => {
   });
 
   test("deduplication cleans up after refresh completes, allowing subsequent refreshes", async () => {
-    await setupService("integration:google");
+    await setupService("google");
 
     let refreshCount = 0;
     mockRefreshOAuth2Token.mockImplementation(() => {
@@ -1480,25 +1478,19 @@ describe("withValidToken refresh deduplication", () => {
     const err401 = Object.assign(new Error("Unauthorized"), { status: 401 });
 
     // First call triggers a refresh (old token → 401 → refresh → token-1)
-    const r1 = await withValidToken(
-      "integration:google",
-      async (token: string) => {
-        if (token !== "token-1") throw err401;
-        return token;
-      },
-    );
+    const r1 = await withValidToken("google", async (token: string) => {
+      if (token !== "token-1") throw err401;
+      return token;
+    });
     expect(r1).toBe("token-1");
     expect(refreshCount).toBe(1);
 
     // Second call also triggers a 401 to verify dedup state was cleaned up
     // and a new refresh is allowed (not deduplicated with the first).
-    const r2 = await withValidToken(
-      "integration:google",
-      async (token: string) => {
-        if (token !== "token-2") throw err401;
-        return token;
-      },
-    );
+    const r2 = await withValidToken("google", async (token: string) => {
+      if (token !== "token-2") throw err401;
+      return token;
+    });
     expect(r2).toBe("token-2");
     // Second refresh should have happened (not deduplicated with the first,
     // since the first already completed)
@@ -1506,7 +1498,7 @@ describe("withValidToken refresh deduplication", () => {
   });
 
   test("deduplication propagates refresh errors to all waiting callers", async () => {
-    await setupService("integration:google");
+    await setupService("google");
 
     mockRefreshOAuth2Token.mockImplementation(() =>
       Promise.reject(
@@ -1524,8 +1516,8 @@ describe("withValidToken refresh deduplication", () => {
     };
 
     // Launch 2 concurrent calls — both should fail with the same error
-    const p1 = withValidToken("integration:google", callback);
-    const p2 = withValidToken("integration:google", callback);
+    const p1 = withValidToken("google", callback);
+    const p2 = withValidToken("google", callback);
 
     const results = await Promise.allSettled([p1, p2]);
 

--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -1059,7 +1059,7 @@ describe("assistant credentials CLI", () => {
       const setResult = await runCli([
         "set",
         "--service",
-        "integration:google",
+        "google",
         "--field",
         "client_secret",
         "secret123",
@@ -1068,13 +1068,13 @@ describe("assistant credentials CLI", () => {
       expect(setResult.exitCode).toBe(0);
       const setParsed = JSON.parse(setResult.stdout);
       expect(setParsed.ok).toBe(true);
-      expect(setParsed.service).toBe("integration:google");
+      expect(setParsed.service).toBe("google");
       expect(setParsed.field).toBe("client_secret");
 
       const revealResult = await runCli([
         "reveal",
         "--service",
-        "integration:google",
+        "google",
         "--field",
         "client_secret",
         "--json",

--- a/assistant/src/__tests__/daemon-credential-client.test.ts
+++ b/assistant/src/__tests__/daemon-credential-client.test.ts
@@ -110,13 +110,13 @@ describe("daemon credential read requests", () => {
 
   test("preserves compound credential service names on metadata reads", async () => {
     const result = await getSecureKeyResultViaDaemon(
-      credentialKey("integration:google", "client_secret"),
+      credentialKey("google", "client_secret"),
     );
 
     expect(result).toEqual({ value: "secret-value", unreachable: false });
     expect(getRequestBody()).toEqual({
       type: "credential",
-      name: "integration:google:client_secret",
+      name: "google:client_secret",
       reveal: true,
     });
   });

--- a/assistant/src/__tests__/integration-status.test.ts
+++ b/assistant/src/__tests__/integration-status.test.ts
@@ -56,8 +56,8 @@ describe("integration-status", () => {
     });
 
     test("returns all connected when all keys are set", async () => {
-      setOAuthConnected("integration:google");
-      setOAuthConnected("integration:slack");
+      setOAuthConnected("google");
+      setOAuthConnected("slack");
       mockTwilioAccountSid = "sid";
       secureKeyValues.set(credentialKey("twilio", "auth_token"), "auth");
       setOAuthConnected("telegram");
@@ -129,8 +129,8 @@ describe("integration-status", () => {
     });
 
     test("all connected", async () => {
-      setOAuthConnected("integration:google");
-      setOAuthConnected("integration:slack");
+      setOAuthConnected("google");
+      setOAuthConnected("slack");
       mockTwilioAccountSid = "sid";
       secureKeyValues.set(credentialKey("twilio", "auth_token"), "auth");
       setOAuthConnected("telegram");
@@ -163,7 +163,7 @@ describe("integration-status", () => {
     });
 
     test("email category checks Gmail", async () => {
-      setOAuthConnected("integration:google");
+      setOAuthConnected("google");
       expect(await hasCapability("email")).toBe(true);
     });
   });

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -37,7 +37,7 @@ let mockUpsertAppCalls: Array<{
 }> = [];
 let mockUpsertAppResult: Record<string, unknown> = {
   id: "app-upsert-1",
-  providerKey: "integration:test",
+  providerKey: "test",
   clientId: "test-client-id",
   createdAt: 1700000000000,
   updatedAt: 1700000000000,
@@ -315,17 +315,13 @@ describe("assistant oauth token <provider-key>", () => {
   });
 
   test("prints bare token in human mode", async () => {
-    const { exitCode, stdout } = await runCli(["token", "integration:twitter"]);
+    const { exitCode, stdout } = await runCli(["token", "twitter"]);
     expect(exitCode).toBe(0);
     expect(stdout).toBe("mock-access-token-xyz\n");
   });
 
   test("prints JSON in --json mode", async () => {
-    const { exitCode, stdout } = await runCli([
-      "token",
-      "integration:twitter",
-      "--json",
-    ]);
+    const { exitCode, stdout } = await runCli(["token", "twitter", "--json"]);
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toEqual({ ok: true, token: "mock-access-token-xyz" });
@@ -338,8 +334,8 @@ describe("assistant oauth token <provider-key>", () => {
       return cb("tok");
     };
 
-    await runCli(["token", "integration:twitter"]);
-    expect(capturedService).toBe("integration:twitter");
+    await runCli(["token", "twitter"]);
+    expect(capturedService).toBe("twitter");
   });
 
   test("works with other provider keys", async () => {
@@ -349,24 +345,20 @@ describe("assistant oauth token <provider-key>", () => {
       return cb("gmail-token");
     };
 
-    const { exitCode, stdout } = await runCli(["token", "integration:google"]);
+    const { exitCode, stdout } = await runCli(["token", "google"]);
     expect(exitCode).toBe(0);
     expect(stdout).toBe("gmail-token\n");
-    expect(capturedService).toBe("integration:google");
+    expect(capturedService).toBe("google");
   });
 
   test("exits 1 when no token exists", async () => {
     mockWithValidToken = async () => {
       throw new Error(
-        'No access token found for "integration:twitter". Authorization required.',
+        'No access token found for "twitter". Authorization required.',
       );
     };
 
-    const { exitCode, stdout } = await runCli([
-      "token",
-      "integration:twitter",
-      "--json",
-    ]);
+    const { exitCode, stdout } = await runCli(["token", "twitter", "--json"]);
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
@@ -375,16 +367,10 @@ describe("assistant oauth token <provider-key>", () => {
 
   test("exits 1 when refresh fails", async () => {
     mockWithValidToken = async () => {
-      throw new Error(
-        'Token refresh failed for "integration:twitter": invalid_grant.',
-      );
+      throw new Error('Token refresh failed for "twitter": invalid_grant.');
     };
 
-    const { exitCode, stdout } = await runCli([
-      "token",
-      "integration:twitter",
-      "--json",
-    ]);
+    const { exitCode, stdout } = await runCli(["token", "twitter", "--json"]);
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
@@ -395,7 +381,7 @@ describe("assistant oauth token <provider-key>", () => {
     // Simulate withValidToken refreshing and returning a new token
     mockWithValidToken = async (_service, cb) => cb("refreshed-new-token");
 
-    const { exitCode, stdout } = await runCli(["token", "integration:twitter"]);
+    const { exitCode, stdout } = await runCli(["token", "twitter"]);
     expect(exitCode).toBe(0);
     expect(stdout).toBe("refreshed-new-token\n");
   });
@@ -413,7 +399,7 @@ describe("assistant oauth token <provider-key>", () => {
 describe("assistant oauth providers list", () => {
   const fakeProviders = [
     {
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: "[]",
@@ -423,7 +409,7 @@ describe("assistant oauth providers list", () => {
       updatedAt: "2025-01-01T00:00:00.000Z",
     },
     {
-      providerKey: "integration:google-calendar",
+      providerKey: "google-calendar",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: "[]",
@@ -433,7 +419,7 @@ describe("assistant oauth providers list", () => {
       updatedAt: "2025-01-01T00:00:00.000Z",
     },
     {
-      providerKey: "integration:slack",
+      providerKey: "slack",
       authUrl: "https://slack.com/oauth/v2/authorize",
       tokenUrl: "https://slack.com/api/oauth.v2.access",
       defaultScopes: "[]",
@@ -443,7 +429,7 @@ describe("assistant oauth providers list", () => {
       updatedAt: "2025-01-01T00:00:00.000Z",
     },
     {
-      providerKey: "integration:twitter",
+      providerKey: "twitter",
       authUrl: "https://twitter.com/i/oauth2/authorize",
       tokenUrl: "https://api.twitter.com/2/oauth2/token",
       defaultScopes: "[]",
@@ -465,10 +451,10 @@ describe("assistant oauth providers list", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(4);
     const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
-    expect(keys).toContain("integration:google");
-    expect(keys).toContain("integration:google-calendar");
-    expect(keys).toContain("integration:slack");
-    expect(keys).toContain("integration:twitter");
+    expect(keys).toContain("google");
+    expect(keys).toContain("google-calendar");
+    expect(keys).toContain("slack");
+    expect(keys).toContain("twitter");
   });
 
   test("filters by single --provider-key value", async () => {
@@ -482,7 +468,7 @@ describe("assistant oauth providers list", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(1);
-    expect(parsed[0].providerKey).toBe("integration:slack");
+    expect(parsed[0].providerKey).toBe("slack");
   });
 
   test("filters by comma-separated OR values", async () => {
@@ -497,9 +483,9 @@ describe("assistant oauth providers list", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(3);
     const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
-    expect(keys).toContain("integration:google");
-    expect(keys).toContain("integration:google-calendar");
-    expect(keys).toContain("integration:slack");
+    expect(keys).toContain("google");
+    expect(keys).toContain("google-calendar");
+    expect(keys).toContain("slack");
   });
 
   test("returns empty array when comma-separated filter has no matches", async () => {
@@ -527,9 +513,9 @@ describe("assistant oauth providers list", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(3);
     const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
-    expect(keys).toContain("integration:google");
-    expect(keys).toContain("integration:google-calendar");
-    expect(keys).toContain("integration:slack");
+    expect(keys).toContain("google");
+    expect(keys).toContain("google-calendar");
+    expect(keys).toContain("slack");
   });
 
   test("ignores empty segments from extra commas in --provider-key", async () => {
@@ -544,9 +530,9 @@ describe("assistant oauth providers list", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(3);
     const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
-    expect(keys).toContain("integration:google");
-    expect(keys).toContain("integration:google-calendar");
-    expect(keys).toContain("integration:slack");
+    expect(keys).toContain("google");
+    expect(keys).toContain("google-calendar");
+    expect(keys).toContain("slack");
   });
 });
 
@@ -560,7 +546,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
     mockUpsertAppCalls = [];
     mockUpsertAppResult = {
       id: "app-upsert-1",
-      providerKey: "integration:google",
+      providerKey: "google",
       clientId: "abc123",
       createdAt: 1700000000000,
       updatedAt: 1700000000000,
@@ -584,7 +570,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
       "apps",
       "upsert",
       "--provider",
-      "integration:google",
+      "google",
       "--client-id",
       "abc123",
       "--client-secret-credential-path",
@@ -594,7 +580,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
     expect(exitCode).toBe(0);
     expect(mockUpsertAppCalls).toHaveLength(1);
     expect(mockUpsertAppCalls[0]).toEqual({
-      provider: "integration:google",
+      provider: "google",
       clientId: "abc123",
       clientSecretOpts: { clientSecretCredentialPath: "custom/path" },
     });
@@ -607,7 +593,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
       "apps",
       "upsert",
       "--provider",
-      "integration:google",
+      "google",
       "--client-id",
       "abc123",
       "--client-secret",
@@ -631,7 +617,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
       "apps",
       "upsert",
       "--provider",
-      "integration:google",
+      "google",
       "--client-id",
       "abc123",
       "--client-secret",
@@ -641,7 +627,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
     expect(exitCode).toBe(0);
     expect(mockUpsertAppCalls).toHaveLength(1);
     expect(mockUpsertAppCalls[0]).toEqual({
-      provider: "integration:google",
+      provider: "google",
       clientId: "abc123",
       clientSecretOpts: { clientSecretValue: "s3cret" },
     });
@@ -652,7 +638,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
       "apps",
       "upsert",
       "--provider",
-      "integration:google",
+      "google",
       "--client-id",
       "abc123",
       "--json",
@@ -660,7 +646,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
     expect(exitCode).toBe(0);
     expect(mockUpsertAppCalls).toHaveLength(1);
     expect(mockUpsertAppCalls[0]).toEqual({
-      provider: "integration:google",
+      provider: "google",
       clientId: "abc123",
       clientSecretOpts: undefined,
     });
@@ -673,20 +659,20 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
       "apps",
       "upsert",
       "--provider",
-      "integration:google",
+      "google",
       "--client-id",
       "abc",
       "--client-secret-credential-path",
-      "integration:google:client_secret",
+      "google:client_secret",
       "--json",
     ]);
     expect(exitCode).toBe(0);
     expect(mockUpsertAppCalls).toHaveLength(1);
     expect(mockUpsertAppCalls[0]).toEqual({
-      provider: "integration:google",
+      provider: "google",
       clientId: "abc",
       clientSecretOpts: {
-        clientSecretCredentialPath: "integration:google:client_secret",
+        clientSecretCredentialPath: "google:client_secret",
       },
     });
     const parsed = JSON.parse(stdout);
@@ -698,22 +684,21 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
       "apps",
       "upsert",
       "--provider",
-      "integration:google",
+      "google",
       "--client-id",
       "abc",
       "--client-secret-credential-path",
-      "credential/integration:google/client_secret",
+      "credential/google/client_secret",
       "--json",
     ]);
     expect(exitCode).toBe(0);
     expect(mockUpsertAppCalls).toHaveLength(1);
     // Already-prefixed path should be passed through as-is
     expect(mockUpsertAppCalls[0]).toEqual({
-      provider: "integration:google",
+      provider: "google",
       clientId: "abc",
       clientSecretOpts: {
-        clientSecretCredentialPath:
-          "credential/integration:google/client_secret",
+        clientSecretCredentialPath: "credential/google/client_secret",
       },
     });
     const parsed = JSON.parse(stdout);
@@ -732,7 +717,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
       "apps",
       "upsert",
       "--provider",
-      "integration:google",
+      "google",
       "--client-id",
       "abc",
       "--client-secret-credential-path",
@@ -761,7 +746,7 @@ describe("assistant oauth ping <provider-key>", () => {
 
   test("returns ok when ping endpoint returns 200", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
@@ -773,16 +758,12 @@ describe("assistant oauth ping <provider-key>", () => {
     });
     mockResolveOAuthConnection = async () => ({
       id: "conn-1",
-      providerKey: "integration:google",
+      providerKey: "google",
       accountInfo: null,
       request: async () => ({ status: 200, headers: {}, body: {} }),
       withToken: async (fn) => fn("mock-access-token-xyz"),
     });
-    const { exitCode, stdout } = await runCli([
-      "ping",
-      "integration:google",
-      "--json",
-    ]);
+    const { exitCode, stdout } = await runCli(["ping", "google", "--json"]);
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(true);
@@ -791,11 +772,7 @@ describe("assistant oauth ping <provider-key>", () => {
 
   test("exits 1 when provider not found", async () => {
     mockGetProvider = () => undefined;
-    const { exitCode, stdout } = await runCli([
-      "ping",
-      "integration:unknown",
-      "--json",
-    ]);
+    const { exitCode, stdout } = await runCli(["ping", "unknown", "--json"]);
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
@@ -823,7 +800,7 @@ describe("assistant oauth ping <provider-key>", () => {
 
   test("exits 1 when ping endpoint returns non-2xx", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
@@ -835,16 +812,12 @@ describe("assistant oauth ping <provider-key>", () => {
     });
     mockResolveOAuthConnection = async () => ({
       id: "conn-1",
-      providerKey: "integration:google",
+      providerKey: "google",
       accountInfo: null,
       request: async () => ({ status: 403, headers: {}, body: "Forbidden" }),
       withToken: async (fn) => fn("mock-access-token-xyz"),
     });
-    const { exitCode, stdout } = await runCli([
-      "ping",
-      "integration:google",
-      "--json",
-    ]);
+    const { exitCode, stdout } = await runCli(["ping", "google", "--json"]);
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
@@ -853,7 +826,7 @@ describe("assistant oauth ping <provider-key>", () => {
 
   test("exits 1 when no connection can be resolved", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
@@ -864,13 +837,9 @@ describe("assistant oauth ping <provider-key>", () => {
       updatedAt: Date.now(),
     });
     mockResolveOAuthConnection = async () => {
-      throw new Error('No access token found for "integration:google".');
+      throw new Error('No access token found for "google".');
     };
-    const { exitCode, stdout } = await runCli([
-      "ping",
-      "integration:google",
-      "--json",
-    ]);
+    const { exitCode, stdout } = await runCli(["ping", "google", "--json"]);
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -666,22 +666,9 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
     });
   });
 
-  test("upsert resolves non-prefixed credential path via metadata store", async () => {
-    // The resolution logic splits on the LAST colon, so
-    // "integration:google:client_secret" → service="integration:google", field="client_secret"
-    mockGetCredentialMetadata = (service, field) =>
-      service === "integration:google" && field === "client_secret"
-        ? {
-            credentialId: "cred-1",
-            service: "integration:google",
-            field: "client_secret",
-            allowedTools: [],
-            allowedDomains: [],
-            createdAt: Date.now(),
-            updatedAt: Date.now(),
-          }
-        : undefined;
-
+  test("upsert passes non-prefixed credential path through unchanged", async () => {
+    // Short-form resolution (splitting on last colon) has been removed.
+    // Non-prefixed paths are now passed through as-is.
     const { exitCode, stdout } = await runCli([
       "apps",
       "upsert",
@@ -695,13 +682,11 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
     ]);
     expect(exitCode).toBe(0);
     expect(mockUpsertAppCalls).toHaveLength(1);
-    // The non-prefixed path should have been resolved to the full credential key
     expect(mockUpsertAppCalls[0]).toEqual({
       provider: "integration:google",
       clientId: "abc",
       clientSecretOpts: {
-        clientSecretCredentialPath:
-          "credential/integration:google/client_secret",
+        clientSecretCredentialPath: "integration:google:client_secret",
       },
     });
     const parsed = JSON.parse(stdout);

--- a/assistant/src/__tests__/oauth-provider-profiles.test.ts
+++ b/assistant/src/__tests__/oauth-provider-profiles.test.ts
@@ -10,7 +10,7 @@ describe("oauth provider behaviors", () => {
     const service = resolveService("gmail");
     const behavior = getProviderBehavior(service);
 
-    expect(service).toBe("integration:google");
+    expect(service).toBe("google");
     expect(behavior).toBeDefined();
     expect(behavior?.injectionTemplates).toBeDefined();
     expect(behavior?.injectionTemplates).toHaveLength(3);

--- a/assistant/src/__tests__/oauth-scope-policy.test.ts
+++ b/assistant/src/__tests__/oauth-scope-policy.test.ts
@@ -12,7 +12,7 @@ function makeProfile(
   overrides: Partial<ScopeResolverInput> = {},
 ): ScopeResolverInput {
   return {
-    service: "integration:test-service",
+    service: "test-service",
     defaultScopes: ["read", "write"],
     scopePolicy: {
       allowAdditionalScopes: false,
@@ -57,9 +57,7 @@ describe("resolveScopes", () => {
     const result = resolveScopes(profile, ["delete"]);
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error).toBe(
-        "Scope 'delete' is forbidden for integration:test-service",
-      );
+      expect(result.error).toBe("Scope 'delete' is forbidden for test-service");
     }
   });
 
@@ -76,7 +74,7 @@ describe("resolveScopes", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toContain(
-        "Additional scopes are not allowed for integration:test-service",
+        "Additional scopes are not allowed for test-service",
       );
       expect(result.allowedScopes).toEqual(["read", "write"]);
     }
@@ -95,7 +93,7 @@ describe("resolveScopes", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toBe(
-        "Scope 'admin' is not in the allowed optional scopes for integration:test-service",
+        "Scope 'admin' is not in the allowed optional scopes for test-service",
       );
       expect(result.allowedScopes).toEqual(["read", "write"]);
     }

--- a/assistant/src/__tests__/slack-messaging-token-resolution.test.ts
+++ b/assistant/src/__tests__/slack-messaging-token-resolution.test.ts
@@ -117,12 +117,12 @@ describe("Slack messaging token resolution", () => {
       expect(await slackProvider.isConnected!()).toBe(true);
     });
 
-    test("returns true when only integration:slack has active OAuth connection (backwards compat)", async () => {
+    test("returns true when only slack has active OAuth connection (backwards compat)", async () => {
       // No bot token
       getSecureKeyAsyncMock.mockImplementation(async () => null);
       // But OAuth provider is connected
       isProviderConnectedMock.mockImplementation(async (service: string) =>
-        service === "integration:slack" ? true : false,
+        service === "slack" ? true : false,
       );
 
       expect(await slackProvider.isConnected!()).toBe(true);
@@ -160,7 +160,7 @@ describe("Slack messaging token resolution", () => {
       expect(result).toBe("xoxb-token-only");
     });
 
-    test("returns OAuthConnection when only OAuth integration:slack credentials exist (backwards compat)", async () => {
+    test("returns OAuthConnection when only OAuth slack credentials exist (backwards compat)", async () => {
       getSecureKeyAsyncMock.mockImplementation(async () => null);
       const oauthConn = {
         accessToken: "xoxp-oauth-token",
@@ -169,16 +169,15 @@ describe("Slack messaging token resolution", () => {
 
       const result = await slackProvider.resolveConnection!();
       expect(result).toBe(oauthConn);
-      expect(resolveOAuthConnectionMock).toHaveBeenCalledWith(
-        "integration:slack",
-        { account: undefined },
-      );
+      expect(resolveOAuthConnectionMock).toHaveBeenCalledWith("slack", {
+        account: undefined,
+      });
     });
 
     test("throws when no credentials exist at all (no Socket Mode, no OAuth)", async () => {
       getSecureKeyAsyncMock.mockImplementation(async () => null);
       resolveOAuthConnectionMock.mockImplementation(async () => {
-        throw new Error("No OAuth connection found for integration:slack");
+        throw new Error("No OAuth connection found for slack");
       });
 
       await expect(slackProvider.resolveConnection!()).rejects.toThrow(
@@ -247,10 +246,9 @@ describe("Slack messaging token resolution", () => {
 
       const result = await getProviderConnection(gmailMessagingProvider);
       expect(result).toBe(oauthConn);
-      expect(resolveOAuthConnectionMock).toHaveBeenCalledWith(
-        "integration:google",
-        { account: undefined },
-      );
+      expect(resolveOAuthConnectionMock).toHaveBeenCalledWith("google", {
+        account: undefined,
+      });
     });
   });
 
@@ -264,7 +262,7 @@ describe("Slack messaging token resolution", () => {
       );
       // Gmail connected via OAuth
       isProviderConnectedMock.mockImplementation(async (service: string) =>
-        service === "integration:google" ? true : false,
+        service === "google" ? true : false,
       );
 
       await expect(resolveProvider()).rejects.toThrow(
@@ -285,7 +283,7 @@ describe("Slack messaging token resolution", () => {
     test("auto-selects Gmail when it is the only connected provider (no Slack credentials)", async () => {
       getSecureKeyAsyncMock.mockImplementation(async () => null);
       isProviderConnectedMock.mockImplementation(async (service: string) =>
-        service === "integration:google" ? true : false,
+        service === "google" ? true : false,
       );
 
       const provider = await resolveProvider();

--- a/assistant/src/__tests__/slack-share-routes.test.ts
+++ b/assistant/src/__tests__/slack-share-routes.test.ts
@@ -111,7 +111,7 @@ describe("handleListSlackChannels", () => {
   });
 
   test("returns channels sorted by type then name", async () => {
-    connectionByProvider["integration:slack"] = { id: "conn-slack-1" };
+    connectionByProvider["slack"] = { id: "conn-slack-1" };
     secureKeyValues.set(
       "oauth_connection/conn-slack-1/access_token",
       "xoxb-test",
@@ -192,7 +192,7 @@ describe("handleShareToSlackChannel", () => {
   });
 
   test("returns 400 for malformed JSON", async () => {
-    connectionByProvider["integration:slack"] = { id: "conn-slack-1" };
+    connectionByProvider["slack"] = { id: "conn-slack-1" };
     secureKeyValues.set(
       "oauth_connection/conn-slack-1/access_token",
       "xoxb-test",
@@ -207,7 +207,7 @@ describe("handleShareToSlackChannel", () => {
   });
 
   test("returns 400 when missing required fields", async () => {
-    connectionByProvider["integration:slack"] = { id: "conn-slack-1" };
+    connectionByProvider["slack"] = { id: "conn-slack-1" };
     secureKeyValues.set(
       "oauth_connection/conn-slack-1/access_token",
       "xoxb-test",
@@ -220,7 +220,7 @@ describe("handleShareToSlackChannel", () => {
   });
 
   test("returns 404 when app not found", async () => {
-    connectionByProvider["integration:slack"] = { id: "conn-slack-1" };
+    connectionByProvider["slack"] = { id: "conn-slack-1" };
     secureKeyValues.set(
       "oauth_connection/conn-slack-1/access_token",
       "xoxb-test",
@@ -232,7 +232,7 @@ describe("handleShareToSlackChannel", () => {
   });
 
   test("posts message and returns success", async () => {
-    connectionByProvider["integration:slack"] = { id: "conn-slack-1" };
+    connectionByProvider["slack"] = { id: "conn-slack-1" };
     secureKeyValues.set(
       "oauth_connection/conn-slack-1/access_token",
       "xoxb-test",

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -397,10 +397,7 @@ Examples:
   credential
     .command("set <value>")
     .description("Store a secret and create or update its metadata")
-    .requiredOption(
-      "--service <service>",
-      "Service namespace (e.g. integration:google)",
-    )
+    .requiredOption("--service <service>", "Service namespace (e.g. google)")
     .requiredOption("--field <field>", "Field name (e.g. client_secret)")
     .option("--label <label>", 'Human-friendly label (e.g. "prod", "work")')
     .option("--description <description>", "What this credential is used for")
@@ -511,10 +508,7 @@ Examples:
           `${service}:${field}`,
         );
         if (secretResult === "error") {
-          writeError(
-            cmd,
-            "Failed to delete credential from secure storage",
-          );
+          writeError(cmd, "Failed to delete credential from secure storage");
           process.exitCode = 1;
           return;
         }

--- a/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
@@ -83,13 +83,9 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
 mock.module("../../../../oauth/provider-behaviors.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   getProviderBehavior: (key: string) => mockGetProviderBehavior(key),
 }));
@@ -136,13 +132,9 @@ mock.module("../../../lib/daemon-credential-client.js", () => ({
 mock.module("../shared.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   isManagedMode: (key: string) => mockIsManagedMode(key),
   requirePlatformClient: async (_cmd: Command) => {
@@ -193,10 +185,6 @@ mock.module("../shared.js", () => ({
     if (!result.ok) return null;
     return result.body as Array<Record<string, unknown>>;
   },
-  toBareProvider: (provider: string): string =>
-    provider.startsWith("integration:")
-      ? provider.slice("integration:".length)
-      : provider,
 }));
 
 // ---------------------------------------------------------------------------
@@ -295,7 +283,7 @@ describe("assistant oauth connect", () => {
   // Provider alias resolution
   // -------------------------------------------------------------------------
 
-  test("provider alias 'gmail' resolves to integration:google", async () => {
+  test("provider alias 'gmail' resolves to google", async () => {
     let capturedProviderKey: string | undefined;
 
     mockGetProvider = (key: string) => {
@@ -312,7 +300,7 @@ describe("assistant oauth connect", () => {
       id: "app-1",
       clientId: "test-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "integration:google",
+      providerKey: "google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -325,7 +313,7 @@ describe("assistant oauth connect", () => {
     });
 
     await runCommand(["connect", "gmail", "--json"]);
-    expect(capturedProviderKey).toBe("integration:google");
+    expect(capturedProviderKey).toBe("google");
   });
 
   // -------------------------------------------------------------------------
@@ -334,7 +322,7 @@ describe("assistant oauth connect", () => {
 
   test("managed mode: prints connect URL without --open-browser", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: "google-oauth",
@@ -361,7 +349,7 @@ describe("assistant oauth connect", () => {
     expect(parsed.connectUrl).toBe(
       "https://platform.example.com/oauth/connect",
     );
-    expect(parsed.provider).toBe("integration:google");
+    expect(parsed.provider).toBe("google");
   });
 
   // -------------------------------------------------------------------------
@@ -370,7 +358,7 @@ describe("assistant oauth connect", () => {
 
   test("managed mode with --open-browser: opens browser and polls for new connection", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: "google-oauth",
@@ -427,7 +415,7 @@ describe("assistant oauth connect", () => {
 
   test("BYO mode: prints auth URL without --open-browser", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: null,
@@ -438,7 +426,7 @@ describe("assistant oauth connect", () => {
       id: "app-1",
       clientId: "byo-client-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "integration:google",
+      providerKey: "google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -448,12 +436,12 @@ describe("assistant oauth connect", () => {
       deferred: true,
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth?state=abc",
       state: "abc",
-      service: "integration:google",
+      service: "google",
     });
 
     const { exitCode, stdout } = await runCommand([
       "connect",
-      "integration:google",
+      "google",
       "--json",
     ]);
     expect(exitCode).toBe(0);
@@ -463,7 +451,7 @@ describe("assistant oauth connect", () => {
     expect(parsed.authUrl).toBe(
       "https://accounts.google.com/o/oauth2/v2/auth?state=abc",
     );
-    expect(parsed.service).toBe("integration:google");
+    expect(parsed.service).toBe("google");
   });
 
   // -------------------------------------------------------------------------
@@ -472,7 +460,7 @@ describe("assistant oauth connect", () => {
 
   test("BYO mode with --open-browser calls orchestrator with isInteractive: true", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: null,
@@ -483,7 +471,7 @@ describe("assistant oauth connect", () => {
       id: "app-1",
       clientId: "test-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "integration:google",
+      providerKey: "google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -501,7 +489,7 @@ describe("assistant oauth connect", () => {
 
     const { exitCode, stdout } = await runCommand([
       "connect",
-      "integration:google",
+      "google",
       "--client-id",
       "test-id",
       "--open-browser",
@@ -525,7 +513,7 @@ describe("assistant oauth connect", () => {
 
   test("BYO mode: missing app with --client-id returns error with hint", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: null,
@@ -535,7 +523,7 @@ describe("assistant oauth connect", () => {
 
     const { exitCode, stdout } = await runCommand([
       "connect",
-      "integration:google",
+      "google",
       "--client-id",
       "nonexistent-id",
       "--json",
@@ -553,7 +541,7 @@ describe("assistant oauth connect", () => {
 
   test("BYO mode: no client_id found returns error with hint", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: null,
@@ -563,7 +551,7 @@ describe("assistant oauth connect", () => {
 
     const { exitCode, stdout } = await runCommand([
       "connect",
-      "integration:google",
+      "google",
       "--json",
     ]);
     expect(exitCode).toBe(1);
@@ -579,7 +567,7 @@ describe("assistant oauth connect", () => {
 
   test("--client-id is silently ignored in managed mode", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: "google-oauth",
@@ -616,7 +604,7 @@ describe("assistant oauth connect", () => {
 
   test("JSON output for deferred case includes ok, deferred, authUrl, service", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:slack",
+      providerKey: "slack",
       authUrl: "https://slack.com/oauth/v2/authorize",
       tokenUrl: "https://slack.com/api/oauth.v2.access",
       managedServiceConfigKey: null,
@@ -627,7 +615,7 @@ describe("assistant oauth connect", () => {
       id: "app-slack",
       clientId: "slack-client-id",
       clientSecretCredentialPath: "oauth_app/app-slack/client_secret",
-      providerKey: "integration:slack",
+      providerKey: "slack",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -637,7 +625,7 @@ describe("assistant oauth connect", () => {
       deferred: true,
       authUrl: "https://slack.com/oauth/v2/authorize?state=xyz",
       state: "xyz",
-      service: "integration:slack",
+      service: "slack",
     });
 
     const { exitCode, stdout } = await runCommand([
@@ -650,7 +638,7 @@ describe("assistant oauth connect", () => {
     expect(parsed).toHaveProperty("ok", true);
     expect(parsed).toHaveProperty("deferred", true);
     expect(parsed).toHaveProperty("authUrl");
-    expect(parsed).toHaveProperty("service", "integration:slack");
+    expect(parsed).toHaveProperty("service", "slack");
   });
 
   // -------------------------------------------------------------------------
@@ -659,7 +647,7 @@ describe("assistant oauth connect", () => {
 
   test("JSON output for completed case includes ok, grantedScopes, accountInfo", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: null,
@@ -670,7 +658,7 @@ describe("assistant oauth connect", () => {
       id: "app-1",
       clientId: "completed-client-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "integration:google",
+      providerKey: "google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -703,7 +691,7 @@ describe("assistant oauth connect", () => {
 
   test("BYO mode: client_secret required but missing returns error with hint", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       tokenEndpointAuthMethod: "client_secret_post",
@@ -715,7 +703,7 @@ describe("assistant oauth connect", () => {
       id: "app-1",
       clientId: "test-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "integration:google",
+      providerKey: "google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -735,7 +723,7 @@ describe("assistant oauth connect", () => {
 
     const { exitCode, stdout } = await runCommand([
       "connect",
-      "integration:google",
+      "google",
       "--json",
     ]);
     expect(exitCode).toBe(1);
@@ -751,7 +739,7 @@ describe("assistant oauth connect", () => {
 
   test("BYO mode: orchestrator error propagates correctly", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: null,
@@ -762,7 +750,7 @@ describe("assistant oauth connect", () => {
       id: "app-1",
       clientId: "client-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "integration:google",
+      providerKey: "google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -774,7 +762,7 @@ describe("assistant oauth connect", () => {
 
     const { exitCode, stdout } = await runCommand([
       "connect",
-      "integration:google",
+      "google",
       "--json",
     ]);
     expect(exitCode).toBe(1);

--- a/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
@@ -100,13 +100,9 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
 mock.module("../../../../oauth/provider-behaviors.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   getProviderBehavior: () => undefined,
 }));
@@ -167,13 +163,9 @@ mock.module("../../../lib/daemon-credential-client.js", () => ({
 mock.module("../shared.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   isManagedMode: (key: string) => mockIsManagedMode(key),
   requirePlatformClient: async (_cmd: Command) => {
@@ -222,10 +214,6 @@ mock.module("../shared.js", () => ({
     if (!result.ok) return null;
     return result.body as Array<Record<string, unknown>>;
   },
-  toBareProvider: (provider: string): string =>
-    provider.startsWith("integration:")
-      ? provider.slice("integration:".length)
-      : provider,
 }));
 
 // ---------------------------------------------------------------------------
@@ -323,7 +311,7 @@ describe("assistant oauth disconnect", () => {
 
   test("both --account and --connection-id returns error", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       managedServiceConfigKey: null,
     });
 
@@ -351,7 +339,7 @@ describe("assistant oauth disconnect", () => {
   describe("managed mode", () => {
     beforeEach(() => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockIsManagedMode = () => true;
@@ -384,7 +372,7 @@ describe("assistant oauth disconnect", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.connectionId).toBe("conn-1");
       expect(parsed.account).toBe("user@gmail.com");
     });
@@ -512,7 +500,7 @@ describe("assistant oauth disconnect", () => {
   describe("BYO mode", () => {
     beforeEach(() => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: null,
       });
       mockIsManagedMode = () => false;
@@ -522,7 +510,7 @@ describe("assistant oauth disconnect", () => {
       mockListActiveConnectionsByProvider = () => [
         {
           id: "conn-1",
-          providerKey: "integration:google",
+          providerKey: "google",
           accountInfo: "user@gmail.com",
           status: "active",
         },
@@ -536,60 +524,14 @@ describe("assistant oauth disconnect", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.connectionId).toBe("conn-1");
       expect(parsed.account).toBe("user@gmail.com");
 
       // Verify disconnectOAuthProvider was called
       expect(mockDisconnectOAuthProviderCalls).toHaveLength(1);
-      expect(mockDisconnectOAuthProviderCalls[0].providerKey).toBe(
-        "integration:google",
-      );
+      expect(mockDisconnectOAuthProviderCalls[0].providerKey).toBe("google");
       expect(mockDisconnectOAuthProviderCalls[0].connectionId).toBe("conn-1");
-    });
-
-    test("single connection also cleans up legacy credential keys", async () => {
-      mockListActiveConnectionsByProvider = () => [
-        {
-          id: "conn-1",
-          providerKey: "integration:google",
-          accountInfo: "user@gmail.com",
-          status: "active",
-        },
-      ];
-
-      await runCommand(["disconnect", "google", "--json"]);
-
-      // Should have attempted to delete legacy keys
-      const expectedFields = [
-        "access_token",
-        "refresh_token",
-        "client_id",
-        "client_secret",
-      ];
-      expect(mockDeleteSecureKeyViaDaemonCalls.length).toBe(
-        expectedFields.length,
-      );
-      for (const field of expectedFields) {
-        expect(
-          mockDeleteSecureKeyViaDaemonCalls.some(
-            (c) =>
-              c.type === "credential" &&
-              c.name === `integration:google:${field}`,
-          ),
-        ).toBe(true);
-      }
-
-      expect(mockDeleteCredentialMetadataCalls.length).toBe(
-        expectedFields.length,
-      );
-      for (const field of expectedFields) {
-        expect(
-          mockDeleteCredentialMetadataCalls.some(
-            (c) => c.service === "integration:google" && c.field === field,
-          ),
-        ).toBe(true);
-      }
     });
 
     test("--account matches accountInfo", async () => {
@@ -597,7 +539,7 @@ describe("assistant oauth disconnect", () => {
         if (opts?.account === "user@gmail.com") {
           return {
             id: "conn-1",
-            providerKey: "integration:google",
+            providerKey: "google",
             accountInfo: "user@gmail.com",
             status: "active",
           };
@@ -641,7 +583,7 @@ describe("assistant oauth disconnect", () => {
         if (id === "conn-123") {
           return {
             id: "conn-123",
-            providerKey: "integration:google",
+            providerKey: "google",
             accountInfo: "user@gmail.com",
             status: "active",
           };
@@ -667,7 +609,7 @@ describe("assistant oauth disconnect", () => {
         if (id === "conn-slack") {
           return {
             id: "conn-slack",
-            providerKey: "integration:slack",
+            providerKey: "slack",
             accountInfo: null,
             status: "active",
           };
@@ -693,13 +635,13 @@ describe("assistant oauth disconnect", () => {
       mockListActiveConnectionsByProvider = () => [
         {
           id: "conn-1",
-          providerKey: "integration:google",
+          providerKey: "google",
           accountInfo: "user1@gmail.com",
           status: "active",
         },
         {
           id: "conn-2",
-          providerKey: "integration:google",
+          providerKey: "google",
           accountInfo: "user2@gmail.com",
           status: "active",
         },
@@ -740,7 +682,7 @@ describe("assistant oauth disconnect", () => {
       mockListActiveConnectionsByProvider = () => [
         {
           id: "conn-1",
-          providerKey: "integration:google",
+          providerKey: "google",
           accountInfo: null,
           status: "active",
         },

--- a/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
@@ -92,13 +92,9 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
 mock.module("../../../../oauth/provider-behaviors.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   getProviderBehavior: () => undefined,
 }));
@@ -133,13 +129,9 @@ mock.module("../../../lib/daemon-credential-client.js", () => ({
 mock.module("../shared.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   isManagedMode: () => false,
   getManagedServiceConfigKey: (key: string) =>
@@ -193,10 +185,6 @@ mock.module("../shared.js", () => ({
     if (!result.ok) return null;
     return result.body as Array<Record<string, unknown>>;
   },
-  toBareProvider: (provider: string): string =>
-    provider.startsWith("integration:")
-      ? provider.slice("integration:".length)
-      : provider,
 }));
 
 // ---------------------------------------------------------------------------
@@ -295,7 +283,7 @@ describe("assistant oauth mode", () => {
       expect(parsed.error).toContain("providers list");
     });
 
-    test("provider alias resolution: gmail resolves to integration:google", async () => {
+    test("provider alias resolution: gmail resolves to google", async () => {
       let capturedProviderKey: string | undefined;
 
       mockGetProvider = (key: string) => {
@@ -311,12 +299,12 @@ describe("assistant oauth mode", () => {
       };
 
       await runCommand(["mode", "gmail", "--json"]);
-      expect(capturedProviderKey).toBe("integration:google");
+      expect(capturedProviderKey).toBe("google");
     });
 
     test("provider without managedServiceConfigKey returns your-own with managedModeSupported: false", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:slack",
+        providerKey: "slack",
         managedServiceConfigKey: null,
       });
       mockGetManagedServiceConfigKey = () => null;
@@ -329,14 +317,14 @@ describe("assistant oauth mode", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:slack");
+      expect(parsed.provider).toBe("slack");
       expect(parsed.mode).toBe("your-own");
       expect(parsed.managedModeSupported).toBe(false);
     });
 
     test("provider in managed mode returns mode: managed with managedModeSupported: true", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -352,14 +340,14 @@ describe("assistant oauth mode", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.mode).toBe("managed");
       expect(parsed.managedModeSupported).toBe(true);
     });
 
     test("provider in your-own mode returns mode: your-own with managedModeSupported: true", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -375,7 +363,7 @@ describe("assistant oauth mode", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.mode).toBe("your-own");
       expect(parsed.managedModeSupported).toBe(true);
     });
@@ -388,7 +376,7 @@ describe("assistant oauth mode", () => {
   describe("set mode", () => {
     test("invalid mode value returns error listing valid values", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -410,7 +398,7 @@ describe("assistant oauth mode", () => {
 
     test("provider without managedServiceConfigKey returns error about managed mode not available when --set managed", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:slack",
+        providerKey: "slack",
         managedServiceConfigKey: null,
       });
       mockGetManagedServiceConfigKey = () => null;
@@ -426,12 +414,12 @@ describe("assistant oauth mode", () => {
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(false);
       expect(parsed.error).toContain("Managed mode is not available");
-      expect(parsed.error).toContain("integration:slack");
+      expect(parsed.error).toContain("slack");
     });
 
     test("provider without managedServiceConfigKey treats --set your-own as successful no-op", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:slack",
+        providerKey: "slack",
         managedServiceConfigKey: null,
       });
       mockGetManagedServiceConfigKey = () => null;
@@ -446,7 +434,7 @@ describe("assistant oauth mode", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:slack");
+      expect(parsed.provider).toBe("slack");
       expect(parsed.mode).toBe("your-own");
       expect(parsed.changed).toBe(false);
       expect(parsed.managedModeSupported).toBe(false);
@@ -454,7 +442,7 @@ describe("assistant oauth mode", () => {
 
     test("set to same mode returns changed: false", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -472,7 +460,7 @@ describe("assistant oauth mode", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.mode).toBe("managed");
       expect(parsed.changed).toBe(false);
       expect(parsed.managedModeSupported).toBe(true);
@@ -480,7 +468,7 @@ describe("assistant oauth mode", () => {
 
     test("switch managed -> your-own with active managed connections and no BYO connections includes hint", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -512,7 +500,7 @@ describe("assistant oauth mode", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.mode).toBe("your-own");
       expect(parsed.changed).toBe(true);
       expect(parsed.managedModeSupported).toBe(true);
@@ -523,7 +511,7 @@ describe("assistant oauth mode", () => {
 
     test("switch your-own -> managed with active BYO connections and no managed connections includes hint", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -536,7 +524,7 @@ describe("assistant oauth mode", () => {
       mockListActiveConnectionsByProvider = () => [
         {
           id: "conn-local-1",
-          providerKey: "integration:google",
+          providerKey: "google",
           status: "active",
         },
       ];
@@ -555,7 +543,7 @@ describe("assistant oauth mode", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.mode).toBe("managed");
       expect(parsed.changed).toBe(true);
       expect(parsed.managedModeSupported).toBe(true);
@@ -566,7 +554,7 @@ describe("assistant oauth mode", () => {
 
     test("switch mode with connections on both sides has no hint", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -589,7 +577,7 @@ describe("assistant oauth mode", () => {
       mockListActiveConnectionsByProvider = () => [
         {
           id: "conn-local-1",
-          providerKey: "integration:google",
+          providerKey: "google",
           status: "active",
         },
       ];
@@ -611,7 +599,7 @@ describe("assistant oauth mode", () => {
 
     test("switch mode with no connections on either side has no hint", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -644,7 +632,7 @@ describe("assistant oauth mode", () => {
 
     test("saveRawConfig is called with the correct nested path", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";

--- a/assistant/src/cli/commands/oauth/__tests__/ping.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/ping.test.ts
@@ -54,13 +54,9 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
 mock.module("../../../../oauth/provider-behaviors.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   getProviderBehavior: () => undefined,
 }));
@@ -103,21 +99,13 @@ mock.module("../../../../util/logger.js", () => ({
 mock.module("../shared.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   isManagedMode: () => false,
   requirePlatformClient: async () => null,
   fetchActiveConnections: async () => [],
-  toBareProvider: (provider: string): string =>
-    provider.startsWith("integration:")
-      ? provider.slice("integration:".length)
-      : provider,
 }));
 
 // ---------------------------------------------------------------------------
@@ -214,7 +202,7 @@ describe("assistant oauth ping", () => {
 
   test("no ping URL configured returns error", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: null,
     });
 
@@ -230,9 +218,9 @@ describe("assistant oauth ping", () => {
   // Provider alias resolution
   // -------------------------------------------------------------------------
 
-  test("resolves provider alias (gmail -> integration:google)", async () => {
+  test("resolves provider alias (gmail -> google)", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
     });
 
@@ -248,13 +236,11 @@ describe("assistant oauth ping", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(true);
-    expect(parsed.provider).toBe("integration:google");
+    expect(parsed.provider).toBe("google");
 
     // Verify resolveOAuthConnection was called with resolved key
     expect(mockResolveOAuthConnectionCalls).toHaveLength(1);
-    expect(mockResolveOAuthConnectionCalls[0].providerKey).toBe(
-      "integration:google",
-    );
+    expect(mockResolveOAuthConnectionCalls[0].providerKey).toBe("google");
   });
 
   // =========================================================================
@@ -264,7 +250,7 @@ describe("assistant oauth ping", () => {
   describe("BYO mode", () => {
     beforeEach(() => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
         managedServiceConfigKey: null,
       });
@@ -287,7 +273,7 @@ describe("assistant oauth ping", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.status).toBe(200);
     });
 
@@ -308,7 +294,7 @@ describe("assistant oauth ping", () => {
       expect(exitCode).toBe(1);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(false);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.status).toBe(500);
       expect(parsed.error).toContain("Ping failed with HTTP 500");
     });
@@ -366,7 +352,7 @@ describe("assistant oauth ping", () => {
   describe("managed mode", () => {
     beforeEach(() => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
         managedServiceConfigKey: "google-oauth",
       });
@@ -389,7 +375,7 @@ describe("assistant oauth ping", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.status).toBe(200);
     });
 
@@ -410,7 +396,7 @@ describe("assistant oauth ping", () => {
       expect(exitCode).toBe(1);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(false);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.status).toBe(502);
       expect(parsed.error).toContain("Ping failed with HTTP 502");
     });
@@ -422,12 +408,12 @@ describe("assistant oauth ping", () => {
 
   test("connection resolution failure (no active connection) with recovery hint", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
     });
 
     mockResolveOAuthConnectionResult = new Error(
-      'No active OAuth connection found for "integration:google". Connect the service first with oauth2_connect.',
+      'No active OAuth connection found for "google". Connect the service first with oauth2_connect.',
     );
 
     const { exitCode, stdout } = await runCommand(["ping", "google", "--json"]);
@@ -445,7 +431,7 @@ describe("assistant oauth ping", () => {
 
   test("--account option passed through to connection resolution", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
     });
 
@@ -478,7 +464,7 @@ describe("assistant oauth ping", () => {
 
   test("--client-id option passed through to connection resolution", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
     });
 
@@ -511,7 +497,7 @@ describe("assistant oauth ping", () => {
 
   test("JSON output mode returns structured response", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
     });
 
@@ -529,7 +515,7 @@ describe("assistant oauth ping", () => {
 
     // Verify JSON structure
     expect(parsed).toHaveProperty("ok", true);
-    expect(parsed).toHaveProperty("provider", "integration:google");
+    expect(parsed).toHaveProperty("provider", "google");
     expect(parsed).toHaveProperty("status", 200);
   });
 
@@ -539,7 +525,7 @@ describe("assistant oauth ping", () => {
 
   test("human output mode logs to stderr on success", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
     });
 
@@ -558,7 +544,7 @@ describe("assistant oauth ping", () => {
     // In human mode, output is still written via writeOutput
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(true);
-    expect(parsed.provider).toBe("integration:google");
+    expect(parsed.provider).toBe("google");
   });
 
   // =========================================================================
@@ -567,7 +553,7 @@ describe("assistant oauth ping", () => {
 
   test("uses configured pingMethod for POST providers", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:dropbox",
+      providerKey: "dropbox",
       pingUrl: "https://api.dropboxapi.com/2/users/get_current_account",
       pingMethod: "POST",
       pingHeaders: null,
@@ -589,7 +575,7 @@ describe("assistant oauth ping", () => {
 
   test("uses configured pingHeaders", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:notion",
+      providerKey: "notion",
       pingUrl: "https://api.notion.com/v1/users/me",
       pingMethod: null,
       pingHeaders: '{"Notion-Version":"2022-06-28"}',
@@ -613,7 +599,7 @@ describe("assistant oauth ping", () => {
 
   test("uses configured pingBody for GraphQL providers", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:linear",
+      providerKey: "linear",
       pingUrl: "https://api.linear.app/graphql",
       pingMethod: "POST",
       pingHeaders: '{"Content-Type":"application/json"}',
@@ -641,7 +627,7 @@ describe("assistant oauth ping", () => {
 
   test("defaults to GET with no extra headers/body when ping config is null", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
       pingMethod: null,
       pingHeaders: null,
@@ -669,7 +655,7 @@ describe("assistant oauth ping", () => {
 
   test("network failure returns error with recovery hint", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
     });
 

--- a/assistant/src/cli/commands/oauth/__tests__/status.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/status.test.ts
@@ -59,13 +59,9 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
 mock.module("../../../../oauth/provider-behaviors.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   getProviderBehavior: () => undefined,
 }));
@@ -112,13 +108,9 @@ mock.module("../../../lib/daemon-credential-client.js", () => ({
 mock.module("../shared.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   isManagedMode: (key: string) => mockIsManagedMode(key),
   requirePlatformClient: async (_cmd: Command) => {
@@ -167,10 +159,6 @@ mock.module("../shared.js", () => ({
     if (!result.ok) return null;
     return result.body as Array<Record<string, unknown>>;
   },
-  toBareProvider: (provider: string): string =>
-    provider.startsWith("integration:")
-      ? provider.slice("integration:".length)
-      : provider,
 }));
 
 // ---------------------------------------------------------------------------
@@ -263,7 +251,7 @@ describe("assistant oauth status", () => {
   describe("managed mode", () => {
     beforeEach(() => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockIsManagedMode = () => true;
@@ -300,7 +288,7 @@ describe("assistant oauth status", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.mode).toBe("managed");
       expect(parsed.connections).toHaveLength(2);
 
@@ -327,7 +315,7 @@ describe("assistant oauth status", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.mode).toBe("managed");
       expect(parsed.connections).toEqual([]);
     });
@@ -388,7 +376,7 @@ describe("assistant oauth status", () => {
   describe("BYO mode", () => {
     beforeEach(() => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: null,
       });
       mockIsManagedMode = () => false;
@@ -399,7 +387,7 @@ describe("assistant oauth status", () => {
       mockListConnections = () => [
         {
           id: "conn-local-1",
-          providerKey: "integration:google",
+          providerKey: "google",
           accountInfo: "localuser@gmail.com",
           grantedScopes: '["email","profile"]',
           expiresAt,
@@ -416,7 +404,7 @@ describe("assistant oauth status", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.mode).toBe("byo");
       expect(parsed.connections).toHaveLength(1);
 
@@ -433,7 +421,7 @@ describe("assistant oauth status", () => {
       mockListConnections = () => [
         {
           id: "conn-local-2",
-          providerKey: "integration:google",
+          providerKey: "google",
           accountInfo: null,
           grantedScopes: "[]",
           expiresAt: null,
@@ -460,7 +448,7 @@ describe("assistant oauth status", () => {
       mockListConnections = () => [
         {
           id: "conn-active",
-          providerKey: "integration:google",
+          providerKey: "google",
           accountInfo: "user@gmail.com",
           grantedScopes: "[]",
           expiresAt: null,
@@ -469,7 +457,7 @@ describe("assistant oauth status", () => {
         },
         {
           id: "conn-revoked",
-          providerKey: "integration:google",
+          providerKey: "google",
           accountInfo: "old@gmail.com",
           grantedScopes: "[]",
           expiresAt: null,
@@ -500,7 +488,7 @@ describe("assistant oauth status", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.mode).toBe("byo");
       expect(parsed.connections).toEqual([]);
     });
@@ -517,7 +505,7 @@ describe("assistant oauth status", () => {
       mockListConnections = () => [
         {
           id: "conn-structure",
-          providerKey: "integration:google",
+          providerKey: "google",
           accountInfo: "check@gmail.com",
           grantedScopes: '["scope1"]',
           expiresAt: Date.now() + 60_000,
@@ -555,7 +543,7 @@ describe("assistant oauth status", () => {
       mockListConnections = () => [
         {
           id: "conn-bad-scopes",
-          providerKey: "integration:google",
+          providerKey: "google",
           accountInfo: null,
           grantedScopes: "not-valid-json",
           expiresAt: null,

--- a/assistant/src/cli/commands/oauth/__tests__/token.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/token.test.ts
@@ -57,13 +57,9 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
 mock.module("../../../../oauth/provider-behaviors.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   getProviderBehavior: () => undefined,
 }));
@@ -100,19 +96,11 @@ mock.module("../../../lib/daemon-credential-client.js", () => ({
 mock.module("../shared.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   isManagedMode: (key: string) => mockIsManagedMode(key),
-  toBareProvider: (provider: string): string =>
-    provider.startsWith("integration:")
-      ? provider.slice("integration:".length)
-      : provider,
 }));
 
 // ---------------------------------------------------------------------------
@@ -219,7 +207,7 @@ describe("assistant oauth token", () => {
     test("no active connection returns error", async () => {
       mockWithValidToken = async () => {
         throw new Error(
-          'No access token found for "integration:google". Authorization required.',
+          'No access token found for "google". Authorization required.',
         );
       };
 
@@ -239,7 +227,7 @@ describe("assistant oauth token", () => {
   // Provider alias resolution
   // =========================================================================
 
-  test("resolves provider alias (gmail -> integration:google)", async () => {
+  test("resolves provider alias (gmail -> google)", async () => {
     let calledWithService = "";
     mockWithValidToken = async (service, callback) => {
       calledWithService = service;
@@ -248,7 +236,7 @@ describe("assistant oauth token", () => {
 
     const { exitCode, stdout } = await runCommand(["token", "gmail", "--json"]);
     expect(exitCode).toBe(0);
-    expect(calledWithService).toBe("integration:google");
+    expect(calledWithService).toBe("google");
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(true);
     expect(parsed.token).toBe("alias-token");
@@ -316,7 +304,7 @@ describe("assistant oauth token", () => {
         if (options?.account === "user@gmail.com") {
           return {
             id: "conn-abc-123",
-            providerKey: "integration:google",
+            providerKey: "google",
             accountInfo: "user@gmail.com",
             status: "active",
           };
@@ -373,7 +361,7 @@ describe("assistant oauth token", () => {
         if (options?.clientId === "my-client-id") {
           return {
             id: "conn-client-456",
-            providerKey: "integration:google",
+            providerKey: "google",
             accountInfo: null,
             status: "active",
           };

--- a/assistant/src/cli/commands/oauth/apps.ts
+++ b/assistant/src/cli/commands/oauth/apps.ts
@@ -48,8 +48,8 @@ a provider with a mode of "your-own" set.
 Examples:
   $ assistant oauth apps list
   $ assistant oauth apps get --id <uuid>
-  $ assistant oauth apps get --provider integration:google
-  $ assistant oauth apps upsert --provider integration:google --client-id abc123
+  $ assistant oauth apps get --provider google
+  $ assistant oauth apps upsert --provider google --client-id abc123
   $ assistant oauth apps delete <id>`,
   );
 
@@ -101,7 +101,7 @@ Examples:
     .option("--id <id>", "App ID (UUID) from 'assistant oauth apps list'")
     .option(
       "--provider <key>",
-      "Provider key (e.g. integration:google) from 'assistant oauth providers list'",
+      "Provider key (e.g. google) from 'assistant oauth providers list'",
     )
     .option(
       "--client-id <id>",
@@ -116,10 +116,10 @@ Three lookup modes are supported:
      $ assistant oauth apps get --id <uuid>
 
   2. By provider + client ID (exact match):
-     $ assistant oauth apps get --provider integration:google --client-id abc123
+     $ assistant oauth apps get --provider google --client-id abc123
 
   3. By provider only (returns the most recently created app):
-     $ assistant oauth apps get --provider integration:google
+     $ assistant oauth apps get --provider google
 
 At least --id or --provider must be specified.`,
     )
@@ -179,7 +179,7 @@ At least --id or --provider must be specified.`,
     .description("Create or return an existing OAuth app registration")
     .requiredOption(
       "--provider <key>",
-      "Provider key (e.g. integration:google) from 'assistant oauth providers list'",
+      "Provider key (e.g. google) from 'assistant oauth providers list'",
     )
     .requiredOption(
       "--client-id <id>",
@@ -208,16 +208,16 @@ existing credential in the store via --client-secret-credential-path. These two
 options are mutually exclusive — providing both is an error.
 
 The --client-secret-credential-path accepts two formats:
-  1. Full credential path: "credential/integration:google/client_secret"
-  2. Short name (service:field): "integration:google:client_secret"
+  1. Full credential path: "credential/google/client_secret"
+  2. Short name (service:field): "google:client_secret"
      Resolved via the metadata store by splitting on the last colon.
 
 Examples:
-  $ assistant oauth apps upsert --provider integration:google --client-id abc123
-  $ assistant oauth apps upsert --provider integration:slack --client-id def456 --client-secret s3cret
-  $ assistant oauth apps upsert --provider integration:slack --client-id def456 --client-secret-credential-path "credential/integration:slack/client_secret"
-  $ assistant oauth apps upsert --provider integration:slack --client-id def456 --client-secret-credential-path "integration:slack:client_secret"
-  $ assistant oauth apps upsert --provider integration:google --client-id abc123 --json`,
+  $ assistant oauth apps upsert --provider google --client-id abc123
+  $ assistant oauth apps upsert --provider slack --client-id def456 --client-secret s3cret
+  $ assistant oauth apps upsert --provider slack --client-id def456 --client-secret-credential-path "credential/slack/client_secret"
+  $ assistant oauth apps upsert --provider slack --client-id def456 --client-secret-credential-path "slack:client_secret"
+  $ assistant oauth apps upsert --provider google --client-id abc123 --json`,
     )
     .action(
       async (

--- a/assistant/src/cli/commands/oauth/apps.ts
+++ b/assistant/src/cli/commands/oauth/apps.ts
@@ -8,8 +8,6 @@ import {
   listApps,
   upsertApp,
 } from "../../../oauth/oauth-store.js";
-import { credentialKey } from "../../../security/credential-key.js";
-import { getCredentialMetadata } from "../../../tools/credentials/metadata-store.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 
@@ -207,16 +205,13 @@ You can supply the client secret directly via --client-secret, or reference an
 existing credential in the store via --client-secret-credential-path. These two
 options are mutually exclusive — providing both is an error.
 
-The --client-secret-credential-path accepts two formats:
-  1. Full credential path: "credential/google/client_secret"
-  2. Short name (service:field): "google:client_secret"
-     Resolved via the metadata store by splitting on the last colon.
+The --client-secret-credential-path must be a full credential path
+(e.g. "credential/google/client_secret").
 
 Examples:
   $ assistant oauth apps upsert --provider google --client-id abc123
   $ assistant oauth apps upsert --provider slack --client-id def456 --client-secret s3cret
   $ assistant oauth apps upsert --provider slack --client-id def456 --client-secret-credential-path "credential/slack/client_secret"
-  $ assistant oauth apps upsert --provider slack --client-id def456 --client-secret-credential-path "slack:client_secret"
   $ assistant oauth apps upsert --provider google --client-id abc123 --json`,
     )
     .action(
@@ -240,28 +235,10 @@ Examples:
             return;
           }
 
-          let resolvedCredentialPath = opts.clientSecretCredentialPath;
-          if (
-            resolvedCredentialPath &&
-            !resolvedCredentialPath.startsWith("credential/")
-          ) {
-            // Attempt to interpret as a credential key — split on the LAST colon to get service/field
-            const lastColon = resolvedCredentialPath.lastIndexOf(":");
-            if (lastColon > 0) {
-              const asService = resolvedCredentialPath.slice(0, lastColon);
-              const asField = resolvedCredentialPath.slice(lastColon + 1);
-              // If a credential exists in metadata with these coordinates, resolve it
-              const meta = getCredentialMetadata(asService, asField);
-              if (meta) {
-                resolvedCredentialPath = credentialKey(asService, asField);
-              }
-            }
-          }
-
           const clientSecretOpts = opts.clientSecret
             ? { clientSecretValue: opts.clientSecret }
-            : resolvedCredentialPath
-              ? { clientSecretCredentialPath: resolvedCredentialPath }
+            : opts.clientSecretCredentialPath
+              ? { clientSecretCredentialPath: opts.clientSecretCredentialPath }
               : undefined;
           const row = await upsertApp(
             opts.provider,

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -40,9 +40,8 @@ export function registerConnectCommand(oauth: Command): void {
       "after",
       `
 Arguments:
-  provider   Provider key, alias, or ID from 'assistant oauth providers list'.
-             Accepts canonical keys (e.g. integration:google), aliases (e.g.
-             gmail), or bare provider names (e.g. google).
+  provider   Provider name (e.g. google, slack, gmail).
+             Run 'assistant oauth providers list' to see available providers.
 
 Options:
   --scopes <scopes...>   Scopes to request for the authorization. In managed
@@ -60,7 +59,7 @@ Options:
 Examples:
   $ assistant oauth connect google
   $ assistant oauth connect gmail --open-browser
-  $ assistant oauth connect integration:google --scopes https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/calendar.events
+  $ assistant oauth connect google --scopes https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/calendar.events
   $ assistant oauth connect google --client-id abc123 --open-browser`,
     )
     .action(

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -16,7 +16,6 @@ import {
   isManagedMode,
   requirePlatformClient,
   resolveService,
-  toBareProvider,
 } from "./shared.js";
 
 const log = getCliLogger("cli");
@@ -121,7 +120,7 @@ Examples:
             if (!client) return;
 
             // Call the platform's OAuth start endpoint
-            const startPath = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/${encodeURIComponent(toBareProvider(providerKey))}/start/`;
+            const startPath = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/${encodeURIComponent(providerKey)}/start/`;
 
             const body: Record<string, unknown> = {};
             if (opts.scopes && opts.scopes.length > 0) {

--- a/assistant/src/cli/commands/oauth/disconnect.ts
+++ b/assistant/src/cli/commands/oauth/disconnect.ts
@@ -7,8 +7,6 @@ import {
   getProvider,
   listActiveConnectionsByProvider,
 } from "../../../oauth/oauth-store.js";
-import { deleteCredentialMetadata } from "../../../tools/credentials/metadata-store.js";
-import { deleteSecureKeyViaDaemon } from "../../lib/daemon-credential-client.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 import {
@@ -284,29 +282,6 @@ Examples:
                 `Failed to disconnect OAuth provider "${providerKey}" — please try again.`,
               );
               return;
-            }
-
-            // Clean up legacy credential keys
-            const legacyFields = [
-              "access_token",
-              "refresh_token",
-              "client_id",
-              "client_secret",
-            ];
-            for (const field of legacyFields) {
-              try {
-                await deleteSecureKeyViaDaemon(
-                  "credential",
-                  `${providerKey}:${field}`,
-                );
-              } catch {
-                // Best-effort cleanup — ignore failures
-              }
-              try {
-                deleteCredentialMetadata(providerKey, field);
-              } catch {
-                // Best-effort cleanup — ignore failures
-              }
             }
 
             const result: Record<string, unknown> = {

--- a/assistant/src/cli/commands/oauth/disconnect.ts
+++ b/assistant/src/cli/commands/oauth/disconnect.ts
@@ -16,7 +16,6 @@ import {
   isManagedMode,
   requirePlatformClient,
   resolveService,
-  toBareProvider,
 } from "./shared.js";
 
 const log = getCliLogger("cli");
@@ -138,7 +137,7 @@ Examples:
               );
               if (matching.length === 0) {
                 writeError(
-                  `No active connection found for "${toBareProvider(providerKey)}" with account "${opts.account}".\n\n` +
+                  `No active connection found for "${providerKey}" with account "${opts.account}".\n\n` +
                     `Run 'assistant oauth status ${provider}' to see connected accounts.`,
                 );
                 return;
@@ -150,7 +149,7 @@ Examples:
               const match = entries.find((c) => c.id === opts.connectionId);
               if (!match) {
                 writeError(
-                  `Connection "${opts.connectionId}" is not an active ${toBareProvider(providerKey)} connection.\n\n` +
+                  `Connection "${opts.connectionId}" is not an active ${providerKey} connection.\n\n` +
                     `Run 'assistant oauth status ${provider}' to see active connections.`,
                 );
                 return;
@@ -161,7 +160,7 @@ Examples:
               // Neither specified — auto-resolve
               if (entries.length === 0) {
                 writeError(
-                  `No active connections found for "${toBareProvider(providerKey)}".\n\n` +
+                  `No active connections found for "${providerKey}".\n\n` +
                     `Run 'assistant oauth status ${provider}' to check connection status.`,
                 );
                 return;
@@ -173,7 +172,7 @@ Examples:
                   account: c.account_label ?? null,
                 }));
                 writeError(
-                  `Multiple active connections for "${toBareProvider(providerKey)}". ` +
+                  `Multiple active connections for "${providerKey}". ` +
                     `Specify which one to disconnect with --account or --connection-id.\n\n` +
                     `Run 'assistant oauth status ${provider}' to see connected accounts and IDs.`,
                   { connections: connectionList },

--- a/assistant/src/cli/commands/oauth/disconnect.ts
+++ b/assistant/src/cli/commands/oauth/disconnect.ts
@@ -39,7 +39,7 @@ export function registerDisconnectCommand(oauth: Command): void {
       "after",
       `
 Arguments:
-  provider   Provider name or key (e.g. google, integration:google, gmail).
+  provider   Provider name (e.g. google, slack, gmail).
              Run 'assistant oauth providers list' to see available providers.
 
 Options:

--- a/assistant/src/cli/commands/oauth/index.ts
+++ b/assistant/src/cli/commands/oauth/index.ts
@@ -36,13 +36,13 @@ You can define entirely new oauth providers to integrate with even if they do no
 
 Examples:
   assistant oauth providers list
-  assistant oauth providers get integration:google
-  assistant oauth mode integration:google --set=managed
-  assistant oauth connect integration:google --open-browser
-  assistant oauth status integration:google
-  assistant oauth ping integration:google
-  assistant oauth request --provider integration:google /gmail/v1/users/me/messages
-  assistant oauth disconnect integration:google`,
+  assistant oauth providers get google
+  assistant oauth mode google --set=managed
+  assistant oauth connect google --open-browser
+  assistant oauth status google
+  assistant oauth ping google
+  assistant oauth request --provider google /gmail/v1/users/me/messages
+  assistant oauth disconnect google`,
   );
 
   // ---------------------------------------------------------------------------

--- a/assistant/src/cli/commands/oauth/mode.ts
+++ b/assistant/src/cli/commands/oauth/mode.ts
@@ -18,7 +18,6 @@ import {
   fetchActiveConnections,
   getManagedServiceConfigKey,
   resolveService,
-  toBareProvider,
 } from "./shared.js";
 
 /**
@@ -216,8 +215,6 @@ Examples:
         // Best-effort check for active connections on old and new modes
         let oldModeConnections = 0;
         let newModeConnections = 0;
-        const bareProvider = toBareProvider(providerKey);
-
         if (currentMode === "managed") {
           // Old mode was managed — check platform connections
           oldModeConnections = await countManagedConnections(providerKey, cmd);
@@ -235,7 +232,7 @@ Examples:
         // Build hint if there are connections on the old mode but none on the new
         let hint: string | undefined;
         if (oldModeConnections > 0 && newModeConnections === 0) {
-          hint = `No active connections in ${newMode} mode. Run 'assistant oauth connect ${bareProvider}' to connect.`;
+          hint = `No active connections in ${newMode} mode. Run 'assistant oauth connect ${providerKey}' to connect.`;
         }
 
         if (shouldOutputJson(cmd)) {

--- a/assistant/src/cli/commands/oauth/mode.ts
+++ b/assistant/src/cli/commands/oauth/mode.ts
@@ -62,7 +62,7 @@ export function registerModeCommand(oauth: Command): void {
       "after",
       `
 Arguments:
-  provider   Provider key, alias, or ID (e.g. google, integration:google).
+  provider   Provider name (e.g. google, slack).
              Run "assistant oauth providers list" to see available providers.
 
 Options:

--- a/assistant/src/cli/commands/oauth/ping.ts
+++ b/assistant/src/cli/commands/oauth/ping.ts
@@ -27,9 +27,8 @@ export function registerPingCommand(oauth: Command): void {
       "after",
       `
 Arguments:
-  provider   Provider key, alias, or provider ID from 'assistant oauth providers list'.
-             Accepts canonical keys (e.g. integration:google), aliases (e.g.
-             gmail), or bare provider names (e.g. google).
+  provider   Provider name (e.g. google, slack).
+             Run 'assistant oauth providers list' to see available providers.
 
 Options:
   --account <account>   Account identifier (e.g. email) to disambiguate when
@@ -40,7 +39,7 @@ Options:
 
 Examples:
   $ assistant oauth ping google
-  $ assistant oauth ping integration:google --json
+  $ assistant oauth ping google --json
   $ assistant oauth ping google --account user@example.com`,
     )
     .action(

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -83,7 +83,7 @@ authorization URL, token URL, default scopes, and other endpoint details.
 They are seeded on startup for built-in integrations (e.g. Google, Slack,
 GitHub) but can also be registered dynamically via the "register" subcommand.
 
-Each provider is identified by a provider key (e.g. "integration:google").`,
+Each provider is identified by a provider key (e.g. "google").`,
   );
 
   // ---------------------------------------------------------------------------
@@ -159,7 +159,7 @@ Examples:
       "after",
       `
 Arguments:
-  provider-key   The full provider key (e.g. "integration:google").
+  provider-key   Provider key (e.g. "google").
                  Must match the key used during registration or seeding.
 
 Returns the full provider configuration including auth URL, token URL,
@@ -167,8 +167,8 @@ default scopes, scope policy, and extra parameters. Exits with code 1
 if the provider key is not found.
 
 Examples:
-  $ assistant oauth providers get integration:google
-  $ assistant oauth providers get integration:twitter --json`,
+  $ assistant oauth providers get google
+  $ assistant oauth providers get twitter --json`,
     )
     .action((providerKey: string, _opts: unknown, cmd: Command) => {
       try {

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -200,7 +200,7 @@ Examples:
     .description("Register a new OAuth provider configuration")
     .requiredOption(
       "--provider-key <key>",
-      "Unique provider key (e.g. \"integration:custom-service\"). Must not collide with an existing key from 'assistant oauth providers list'.",
+      "Unique provider key (e.g. \"custom-service\"). Must not collide with an existing key from 'assistant oauth providers list'.",
     )
     .requiredOption("--auth-url <url>", "Authorization endpoint URL")
     .requiredOption("--token-url <url>", "Token endpoint URL")
@@ -234,7 +234,7 @@ Examples:
       "after",
       `
 Arguments (via options):
-  --provider-key        Unique identifier for this provider (e.g. "integration:custom-service").
+  --provider-key        Unique identifier for this provider (e.g. "custom-service").
                         Must not collide with an existing provider key.
   --auth-url            The OAuth authorization endpoint URL.
   --token-url           The OAuth token endpoint URL.
@@ -265,16 +265,16 @@ On success, returns the full provider row including generated timestamps.
 
 Examples:
   $ assistant oauth providers register \\
-      --provider-key integration:custom-api \\
+      --provider-key custom-api \\
       --auth-url https://custom-api.example.com/oauth/authorize \\
       --token-url https://custom-api.example.com/oauth/token
   $ assistant oauth providers register \\
-      --provider-key integration:my-service \\
+      --provider-key my-service \\
       --auth-url https://my-service.com/auth \\
       --token-url https://my-service.com/token \\
       --scopes read,write --json
   $ assistant oauth providers register \\
-      --provider-key integration:custom-api \\
+      --provider-key custom-api \\
       --auth-url https://example.com/auth \\
       --token-url https://example.com/token \\
       --ping-url https://example.com/user`,

--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -88,10 +88,7 @@ export function registerRequestCommand(oauth: Command): void {
     .description(
       "The recommended way to make an authenticated request to an OAuth provider (supports a curl-like interface)",
     )
-    .requiredOption(
-      "--provider <key>",
-      "Provider key (e.g. integration:google) or alias (e.g. gmail)",
-    )
+    .requiredOption("--provider <key>", "Provider name (e.g. google, slack)")
     .option("-X, --request <method>", "HTTP method (default: GET)")
     .option(
       "-H, --header <header>",
@@ -130,11 +127,11 @@ Note: The Authorization header is set automatically. User-supplied
 -H "Authorization: ..." will be overridden by the OAuth bearer token.
 
 Examples:
-  $ assistant oauth request --provider integration:twitter https://api.x.com/2/tweets
+  $ assistant oauth request --provider twitter https://api.x.com/2/tweets
   $ assistant oauth request --provider gmail /gmail/v1/users/me/messages -G
-  $ assistant oauth request --provider integration:twitter -X POST -d '{"text":"Hello"}' https://api.x.com/2/tweets
-  $ assistant oauth request --provider integration:google -d @body.json https://www.googleapis.com/calendar/v3/calendars
-  $ assistant oauth request --provider integration:slack -H "Content-Type: application/json" -d '{"channel":"C123"}' /api/chat.postMessage --json`,
+  $ assistant oauth request --provider twitter -X POST -d '{"text":"Hello"}' https://api.x.com/2/tweets
+  $ assistant oauth request --provider google -d @body.json https://www.googleapis.com/calendar/v3/calendars
+  $ assistant oauth request --provider slack -H "Content-Type: application/json" -d '{"channel":"C123"}' /api/chat.postMessage --json`,
     )
     .action(
       async (

--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -14,7 +14,7 @@ import {
 } from "../../../oauth/oauth-store.js";
 import { VellumPlatformClient } from "../../../platform/client.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
-import { isManagedMode, resolveService, toBareProvider } from "./shared.js";
+import { isManagedMode, resolveService } from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -233,7 +233,7 @@ Examples:
               const client = await VellumPlatformClient.create();
               if (client && client.platformAssistantId) {
                 const params = new URLSearchParams();
-                params.set("provider", toBareProvider(providerKey));
+                params.set("provider", providerKey);
                 params.set("status", "ACTIVE");
                 params.set("account_identifier", opts.account);
 

--- a/assistant/src/cli/commands/oauth/shared.ts
+++ b/assistant/src/cli/commands/oauth/shared.ts
@@ -32,17 +32,6 @@ export interface PlatformConnectionEntry {
 // ---------------------------------------------------------------------------
 
 /**
- * Extract the bare provider slug (e.g. "google") from either a raw CLI
- * argument or a canonical provider key (e.g. "integration:google").
- * Platform API paths expect the bare slug, not the internal key.
- */
-export function toBareProvider(provider: string): string {
-  return provider.startsWith("integration:")
-    ? provider.slice("integration:".length)
-    : provider;
-}
-
-/**
  * Return the provider's `managedServiceConfigKey` if it exists and is a valid
  * key in `ServicesSchema.shape`, or `null` otherwise. This centralises the
  * lookup so that callers (e.g. `isManagedMode`, `mode.ts`) don't duplicate the
@@ -104,7 +93,7 @@ export async function fetchActiveConnections(
   options?: { silent?: boolean },
 ): Promise<PlatformConnectionEntry[] | null> {
   const params = new URLSearchParams();
-  params.set("provider", toBareProvider(provider));
+  params.set("provider", provider);
   params.set("status", "ACTIVE");
 
   const path = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/connections/?${params.toString()}`;

--- a/assistant/src/cli/commands/oauth/status.ts
+++ b/assistant/src/cli/commands/oauth/status.ts
@@ -24,8 +24,7 @@ export function registerStatusCommand(oauth: Command): void {
       "after",
       `
 Arguments:
-  provider   Provider name or key. Accepts bare names (google, slack),
-             canonical keys (integration:google), or aliases (gmail).
+  provider   Provider name (e.g. google, slack).
              Run 'assistant oauth providers list' to see all available providers.
 
 The output includes connection IDs and account identifiers that can be used
@@ -36,7 +35,7 @@ as inputs to other commands:
 
 Examples:
   $ assistant oauth status google
-  $ assistant oauth status integration:google --json`,
+  $ assistant oauth status google --json`,
     )
     .action(
       async (

--- a/assistant/src/cli/commands/oauth/token.ts
+++ b/assistant/src/cli/commands/oauth/token.ts
@@ -45,10 +45,9 @@ export function registerTokenCommand(oauth: Command): void {
       "after",
       `
 Arguments:
-  provider   Provider name or key. Accepts bare names (google, slack),
-             canonical keys (integration:google), aliases (gmail), or
-             provider IDs. Run 'assistant oauth providers list' to see
-             all available providers.
+  provider   Provider name (e.g. google, slack).
+             Run 'assistant oauth providers list' to see all available
+             providers.
 
 Options:
   --account <account>   Select a specific account when multiple connections
@@ -74,7 +73,7 @@ shell (VELLUM_UNTRUSTED_SHELL=1) to prevent token exfiltration.
 
 Examples:
   $ assistant oauth token google
-  $ assistant oauth token integration:twitter --json
+  $ assistant oauth token twitter --json
   $ assistant oauth token google --account user@gmail.com
   $ assistant oauth token google --client-id abc123`,
     )

--- a/assistant/src/cli/lib/daemon-credential-client.ts
+++ b/assistant/src/cli/lib/daemon-credential-client.ts
@@ -88,34 +88,6 @@ async function daemonFetch(
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Derive the canonical credential storage key from a "service:field" name.
- * Mirrors the parsing in secret-routes.ts handleAddSecret / handleDeleteSecret.
- *
- * Uses lastIndexOf to split on the *last* colon so compound service names
- * (e.g. "integration:google") are preserved intact while the single-segment
- * field name is extracted correctly.
- */
-function deriveCredentialStorageKey(name: string): string {
-  // Already a canonical storage key (credential/service/field) — return as-is
-  // to avoid double-encoding (e.g. "credential/integration:google/access_token"
-  // would otherwise become "credential/credential/integration/google/access_token").
-  if (name.startsWith("credential/")) {
-    return name;
-  }
-
-  const colonIdx = name.lastIndexOf(":");
-  if (colonIdx < 1 || colonIdx === name.length - 1) {
-    // Malformed — return raw name so the caller stores *something*.
-    // The daemon would reject this with a 400, so this only fires in
-    // the offline fallback path with bad input.
-    return name;
-  }
-  const service = name.slice(0, colonIdx);
-  const field = name.slice(colonIdx + 1);
-  return credentialKey(service, field);
-}
-
 function deriveReadSecretRequest(account: string): {
   type: "api_key" | "credential";
   name: string;
@@ -227,11 +199,17 @@ export async function setSecureKeyViaDaemon(
   }
 
   // Daemon unreachable — fall back to direct write.
-  // For credentials, derive the canonical storage key (credential/service/field)
-  // to match the daemon path which uses credentialKey().
-  const storageKey =
-    type === "credential" ? deriveCredentialStorageKey(name) : name;
-  return setSecureKeyAsync(storageKey, value);
+  // For credentials, convert "service:field" to the canonical
+  // "credential/service/field" storage key using credentialKey().
+  if (type === "credential" && !name.startsWith("credential/")) {
+    const colonIdx = name.lastIndexOf(":");
+    if (colonIdx > 0 && colonIdx < name.length - 1) {
+      const service = name.slice(0, colonIdx);
+      const field = name.slice(colonIdx + 1);
+      return setSecureKeyAsync(credentialKey(service, field), value);
+    }
+  }
+  return setSecureKeyAsync(name, value);
 }
 
 /**
@@ -260,11 +238,17 @@ export async function deleteSecureKeyViaDaemon(
   }
 
   // Daemon unreachable — fall back to direct delete.
-  // For credentials, derive the canonical storage key (credential/service/field)
-  // to match the daemon path which uses credentialKey().
-  const storageKey =
-    type === "credential" ? deriveCredentialStorageKey(name) : name;
-  return deleteSecureKeyAsync(storageKey);
+  // For credentials, convert "service:field" to the canonical
+  // "credential/service/field" storage key using credentialKey().
+  if (type === "credential" && !name.startsWith("credential/")) {
+    const colonIdx = name.lastIndexOf(":");
+    if (colonIdx > 0 && colonIdx < name.length - 1) {
+      const service = name.slice(0, colonIdx);
+      const field = name.slice(colonIdx + 1);
+      return deleteSecureKeyAsync(credentialKey(service, field));
+    }
+  }
+  return deleteSecureKeyAsync(name);
 }
 
 /**

--- a/assistant/src/config/bundled-skills/contacts/tools/google-contacts.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/google-contacts.ts
@@ -44,7 +44,7 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     switch (action) {

--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -19,7 +19,7 @@ Do not offer AgentMail as an option or mention it unless the user specifically a
 ## Communication Style
 
 - **Be action-oriented.** When the user asks to do something ("declutter", "check my email"), start doing it immediately. Don't ask for permission to read their inbox - that's obviously what they want.
-- **Keep it human.** Never mention OAuth, tokens, APIs, sandboxes, credential proxies, or other technical internals. If something isn't working, say "Gmail needs to be reconnected" - not "the OAuth2 access token for integration:google has expired."
+- **Keep it human.** Never mention OAuth, tokens, APIs, sandboxes, credential proxies, or other technical internals. If something isn't working, say "Gmail needs to be reconnected" - not "the OAuth2 access token for google has expired."
 - **Show progress.** When running a tool that scans many emails, tell the user what you're doing: "Scanning your inbox for clutter..." Don't go silent.
 - **Be brief and warm.** One or two sentences per update is plenty. Don't over-explain what you're about to do - just do it and narrate lightly.
 

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
@@ -35,7 +35,7 @@ export async function run(
     }
 
     try {
-      const connection = await resolveOAuthConnection("integration:google", {
+      const connection = await resolveOAuthConnection("google", {
         account,
       });
       const allMessageIds: string[] = [];
@@ -106,7 +106,7 @@ export async function run(
   } else if (messageId) {
     // Single message path
     try {
-      const connection = await resolveOAuthConnection("integration:google", {
+      const connection = await resolveOAuthConnection("google", {
         account,
       });
       await modifyMessage(connection, messageId, { removeLabelIds: ["INBOX"] });
@@ -126,7 +126,7 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     if (messageIds.length === 1) {

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-attachments.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-attachments.ts
@@ -57,7 +57,7 @@ export async function run(
 
   if (action === "list") {
     try {
-      const connection = await resolveOAuthConnection("integration:google", {
+      const connection = await resolveOAuthConnection("google", {
         account,
       });
       const message = await getMessage(connection, messageId, "full");
@@ -81,7 +81,7 @@ export async function run(
     if (!filename) return err("filename is required for download.");
 
     try {
-      const connection = await resolveOAuthConnection("integration:google", {
+      const connection = await resolveOAuthConnection("google", {
         account,
       });
       const attachment = await getAttachment(

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-draft.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-draft.ts
@@ -23,7 +23,7 @@ export async function run(
   if (!body) return err("body is required.");
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     const draft = await createDraft(

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-filters.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-filters.ts
@@ -26,7 +26,7 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     switch (action) {

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-follow-up.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-follow-up.ts
@@ -38,7 +38,7 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     switch (action) {

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-forward.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-forward.ts
@@ -76,7 +76,7 @@ export async function run(
   if (!forwardTo) return err("to is required.");
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     const message = await getMessage(connection, messageId, "full");

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-label.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-label.ts
@@ -21,7 +21,7 @@ export async function run(
 
   if (messageIds && messageIds.length > 0) {
     try {
-      const connection = await resolveOAuthConnection("integration:google", {
+      const connection = await resolveOAuthConnection("google", {
         account,
       });
       await batchModifyMessages(connection, messageIds, {
@@ -36,7 +36,7 @@ export async function run(
 
   if (messageId) {
     try {
-      const connection = await resolveOAuthConnection("integration:google", {
+      const connection = await resolveOAuthConnection("google", {
         account,
       });
       await modifyMessage(connection, messageId, {

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
@@ -56,7 +56,7 @@ export async function run(
   const query = `in:inbox -has:unsubscribe newer_than:${timeRange}`;
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     // Pipeline: fire metadata fetches for each page of IDs as they arrive

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-send-draft.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-send-draft.ts
@@ -15,7 +15,7 @@ export async function run(
   if (!draftId) return err("draft_id is required.");
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     const msg = await sendDraft(connection, draftId);

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
@@ -58,7 +58,7 @@ export async function run(
   const inputPageToken = input.page_token as string | undefined;
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     // Pipeline: fire metadata fetches for each page of IDs as they arrive,

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-trash.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-trash.ts
@@ -18,7 +18,7 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     await trashMessage(connection, messageId);

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
@@ -32,7 +32,7 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     const message = await getMessage(connection, messageId, "metadata", [

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-vacation.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-vacation.ts
@@ -22,7 +22,7 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection("integration:google", {
+    const connection = await resolveOAuthConnection("google", {
       account,
     });
     switch (action) {

--- a/assistant/src/config/bundled-skills/google-calendar/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/shared.ts
@@ -13,5 +13,5 @@ export function ok(content: string): ToolExecutionResult {
 export async function getCalendarConnection(
   account?: string,
 ): Promise<OAuthConnection> {
-  return resolveOAuthConnection("integration:google", { account });
+  return resolveOAuthConnection("google", { account });
 }

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -30,7 +30,7 @@ Do not offer AgentMail as an option or mention it unless the user specifically a
 ## Communication Style
 
 - **Be action-oriented.** When the user asks to do something ("declutter", "check my email"), start doing it immediately. Don't ask for permission to read their inbox - that's obviously what they want.
-- **Keep it human.** Never mention OAuth, tokens, APIs, sandboxes, credential proxies, or other technical internals. If something isn't working, say "Gmail needs to be reconnected" - not "the OAuth2 access token for integration:google has expired."
+- **Keep it human.** Never mention OAuth, tokens, APIs, sandboxes, credential proxies, or other technical internals. If something isn't working, say "Gmail needs to be reconnected" - not "the OAuth2 access token for google has expired."
 - **Show progress.** When running a tool that scans many emails, tell the user what you're doing: "Scanning your inbox for clutter..." Don't go silent.
 - **Be brief and warm.** One or two sentences per update is plenty. Don't over-explain what you're about to do - just do it and narrate lightly.
 

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -117,6 +117,7 @@ import {
   migrateScheduleOneShotRouting,
   migrateScheduleQuietFlag,
   migrateSchemaIndexesAndColumns,
+  migrateStripIntegrationPrefixFromProviderKeys,
   migrateUsageDashboardIndexes,
   migrateVoiceInviteColumns,
   migrateVoiceInviteDisplayMetadata,
@@ -515,6 +516,9 @@ export function initializeDb(): void {
 
   // 92. Add ping_method, ping_headers, ping_body columns to oauth_providers
   migrateOAuthProvidersPingConfig(database);
+
+  // 93. Strip `integration:` prefix from provider_key across OAuth tables
+  migrateStripIntegrationPrefixFromProviderKeys(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/196-strip-integration-prefix-from-provider-keys.ts
+++ b/assistant/src/memory/migrations/196-strip-integration-prefix-from-provider-keys.ts
@@ -83,6 +83,14 @@ export function migrateStripIntegrationPrefixFromProviderKeys(
               .run(newKey, oldKey);
           }
         }
+
+        // Also update the watchers table — credential_service stores provider
+        // keys like "integration:google" that feed into resolveOAuthConnection().
+        raw
+          .prepare(
+            /*sql*/ `UPDATE watchers SET credential_service = REPLACE(credential_service, 'integration:', '') WHERE credential_service LIKE 'integration:%'`,
+          )
+          .run();
       } finally {
         raw.exec("PRAGMA foreign_keys = ON");
       }
@@ -154,6 +162,23 @@ export function migrateStripIntegrationPrefixFromProviderKeysDown(
           )
           .run(prefixedKey, bareKey);
       }
+    }
+
+    // Reverse the watchers table update — re-add the prefix for keys that
+    // aren't known bare-name providers.
+    const watcherRows = raw
+      .prepare(
+        /*sql*/ `SELECT DISTINCT credential_service FROM watchers WHERE credential_service NOT LIKE 'integration:%'`,
+      )
+      .all() as Array<{ credential_service: string }>;
+
+    for (const { credential_service: bareKey } of watcherRows) {
+      if (ALWAYS_BARE.has(bareKey)) continue;
+      raw
+        .prepare(
+          /*sql*/ `UPDATE watchers SET credential_service = ? WHERE credential_service = ?`,
+        )
+        .run(`integration:${bareKey}`, bareKey);
     }
   } finally {
     raw.exec("PRAGMA foreign_keys = ON");

--- a/assistant/src/memory/migrations/196-strip-integration-prefix-from-provider-keys.ts
+++ b/assistant/src/memory/migrations/196-strip-integration-prefix-from-provider-keys.ts
@@ -1,0 +1,161 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+/**
+ * One-shot migration: strip the `integration:` prefix from provider_key
+ * values across all three OAuth tables (oauth_providers, oauth_apps,
+ * oauth_connections).
+ *
+ * Historically provider keys were stored as `integration:google`,
+ * `integration:slack`, etc.  The codebase is moving to bare-name keys
+ * (`google`, `slack`) for simplicity.  Providers that were already stored
+ * with bare names (e.g. `slack_channel`, `telegram`) are unaffected.
+ *
+ * If a bare-name key already exists (runtime seed data created it), the
+ * old `integration:` rows are orphaned — we delete them instead of
+ * renaming to avoid UNIQUE constraint violations.
+ *
+ * FK constraints require us to update child tables (oauth_apps,
+ * oauth_connections) before the parent (oauth_providers), or disable FKs.
+ * We disable FKs for safety and update all three tables atomically.
+ */
+export function migrateStripIntegrationPrefixFromProviderKeys(
+  database: DrizzleDb,
+): void {
+  withCrashRecovery(
+    database,
+    "migration_strip_integration_prefix_from_provider_keys_v1",
+    () => {
+      const raw = getSqliteFrom(database);
+
+      raw.exec("PRAGMA foreign_keys = OFF");
+      try {
+        // Find all provider keys with the integration: prefix.
+        const rows = raw
+          .prepare(
+            /*sql*/ `SELECT provider_key FROM oauth_providers WHERE provider_key LIKE 'integration:%'`,
+          )
+          .all() as Array<{ provider_key: string }>;
+
+        for (const { provider_key: oldKey } of rows) {
+          const newKey = oldKey.replace(/^integration:/, "");
+
+          // Check if the bare-name key already exists (seed data may have created it).
+          const bareExists = raw
+            .prepare(
+              /*sql*/ `SELECT 1 FROM oauth_providers WHERE provider_key = ?`,
+            )
+            .get(newKey);
+
+          if (bareExists) {
+            // Bare-name provider already exists — delete the old prefixed rows
+            // to avoid UNIQUE constraint violations.
+            raw
+              .prepare(
+                /*sql*/ `DELETE FROM oauth_connections WHERE provider_key = ?`,
+              )
+              .run(oldKey);
+            raw
+              .prepare(/*sql*/ `DELETE FROM oauth_apps WHERE provider_key = ?`)
+              .run(oldKey);
+            raw
+              .prepare(
+                /*sql*/ `DELETE FROM oauth_providers WHERE provider_key = ?`,
+              )
+              .run(oldKey);
+          } else {
+            // Rename: update child tables first, then parent.
+            raw
+              .prepare(
+                /*sql*/ `UPDATE oauth_connections SET provider_key = ? WHERE provider_key = ?`,
+              )
+              .run(newKey, oldKey);
+            raw
+              .prepare(
+                /*sql*/ `UPDATE oauth_apps SET provider_key = ? WHERE provider_key = ?`,
+              )
+              .run(newKey, oldKey);
+            raw
+              .prepare(
+                /*sql*/ `UPDATE oauth_providers SET provider_key = ? WHERE provider_key = ?`,
+              )
+              .run(newKey, oldKey);
+          }
+        }
+      } finally {
+        raw.exec("PRAGMA foreign_keys = ON");
+      }
+    },
+  );
+}
+
+/**
+ * Reverse: re-add the `integration:` prefix to provider keys that don't
+ * already have one and aren't known bare-name providers.
+ *
+ * This is a best-effort rollback — we prefix all keys that look like they
+ * were originally `integration:` prefixed.  Known bare-name keys
+ * (`slack_channel`, `telegram`) are left as-is because they never had the
+ * prefix.
+ */
+export function migrateStripIntegrationPrefixFromProviderKeysDown(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  // Keys that were always bare — never had an integration: prefix.
+  const ALWAYS_BARE = new Set(["slack_channel", "telegram"]);
+
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    const rows = raw
+      .prepare(
+        /*sql*/ `SELECT provider_key FROM oauth_providers WHERE provider_key NOT LIKE 'integration:%'`,
+      )
+      .all() as Array<{ provider_key: string }>;
+
+    for (const { provider_key: bareKey } of rows) {
+      if (ALWAYS_BARE.has(bareKey)) continue;
+
+      const prefixedKey = `integration:${bareKey}`;
+
+      // If the prefixed key already exists, delete the bare rows.
+      const prefixedExists = raw
+        .prepare(/*sql*/ `SELECT 1 FROM oauth_providers WHERE provider_key = ?`)
+        .get(prefixedKey);
+
+      if (prefixedExists) {
+        raw
+          .prepare(
+            /*sql*/ `DELETE FROM oauth_connections WHERE provider_key = ?`,
+          )
+          .run(bareKey);
+        raw
+          .prepare(/*sql*/ `DELETE FROM oauth_apps WHERE provider_key = ?`)
+          .run(bareKey);
+        raw
+          .prepare(/*sql*/ `DELETE FROM oauth_providers WHERE provider_key = ?`)
+          .run(bareKey);
+      } else {
+        raw
+          .prepare(
+            /*sql*/ `UPDATE oauth_connections SET provider_key = ? WHERE provider_key = ?`,
+          )
+          .run(prefixedKey, bareKey);
+        raw
+          .prepare(
+            /*sql*/ `UPDATE oauth_apps SET provider_key = ? WHERE provider_key = ?`,
+          )
+          .run(prefixedKey, bareKey);
+        raw
+          .prepare(
+            /*sql*/ `UPDATE oauth_providers SET provider_key = ? WHERE provider_key = ?`,
+          )
+          .run(prefixedKey, bareKey);
+      }
+    }
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -134,6 +134,7 @@ export { migrateContactsUserFileColumn } from "./192-contacts-user-file-column.j
 export { migrateAddSourceTypeColumns } from "./193-add-source-type-columns.js";
 export { migrateCreateMemoryRecallLogs } from "./194-memory-recall-logs.js";
 export { migrateOAuthProvidersPingConfig } from "./195-oauth-providers-ping-config.js";
+export { migrateStripIntegrationPrefixFromProviderKeys } from "./196-strip-integration-prefix-from-provider-keys.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -38,6 +38,7 @@ import { migrateBackfillInlineAttachmentsToDiskDown } from "./180-backfill-inlin
 import { migrateRenameThreadStartersCheckpointsDown } from "./181-rename-thread-starters-checkpoints.js";
 import { migrateBackfillAudioAttachmentMimeTypesDown } from "./191-backfill-audio-attachment-mime-types.js";
 import { migrateAddSourceTypeColumnsDown } from "./193-add-source-type-columns.js";
+import { migrateStripIntegrationPrefixFromProviderKeysDown } from "./196-strip-integration-prefix-from-provider-keys.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -332,6 +333,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Add source_type and source_message_role columns to memory_items with backfill from verification_state and source messages",
     down: migrateAddSourceTypeColumnsDown,
+  },
+  {
+    key: "migration_strip_integration_prefix_from_provider_keys_v1",
+    version: 38,
+    description:
+      "Strip integration: prefix from provider_key across oauth_providers, oauth_apps, and oauth_connections",
+    down: migrateStripIntegrationPrefixFromProviderKeysDown,
   },
 ];
 

--- a/assistant/src/messaging/providers/gmail/adapter.ts
+++ b/assistant/src/messaging/providers/gmail/adapter.ts
@@ -86,7 +86,7 @@ function mapGmailMessage(msg: GmailMessage): Message {
 export const gmailMessagingProvider: MessagingProvider = {
   id: "gmail",
   displayName: "Gmail",
-  credentialService: "integration:google",
+  credentialService: "google",
   capabilities: new Set([
     "threads",
     "labels",

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -113,7 +113,7 @@ function mapSearchMatch(match: SlackSearchMatch): Message {
 export const slackProvider: MessagingProvider = {
   id: "slack",
   displayName: "Slack",
-  credentialService: "integration:slack",
+  credentialService: "slack",
   capabilities: new Set(["reactions", "threads", "leave_channel"]),
 
   async isConnected(): Promise<boolean> {
@@ -124,8 +124,8 @@ export const slackProvider: MessagingProvider = {
       credentialKey("slack_channel", "bot_token"),
     );
     if (botToken) return true;
-    // Preserve existing OAuth path (integration:slack) for backwards compat.
-    return isProviderConnected("integration:slack");
+    // Preserve existing OAuth path for backwards compat.
+    return isProviderConnected("slack");
   },
 
   async resolveConnection(account?: string): Promise<OAuthConnection | string> {
@@ -135,8 +135,8 @@ export const slackProvider: MessagingProvider = {
       credentialKey("slack_channel", "bot_token"),
     );
     if (botToken) return botToken;
-    // Preserve existing OAuth path (integration:slack) for backwards compat.
-    return resolveOAuthConnection("integration:slack", { account });
+    // Preserve existing OAuth path for backwards compat.
+    return resolveOAuthConnection("slack", { account });
   },
 
   async testConnection(

--- a/assistant/src/oauth/byo-connection.test.ts
+++ b/assistant/src/oauth/byo-connection.test.ts
@@ -195,7 +195,7 @@ async function setupCredential(
     tokenUrl: "https://oauth2.googleapis.com/token",
     // Only well-known providers (gmail) have a baseUrl; custom services don't
     baseUrl:
-      service === "integration:google"
+      service === "google"
         ? "https://gmail.googleapis.com/gmail/v1/users/me"
         : undefined,
   });
@@ -230,7 +230,7 @@ async function setupCredential(
   upsertCredentialMetadata(service, "access_token", {});
 }
 
-function createConnection(service = "integration:google"): BYOOAuthConnection {
+function createConnection(service = "google"): BYOOAuthConnection {
   return new BYOOAuthConnection({
     id: `conn-${service}`,
     providerKey: service,
@@ -246,7 +246,7 @@ function createConnection(service = "integration:google"): BYOOAuthConnection {
 describe("BYOOAuthConnection", () => {
   describe("request()", () => {
     test("makes authenticated request with Bearer token", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       const result = await conn.request({
@@ -270,7 +270,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("appends query parameters", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       await conn.request({
@@ -286,7 +286,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("uses per-request baseUrl override", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       await conn.request({
@@ -300,7 +300,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("sends JSON body for POST requests", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       await conn.request({
@@ -320,7 +320,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("retries once on 401 response", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       // First call returns 401, second returns 200
@@ -348,7 +348,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("handles empty response body", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       globalThis.fetch = mock(() =>
@@ -365,7 +365,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("handles non-JSON response body", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       globalThis.fetch = mock(() =>
@@ -382,7 +382,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("returns response headers", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       globalThis.fetch = mock(() =>
@@ -406,7 +406,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("includes custom request headers", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       await conn.request({
@@ -425,7 +425,7 @@ describe("BYOOAuthConnection", () => {
   describe("proactive token refresh", () => {
     test("refreshes token when near expiry (within 5-minute buffer)", async () => {
       // Set token to expire in 2 minutes (within 5-min buffer)
-      await setupCredential("integration:google", {
+      await setupCredential("google", {
         expiresAt: Date.now() + 2 * 60 * 1000,
       });
       const conn = createConnection();
@@ -449,7 +449,7 @@ describe("BYOOAuthConnection", () => {
 
   describe("withToken()", () => {
     test("provides valid token to callback", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       const result = await conn.withToken(async (token) => {
@@ -460,7 +460,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("retries callback on 401 error", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       let callCount = 0;
@@ -493,25 +493,23 @@ describe("BYOOAuthConnection", () => {
 
 describe("resolveOAuthConnection", () => {
   test("returns a BYOOAuthConnection for valid credential", async () => {
-    await setupCredential("integration:google");
-    const conn = await resolveOAuthConnection("integration:google");
+    await setupCredential("google");
+    const conn = await resolveOAuthConnection("google");
 
     expect(conn).toBeInstanceOf(BYOOAuthConnection);
-    expect(conn.providerKey).toBe("integration:google");
+    expect(conn.providerKey).toBe("google");
   });
 
   test("throws when no credential metadata exists", async () => {
-    await expect(resolveOAuthConnection("integration:unknown")).rejects.toThrow(
-      /No active OAuth connection found for "integration:unknown"/,
+    await expect(resolveOAuthConnection("unknown")).rejects.toThrow(
+      /No active OAuth connection found for "unknown"/,
     );
   });
 
   test("throws when no base URL configured", async () => {
-    await setupCredential("integration:custom-service");
-    await expect(
-      resolveOAuthConnection("integration:custom-service"),
-    ).rejects.toThrow(
-      /No base URL configured for "integration:custom-service"/,
+    await setupCredential("custom-service");
+    await expect(resolveOAuthConnection("custom-service")).rejects.toThrow(
+      /No base URL configured for "custom-service"/,
     );
   });
 });

--- a/assistant/src/oauth/connect-types.ts
+++ b/assistant/src/oauth/connect-types.ts
@@ -40,7 +40,7 @@ export interface OAuthScopePolicy {
  * templates, skill IDs) and cannot be serialised to a DB row.
  */
 export interface OAuthProviderBehavior {
-  /** Canonical service key (e.g. "integration:twitter"). */
+  /** Canonical service key (e.g. "twitter"). */
   service: string;
   /**
    * Async function that verifies the user's identity after a successful

--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -79,13 +79,13 @@ function makeMockClient() {
 
 function setupDefaults(): void {
   mockProvider = {
-    providerKey: "integration:google",
+    providerKey: "google",
     baseUrl: "https://gmail.googleapis.com/gmail/v1/users/me",
     managedServiceConfigKey: null,
   };
   mockConnection = {
     id: "conn-1",
-    providerKey: "integration:google",
+    providerKey: "google",
     oauthAppId: "app-1",
     accountInfo: "user@example.com",
     grantedScopes: JSON.stringify(["scope-a", "scope-b"]),
@@ -122,26 +122,26 @@ describe("resolveOAuthConnection", () => {
   });
 
   test("returns BYOOAuthConnection when provider has no managedServiceConfigKey", async () => {
-    const result = await resolveOAuthConnection("integration:google");
+    const result = await resolveOAuthConnection("google");
     expect(result).toBeInstanceOf(BYOOAuthConnection);
     expect(result.id).toBe("conn-1");
-    expect(result.providerKey).toBe("integration:google");
+    expect(result.providerKey).toBe("google");
   });
 
   test("returns PlatformOAuthConnection when managed mode is active", async () => {
     mockProvider!.managedServiceConfigKey = "google-oauth";
 
-    const result = await resolveOAuthConnection("integration:google");
+    const result = await resolveOAuthConnection("google");
     expect(result).toBeInstanceOf(PlatformOAuthConnection);
-    expect(result.id).toBe("integration:google");
-    expect(result.providerKey).toBe("integration:google");
+    expect(result.id).toBe("google");
+    expect(result.providerKey).toBe("google");
     expect(result.accountInfo).toBeNull();
   });
 
   test("passes account through to PlatformOAuthConnection", async () => {
     mockProvider!.managedServiceConfigKey = "google-oauth";
 
-    const result = await resolveOAuthConnection("integration:google", {
+    const result = await resolveOAuthConnection("google", {
       account: "user@example.com",
     });
     expect(result).toBeInstanceOf(PlatformOAuthConnection);
@@ -154,7 +154,7 @@ describe("resolveOAuthConnection", () => {
       mode: "your-own",
     };
 
-    const result = await resolveOAuthConnection("integration:google");
+    const result = await resolveOAuthConnection("google");
     expect(result).toBeInstanceOf(BYOOAuthConnection);
     expect(result.id).toBe("conn-1");
   });
@@ -164,21 +164,21 @@ describe("resolveOAuthConnection", () => {
     mockConnection = undefined;
     mockAccessToken = undefined;
 
-    const result = await resolveOAuthConnection("integration:google");
+    const result = await resolveOAuthConnection("google");
     expect(result).toBeInstanceOf(PlatformOAuthConnection);
   });
 
   test("managed path ignores clientId option", async () => {
     mockProvider!.managedServiceConfigKey = "google-oauth";
 
-    const result = await resolveOAuthConnection("integration:google", {
+    const result = await resolveOAuthConnection("google", {
       clientId: "some-client-id",
     });
     expect(result).toBeInstanceOf(PlatformOAuthConnection);
   });
 
   test("BYO path narrows by clientId when provided", async () => {
-    const result = await resolveOAuthConnection("integration:google", {
+    const result = await resolveOAuthConnection("google", {
       clientId: "client-1",
     });
     expect(result).toBeInstanceOf(BYOOAuthConnection);
@@ -187,7 +187,7 @@ describe("resolveOAuthConnection", () => {
 
   test("BYO path returns no credential when clientId does not match", async () => {
     await expect(
-      resolveOAuthConnection("integration:google", {
+      resolveOAuthConnection("google", {
         clientId: "wrong-client",
       }),
     ).rejects.toThrow(/No active OAuth connection found/);

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -29,7 +29,7 @@ export interface ResolveOAuthConnectionOptions {
  * BYO providers resolve from the local SQLite oauth-store and require an
  * active connection row and a stored access token.
  *
- * @param providerKey - Provider identifier (e.g. "integration:google").
+ * @param providerKey - Provider identifier (e.g. "google").
  *   Maps to the `provider_key` primary key in the `oauth_providers` table.
  * @param options.clientId - Optional OAuth app client ID. When multiple BYO
  *   apps exist for the same provider, narrows the connection lookup to the

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -59,11 +59,9 @@ export async function resolveOAuthConnection(
         );
       }
 
-      const providerSlug = providerKey.replace(/^integration:/, "");
-
       const connectionId = await resolvePlatformConnectionId({
         client,
-        provider: providerSlug,
+        provider: providerKey,
         account,
       });
 

--- a/assistant/src/oauth/platform-connection.test.ts
+++ b/assistant/src/oauth/platform-connection.test.ts
@@ -35,7 +35,7 @@ function makeMockClient(
 
 const DEFAULT_OPTIONS = {
   id: "conn-1",
-  providerKey: "integration:google",
+  providerKey: "google",
   externalId: "ext-123",
   accountInfo: "user@example.com",
   client: makeMockClient(),
@@ -192,7 +192,7 @@ describe("PlatformOAuthConnection", () => {
     const conn = new PlatformOAuthConnection({
       ...DEFAULT_OPTIONS,
       client,
-      providerKey: "integration:slack",
+      providerKey: "slack",
       connectionId: "slack-conn-456",
     });
     await conn.request({ method: "GET", path: "/test" });

--- a/assistant/src/oauth/provider-behaviors.ts
+++ b/assistant/src/oauth/provider-behaviors.ts
@@ -16,8 +16,8 @@ import type { OAuthProviderBehavior } from "./connect-types.js";
 // ---------------------------------------------------------------------------
 
 const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
-  "integration:google": {
-    service: "integration:google",
+  google: {
+    service: "google",
     // Google APIs for Gmail/Calendar/Contacts span multiple hosts; register
     // all of them so proxied bash can inject the OAuth bearer token reliably.
     injectionTemplates: [
@@ -71,8 +71,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:slack": {
-    service: "integration:slack",
+  slack: {
+    service: "slack",
     loopbackPort: 17322,
     injectionTemplates: [
       {
@@ -112,8 +112,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:notion": {
-    service: "integration:notion",
+  notion: {
+    service: "notion",
     loopbackPort: 17323,
     injectionTemplates: [
       {
@@ -155,8 +155,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:twitter": {
-    service: "integration:twitter",
+  twitter: {
+    service: "twitter",
     injectionTemplates: [
       {
         hostPattern: "api.x.com",
@@ -189,8 +189,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
       return undefined;
     },
   },
-  "integration:github": {
-    service: "integration:github",
+  github: {
+    service: "github",
     loopbackPort: 17332,
     injectionTemplates: [
       {
@@ -225,8 +225,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:linear": {
-    service: "integration:linear",
+  linear: {
+    service: "linear",
     loopbackPort: 17324,
     injectionTemplates: [
       {
@@ -268,8 +268,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:spotify": {
-    service: "integration:spotify",
+  spotify: {
+    service: "spotify",
     loopbackPort: 17333,
     injectionTemplates: [
       {
@@ -307,8 +307,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:todoist": {
-    service: "integration:todoist",
+  todoist: {
+    service: "todoist",
     loopbackPort: 17325,
     injectionTemplates: [
       {
@@ -350,8 +350,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:discord": {
-    service: "integration:discord",
+  discord: {
+    service: "discord",
     loopbackPort: 17326,
     injectionTemplates: [
       {
@@ -389,8 +389,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:dropbox": {
-    service: "integration:dropbox",
+  dropbox: {
+    service: "dropbox",
     loopbackPort: 17327,
     injectionTemplates: [
       {
@@ -438,8 +438,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:asana": {
-    service: "integration:asana",
+  asana: {
+    service: "asana",
     loopbackPort: 17328,
     injectionTemplates: [
       {
@@ -476,8 +476,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:airtable": {
-    service: "integration:airtable",
+  airtable: {
+    service: "airtable",
     loopbackPort: 17329,
     injectionTemplates: [
       {
@@ -512,8 +512,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:hubspot": {
-    service: "integration:hubspot",
+  hubspot: {
+    service: "hubspot",
     loopbackPort: 17330,
     injectionTemplates: [
       {
@@ -551,8 +551,8 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     },
   },
 
-  "integration:figma": {
-    service: "integration:figma",
+  figma: {
+    service: "figma",
     loopbackPort: 17331,
     injectionTemplates: [
       {
@@ -597,33 +597,12 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
 
 /** Map shorthand aliases to canonical service names. */
 export const SERVICE_ALIASES: Record<string, string> = {
-  gmail: "integration:google",
-  google: "integration:google",
-  slack: "integration:slack",
-  notion: "integration:notion",
-  twitter: "integration:twitter",
-  github: "integration:github",
-  linear: "integration:linear",
-  spotify: "integration:spotify",
-  todoist: "integration:todoist",
-  discord: "integration:discord",
-  dropbox: "integration:dropbox",
-  asana: "integration:asana",
-  airtable: "integration:airtable",
-  hubspot: "integration:hubspot",
-  figma: "integration:figma",
+  gmail: "google",
 };
 
-/**
- * Resolve a service name through aliases, then fall back to `integration:`
- * prefix for providers registered in PROVIDER_BEHAVIORS without a
- * SERVICE_ALIASES entry.
- */
+/** Resolve a service name through aliases. */
 export function resolveService(service: string): string {
-  if (SERVICE_ALIASES[service]) return SERVICE_ALIASES[service];
-  if (!service.includes(":") && PROVIDER_BEHAVIORS[`integration:${service}`])
-    return `integration:${service}`;
-  return service;
+  return SERVICE_ALIASES[service] ?? service;
 }
 
 /** Look up a provider behavior by canonical service name. */

--- a/assistant/src/oauth/provider-behaviors.ts
+++ b/assistant/src/oauth/provider-behaviors.ts
@@ -15,7 +15,7 @@ import type { OAuthProviderBehavior } from "./connect-types.js";
 // Provider behaviors
 // ---------------------------------------------------------------------------
 
-const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
+export const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
   google: {
     service: "google",
     // Google APIs for Gmail/Calendar/Contacts span multiple hosts; register

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -46,8 +46,8 @@ const PROVIDER_SEED_DATA: Record<
     requiresClientSecret?: boolean;
   }
 > = {
-  "integration:google": {
-    providerKey: "integration:google",
+  google: {
+    providerKey: "google",
     authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
     tokenUrl: "https://oauth2.googleapis.com/token",
     userinfoUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
@@ -79,8 +79,8 @@ const PROVIDER_SEED_DATA: Record<
     managedServiceConfigKey: "google-oauth",
   },
 
-  "integration:slack": {
-    providerKey: "integration:slack",
+  slack: {
+    providerKey: "slack",
     authUrl: "https://slack.com/oauth/v2/authorize",
     tokenUrl: "https://slack.com/api/oauth.v2.access",
     pingUrl: "https://slack.com/api/auth.test",
@@ -116,8 +116,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:notion": {
-    providerKey: "integration:notion",
+  notion: {
+    providerKey: "notion",
     authUrl: "https://api.notion.com/v1/oauth/authorize",
     tokenUrl: "https://api.notion.com/v1/oauth/token",
     pingUrl: "https://api.notion.com/v1/users/me",
@@ -138,8 +138,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:twitter": {
-    providerKey: "integration:twitter",
+  twitter: {
+    providerKey: "twitter",
     authUrl: "https://twitter.com/i/oauth2/authorize",
     tokenUrl: "https://api.x.com/2/oauth2/token",
     pingUrl: "https://api.x.com/2/users/me",
@@ -163,8 +163,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "gateway",
   },
 
-  "integration:github": {
-    providerKey: "integration:github",
+  github: {
+    providerKey: "github",
     authUrl: "https://github.com/login/oauth/authorize",
     tokenUrl: "https://github.com/login/oauth/access_token",
     pingUrl: "https://api.github.com/user",
@@ -187,8 +187,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:linear": {
-    providerKey: "integration:linear",
+  linear: {
+    providerKey: "linear",
     authUrl: "https://linear.app/oauth/authorize",
     tokenUrl: "https://api.linear.app/oauth/token",
     pingUrl: "https://api.linear.app/graphql",
@@ -210,8 +210,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:spotify": {
-    providerKey: "integration:spotify",
+  spotify: {
+    providerKey: "spotify",
     authUrl: "https://accounts.spotify.com/authorize",
     tokenUrl: "https://accounts.spotify.com/api/token",
     pingUrl: "https://api.spotify.com/v1/me",
@@ -240,8 +240,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:todoist": {
-    providerKey: "integration:todoist",
+  todoist: {
+    providerKey: "todoist",
     authUrl: "https://todoist.com/oauth/authorize",
     tokenUrl: "https://todoist.com/oauth/access_token",
     pingUrl: "https://api.todoist.com/rest/v2/projects",
@@ -259,8 +259,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:discord": {
-    providerKey: "integration:discord",
+  discord: {
+    providerKey: "discord",
     authUrl: "https://discord.com/oauth2/authorize",
     tokenUrl: "https://discord.com/api/v10/oauth2/token",
     pingUrl: "https://discord.com/api/v10/users/@me",
@@ -283,8 +283,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:dropbox": {
-    providerKey: "integration:dropbox",
+  dropbox: {
+    providerKey: "dropbox",
     authUrl: "https://www.dropbox.com/oauth2/authorize",
     tokenUrl: "https://api.dropboxapi.com/oauth2/token",
     pingUrl: "https://api.dropboxapi.com/2/users/get_current_account",
@@ -309,8 +309,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:asana": {
-    providerKey: "integration:asana",
+  asana: {
+    providerKey: "asana",
     authUrl: "https://app.asana.com/-/oauth_authorize",
     tokenUrl: "https://app.asana.com/-/oauth_token",
     pingUrl: "https://app.asana.com/api/1.0/users/me",
@@ -328,8 +328,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:airtable": {
-    providerKey: "integration:airtable",
+  airtable: {
+    providerKey: "airtable",
     authUrl: "https://airtable.com/oauth2/v1/authorize",
     tokenUrl: "https://airtable.com/oauth2/v1/token",
     pingUrl: "https://api.airtable.com/v0/meta/whoami",
@@ -352,8 +352,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:hubspot": {
-    providerKey: "integration:hubspot",
+  hubspot: {
+    providerKey: "hubspot",
     authUrl: "https://app.hubspot.com/oauth/authorize",
     tokenUrl: "https://api.hubapi.com/oauth/v1/token",
     pingUrl: "https://api.hubapi.com/crm/v3/objects/contacts?limit=1",
@@ -380,8 +380,8 @@ const PROVIDER_SEED_DATA: Record<
     callbackTransport: "loopback",
   },
 
-  "integration:figma": {
-    providerKey: "integration:figma",
+  figma: {
+    providerKey: "figma",
     authUrl: "https://www.figma.com/oauth",
     tokenUrl: "https://api.figma.com/v1/oauth/token",
     pingUrl: "https://api.figma.com/v1/me",

--- a/assistant/src/runtime/routes/integrations/slack/share.ts
+++ b/assistant/src/runtime/routes/integrations/slack/share.ts
@@ -28,7 +28,7 @@ const log = getLogger("slack-share");
  * Resolve the Slack bot token from the OAuth connection store.
  */
 async function resolveSlackToken(): Promise<string | undefined> {
-  const conn = getConnectionByProvider("integration:slack");
+  const conn = getConnectionByProvider("slack");
   return conn
     ? await getSecureKeyAsync(`oauth_connection/${conn.id}/access_token`)
     : undefined;

--- a/assistant/src/schedule/integration-status.ts
+++ b/assistant/src/schedule/integration-status.ts
@@ -15,12 +15,12 @@ const INTEGRATION_PROBES: IntegrationProbe[] = [
   {
     name: "Gmail",
     category: "email",
-    isConnected: () => isProviderConnected("integration:google"),
+    isConnected: () => isProviderConnected("google"),
   },
   {
     name: "Slack",
     category: "messaging",
-    isConnected: () => isProviderConnected("integration:slack"),
+    isConnected: () => isProviderConnected("slack"),
   },
   {
     name: "Twilio",

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -35,16 +35,13 @@ import { getSecureKeyAsync, setSecureKeyAsync } from "./secure-keys.js";
 
 const log = getLogger("token-manager");
 
-const MESSAGING_SERVICES = new Set(["integration:google", "integration:slack"]);
+const MESSAGING_SERVICES = new Set(["google", "slack"]);
 
 function recoveryHint(service: string): string {
-  const shortName = service.startsWith("integration:")
-    ? service.slice("integration:".length)
-    : service;
   if (MESSAGING_SERVICES.has(service)) {
-    return ` Reconnect ${shortName} — follow the Error Recovery steps in the messaging skill. Do not present options or explain the error to the user.`;
+    return ` Reconnect ${service} — follow the Error Recovery steps in the messaging skill. Do not present options or explain the error to the user.`;
   }
-  return ` Re-authorization required for ${shortName}. Do not present options or explain the error to the user.`;
+  return ` Re-authorization required for ${service}. Do not present options or explain the error to the user.`;
 }
 
 // ── Shared circuit breaker & deduplication instances ──────────────────

--- a/assistant/src/tools/credentials/post-connect-hooks.ts
+++ b/assistant/src/tools/credentials/post-connect-hooks.ts
@@ -48,7 +48,7 @@ async function slackWelcomeDM(ctx: PostConnectHookContext): Promise<void> {
 // ---------------------------------------------------------------------------
 
 const POST_CONNECT_HOOKS: Record<string, PostConnectHook> = {
-  "integration:slack": slackWelcomeDM,
+  slack: slackWelcomeDM,
 };
 
 /**

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -14,8 +14,8 @@ import {
 } from "../../oauth/oauth-store.js";
 import {
   getProviderBehavior,
+  PROVIDER_BEHAVIORS,
   resolveService,
-  SERVICE_ALIASES,
 } from "../../oauth/provider-behaviors.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
@@ -829,7 +829,7 @@ class CredentialStoreTool implements Tool {
             isError: true,
           };
 
-        // Resolve aliases (e.g. "gmail" → "integration:google")
+        // Resolve aliases (e.g. "gmail" → "google")
         const service = resolveService(rawService);
 
         // Code-side behavioral fields (identityVerifier, setup, etc.)
@@ -975,7 +975,7 @@ class CredentialStoreTool implements Tool {
         if (!descProviderRow) {
           return {
             content: `No well-known OAuth config found for "${rawService}". Available services: ${Object.keys(
-              SERVICE_ALIASES,
+              PROVIDER_BEHAVIORS,
             ).join(", ")}`,
             isError: false,
           };

--- a/assistant/src/watcher/providers/github.ts
+++ b/assistant/src/watcher/providers/github.ts
@@ -6,7 +6,7 @@
  * start from "now" and don't replay historical notifications.
  *
  * The credential service expects a GitHub Personal Access Token (or fine-grained
- * token) stored under `integration:github`. The token needs at minimum the
+ * token) stored under `github`. The token needs at minimum the
  * `notifications` scope (classic) or Notification read permission (fine-grained).
  */
 
@@ -117,7 +117,7 @@ async function fetchNotificationsPage(
 export const githubProvider: WatcherProvider = {
   id: "github",
   displayName: "GitHub",
-  requiredCredentialService: "integration:github",
+  requiredCredentialService: "github",
 
   async getInitialWatermark(_credentialService: string): Promise<string> {
     // Start from "now" so we don't replay all existing notifications

--- a/assistant/src/watcher/providers/gmail.ts
+++ b/assistant/src/watcher/providers/gmail.ts
@@ -115,7 +115,7 @@ class HistoryExpiredError extends Error {
 export const gmailProvider: WatcherProvider = {
   id: "gmail",
   displayName: "Gmail",
-  requiredCredentialService: "integration:google",
+  requiredCredentialService: "google",
 
   async getInitialWatermark(credentialService: string): Promise<string> {
     const connection = await resolveOAuthConnection(credentialService);

--- a/assistant/src/watcher/providers/google-calendar.ts
+++ b/assistant/src/watcher/providers/google-calendar.ts
@@ -25,7 +25,7 @@ import type {
 const log = getLogger("watcher:google-calendar");
 
 /** The credential service — calendar shares OAuth tokens with Gmail. */
-const CREDENTIAL_SERVICE = "integration:google";
+const CREDENTIAL_SERVICE = "google";
 
 function eventToItem(event: CalendarEvent, eventType: string): WatcherItem {
   const start = event.start?.dateTime ?? event.start?.date ?? "";

--- a/assistant/src/watcher/providers/linear.ts
+++ b/assistant/src/watcher/providers/linear.ts
@@ -9,7 +9,7 @@
  * for issues assigned to the authenticated user.
  *
  * The credential service expects a Linear API key (personal or OAuth access token)
- * stored under `integration:linear`. The token only needs read access to notifications
+ * stored under `linear`. The token only needs read access to notifications
  * and issues.
  */
 
@@ -495,7 +495,7 @@ function issueToStatusChangeItem(
 export const linearProvider: WatcherProvider = {
   id: "linear",
   displayName: "Linear",
-  requiredCredentialService: "integration:linear",
+  requiredCredentialService: "linear",
 
   async getInitialWatermark(_credentialService: string): Promise<string> {
     // Start from "now" so we don't replay all existing notifications

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -479,7 +479,7 @@ struct SettingsPanel: View {
                     .background(VColor.borderBase)
                     .padding(.vertical, VSpacing.sm)
 
-                OAuthProviderServiceCard(store: store, authManager: authManager, showToast: showToast, providerKey: "integration:google")
+                OAuthProviderServiceCard(store: store, authManager: authManager, showToast: showToast, providerKey: "google")
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2126,15 +2126,15 @@ public final class SettingsStore: ObservableObject {
         }
         if let googleOAuth = services["google-oauth"] as? [String: Any],
            let mode = googleOAuth["mode"] as? String {
-            self.managedOAuthMode["integration:google"] = mode
+            self.managedOAuthMode["google"] = mode
         } else if let legacy = services["integration:google"] as? [String: Any],
                   let mode = legacy["mode"] as? String {
             // Migrate from the legacy key that was written due to a bug where
             // setManagedOAuthMode fell back to the raw providerKey when metadata
             // hadn't loaded yet. Read the value and re-save under the correct key
             // so subsequent launches use the canonical path.
-            self.managedOAuthMode["integration:google"] = mode
-            setManagedOAuthMode(mode, providerKey: "integration:google")
+            self.managedOAuthMode["google"] = mode
+            setManagedOAuthMode(mode, providerKey: "google")
         }
     }
 
@@ -2179,12 +2179,9 @@ public final class SettingsStore: ObservableObject {
 
     func setManagedOAuthMode(_ mode: String, providerKey: String) {
         managedOAuthMode[providerKey] = mode
-        // Derive the config service key deterministically from providerKey so it
-        // matches the key that loadServiceModes() reads on startup. Previously
-        // this depended on provider metadata being loaded, which caused a race:
-        // if metadata hadn't arrived yet the fallback wrote under the wrong key.
-        let slug = providerKey.hasPrefix("integration:") ? String(providerKey.dropFirst("integration:".count)) : providerKey
-        let serviceKey = "\(slug)-oauth"
+        // Derive the config service key from providerKey (e.g. "google" → "google-oauth")
+        // so it matches the key that loadServiceModes() reads on startup.
+        let serviceKey = "\(providerKey)-oauth"
         Task {
             let success = await settingsClient.patchConfig([
                 "services": [serviceKey: ["mode": mode]]
@@ -2274,11 +2271,9 @@ public final class SettingsStore: ObservableObject {
         guard managedOAuthMode[providerKey] == "managed" else { return }
         guard let assistantId = await resolvePlatformAssistantId(userId: userId) else { return }
 
-        let providerSlug = providerKey.hasPrefix("integration:") ? String(providerKey.dropFirst("integration:".count)) : providerKey
-
         do {
             let connections = try await PlatformOAuthService.shared.listConnections(assistantId: assistantId)
-            managedOAuthConnections[providerKey] = connections.filter { $0.provider == providerSlug }
+            managedOAuthConnections[providerKey] = connections.filter { $0.provider == providerKey }
             managedOAuthError[providerKey] = nil
         } catch {
             log.error("Failed to fetch managed OAuth connections for \(providerKey): \(error)")
@@ -2288,8 +2283,6 @@ public final class SettingsStore: ObservableObject {
     }
 
     func startManagedOAuthConnect(providerKey: String, userId: String? = nil) {
-        let providerSlug = providerKey.hasPrefix("integration:") ? String(providerKey.dropFirst("integration:".count)) : providerKey
-
         Task {
             managedOAuthIsConnecting[providerKey] = true
             managedOAuthError[providerKey] = nil
@@ -2302,9 +2295,9 @@ public final class SettingsStore: ObservableObject {
 
             do {
                 let response = try await PlatformOAuthService.shared.startOAuthConnect(
-                    provider: providerSlug,
+                    provider: providerKey,
                     assistantId: assistantId,
-                    redirectAfterConnect: "vellum-assistant://oauth/\(providerSlug)/callback"
+                    redirectAfterConnect: "vellum-assistant://oauth/\(providerKey)/callback"
                 )
 
                 guard let connectURL = URL(string: response.connect_url) else {
@@ -3144,11 +3137,8 @@ struct OAuthProviderMetadata: Codable, Sendable {
     let client_id_placeholder: String?
     let requires_client_secret: Int
 
-    /// Derive the platform OAuth slug from provider_key (e.g. "integration:google" → "google").
+    /// The platform OAuth slug is the provider_key itself (bare name, e.g. "google").
     var platformOAuthSlug: String {
-        if provider_key.hasPrefix("integration:") {
-            return String(provider_key.dropFirst("integration:".count))
-        }
         return provider_key
     }
 }

--- a/credential-executor/src/__tests__/command-executor.test.ts
+++ b/credential-executor/src/__tests__/command-executor.test.ts
@@ -1482,7 +1482,7 @@ describe("executeAuthenticatedCommand — integration: local OAuth", () => {
     });
     addCommandGrant(
       deps.persistentStore,
-      "local_oauth:integration:google/conn-123",
+      "local_oauth:google/conn-123",
       digest,
       "list",
     );
@@ -1490,7 +1490,7 @@ describe("executeAuthenticatedCommand — integration: local OAuth", () => {
     const request: ExecuteCommandRequest = {
       bundleDigest: digest,
       profileName: "list",
-      credentialHandle: "local_oauth:integration:google/conn-123",
+      credentialHandle: "local_oauth:google/conn-123",
       argv: ["list", "--format", "json"],
       workspaceDir: testWorkspaceDir,
       purpose: "OAuth pipeline test",

--- a/credential-executor/src/__tests__/http-executor.test.ts
+++ b/credential-executor/src/__tests__/http-executor.test.ts
@@ -102,7 +102,7 @@ function buildOAuthConnection(
 ): OAuthConnectionRecord {
   return {
     id: overrides.id ?? "conn-uuid-1",
-    providerKey: overrides.providerKey ?? "integration:google",
+    providerKey: overrides.providerKey ?? "google",
     accountInfo: overrides.accountInfo ?? "user@example.com",
     grantedScopes: overrides.grantedScopes ?? ["openid", "email"],
     accessTokenPath: overrides.accessTokenPath ??
@@ -434,7 +434,7 @@ describe("HTTP executor: local OAuth", () => {
   beforeEach(() => {
     connection = buildOAuthConnection({
       id: "conn-google-1",
-      providerKey: "integration:google",
+      providerKey: "google",
       expiresAt: Date.now() + 3600000, // valid for 1 hour
     });
 
@@ -451,7 +451,7 @@ describe("HTTP executor: local OAuth", () => {
   });
 
   test("successful OAuth request with matching grant", async () => {
-    const handle = localOAuthHandle("integration:google", "conn-google-1");
+    const handle = localOAuthHandle("google", "conn-google-1");
 
     fixture.persistentStore.add({
       id: "grant-google-calendar",
@@ -492,7 +492,7 @@ describe("HTTP executor: local OAuth", () => {
   });
 
   test("OAuth token scrubbed from response body", async () => {
-    const handle = localOAuthHandle("integration:google", "conn-google-1");
+    const handle = localOAuthHandle("google", "conn-google-1");
 
     fixture.persistentStore.add({
       id: "grant-google-debug",

--- a/credential-executor/src/__tests__/local-materializers.test.ts
+++ b/credential-executor/src/__tests__/local-materializers.test.ts
@@ -98,7 +98,7 @@ function buildOAuthConnection(
 ): OAuthConnectionRecord {
   return {
     id: overrides.id ?? "conn-uuid-1",
-    providerKey: overrides.providerKey ?? "integration:google",
+    providerKey: overrides.providerKey ?? "google",
     accountInfo: overrides.accountInfo ?? "user@example.com",
     grantedScopes: overrides.grantedScopes ?? ["openid", "email"],
     accessTokenPath: overrides.accessTokenPath ??
@@ -227,10 +227,10 @@ describe("local OAuth subject resolution", () => {
   test("resolves a valid OAuth handle to an OAuth subject", () => {
     const conn = buildOAuthConnection({
       id: "conn-abc",
-      providerKey: "integration:google",
+      providerKey: "google",
     });
     const deps = createResolverDeps({ oauthConnections: [conn] });
-    const handle = localOAuthHandle("integration:google", "conn-abc");
+    const handle = localOAuthHandle("google", "conn-abc");
 
     const result = resolveLocalSubject(handle, deps);
 
@@ -239,12 +239,12 @@ describe("local OAuth subject resolution", () => {
     expect(result.subject.type).toBe(HandleType.LocalOAuth);
     if (result.subject.type !== HandleType.LocalOAuth) return;
     expect(result.subject.connection.id).toBe("conn-abc");
-    expect(result.subject.connection.providerKey).toBe("integration:google");
+    expect(result.subject.connection.providerKey).toBe("google");
   });
 
   test("fails when the connection does not exist", () => {
     const deps = createResolverDeps({ oauthConnections: [] });
-    const handle = localOAuthHandle("integration:google", "missing-conn");
+    const handle = localOAuthHandle("google", "missing-conn");
 
     const result = resolveLocalSubject(handle, deps);
 
@@ -257,19 +257,19 @@ describe("local OAuth subject resolution", () => {
   test("fails when provider key in handle does not match connection", () => {
     const conn = buildOAuthConnection({
       id: "conn-xyz",
-      providerKey: "integration:slack",
+      providerKey: "slack",
     });
     const deps = createResolverDeps({ oauthConnections: [conn] });
     // Handle says google but connection is slack
-    const handle = localOAuthHandle("integration:google", "conn-xyz");
+    const handle = localOAuthHandle("google", "conn-xyz");
 
     const result = resolveLocalSubject(handle, deps);
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error).toMatch(/providerKey/);
-    expect(result.error).toMatch(/integration:slack/);
-    expect(result.error).toMatch(/integration:google/);
+    expect(result.error).toMatch(/slack/);
+    expect(result.error).toMatch(/google/);
   });
 });
 
@@ -378,13 +378,13 @@ describe("OAuth token materialisation", () => {
   test("materialises a valid non-expired access token", async () => {
     const conn = buildOAuthConnection({
       id: "conn-1",
-      providerKey: "integration:google",
+      providerKey: "google",
       // Token expires in the future (1 hour from now)
       expiresAt: Date.now() + 60 * 60 * 1000,
       hasRefreshToken: true,
     });
     const deps = createResolverDeps({ oauthConnections: [conn] });
-    const handle = localOAuthHandle("integration:google", "conn-1");
+    const handle = localOAuthHandle("google", "conn-1");
 
     const resolved = resolveLocalSubject(handle, deps);
     expect(resolved.ok).toBe(true);
@@ -408,11 +408,11 @@ describe("OAuth token materialisation", () => {
   test("fails when no access token is stored (disconnected connection)", async () => {
     const conn = buildOAuthConnection({
       id: "conn-disconnected",
-      providerKey: "integration:slack",
+      providerKey: "slack",
       hasRefreshToken: false,
     });
     const deps = createResolverDeps({ oauthConnections: [conn] });
-    const handle = localOAuthHandle("integration:slack", "conn-disconnected");
+    const handle = localOAuthHandle("slack", "conn-disconnected");
 
     const resolved = resolveLocalSubject(handle, deps);
     expect(resolved.ok).toBe(true);
@@ -435,14 +435,14 @@ describe("OAuth token materialisation", () => {
   test("fails when token is expired and hasRefreshToken is false", async () => {
     const conn = buildOAuthConnection({
       id: "conn-expired-no-refresh",
-      providerKey: "integration:google",
+      providerKey: "google",
       // Token expired 10 minutes ago
       expiresAt: Date.now() - 10 * 60 * 1000,
       hasRefreshToken: false,
     });
     const deps = createResolverDeps({ oauthConnections: [conn] });
     const handle = localOAuthHandle(
-      "integration:google",
+      "google",
       "conn-expired-no-refresh",
     );
 
@@ -469,12 +469,12 @@ describe("OAuth token materialisation", () => {
   test("materialises a token with null expiresAt (no expiry info)", async () => {
     const conn = buildOAuthConnection({
       id: "conn-noexpiry",
-      providerKey: "integration:github",
+      providerKey: "github",
       expiresAt: null,
       hasRefreshToken: false,
     });
     const deps = createResolverDeps({ oauthConnections: [conn] });
-    const handle = localOAuthHandle("integration:github", "conn-noexpiry");
+    const handle = localOAuthHandle("github", "conn-noexpiry");
 
     const resolved = resolveLocalSubject(handle, deps);
     expect(resolved.ok).toBe(true);
@@ -504,13 +504,13 @@ describe("OAuth refresh-on-expiry", () => {
   test("refreshes an expired token and returns the new access token", async () => {
     const conn = buildOAuthConnection({
       id: "conn-expired",
-      providerKey: "integration:google",
+      providerKey: "google",
       // Token expired 10 minutes ago
       expiresAt: Date.now() - 10 * 60 * 1000,
       hasRefreshToken: true,
     });
     const deps = createResolverDeps({ oauthConnections: [conn] });
-    const handle = localOAuthHandle("integration:google", "conn-expired");
+    const handle = localOAuthHandle("google", "conn-expired");
 
     const resolved = resolveLocalSubject(handle, deps);
     expect(resolved.ok).toBe(true);
@@ -545,12 +545,12 @@ describe("OAuth refresh-on-expiry", () => {
   test("fails when token is expired but no refresh function is configured", async () => {
     const conn = buildOAuthConnection({
       id: "conn-no-refresh-fn",
-      providerKey: "integration:google",
+      providerKey: "google",
       expiresAt: Date.now() - 10 * 60 * 1000,
       hasRefreshToken: true,
     });
     const deps = createResolverDeps({ oauthConnections: [conn] });
-    const handle = localOAuthHandle("integration:google", "conn-no-refresh-fn");
+    const handle = localOAuthHandle("google", "conn-no-refresh-fn");
 
     const resolved = resolveLocalSubject(handle, deps);
     expect(resolved.ok).toBe(true);
@@ -577,13 +577,13 @@ describe("OAuth refresh-on-expiry", () => {
   test("fails when token is expired and no refresh token is stored", async () => {
     const conn = buildOAuthConnection({
       id: "conn-no-stored-refresh",
-      providerKey: "integration:google",
+      providerKey: "google",
       expiresAt: Date.now() - 10 * 60 * 1000,
       hasRefreshToken: true,
     });
     const deps = createResolverDeps({ oauthConnections: [conn] });
     const handle = localOAuthHandle(
-      "integration:google",
+      "google",
       "conn-no-stored-refresh",
     );
 
@@ -617,13 +617,13 @@ describe("OAuth refresh-on-expiry", () => {
   test("fails when refresh function returns a failure result", async () => {
     const conn = buildOAuthConnection({
       id: "conn-refresh-fail",
-      providerKey: "integration:google",
+      providerKey: "google",
       expiresAt: Date.now() - 10 * 60 * 1000,
       hasRefreshToken: true,
     });
     const deps = createResolverDeps({ oauthConnections: [conn] });
     const handle = localOAuthHandle(
-      "integration:google",
+      "google",
       "conn-refresh-fail",
     );
 
@@ -662,12 +662,12 @@ describe("refresh circuit breaker", () => {
   test("trips after repeated refresh failures and returns error", async () => {
     const conn = buildOAuthConnection({
       id: "conn-breaker",
-      providerKey: "integration:google",
+      providerKey: "google",
       expiresAt: Date.now() - 10 * 60 * 1000,
       hasRefreshToken: true,
     });
     const deps = createResolverDeps({ oauthConnections: [conn] });
-    const handle = localOAuthHandle("integration:google", "conn-breaker");
+    const handle = localOAuthHandle("google", "conn-breaker");
 
     const resolved = resolveLocalSubject(handle, deps);
     expect(resolved.ok).toBe(true);
@@ -724,7 +724,7 @@ describe("deterministic fail-closed behaviour", () => {
 
     // Missing OAuth connection
     const r3 = resolveLocalSubject(
-      localOAuthHandle("integration:x", "missing-conn"),
+      localOAuthHandle("x", "missing-conn"),
       deps,
     );
     expect(r3.ok).toBe(false);
@@ -765,10 +765,10 @@ describe("deterministic fail-closed behaviour", () => {
   test("OAuth disconnection detected before any refresh attempt", async () => {
     const conn = buildOAuthConnection({
       id: "conn-disco",
-      providerKey: "integration:slack",
+      providerKey: "slack",
     });
     const deps = createResolverDeps({ oauthConnections: [conn] });
-    const handle = localOAuthHandle("integration:slack", "conn-disco");
+    const handle = localOAuthHandle("slack", "conn-disco");
 
     const resolved = resolveLocalSubject(handle, deps);
     expect(resolved.ok).toBe(true);
@@ -831,12 +831,12 @@ describe("end-to-end local materialisation", () => {
   test("full pipeline: resolve OAuth handle -> materialise token", async () => {
     const conn = buildOAuthConnection({
       id: "conn-e2e",
-      providerKey: "integration:linear",
+      providerKey: "linear",
       expiresAt: Date.now() + 3600 * 1000,
       hasRefreshToken: true,
     });
     const deps = createResolverDeps({ oauthConnections: [conn] });
-    const handle = localOAuthHandle("integration:linear", "conn-e2e");
+    const handle = localOAuthHandle("linear", "conn-e2e");
 
     // Step 1: Resolve
     const resolved = resolveLocalSubject(handle, deps);

--- a/credential-executor/src/__tests__/managed-materializers.test.ts
+++ b/credential-executor/src/__tests__/managed-materializers.test.ts
@@ -264,7 +264,7 @@ describe("resolveManagedSubject", () => {
 
   test("rejects a local_oauth handle", async () => {
     const result = await resolveManagedSubject(
-      "local_oauth:integration:google/conn_local1",
+      "local_oauth:google/conn_local1",
       {
         platformBaseUrl: TEST_PLATFORM_URL,
         assistantApiKey: TEST_API_KEY,

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1738,7 +1738,7 @@ export function buildSchema(): Record<string, unknown> {
               required: true,
               schema: { type: "string" },
               description:
-                "OAuth provider key to filter by, for example `integration:google`.",
+                "OAuth provider key to filter by, for example `google`.",
             },
           ],
           security: [{ BearerAuth: [] }],

--- a/packages/ces-contracts/src/__tests__/grants.test.ts
+++ b/packages/ces-contracts/src/__tests__/grants.test.ts
@@ -71,19 +71,19 @@ describe("handles", () => {
 
   describe("localOAuthHandle", () => {
     test("constructs the expected format", () => {
-      expect(localOAuthHandle("integration:google", "conn-123")).toBe(
-        "local_oauth:integration:google/conn-123",
+      expect(localOAuthHandle("google", "conn-123")).toBe(
+        "local_oauth:google/conn-123",
       );
     });
 
-    test("roundtrips with integration: prefix in providerKey", () => {
-      const raw = localOAuthHandle("integration:slack", "conn-abc");
+    test("roundtrips through parseHandle", () => {
+      const raw = localOAuthHandle("slack", "conn-abc");
       const result = parseHandle(raw);
       expect(result.ok).toBe(true);
       if (!result.ok) return;
       expect(result.handle.type).toBe(HandleType.LocalOAuth);
       if (result.handle.type !== HandleType.LocalOAuth) return;
-      expect(result.handle.providerKey).toBe("integration:slack");
+      expect(result.handle.providerKey).toBe("slack");
       expect(result.handle.connectionId).toBe("conn-abc");
     });
   });
@@ -133,7 +133,7 @@ describe("handles", () => {
     });
 
     test("rejects local_oauth with no slash", () => {
-      const result = parseHandle("local_oauth:integration:google");
+      const result = parseHandle("local_oauth:google");
       expect(result.ok).toBe(false);
     });
 
@@ -150,7 +150,7 @@ describe("handles", () => {
       ).not.toThrow();
       expect(() =>
         CredentialHandleSchema.parse(
-          "local_oauth:integration:google/conn-1",
+          "local_oauth:google/conn-1",
         ),
       ).not.toThrow();
       expect(() =>

--- a/packages/ces-contracts/src/handles.ts
+++ b/packages/ces-contracts/src/handles.ts
@@ -13,7 +13,7 @@
  *
  * 2. **Local OAuth** — references a locally persisted OAuth connection.
  *    Format: `local_oauth:<providerKey>/<connectionId>` where providerKey
- *    uses the existing `integration:*` keys (e.g. `integration:google`).
+ *    is the bare provider name (e.g. `google`).
  *
  * 3. **Managed OAuth** — references an OAuth connection managed by the
  *    platform. Format: `platform_oauth:<connectionId>` where connectionId
@@ -50,7 +50,7 @@ export interface LocalStaticHandle {
 
 export interface LocalOAuthHandle {
   type: typeof HandleType.LocalOAuth;
-  /** Provider key (e.g. "integration:google", "integration:slack"). */
+  /** Provider key (e.g. "google", "slack"). */
   providerKey: string;
   /** Connection identifier. */
   connectionId: string;
@@ -146,8 +146,9 @@ export function parseHandle(raw: string): ParseHandleResult {
     }
 
     case HandleType.LocalOAuth: {
-      // providerKey may itself contain a colon (e.g. "integration:google"),
-      // so we split on the *last* "/" to separate providerKey from connectionId.
+      // providerKey is typically a bare name (e.g. "google"), but legacy handles
+      // may contain a colon (e.g. "integration:google"), so we split on the
+      // *last* "/" to separate providerKey from connectionId.
       const lastSlashIdx = rest.lastIndexOf("/");
       if (
         lastSlashIdx === -1 ||

--- a/packages/credential-storage/src/index.ts
+++ b/packages/credential-storage/src/index.ts
@@ -98,7 +98,7 @@ export interface SecureKeyBackend {
 export interface OAuthConnectionRecord {
   /** Unique identifier for this connection. */
   id: string;
-  /** Provider key (e.g. "integration:google", "integration:slack"). */
+  /** Provider key (e.g. "google", "slack"). */
   providerKey: string;
   /** Account identifier (e.g. email address). */
   accountInfo: string | null;

--- a/skills/airtable-oauth-setup/SKILL.md
+++ b/skills/airtable-oauth-setup/SKILL.md
@@ -120,7 +120,7 @@ bash:
     assistant oauth apps upsert --provider airtable --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "airtable:oauth_secret"
+    ) --client-secret-credential-path "credential/airtable/oauth_secret"
 ```
 
 **Milestone (6 of 8):** "Credentials saved - just the authorization step left."

--- a/skills/airtable-oauth-setup/SKILL.md
+++ b/skills/airtable-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:airtable`
+- **Provider key:** `airtable`
 - **Dashboard:** `https://airtable.com/create/oauth`
 - **Ping URL:** `https://api.airtable.com/v0/meta/whoami`
 - **Callback transport:** Loopback (port 17329)
@@ -105,7 +105,7 @@ Collect the OAuth secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:airtable"
+  service: "airtable"
   field: "oauth_secret"
   label: "Airtable OAuth Secret"
   description: "Copy the OAuth secret from the integration page (you may need to click Show or Generate first) and paste it here."
@@ -117,10 +117,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:airtable --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider airtable --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:airtable:oauth_secret"
+    ) --client-secret-credential-path "airtable:oauth_secret"
 ```
 
 **Milestone (6 of 8):** "Credentials saved - just the authorization step left."
@@ -136,7 +136,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:airtable
+    assistant oauth connect airtable
 ```
 
 ---
@@ -148,7 +148,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:airtable
+    assistant oauth ping airtable
 ```
 
 **On success:** "Airtable is connected! You can now ask me to read and update records in your Airtable bases."

--- a/skills/airtable-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/airtable-oauth-setup/references/path-b-manual-setup.md
@@ -116,7 +116,7 @@ bash:
     assistant oauth apps upsert --provider airtable --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "airtable:oauth_secret"
+    ) --client-secret-credential-path "credential/airtable/oauth_secret"
 ```
 
 ```

--- a/skills/airtable-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/airtable-oauth-setup/references/path-b-manual-setup.md
@@ -82,7 +82,7 @@ Wait for the Client ID, then store it:
 
 ```
 credential_store store:
-  service: "integration:airtable"
+  service: "airtable"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -95,7 +95,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:airtable"
+  service: "airtable"
   field: "oauth_secret"
   value: "<the oauth secret the user sent>"
 ```
@@ -113,16 +113,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:airtable --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider airtable --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:airtable:oauth_secret"
+    ) --client-secret-credential-path "airtable:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:airtable
+    assistant oauth connect airtable
 ```
 
 Send the returned auth URL to the user. Tell them to click **Grant access** on the Airtable consent page.

--- a/skills/asana-oauth-setup/SKILL.md
+++ b/skills/asana-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:asana`
+- **Provider key:** `asana`
 - **Dashboard:** `https://app.asana.com/0/my-apps`
 - **Ping URL:** `https://app.asana.com/api/1.0/users/me`
 - **Callback transport:** Loopback (port 17328)
@@ -89,7 +89,7 @@ Collect the app secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:asana"
+  service: "asana"
   field: "oauth_secret"
   label: "Asana OAuth App Secret"
   description: "Copy the app secret from the OAuth section of your Asana app settings (you may need to click Show first) and paste it here."
@@ -101,10 +101,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:asana --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider asana --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:asana:oauth_secret"
+    ) --client-secret-credential-path "asana:oauth_secret"
 ```
 
 **Milestone (5 of 7):** "Credentials saved - just the authorization step left."
@@ -120,7 +120,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:asana
+    assistant oauth connect asana
 ```
 
 ---
@@ -132,7 +132,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:asana
+    assistant oauth ping asana
 ```
 
 **On success:** "Asana is connected! You can now ask me to check your Asana tasks, create projects, manage assignments, and track your work."

--- a/skills/asana-oauth-setup/SKILL.md
+++ b/skills/asana-oauth-setup/SKILL.md
@@ -104,7 +104,7 @@ bash:
     assistant oauth apps upsert --provider asana --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "asana:oauth_secret"
+    ) --client-secret-credential-path "credential/asana/oauth_secret"
 ```
 
 **Milestone (5 of 7):** "Credentials saved - just the authorization step left."

--- a/skills/asana-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/asana-oauth-setup/references/path-b-manual-setup.md
@@ -70,7 +70,7 @@ Wait for the Client ID, then store it:
 
 ```
 credential_store store:
-  service: "integration:asana"
+  service: "asana"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -83,7 +83,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:asana"
+  service: "asana"
   field: "oauth_secret"
   value: "<the app secret the user sent>"
 ```
@@ -101,16 +101,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:asana --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider asana --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:asana:oauth_secret"
+    ) --client-secret-credential-path "asana:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:asana
+    assistant oauth connect asana
 ```
 
 Send the returned auth URL to the user. Tell them to click **Allow** on the Asana consent page.

--- a/skills/asana-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/asana-oauth-setup/references/path-b-manual-setup.md
@@ -104,7 +104,7 @@ bash:
     assistant oauth apps upsert --provider asana --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "asana:oauth_secret"
+    ) --client-secret-credential-path "credential/asana/oauth_secret"
 ```
 
 ```

--- a/skills/discord-oauth-setup/SKILL.md
+++ b/skills/discord-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:discord`
+- **Provider key:** `discord`
 - **Dashboard:** `https://discord.com/developers/applications`
 - **Ping URL:** `https://discord.com/api/v10/users/@me`
 - **Callback transport:** Loopback (port 17326)
@@ -110,7 +110,7 @@ Collect the app secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:discord"
+  service: "discord"
   field: "oauth_secret"
   label: "Discord OAuth App Secret"
   description: "Paste the app secret you just copied from the OAuth2 page."
@@ -122,10 +122,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:discord --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider discord --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:discord:oauth_secret"
+    ) --client-secret-credential-path "discord:oauth_secret"
 ```
 
 **Milestone (7 of 9):** "Credentials saved - just the authorization step left."
@@ -141,7 +141,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:discord --scopes identify guilds guilds.members.read messages.read
+    assistant oauth connect discord --scopes identify guilds guilds.members.read messages.read
 ```
 
 ---
@@ -153,7 +153,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:discord
+    assistant oauth ping discord
 ```
 
 **On success:** "Discord is connected! You can now ask me to check your Discord servers, read messages, and look up server members."

--- a/skills/discord-oauth-setup/SKILL.md
+++ b/skills/discord-oauth-setup/SKILL.md
@@ -125,7 +125,7 @@ bash:
     assistant oauth apps upsert --provider discord --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "discord:oauth_secret"
+    ) --client-secret-credential-path "credential/discord/oauth_secret"
 ```
 
 **Milestone (7 of 9):** "Credentials saved - just the authorization step left."

--- a/skills/discord-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/discord-oauth-setup/references/path-b-manual-setup.md
@@ -114,7 +114,7 @@ bash:
     assistant oauth apps upsert --provider discord --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "discord:oauth_secret"
+    ) --client-secret-credential-path "credential/discord/oauth_secret"
 ```
 
 ```

--- a/skills/discord-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/discord-oauth-setup/references/path-b-manual-setup.md
@@ -80,7 +80,7 @@ Wait for the Client ID, then store it:
 
 ```
 credential_store store:
-  service: "integration:discord"
+  service: "discord"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -93,7 +93,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:discord"
+  service: "discord"
   field: "oauth_secret"
   value: "<the app secret the user sent>"
 ```
@@ -111,16 +111,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:discord --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider discord --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:discord:oauth_secret"
+    ) --client-secret-credential-path "discord:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:discord --scopes identify guilds guilds.members.read messages.read
+    assistant oauth connect discord --scopes identify guilds guilds.members.read messages.read
 ```
 
 Send the returned auth URL to the user. Tell them to click **Authorize** on the Discord consent page.

--- a/skills/dropbox-oauth-setup/SKILL.md
+++ b/skills/dropbox-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:dropbox`
+- **Provider key:** `dropbox`
 - **Dashboard:** `https://www.dropbox.com/developers/apps`
 - **Ping URL:** `https://api.dropboxapi.com/2/users/get_current_account` (POST, no body)
 - **Callback transport:** Loopback (port 17327)
@@ -129,7 +129,7 @@ Collect the App secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:dropbox"
+  service: "dropbox"
   field: "oauth_secret"
   label: "Dropbox App Secret"
   description: "Copy the App secret from the Settings page (click Show to reveal it) and paste it here."
@@ -141,10 +141,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:dropbox --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider dropbox --client-id $(cat <<'EOF'
     <app-key>
     EOF
-    ) --client-secret-credential-path "integration:dropbox:oauth_secret"
+    ) --client-secret-credential-path "dropbox:oauth_secret"
 ```
 
 **Milestone (8 of 11):** "Credentials saved - just the authorization step left."
@@ -160,7 +160,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:dropbox
+    assistant oauth connect dropbox
 ```
 
 ---
@@ -172,7 +172,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:dropbox
+    assistant oauth ping dropbox
 ```
 
 **On success:** "Dropbox is connected! You can now ask me to read files, upload documents, and browse your Dropbox."

--- a/skills/dropbox-oauth-setup/SKILL.md
+++ b/skills/dropbox-oauth-setup/SKILL.md
@@ -144,7 +144,7 @@ bash:
     assistant oauth apps upsert --provider dropbox --client-id $(cat <<'EOF'
     <app-key>
     EOF
-    ) --client-secret-credential-path "dropbox:oauth_secret"
+    ) --client-secret-credential-path "credential/dropbox/oauth_secret"
 ```
 
 **Milestone (8 of 11):** "Credentials saved - just the authorization step left."

--- a/skills/dropbox-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/dropbox-oauth-setup/references/path-b-manual-setup.md
@@ -118,7 +118,7 @@ bash:
     assistant oauth apps upsert --provider dropbox --client-id $(cat <<'EOF'
     <app-key>
     EOF
-    ) --client-secret-credential-path "dropbox:oauth_secret"
+    ) --client-secret-credential-path "credential/dropbox/oauth_secret"
 ```
 
 ```

--- a/skills/dropbox-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/dropbox-oauth-setup/references/path-b-manual-setup.md
@@ -84,7 +84,7 @@ Wait for the App key, then store it:
 
 ```
 credential_store store:
-  service: "integration:dropbox"
+  service: "dropbox"
   field: "client_id"
   value: "<the app key the user sent>"
 ```
@@ -97,7 +97,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:dropbox"
+  service: "dropbox"
   field: "oauth_secret"
   value: "<the app secret the user sent>"
 ```
@@ -115,16 +115,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:dropbox --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider dropbox --client-id $(cat <<'EOF'
     <app-key>
     EOF
-    ) --client-secret-credential-path "integration:dropbox:oauth_secret"
+    ) --client-secret-credential-path "dropbox:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:dropbox
+    assistant oauth connect dropbox
 ```
 
 Send the returned auth URL to the user. Tell them to click **Allow** on the Dropbox consent page.

--- a/skills/figma-oauth-setup/SKILL.md
+++ b/skills/figma-oauth-setup/SKILL.md
@@ -125,7 +125,7 @@ bash:
     assistant oauth apps upsert --provider figma --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "figma:oauth_secret"
+    ) --client-secret-credential-path "credential/figma/oauth_secret"
 ```
 
 **Milestone (6 of 7):** "Credentials saved - just the authorization step left."

--- a/skills/figma-oauth-setup/SKILL.md
+++ b/skills/figma-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:figma`
+- **Provider key:** `figma`
 - **Dashboard:** `https://www.figma.com/developers/apps`
 - **Ping URL:** `https://api.figma.com/v1/me`
 - **Callback transport:** Loopback (port 17331)
@@ -110,7 +110,7 @@ Collect the app secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:figma"
+  service: "figma"
   field: "oauth_secret"
   label: "Figma OAuth App Secret"
   description: "Copy the app secret from the Figma app settings page and paste it here."
@@ -122,10 +122,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:figma --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider figma --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:figma:oauth_secret"
+    ) --client-secret-credential-path "figma:oauth_secret"
 ```
 
 **Milestone (6 of 7):** "Credentials saved - just the authorization step left."
@@ -141,7 +141,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:figma
+    assistant oauth connect figma
 ```
 
 After authorization completes, verify the connection:
@@ -149,7 +149,7 @@ After authorization completes, verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:figma
+    assistant oauth ping figma
 ```
 
 **On success:** "Figma is connected! You can now ask me to browse your design files, inspect components, and post comments."

--- a/skills/figma-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/figma-oauth-setup/references/path-b-manual-setup.md
@@ -73,7 +73,7 @@ Wait for the Client ID, then store it:
 
 ```
 credential_store store:
-  service: "integration:figma"
+  service: "figma"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -86,7 +86,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:figma"
+  service: "figma"
   field: "oauth_secret"
   value: "<the app secret the user sent>"
 ```
@@ -104,16 +104,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:figma --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider figma --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:figma:oauth_secret"
+    ) --client-secret-credential-path "figma:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:figma
+    assistant oauth connect figma
 ```
 
 Send the returned auth URL to the user. Tell them to click **Allow access** on the Figma consent page.

--- a/skills/figma-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/figma-oauth-setup/references/path-b-manual-setup.md
@@ -107,7 +107,7 @@ bash:
     assistant oauth apps upsert --provider figma --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "figma:oauth_secret"
+    ) --client-secret-credential-path "credential/figma/oauth_secret"
 ```
 
 ```

--- a/skills/github-oauth-setup/SKILL.md
+++ b/skills/github-oauth-setup/SKILL.md
@@ -119,7 +119,7 @@ bash:
     assistant oauth apps upsert --provider github --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "github:<secret-field>"
+    ) --client-secret-credential-path "credential/github/<secret-field>"
 ```
 
 **Milestone (5 of 8):** "Credentials saved - just the authorization step left."

--- a/skills/github-oauth-setup/SKILL.md
+++ b/skills/github-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:github`
+- **Provider key:** `github`
 - **Dashboard:** `https://github.com/settings/developers`
 - **Ping URL:** `https://api.github.com/user`
 - **Callback transport:** Loopback
@@ -58,7 +58,7 @@ Resolve the callback URL:
 
 ```
 bash:
-  command: assistant oauth providers get integration:github --json
+  command: assistant oauth providers get github --json
 ```
 
 Use the `redirectUri` from the JSON response:
@@ -102,7 +102,7 @@ Collect the app secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:github"
+  service: "github"
   field: <secret-field>
   label: "GitHub OAuth App Secret"
   description: "Paste the app secret you just generated from the GitHub OAuth App page."
@@ -116,10 +116,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:github --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider github --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:github:<secret-field>"
+    ) --client-secret-credential-path "github:<secret-field>"
 ```
 
 **Milestone (5 of 8):** "Credentials saved - just the authorization step left."
@@ -147,7 +147,7 @@ These scopes are passed during the authorization step below.
 ```
 bash:
   command: |
-    assistant oauth connect integration:github --scopes repo read:user notifications
+    assistant oauth connect github --scopes repo read:user notifications
 ```
 
 **Milestone (7 of 8):** "Authorization complete - let's verify it works."
@@ -161,7 +161,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:github
+    assistant oauth ping github
 ```
 
 **On success:** "GitHub is connected! You can now ask me to check your repositories, notifications, pull requests, and issues."

--- a/skills/github-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/github-oauth-setup/references/path-b-manual-setup.md
@@ -95,7 +95,7 @@ bash:
     assistant oauth apps upsert --provider github --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "github:<secret-field>"
+    ) --client-secret-credential-path "credential/github/<secret-field>"
 ```
 
 ```

--- a/skills/github-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/github-oauth-setup/references/path-b-manual-setup.md
@@ -59,7 +59,7 @@ Wait for the Client ID, then store it:
 
 ```
 credential_store store:
-  service: "integration:github"
+  service: "github"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -72,7 +72,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:github"
+  service: "github"
   field: <secret-field>
   value: "<the app secret the user sent>"
 ```
@@ -92,16 +92,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:github --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider github --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:github:<secret-field>"
+    ) --client-secret-credential-path "github:<secret-field>"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:github --scopes repo read:user notifications
+    assistant oauth connect github --scopes repo read:user notifications
 ```
 
 Send the returned auth URL to the user. Tell them to click **Authorize** on the GitHub consent page.

--- a/skills/google-oauth-applescript/SKILL.md
+++ b/skills/google-oauth-applescript/SKILL.md
@@ -15,7 +15,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:google`
+- **Provider key:** `google`
 - **Provider search keys:** `gmail`, `google`
 - **Credential type (Path A):** Desktop app
 - **Credential type (Path B):** Web application (callback through public gateway)

--- a/skills/google-oauth-applescript/references/path-b-manual-setup.md
+++ b/skills/google-oauth-applescript/references/path-b-manual-setup.md
@@ -130,7 +130,7 @@ After the user sends it:
 
 ```
 credential_store store:
-  service: "integration:google"
+  service: "google"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -149,7 +149,7 @@ After the user sends the suffix, reconstruct and store the full secret:
 
 ```
 credential_store store:
-  service: "integration:google"
+  service: "google"
   field: "client_secret"
   value: "GOCSPX-<the suffix the user sent>"
 ```
@@ -165,7 +165,7 @@ Tell the user:
 ```
 credential_store:
   action: "oauth2_connect"
-  service: "integration:google"
+  service: "google"
 ```
 
 Send the returned auth URL to the user. If they see **This app isn't verified**, tell them to click **Advanced** and continue to **Vellum Assistant**.

--- a/skills/hubspot-oauth-setup/SKILL.md
+++ b/skills/hubspot-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:hubspot`
+- **Provider key:** `hubspot`
 - **Dashboard:** `https://app.hubspot.com/developer`
 - **Ping URL:** `https://api.hubapi.com/crm/v3/objects/contacts?limit=1`
 - **Callback transport:** Loopback (port 17330)
@@ -123,7 +123,7 @@ Collect the app secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:hubspot"
+  service: "hubspot"
   field: "oauth_secret"
   label: "HubSpot OAuth App Secret"
   description: "Copy the App Secret from the Auth tab and paste it here."
@@ -135,10 +135,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:hubspot --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider hubspot --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:hubspot:oauth_secret"
+    ) --client-secret-credential-path "hubspot:oauth_secret"
 ```
 
 Then authorize:
@@ -150,7 +150,7 @@ Then authorize:
 ```
 bash:
   command: |
-    assistant oauth connect integration:hubspot
+    assistant oauth connect hubspot
 ```
 
 **Milestone (9 of 10):** "Credentials saved and authorized - let's verify."
@@ -164,7 +164,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:hubspot
+    assistant oauth ping hubspot
 ```
 
 **On success:** "HubSpot is connected! You can now ask me to look up contacts, manage deals, and browse company records in your HubSpot CRM."

--- a/skills/hubspot-oauth-setup/SKILL.md
+++ b/skills/hubspot-oauth-setup/SKILL.md
@@ -138,7 +138,7 @@ bash:
     assistant oauth apps upsert --provider hubspot --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "hubspot:oauth_secret"
+    ) --client-secret-credential-path "credential/hubspot/oauth_secret"
 ```
 
 Then authorize:

--- a/skills/hubspot-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/hubspot-oauth-setup/references/path-b-manual-setup.md
@@ -84,7 +84,7 @@ Wait for the Client ID, then store it:
 
 ```
 credential_store store:
-  service: "integration:hubspot"
+  service: "hubspot"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -97,7 +97,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:hubspot"
+  service: "hubspot"
   field: "oauth_secret"
   value: "<the app secret the user sent>"
 ```
@@ -115,16 +115,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:hubspot --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider hubspot --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:hubspot:oauth_secret"
+    ) --client-secret-credential-path "hubspot:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:hubspot
+    assistant oauth connect hubspot
 ```
 
 Send the returned auth URL to the user. Tell them to select their HubSpot account and click **Grant access** on the consent page.

--- a/skills/hubspot-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/hubspot-oauth-setup/references/path-b-manual-setup.md
@@ -118,7 +118,7 @@ bash:
     assistant oauth apps upsert --provider hubspot --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "hubspot:oauth_secret"
+    ) --client-secret-credential-path "credential/hubspot/oauth_secret"
 ```
 
 ```

--- a/skills/linear-oauth-setup/SKILL.md
+++ b/skills/linear-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:linear`
+- **Provider key:** `linear`
 - **Auth URL:** `https://linear.app/oauth/authorize`
 - **Token URL:** `https://api.linear.app/oauth/token`
 - **Ping URL:** `https://api.linear.app/graphql`
@@ -86,7 +86,7 @@ Collect the secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:linear"
+  service: "linear"
   field: "oauth_secret"
   label: "Linear OAuth App Secret"
   description: "Copy the app secret from the Linear OAuth application page and paste it here."
@@ -118,10 +118,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:linear --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider linear --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:linear:oauth_secret"
+    ) --client-secret-credential-path "linear:oauth_secret"
 ```
 
 **Milestone (6 of 8):** "Credentials saved - just the authorization step left."
@@ -137,7 +137,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:linear
+    assistant oauth connect linear
 ```
 
 ---
@@ -149,7 +149,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:linear
+    assistant oauth ping linear
 ```
 
 **On success:** "Linear is connected! You can now ask me to create issues, check your assignments, search across projects, and manage your Linear workflow."

--- a/skills/linear-oauth-setup/SKILL.md
+++ b/skills/linear-oauth-setup/SKILL.md
@@ -121,7 +121,7 @@ bash:
     assistant oauth apps upsert --provider linear --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "linear:oauth_secret"
+    ) --client-secret-credential-path "credential/linear/oauth_secret"
 ```
 
 **Milestone (6 of 8):** "Credentials saved - just the authorization step left."

--- a/skills/linear-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/linear-oauth-setup/references/path-b-manual-setup.md
@@ -55,7 +55,7 @@ Wait for the Client ID, then store it:
 
 ```
 credential_store store:
-  service: "integration:linear"
+  service: "linear"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -68,7 +68,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:linear"
+  service: "linear"
   field: "oauth_secret"
   value: "<the secret the user sent>"
 ```
@@ -86,16 +86,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:linear --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider linear --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:linear:oauth_secret"
+    ) --client-secret-credential-path "linear:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:linear
+    assistant oauth connect linear
 ```
 
 Send the returned auth URL to the user. Tell them to click **Authorize** on the Linear consent page.

--- a/skills/linear-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/linear-oauth-setup/references/path-b-manual-setup.md
@@ -89,7 +89,7 @@ bash:
     assistant oauth apps upsert --provider linear --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "linear:oauth_secret"
+    ) --client-secret-credential-path "credential/linear/oauth_secret"
 ```
 
 ```

--- a/skills/notion-oauth-setup/SKILL.md
+++ b/skills/notion-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:notion`
+- **Provider key:** `notion`
 - **Default credential type:** Internal integration (API token)
 - **No OAuth flow required** for the default path - just copy the integration secret and grant page access
 
@@ -81,7 +81,7 @@ Collect the secret securely:
 
 ```
 credential_store prompt:
-  service: "integration:notion"
+  service: "notion"
   field: "internal_secret"
   label: "Notion Internal Integration Secret"
   description: "Paste the Internal Integration Secret you just copied."
@@ -111,7 +111,7 @@ Verify the connection works by calling the Notion API with the stored secret:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant credentials reveal --service integration:notion --field internal_secret)" \
+    curl -s -H "Authorization: Bearer $(assistant credentials reveal --service notion --field internal_secret)" \
       -H "Notion-Version: 2022-06-28" \
       "https://api.notion.com/v1/users/me"
 ```

--- a/skills/notion-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/notion-oauth-setup/references/path-b-manual-setup.md
@@ -55,7 +55,7 @@ After the user sends the secret:
 
 ```
 credential_store prompt:
-  service: "integration:notion"
+  service: "notion"
   field: "internal_secret"
   label: "Notion Internal Integration Secret"
   description: "Paste the Internal Integration Secret."
@@ -66,7 +66,7 @@ If using `credential_store store` instead (when the user sent it as plaintext):
 
 ```
 credential_store store:
-  service: "integration:notion"
+  service: "notion"
   field: "internal_secret"
   value: "<the secret the user sent>"
 ```
@@ -95,7 +95,7 @@ Verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant credentials reveal --service integration:notion --field internal_secret)" \
+    curl -s -H "Authorization: Bearer $(assistant credentials reveal --service notion --field internal_secret)" \
       -H "Notion-Version: 2022-06-28" \
       "https://api.notion.com/v1/users/me"
 ```

--- a/skills/notion-oauth-setup/references/path-b-public-oauth.md
+++ b/skills/notion-oauth-setup/references/path-b-public-oauth.md
@@ -61,7 +61,7 @@ After receiving the Client ID, collect the secret securely:
 
 ```
 credential_store prompt:
-  service: "integration:notion"
+  service: "notion"
   field: "client_secret"
   label: "Notion OAuth Client Secret"
   description: "Copy the Client Secret from the Notion integration page and paste it here."
@@ -73,16 +73,16 @@ credential_store prompt:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:notion --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider notion --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "credential/integration:notion/client_secret"
+    ) --client-secret-credential-path "credential/notion/client_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:notion
+    assistant oauth connect notion
 ```
 
 ### Step 5: Verify Connection
@@ -90,5 +90,5 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth ping integration:notion
+    assistant oauth ping notion
 ```

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -8,7 +8,7 @@ metadata:
     display-name: "Notion"
 ---
 
-You have access to the Notion API via stored credentials for `integration:notion`. Both Internal integration secrets and OAuth access tokens are supported.
+You have access to the Notion API via stored credentials for `notion`. Both Internal integration secrets and OAuth access tokens are supported.
 
 ## Authentication
 
@@ -18,7 +18,7 @@ You have access to the Notion API via stored credentials for `integration:notion
 credential_store action=list
 ```
 
-Look for an entry with `service: "integration:notion"`. The credential may be stored under one of two fields depending on how the user set up the integration:
+Look for an entry with `service: "notion"`. The credential may be stored under one of two fields depending on how the user set up the integration:
 
 - `field: "internal_secret"` - Internal integration (new default setup)
 - `field: "access_token"` - OAuth/Public integration (legacy setup)
@@ -33,7 +33,7 @@ Use `bash` with `assistant credentials reveal` to inject the token into the Auth
 bash:
   command: |
     curl -s -X POST https://api.notion.com/v1/search \
-      -H "Authorization: Bearer $(assistant credentials reveal --service integration:notion --field internal_secret)" \
+      -H "Authorization: Bearer $(assistant credentials reveal --service notion --field internal_secret)" \
       -H "Notion-Version: 2022-06-28" \
       -H "Content-Type: application/json" \
       -d '{}'

--- a/skills/spotify-oauth-setup/SKILL.md
+++ b/skills/spotify-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:spotify`
+- **Provider key:** `spotify`
 - **Dashboard:** `https://developer.spotify.com/dashboard`
 - **Ping URL:** `https://api.spotify.com/v1/me`
 - **Callback transport:** Loopback
@@ -58,7 +58,7 @@ Before providing the redirect URI, resolve it:
 
 ```
 bash:
-  command: assistant oauth providers get integration:spotify --json
+  command: assistant oauth providers get spotify --json
 ```
 
 - If the `redirectUri` is a concrete URL (e.g. `http://localhost:…/oauth/callback`), tell the user to enter that exact URL as the redirect URI.
@@ -103,7 +103,7 @@ Collect the app secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:spotify"
+  service: "spotify"
   field: "oauth_secret"
   label: "Spotify OAuth App Secret"
   description: "Copy the app secret from the Settings page (click View app secret to reveal it) and paste it here."
@@ -115,10 +115,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:spotify --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider spotify --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:spotify:oauth_secret"
+    ) --client-secret-credential-path "spotify:oauth_secret"
 ```
 
 **Milestone (4 of 7):** "Credentials saved - just the authorization step left."
@@ -134,7 +134,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:spotify
+    assistant oauth connect spotify
 ```
 
 The scopes requested will include:
@@ -158,7 +158,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:spotify
+    assistant oauth ping spotify
 ```
 
 **On success:** "Spotify is connected! You can now ask me to control playback, manage your playlists, check what's playing, and browse your library."

--- a/skills/spotify-oauth-setup/SKILL.md
+++ b/skills/spotify-oauth-setup/SKILL.md
@@ -118,7 +118,7 @@ bash:
     assistant oauth apps upsert --provider spotify --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "spotify:oauth_secret"
+    ) --client-secret-credential-path "credential/spotify/oauth_secret"
 ```
 
 **Milestone (4 of 7):** "Credentials saved - just the authorization step left."

--- a/skills/spotify-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/spotify-oauth-setup/references/path-b-manual-setup.md
@@ -61,7 +61,7 @@ Wait for the Client ID, then store it:
 
 ```
 credential_store store:
-  service: "integration:spotify"
+  service: "spotify"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -74,7 +74,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:spotify"
+  service: "spotify"
   field: "oauth_secret"
   value: "<the app secret the user sent>"
 ```
@@ -92,16 +92,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:spotify --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider spotify --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:spotify:oauth_secret"
+    ) --client-secret-credential-path "spotify:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:spotify
+    assistant oauth connect spotify
 ```
 
 Send the returned auth URL to the user. Tell them to click **Agree** on the Spotify consent page.

--- a/skills/spotify-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/spotify-oauth-setup/references/path-b-manual-setup.md
@@ -95,7 +95,7 @@ bash:
     assistant oauth apps upsert --provider spotify --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "spotify:oauth_secret"
+    ) --client-secret-credential-path "credential/spotify/oauth_secret"
 ```
 
 ```

--- a/skills/todoist-oauth-setup/SKILL.md
+++ b/skills/todoist-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:todoist`
+- **Provider key:** `todoist`
 - **Dashboard:** `https://developer.todoist.com/appconsole.html`
 - **Scopes:** `data:read_write`
 - **Callback transport:** Loopback (port 17325)
@@ -77,7 +77,7 @@ Collect the app secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:todoist"
+  service: "todoist"
   field: "app_secret"
   label: "Todoist OAuth App Secret"
   description: "Copy the app secret from the Todoist app settings page and paste it here."
@@ -89,10 +89,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:todoist --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider todoist --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:todoist:app_secret"
+    ) --client-secret-credential-path "todoist:app_secret"
 ```
 
 **Milestone (5 of 7):** "Credentials saved - just the authorization step left."
@@ -108,7 +108,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:todoist
+    assistant oauth connect todoist
 ```
 
 ---
@@ -120,7 +120,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:todoist
+    assistant oauth ping todoist
 ```
 
 **On success:** "Todoist is connected! You can now ask me to manage your tasks, create projects, and organize your to-do lists."

--- a/skills/todoist-oauth-setup/SKILL.md
+++ b/skills/todoist-oauth-setup/SKILL.md
@@ -92,7 +92,7 @@ bash:
     assistant oauth apps upsert --provider todoist --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "todoist:app_secret"
+    ) --client-secret-credential-path "credential/todoist/app_secret"
 ```
 
 **Milestone (5 of 7):** "Credentials saved - just the authorization step left."

--- a/skills/todoist-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/todoist-oauth-setup/references/path-b-manual-setup.md
@@ -102,7 +102,7 @@ bash:
     assistant oauth apps upsert --provider todoist --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "todoist:app_secret"
+    ) --client-secret-credential-path "credential/todoist/app_secret"
 ```
 
 ```

--- a/skills/todoist-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/todoist-oauth-setup/references/path-b-manual-setup.md
@@ -68,7 +68,7 @@ Wait for the Client ID, then store it:
 
 ```
 credential_store store:
-  service: "integration:todoist"
+  service: "todoist"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -81,7 +81,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:todoist"
+  service: "todoist"
   field: "app_secret"
   value: "<the secret the user sent>"
 ```
@@ -99,16 +99,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:todoist --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider todoist --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:todoist:app_secret"
+    ) --client-secret-credential-path "todoist:app_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:todoist
+    assistant oauth connect todoist
 ```
 
 Send the returned auth URL to the user. Tell them to click **Agree** on the Todoist consent page.

--- a/skills/twitter-oauth-setup/SKILL.md
+++ b/skills/twitter-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:twitter`
+- **Provider key:** `twitter`
 - **Auth URL:** `https://twitter.com/i/oauth2/authorize`
 - **Token URL:** `https://api.x.com/2/oauth2/token`
 - **Ping URL:** `https://api.x.com/2/users/me`
@@ -110,7 +110,7 @@ Before providing the redirect URI, resolve it:
 
 ```
 bash:
-  command: assistant oauth providers list --provider-key "integration:twitter" --json
+  command: assistant oauth providers list --provider-key "twitter" --json
 ```
 
 Check the redirect URI situation. Since callbackTransport is `gateway`, public ingress must be configured:
@@ -152,7 +152,7 @@ Collect Client Secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:twitter"
+  service: "twitter"
   field: "client_secret"
   label: "Twitter OAuth 2.0 Client Secret"
   description: "Copy the Client Secret from the Keys and tokens page and paste it here."
@@ -164,10 +164,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:twitter --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider twitter --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "credential/integration:twitter/client_secret"
+    ) --client-secret-credential-path "credential/twitter/client_secret"
 ```
 
 **Milestone (6 of 8):** "Credentials saved - just the authorization step left."
@@ -183,7 +183,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:twitter
+    assistant oauth connect twitter
 ```
 
 ---
@@ -195,7 +195,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:twitter
+    assistant oauth ping twitter
 ```
 
 **On success:** "Twitter is connected! You can now ask me to read your timeline, post tweets, and check your profile."

--- a/skills/twitter-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/twitter-oauth-setup/references/path-b-manual-setup.md
@@ -81,7 +81,7 @@ Wait for the Client ID, then store it:
 
 ```
 credential_store store:
-  service: "integration:twitter"
+  service: "twitter"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -94,7 +94,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:twitter"
+  service: "twitter"
   field: "client_secret"
   value: "<the client secret the user sent>"
 ```
@@ -112,16 +112,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:twitter --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider twitter --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "credential/integration:twitter/client_secret"
+    ) --client-secret-credential-path "credential/twitter/client_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:twitter
+    assistant oauth connect twitter
 ```
 
 Send the returned auth URL to the user. Tell them to review the permissions and click **Authorize app**.


### PR DESCRIPTION
## Summary
Remove the `integration:` prefix from all OAuth provider keys, unifying around bare names like `"google"` instead of `"integration:google"`. This eliminates the confusing three-format naming system (canonical `integration:X`, bare `X`, aliases like `gmail`) in favor of a single simple format that matches what the Vellum Platform API already uses.

## PRs merged into feature branch
- #21505: feat: rename OAuth provider keys from `integration:X` to `X` in seed data and behaviors
- #21508: feat: add migration 196 to strip `integration:` prefix from OAuth provider keys
- #21511: refactor: remove `toBareProvider()` and `integration:` stripping from connection resolver
- #21514: refactor: delete legacy credential key derivation from provider keys
- #21516: refactor: update all hardcoded `integration:X` provider key references to bare names
- #21518: refactor: update CES handle comments and tests for bare provider keys
- #21515: docs: update OAuth CLI help text to use bare provider names
- #21512: docs: update OAuth documentation and SKILL.md files for bare provider names
- #21520: test: update all OAuth test files to use bare provider names

Part of plan: simplify-oauth-provider-keys.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
