### PR TITLE
fix: show nice completion page after managed OAuth CLI flow

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.0.0
 info:
   title: Vellum Assistant API
-  version: 0.5.10
+  version: 0.5.11
   description: Auto-generated OpenAPI specification for the Vellum Assistant runtime HTTP server.
 servers:
   - url: http://127.0.0.1:7821

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -1,3 +1,5 @@
+import { createServer, type Server } from "node:http";
+
 import type { Command } from "commander";
 
 import { orchestrateOAuthConnect } from "../../../oauth/connect-orchestrator.js";
@@ -19,6 +21,71 @@ import {
 } from "./shared.js";
 
 const log = getCliLogger("cli");
+
+// ---------------------------------------------------------------------------
+// Managed OAuth redirect page
+// ---------------------------------------------------------------------------
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function renderOAuthCompletePage(message: string, success: boolean): string {
+  const title = success ? "Authorization Successful" : "Authorization Failed";
+  const color = success ? "#4CAF50" : "#f44336";
+  const icon = success ? "&#10003;" : "&#10007;";
+  return `<!DOCTYPE html><html><head><title>${escapeHtml(title)}</title><style>body{font-family:system-ui,-apple-system,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0;background:#f5f5f5}div{text-align:center;padding:2.5rem;background:white;border-radius:12px;box-shadow:0 2px 8px rgba(0,0,0,0.1);max-width:420px}.icon{font-size:3rem;color:${color};margin-bottom:0.5rem}h1{color:#333;font-size:1.4rem;margin:0.5rem 0}p{color:#666;font-size:0.95rem;line-height:1.5}</style></head><body><div><div class="icon">${icon}</div><h1>${escapeHtml(title)}</h1><p>${escapeHtml(message)}</p></div></body></html>`;
+}
+
+/**
+ * Start a temporary loopback server to serve a nice completion page after the
+ * platform redirects the user's browser following a managed OAuth flow.
+ * Returns the base URL and a cleanup function.
+ */
+function startManagedRedirectServer(): Promise<{
+  redirectUrl: string;
+  cleanup: () => void;
+}> {
+  return new Promise((resolve, reject) => {
+    const server: Server = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      const error = url.searchParams.get("error");
+      const errorDesc = url.searchParams.get("error_description");
+
+      if (error) {
+        const message = errorDesc ?? error;
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end(renderOAuthCompletePage(message, false));
+      } else {
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end(
+          renderOAuthCompletePage(
+            "You can close this tab and return to your terminal.",
+            true,
+          ),
+        );
+      }
+    });
+
+    server.listen(0, "localhost", () => {
+      const addr = server.address() as { port: number };
+      const redirectUrl = `http://localhost:${addr.port}/oauth/complete`;
+      resolve({
+        redirectUrl,
+        cleanup: () => server.close(),
+      });
+    });
+
+    server.on("error", (err) => {
+      reject(new Error(`Failed to start redirect server: ${err.message}`));
+    });
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Command registration
@@ -126,6 +193,20 @@ Examples:
               body.requested_scopes = opts.scopes;
             }
 
+            // When opening the browser, start a local server to show a nice
+            // completion page instead of redirecting to the platform website.
+            let redirectServer:
+              | { redirectUrl: string; cleanup: () => void }
+              | undefined;
+            if (opts.openBrowser) {
+              try {
+                redirectServer = await startManagedRedirectServer();
+                body.redirect_after_connect = redirectServer.redirectUrl;
+              } catch {
+                // Non-fatal — fall back to platform default redirect
+              }
+            }
+
             const response = await client.fetch(startPath, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
@@ -133,6 +214,7 @@ Examples:
             });
 
             if (!response.ok) {
+              redirectServer?.cleanup();
               const errorText = await response.text().catch(() => "");
               writeError(
                 `Platform returned HTTP ${response.status}${errorText ? `: ${errorText}` : ""}`,
@@ -145,6 +227,7 @@ Examples:
             };
 
             if (!result.connect_url) {
+              redirectServer?.cleanup();
               writeError(
                 "Platform did not return a connect URL — the OAuth flow could not be started",
               );
@@ -159,6 +242,7 @@ Examples:
                 cmd,
               );
               if (!snapshotEntries) {
+                redirectServer?.cleanup();
                 // fetchActiveConnections already wrote the error output
                 return;
               }
@@ -201,6 +285,9 @@ Examples:
                   break;
                 }
               }
+
+              // Clean up the redirect server now that polling is done
+              redirectServer?.cleanup();
 
               if (newConnection) {
                 // Success — new connection found

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -9,6 +9,7 @@ import {
   getProvider,
 } from "../../../oauth/oauth-store.js";
 import { getProviderBehavior } from "../../../oauth/provider-behaviors.js";
+import { renderOAuthCompletionPage } from "../../../security/oauth-completion-page.js";
 import { openInBrowser } from "../../../util/browser.js";
 import { getSecureKeyViaDaemon } from "../../lib/daemon-credential-client.js";
 import { getCliLogger } from "../../logger.js";
@@ -21,26 +22,6 @@ import {
 } from "./shared.js";
 
 const log = getCliLogger("cli");
-
-// ---------------------------------------------------------------------------
-// Managed OAuth redirect page
-// ---------------------------------------------------------------------------
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
-
-function renderOAuthCompletePage(message: string, success: boolean): string {
-  const title = success ? "Authorization Successful" : "Authorization Failed";
-  const color = success ? "#4CAF50" : "#f44336";
-  const icon = success ? "&#10003;" : "&#10007;";
-  return `<!DOCTYPE html><html><head><title>${escapeHtml(title)}</title><style>body{font-family:system-ui,-apple-system,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0;background:#f5f5f5}div{text-align:center;padding:2.5rem;background:white;border-radius:12px;box-shadow:0 2px 8px rgba(0,0,0,0.1);max-width:420px}.icon{font-size:3rem;color:${color};margin-bottom:0.5rem}h1{color:#333;font-size:1.4rem;margin:0.5rem 0}p{color:#666;font-size:0.95rem;line-height:1.5}</style></head><body><div><div class="icon">${icon}</div><h1>${escapeHtml(title)}</h1><p>${escapeHtml(message)}</p></div></body></html>`;
-}
 
 /**
  * Start a temporary loopback server to serve a nice completion page after the
@@ -60,11 +41,11 @@ function startManagedRedirectServer(): Promise<{
       if (error) {
         const message = errorDesc ?? error;
         res.writeHead(200, { "Content-Type": "text/html" });
-        res.end(renderOAuthCompletePage(message, false));
+        res.end(renderOAuthCompletionPage(message, false));
       } else {
         res.writeHead(200, { "Content-Type": "text/html" });
         res.end(
-          renderOAuthCompletePage(
+          renderOAuthCompletionPage(
             "You can close this tab and return to your terminal.",
             true,
           ),

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -188,134 +188,134 @@ Examples:
               }
             }
 
-            const response = await client.fetch(startPath, {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify(body),
-            });
+            try {
+              const response = await client.fetch(startPath, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(body),
+              });
 
-            if (!response.ok) {
-              redirectServer?.cleanup();
-              const errorText = await response.text().catch(() => "");
-              writeError(
-                `Platform returned HTTP ${response.status}${errorText ? `: ${errorText}` : ""}`,
-              );
-              return;
-            }
-
-            const result = (await response.json()) as {
-              connect_url?: string;
-            };
-
-            if (!result.connect_url) {
-              redirectServer?.cleanup();
-              writeError(
-                "Platform did not return a connect URL — the OAuth flow could not be started",
-              );
-              return;
-            }
-
-            if (opts.openBrowser) {
-              // Snapshot existing connection IDs before opening browser
-              const snapshotEntries = await fetchActiveConnections(
-                client,
-                providerKey,
-                cmd,
-              );
-              if (!snapshotEntries) {
-                redirectServer?.cleanup();
-                // fetchActiveConnections already wrote the error output
+              if (!response.ok) {
+                const errorText = await response.text().catch(() => "");
+                writeError(
+                  `Platform returned HTTP ${response.status}${errorText ? `: ${errorText}` : ""}`,
+                );
                 return;
               }
-              const snapshotIds = new Set(snapshotEntries.map((e) => e.id));
 
-              openInBrowser(result.connect_url);
+              const result = (await response.json()) as {
+                connect_url?: string;
+              };
 
-              if (!jsonMode) {
-                log.info(
-                  `Opening browser to connect ${providerKey}. Waiting for authorization...`,
+              if (!result.connect_url) {
+                writeError(
+                  "Platform did not return a connect URL — the OAuth flow could not be started",
                 );
+                return;
               }
 
-              // Poll for a new connection every 2s for up to 5 minutes
-              const pollIntervalMs = 2000;
-              const timeoutMs = 5 * 60 * 1000;
-              const deadline = Date.now() + timeoutMs;
-              let newConnection: {
-                id: string;
-                account_label?: string;
-                scopes_granted?: string[];
-              } | null = null;
-
-              while (Date.now() < deadline) {
-                await new Promise((r) => setTimeout(r, pollIntervalMs));
-
-                const currentEntries = await fetchActiveConnections(
+              if (opts.openBrowser) {
+                // Snapshot existing connection IDs before opening browser
+                const snapshotEntries = await fetchActiveConnections(
                   client,
                   providerKey,
                   cmd,
-                  { silent: true },
                 );
-                if (!currentEntries) continue;
-
-                const found = currentEntries.find(
-                  (e) => !snapshotIds.has(e.id),
-                );
-                if (found) {
-                  newConnection = found;
-                  break;
+                if (!snapshotEntries) {
+                  // fetchActiveConnections already wrote the error output
+                  return;
                 }
-              }
+                const snapshotIds = new Set(snapshotEntries.map((e) => e.id));
 
-              // Clean up the redirect server now that polling is done
-              redirectServer?.cleanup();
+                openInBrowser(result.connect_url);
 
-              if (newConnection) {
-                // Success — new connection found
-                if (jsonMode) {
-                  writeOutput(cmd, {
-                    ok: true,
-                    provider: providerKey,
-                    connectionId: newConnection.id,
-                    accountLabel: newConnection.account_label ?? null,
-                    scopesGranted: newConnection.scopes_granted ?? [],
-                  });
+                if (!jsonMode) {
+                  log.info(
+                    `Opening browser to connect ${providerKey}. Waiting for authorization...`,
+                  );
+                }
+
+                // Poll for a new connection every 2s for up to 5 minutes
+                const pollIntervalMs = 2000;
+                const timeoutMs = 5 * 60 * 1000;
+                const deadline = Date.now() + timeoutMs;
+                let newConnection: {
+                  id: string;
+                  account_label?: string;
+                  scopes_granted?: string[];
+                } | null = null;
+
+                while (Date.now() < deadline) {
+                  await new Promise((r) => setTimeout(r, pollIntervalMs));
+
+                  const currentEntries = await fetchActiveConnections(
+                    client,
+                    providerKey,
+                    cmd,
+                    { silent: true },
+                  );
+                  if (!currentEntries) continue;
+
+                  const found = currentEntries.find(
+                    (e) => !snapshotIds.has(e.id),
+                  );
+                  if (found) {
+                    newConnection = found;
+                    break;
+                  }
+                }
+
+                if (newConnection) {
+                  // Success — new connection found
+                  if (jsonMode) {
+                    writeOutput(cmd, {
+                      ok: true,
+                      provider: providerKey,
+                      connectionId: newConnection.id,
+                      accountLabel: newConnection.account_label ?? null,
+                      scopesGranted: newConnection.scopes_granted ?? [],
+                    });
+                  } else {
+                    const label = newConnection.account_label
+                      ? ` as ${newConnection.account_label}`
+                      : "";
+                    process.stdout.write(
+                      `Connected to ${providerKey}${label}\n`,
+                    );
+                  }
                 } else {
-                  const label = newConnection.account_label
-                    ? ` as ${newConnection.account_label}`
-                    : "";
-                  process.stdout.write(`Connected to ${providerKey}${label}\n`);
+                  // Timeout — authorization may still be in progress
+                  if (jsonMode) {
+                    writeOutput(cmd, {
+                      ok: true,
+                      deferred: true,
+                      provider: providerKey,
+                      connectUrl: result.connect_url,
+                      message:
+                        "Authorization may still be in progress. Check with 'assistant oauth status <provider>'.",
+                    });
+                  } else {
+                    process.stdout.write(
+                      `Timed out waiting for authorization. It may still be in progress.\n` +
+                        `Check with: assistant oauth status ${providerKey}\n`,
+                    );
+                  }
                 }
               } else {
-                // Timeout — authorization may still be in progress
+                // No --open-browser: output the connect URL
                 if (jsonMode) {
                   writeOutput(cmd, {
                     ok: true,
                     deferred: true,
-                    provider: providerKey,
                     connectUrl: result.connect_url,
-                    message:
-                      "Authorization may still be in progress. Check with 'assistant oauth status <provider>'.",
+                    provider: providerKey,
                   });
                 } else {
-                  process.stdout.write(
-                    `Timed out waiting for authorization. It may still be in progress.\n` +
-                      `Check with: assistant oauth status ${providerKey}\n`,
-                  );
+                  process.stdout.write(result.connect_url + "\n");
                 }
               }
-            } else {
-              // No --open-browser: output the connect URL
-              if (jsonMode) {
-                writeOutput(cmd, {
-                  ok: true,
-                  deferred: true,
-                  connectUrl: result.connect_url,
-                  provider: providerKey,
-                });
-              } else {
-                process.stdout.write(result.connect_url + "\n");
-              }
+            } finally {
+              redirectServer?.cleanup();
             }
           } else {
             // =============================================================

--- a/assistant/src/security/oauth-completion-page.ts
+++ b/assistant/src/security/oauth-completion-page.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared HTML rendering for OAuth completion pages shown in the browser
+ * after a loopback/redirect OAuth flow completes.
+ */
+
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function renderOAuthCompletionPage(
+  message: string,
+  success: boolean,
+): string {
+  const title = success ? "Authorization Successful" : "Authorization Failed";
+  const color = success ? "#4CAF50" : "#f44336";
+  return `<!DOCTYPE html><html><head><title>${escapeHtml(title)}</title><style>body{font-family:system-ui,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0;background:#f5f5f5}div{text-align:center;padding:2rem;background:white;border-radius:8px;box-shadow:0 2px 4px rgba(0,0,0,0.1)}h1{color:${color}}</style></head><body><div><h1>${escapeHtml(title)}</h1><p>${escapeHtml(message)}</p></div></body></html>`;
+}

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -20,6 +20,7 @@ import { createHash, randomBytes } from "node:crypto";
 import { createServer, type Server } from "node:http";
 
 import { getLogger } from "../util/logger.js";
+import { renderOAuthCompletionPage as renderLoopbackPage } from "./oauth-completion-page.js";
 
 const log = getLogger("oauth2");
 
@@ -431,21 +432,6 @@ function startLoopbackServerAndWaitForCode(
       }
     });
   });
-}
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
-
-function renderLoopbackPage(message: string, success: boolean): string {
-  const title = success ? "Authorization Successful" : "Authorization Failed";
-  const color = success ? "#4CAF50" : "#f44336";
-  return `<!DOCTYPE html><html><head><title>${escapeHtml(title)}</title><style>body{font-family:system-ui,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0;background:#f5f5f5}div{text-align:center;padding:2rem;background:white;border-radius:8px;box-shadow:0 2px 4px rgba(0,0,0,0.1)}h1{color:${color}}</style></head><body><div><h1>${escapeHtml(title)}</h1><p>${escapeHtml(message)}</p></div></body></html>`;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- When using `assistant oauth connect --open-browser` in managed mode, the user's browser was redirected to the platform website after completing OAuth
- Now starts a temporary localhost server and passes its URL as `redirect_after_connect`, so the browser lands on a clean success/error page instead
- Matches the visual style of the existing BYO OAuth loopback completion pages

## Test plan
- [x] Existing tests pass (13/13)
- [ ] Manual: `assistant oauth connect google --open-browser` in managed mode → browser shows "Authorization Successful" page after completing OAuth
- [ ] Manual: verify non-`--open-browser` managed path is unchanged (just prints connect URL)
- [ ] Manual: verify BYO path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
