### PR TITLE
fix: avatar below thinking indicator, single avatar at a time

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -40,6 +40,8 @@ struct ChatBubble: View {
     var processingStatusText: String?
     /// Whether the message-tts feature flag is enabled. Passed from the parent.
     var isTTSEnabled: Bool = false
+    /// When true, hide the inline avatar (e.g. thinking indicator is showing it instead).
+    var hideInlineAvatar: Bool = false
     @State private var audioPlayer = MessageAudioPlayer()
     @State private var isHovered = false
     /// Stores async-parsed segments for large messages (>500 chars) that missed the
@@ -82,7 +84,8 @@ struct ChatBubble: View {
         isLatestAssistantMessage: Bool = false,
         isProcessingAfterTools: Bool = false,
         processingStatusText: String? = nil,
-        activeSurfaceId: String? = nil
+        activeSurfaceId: String? = nil,
+        hideInlineAvatar: Bool = false
     ) {
         self.message = message
         self.decidedConfirmation = decidedConfirmation
@@ -107,6 +110,7 @@ struct ChatBubble: View {
         self.isProcessingAfterTools = isProcessingAfterTools
         self.processingStatusText = processingStatusText
         self.activeSurfaceId = activeSurfaceId
+        self.hideInlineAvatar = hideInlineAvatar
 
         // Eagerly compute interleaved content cache so the first body
         // evaluation uses the correct layout path (no flash).
@@ -403,10 +407,13 @@ struct ChatBubble: View {
             mediaEmbedIntents = resolved
         }
 
-        // Avatar below the latest assistant message
-        if isLatestAssistantMessage && !isUser {
-            inlineAvatar
-                .padding(.top, VSpacing.sm)
+        // Avatar below the latest assistant message, left-aligned
+        if isLatestAssistantMessage && !isUser && !hideInlineAvatar {
+            HStack {
+                inlineAvatar
+                Spacer()
+            }
+            .padding(.top, VSpacing.sm)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -640,6 +640,35 @@ struct MessageListView: View {
         .transition(.opacity.combined(with: .move(edge: .bottom)))
     }
 
+    @ViewBuilder
+    private var thinkingAvatarRow: some View {
+        let avatarSize = ConversationAvatarFollower.avatarSize
+        if appearance.customAvatarImage != nil {
+            HStack {
+                VAvatarImage(image: appearance.chatAvatarImage, size: avatarSize)
+                Spacer()
+            }
+            .accessibilityHidden(true)
+        } else if let body = appearance.characterBodyShape,
+                  let eyes = appearance.characterEyeStyle,
+                  let color = appearance.characterColor {
+            HStack {
+                AnimatedAvatarView(bodyShape: body, eyeStyle: eyes, color: color,
+                                   size: avatarSize, blinkEnabled: true, pokeEnabled: true)
+                    .frame(width: avatarSize, height: avatarSize)
+                    .modifier(AvatarWiggleModifier(isActive: true))
+                Spacer()
+            }
+            .accessibilityHidden(true)
+        } else {
+            HStack {
+                VAvatarImage(image: appearance.chatAvatarImage, size: avatarSize)
+                Spacer()
+            }
+            .accessibilityHidden(true)
+        }
+    }
+
     var body: some View {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: VSpacing.md) {
@@ -742,6 +771,9 @@ struct MessageListView: View {
                         } else {
                             thinkingIndicatorRow(hasUserMessage: state.hasUserMessage)
                         }
+                        // Show avatar below thinking indicator so it moves
+                        // immediately when the user sends a message.
+                        thinkingAvatarRow
                     } else if isCompacting && !state.shouldShowThinkingIndicator && !state.canInlineProcessing {
                         compactingIndicatorRow()
                     }
@@ -1133,7 +1165,8 @@ private struct MessageCellView: View, Equatable {
                 isLatestAssistantMessage: message.role == .assistant && message.id == latestAssistantId,
                 isProcessingAfterTools: canInlineProcessing && message.id == latestAssistantId,
                 processingStatusText: canInlineProcessing && message.id == latestAssistantId ? assistantStatusText : nil,
-                activeSurfaceId: activeSurfaceId
+                activeSurfaceId: activeSurfaceId,
+                hideInlineAvatar: shouldShowThinkingIndicator && anchoredThinkingIndex == nil
             )
         }
     }
@@ -1220,7 +1253,8 @@ private struct MessageCellView: View, Equatable {
                 isLatestAssistantMessage: message.role == .assistant && message.id == latestAssistantId,
                 isProcessingAfterTools: canInlineProcessing && message.id == latestAssistantId,
                 processingStatusText: canInlineProcessing && message.id == latestAssistantId ? assistantStatusText : nil,
-                activeSurfaceId: activeSurfaceId
+                activeSurfaceId: activeSurfaceId,
+                hideInlineAvatar: shouldShowThinkingIndicator && anchoredThinkingIndex == nil
             )
             .background(
                 RoundedRectangle(cornerRadius: VRadius.md)


### PR DESCRIPTION
## Summary
- Avatar now appears below the thinking indicator immediately when the user sends a message
- Previous assistant message's avatar hides when thinking indicator is active (only one avatar at a time)
- Added `thinkingAvatarRow` to MessageListView with wiggle animation during thinking
- Added `hideInlineAvatar` parameter to ChatBubble to control visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
