### PR TITLE
feat: move avatar inline on latest assistant message

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -31,6 +31,7 @@ struct ChatBubble: View {
     var onRetryConversationError: (() -> Void)?
 
     var isLatestAssistantMessage: Bool = false
+    @State private var avatarBounceScale: CGFloat = 1.0
     /// When true, the assistant is still processing after tool calls completed.
     /// Renders an inline loading indicator in trailingStatus to avoid a separate
     /// standalone thinking row (which would stack a duplicate avatar).
@@ -401,6 +402,50 @@ struct ChatBubble: View {
             guard !Task.isCancelled else { return }
             mediaEmbedIntents = resolved
         }
+
+        // Avatar below the latest assistant message
+        if isLatestAssistantMessage && !isUser {
+            inlineAvatar
+                .padding(.top, VSpacing.sm)
+        }
+    }
+
+    // MARK: - Inline Avatar
+
+    @ViewBuilder
+    private var inlineAvatar: some View {
+        let appearance = AvatarAppearanceManager.shared
+        let avatarSize = ConversationAvatarFollower.avatarSize
+
+        if appearance.customAvatarImage != nil {
+            VAvatarImage(image: appearance.chatAvatarImage, size: avatarSize)
+                .scaleEffect(avatarBounceScale)
+                .onTapGesture { triggerBounce() }
+        } else if let bodyShape = appearance.characterBodyShape,
+                  let eyeStyle = appearance.characterEyeStyle,
+                  let color = appearance.characterColor {
+            AnimatedAvatarView(bodyShape: bodyShape, eyeStyle: eyeStyle, color: color,
+                               size: avatarSize, blinkEnabled: true, pokeEnabled: true)
+                .frame(width: avatarSize, height: avatarSize)
+                .modifier(AvatarWiggleModifier(isActive: message.isStreaming))
+                .scaleEffect(avatarBounceScale)
+                .onTapGesture { triggerBounce() }
+        } else {
+            VAvatarImage(image: appearance.chatAvatarImage, size: avatarSize)
+                .scaleEffect(avatarBounceScale)
+                .onTapGesture { triggerBounce() }
+        }
+    }
+
+    private func triggerBounce() {
+        withAnimation(.spring(response: 0.3, dampingFraction: 0.4)) {
+            avatarBounceScale = 1.15
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
+                avatarBounceScale = 1.0
+            }
+        }
     }
 
     // MARK: - Send Failed Indicator
@@ -750,6 +795,51 @@ private struct ConditionalCompositingGroup: ViewModifier {
             content.compositingGroup()
         } else {
             content
+        }
+    }
+}
+
+// MARK: - Avatar Wiggle Modifier
+
+/// Applies a gentle wiggle animation (rotation + scale breathing) while active,
+/// signaling the assistant is streaming/thinking.
+struct AvatarWiggleModifier: ViewModifier {
+    let isActive: Bool
+
+    @State private var wiggleAngle: Double = 0
+    @State private var breathScale: CGFloat = 1.0
+
+    func body(content: Content) -> some View {
+        content
+            .rotationEffect(.degrees(wiggleAngle))
+            .scaleEffect(breathScale)
+            .onChange(of: isActive) {
+                if isActive {
+                    startWiggle()
+                } else {
+                    stopWiggle()
+                }
+            }
+            .onAppear {
+                if isActive {
+                    startWiggle()
+                }
+            }
+    }
+
+    private func startWiggle() {
+        withAnimation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true)) {
+            wiggleAngle = 3
+        }
+        withAnimation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true)) {
+            breathScale = 1.03
+        }
+    }
+
+    private func stopWiggle() {
+        withAnimation(.easeOut(duration: 0.3)) {
+            wiggleAngle = 0
+            breathScale = 1.0
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -746,11 +746,6 @@ struct MessageListView: View {
                         compactingIndicatorRow()
                     }
 
-                    if state.hasMessages && ConversationAvatarFollower.bottomInset > 0 {
-                        Color.clear
-                            .frame(height: ConversationAvatarFollower.bottomInset)
-                            .accessibilityHidden(true)
-                    }
 
                     Color.clear.frame(height: 1)
                         .id("scroll-bottom-anchor")
@@ -855,10 +850,6 @@ struct MessageListView: View {
                     conversationId: conversationId,
                     loadPreviousMessagePage: loadPreviousMessagePage
                 )
-            }
-            .overlay(alignment: .bottom) {
-                conversationTailAvatar
-                    .padding(.bottom, ConversationAvatarFollower.verticalOffset)
             }
             .overlay(alignment: .bottom) {
                 if !isNearBottom && !scrollCoordinator.isAtBottom {


### PR DESCRIPTION
## Summary
- Moved the assistant avatar from a floating bottom-overlay on the ScrollView to inline below the latest assistant message
- Avatar is now always visible on the latest assistant message (including during streaming)
- During streaming: wiggle animation (gentle rotation oscillation and scale breathing)
- On click: bounce animation (spring scale)
- Idle: blinking eyes (AnimatedAvatarView built-in behavior)
- Removed the floating overlay, bottom inset spacer, and scroll-proximity visibility logic from MessageListView
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
