### PR TITLE
fix: update stale comments and SERVICE_ALIASES error message for bare provider keys

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -483,13 +483,9 @@ describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store"
   });
 
   test("upsertCredentialMetadata does not accept oauth2ClientSecret or other OAuth fields", () => {
-    const record = upsertCredentialMetadata(
-      "integration:google",
-      "access_token",
-      {
-        allowedTools: ["api_request"],
-      },
-    );
+    const record = upsertCredentialMetadata("google", "access_token", {
+      allowedTools: ["api_request"],
+    });
     expect("oauth2ClientSecret" in record).toBe(false);
     expect("oauth2TokenUrl" in record).toBe(false);
     expect("oauth2ClientId" in record).toBe(false);
@@ -497,14 +493,14 @@ describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store"
 
   test("client secret is read from secure store, not metadata", async () => {
     await setSecureKeyAsync(
-      credentialKey("integration:google", "client_secret"),
+      credentialKey("google", "client_secret"),
       "my-secret",
     );
-    upsertCredentialMetadata("integration:google", "access_token", {
+    upsertCredentialMetadata("google", "access_token", {
       allowedTools: ["api_request"],
     });
 
-    const meta = getCredentialMetadata("integration:google", "access_token");
+    const meta = getCredentialMetadata("google", "access_token");
     expect(meta).toBeDefined();
     expect("oauth2ClientSecret" in meta!).toBe(false);
     // OAuth-specific fields are no longer in metadata (v5)
@@ -513,9 +509,7 @@ describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store"
 
     // Secret is in secure store
     expect(
-      await getSecureKeyAsync(
-        credentialKey("integration:google", "client_secret"),
-      ),
+      await getSecureKeyAsync(credentialKey("google", "client_secret")),
     ).toBe("my-secret");
   });
 
@@ -525,7 +519,7 @@ describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store"
       credentials: [
         {
           credentialId: "cred-v2-secret",
-          service: "integration:google",
+          service: "google",
           field: "access_token",
           allowedTools: [],
           allowedDomains: [],
@@ -543,7 +537,7 @@ describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store"
       "utf-8",
     );
 
-    const meta = getCredentialMetadata("integration:google", "access_token");
+    const meta = getCredentialMetadata("google", "access_token");
     expect(meta).toBeDefined();
     expect("oauth2ClientSecret" in meta!).toBe(false);
 

--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -736,7 +736,7 @@ describe("credential_store tool", () => {
       await credentialStoreTool.execute(
         {
           action: "store",
-          service: "integration:google",
+          service: "google",
           field: "api_key",
           value: "test-value",
         },
@@ -744,9 +744,9 @@ describe("credential_store tool", () => {
       );
 
       // Simulate an active OAuth connection for this service
-      mockConnections.set("integration:google", {
+      mockConnections.set("google", {
         id: "conn-gmail",
-        providerKey: "integration:google",
+        providerKey: "google",
         oauthAppId: "app-gmail",
         expiresAt: Date.now() + 3600_000,
       });
@@ -754,7 +754,7 @@ describe("credential_store tool", () => {
       const result = await credentialStoreTool.execute(
         {
           action: "delete",
-          service: "integration:google",
+          service: "google",
           field: "api_key",
         },
         _ctx,
@@ -764,9 +764,7 @@ describe("credential_store tool", () => {
       expect(result.content).toContain("Deleted credential");
       // Verify disconnectOAuthProvider was called with the service name
       expect(mockDisconnectOAuthProvider).toHaveBeenCalledTimes(1);
-      expect(mockDisconnectOAuthProvider).toHaveBeenCalledWith(
-        "integration:google",
-      );
+      expect(mockDisconnectOAuthProvider).toHaveBeenCalledWith("google");
     });
   });
 
@@ -1354,7 +1352,7 @@ describe("withValidToken refresh deduplication", () => {
   }
 
   test("3 concurrent 401 refreshes for the same service call doRefresh exactly once", async () => {
-    await setupService("integration:google");
+    await setupService("google");
 
     let resolveRefresh!: (value: {
       accessToken: string;
@@ -1378,9 +1376,9 @@ describe("withValidToken refresh deduplication", () => {
 
     // Launch 3 concurrent withValidToken calls — all will get a non-expired
     // token first, call the callback, get a 401, and then try to refresh.
-    const p1 = withValidToken("integration:google", callback);
-    const p2 = withValidToken("integration:google", callback);
-    const p3 = withValidToken("integration:google", callback);
+    const p1 = withValidToken("google", callback);
+    const p2 = withValidToken("google", callback);
+    const p3 = withValidToken("google", callback);
 
     // Let the event loop tick so all 3 calls enter the 401 retry path
     await new Promise((r) => setTimeout(r, 10));
@@ -1402,8 +1400,8 @@ describe("withValidToken refresh deduplication", () => {
   });
 
   test("concurrent refreshes for different services proceed independently", async () => {
-    await setupService("integration:google");
-    await setupService("integration:slack");
+    await setupService("google");
+    await setupService("slack");
 
     let resolveGmail!: (value: {
       accessToken: string;
@@ -1447,8 +1445,8 @@ describe("withValidToken refresh deduplication", () => {
       return `slack-${token}`;
     };
 
-    const p1 = withValidToken("integration:google", gmailCallback);
-    const p2 = withValidToken("integration:slack", slackCallback);
+    const p1 = withValidToken("google", gmailCallback);
+    const p2 = withValidToken("slack", slackCallback);
 
     await new Promise((r) => setTimeout(r, 10));
 
@@ -1466,7 +1464,7 @@ describe("withValidToken refresh deduplication", () => {
   });
 
   test("deduplication cleans up after refresh completes, allowing subsequent refreshes", async () => {
-    await setupService("integration:google");
+    await setupService("google");
 
     let refreshCount = 0;
     mockRefreshOAuth2Token.mockImplementation(() => {
@@ -1480,25 +1478,19 @@ describe("withValidToken refresh deduplication", () => {
     const err401 = Object.assign(new Error("Unauthorized"), { status: 401 });
 
     // First call triggers a refresh (old token → 401 → refresh → token-1)
-    const r1 = await withValidToken(
-      "integration:google",
-      async (token: string) => {
-        if (token !== "token-1") throw err401;
-        return token;
-      },
-    );
+    const r1 = await withValidToken("google", async (token: string) => {
+      if (token !== "token-1") throw err401;
+      return token;
+    });
     expect(r1).toBe("token-1");
     expect(refreshCount).toBe(1);
 
     // Second call also triggers a 401 to verify dedup state was cleaned up
     // and a new refresh is allowed (not deduplicated with the first).
-    const r2 = await withValidToken(
-      "integration:google",
-      async (token: string) => {
-        if (token !== "token-2") throw err401;
-        return token;
-      },
-    );
+    const r2 = await withValidToken("google", async (token: string) => {
+      if (token !== "token-2") throw err401;
+      return token;
+    });
     expect(r2).toBe("token-2");
     // Second refresh should have happened (not deduplicated with the first,
     // since the first already completed)
@@ -1506,7 +1498,7 @@ describe("withValidToken refresh deduplication", () => {
   });
 
   test("deduplication propagates refresh errors to all waiting callers", async () => {
-    await setupService("integration:google");
+    await setupService("google");
 
     mockRefreshOAuth2Token.mockImplementation(() =>
       Promise.reject(
@@ -1524,8 +1516,8 @@ describe("withValidToken refresh deduplication", () => {
     };
 
     // Launch 2 concurrent calls — both should fail with the same error
-    const p1 = withValidToken("integration:google", callback);
-    const p2 = withValidToken("integration:google", callback);
+    const p1 = withValidToken("google", callback);
+    const p2 = withValidToken("google", callback);
 
     const results = await Promise.allSettled([p1, p2]);
 

--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -1059,7 +1059,7 @@ describe("assistant credentials CLI", () => {
       const setResult = await runCli([
         "set",
         "--service",
-        "integration:google",
+        "google",
         "--field",
         "client_secret",
         "secret123",
@@ -1068,13 +1068,13 @@ describe("assistant credentials CLI", () => {
       expect(setResult.exitCode).toBe(0);
       const setParsed = JSON.parse(setResult.stdout);
       expect(setParsed.ok).toBe(true);
-      expect(setParsed.service).toBe("integration:google");
+      expect(setParsed.service).toBe("google");
       expect(setParsed.field).toBe("client_secret");
 
       const revealResult = await runCli([
         "reveal",
         "--service",
-        "integration:google",
+        "google",
         "--field",
         "client_secret",
         "--json",

--- a/assistant/src/__tests__/daemon-credential-client.test.ts
+++ b/assistant/src/__tests__/daemon-credential-client.test.ts
@@ -110,13 +110,13 @@ describe("daemon credential read requests", () => {
 
   test("preserves compound credential service names on metadata reads", async () => {
     const result = await getSecureKeyResultViaDaemon(
-      credentialKey("integration:google", "client_secret"),
+      credentialKey("google", "client_secret"),
     );
 
     expect(result).toEqual({ value: "secret-value", unreachable: false });
     expect(getRequestBody()).toEqual({
       type: "credential",
-      name: "integration:google:client_secret",
+      name: "google:client_secret",
       reveal: true,
     });
   });

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -37,7 +37,7 @@ let mockUpsertAppCalls: Array<{
 }> = [];
 let mockUpsertAppResult: Record<string, unknown> = {
   id: "app-upsert-1",
-  providerKey: "integration:test",
+  providerKey: "test",
   clientId: "test-client-id",
   createdAt: 1700000000000,
   updatedAt: 1700000000000,
@@ -315,17 +315,13 @@ describe("assistant oauth token <provider-key>", () => {
   });
 
   test("prints bare token in human mode", async () => {
-    const { exitCode, stdout } = await runCli(["token", "integration:twitter"]);
+    const { exitCode, stdout } = await runCli(["token", "twitter"]);
     expect(exitCode).toBe(0);
     expect(stdout).toBe("mock-access-token-xyz\n");
   });
 
   test("prints JSON in --json mode", async () => {
-    const { exitCode, stdout } = await runCli([
-      "token",
-      "integration:twitter",
-      "--json",
-    ]);
+    const { exitCode, stdout } = await runCli(["token", "twitter", "--json"]);
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toEqual({ ok: true, token: "mock-access-token-xyz" });
@@ -338,8 +334,8 @@ describe("assistant oauth token <provider-key>", () => {
       return cb("tok");
     };
 
-    await runCli(["token", "integration:twitter"]);
-    expect(capturedService).toBe("integration:twitter");
+    await runCli(["token", "twitter"]);
+    expect(capturedService).toBe("twitter");
   });
 
   test("works with other provider keys", async () => {
@@ -349,24 +345,20 @@ describe("assistant oauth token <provider-key>", () => {
       return cb("gmail-token");
     };
 
-    const { exitCode, stdout } = await runCli(["token", "integration:google"]);
+    const { exitCode, stdout } = await runCli(["token", "google"]);
     expect(exitCode).toBe(0);
     expect(stdout).toBe("gmail-token\n");
-    expect(capturedService).toBe("integration:google");
+    expect(capturedService).toBe("google");
   });
 
   test("exits 1 when no token exists", async () => {
     mockWithValidToken = async () => {
       throw new Error(
-        'No access token found for "integration:twitter". Authorization required.',
+        'No access token found for "twitter". Authorization required.',
       );
     };
 
-    const { exitCode, stdout } = await runCli([
-      "token",
-      "integration:twitter",
-      "--json",
-    ]);
+    const { exitCode, stdout } = await runCli(["token", "twitter", "--json"]);
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
@@ -375,16 +367,10 @@ describe("assistant oauth token <provider-key>", () => {
 
   test("exits 1 when refresh fails", async () => {
     mockWithValidToken = async () => {
-      throw new Error(
-        'Token refresh failed for "integration:twitter": invalid_grant.',
-      );
+      throw new Error('Token refresh failed for "twitter": invalid_grant.');
     };
 
-    const { exitCode, stdout } = await runCli([
-      "token",
-      "integration:twitter",
-      "--json",
-    ]);
+    const { exitCode, stdout } = await runCli(["token", "twitter", "--json"]);
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
@@ -395,7 +381,7 @@ describe("assistant oauth token <provider-key>", () => {
     // Simulate withValidToken refreshing and returning a new token
     mockWithValidToken = async (_service, cb) => cb("refreshed-new-token");
 
-    const { exitCode, stdout } = await runCli(["token", "integration:twitter"]);
+    const { exitCode, stdout } = await runCli(["token", "twitter"]);
     expect(exitCode).toBe(0);
     expect(stdout).toBe("refreshed-new-token\n");
   });
@@ -413,7 +399,7 @@ describe("assistant oauth token <provider-key>", () => {
 describe("assistant oauth providers list", () => {
   const fakeProviders = [
     {
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: "[]",
@@ -423,7 +409,7 @@ describe("assistant oauth providers list", () => {
       updatedAt: "2025-01-01T00:00:00.000Z",
     },
     {
-      providerKey: "integration:google-calendar",
+      providerKey: "google-calendar",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: "[]",
@@ -433,7 +419,7 @@ describe("assistant oauth providers list", () => {
       updatedAt: "2025-01-01T00:00:00.000Z",
     },
     {
-      providerKey: "integration:slack",
+      providerKey: "slack",
       authUrl: "https://slack.com/oauth/v2/authorize",
       tokenUrl: "https://slack.com/api/oauth.v2.access",
       defaultScopes: "[]",
@@ -443,7 +429,7 @@ describe("assistant oauth providers list", () => {
       updatedAt: "2025-01-01T00:00:00.000Z",
     },
     {
-      providerKey: "integration:twitter",
+      providerKey: "twitter",
       authUrl: "https://twitter.com/i/oauth2/authorize",
       tokenUrl: "https://api.twitter.com/2/oauth2/token",
       defaultScopes: "[]",
@@ -465,10 +451,10 @@ describe("assistant oauth providers list", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(4);
     const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
-    expect(keys).toContain("integration:google");
-    expect(keys).toContain("integration:google-calendar");
-    expect(keys).toContain("integration:slack");
-    expect(keys).toContain("integration:twitter");
+    expect(keys).toContain("google");
+    expect(keys).toContain("google-calendar");
+    expect(keys).toContain("slack");
+    expect(keys).toContain("twitter");
   });
 
   test("filters by single --provider-key value", async () => {
@@ -482,7 +468,7 @@ describe("assistant oauth providers list", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(1);
-    expect(parsed[0].providerKey).toBe("integration:slack");
+    expect(parsed[0].providerKey).toBe("slack");
   });
 
   test("filters by comma-separated OR values", async () => {
@@ -497,9 +483,9 @@ describe("assistant oauth providers list", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(3);
     const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
-    expect(keys).toContain("integration:google");
-    expect(keys).toContain("integration:google-calendar");
-    expect(keys).toContain("integration:slack");
+    expect(keys).toContain("google");
+    expect(keys).toContain("google-calendar");
+    expect(keys).toContain("slack");
   });
 
   test("returns empty array when comma-separated filter has no matches", async () => {
@@ -527,9 +513,9 @@ describe("assistant oauth providers list", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(3);
     const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
-    expect(keys).toContain("integration:google");
-    expect(keys).toContain("integration:google-calendar");
-    expect(keys).toContain("integration:slack");
+    expect(keys).toContain("google");
+    expect(keys).toContain("google-calendar");
+    expect(keys).toContain("slack");
   });
 
   test("ignores empty segments from extra commas in --provider-key", async () => {
@@ -544,9 +530,9 @@ describe("assistant oauth providers list", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(3);
     const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
-    expect(keys).toContain("integration:google");
-    expect(keys).toContain("integration:google-calendar");
-    expect(keys).toContain("integration:slack");
+    expect(keys).toContain("google");
+    expect(keys).toContain("google-calendar");
+    expect(keys).toContain("slack");
   });
 });
 
@@ -560,7 +546,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
     mockUpsertAppCalls = [];
     mockUpsertAppResult = {
       id: "app-upsert-1",
-      providerKey: "integration:google",
+      providerKey: "google",
       clientId: "abc123",
       createdAt: 1700000000000,
       updatedAt: 1700000000000,
@@ -584,7 +570,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
       "apps",
       "upsert",
       "--provider",
-      "integration:google",
+      "google",
       "--client-id",
       "abc123",
       "--client-secret-credential-path",
@@ -594,7 +580,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
     expect(exitCode).toBe(0);
     expect(mockUpsertAppCalls).toHaveLength(1);
     expect(mockUpsertAppCalls[0]).toEqual({
-      provider: "integration:google",
+      provider: "google",
       clientId: "abc123",
       clientSecretOpts: { clientSecretCredentialPath: "custom/path" },
     });
@@ -607,7 +593,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
       "apps",
       "upsert",
       "--provider",
-      "integration:google",
+      "google",
       "--client-id",
       "abc123",
       "--client-secret",
@@ -631,7 +617,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
       "apps",
       "upsert",
       "--provider",
-      "integration:google",
+      "google",
       "--client-id",
       "abc123",
       "--client-secret",
@@ -641,7 +627,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
     expect(exitCode).toBe(0);
     expect(mockUpsertAppCalls).toHaveLength(1);
     expect(mockUpsertAppCalls[0]).toEqual({
-      provider: "integration:google",
+      provider: "google",
       clientId: "abc123",
       clientSecretOpts: { clientSecretValue: "s3cret" },
     });
@@ -652,7 +638,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
       "apps",
       "upsert",
       "--provider",
-      "integration:google",
+      "google",
       "--client-id",
       "abc123",
       "--json",
@@ -660,7 +646,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
     expect(exitCode).toBe(0);
     expect(mockUpsertAppCalls).toHaveLength(1);
     expect(mockUpsertAppCalls[0]).toEqual({
-      provider: "integration:google",
+      provider: "google",
       clientId: "abc123",
       clientSecretOpts: undefined,
     });
@@ -673,20 +659,20 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
       "apps",
       "upsert",
       "--provider",
-      "integration:google",
+      "google",
       "--client-id",
       "abc",
       "--client-secret-credential-path",
-      "integration:google:client_secret",
+      "google:client_secret",
       "--json",
     ]);
     expect(exitCode).toBe(0);
     expect(mockUpsertAppCalls).toHaveLength(1);
     expect(mockUpsertAppCalls[0]).toEqual({
-      provider: "integration:google",
+      provider: "google",
       clientId: "abc",
       clientSecretOpts: {
-        clientSecretCredentialPath: "integration:google:client_secret",
+        clientSecretCredentialPath: "google:client_secret",
       },
     });
     const parsed = JSON.parse(stdout);
@@ -698,22 +684,21 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
       "apps",
       "upsert",
       "--provider",
-      "integration:google",
+      "google",
       "--client-id",
       "abc",
       "--client-secret-credential-path",
-      "credential/integration:google/client_secret",
+      "credential/google/client_secret",
       "--json",
     ]);
     expect(exitCode).toBe(0);
     expect(mockUpsertAppCalls).toHaveLength(1);
     // Already-prefixed path should be passed through as-is
     expect(mockUpsertAppCalls[0]).toEqual({
-      provider: "integration:google",
+      provider: "google",
       clientId: "abc",
       clientSecretOpts: {
-        clientSecretCredentialPath:
-          "credential/integration:google/client_secret",
+        clientSecretCredentialPath: "credential/google/client_secret",
       },
     });
     const parsed = JSON.parse(stdout);
@@ -732,7 +717,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
       "apps",
       "upsert",
       "--provider",
-      "integration:google",
+      "google",
       "--client-id",
       "abc",
       "--client-secret-credential-path",
@@ -761,7 +746,7 @@ describe("assistant oauth ping <provider-key>", () => {
 
   test("returns ok when ping endpoint returns 200", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
@@ -773,16 +758,12 @@ describe("assistant oauth ping <provider-key>", () => {
     });
     mockResolveOAuthConnection = async () => ({
       id: "conn-1",
-      providerKey: "integration:google",
+      providerKey: "google",
       accountInfo: null,
       request: async () => ({ status: 200, headers: {}, body: {} }),
       withToken: async (fn) => fn("mock-access-token-xyz"),
     });
-    const { exitCode, stdout } = await runCli([
-      "ping",
-      "integration:google",
-      "--json",
-    ]);
+    const { exitCode, stdout } = await runCli(["ping", "google", "--json"]);
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(true);
@@ -791,11 +772,7 @@ describe("assistant oauth ping <provider-key>", () => {
 
   test("exits 1 when provider not found", async () => {
     mockGetProvider = () => undefined;
-    const { exitCode, stdout } = await runCli([
-      "ping",
-      "integration:unknown",
-      "--json",
-    ]);
+    const { exitCode, stdout } = await runCli(["ping", "unknown", "--json"]);
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
@@ -823,7 +800,7 @@ describe("assistant oauth ping <provider-key>", () => {
 
   test("exits 1 when ping endpoint returns non-2xx", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
@@ -835,16 +812,12 @@ describe("assistant oauth ping <provider-key>", () => {
     });
     mockResolveOAuthConnection = async () => ({
       id: "conn-1",
-      providerKey: "integration:google",
+      providerKey: "google",
       accountInfo: null,
       request: async () => ({ status: 403, headers: {}, body: "Forbidden" }),
       withToken: async (fn) => fn("mock-access-token-xyz"),
     });
-    const { exitCode, stdout } = await runCli([
-      "ping",
-      "integration:google",
-      "--json",
-    ]);
+    const { exitCode, stdout } = await runCli(["ping", "google", "--json"]);
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
@@ -853,7 +826,7 @@ describe("assistant oauth ping <provider-key>", () => {
 
   test("exits 1 when no connection can be resolved", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
@@ -864,13 +837,9 @@ describe("assistant oauth ping <provider-key>", () => {
       updatedAt: Date.now(),
     });
     mockResolveOAuthConnection = async () => {
-      throw new Error('No access token found for "integration:google".');
+      throw new Error('No access token found for "google".');
     };
-    const { exitCode, stdout } = await runCli([
-      "ping",
-      "integration:google",
-      "--json",
-    ]);
+    const { exitCode, stdout } = await runCli(["ping", "google", "--json"]);
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);

--- a/assistant/src/__tests__/oauth-scope-policy.test.ts
+++ b/assistant/src/__tests__/oauth-scope-policy.test.ts
@@ -12,7 +12,7 @@ function makeProfile(
   overrides: Partial<ScopeResolverInput> = {},
 ): ScopeResolverInput {
   return {
-    service: "integration:test-service",
+    service: "test-service",
     defaultScopes: ["read", "write"],
     scopePolicy: {
       allowAdditionalScopes: false,
@@ -57,9 +57,7 @@ describe("resolveScopes", () => {
     const result = resolveScopes(profile, ["delete"]);
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error).toBe(
-        "Scope 'delete' is forbidden for integration:test-service",
-      );
+      expect(result.error).toBe("Scope 'delete' is forbidden for test-service");
     }
   });
 
@@ -76,7 +74,7 @@ describe("resolveScopes", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toContain(
-        "Additional scopes are not allowed for integration:test-service",
+        "Additional scopes are not allowed for test-service",
       );
       expect(result.allowedScopes).toEqual(["read", "write"]);
     }
@@ -95,7 +93,7 @@ describe("resolveScopes", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toBe(
-        "Scope 'admin' is not in the allowed optional scopes for integration:test-service",
+        "Scope 'admin' is not in the allowed optional scopes for test-service",
       );
       expect(result.allowedScopes).toEqual(["read", "write"]);
     }

--- a/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
@@ -83,13 +83,9 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
 mock.module("../../../../oauth/provider-behaviors.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   getProviderBehavior: (key: string) => mockGetProviderBehavior(key),
 }));
@@ -136,13 +132,9 @@ mock.module("../../../lib/daemon-credential-client.js", () => ({
 mock.module("../shared.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   isManagedMode: (key: string) => mockIsManagedMode(key),
   requirePlatformClient: async (_cmd: Command) => {
@@ -193,10 +185,6 @@ mock.module("../shared.js", () => ({
     if (!result.ok) return null;
     return result.body as Array<Record<string, unknown>>;
   },
-  toBareProvider: (provider: string): string =>
-    provider.startsWith("integration:")
-      ? provider.slice("integration:".length)
-      : provider,
 }));
 
 // ---------------------------------------------------------------------------
@@ -295,7 +283,7 @@ describe("assistant oauth connect", () => {
   // Provider alias resolution
   // -------------------------------------------------------------------------
 
-  test("provider alias 'gmail' resolves to integration:google", async () => {
+  test("provider alias 'gmail' resolves to google", async () => {
     let capturedProviderKey: string | undefined;
 
     mockGetProvider = (key: string) => {
@@ -312,7 +300,7 @@ describe("assistant oauth connect", () => {
       id: "app-1",
       clientId: "test-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "integration:google",
+      providerKey: "google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -325,7 +313,7 @@ describe("assistant oauth connect", () => {
     });
 
     await runCommand(["connect", "gmail", "--json"]);
-    expect(capturedProviderKey).toBe("integration:google");
+    expect(capturedProviderKey).toBe("google");
   });
 
   // -------------------------------------------------------------------------
@@ -334,7 +322,7 @@ describe("assistant oauth connect", () => {
 
   test("managed mode: prints connect URL without --open-browser", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: "google-oauth",
@@ -361,7 +349,7 @@ describe("assistant oauth connect", () => {
     expect(parsed.connectUrl).toBe(
       "https://platform.example.com/oauth/connect",
     );
-    expect(parsed.provider).toBe("integration:google");
+    expect(parsed.provider).toBe("google");
   });
 
   // -------------------------------------------------------------------------
@@ -370,7 +358,7 @@ describe("assistant oauth connect", () => {
 
   test("managed mode with --open-browser: opens browser and polls for new connection", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: "google-oauth",
@@ -427,7 +415,7 @@ describe("assistant oauth connect", () => {
 
   test("BYO mode: prints auth URL without --open-browser", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: null,
@@ -438,7 +426,7 @@ describe("assistant oauth connect", () => {
       id: "app-1",
       clientId: "byo-client-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "integration:google",
+      providerKey: "google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -448,12 +436,12 @@ describe("assistant oauth connect", () => {
       deferred: true,
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth?state=abc",
       state: "abc",
-      service: "integration:google",
+      service: "google",
     });
 
     const { exitCode, stdout } = await runCommand([
       "connect",
-      "integration:google",
+      "google",
       "--json",
     ]);
     expect(exitCode).toBe(0);
@@ -463,7 +451,7 @@ describe("assistant oauth connect", () => {
     expect(parsed.authUrl).toBe(
       "https://accounts.google.com/o/oauth2/v2/auth?state=abc",
     );
-    expect(parsed.service).toBe("integration:google");
+    expect(parsed.service).toBe("google");
   });
 
   // -------------------------------------------------------------------------
@@ -472,7 +460,7 @@ describe("assistant oauth connect", () => {
 
   test("BYO mode with --open-browser calls orchestrator with isInteractive: true", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: null,
@@ -483,7 +471,7 @@ describe("assistant oauth connect", () => {
       id: "app-1",
       clientId: "test-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "integration:google",
+      providerKey: "google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -501,7 +489,7 @@ describe("assistant oauth connect", () => {
 
     const { exitCode, stdout } = await runCommand([
       "connect",
-      "integration:google",
+      "google",
       "--client-id",
       "test-id",
       "--open-browser",
@@ -525,7 +513,7 @@ describe("assistant oauth connect", () => {
 
   test("BYO mode: missing app with --client-id returns error with hint", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: null,
@@ -535,7 +523,7 @@ describe("assistant oauth connect", () => {
 
     const { exitCode, stdout } = await runCommand([
       "connect",
-      "integration:google",
+      "google",
       "--client-id",
       "nonexistent-id",
       "--json",
@@ -553,7 +541,7 @@ describe("assistant oauth connect", () => {
 
   test("BYO mode: no client_id found returns error with hint", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: null,
@@ -563,7 +551,7 @@ describe("assistant oauth connect", () => {
 
     const { exitCode, stdout } = await runCommand([
       "connect",
-      "integration:google",
+      "google",
       "--json",
     ]);
     expect(exitCode).toBe(1);
@@ -579,7 +567,7 @@ describe("assistant oauth connect", () => {
 
   test("--client-id is silently ignored in managed mode", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: "google-oauth",
@@ -616,7 +604,7 @@ describe("assistant oauth connect", () => {
 
   test("JSON output for deferred case includes ok, deferred, authUrl, service", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:slack",
+      providerKey: "slack",
       authUrl: "https://slack.com/oauth/v2/authorize",
       tokenUrl: "https://slack.com/api/oauth.v2.access",
       managedServiceConfigKey: null,
@@ -627,7 +615,7 @@ describe("assistant oauth connect", () => {
       id: "app-slack",
       clientId: "slack-client-id",
       clientSecretCredentialPath: "oauth_app/app-slack/client_secret",
-      providerKey: "integration:slack",
+      providerKey: "slack",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -637,7 +625,7 @@ describe("assistant oauth connect", () => {
       deferred: true,
       authUrl: "https://slack.com/oauth/v2/authorize?state=xyz",
       state: "xyz",
-      service: "integration:slack",
+      service: "slack",
     });
 
     const { exitCode, stdout } = await runCommand([
@@ -650,7 +638,7 @@ describe("assistant oauth connect", () => {
     expect(parsed).toHaveProperty("ok", true);
     expect(parsed).toHaveProperty("deferred", true);
     expect(parsed).toHaveProperty("authUrl");
-    expect(parsed).toHaveProperty("service", "integration:slack");
+    expect(parsed).toHaveProperty("service", "slack");
   });
 
   // -------------------------------------------------------------------------
@@ -659,7 +647,7 @@ describe("assistant oauth connect", () => {
 
   test("JSON output for completed case includes ok, grantedScopes, accountInfo", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: null,
@@ -670,7 +658,7 @@ describe("assistant oauth connect", () => {
       id: "app-1",
       clientId: "completed-client-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "integration:google",
+      providerKey: "google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -703,7 +691,7 @@ describe("assistant oauth connect", () => {
 
   test("BYO mode: client_secret required but missing returns error with hint", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       tokenEndpointAuthMethod: "client_secret_post",
@@ -715,7 +703,7 @@ describe("assistant oauth connect", () => {
       id: "app-1",
       clientId: "test-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "integration:google",
+      providerKey: "google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -735,7 +723,7 @@ describe("assistant oauth connect", () => {
 
     const { exitCode, stdout } = await runCommand([
       "connect",
-      "integration:google",
+      "google",
       "--json",
     ]);
     expect(exitCode).toBe(1);
@@ -751,7 +739,7 @@ describe("assistant oauth connect", () => {
 
   test("BYO mode: orchestrator error propagates correctly", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: null,
@@ -762,7 +750,7 @@ describe("assistant oauth connect", () => {
       id: "app-1",
       clientId: "client-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "integration:google",
+      providerKey: "google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -774,7 +762,7 @@ describe("assistant oauth connect", () => {
 
     const { exitCode, stdout } = await runCommand([
       "connect",
-      "integration:google",
+      "google",
       "--json",
     ]);
     expect(exitCode).toBe(1);

--- a/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
@@ -100,13 +100,9 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
 mock.module("../../../../oauth/provider-behaviors.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   getProviderBehavior: () => undefined,
 }));
@@ -167,13 +163,9 @@ mock.module("../../../lib/daemon-credential-client.js", () => ({
 mock.module("../shared.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   isManagedMode: (key: string) => mockIsManagedMode(key),
   requirePlatformClient: async (_cmd: Command) => {
@@ -222,10 +214,6 @@ mock.module("../shared.js", () => ({
     if (!result.ok) return null;
     return result.body as Array<Record<string, unknown>>;
   },
-  toBareProvider: (provider: string): string =>
-    provider.startsWith("integration:")
-      ? provider.slice("integration:".length)
-      : provider,
 }));
 
 // ---------------------------------------------------------------------------
@@ -323,7 +311,7 @@ describe("assistant oauth disconnect", () => {
 
   test("both --account and --connection-id returns error", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       managedServiceConfigKey: null,
     });
 
@@ -351,7 +339,7 @@ describe("assistant oauth disconnect", () => {
   describe("managed mode", () => {
     beforeEach(() => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockIsManagedMode = () => true;
@@ -384,7 +372,7 @@ describe("assistant oauth disconnect", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.connectionId).toBe("conn-1");
       expect(parsed.account).toBe("user@gmail.com");
     });
@@ -512,7 +500,7 @@ describe("assistant oauth disconnect", () => {
   describe("BYO mode", () => {
     beforeEach(() => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: null,
       });
       mockIsManagedMode = () => false;
@@ -522,7 +510,7 @@ describe("assistant oauth disconnect", () => {
       mockListActiveConnectionsByProvider = () => [
         {
           id: "conn-1",
-          providerKey: "integration:google",
+          providerKey: "google",
           accountInfo: "user@gmail.com",
           status: "active",
         },
@@ -536,60 +524,14 @@ describe("assistant oauth disconnect", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.connectionId).toBe("conn-1");
       expect(parsed.account).toBe("user@gmail.com");
 
       // Verify disconnectOAuthProvider was called
       expect(mockDisconnectOAuthProviderCalls).toHaveLength(1);
-      expect(mockDisconnectOAuthProviderCalls[0].providerKey).toBe(
-        "integration:google",
-      );
+      expect(mockDisconnectOAuthProviderCalls[0].providerKey).toBe("google");
       expect(mockDisconnectOAuthProviderCalls[0].connectionId).toBe("conn-1");
-    });
-
-    test("single connection also cleans up legacy credential keys", async () => {
-      mockListActiveConnectionsByProvider = () => [
-        {
-          id: "conn-1",
-          providerKey: "integration:google",
-          accountInfo: "user@gmail.com",
-          status: "active",
-        },
-      ];
-
-      await runCommand(["disconnect", "google", "--json"]);
-
-      // Should have attempted to delete legacy keys
-      const expectedFields = [
-        "access_token",
-        "refresh_token",
-        "client_id",
-        "client_secret",
-      ];
-      expect(mockDeleteSecureKeyViaDaemonCalls.length).toBe(
-        expectedFields.length,
-      );
-      for (const field of expectedFields) {
-        expect(
-          mockDeleteSecureKeyViaDaemonCalls.some(
-            (c) =>
-              c.type === "credential" &&
-              c.name === `integration:google:${field}`,
-          ),
-        ).toBe(true);
-      }
-
-      expect(mockDeleteCredentialMetadataCalls.length).toBe(
-        expectedFields.length,
-      );
-      for (const field of expectedFields) {
-        expect(
-          mockDeleteCredentialMetadataCalls.some(
-            (c) => c.service === "integration:google" && c.field === field,
-          ),
-        ).toBe(true);
-      }
     });
 
     test("--account matches accountInfo", async () => {
@@ -597,7 +539,7 @@ describe("assistant oauth disconnect", () => {
         if (opts?.account === "user@gmail.com") {
           return {
             id: "conn-1",
-            providerKey: "integration:google",
+            providerKey: "google",
             accountInfo: "user@gmail.com",
             status: "active",
           };
@@ -641,7 +583,7 @@ describe("assistant oauth disconnect", () => {
         if (id === "conn-123") {
           return {
             id: "conn-123",
-            providerKey: "integration:google",
+            providerKey: "google",
             accountInfo: "user@gmail.com",
             status: "active",
           };
@@ -667,7 +609,7 @@ describe("assistant oauth disconnect", () => {
         if (id === "conn-slack") {
           return {
             id: "conn-slack",
-            providerKey: "integration:slack",
+            providerKey: "slack",
             accountInfo: null,
             status: "active",
           };
@@ -693,13 +635,13 @@ describe("assistant oauth disconnect", () => {
       mockListActiveConnectionsByProvider = () => [
         {
           id: "conn-1",
-          providerKey: "integration:google",
+          providerKey: "google",
           accountInfo: "user1@gmail.com",
           status: "active",
         },
         {
           id: "conn-2",
-          providerKey: "integration:google",
+          providerKey: "google",
           accountInfo: "user2@gmail.com",
           status: "active",
         },
@@ -740,7 +682,7 @@ describe("assistant oauth disconnect", () => {
       mockListActiveConnectionsByProvider = () => [
         {
           id: "conn-1",
-          providerKey: "integration:google",
+          providerKey: "google",
           accountInfo: null,
           status: "active",
         },

--- a/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
@@ -92,13 +92,9 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
 mock.module("../../../../oauth/provider-behaviors.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   getProviderBehavior: () => undefined,
 }));
@@ -133,13 +129,9 @@ mock.module("../../../lib/daemon-credential-client.js", () => ({
 mock.module("../shared.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   isManagedMode: () => false,
   getManagedServiceConfigKey: (key: string) =>
@@ -193,10 +185,6 @@ mock.module("../shared.js", () => ({
     if (!result.ok) return null;
     return result.body as Array<Record<string, unknown>>;
   },
-  toBareProvider: (provider: string): string =>
-    provider.startsWith("integration:")
-      ? provider.slice("integration:".length)
-      : provider,
 }));
 
 // ---------------------------------------------------------------------------
@@ -295,7 +283,7 @@ describe("assistant oauth mode", () => {
       expect(parsed.error).toContain("providers list");
     });
 
-    test("provider alias resolution: gmail resolves to integration:google", async () => {
+    test("provider alias resolution: gmail resolves to google", async () => {
       let capturedProviderKey: string | undefined;
 
       mockGetProvider = (key: string) => {
@@ -311,12 +299,12 @@ describe("assistant oauth mode", () => {
       };
 
       await runCommand(["mode", "gmail", "--json"]);
-      expect(capturedProviderKey).toBe("integration:google");
+      expect(capturedProviderKey).toBe("google");
     });
 
     test("provider without managedServiceConfigKey returns your-own with managedModeSupported: false", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:slack",
+        providerKey: "slack",
         managedServiceConfigKey: null,
       });
       mockGetManagedServiceConfigKey = () => null;
@@ -329,14 +317,14 @@ describe("assistant oauth mode", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:slack");
+      expect(parsed.provider).toBe("slack");
       expect(parsed.mode).toBe("your-own");
       expect(parsed.managedModeSupported).toBe(false);
     });
 
     test("provider in managed mode returns mode: managed with managedModeSupported: true", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -352,14 +340,14 @@ describe("assistant oauth mode", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.mode).toBe("managed");
       expect(parsed.managedModeSupported).toBe(true);
     });
 
     test("provider in your-own mode returns mode: your-own with managedModeSupported: true", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -375,7 +363,7 @@ describe("assistant oauth mode", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.mode).toBe("your-own");
       expect(parsed.managedModeSupported).toBe(true);
     });
@@ -388,7 +376,7 @@ describe("assistant oauth mode", () => {
   describe("set mode", () => {
     test("invalid mode value returns error listing valid values", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -410,7 +398,7 @@ describe("assistant oauth mode", () => {
 
     test("provider without managedServiceConfigKey returns error about managed mode not available when --set managed", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:slack",
+        providerKey: "slack",
         managedServiceConfigKey: null,
       });
       mockGetManagedServiceConfigKey = () => null;
@@ -426,12 +414,12 @@ describe("assistant oauth mode", () => {
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(false);
       expect(parsed.error).toContain("Managed mode is not available");
-      expect(parsed.error).toContain("integration:slack");
+      expect(parsed.error).toContain("slack");
     });
 
     test("provider without managedServiceConfigKey treats --set your-own as successful no-op", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:slack",
+        providerKey: "slack",
         managedServiceConfigKey: null,
       });
       mockGetManagedServiceConfigKey = () => null;
@@ -446,7 +434,7 @@ describe("assistant oauth mode", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:slack");
+      expect(parsed.provider).toBe("slack");
       expect(parsed.mode).toBe("your-own");
       expect(parsed.changed).toBe(false);
       expect(parsed.managedModeSupported).toBe(false);
@@ -454,7 +442,7 @@ describe("assistant oauth mode", () => {
 
     test("set to same mode returns changed: false", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -472,7 +460,7 @@ describe("assistant oauth mode", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.mode).toBe("managed");
       expect(parsed.changed).toBe(false);
       expect(parsed.managedModeSupported).toBe(true);
@@ -480,7 +468,7 @@ describe("assistant oauth mode", () => {
 
     test("switch managed -> your-own with active managed connections and no BYO connections includes hint", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -512,7 +500,7 @@ describe("assistant oauth mode", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.mode).toBe("your-own");
       expect(parsed.changed).toBe(true);
       expect(parsed.managedModeSupported).toBe(true);
@@ -523,7 +511,7 @@ describe("assistant oauth mode", () => {
 
     test("switch your-own -> managed with active BYO connections and no managed connections includes hint", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -536,7 +524,7 @@ describe("assistant oauth mode", () => {
       mockListActiveConnectionsByProvider = () => [
         {
           id: "conn-local-1",
-          providerKey: "integration:google",
+          providerKey: "google",
           status: "active",
         },
       ];
@@ -555,7 +543,7 @@ describe("assistant oauth mode", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.mode).toBe("managed");
       expect(parsed.changed).toBe(true);
       expect(parsed.managedModeSupported).toBe(true);
@@ -566,7 +554,7 @@ describe("assistant oauth mode", () => {
 
     test("switch mode with connections on both sides has no hint", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -589,7 +577,7 @@ describe("assistant oauth mode", () => {
       mockListActiveConnectionsByProvider = () => [
         {
           id: "conn-local-1",
-          providerKey: "integration:google",
+          providerKey: "google",
           status: "active",
         },
       ];
@@ -611,7 +599,7 @@ describe("assistant oauth mode", () => {
 
     test("switch mode with no connections on either side has no hint", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -644,7 +632,7 @@ describe("assistant oauth mode", () => {
 
     test("saveRawConfig is called with the correct nested path", async () => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";

--- a/assistant/src/cli/commands/oauth/__tests__/ping.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/ping.test.ts
@@ -54,13 +54,9 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
 mock.module("../../../../oauth/provider-behaviors.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   getProviderBehavior: () => undefined,
 }));
@@ -103,21 +99,13 @@ mock.module("../../../../util/logger.js", () => ({
 mock.module("../shared.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   isManagedMode: () => false,
   requirePlatformClient: async () => null,
   fetchActiveConnections: async () => [],
-  toBareProvider: (provider: string): string =>
-    provider.startsWith("integration:")
-      ? provider.slice("integration:".length)
-      : provider,
 }));
 
 // ---------------------------------------------------------------------------
@@ -214,7 +202,7 @@ describe("assistant oauth ping", () => {
 
   test("no ping URL configured returns error", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: null,
     });
 
@@ -230,9 +218,9 @@ describe("assistant oauth ping", () => {
   // Provider alias resolution
   // -------------------------------------------------------------------------
 
-  test("resolves provider alias (gmail -> integration:google)", async () => {
+  test("resolves provider alias (gmail -> google)", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
     });
 
@@ -248,13 +236,11 @@ describe("assistant oauth ping", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(true);
-    expect(parsed.provider).toBe("integration:google");
+    expect(parsed.provider).toBe("google");
 
     // Verify resolveOAuthConnection was called with resolved key
     expect(mockResolveOAuthConnectionCalls).toHaveLength(1);
-    expect(mockResolveOAuthConnectionCalls[0].providerKey).toBe(
-      "integration:google",
-    );
+    expect(mockResolveOAuthConnectionCalls[0].providerKey).toBe("google");
   });
 
   // =========================================================================
@@ -264,7 +250,7 @@ describe("assistant oauth ping", () => {
   describe("BYO mode", () => {
     beforeEach(() => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
         managedServiceConfigKey: null,
       });
@@ -287,7 +273,7 @@ describe("assistant oauth ping", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.status).toBe(200);
     });
 
@@ -308,7 +294,7 @@ describe("assistant oauth ping", () => {
       expect(exitCode).toBe(1);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(false);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.status).toBe(500);
       expect(parsed.error).toContain("Ping failed with HTTP 500");
     });
@@ -366,7 +352,7 @@ describe("assistant oauth ping", () => {
   describe("managed mode", () => {
     beforeEach(() => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
         managedServiceConfigKey: "google-oauth",
       });
@@ -389,7 +375,7 @@ describe("assistant oauth ping", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.status).toBe(200);
     });
 
@@ -410,7 +396,7 @@ describe("assistant oauth ping", () => {
       expect(exitCode).toBe(1);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(false);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.status).toBe(502);
       expect(parsed.error).toContain("Ping failed with HTTP 502");
     });
@@ -422,12 +408,12 @@ describe("assistant oauth ping", () => {
 
   test("connection resolution failure (no active connection) with recovery hint", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
     });
 
     mockResolveOAuthConnectionResult = new Error(
-      'No active OAuth connection found for "integration:google". Connect the service first with oauth2_connect.',
+      'No active OAuth connection found for "google". Connect the service first with oauth2_connect.',
     );
 
     const { exitCode, stdout } = await runCommand(["ping", "google", "--json"]);
@@ -445,7 +431,7 @@ describe("assistant oauth ping", () => {
 
   test("--account option passed through to connection resolution", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
     });
 
@@ -478,7 +464,7 @@ describe("assistant oauth ping", () => {
 
   test("--client-id option passed through to connection resolution", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
     });
 
@@ -511,7 +497,7 @@ describe("assistant oauth ping", () => {
 
   test("JSON output mode returns structured response", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
     });
 
@@ -529,7 +515,7 @@ describe("assistant oauth ping", () => {
 
     // Verify JSON structure
     expect(parsed).toHaveProperty("ok", true);
-    expect(parsed).toHaveProperty("provider", "integration:google");
+    expect(parsed).toHaveProperty("provider", "google");
     expect(parsed).toHaveProperty("status", 200);
   });
 
@@ -539,7 +525,7 @@ describe("assistant oauth ping", () => {
 
   test("human output mode logs to stderr on success", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
     });
 
@@ -558,7 +544,7 @@ describe("assistant oauth ping", () => {
     // In human mode, output is still written via writeOutput
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(true);
-    expect(parsed.provider).toBe("integration:google");
+    expect(parsed.provider).toBe("google");
   });
 
   // =========================================================================
@@ -567,7 +553,7 @@ describe("assistant oauth ping", () => {
 
   test("uses configured pingMethod for POST providers", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:dropbox",
+      providerKey: "dropbox",
       pingUrl: "https://api.dropboxapi.com/2/users/get_current_account",
       pingMethod: "POST",
       pingHeaders: null,
@@ -589,7 +575,7 @@ describe("assistant oauth ping", () => {
 
   test("uses configured pingHeaders", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:notion",
+      providerKey: "notion",
       pingUrl: "https://api.notion.com/v1/users/me",
       pingMethod: null,
       pingHeaders: '{"Notion-Version":"2022-06-28"}',
@@ -613,7 +599,7 @@ describe("assistant oauth ping", () => {
 
   test("uses configured pingBody for GraphQL providers", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:linear",
+      providerKey: "linear",
       pingUrl: "https://api.linear.app/graphql",
       pingMethod: "POST",
       pingHeaders: '{"Content-Type":"application/json"}',
@@ -641,7 +627,7 @@ describe("assistant oauth ping", () => {
 
   test("defaults to GET with no extra headers/body when ping config is null", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
       pingMethod: null,
       pingHeaders: null,
@@ -669,7 +655,7 @@ describe("assistant oauth ping", () => {
 
   test("network failure returns error with recovery hint", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:google",
+      providerKey: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
     });
 

--- a/assistant/src/cli/commands/oauth/__tests__/status.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/status.test.ts
@@ -59,13 +59,9 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
 mock.module("../../../../oauth/provider-behaviors.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   getProviderBehavior: () => undefined,
 }));
@@ -112,13 +108,9 @@ mock.module("../../../lib/daemon-credential-client.js", () => ({
 mock.module("../shared.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   isManagedMode: (key: string) => mockIsManagedMode(key),
   requirePlatformClient: async (_cmd: Command) => {
@@ -167,10 +159,6 @@ mock.module("../shared.js", () => ({
     if (!result.ok) return null;
     return result.body as Array<Record<string, unknown>>;
   },
-  toBareProvider: (provider: string): string =>
-    provider.startsWith("integration:")
-      ? provider.slice("integration:".length)
-      : provider,
 }));
 
 // ---------------------------------------------------------------------------
@@ -263,7 +251,7 @@ describe("assistant oauth status", () => {
   describe("managed mode", () => {
     beforeEach(() => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockIsManagedMode = () => true;
@@ -300,7 +288,7 @@ describe("assistant oauth status", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.mode).toBe("managed");
       expect(parsed.connections).toHaveLength(2);
 
@@ -327,7 +315,7 @@ describe("assistant oauth status", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.mode).toBe("managed");
       expect(parsed.connections).toEqual([]);
     });
@@ -388,7 +376,7 @@ describe("assistant oauth status", () => {
   describe("BYO mode", () => {
     beforeEach(() => {
       mockGetProvider = () => ({
-        providerKey: "integration:google",
+        providerKey: "google",
         managedServiceConfigKey: null,
       });
       mockIsManagedMode = () => false;
@@ -399,7 +387,7 @@ describe("assistant oauth status", () => {
       mockListConnections = () => [
         {
           id: "conn-local-1",
-          providerKey: "integration:google",
+          providerKey: "google",
           accountInfo: "localuser@gmail.com",
           grantedScopes: '["email","profile"]',
           expiresAt,
@@ -416,7 +404,7 @@ describe("assistant oauth status", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.mode).toBe("byo");
       expect(parsed.connections).toHaveLength(1);
 
@@ -433,7 +421,7 @@ describe("assistant oauth status", () => {
       mockListConnections = () => [
         {
           id: "conn-local-2",
-          providerKey: "integration:google",
+          providerKey: "google",
           accountInfo: null,
           grantedScopes: "[]",
           expiresAt: null,
@@ -460,7 +448,7 @@ describe("assistant oauth status", () => {
       mockListConnections = () => [
         {
           id: "conn-active",
-          providerKey: "integration:google",
+          providerKey: "google",
           accountInfo: "user@gmail.com",
           grantedScopes: "[]",
           expiresAt: null,
@@ -469,7 +457,7 @@ describe("assistant oauth status", () => {
         },
         {
           id: "conn-revoked",
-          providerKey: "integration:google",
+          providerKey: "google",
           accountInfo: "old@gmail.com",
           grantedScopes: "[]",
           expiresAt: null,
@@ -500,7 +488,7 @@ describe("assistant oauth status", () => {
       expect(exitCode).toBe(0);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(true);
-      expect(parsed.provider).toBe("integration:google");
+      expect(parsed.provider).toBe("google");
       expect(parsed.mode).toBe("byo");
       expect(parsed.connections).toEqual([]);
     });
@@ -517,7 +505,7 @@ describe("assistant oauth status", () => {
       mockListConnections = () => [
         {
           id: "conn-structure",
-          providerKey: "integration:google",
+          providerKey: "google",
           accountInfo: "check@gmail.com",
           grantedScopes: '["scope1"]',
           expiresAt: Date.now() + 60_000,
@@ -555,7 +543,7 @@ describe("assistant oauth status", () => {
       mockListConnections = () => [
         {
           id: "conn-bad-scopes",
-          providerKey: "integration:google",
+          providerKey: "google",
           accountInfo: null,
           grantedScopes: "not-valid-json",
           expiresAt: null,

--- a/assistant/src/cli/commands/oauth/__tests__/token.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/token.test.ts
@@ -57,13 +57,9 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
 mock.module("../../../../oauth/provider-behaviors.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   getProviderBehavior: () => undefined,
 }));
@@ -100,19 +96,11 @@ mock.module("../../../lib/daemon-credential-client.js", () => ({
 mock.module("../shared.js", () => ({
   resolveService: (service: string) => {
     const aliases: Record<string, string> = {
-      gmail: "integration:google",
-      google: "integration:google",
-      slack: "integration:slack",
+      gmail: "google",
     };
-    if (aliases[service]) return aliases[service];
-    if (!service.includes(":")) return `integration:${service}`;
-    return service;
+    return aliases[service] ?? service;
   },
   isManagedMode: (key: string) => mockIsManagedMode(key),
-  toBareProvider: (provider: string): string =>
-    provider.startsWith("integration:")
-      ? provider.slice("integration:".length)
-      : provider,
 }));
 
 // ---------------------------------------------------------------------------
@@ -219,7 +207,7 @@ describe("assistant oauth token", () => {
     test("no active connection returns error", async () => {
       mockWithValidToken = async () => {
         throw new Error(
-          'No access token found for "integration:google". Authorization required.',
+          'No access token found for "google". Authorization required.',
         );
       };
 
@@ -239,7 +227,7 @@ describe("assistant oauth token", () => {
   // Provider alias resolution
   // =========================================================================
 
-  test("resolves provider alias (gmail -> integration:google)", async () => {
+  test("resolves provider alias (gmail -> google)", async () => {
     let calledWithService = "";
     mockWithValidToken = async (service, callback) => {
       calledWithService = service;
@@ -248,7 +236,7 @@ describe("assistant oauth token", () => {
 
     const { exitCode, stdout } = await runCommand(["token", "gmail", "--json"]);
     expect(exitCode).toBe(0);
-    expect(calledWithService).toBe("integration:google");
+    expect(calledWithService).toBe("google");
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(true);
     expect(parsed.token).toBe("alias-token");
@@ -316,7 +304,7 @@ describe("assistant oauth token", () => {
         if (options?.account === "user@gmail.com") {
           return {
             id: "conn-abc-123",
-            providerKey: "integration:google",
+            providerKey: "google",
             accountInfo: "user@gmail.com",
             status: "active",
           };
@@ -373,7 +361,7 @@ describe("assistant oauth token", () => {
         if (options?.clientId === "my-client-id") {
           return {
             id: "conn-client-456",
-            providerKey: "integration:google",
+            providerKey: "google",
             accountInfo: null,
             status: "active",
           };

--- a/assistant/src/oauth/byo-connection.test.ts
+++ b/assistant/src/oauth/byo-connection.test.ts
@@ -195,7 +195,7 @@ async function setupCredential(
     tokenUrl: "https://oauth2.googleapis.com/token",
     // Only well-known providers (gmail) have a baseUrl; custom services don't
     baseUrl:
-      service === "integration:google"
+      service === "google"
         ? "https://gmail.googleapis.com/gmail/v1/users/me"
         : undefined,
   });
@@ -230,7 +230,7 @@ async function setupCredential(
   upsertCredentialMetadata(service, "access_token", {});
 }
 
-function createConnection(service = "integration:google"): BYOOAuthConnection {
+function createConnection(service = "google"): BYOOAuthConnection {
   return new BYOOAuthConnection({
     id: `conn-${service}`,
     providerKey: service,
@@ -246,7 +246,7 @@ function createConnection(service = "integration:google"): BYOOAuthConnection {
 describe("BYOOAuthConnection", () => {
   describe("request()", () => {
     test("makes authenticated request with Bearer token", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       const result = await conn.request({
@@ -270,7 +270,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("appends query parameters", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       await conn.request({
@@ -286,7 +286,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("uses per-request baseUrl override", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       await conn.request({
@@ -300,7 +300,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("sends JSON body for POST requests", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       await conn.request({
@@ -320,7 +320,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("retries once on 401 response", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       // First call returns 401, second returns 200
@@ -348,7 +348,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("handles empty response body", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       globalThis.fetch = mock(() =>
@@ -365,7 +365,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("handles non-JSON response body", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       globalThis.fetch = mock(() =>
@@ -382,7 +382,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("returns response headers", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       globalThis.fetch = mock(() =>
@@ -406,7 +406,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("includes custom request headers", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       await conn.request({
@@ -425,7 +425,7 @@ describe("BYOOAuthConnection", () => {
   describe("proactive token refresh", () => {
     test("refreshes token when near expiry (within 5-minute buffer)", async () => {
       // Set token to expire in 2 minutes (within 5-min buffer)
-      await setupCredential("integration:google", {
+      await setupCredential("google", {
         expiresAt: Date.now() + 2 * 60 * 1000,
       });
       const conn = createConnection();
@@ -449,7 +449,7 @@ describe("BYOOAuthConnection", () => {
 
   describe("withToken()", () => {
     test("provides valid token to callback", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       const result = await conn.withToken(async (token) => {
@@ -460,7 +460,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("retries callback on 401 error", async () => {
-      await setupCredential("integration:google");
+      await setupCredential("google");
       const conn = createConnection();
 
       let callCount = 0;
@@ -493,25 +493,23 @@ describe("BYOOAuthConnection", () => {
 
 describe("resolveOAuthConnection", () => {
   test("returns a BYOOAuthConnection for valid credential", async () => {
-    await setupCredential("integration:google");
-    const conn = await resolveOAuthConnection("integration:google");
+    await setupCredential("google");
+    const conn = await resolveOAuthConnection("google");
 
     expect(conn).toBeInstanceOf(BYOOAuthConnection);
-    expect(conn.providerKey).toBe("integration:google");
+    expect(conn.providerKey).toBe("google");
   });
 
   test("throws when no credential metadata exists", async () => {
-    await expect(resolveOAuthConnection("integration:unknown")).rejects.toThrow(
-      /No active OAuth connection found for "integration:unknown"/,
+    await expect(resolveOAuthConnection("unknown")).rejects.toThrow(
+      /No active OAuth connection found for "unknown"/,
     );
   });
 
   test("throws when no base URL configured", async () => {
-    await setupCredential("integration:custom-service");
-    await expect(
-      resolveOAuthConnection("integration:custom-service"),
-    ).rejects.toThrow(
-      /No base URL configured for "integration:custom-service"/,
+    await setupCredential("custom-service");
+    await expect(resolveOAuthConnection("custom-service")).rejects.toThrow(
+      /No base URL configured for "custom-service"/,
     );
   });
 });

--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -79,13 +79,13 @@ function makeMockClient() {
 
 function setupDefaults(): void {
   mockProvider = {
-    providerKey: "integration:google",
+    providerKey: "google",
     baseUrl: "https://gmail.googleapis.com/gmail/v1/users/me",
     managedServiceConfigKey: null,
   };
   mockConnection = {
     id: "conn-1",
-    providerKey: "integration:google",
+    providerKey: "google",
     oauthAppId: "app-1",
     accountInfo: "user@example.com",
     grantedScopes: JSON.stringify(["scope-a", "scope-b"]),
@@ -122,26 +122,26 @@ describe("resolveOAuthConnection", () => {
   });
 
   test("returns BYOOAuthConnection when provider has no managedServiceConfigKey", async () => {
-    const result = await resolveOAuthConnection("integration:google");
+    const result = await resolveOAuthConnection("google");
     expect(result).toBeInstanceOf(BYOOAuthConnection);
     expect(result.id).toBe("conn-1");
-    expect(result.providerKey).toBe("integration:google");
+    expect(result.providerKey).toBe("google");
   });
 
   test("returns PlatformOAuthConnection when managed mode is active", async () => {
     mockProvider!.managedServiceConfigKey = "google-oauth";
 
-    const result = await resolveOAuthConnection("integration:google");
+    const result = await resolveOAuthConnection("google");
     expect(result).toBeInstanceOf(PlatformOAuthConnection);
-    expect(result.id).toBe("integration:google");
-    expect(result.providerKey).toBe("integration:google");
+    expect(result.id).toBe("google");
+    expect(result.providerKey).toBe("google");
     expect(result.accountInfo).toBeNull();
   });
 
   test("passes account through to PlatformOAuthConnection", async () => {
     mockProvider!.managedServiceConfigKey = "google-oauth";
 
-    const result = await resolveOAuthConnection("integration:google", {
+    const result = await resolveOAuthConnection("google", {
       account: "user@example.com",
     });
     expect(result).toBeInstanceOf(PlatformOAuthConnection);
@@ -154,7 +154,7 @@ describe("resolveOAuthConnection", () => {
       mode: "your-own",
     };
 
-    const result = await resolveOAuthConnection("integration:google");
+    const result = await resolveOAuthConnection("google");
     expect(result).toBeInstanceOf(BYOOAuthConnection);
     expect(result.id).toBe("conn-1");
   });
@@ -164,21 +164,21 @@ describe("resolveOAuthConnection", () => {
     mockConnection = undefined;
     mockAccessToken = undefined;
 
-    const result = await resolveOAuthConnection("integration:google");
+    const result = await resolveOAuthConnection("google");
     expect(result).toBeInstanceOf(PlatformOAuthConnection);
   });
 
   test("managed path ignores clientId option", async () => {
     mockProvider!.managedServiceConfigKey = "google-oauth";
 
-    const result = await resolveOAuthConnection("integration:google", {
+    const result = await resolveOAuthConnection("google", {
       clientId: "some-client-id",
     });
     expect(result).toBeInstanceOf(PlatformOAuthConnection);
   });
 
   test("BYO path narrows by clientId when provided", async () => {
-    const result = await resolveOAuthConnection("integration:google", {
+    const result = await resolveOAuthConnection("google", {
       clientId: "client-1",
     });
     expect(result).toBeInstanceOf(BYOOAuthConnection);
@@ -187,7 +187,7 @@ describe("resolveOAuthConnection", () => {
 
   test("BYO path returns no credential when clientId does not match", async () => {
     await expect(
-      resolveOAuthConnection("integration:google", {
+      resolveOAuthConnection("google", {
         clientId: "wrong-client",
       }),
     ).rejects.toThrow(/No active OAuth connection found/);

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -29,7 +29,7 @@ export interface ResolveOAuthConnectionOptions {
  * BYO providers resolve from the local SQLite oauth-store and require an
  * active connection row and a stored access token.
  *
- * @param providerKey - Provider identifier (e.g. "integration:google").
+ * @param providerKey - Provider identifier (e.g. "google").
  *   Maps to the `provider_key` primary key in the `oauth_providers` table.
  * @param options.clientId - Optional OAuth app client ID. When multiple BYO
  *   apps exist for the same provider, narrows the connection lookup to the

--- a/assistant/src/oauth/platform-connection.test.ts
+++ b/assistant/src/oauth/platform-connection.test.ts
@@ -35,7 +35,7 @@ function makeMockClient(
 
 const DEFAULT_OPTIONS = {
   id: "conn-1",
-  providerKey: "integration:google",
+  providerKey: "google",
   externalId: "ext-123",
   accountInfo: "user@example.com",
   client: makeMockClient(),
@@ -192,7 +192,7 @@ describe("PlatformOAuthConnection", () => {
     const conn = new PlatformOAuthConnection({
       ...DEFAULT_OPTIONS,
       client,
-      providerKey: "integration:slack",
+      providerKey: "slack",
       connectionId: "slack-conn-456",
     });
     await conn.request({ method: "GET", path: "/test" });

--- a/assistant/src/oauth/provider-behaviors.ts
+++ b/assistant/src/oauth/provider-behaviors.ts
@@ -15,7 +15,7 @@ import type { OAuthProviderBehavior } from "./connect-types.js";
 // Provider behaviors
 // ---------------------------------------------------------------------------
 
-const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
+export const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
   google: {
     service: "google",
     // Google APIs for Gmail/Calendar/Contacts span multiple hosts; register

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -14,8 +14,8 @@ import {
 } from "../../oauth/oauth-store.js";
 import {
   getProviderBehavior,
+  PROVIDER_BEHAVIORS,
   resolveService,
-  SERVICE_ALIASES,
 } from "../../oauth/provider-behaviors.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
@@ -829,7 +829,7 @@ class CredentialStoreTool implements Tool {
             isError: true,
           };
 
-        // Resolve aliases (e.g. "gmail" → "integration:google")
+        // Resolve aliases (e.g. "gmail" → "google")
         const service = resolveService(rawService);
 
         // Code-side behavioral fields (identityVerifier, setup, etc.)
@@ -975,7 +975,7 @@ class CredentialStoreTool implements Tool {
         if (!descProviderRow) {
           return {
             content: `No well-known OAuth config found for "${rawService}". Available services: ${Object.keys(
-              SERVICE_ALIASES,
+              PROVIDER_BEHAVIORS,
             ).join(", ")}`,
             isError: false,
           };


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for simplify-oauth-provider-keys.md.

**Gap 1:** SERVICE_ALIASES error message now only lists 'gmail' since aliases were reduced. Replaced with PROVIDER_BEHAVIORS keys to list all known providers (google, slack, notion, twitter, github, linear, spotify, todoist, discord, dropbox, asana, airtable, hubspot, figma).

**Gap 2:** Stale JSDoc in connection-resolver.ts still references integration:google — updated to bare 'google'.

**Gap 3:** Stale comment in vault.ts still references integration:google — updated to bare 'google'.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
