### PR TITLE
fix: update macOS client to use bare OAuth provider keys

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -479,7 +479,7 @@ struct SettingsPanel: View {
                     .background(VColor.borderBase)
                     .padding(.vertical, VSpacing.sm)
 
-                OAuthProviderServiceCard(store: store, authManager: authManager, showToast: showToast, providerKey: "integration:google")
+                OAuthProviderServiceCard(store: store, authManager: authManager, showToast: showToast, providerKey: "google")
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2126,15 +2126,15 @@ public final class SettingsStore: ObservableObject {
         }
         if let googleOAuth = services["google-oauth"] as? [String: Any],
            let mode = googleOAuth["mode"] as? String {
-            self.managedOAuthMode["integration:google"] = mode
+            self.managedOAuthMode["google"] = mode
         } else if let legacy = services["integration:google"] as? [String: Any],
                   let mode = legacy["mode"] as? String {
             // Migrate from the legacy key that was written due to a bug where
             // setManagedOAuthMode fell back to the raw providerKey when metadata
             // hadn't loaded yet. Read the value and re-save under the correct key
             // so subsequent launches use the canonical path.
-            self.managedOAuthMode["integration:google"] = mode
-            setManagedOAuthMode(mode, providerKey: "integration:google")
+            self.managedOAuthMode["google"] = mode
+            setManagedOAuthMode(mode, providerKey: "google")
         }
     }
 
@@ -2179,12 +2179,9 @@ public final class SettingsStore: ObservableObject {
 
     func setManagedOAuthMode(_ mode: String, providerKey: String) {
         managedOAuthMode[providerKey] = mode
-        // Derive the config service key deterministically from providerKey so it
-        // matches the key that loadServiceModes() reads on startup. Previously
-        // this depended on provider metadata being loaded, which caused a race:
-        // if metadata hadn't arrived yet the fallback wrote under the wrong key.
-        let slug = providerKey.hasPrefix("integration:") ? String(providerKey.dropFirst("integration:".count)) : providerKey
-        let serviceKey = "\(slug)-oauth"
+        // Derive the config service key from providerKey (e.g. "google" → "google-oauth")
+        // so it matches the key that loadServiceModes() reads on startup.
+        let serviceKey = "\(providerKey)-oauth"
         Task {
             let success = await settingsClient.patchConfig([
                 "services": [serviceKey: ["mode": mode]]
@@ -2274,11 +2271,9 @@ public final class SettingsStore: ObservableObject {
         guard managedOAuthMode[providerKey] == "managed" else { return }
         guard let assistantId = await resolvePlatformAssistantId(userId: userId) else { return }
 
-        let providerSlug = providerKey.hasPrefix("integration:") ? String(providerKey.dropFirst("integration:".count)) : providerKey
-
         do {
             let connections = try await PlatformOAuthService.shared.listConnections(assistantId: assistantId)
-            managedOAuthConnections[providerKey] = connections.filter { $0.provider == providerSlug }
+            managedOAuthConnections[providerKey] = connections.filter { $0.provider == providerKey }
             managedOAuthError[providerKey] = nil
         } catch {
             log.error("Failed to fetch managed OAuth connections for \(providerKey): \(error)")
@@ -2288,8 +2283,6 @@ public final class SettingsStore: ObservableObject {
     }
 
     func startManagedOAuthConnect(providerKey: String, userId: String? = nil) {
-        let providerSlug = providerKey.hasPrefix("integration:") ? String(providerKey.dropFirst("integration:".count)) : providerKey
-
         Task {
             managedOAuthIsConnecting[providerKey] = true
             managedOAuthError[providerKey] = nil
@@ -2302,9 +2295,9 @@ public final class SettingsStore: ObservableObject {
 
             do {
                 let response = try await PlatformOAuthService.shared.startOAuthConnect(
-                    provider: providerSlug,
+                    provider: providerKey,
                     assistantId: assistantId,
-                    redirectAfterConnect: "vellum-assistant://oauth/\(providerSlug)/callback"
+                    redirectAfterConnect: "vellum-assistant://oauth/\(providerKey)/callback"
                 )
 
                 guard let connectURL = URL(string: response.connect_url) else {
@@ -3144,11 +3137,8 @@ struct OAuthProviderMetadata: Codable, Sendable {
     let client_id_placeholder: String?
     let requires_client_secret: Int
 
-    /// Derive the platform OAuth slug from provider_key (e.g. "integration:google" → "google").
+    /// The platform OAuth slug is the provider_key itself (bare name, e.g. "google").
     var platformOAuthSlug: String {
-        if provider_key.hasPrefix("integration:") {
-            return String(provider_key.dropFirst("integration:".count))
-        }
         return provider_key
     }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for simplify-oauth-provider-keys.md.

**Gap:** macOS client hardcodes integration:google provider keys
**What was expected:** All provider key references should use bare names
**What was found:** SettingsPanel.swift and SettingsStore.swift pass integration:google to daemon APIs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
