### PR TITLE
feat: consolidate secret detection patterns into single source of truth

### DIFF
--- a/assistant/src/__tests__/secret-ingress-channel.test.ts
+++ b/assistant/src/__tests__/secret-ingress-channel.test.ts
@@ -118,7 +118,7 @@ describe("secret ingress — channel inbound path", () => {
     );
 
     expect(result.blocked).toBe(true);
-    expect(result.detectedTypes).toContain("Google OAuth Secret");
+    expect(result.detectedTypes).toContain("Google OAuth Client Secret");
   });
 
   test("channel inbound with normal text returns blocked: false", () => {

--- a/assistant/src/__tests__/secret-ingress.test.ts
+++ b/assistant/src/__tests__/secret-ingress.test.ts
@@ -66,7 +66,7 @@ describe("checkIngressForSecrets", () => {
       "My client secret is GOCSPX-abcdefghijklmnopqrstuvwxyz12",
     );
     expect(result.blocked).toBe(true);
-    expect(result.detectedTypes).toContain("Google OAuth Secret");
+    expect(result.detectedTypes).toContain("Google OAuth Client Secret");
     expect(result.userNotice).toBeDefined();
   });
 
@@ -134,7 +134,7 @@ describe("checkIngressForSecrets", () => {
     const key = "sk-proj-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCd";
     const result = checkIngressForSecrets(`My key: ${key}`);
     expect(result.blocked).toBe(true);
-    expect(result.detectedTypes).toContain("OpenAI API Key");
+    expect(result.detectedTypes).toContain("OpenAI Project Key");
   });
 
   test("blocks Google API key (AIza*)", () => {
@@ -148,7 +148,7 @@ describe("checkIngressForSecrets", () => {
   test("blocks GitLab PAT (glpat-*)", () => {
     const result = checkIngressForSecrets("glpat-abcdefghijklmnopqrst");
     expect(result.blocked).toBe(true);
-    expect(result.detectedTypes).toContain("GitLab PAT");
+    expect(result.detectedTypes).toContain("GitLab Token");
   });
 
   test("blocks Telegram Bot Token", () => {

--- a/assistant/src/security/AGENTS.md
+++ b/assistant/src/security/AGENTS.md
@@ -1,0 +1,7 @@
+# Security — Agent Instructions
+
+## Integration API Key Patterns
+
+When adding a new third-party integration, check whether the service uses a recognizable API key prefix (e.g., `lin_api_`, `sk-ant-`, `ghp_`). If it does, add a corresponding entry to `PREFIX_PATTERNS` in `secret-patterns.ts`. This is the single source of truth for prefix-based secret detection — ingress blocking, tool output scanning, and log redaction all consume this list.
+
+OAuth-only services with opaque access tokens (no fixed prefix) do not need a pattern.

--- a/assistant/src/security/secret-ingress.ts
+++ b/assistant/src/security/secret-ingress.ts
@@ -1,16 +1,15 @@
 /**
  * Ingress secret detection for user messages.
  *
- * Uses a curated subset of high-confidence, prefix-based patterns to
- * deterministically block messages containing real secrets. Unlike
- * `scanText()` from `secret-scanner.ts`, this intentionally excludes
- * broad patterns (JWT, DB URLs, generic `password=`/`secret=` assignments,
- * high-entropy hex/base64, encoded-secret detection) that cause false
- * positives on legitimate user input.
+ * Consumes `PREFIX_PATTERNS` from `secret-patterns.ts` — the single source
+ * of truth for prefix-based secret detection.  This module intentionally
+ * does NOT import `scanText()` or any entropy/encoding logic to avoid
+ * false positives on legitimate user input.
  */
 
 import { getConfig } from "../config/loader.js";
 import { isAllowlisted } from "./secret-allowlist.js";
+import { PREFIX_PATTERNS } from "./secret-patterns.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -21,72 +20,6 @@ export interface IngressCheckResult {
   detectedTypes: string[];
   userNotice?: string;
 }
-
-// ---------------------------------------------------------------------------
-// High-confidence prefix-based patterns
-// ---------------------------------------------------------------------------
-
-interface SecretPattern {
-  label: string;
-  regex: RegExp;
-}
-
-const INGRESS_PATTERNS: SecretPattern[] = [
-  // AWS
-  { label: "AWS Access Key", regex: /AKIA[0-9A-Z]{16}/ },
-
-  // GitHub
-  { label: "GitHub Token", regex: /gh[pousr]_[A-Za-z0-9_]{36,}/ },
-  { label: "GitHub PAT", regex: /github_pat_[A-Za-z0-9_]{22,}/ },
-
-  // GitLab
-  { label: "GitLab PAT", regex: /glpat-[A-Za-z0-9\-_]{20,}/ },
-
-  // Stripe
-  { label: "Stripe Secret Key", regex: /sk_live_[A-Za-z0-9]{24,}/ },
-  { label: "Stripe Restricted Key", regex: /rk_live_[A-Za-z0-9]{24,}/ },
-
-  // Slack
-  {
-    label: "Slack Bot Token",
-    regex: /xoxb-[0-9]{10,}-[0-9]{10,}-[A-Za-z0-9]{24,}/,
-  },
-  {
-    label: "Slack User Token",
-    regex: /xoxp-[0-9]{10,}-[0-9]{10,}-[A-Za-z0-9]{24,}/,
-  },
-
-  // Telegram
-  { label: "Telegram Bot Token", regex: /\b[0-9]{8,10}:[A-Za-z0-9_-]{35}\b/ },
-
-  // Anthropic
-  { label: "Anthropic API Key", regex: /sk-ant-[A-Za-z0-9\-_]{80,}/ },
-
-  // OpenAI
-  { label: "OpenAI API Key", regex: /sk-proj-[A-Za-z0-9\-_]{40,}/ },
-
-  // Google
-  { label: "Google API Key", regex: /AIza[A-Za-z0-9\-_]{35}/ },
-  { label: "Google OAuth Secret", regex: /GOCSPX-[A-Za-z0-9\-_]{28}/ },
-
-  // Twilio
-  { label: "Twilio API Key", regex: /\bSK[0-9a-f]{32}\b/ },
-
-  // SendGrid
-  {
-    label: "SendGrid API Key",
-    regex: /SG\.[A-Za-z0-9\-_]{22}\.[A-Za-z0-9\-_]{43}/,
-  },
-
-  // npm
-  { label: "npm Token", regex: /npm_[A-Za-z0-9]{36}/ },
-
-  // Private keys
-  {
-    label: "Private Key",
-    regex: /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
-  },
-];
 
 // ---------------------------------------------------------------------------
 // Placeholder detection (inline — not imported from secret-scanner.ts)
@@ -164,7 +97,7 @@ function isPlaceholder(value: string): boolean {
   // Strip known prefixes to isolate the variable part
   const variablePart = value
     .replace(
-      /^(?:AKIA|gh[pousr]_|github_pat_|glpat-|sk_live_|rk_live_|xoxb-|xoxp-|sk-ant-|sk-proj-|AIza|GOCSPX-|SK|SG\.|npm_|-----BEGIN [A-Z ]*PRIVATE KEY-----)/,
+      /^(?:AKIA|gh[pousr]_|github_pat_|glpat-|sk_live_|rk_live_|xoxb-|xoxp-|xapp-|sk-ant-|sk-proj-|sk-or-v1-|AIza|GOCSPX-|SK|SG\.|npm_|pypi-|key-|lin_api_|ntn_|fw_|pplx-|-----BEGIN [A-Z ]*PRIVATE KEY-----)/,
       "",
     )
     .replace(/[^A-Za-z0-9]/g, "");
@@ -202,7 +135,7 @@ export function checkIngressForSecrets(content: string): IngressCheckResult {
 
   const detectedTypes: string[] = [];
 
-  for (const { label, regex } of INGRESS_PATTERNS) {
+  for (const { label, regex } of PREFIX_PATTERNS) {
     // Use a global version to find all matches
     const globalRegex = new RegExp(regex.source, "g");
     let match: RegExpExecArray | null;

--- a/assistant/src/security/secret-patterns.ts
+++ b/assistant/src/security/secret-patterns.ts
@@ -1,0 +1,133 @@
+/**
+ * Shared prefix-based secret patterns — the single source of truth.
+ *
+ * Ingress blocking, tool output scanning, and log redaction all consume
+ * this list.  When adding a new integration, add its API key pattern here.
+ *
+ * This module is intentionally data-only: no imports, no entropy logic,
+ * no config — safe for hot-path consumers like log serializers.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SecretPrefixPattern {
+  /** Human-readable label shown in block notices and redaction tags. */
+  label: string;
+  /**
+   * Regex that matches the token value.  Must NOT include the `g` flag or
+   * capture groups — consumers add those as needed.
+   */
+  regex: RegExp;
+}
+
+// ---------------------------------------------------------------------------
+// Prefix patterns
+// ---------------------------------------------------------------------------
+
+/**
+ * High-confidence, prefix-based secret patterns.
+ *
+ * Each entry matches a known API key / token format by its distinctive
+ * prefix.  Patterns that require surrounding context (entropy analysis,
+ * keyword proximity, URL structure) do NOT belong here — they stay in
+ * `secret-scanner.ts` as scanner-only patterns.
+ *
+ * **When adding a new third-party integration, add its API key pattern
+ * here.**  If the service uses only opaque OAuth access tokens (no fixed
+ * prefix), no pattern is needed.
+ */
+export const PREFIX_PATTERNS: SecretPrefixPattern[] = [
+  // -- AWS --
+  { label: "AWS Access Key", regex: /AKIA[0-9A-Z]{16}/ },
+
+  // -- GitHub --
+  { label: "GitHub Token", regex: /gh[pousr]_[A-Za-z0-9_]{36,}/ },
+  { label: "GitHub Fine-Grained PAT", regex: /github_pat_[A-Za-z0-9_]{22,}/ },
+
+  // -- GitLab --
+  { label: "GitLab Token", regex: /glpat-[A-Za-z0-9\-_]{20,}/ },
+
+  // -- Stripe --
+  { label: "Stripe Secret Key", regex: /sk_live_[A-Za-z0-9]{24,}/ },
+  { label: "Stripe Restricted Key", regex: /rk_live_[A-Za-z0-9]{24,}/ },
+
+  // -- Slack --
+  {
+    label: "Slack Bot Token",
+    regex: /xoxb-[0-9]{10,}-[0-9]{10,}-[A-Za-z0-9]{24,}/,
+  },
+  {
+    label: "Slack User Token",
+    regex: /xoxp-[0-9]{10,}-[0-9]{10,}-[0-9]{10,}-[a-f0-9]{32}/,
+  },
+  {
+    label: "Slack App Token",
+    regex: /xapp-[0-9]+-[A-Za-z0-9]+-[0-9]+-[A-Za-z0-9]+/,
+  },
+
+  // -- Telegram --
+  {
+    label: "Telegram Bot Token",
+    // Format: <bot_id>:<secret> where bot_id is 8–10 digits, secret is 35 chars
+    regex: /[0-9]{8,10}:[A-Za-z0-9_-]{35}/,
+  },
+
+  // -- Anthropic --
+  { label: "Anthropic API Key", regex: /sk-ant-[A-Za-z0-9\-_]{80,}/ },
+
+  // -- OpenAI --
+  {
+    label: "OpenAI API Key",
+    regex: /sk-[A-Za-z0-9]{20}T3BlbkFJ[A-Za-z0-9]{20}/,
+  },
+  { label: "OpenAI Project Key", regex: /sk-proj-[A-Za-z0-9\-_]{40,}/ },
+
+  // -- Google --
+  { label: "Google API Key", regex: /AIza[A-Za-z0-9\-_]{35}/ },
+  {
+    label: "Google OAuth Client Secret",
+    regex: /GOCSPX-[A-Za-z0-9\-_]{28}/,
+  },
+
+  // -- Twilio --
+  { label: "Twilio API Key", regex: /SK[0-9a-f]{32}/ },
+
+  // -- SendGrid --
+  {
+    label: "SendGrid API Key",
+    regex: /SG\.[A-Za-z0-9\-_]{22}\.[A-Za-z0-9\-_]{43}/,
+  },
+
+  // -- Mailgun --
+  { label: "Mailgun API Key", regex: /key-[A-Za-z0-9]{32}/ },
+
+  // -- npm --
+  { label: "npm Token", regex: /npm_[A-Za-z0-9]{36}/ },
+
+  // -- PyPI --
+  { label: "PyPI API Token", regex: /pypi-[A-Za-z0-9\-_]{50,}/ },
+
+  // -- Private keys --
+  {
+    label: "Private Key",
+    regex:
+      /-----BEGIN (?:RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY(?:\s+BLOCK)?-----/,
+  },
+
+  // -- Linear --
+  { label: "Linear API Key", regex: /lin_api_[A-Za-z0-9]{32,}/ },
+
+  // -- Notion --
+  { label: "Notion Integration Token", regex: /ntn_[A-Za-z0-9]{40,}/ },
+
+  // -- OpenRouter --
+  { label: "OpenRouter API Key", regex: /sk-or-v1-[A-Za-z0-9\-_]{40,}/ },
+
+  // -- Fireworks --
+  { label: "Fireworks API Key", regex: /fw_[A-Za-z0-9]{32,}/ },
+
+  // -- Perplexity --
+  { label: "Perplexity API Key", regex: /pplx-[A-Za-z0-9]{40,}/ },
+];

--- a/assistant/src/security/secret-scanner.ts
+++ b/assistant/src/security/secret-scanner.ts
@@ -6,6 +6,7 @@
 
 import { getLogger } from "../util/logger.js";
 import { isAllowlisted } from "./secret-allowlist.js";
+import { PREFIX_PATTERNS } from "./secret-patterns.js";
 
 const log = getLogger("secret-scanner");
 
@@ -29,12 +30,29 @@ export interface SecretPattern {
 // Known-format patterns
 // ---------------------------------------------------------------------------
 
-const PATTERNS: SecretPattern[] = [
-  // -- AWS --
-  {
-    type: "AWS Access Key",
-    regex: /\b(AKIA[0-9A-Z]{16})\b/g,
-  },
+// Patterns that need custom boundary handling instead of simple \b wrapping.
+// Telegram: last char can be '-' (not a word char), so \b fails.
+// Private Key: starts with '-----' (not word chars), so \b fails.
+const CUSTOM_BOUNDARY: Record<string, (src: string) => string> = {
+  "Telegram Bot Token": (src) => `\\b(${src})(?=[^A-Za-z0-9_-]|$)`,
+  "Private Key": (src) => `(${src})`,
+};
+
+// Derive prefix-based patterns from the shared source of truth, adding
+// capture groups and the global flag that scanText() expects.
+const PREFIX_DERIVED: SecretPattern[] = PREFIX_PATTERNS.map((p) => {
+  const src = p.regex.source;
+  const custom = CUSTOM_BOUNDARY[p.label];
+  const pattern = custom ? custom(src) : `\\b(${src})\\b`;
+  return {
+    type: p.label,
+    regex: new RegExp(pattern, "g"),
+  };
+});
+
+// Scanner-only patterns that require surrounding context or are not
+// simple prefix matches — these stay defined here.
+const SCANNER_ONLY_PATTERNS: SecretPattern[] = [
   {
     type: "AWS Secret Key",
     // 40 chars of base-64 alphabet, preceded by a key-value separator.
@@ -43,112 +61,12 @@ const PATTERNS: SecretPattern[] = [
     regex: /(?<=['"=:\s])([A-Za-z0-9+/]{40})(?=\s|['"]|$)/g,
   },
 
-  // -- GitHub --
-  {
-    type: "GitHub Token",
-    // ghp_ (PAT), gho_ (OAuth), ghu_ (user-to-server), ghs_ (server-to-server), ghr_ (refresh)
-    regex: /\b(gh[pousr]_[A-Za-z0-9_]{36,255})\b/g,
-  },
-  {
-    type: "GitHub Fine-Grained PAT",
-    regex: /\b(github_pat_[A-Za-z0-9_]{22,255})\b/g,
-  },
-
-  // -- GitLab --
-  {
-    type: "GitLab Token",
-    regex: /\b(glpat-[A-Za-z0-9\-_]{20,})\b/g,
-  },
-
-  // -- Stripe --
-  {
-    type: "Stripe Secret Key",
-    regex: /\b(sk_live_[A-Za-z0-9]{24,})\b/g,
-  },
-  {
-    type: "Stripe Restricted Key",
-    regex: /\b(rk_live_[A-Za-z0-9]{24,})\b/g,
-  },
-
-  // -- Slack --
-  {
-    type: "Slack Bot Token",
-    regex: /\b(xoxb-[0-9]{10,}-[0-9]{10,}-[A-Za-z0-9]{24,})\b/g,
-  },
-  {
-    type: "Slack User Token",
-    regex: /\b(xoxp-[0-9]{10,}-[0-9]{10,}-[0-9]{10,}-[a-f0-9]{32})\b/g,
-  },
   {
     type: "Slack Webhook",
     regex:
       /(https:\/\/hooks\.slack\.com\/services\/T[A-Z0-9]+\/B[A-Z0-9]+\/[A-Za-z0-9]+)/g,
   },
 
-  // -- Telegram --
-  {
-    type: "Telegram Bot Token",
-    // Format: <bot_id>:<secret> where bot_id is 8-10 digits and secret is 35 alphanumeric/dash/underscore chars
-    regex: /\b([0-9]{8,10}:[A-Za-z0-9_-]{35})(?=[^A-Za-z0-9_-]|$)/g,
-  },
-
-  // -- Anthropic --
-  {
-    type: "Anthropic API Key",
-    regex: /\b(sk-ant-[A-Za-z0-9\-_]{80,})\b/g,
-  },
-
-  // -- OpenAI --
-  {
-    type: "OpenAI API Key",
-    regex: /\b(sk-[A-Za-z0-9]{20}T3BlbkFJ[A-Za-z0-9]{20})\b/g,
-  },
-  {
-    type: "OpenAI Project Key",
-    regex: /\b(sk-proj-[A-Za-z0-9\-_]{40,})\b/g,
-  },
-
-  // -- Google --
-  {
-    type: "Google API Key",
-    regex: /\b(AIza[A-Za-z0-9\-_]{35})\b/g,
-  },
-  {
-    type: "Google OAuth Client Secret",
-    regex: /\b(GOCSPX-[A-Za-z0-9\-_]{28})\b/g,
-  },
-
-  // -- Twilio --
-  {
-    type: "Twilio API Key",
-    regex: /\b(SK[0-9a-f]{32})\b/g,
-  },
-
-  // -- SendGrid --
-  {
-    type: "SendGrid API Key",
-    regex: /\b(SG\.[A-Za-z0-9\-_]{22}\.[A-Za-z0-9\-_]{43})\b/g,
-  },
-
-  // -- Mailgun --
-  {
-    type: "Mailgun API Key",
-    regex: /\b(key-[A-Za-z0-9]{32})\b/g,
-  },
-
-  // -- npm --
-  {
-    type: "npm Token",
-    regex: /\b(npm_[A-Za-z0-9]{36})\b/g,
-  },
-
-  // -- PyPI --
-  {
-    type: "PyPI API Token",
-    regex: /\b(pypi-[A-Za-z0-9\-_]{50,})\b/g,
-  },
-
-  // -- Heroku --
   {
     type: "Heroku API Key",
     // Require a heroku-related keyword prefix to avoid flagging every UUID
@@ -156,39 +74,32 @@ const PATTERNS: SecretPattern[] = [
       /(?:heroku[_-]?api[_-]?key|HEROKU[_-]?API[_-]?KEY|heroku[_-]?auth[_-]?token)\s*[:=]\s*['"]?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})['"]?/gi,
   },
 
-  // -- Private keys --
-  {
-    type: "Private Key",
-    regex:
-      /(-----BEGIN (?:RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY(?:\s+BLOCK)?-----)/g,
-  },
-
-  // -- JWT --
   {
     type: "JSON Web Token",
     regex: /\b(eyJ[A-Za-z0-9\-_]+\.eyJ[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_.+/=]+)/g,
   },
 
-  // -- Connection strings --
   {
     type: "Database Connection String",
     regex:
       /((?:mongodb(?:\+srv)?|postgres(?:ql)?|mysql|mssql|redis|amqp|amqps):\/\/[^\s'"]+)/g,
   },
 
-  // -- Generic "password" / "secret" / "token" assignments (quoted) --
+  // Generic "password" / "secret" / "token" assignments (quoted)
   {
     type: "Generic Secret Assignment",
     regex:
       /(?:password|passwd|secret|token|api[_-]?key|access[_-]?key|auth[_-]?token|credentials)\s*[:=]\s*['"]([^'"]{8,})['"]/gi,
   },
-  // -- Generic assignments (unquoted, e.g. .env files) --
+  // Generic assignments (unquoted, e.g. .env files)
   {
     type: "Generic Secret Assignment",
     regex:
       /(?:password|passwd|secret|token|api[_-]?key|access[_-]?key|auth[_-]?token|credentials)\s*=\s*([^\s'"]{8,})/gi,
   },
 ];
+
+const PATTERNS: SecretPattern[] = [...PREFIX_DERIVED, ...SCANNER_ONLY_PATTERNS];
 
 // ---------------------------------------------------------------------------
 // Known placeholder values that should NOT be flagged

--- a/assistant/src/util/log-redact.ts
+++ b/assistant/src/util/log-redact.ts
@@ -3,47 +3,22 @@
  * authorization headers) from logged values.  Applied to every pino instance
  * so secrets never reach log files even when errors bubble up opaque objects.
  *
- * API-key patterns are intentionally duplicated from security/secret-scanner.ts
- * rather than imported — the scanner carries entropy analysis, encoded-secret
- * detection, and other heavyweight logic that a hot-path serializer should not
- * pull in.
+ * API-key patterns are imported from security/secret-patterns.ts — the shared
+ * source of truth.  That module is data-only (no entropy, encoding, or config
+ * logic) so it is safe for this hot-path serializer.
  */
 
+import { PREFIX_PATTERNS } from "../security/secret-patterns.js";
+
 // ---------------------------------------------------------------------------
-// Sensitive-value patterns (subset of secret-scanner PATTERNS)
+// Sensitive-value patterns (derived from shared PREFIX_PATTERNS)
 // ---------------------------------------------------------------------------
 
 const BEARER_RE = /Bearer [A-Za-z0-9._\-]+/g;
 
-const API_KEY_PATTERNS: RegExp[] = [
-  // AWS
-  /AKIA[0-9A-Z]{16}/g,
-  // GitHub
-  /gh[pousr]_[A-Za-z0-9_]{36,255}/g,
-  /github_pat_[A-Za-z0-9_]{22,255}/g,
-  // GitLab
-  /glpat-[A-Za-z0-9\-_]{20,}/g,
-  // Stripe
-  /sk_live_[A-Za-z0-9]{24,}/g,
-  /rk_live_[A-Za-z0-9]{24,}/g,
-  // Slack
-  /xoxb-[0-9]{10,}-[0-9]{10,}-[A-Za-z0-9]{24,}/g,
-  /xoxp-[0-9]{10,}-[0-9]{10,}-[0-9]{10,}-[a-f0-9]{32}/g,
-  // Anthropic
-  /sk-ant-[A-Za-z0-9\-_]{80,}/g,
-  // OpenAI
-  /sk-[A-Za-z0-9]{20}T3BlbkFJ[A-Za-z0-9]{20}/g,
-  /sk-proj-[A-Za-z0-9\-_]{40,}/g,
-  // Google
-  /AIza[A-Za-z0-9\-_]{35}/g,
-  /GOCSPX-[A-Za-z0-9\-_]{28}/g,
-  // SendGrid
-  /SG\.[A-Za-z0-9\-_]{22}\.[A-Za-z0-9\-_]{43}/g,
-  // Telegram bot token
-  /[0-9]{8,10}:[A-Za-z0-9_-]{35}/g,
-  // npm
-  /npm_[A-Za-z0-9]{36}/g,
-];
+const API_KEY_PATTERNS: RegExp[] = PREFIX_PATTERNS.map(
+  (p) => new RegExp(p.regex.source, "g"),
+);
 
 // Header names whose values should always be fully redacted
 const SENSITIVE_HEADERS = new Set([


### PR DESCRIPTION
## Summary
- Extracts all prefix-based secret patterns into `secret-patterns.ts` — the single source of truth for ingress blocking, tool output scanning, and log redaction
- Wires `secret-scanner.ts`, `secret-ingress.ts`, and `log-redact.ts` to import from the shared module, eliminating three duplicate pattern lists
- Adds detection patterns for Linear (`lin_api_`), Notion (`ntn_`), OpenRouter (`sk-or-v1-`), Slack App Token (`xapp-`), Fireworks (`fw_`), and Perplexity (`pplx-`)
- Adds `assistant/src/security/AGENTS.md` requiring new integrations to register their API key pattern

## Behavioral changes
- Ingress labels aligned to scanner canonical names: `"GitHub PAT"` → `"GitHub Fine-Grained PAT"`, `"GitLab PAT"` → `"GitLab Token"`, `"Google OAuth Secret"` → `"Google OAuth Client Secret"`, `"OpenAI API Key"` (for sk-proj-) → `"OpenAI Project Key"`
- Log redaction expanded to cover Twilio, Mailgun, PyPI, Private Key, and new integration patterns
- `secret-patterns.ts` is data-only (no imports) — safe for hot-path log serializers

## Test plan
- [x] `bun test src/__tests__/secret-scanner.test.ts` — 130 pass
- [x] `bun test src/__tests__/secret-ingress.test.ts` — 27 pass
- [x] `bun test src/__tests__/secret-ingress-cli.test.ts` — 6 pass
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run lint` — clean

Closes JARVIS-357

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
