### PR TITLE
fix: update providers register and credentials set help text to use bare provider names

### DIFF
--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -397,10 +397,7 @@ Examples:
   credential
     .command("set <value>")
     .description("Store a secret and create or update its metadata")
-    .requiredOption(
-      "--service <service>",
-      "Service namespace (e.g. integration:google)",
-    )
+    .requiredOption("--service <service>", "Service namespace (e.g. google)")
     .requiredOption("--field <field>", "Field name (e.g. client_secret)")
     .option("--label <label>", 'Human-friendly label (e.g. "prod", "work")')
     .option("--description <description>", "What this credential is used for")
@@ -511,10 +508,7 @@ Examples:
           `${service}:${field}`,
         );
         if (secretResult === "error") {
-          writeError(
-            cmd,
-            "Failed to delete credential from secure storage",
-          );
+          writeError(cmd, "Failed to delete credential from secure storage");
           process.exitCode = 1;
           return;
         }

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -200,7 +200,7 @@ Examples:
     .description("Register a new OAuth provider configuration")
     .requiredOption(
       "--provider-key <key>",
-      "Unique provider key (e.g. \"integration:custom-service\"). Must not collide with an existing key from 'assistant oauth providers list'.",
+      "Unique provider key (e.g. \"custom-service\"). Must not collide with an existing key from 'assistant oauth providers list'.",
     )
     .requiredOption("--auth-url <url>", "Authorization endpoint URL")
     .requiredOption("--token-url <url>", "Token endpoint URL")
@@ -234,7 +234,7 @@ Examples:
       "after",
       `
 Arguments (via options):
-  --provider-key        Unique identifier for this provider (e.g. "integration:custom-service").
+  --provider-key        Unique identifier for this provider (e.g. "custom-service").
                         Must not collide with an existing provider key.
   --auth-url            The OAuth authorization endpoint URL.
   --token-url           The OAuth token endpoint URL.
@@ -265,16 +265,16 @@ On success, returns the full provider row including generated timestamps.
 
 Examples:
   $ assistant oauth providers register \\
-      --provider-key integration:custom-api \\
+      --provider-key custom-api \\
       --auth-url https://custom-api.example.com/oauth/authorize \\
       --token-url https://custom-api.example.com/oauth/token
   $ assistant oauth providers register \\
-      --provider-key integration:my-service \\
+      --provider-key my-service \\
       --auth-url https://my-service.com/auth \\
       --token-url https://my-service.com/token \\
       --scopes read,write --json
   $ assistant oauth providers register \\
-      --provider-key integration:custom-api \\
+      --provider-key custom-api \\
       --auth-url https://example.com/auth \\
       --token-url https://example.com/token \\
       --ping-url https://example.com/user`,


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for simplify-oauth-provider-keys.md.

**Gap 1:** providers register help text still uses integration:X prefix
**Gap 2:** credentials set help text suggests integration:google as service namespace
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
