### PR TITLE
feat: prefer deep link redirects for OAuth across CLI and settings

### DIFF
--- a/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
@@ -45,6 +45,8 @@ let mockPlatformFetchResults: Array<{
 let mockPlatformFetchCallIndex = 0;
 
 let mockIsManagedMode: (key: string) => boolean = () => false;
+/** Optional interceptor called with each platform fetch's parsed body. */
+let mockPlatformFetchInterceptor: ((path: string, body: unknown) => void) | null = null;
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -163,7 +165,16 @@ mock.module("../shared.js", () => ({
     return {
       platformAssistantId: (mockPlatformClientResult as Record<string, unknown>)
         .platformAssistantId,
-      fetch: async (_path: string, _init?: RequestInit): Promise<Response> => {
+      fetch: async (path: string, init?: RequestInit): Promise<Response> => {
+        // Allow tests to intercept and inspect the request body
+        if (mockPlatformFetchInterceptor && init?.body) {
+          try {
+            const parsed = JSON.parse(String(init.body));
+            mockPlatformFetchInterceptor(path, parsed);
+          } catch {
+            // non-JSON body, skip
+          }
+        }
         const idx = mockPlatformFetchCallIndex++;
         const result = mockPlatformFetchResults[idx] ?? {
           ok: false,
@@ -269,6 +280,7 @@ describe("assistant oauth connect", () => {
     mockPlatformFetchResults = [];
     mockPlatformFetchCallIndex = 0;
     mockIsManagedMode = () => false;
+    mockPlatformFetchInterceptor = null;
     process.exitCode = 0;
   });
 
@@ -368,7 +380,7 @@ describe("assistant oauth connect", () => {
   // Managed mode with --open-browser: opens browser and polls
   // -------------------------------------------------------------------------
 
-  test("managed mode with --open-browser: opens browser and polls for new connection", async () => {
+  test("managed mode with --open-browser: opens browser and waits for loopback callback", async () => {
     mockGetProvider = () => ({
       providerKey: "integration:google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
@@ -378,18 +390,34 @@ describe("assistant oauth connect", () => {
     mockIsManagedMode = () => true;
     mockPlatformClientResult = { platformAssistantId: "asst-123" };
 
-    // First call: /start/ endpoint returns connect_url
-    // Second call: fetchActiveConnections snapshot (before browser)
-    // Third call: fetchActiveConnections poll (new connection found)
+    let capturedRedirectUrl: string | undefined;
+
+    // When the platform start endpoint is called, capture the
+    // redirect_after_connect URL and simulate the platform redirecting
+    // back to our loopback server after a short delay.
+    mockPlatformFetchInterceptor = (_path, body) => {
+      const b = body as Record<string, unknown>;
+      if (b.redirect_after_connect) {
+        capturedRedirectUrl = b.redirect_after_connect as string;
+        setTimeout(async () => {
+          try {
+            await fetch(`${capturedRedirectUrl}?oauth_status=connected`);
+          } catch {
+            // Loopback may have closed
+          }
+        }, 50);
+      }
+    };
+
+    // Platform start endpoint returns connect_url.
+    // fetchActiveConnections returns the new connection after callback.
     mockPlatformFetchResults = [
       {
         ok: true,
         status: 200,
         body: { connect_url: "https://platform.example.com/oauth/connect" },
       },
-      // Snapshot — empty
-      { ok: true, status: 200, body: [] },
-      // Poll — new connection appeared
+      // fetchActiveConnections after successful callback
       {
         ok: true,
         status: 200,
@@ -415,6 +443,8 @@ describe("assistant oauth connect", () => {
     expect(parsed.connectionId).toBe("conn-new");
     expect(parsed.accountLabel).toBe("user@gmail.com");
     expect(parsed.scopesGranted).toEqual(["email"]);
+    expect(capturedRedirectUrl).toBeDefined();
+    expect(capturedRedirectUrl).toContain("localhost");
     expect(mockOpenInBrowserCalls.length).toBeGreaterThanOrEqual(1);
     expect(mockOpenInBrowserCalls[0]).toBe(
       "https://platform.example.com/oauth/connect",

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -1,3 +1,5 @@
+import { createServer } from "node:http";
+
 import type { Command } from "commander";
 
 import { orchestrateOAuthConnect } from "../../../oauth/connect-orchestrator.js";
@@ -51,9 +53,8 @@ Options:
                          (use full scope URLs where required). In BYO mode,
                          scopes are appended to the provider's defaults.
   --open-browser         Open the authorization URL in your browser and wait
-                         for completion. In managed mode, polls for a new
-                         platform connection. In BYO mode, starts a local
-                         callback server and blocks until the OAuth redirect.
+                         for completion. Uses a local callback server to
+                         receive the redirect when authorization finishes.
   --client-id <id>       BYO-only: select a specific OAuth app when multiple
                          apps exist for the same provider. Ignored for
                          platform-managed providers.
@@ -123,9 +124,21 @@ Examples:
             // Call the platform's OAuth start endpoint
             const startPath = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/${encodeURIComponent(toBareProvider(providerKey))}/start/`;
 
+            // When --open-browser, start a loopback server first so we can
+            // pass its URL as redirect_after_connect in a single request.
+            let loopback:
+              | Awaited<ReturnType<typeof startManagedLoopbackServer>>
+              | undefined;
+            if (opts.openBrowser) {
+              loopback = await startManagedLoopbackServer();
+            }
+
             const body: Record<string, unknown> = {};
             if (opts.scopes && opts.scopes.length > 0) {
               body.requested_scopes = opts.scopes;
+            }
+            if (loopback) {
+              body.redirect_after_connect = loopback.redirectUrl;
             }
 
             const response = await client.fetch(startPath, {
@@ -153,19 +166,7 @@ Examples:
               return;
             }
 
-            if (opts.openBrowser) {
-              // Snapshot existing connection IDs before opening browser
-              const snapshotEntries = await fetchActiveConnections(
-                client,
-                providerKey,
-                cmd,
-              );
-              if (!snapshotEntries) {
-                // fetchActiveConnections already wrote the error output
-                return;
-              }
-              const snapshotIds = new Set(snapshotEntries.map((e) => e.id));
-
+            if (loopback) {
               openInBrowser(result.connect_url);
 
               if (!jsonMode) {
@@ -174,68 +175,43 @@ Examples:
                 );
               }
 
-              // Poll for a new connection every 2s for up to 5 minutes
-              const pollIntervalMs = 2000;
-              const timeoutMs = 5 * 60 * 1000;
-              const deadline = Date.now() + timeoutMs;
-              let newConnection: {
-                id: string;
-                account_label?: string;
-                scopes_granted?: string[];
-              } | null = null;
+              // Wait for the platform to redirect back to our loopback server
+              const callbackResult = await loopback.callbackPromise;
 
-              while (Date.now() < deadline) {
-                await new Promise((r) => setTimeout(r, pollIntervalMs));
-
+              if (callbackResult.status === "connected") {
+                // Fetch the new connection details
                 const currentEntries = await fetchActiveConnections(
                   client,
                   providerKey,
                   cmd,
-                  { silent: true },
                 );
-                if (!currentEntries) continue;
-
-                const found = currentEntries.find(
-                  (e) => !snapshotIds.has(e.id),
-                );
-                if (found) {
-                  newConnection = found;
-                  break;
-                }
-              }
-
-              if (newConnection) {
-                // Success — new connection found
+                // Best-effort: find the most recent connection
+                const newest = currentEntries?.[currentEntries.length - 1];
                 if (jsonMode) {
                   writeOutput(cmd, {
                     ok: true,
                     provider: providerKey,
-                    connectionId: newConnection.id,
-                    accountLabel: newConnection.account_label ?? null,
-                    scopesGranted: newConnection.scopes_granted ?? [],
+                    connectionId: newest?.id ?? null,
+                    accountLabel: newest?.account_label ?? null,
+                    scopesGranted: newest?.scopes_granted ?? [],
                   });
                 } else {
-                  const label = newConnection.account_label
-                    ? ` as ${newConnection.account_label}`
+                  const label = newest?.account_label
+                    ? ` as ${newest.account_label}`
                     : "";
                   process.stdout.write(`Connected to ${providerKey}${label}\n`);
                 }
               } else {
-                // Timeout — authorization may still be in progress
+                // Error or timeout
+                const errorDetail = callbackResult.error ?? "unknown error";
                 if (jsonMode) {
                   writeOutput(cmd, {
-                    ok: true,
-                    deferred: true,
+                    ok: false,
+                    error: `OAuth connection failed: ${errorDetail}`,
                     provider: providerKey,
-                    connectUrl: result.connect_url,
-                    message:
-                      "Authorization may still be in progress. Check with 'assistant oauth status <provider>'.",
                   });
                 } else {
-                  process.stdout.write(
-                    `Timed out waiting for authorization. It may still be in progress.\n` +
-                      `Check with: assistant oauth status ${providerKey}\n`,
-                  );
+                  writeError(`OAuth connection failed: ${errorDetail}`);
                 }
               }
             } else {
@@ -361,4 +337,125 @@ Examples:
         }
       },
     );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface ManagedLoopbackResult {
+  status: "connected" | "error" | "timeout";
+  error?: string;
+}
+
+/**
+ * Start a temporary loopback HTTP server that waits for the platform to
+ * redirect back after managed OAuth completes. Returns the redirect URL
+ * to pass as `redirect_after_connect` and a promise that resolves with
+ * the callback result.
+ */
+function startManagedLoopbackServer(): Promise<{
+  redirectUrl: string;
+  callbackPromise: Promise<ManagedLoopbackResult>;
+}> {
+  return new Promise((resolveSetup, rejectSetup) => {
+    const TIMEOUT_MS = 5 * 60 * 1000;
+    let settled = false;
+    let resultResolve: (result: ManagedLoopbackResult) => void;
+    const callbackPromise = new Promise<ManagedLoopbackResult>((resolve) => {
+      resultResolve = resolve;
+    });
+
+    const server = createServer((req, res) => {
+      if (settled) {
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end("Already handled.");
+        return;
+      }
+
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+
+      if (url.pathname !== "/oauth/callback") {
+        res.writeHead(404, { "Content-Type": "text/plain" });
+        res.end("Not found");
+        return;
+      }
+
+      settled = true;
+
+      const oauthStatus = url.searchParams.get("oauth_status");
+      const oauthCode = url.searchParams.get("oauth_code");
+
+      if (oauthStatus === "connected") {
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end(renderCallbackPage(true));
+        cleanup();
+        resultResolve({ status: "connected" });
+      } else {
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end(renderCallbackPage(false, oauthCode ?? undefined));
+        cleanup();
+        resultResolve({
+          status: "error",
+          error: oauthCode ?? "OAuth connection failed",
+        });
+      }
+    });
+
+    const timeout = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        cleanup();
+        resultResolve({ status: "timeout", error: "Timed out waiting for authorization" });
+      }
+    }, TIMEOUT_MS);
+    if (typeof timeout === "object" && "unref" in timeout) timeout.unref();
+
+    function cleanup() {
+      clearTimeout(timeout);
+      server.close();
+    }
+
+    server.listen(0, "localhost", () => {
+      const addr = server.address() as { port: number };
+      const redirectUrl = `http://localhost:${addr.port}/oauth/callback`;
+      resolveSetup({ redirectUrl, callbackPromise });
+    });
+
+    server.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        cleanup();
+        rejectSetup(
+          new Error(`Failed to start loopback server: ${err.message}`),
+        );
+      }
+    });
+  });
+}
+
+function renderCallbackPage(success: boolean, errorCode?: string): string {
+  const title = success ? "Authorization Successful" : "Authorization Failed";
+  const color = success ? "#4CAF50" : "#f44336";
+  const icon = success ? "✓" : "✗";
+  const message = success
+    ? "Your account has been connected. You can return to the app."
+    : `Something went wrong${errorCode ? ` (${errorCode})` : ""}. Please return to the app and try again.`;
+  return `<!DOCTYPE html>
+<html><head>
+<title>${title}</title>
+<style>
+  body { font-family: system-ui, -apple-system, sans-serif; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; background: #f5f5f5; color: #333; }
+  .card { text-align: center; padding: 3rem 2.5rem; background: white; border-radius: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); max-width: 420px; }
+  .icon { font-size: 3rem; width: 64px; height: 64px; line-height: 64px; border-radius: 50%; margin: 0 auto 1.5rem; background: ${color}18; color: ${color}; }
+  h1 { color: ${color}; margin: 0 0 0.75rem; font-size: 1.5rem; }
+  p { margin: 0; color: #666; line-height: 1.5; }
+</style>
+</head><body>
+<div class="card">
+  <div class="icon">${icon}</div>
+  <h1>${title}</h1>
+  <p>${message}</p>
+</div>
+</body></html>`;
 }

--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -90,6 +90,12 @@ export interface OAuthConnectOptions {
   openUrl?: (url: string) => void;
   /** Send a message to the client (e.g. open_url). */
   sendToClient?: (msg: { type: string; [key: string]: unknown }) => void;
+  /**
+   * When set, the loopback server redirects to this URL after the OAuth
+   * callback instead of rendering an HTML page. Used by clients that
+   * listen for deep-link callbacks (e.g. `vellum-assistant://...`).
+   */
+  redirectAfterCallback?: string;
 
   /**
    * Called when the deferred (non-interactive) flow completes — either
@@ -266,7 +272,7 @@ export async function orchestrateOAuthConnect(
       const prepared = await prepareOAuth2Flow(
         oauthConfig,
         callbackTransport === "loopback"
-          ? { callbackTransport, loopbackPort }
+          ? { callbackTransport, loopbackPort, redirectAfterCallback: options.redirectAfterCallback }
           : callbackTransport === "gateway"
             ? { callbackTransport }
             : undefined,
@@ -384,7 +390,7 @@ export async function orchestrateOAuthConnect(
         },
       },
       callbackTransport === "loopback"
-        ? { callbackTransport, loopbackPort }
+        ? { callbackTransport, loopbackPort, redirectAfterCallback: options.redirectAfterCallback }
         : callbackTransport === "gateway"
           ? { callbackTransport }
           : undefined,

--- a/assistant/src/runtime/routes/oauth-apps.ts
+++ b/assistant/src/runtime/routes/oauth-apps.ts
@@ -259,7 +259,7 @@ export function oauthAppsRouteDefinitions(): RouteDefinition[] {
           );
         }
 
-        let body: { scopes?: string[] } = {};
+        let body: { scopes?: string[]; redirect_after_callback?: string } = {};
         try {
           const text = await req.text();
           if (text) {
@@ -277,6 +277,7 @@ export function oauthAppsRouteDefinitions(): RouteDefinition[] {
           clientSecret,
           requestedScopes: body.scopes,
           isInteractive: false,
+          redirectAfterCallback: body.redirect_after_callback,
         });
 
         if (result.success && result.deferred) {

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -70,6 +70,13 @@ export interface OAuth2FlowOptions {
    *  instead of an OS-assigned random port. Required for providers like Slack that
    *  need pre-registered redirect URIs. */
   loopbackPort?: number;
+  /**
+   * When set, the loopback server redirects to this URL after the OAuth callback
+   * instead of rendering an HTML page. The URL receives query params:
+   * `oauth_status=connected` on success, or `oauth_status=error&oauth_code=<err>` on failure.
+   * Used by clients (e.g. macOS settings) that listen for deep-link callbacks.
+   */
+  redirectAfterCallback?: string;
 }
 
 export interface OAuth2FlowResult {
@@ -259,6 +266,7 @@ async function runLoopbackFlow(
   codeChallenge: string,
   state: string,
   loopbackPort?: number,
+  redirectAfterCallback?: string,
 ): Promise<OAuth2FlowResult> {
   const { code, redirectUri } = await startLoopbackServerAndWaitForCode(
     config,
@@ -266,6 +274,7 @@ async function runLoopbackFlow(
     codeChallenge,
     state,
     loopbackPort,
+    redirectAfterCallback,
   );
 
   return await exchangeCodeForTokens(config, code, redirectUri, codeVerifier);
@@ -283,10 +292,31 @@ function startLoopbackServerAndWaitForCode(
   codeChallenge: string,
   state: string,
   loopbackPort?: number,
+  redirectAfterCallback?: string,
 ): Promise<{ code: string; redirectUri: string }> {
   return new Promise((resolve, reject) => {
     let settled = false;
     let boundRedirectUri = "";
+
+    /** Respond with either a redirect (deep link) or an HTML page. */
+    function respond(
+      res: import("node:http").ServerResponse,
+      message: string,
+      success: boolean,
+      statusCode: number,
+      errorCode?: string,
+    ) {
+      if (redirectAfterCallback) {
+        const target = new URL(redirectAfterCallback);
+        target.searchParams.set("oauth_status", success ? "connected" : "error");
+        if (errorCode) target.searchParams.set("oauth_code", errorCode);
+        res.writeHead(302, { Location: target.toString() });
+        res.end();
+      } else {
+        res.writeHead(statusCode, { "Content-Type": "text/html" });
+        res.end(renderLoopbackPage(message, success));
+      }
+    }
 
     const server: Server = createServer((req, res) => {
       log.info(
@@ -299,8 +329,7 @@ function startLoopbackServerAndWaitForCode(
       );
 
       if (settled) {
-        res.writeHead(400, { "Content-Type": "text/html" });
-        res.end(renderLoopbackPage("Authorization already completed", false));
+        respond(res, "Authorization already completed", false, 400);
         return;
       }
 
@@ -322,8 +351,7 @@ function startLoopbackServerAndWaitForCode(
 
       if (callbackState !== state) {
         log.warn("oauth2 loopback: state mismatch in callback");
-        res.writeHead(400, { "Content-Type": "text/html" });
-        res.end(renderLoopbackPage("Invalid state parameter", false));
+        respond(res, "Invalid state parameter", false, 400);
         return;
       }
 
@@ -335,10 +363,7 @@ function startLoopbackServerAndWaitForCode(
           { error, errorDesc },
           "oauth2 loopback: authorization denied by user/provider",
         );
-        res.writeHead(200, { "Content-Type": "text/html" });
-        res.end(
-          renderLoopbackPage(`Authorization failed: ${errorDesc}`, false),
-        );
+        respond(res, `Authorization failed: ${errorDesc}`, false, 200, error);
         cleanup();
         reject(new Error(`OAuth2 authorization denied: ${error}`));
         return;
@@ -346,8 +371,7 @@ function startLoopbackServerAndWaitForCode(
 
       if (!code) {
         log.error("oauth2 loopback: callback missing authorization code");
-        res.writeHead(400, { "Content-Type": "text/html" });
-        res.end(renderLoopbackPage("Missing authorization code", false));
+        respond(res, "Missing authorization code", false, 400, "missing_code");
         cleanup();
         reject(new Error("OAuth2 callback missing authorization code"));
         return;
@@ -356,13 +380,7 @@ function startLoopbackServerAndWaitForCode(
       log.info(
         "oauth2 loopback: authorization code received, exchanging for tokens",
       );
-      res.writeHead(200, { "Content-Type": "text/html" });
-      res.end(
-        renderLoopbackPage(
-          "Authorization successful! You can close this tab.",
-          true,
-        ),
-      );
+      respond(res, "Authorization successful! You can close this tab.", true, 200);
       cleanup();
       resolve({ code, redirectUri: boundRedirectUri });
     });
@@ -478,7 +496,7 @@ export async function prepareOAuth2Flow(
   const transport = options?.callbackTransport ?? "loopback";
 
   if (transport === "loopback") {
-    return prepareLoopbackFlow(config, options?.loopbackPort);
+    return prepareLoopbackFlow(config, options?.loopbackPort, options?.redirectAfterCallback);
   }
 
   // Dynamic imports required here to avoid circular dependencies with
@@ -536,6 +554,7 @@ export async function prepareOAuth2Flow(
 async function prepareLoopbackFlow(
   config: OAuth2Config,
   loopbackPort?: number,
+  redirectAfterCallback?: string,
 ): Promise<OAuth2PreparedFlow> {
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = generateCodeChallenge(codeVerifier);
@@ -544,6 +563,7 @@ async function prepareLoopbackFlow(
   const { redirectUri, codePromise } = await startLoopbackServerForPreparedFlow(
     state,
     loopbackPort,
+    redirectAfterCallback,
   );
 
   const authParams = new URLSearchParams({
@@ -580,6 +600,7 @@ async function prepareLoopbackFlow(
 function startLoopbackServerForPreparedFlow(
   state: string,
   loopbackPort?: number,
+  redirectAfterCallback?: string,
 ): Promise<{ redirectUri: string; codePromise: Promise<string> }> {
   return new Promise((resolveSetup, rejectSetup) => {
     let settled = false;
@@ -591,10 +612,29 @@ function startLoopbackServerForPreparedFlow(
       codeReject = reject;
     });
 
+    /** Respond with either a redirect (deep link) or an HTML page. */
+    function respond(
+      res: import("node:http").ServerResponse,
+      message: string,
+      success: boolean,
+      statusCode: number,
+      errorCode?: string,
+    ) {
+      if (redirectAfterCallback) {
+        const target = new URL(redirectAfterCallback);
+        target.searchParams.set("oauth_status", success ? "connected" : "error");
+        if (errorCode) target.searchParams.set("oauth_code", errorCode);
+        res.writeHead(302, { Location: target.toString() });
+        res.end();
+      } else {
+        res.writeHead(statusCode, { "Content-Type": "text/html" });
+        res.end(renderLoopbackPage(message, success));
+      }
+    }
+
     const server: Server = createServer((req, res) => {
       if (settled) {
-        res.writeHead(400, { "Content-Type": "text/html" });
-        res.end(renderLoopbackPage("Authorization already completed", false));
+        respond(res, "Authorization already completed", false, 400);
         return;
       }
 
@@ -611,8 +651,7 @@ function startLoopbackServerForPreparedFlow(
       const error = url.searchParams.get("error");
 
       if (callbackState !== state) {
-        res.writeHead(400, { "Content-Type": "text/html" });
-        res.end(renderLoopbackPage("Invalid state parameter", false));
+        respond(res, "Invalid state parameter", false, 400);
         return;
       }
 
@@ -620,30 +659,20 @@ function startLoopbackServerForPreparedFlow(
 
       if (error) {
         const errorDesc = url.searchParams.get("error_description") ?? error;
-        res.writeHead(200, { "Content-Type": "text/html" });
-        res.end(
-          renderLoopbackPage(`Authorization failed: ${errorDesc}`, false),
-        );
+        respond(res, `Authorization failed: ${errorDesc}`, false, 200, error);
         cleanup();
         codeReject(new Error(`OAuth2 authorization denied: ${error}`));
         return;
       }
 
       if (!code) {
-        res.writeHead(400, { "Content-Type": "text/html" });
-        res.end(renderLoopbackPage("Missing authorization code", false));
+        respond(res, "Missing authorization code", false, 400, "missing_code");
         cleanup();
         codeReject(new Error("OAuth2 callback missing authorization code"));
         return;
       }
 
-      res.writeHead(200, { "Content-Type": "text/html" });
-      res.end(
-        renderLoopbackPage(
-          "Authorization successful! You can close this tab.",
-          true,
-        ),
-      );
+      respond(res, "Authorization successful! You can close this tab.", true, 200);
       cleanup();
       codeResolve(code);
     });
@@ -769,6 +798,7 @@ export async function startOAuth2Flow(
     codeChallenge,
     state,
     options?.loopbackPort,
+    options?.redirectAfterCallback,
   );
 }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -227,6 +227,8 @@ public final class SettingsStore: ObservableObject {
     @Published var managedOAuthError: [String: String] = [:]
     /// Strong reference to prevent the auth session from being deallocated mid-flow.
     private var managedOAuthWebAuthSession: ASWebAuthenticationSession?
+    /// Strong reference for BYO OAuth auth session.
+    private var yourOwnOAuthWebAuthSession: ASWebAuthenticationSession?
 
     // MARK: - Your Own OAuth State
 
@@ -325,7 +327,6 @@ public final class SettingsStore: ObservableObject {
     private var pendingIngressEnabled: Bool?
     private var pendingIngressUrl: String?
     private var routingSourceRefreshTask: Task<Void, Never>?
-    private var yourOwnOAuthConnectPollingTask: Task<Void, Never>?
 
     /// Last model reported by the daemon — used to skip redundant model_set calls
     /// that would otherwise reinitialize providers and evict idle conversations.
@@ -2493,8 +2494,8 @@ public final class SettingsStore: ObservableObject {
     }
 
     func cancelYourOwnOAuthConnect() {
-        yourOwnOAuthConnectPollingTask?.cancel()
-        yourOwnOAuthConnectPollingTask = nil
+        yourOwnOAuthWebAuthSession?.cancel()
+        yourOwnOAuthWebAuthSession = nil
         yourOwnOAuthConnectingAppId = nil
     }
 
@@ -2503,8 +2504,20 @@ public final class SettingsStore: ObservableObject {
         let providerKey = yourOwnOAuthApps.first(where: { $0.value.contains(where: { $0.id == appId }) })?.key
         if let providerKey { yourOwnOAuthError[providerKey] = nil }
         Task {
+            defer { if self.yourOwnOAuthConnectingAppId == appId { self.yourOwnOAuthConnectingAppId = nil } }
+
             do {
-                let response = try await GatewayHTTPClient.post(path: "oauth/apps/\(appId)/connect", json: [:], timeout: 10)
+                let providerSlug = providerKey.map { key in
+                    key.hasPrefix("integration:") ? String(key.dropFirst("integration:".count)) : key
+                } ?? "oauth"
+                let callbackScheme = "vellum-assistant"
+                let redirectAfterCallback = "\(callbackScheme)://oauth/\(providerSlug)/byo-callback"
+
+                let response = try await GatewayHTTPClient.post(
+                    path: "oauth/apps/\(appId)/connect",
+                    json: ["redirect_after_callback": redirectAfterCallback],
+                    timeout: 10
+                )
                 guard response.isSuccess else {
                     let errorMsg: String
                     if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
@@ -2514,7 +2527,6 @@ public final class SettingsStore: ObservableObject {
                         errorMsg = "HTTP \(response.statusCode)"
                     }
                     if let providerKey { self.yourOwnOAuthError[providerKey] = "Failed to start connect: \(errorMsg)" }
-                    if self.yourOwnOAuthConnectingAppId == appId { self.yourOwnOAuthConnectingAppId = nil }
                     return
                 }
 
@@ -2523,46 +2535,40 @@ public final class SettingsStore: ObservableObject {
 
                 guard let authURL = URL(string: connectResponse.auth_url) else {
                     if let providerKey { self.yourOwnOAuthError[providerKey] = "Invalid auth URL" }
-                    if self.yourOwnOAuthConnectingAppId == appId { self.yourOwnOAuthConnectingAppId = nil }
                     return
                 }
 
-                NSWorkspace.shared.open(authURL)
-
-                // Start polling — detect new connections OR re-authed (updated) connections
-                let existingConnections = self.yourOwnOAuthConnectionsByApp[appId] ?? []
-                let initialCount = existingConnections.count
-                let maxUpdatedAt = existingConnections.map(\.updated_at).max() ?? 0
-                self.yourOwnOAuthConnectPollingTask?.cancel()
-                self.yourOwnOAuthConnectPollingTask = Task {
-                    let pollInterval: UInt64 = 3_000_000_000 // 3 seconds
-                    let timeout: UInt64 = 300_000_000_000 // 5 minutes
-                    let startTime = DispatchTime.now().uptimeNanoseconds
-
-                    while !Task.isCancelled {
-                        try? await Task.sleep(nanoseconds: pollInterval)
-                        guard !Task.isCancelled else { break }
-
-                        await self.fetchYourOwnOAuthConnections(appId: appId)
-                        let current = self.yourOwnOAuthConnectionsByApp[appId] ?? []
-
-                        // New connection added
-                        if current.count > initialCount { break }
-
-                        // Existing connection re-authed (updated_at changed)
-                        let currentMaxUpdatedAt = current.map(\.updated_at).max() ?? 0
-                        if currentMaxUpdatedAt > maxUpdatedAt { break }
-
-                        let elapsed = DispatchTime.now().uptimeNanoseconds - startTime
-                        if elapsed >= timeout { break }
+                let callbackURL: URL = try await withCheckedThrowingContinuation { continuation in
+                    let session = ASWebAuthenticationSession(url: authURL, callbackURLScheme: callbackScheme) { [weak self] callbackURL, error in
+                        self?.yourOwnOAuthWebAuthSession = nil
+                        if let error {
+                            continuation.resume(throwing: error)
+                        } else if let callbackURL {
+                            continuation.resume(returning: callbackURL)
+                        } else {
+                            continuation.resume(throwing: URLError(.badServerResponse))
+                        }
                     }
-
-                    if self.yourOwnOAuthConnectingAppId == appId { self.yourOwnOAuthConnectingAppId = nil }
+                    session.prefersEphemeralWebBrowserSession = false
+                    session.presentationContextProvider = WebAuthPresentationContext.shared
+                    self.yourOwnOAuthWebAuthSession = session
+                    session.start()
                 }
+
+                let components = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)
+                let oauthStatus = components?.queryItems?.first(where: { $0.name == "oauth_status" })?.value
+
+                if oauthStatus == "connected" {
+                    await self.fetchYourOwnOAuthConnections(appId: appId)
+                } else if oauthStatus == "error" {
+                    let errorCode = components?.queryItems?.first(where: { $0.name == "oauth_code" })?.value
+                    if let providerKey { self.yourOwnOAuthError[providerKey] = errorCode ?? "OAuth connection failed" }
+                }
+            } catch let error as ASWebAuthenticationSessionError where error.code == .canceledLogin {
+                log.info("User cancelled BYO OAuth connect for app \(appId)")
             } catch {
                 log.error("Failed to start Your Own OAuth connect: \(error)")
                 if let providerKey { self.yourOwnOAuthError[providerKey] = "Failed to start connect: \(error.localizedDescription)" }
-                if self.yourOwnOAuthConnectingAppId == appId { self.yourOwnOAuthConnectingAppId = nil }
             }
         }
     }


### PR DESCRIPTION
## Summary
- **CLI managed OAuth**: Replaces polling (every 2s for up to 5min) with a loopback server that receives the platform's `redirect_after_connect` callback instantly. Shows a styled success/error page telling the user to return to the app.
- **Settings BYO OAuth**: Switches from `NSWorkspace.shared.open()` + polling to `ASWebAuthenticationSession` with `vellum-assistant://` deep link callback, matching the managed settings flow.
- **Loopback server**: Adds `redirectAfterCallback` option — when set, responds with a 302 redirect to a deep link URL instead of rendering an HTML page. Threaded through the orchestrator and BYO connect endpoint.

## Test plan
- [ ] CLI: `assistant oauth connect google --open-browser` in managed mode opens browser, receives redirect callback, shows styled page
- [ ] CLI: `assistant oauth connect google --open-browser` in BYO mode works as before
- [ ] Settings: Managed OAuth connect flow unchanged
- [ ] Settings: BYO OAuth connect uses ASWebAuthenticationSession (no separate browser tab)
- [ ] Unit tests pass (`bun test src/cli/commands/oauth/__tests__/connect.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
