### PR TITLE
fix: update skill credential paths to use full credential/provider/field format

### DIFF
--- a/skills/airtable-oauth-setup/SKILL.md
+++ b/skills/airtable-oauth-setup/SKILL.md
@@ -120,7 +120,7 @@ bash:
     assistant oauth apps upsert --provider airtable --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "airtable:oauth_secret"
+    ) --client-secret-credential-path "credential/airtable/oauth_secret"
 ```
 
 **Milestone (6 of 8):** "Credentials saved - just the authorization step left."

--- a/skills/airtable-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/airtable-oauth-setup/references/path-b-manual-setup.md
@@ -116,7 +116,7 @@ bash:
     assistant oauth apps upsert --provider airtable --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "airtable:oauth_secret"
+    ) --client-secret-credential-path "credential/airtable/oauth_secret"
 ```
 
 ```

--- a/skills/asana-oauth-setup/SKILL.md
+++ b/skills/asana-oauth-setup/SKILL.md
@@ -104,7 +104,7 @@ bash:
     assistant oauth apps upsert --provider asana --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "asana:oauth_secret"
+    ) --client-secret-credential-path "credential/asana/oauth_secret"
 ```
 
 **Milestone (5 of 7):** "Credentials saved - just the authorization step left."

--- a/skills/asana-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/asana-oauth-setup/references/path-b-manual-setup.md
@@ -104,7 +104,7 @@ bash:
     assistant oauth apps upsert --provider asana --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "asana:oauth_secret"
+    ) --client-secret-credential-path "credential/asana/oauth_secret"
 ```
 
 ```

--- a/skills/discord-oauth-setup/SKILL.md
+++ b/skills/discord-oauth-setup/SKILL.md
@@ -125,7 +125,7 @@ bash:
     assistant oauth apps upsert --provider discord --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "discord:oauth_secret"
+    ) --client-secret-credential-path "credential/discord/oauth_secret"
 ```
 
 **Milestone (7 of 9):** "Credentials saved - just the authorization step left."

--- a/skills/discord-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/discord-oauth-setup/references/path-b-manual-setup.md
@@ -114,7 +114,7 @@ bash:
     assistant oauth apps upsert --provider discord --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "discord:oauth_secret"
+    ) --client-secret-credential-path "credential/discord/oauth_secret"
 ```
 
 ```

--- a/skills/dropbox-oauth-setup/SKILL.md
+++ b/skills/dropbox-oauth-setup/SKILL.md
@@ -144,7 +144,7 @@ bash:
     assistant oauth apps upsert --provider dropbox --client-id $(cat <<'EOF'
     <app-key>
     EOF
-    ) --client-secret-credential-path "dropbox:oauth_secret"
+    ) --client-secret-credential-path "credential/dropbox/oauth_secret"
 ```
 
 **Milestone (8 of 11):** "Credentials saved - just the authorization step left."

--- a/skills/dropbox-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/dropbox-oauth-setup/references/path-b-manual-setup.md
@@ -118,7 +118,7 @@ bash:
     assistant oauth apps upsert --provider dropbox --client-id $(cat <<'EOF'
     <app-key>
     EOF
-    ) --client-secret-credential-path "dropbox:oauth_secret"
+    ) --client-secret-credential-path "credential/dropbox/oauth_secret"
 ```
 
 ```

--- a/skills/figma-oauth-setup/SKILL.md
+++ b/skills/figma-oauth-setup/SKILL.md
@@ -125,7 +125,7 @@ bash:
     assistant oauth apps upsert --provider figma --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "figma:oauth_secret"
+    ) --client-secret-credential-path "credential/figma/oauth_secret"
 ```
 
 **Milestone (6 of 7):** "Credentials saved - just the authorization step left."

--- a/skills/figma-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/figma-oauth-setup/references/path-b-manual-setup.md
@@ -107,7 +107,7 @@ bash:
     assistant oauth apps upsert --provider figma --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "figma:oauth_secret"
+    ) --client-secret-credential-path "credential/figma/oauth_secret"
 ```
 
 ```

--- a/skills/github-oauth-setup/SKILL.md
+++ b/skills/github-oauth-setup/SKILL.md
@@ -119,7 +119,7 @@ bash:
     assistant oauth apps upsert --provider github --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "github:<secret-field>"
+    ) --client-secret-credential-path "credential/github/<secret-field>"
 ```
 
 **Milestone (5 of 8):** "Credentials saved - just the authorization step left."

--- a/skills/github-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/github-oauth-setup/references/path-b-manual-setup.md
@@ -95,7 +95,7 @@ bash:
     assistant oauth apps upsert --provider github --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "github:<secret-field>"
+    ) --client-secret-credential-path "credential/github/<secret-field>"
 ```
 
 ```

--- a/skills/hubspot-oauth-setup/SKILL.md
+++ b/skills/hubspot-oauth-setup/SKILL.md
@@ -138,7 +138,7 @@ bash:
     assistant oauth apps upsert --provider hubspot --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "hubspot:oauth_secret"
+    ) --client-secret-credential-path "credential/hubspot/oauth_secret"
 ```
 
 Then authorize:

--- a/skills/hubspot-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/hubspot-oauth-setup/references/path-b-manual-setup.md
@@ -118,7 +118,7 @@ bash:
     assistant oauth apps upsert --provider hubspot --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "hubspot:oauth_secret"
+    ) --client-secret-credential-path "credential/hubspot/oauth_secret"
 ```
 
 ```

--- a/skills/linear-oauth-setup/SKILL.md
+++ b/skills/linear-oauth-setup/SKILL.md
@@ -121,7 +121,7 @@ bash:
     assistant oauth apps upsert --provider linear --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "linear:oauth_secret"
+    ) --client-secret-credential-path "credential/linear/oauth_secret"
 ```
 
 **Milestone (6 of 8):** "Credentials saved - just the authorization step left."

--- a/skills/linear-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/linear-oauth-setup/references/path-b-manual-setup.md
@@ -89,7 +89,7 @@ bash:
     assistant oauth apps upsert --provider linear --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "linear:oauth_secret"
+    ) --client-secret-credential-path "credential/linear/oauth_secret"
 ```
 
 ```

--- a/skills/spotify-oauth-setup/SKILL.md
+++ b/skills/spotify-oauth-setup/SKILL.md
@@ -118,7 +118,7 @@ bash:
     assistant oauth apps upsert --provider spotify --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "spotify:oauth_secret"
+    ) --client-secret-credential-path "credential/spotify/oauth_secret"
 ```
 
 **Milestone (4 of 7):** "Credentials saved - just the authorization step left."

--- a/skills/spotify-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/spotify-oauth-setup/references/path-b-manual-setup.md
@@ -95,7 +95,7 @@ bash:
     assistant oauth apps upsert --provider spotify --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "spotify:oauth_secret"
+    ) --client-secret-credential-path "credential/spotify/oauth_secret"
 ```
 
 ```

--- a/skills/todoist-oauth-setup/SKILL.md
+++ b/skills/todoist-oauth-setup/SKILL.md
@@ -92,7 +92,7 @@ bash:
     assistant oauth apps upsert --provider todoist --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "todoist:app_secret"
+    ) --client-secret-credential-path "credential/todoist/app_secret"
 ```
 
 **Milestone (5 of 7):** "Credentials saved - just the authorization step left."

--- a/skills/todoist-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/todoist-oauth-setup/references/path-b-manual-setup.md
@@ -102,7 +102,7 @@ bash:
     assistant oauth apps upsert --provider todoist --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "todoist:app_secret"
+    ) --client-secret-credential-path "credential/todoist/app_secret"
 ```
 
 ```


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for simplify-oauth-provider-keys.md.

**Gap:** OAuth setup skills use short-format credential paths (e.g. airtable:oauth_secret) that no longer resolve after the removal of short-format resolution logic in apps.ts
**Fix:** Updated all 20 skill files to use the full credential/provider/field format (e.g. credential/airtable/oauth_secret)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
