### PR TITLE
fix: update skills directory to use bare provider names

### DIFF
--- a/skills/airtable-oauth-setup/SKILL.md
+++ b/skills/airtable-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:airtable`
+- **Provider key:** `airtable`
 - **Dashboard:** `https://airtable.com/create/oauth`
 - **Ping URL:** `https://api.airtable.com/v0/meta/whoami`
 - **Callback transport:** Loopback (port 17329)
@@ -105,7 +105,7 @@ Collect the OAuth secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:airtable"
+  service: "airtable"
   field: "oauth_secret"
   label: "Airtable OAuth Secret"
   description: "Copy the OAuth secret from the integration page (you may need to click Show or Generate first) and paste it here."
@@ -117,10 +117,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:airtable --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider airtable --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:airtable:oauth_secret"
+    ) --client-secret-credential-path "airtable:oauth_secret"
 ```
 
 **Milestone (6 of 8):** "Credentials saved - just the authorization step left."
@@ -136,7 +136,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:airtable
+    assistant oauth connect airtable
 ```
 
 ---
@@ -148,7 +148,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:airtable
+    assistant oauth ping airtable
 ```
 
 **On success:** "Airtable is connected! You can now ask me to read and update records in your Airtable bases."

--- a/skills/airtable-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/airtable-oauth-setup/references/path-b-manual-setup.md
@@ -82,7 +82,7 @@ Wait for the Client ID, then store it:
 
 ```
 credential_store store:
-  service: "integration:airtable"
+  service: "airtable"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -95,7 +95,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:airtable"
+  service: "airtable"
   field: "oauth_secret"
   value: "<the oauth secret the user sent>"
 ```
@@ -113,16 +113,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:airtable --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider airtable --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:airtable:oauth_secret"
+    ) --client-secret-credential-path "airtable:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:airtable
+    assistant oauth connect airtable
 ```
 
 Send the returned auth URL to the user. Tell them to click **Grant access** on the Airtable consent page.

--- a/skills/asana-oauth-setup/SKILL.md
+++ b/skills/asana-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:asana`
+- **Provider key:** `asana`
 - **Dashboard:** `https://app.asana.com/0/my-apps`
 - **Ping URL:** `https://app.asana.com/api/1.0/users/me`
 - **Callback transport:** Loopback (port 17328)
@@ -89,7 +89,7 @@ Collect the app secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:asana"
+  service: "asana"
   field: "oauth_secret"
   label: "Asana OAuth App Secret"
   description: "Copy the app secret from the OAuth section of your Asana app settings (you may need to click Show first) and paste it here."
@@ -101,10 +101,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:asana --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider asana --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:asana:oauth_secret"
+    ) --client-secret-credential-path "asana:oauth_secret"
 ```
 
 **Milestone (5 of 7):** "Credentials saved - just the authorization step left."
@@ -120,7 +120,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:asana
+    assistant oauth connect asana
 ```
 
 ---
@@ -132,7 +132,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:asana
+    assistant oauth ping asana
 ```
 
 **On success:** "Asana is connected! You can now ask me to check your Asana tasks, create projects, manage assignments, and track your work."

--- a/skills/asana-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/asana-oauth-setup/references/path-b-manual-setup.md
@@ -70,7 +70,7 @@ Wait for the Client ID, then store it:
 
 ```
 credential_store store:
-  service: "integration:asana"
+  service: "asana"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -83,7 +83,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:asana"
+  service: "asana"
   field: "oauth_secret"
   value: "<the app secret the user sent>"
 ```
@@ -101,16 +101,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:asana --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider asana --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:asana:oauth_secret"
+    ) --client-secret-credential-path "asana:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:asana
+    assistant oauth connect asana
 ```
 
 Send the returned auth URL to the user. Tell them to click **Allow** on the Asana consent page.

--- a/skills/discord-oauth-setup/SKILL.md
+++ b/skills/discord-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:discord`
+- **Provider key:** `discord`
 - **Dashboard:** `https://discord.com/developers/applications`
 - **Ping URL:** `https://discord.com/api/v10/users/@me`
 - **Callback transport:** Loopback (port 17326)
@@ -110,7 +110,7 @@ Collect the app secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:discord"
+  service: "discord"
   field: "oauth_secret"
   label: "Discord OAuth App Secret"
   description: "Paste the app secret you just copied from the OAuth2 page."
@@ -122,10 +122,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:discord --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider discord --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:discord:oauth_secret"
+    ) --client-secret-credential-path "discord:oauth_secret"
 ```
 
 **Milestone (7 of 9):** "Credentials saved - just the authorization step left."
@@ -141,7 +141,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:discord --scopes identify guilds guilds.members.read messages.read
+    assistant oauth connect discord --scopes identify guilds guilds.members.read messages.read
 ```
 
 ---
@@ -153,7 +153,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:discord
+    assistant oauth ping discord
 ```
 
 **On success:** "Discord is connected! You can now ask me to check your Discord servers, read messages, and look up server members."

--- a/skills/discord-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/discord-oauth-setup/references/path-b-manual-setup.md
@@ -80,7 +80,7 @@ Wait for the Client ID, then store it:
 
 ```
 credential_store store:
-  service: "integration:discord"
+  service: "discord"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -93,7 +93,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:discord"
+  service: "discord"
   field: "oauth_secret"
   value: "<the app secret the user sent>"
 ```
@@ -111,16 +111,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:discord --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider discord --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:discord:oauth_secret"
+    ) --client-secret-credential-path "discord:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:discord --scopes identify guilds guilds.members.read messages.read
+    assistant oauth connect discord --scopes identify guilds guilds.members.read messages.read
 ```
 
 Send the returned auth URL to the user. Tell them to click **Authorize** on the Discord consent page.

--- a/skills/dropbox-oauth-setup/SKILL.md
+++ b/skills/dropbox-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:dropbox`
+- **Provider key:** `dropbox`
 - **Dashboard:** `https://www.dropbox.com/developers/apps`
 - **Ping URL:** `https://api.dropboxapi.com/2/users/get_current_account` (POST, no body)
 - **Callback transport:** Loopback (port 17327)
@@ -129,7 +129,7 @@ Collect the App secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:dropbox"
+  service: "dropbox"
   field: "oauth_secret"
   label: "Dropbox App Secret"
   description: "Copy the App secret from the Settings page (click Show to reveal it) and paste it here."
@@ -141,10 +141,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:dropbox --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider dropbox --client-id $(cat <<'EOF'
     <app-key>
     EOF
-    ) --client-secret-credential-path "integration:dropbox:oauth_secret"
+    ) --client-secret-credential-path "dropbox:oauth_secret"
 ```
 
 **Milestone (8 of 11):** "Credentials saved - just the authorization step left."
@@ -160,7 +160,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:dropbox
+    assistant oauth connect dropbox
 ```
 
 ---
@@ -172,7 +172,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:dropbox
+    assistant oauth ping dropbox
 ```
 
 **On success:** "Dropbox is connected! You can now ask me to read files, upload documents, and browse your Dropbox."

--- a/skills/dropbox-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/dropbox-oauth-setup/references/path-b-manual-setup.md
@@ -84,7 +84,7 @@ Wait for the App key, then store it:
 
 ```
 credential_store store:
-  service: "integration:dropbox"
+  service: "dropbox"
   field: "client_id"
   value: "<the app key the user sent>"
 ```
@@ -97,7 +97,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:dropbox"
+  service: "dropbox"
   field: "oauth_secret"
   value: "<the app secret the user sent>"
 ```
@@ -115,16 +115,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:dropbox --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider dropbox --client-id $(cat <<'EOF'
     <app-key>
     EOF
-    ) --client-secret-credential-path "integration:dropbox:oauth_secret"
+    ) --client-secret-credential-path "dropbox:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:dropbox
+    assistant oauth connect dropbox
 ```
 
 Send the returned auth URL to the user. Tell them to click **Allow** on the Dropbox consent page.

--- a/skills/figma-oauth-setup/SKILL.md
+++ b/skills/figma-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:figma`
+- **Provider key:** `figma`
 - **Dashboard:** `https://www.figma.com/developers/apps`
 - **Ping URL:** `https://api.figma.com/v1/me`
 - **Callback transport:** Loopback (port 17331)
@@ -110,7 +110,7 @@ Collect the app secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:figma"
+  service: "figma"
   field: "oauth_secret"
   label: "Figma OAuth App Secret"
   description: "Copy the app secret from the Figma app settings page and paste it here."
@@ -122,10 +122,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:figma --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider figma --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:figma:oauth_secret"
+    ) --client-secret-credential-path "figma:oauth_secret"
 ```
 
 **Milestone (6 of 7):** "Credentials saved - just the authorization step left."
@@ -141,7 +141,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:figma
+    assistant oauth connect figma
 ```
 
 After authorization completes, verify the connection:
@@ -149,7 +149,7 @@ After authorization completes, verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:figma
+    assistant oauth ping figma
 ```
 
 **On success:** "Figma is connected! You can now ask me to browse your design files, inspect components, and post comments."

--- a/skills/figma-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/figma-oauth-setup/references/path-b-manual-setup.md
@@ -73,7 +73,7 @@ Wait for the Client ID, then store it:
 
 ```
 credential_store store:
-  service: "integration:figma"
+  service: "figma"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -86,7 +86,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:figma"
+  service: "figma"
   field: "oauth_secret"
   value: "<the app secret the user sent>"
 ```
@@ -104,16 +104,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:figma --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider figma --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:figma:oauth_secret"
+    ) --client-secret-credential-path "figma:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:figma
+    assistant oauth connect figma
 ```
 
 Send the returned auth URL to the user. Tell them to click **Allow access** on the Figma consent page.

--- a/skills/github-oauth-setup/SKILL.md
+++ b/skills/github-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:github`
+- **Provider key:** `github`
 - **Dashboard:** `https://github.com/settings/developers`
 - **Ping URL:** `https://api.github.com/user`
 - **Callback transport:** Loopback
@@ -58,7 +58,7 @@ Resolve the callback URL:
 
 ```
 bash:
-  command: assistant oauth providers get integration:github --json
+  command: assistant oauth providers get github --json
 ```
 
 Use the `redirectUri` from the JSON response:
@@ -102,7 +102,7 @@ Collect the app secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:github"
+  service: "github"
   field: <secret-field>
   label: "GitHub OAuth App Secret"
   description: "Paste the app secret you just generated from the GitHub OAuth App page."
@@ -116,10 +116,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:github --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider github --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:github:<secret-field>"
+    ) --client-secret-credential-path "github:<secret-field>"
 ```
 
 **Milestone (5 of 8):** "Credentials saved - just the authorization step left."
@@ -147,7 +147,7 @@ These scopes are passed during the authorization step below.
 ```
 bash:
   command: |
-    assistant oauth connect integration:github --scopes repo read:user notifications
+    assistant oauth connect github --scopes repo read:user notifications
 ```
 
 **Milestone (7 of 8):** "Authorization complete - let's verify it works."
@@ -161,7 +161,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:github
+    assistant oauth ping github
 ```
 
 **On success:** "GitHub is connected! You can now ask me to check your repositories, notifications, pull requests, and issues."

--- a/skills/github-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/github-oauth-setup/references/path-b-manual-setup.md
@@ -59,7 +59,7 @@ Wait for the Client ID, then store it:
 
 ```
 credential_store store:
-  service: "integration:github"
+  service: "github"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -72,7 +72,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:github"
+  service: "github"
   field: <secret-field>
   value: "<the app secret the user sent>"
 ```
@@ -92,16 +92,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:github --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider github --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:github:<secret-field>"
+    ) --client-secret-credential-path "github:<secret-field>"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:github --scopes repo read:user notifications
+    assistant oauth connect github --scopes repo read:user notifications
 ```
 
 Send the returned auth URL to the user. Tell them to click **Authorize** on the GitHub consent page.

--- a/skills/google-oauth-applescript/SKILL.md
+++ b/skills/google-oauth-applescript/SKILL.md
@@ -15,7 +15,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:google`
+- **Provider key:** `google`
 - **Provider search keys:** `gmail`, `google`
 - **Credential type (Path A):** Desktop app
 - **Credential type (Path B):** Web application (callback through public gateway)

--- a/skills/google-oauth-applescript/references/path-b-manual-setup.md
+++ b/skills/google-oauth-applescript/references/path-b-manual-setup.md
@@ -130,7 +130,7 @@ After the user sends it:
 
 ```
 credential_store store:
-  service: "integration:google"
+  service: "google"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -149,7 +149,7 @@ After the user sends the suffix, reconstruct and store the full secret:
 
 ```
 credential_store store:
-  service: "integration:google"
+  service: "google"
   field: "client_secret"
   value: "GOCSPX-<the suffix the user sent>"
 ```
@@ -165,7 +165,7 @@ Tell the user:
 ```
 credential_store:
   action: "oauth2_connect"
-  service: "integration:google"
+  service: "google"
 ```
 
 Send the returned auth URL to the user. If they see **This app isn't verified**, tell them to click **Advanced** and continue to **Vellum Assistant**.

--- a/skills/hubspot-oauth-setup/SKILL.md
+++ b/skills/hubspot-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:hubspot`
+- **Provider key:** `hubspot`
 - **Dashboard:** `https://app.hubspot.com/developer`
 - **Ping URL:** `https://api.hubapi.com/crm/v3/objects/contacts?limit=1`
 - **Callback transport:** Loopback (port 17330)
@@ -123,7 +123,7 @@ Collect the app secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:hubspot"
+  service: "hubspot"
   field: "oauth_secret"
   label: "HubSpot OAuth App Secret"
   description: "Copy the App Secret from the Auth tab and paste it here."
@@ -135,10 +135,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:hubspot --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider hubspot --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:hubspot:oauth_secret"
+    ) --client-secret-credential-path "hubspot:oauth_secret"
 ```
 
 Then authorize:
@@ -150,7 +150,7 @@ Then authorize:
 ```
 bash:
   command: |
-    assistant oauth connect integration:hubspot
+    assistant oauth connect hubspot
 ```
 
 **Milestone (9 of 10):** "Credentials saved and authorized - let's verify."
@@ -164,7 +164,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:hubspot
+    assistant oauth ping hubspot
 ```
 
 **On success:** "HubSpot is connected! You can now ask me to look up contacts, manage deals, and browse company records in your HubSpot CRM."

--- a/skills/hubspot-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/hubspot-oauth-setup/references/path-b-manual-setup.md
@@ -84,7 +84,7 @@ Wait for the Client ID, then store it:
 
 ```
 credential_store store:
-  service: "integration:hubspot"
+  service: "hubspot"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -97,7 +97,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:hubspot"
+  service: "hubspot"
   field: "oauth_secret"
   value: "<the app secret the user sent>"
 ```
@@ -115,16 +115,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:hubspot --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider hubspot --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:hubspot:oauth_secret"
+    ) --client-secret-credential-path "hubspot:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:hubspot
+    assistant oauth connect hubspot
 ```
 
 Send the returned auth URL to the user. Tell them to select their HubSpot account and click **Grant access** on the consent page.

--- a/skills/linear-oauth-setup/SKILL.md
+++ b/skills/linear-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:linear`
+- **Provider key:** `linear`
 - **Auth URL:** `https://linear.app/oauth/authorize`
 - **Token URL:** `https://api.linear.app/oauth/token`
 - **Ping URL:** `https://api.linear.app/graphql`
@@ -86,7 +86,7 @@ Collect the secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:linear"
+  service: "linear"
   field: "oauth_secret"
   label: "Linear OAuth App Secret"
   description: "Copy the app secret from the Linear OAuth application page and paste it here."
@@ -118,10 +118,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:linear --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider linear --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:linear:oauth_secret"
+    ) --client-secret-credential-path "linear:oauth_secret"
 ```
 
 **Milestone (6 of 8):** "Credentials saved - just the authorization step left."
@@ -137,7 +137,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:linear
+    assistant oauth connect linear
 ```
 
 ---
@@ -149,7 +149,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:linear
+    assistant oauth ping linear
 ```
 
 **On success:** "Linear is connected! You can now ask me to create issues, check your assignments, search across projects, and manage your Linear workflow."

--- a/skills/linear-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/linear-oauth-setup/references/path-b-manual-setup.md
@@ -55,7 +55,7 @@ Wait for the Client ID, then store it:
 
 ```
 credential_store store:
-  service: "integration:linear"
+  service: "linear"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -68,7 +68,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:linear"
+  service: "linear"
   field: "oauth_secret"
   value: "<the secret the user sent>"
 ```
@@ -86,16 +86,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:linear --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider linear --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:linear:oauth_secret"
+    ) --client-secret-credential-path "linear:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:linear
+    assistant oauth connect linear
 ```
 
 Send the returned auth URL to the user. Tell them to click **Authorize** on the Linear consent page.

--- a/skills/notion-oauth-setup/SKILL.md
+++ b/skills/notion-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:notion`
+- **Provider key:** `notion`
 - **Default credential type:** Internal integration (API token)
 - **No OAuth flow required** for the default path - just copy the integration secret and grant page access
 
@@ -81,7 +81,7 @@ Collect the secret securely:
 
 ```
 credential_store prompt:
-  service: "integration:notion"
+  service: "notion"
   field: "internal_secret"
   label: "Notion Internal Integration Secret"
   description: "Paste the Internal Integration Secret you just copied."
@@ -111,7 +111,7 @@ Verify the connection works by calling the Notion API with the stored secret:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant credentials reveal --service integration:notion --field internal_secret)" \
+    curl -s -H "Authorization: Bearer $(assistant credentials reveal --service notion --field internal_secret)" \
       -H "Notion-Version: 2022-06-28" \
       "https://api.notion.com/v1/users/me"
 ```

--- a/skills/notion-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/notion-oauth-setup/references/path-b-manual-setup.md
@@ -77,7 +77,7 @@ Tell the user:
 
 > **Step 3: Grant page access**
 >
-> Now you need to share your Notion pages with the 
+> Now you need to share your Notion pages with the integration:
 >
 > 1. Open any Notion page you want to connect
 > 2. Click the **"..."** menu (top-right) or the **Share** button

--- a/skills/notion-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/notion-oauth-setup/references/path-b-manual-setup.md
@@ -55,7 +55,7 @@ After the user sends the secret:
 
 ```
 credential_store prompt:
-  service: "integration:notion"
+  service: "notion"
   field: "internal_secret"
   label: "Notion Internal Integration Secret"
   description: "Paste the Internal Integration Secret."
@@ -66,7 +66,7 @@ If using `credential_store store` instead (when the user sent it as plaintext):
 
 ```
 credential_store store:
-  service: "integration:notion"
+  service: "notion"
   field: "internal_secret"
   value: "<the secret the user sent>"
 ```
@@ -77,7 +77,7 @@ Tell the user:
 
 > **Step 3: Grant page access**
 >
-> Now you need to share your Notion pages with the integration:
+> Now you need to share your Notion pages with the 
 >
 > 1. Open any Notion page you want to connect
 > 2. Click the **"..."** menu (top-right) or the **Share** button
@@ -95,7 +95,7 @@ Verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant credentials reveal --service integration:notion --field internal_secret)" \
+    curl -s -H "Authorization: Bearer $(assistant credentials reveal --service notion --field internal_secret)" \
       -H "Notion-Version: 2022-06-28" \
       "https://api.notion.com/v1/users/me"
 ```

--- a/skills/notion-oauth-setup/references/path-b-public-oauth.md
+++ b/skills/notion-oauth-setup/references/path-b-public-oauth.md
@@ -61,7 +61,7 @@ After receiving the Client ID, collect the secret securely:
 
 ```
 credential_store prompt:
-  service: "integration:notion"
+  service: "notion"
   field: "client_secret"
   label: "Notion OAuth Client Secret"
   description: "Copy the Client Secret from the Notion integration page and paste it here."
@@ -73,16 +73,16 @@ credential_store prompt:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:notion --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider notion --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "credential/integration:notion/client_secret"
+    ) --client-secret-credential-path "credential/notion/client_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:notion
+    assistant oauth connect notion
 ```
 
 ### Step 5: Verify Connection
@@ -90,5 +90,5 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth ping integration:notion
+    assistant oauth ping notion
 ```

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -18,7 +18,7 @@ You have access to the Notion API via stored credentials for `notion`. Both Inte
 credential_store action=list
 ```
 
-Look for an entry with `service: "notion"`. The credential may be stored under one of two fields depending on how the user set up the 
+Look for an entry with `service: "notion"`. The credential may be stored under one of two fields depending on how the user set up the integration:
 
 - `field: "internal_secret"` - Internal integration (new default setup)
 - `field: "access_token"` - OAuth/Public integration (legacy setup)

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -8,7 +8,7 @@ metadata:
     display-name: "Notion"
 ---
 
-You have access to the Notion API via stored credentials for `integration:notion`. Both Internal integration secrets and OAuth access tokens are supported.
+You have access to the Notion API via stored credentials for `notion`. Both Internal integration secrets and OAuth access tokens are supported.
 
 ## Authentication
 
@@ -18,7 +18,7 @@ You have access to the Notion API via stored credentials for `integration:notion
 credential_store action=list
 ```
 
-Look for an entry with `service: "integration:notion"`. The credential may be stored under one of two fields depending on how the user set up the integration:
+Look for an entry with `service: "notion"`. The credential may be stored under one of two fields depending on how the user set up the 
 
 - `field: "internal_secret"` - Internal integration (new default setup)
 - `field: "access_token"` - OAuth/Public integration (legacy setup)
@@ -33,7 +33,7 @@ Use `bash` with `assistant credentials reveal` to inject the token into the Auth
 bash:
   command: |
     curl -s -X POST https://api.notion.com/v1/search \
-      -H "Authorization: Bearer $(assistant credentials reveal --service integration:notion --field internal_secret)" \
+      -H "Authorization: Bearer $(assistant credentials reveal --service notion --field internal_secret)" \
       -H "Notion-Version: 2022-06-28" \
       -H "Content-Type: application/json" \
       -d '{}'

--- a/skills/spotify-oauth-setup/SKILL.md
+++ b/skills/spotify-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:spotify`
+- **Provider key:** `spotify`
 - **Dashboard:** `https://developer.spotify.com/dashboard`
 - **Ping URL:** `https://api.spotify.com/v1/me`
 - **Callback transport:** Loopback
@@ -58,7 +58,7 @@ Before providing the redirect URI, resolve it:
 
 ```
 bash:
-  command: assistant oauth providers get integration:spotify --json
+  command: assistant oauth providers get spotify --json
 ```
 
 - If the `redirectUri` is a concrete URL (e.g. `http://localhost:…/oauth/callback`), tell the user to enter that exact URL as the redirect URI.
@@ -103,7 +103,7 @@ Collect the app secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:spotify"
+  service: "spotify"
   field: "oauth_secret"
   label: "Spotify OAuth App Secret"
   description: "Copy the app secret from the Settings page (click View app secret to reveal it) and paste it here."
@@ -115,10 +115,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:spotify --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider spotify --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:spotify:oauth_secret"
+    ) --client-secret-credential-path "spotify:oauth_secret"
 ```
 
 **Milestone (4 of 7):** "Credentials saved - just the authorization step left."
@@ -134,7 +134,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:spotify
+    assistant oauth connect spotify
 ```
 
 The scopes requested will include:
@@ -158,7 +158,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:spotify
+    assistant oauth ping spotify
 ```
 
 **On success:** "Spotify is connected! You can now ask me to control playback, manage your playlists, check what's playing, and browse your library."

--- a/skills/spotify-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/spotify-oauth-setup/references/path-b-manual-setup.md
@@ -61,7 +61,7 @@ Wait for the Client ID, then store it:
 
 ```
 credential_store store:
-  service: "integration:spotify"
+  service: "spotify"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -74,7 +74,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:spotify"
+  service: "spotify"
   field: "oauth_secret"
   value: "<the app secret the user sent>"
 ```
@@ -92,16 +92,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:spotify --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider spotify --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:spotify:oauth_secret"
+    ) --client-secret-credential-path "spotify:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:spotify
+    assistant oauth connect spotify
 ```
 
 Send the returned auth URL to the user. Tell them to click **Agree** on the Spotify consent page.

--- a/skills/todoist-oauth-setup/SKILL.md
+++ b/skills/todoist-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:todoist`
+- **Provider key:** `todoist`
 - **Dashboard:** `https://developer.todoist.com/appconsole.html`
 - **Scopes:** `data:read_write`
 - **Callback transport:** Loopback (port 17325)
@@ -77,7 +77,7 @@ Collect the app secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:todoist"
+  service: "todoist"
   field: "app_secret"
   label: "Todoist OAuth App Secret"
   description: "Copy the app secret from the Todoist app settings page and paste it here."
@@ -89,10 +89,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:todoist --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider todoist --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:todoist:app_secret"
+    ) --client-secret-credential-path "todoist:app_secret"
 ```
 
 **Milestone (5 of 7):** "Credentials saved - just the authorization step left."
@@ -108,7 +108,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:todoist
+    assistant oauth connect todoist
 ```
 
 ---
@@ -120,7 +120,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:todoist
+    assistant oauth ping todoist
 ```
 
 **On success:** "Todoist is connected! You can now ask me to manage your tasks, create projects, and organize your to-do lists."

--- a/skills/todoist-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/todoist-oauth-setup/references/path-b-manual-setup.md
@@ -68,7 +68,7 @@ Wait for the Client ID, then store it:
 
 ```
 credential_store store:
-  service: "integration:todoist"
+  service: "todoist"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -81,7 +81,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:todoist"
+  service: "todoist"
   field: "app_secret"
   value: "<the secret the user sent>"
 ```
@@ -99,16 +99,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:todoist --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider todoist --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "integration:todoist:app_secret"
+    ) --client-secret-credential-path "todoist:app_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:todoist
+    assistant oauth connect todoist
 ```
 
 Send the returned auth URL to the user. Tell them to click **Agree** on the Todoist consent page.

--- a/skills/twitter-oauth-setup/SKILL.md
+++ b/skills/twitter-oauth-setup/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Provider Details
 
-- **Provider key:** `integration:twitter`
+- **Provider key:** `twitter`
 - **Auth URL:** `https://twitter.com/i/oauth2/authorize`
 - **Token URL:** `https://api.x.com/2/oauth2/token`
 - **Ping URL:** `https://api.x.com/2/users/me`
@@ -110,7 +110,7 @@ Before providing the redirect URI, resolve it:
 
 ```
 bash:
-  command: assistant oauth providers list --provider-key "integration:twitter" --json
+  command: assistant oauth providers list --provider-key "twitter" --json
 ```
 
 Check the redirect URI situation. Since callbackTransport is `gateway`, public ingress must be configured:
@@ -152,7 +152,7 @@ Collect Client Secret via secure prompt:
 
 ```
 credential_store prompt:
-  service: "integration:twitter"
+  service: "twitter"
   field: "client_secret"
   label: "Twitter OAuth 2.0 Client Secret"
   description: "Copy the Client Secret from the Keys and tokens page and paste it here."
@@ -164,10 +164,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:twitter --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider twitter --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "credential/integration:twitter/client_secret"
+    ) --client-secret-credential-path "credential/twitter/client_secret"
 ```
 
 **Milestone (6 of 8):** "Credentials saved - just the authorization step left."
@@ -183,7 +183,7 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connect integration:twitter
+    assistant oauth connect twitter
 ```
 
 ---
@@ -195,7 +195,7 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    assistant oauth ping integration:twitter
+    assistant oauth ping twitter
 ```
 
 **On success:** "Twitter is connected! You can now ask me to read your timeline, post tweets, and check your profile."

--- a/skills/twitter-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/twitter-oauth-setup/references/path-b-manual-setup.md
@@ -81,7 +81,7 @@ Wait for the Client ID, then store it:
 
 ```
 credential_store store:
-  service: "integration:twitter"
+  service: "twitter"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -94,7 +94,7 @@ Store the secret:
 
 ```
 credential_store store:
-  service: "integration:twitter"
+  service: "twitter"
   field: "client_secret"
   value: "<the client secret the user sent>"
 ```
@@ -112,16 +112,16 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:twitter --client-id $(cat <<'EOF'
+    assistant oauth apps upsert --provider twitter --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "credential/integration:twitter/client_secret"
+    ) --client-secret-credential-path "credential/twitter/client_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connect integration:twitter
+    assistant oauth connect twitter
 ```
 
 Send the returned auth URL to the user. Tell them to review the permissions and click **Authorize app**.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for simplify-oauth-provider-keys.md.

**Gap:** Skills directory (27 files) still has integration:X references
**What was expected:** All provider key references should use bare names
**What was found:** 28 skill files still instruct the AI to use integration:X format

Updated 143 occurrences across 28 files in the skills/ directory, converting all `integration:X` provider key references to bare `X` names. This covers:
- `service: "integration:X"` -> `service: "X"` in credential_store calls
- `"integration:X:oauth_secret"` -> `"X:oauth_secret"` in client-secret-credential-path args
- `--provider integration:X` -> `--provider X` in oauth apps upsert commands
- `assistant oauth connect integration:X` -> `assistant oauth connect X`
- `--provider-key "integration:X"` -> `--provider-key "X"` in provider list commands
- Backtick-wrapped `integration:X` in inline docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
