### PR TITLE
fix: include watchers.credential_service in provider key migration

### DIFF
--- a/assistant/src/memory/migrations/196-strip-integration-prefix-from-provider-keys.ts
+++ b/assistant/src/memory/migrations/196-strip-integration-prefix-from-provider-keys.ts
@@ -83,6 +83,14 @@ export function migrateStripIntegrationPrefixFromProviderKeys(
               .run(newKey, oldKey);
           }
         }
+
+        // Also update the watchers table — credential_service stores provider
+        // keys like "integration:google" that feed into resolveOAuthConnection().
+        raw
+          .prepare(
+            /*sql*/ `UPDATE watchers SET credential_service = REPLACE(credential_service, 'integration:', '') WHERE credential_service LIKE 'integration:%'`,
+          )
+          .run();
       } finally {
         raw.exec("PRAGMA foreign_keys = ON");
       }
@@ -154,6 +162,23 @@ export function migrateStripIntegrationPrefixFromProviderKeysDown(
           )
           .run(prefixedKey, bareKey);
       }
+    }
+
+    // Reverse the watchers table update — re-add the prefix for keys that
+    // aren't known bare-name providers.
+    const watcherRows = raw
+      .prepare(
+        /*sql*/ `SELECT DISTINCT credential_service FROM watchers WHERE credential_service NOT LIKE 'integration:%'`,
+      )
+      .all() as Array<{ credential_service: string }>;
+
+    for (const { credential_service: bareKey } of watcherRows) {
+      if (ALWAYS_BARE.has(bareKey)) continue;
+      raw
+        .prepare(
+          /*sql*/ `UPDATE watchers SET credential_service = ? WHERE credential_service = ?`,
+        )
+        .run(`integration:${bareKey}`, bareKey);
     }
   } finally {
     raw.exec("PRAGMA foreign_keys = ON");


### PR DESCRIPTION
## Summary
Fixes gap identified during external review of simplify-oauth-provider-keys.md.

**Gap:** Migration 196 strips the integration: prefix from OAuth tables but misses the watchers.credential_service column
**Impact:** Existing watchers would fail to resolve OAuth connections after migration
**Fix:** Add UPDATE watchers SET credential_service = ... to migration 196
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
