### PR TITLE
fix: release file data from memory after upload submission

### DIFF
--- a/clients/shared/Features/Surfaces/FileUploadSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/FileUploadSurfaceView.swift
@@ -367,6 +367,12 @@ public struct FileUploadSurfaceView: View {
 
         isSubmitted = true
         onSubmit(filesPayload)
+
+        // Release heavy file data from memory — the success state only needs
+        // filename and size for display.
+        selectedFiles = selectedFiles.map {
+            SelectedFile(filename: $0.filename, mimeType: $0.mimeType, data: Data(), size: $0.size)
+        }
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary
- After `submitFiles()`, clear the heavy `Data` blobs from `selectedFiles` since the success state only needs `filename` and `size` for display
- Prevents holding potentially large file payloads (up to `maxSizeBytes` per file) in memory unnecessarily
- Per `clients/AGENTS.md`: "Release heavy resources promptly. Clear large data (base64 payloads, image data, surface HTML) from memory once it is no longer displayed."

## Test plan
- [ ] Upload files via file upload surface
- [ ] Verify success state still shows filenames and sizes correctly
- [ ] Verify image thumbnails in success state gracefully fall back to generic icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
