### PR TITLE
Remove gmail alias references from help text, docs, and skill files

### DIFF
--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -221,7 +221,7 @@ The OAuth extensibility layer makes adding a new OAuth provider a declarative op
 
 Protocol fields (`authUrl`, `tokenUrl`, `defaultScopes`, `scopePolicy`, `callbackTransport`) are stored in the `oauth_providers` database table rather than in code.
 
-Registered providers: `google`, `slack`, `notion`. The `gmail` alias resolves to the `google` provider.
+Registered providers: `google`, `slack`, `notion`.
 
 ### Scope Policy Engine
 

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -40,7 +40,7 @@ export function registerConnectCommand(oauth: Command): void {
       "after",
       `
 Arguments:
-  provider   Provider name (e.g. google, slack, gmail).
+  provider   Provider name (e.g. google, slack, notion).
              Run 'assistant oauth providers list' to see available providers.
 
 Options:
@@ -58,7 +58,7 @@ Options:
 
 Examples:
   $ assistant oauth connect google
-  $ assistant oauth connect gmail --open-browser
+  $ assistant oauth connect google --open-browser
   $ assistant oauth connect google --scopes https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/calendar.events
   $ assistant oauth connect google --client-id abc123 --open-browser`,
     )

--- a/assistant/src/cli/commands/oauth/disconnect.ts
+++ b/assistant/src/cli/commands/oauth/disconnect.ts
@@ -37,7 +37,7 @@ export function registerDisconnectCommand(oauth: Command): void {
       "after",
       `
 Arguments:
-  provider   Provider name (e.g. google, slack, gmail).
+  provider   Provider name (e.g. google, slack, notion).
              Run 'assistant oauth providers list' to see available providers.
 
 Options:

--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -128,7 +128,7 @@ Note: The Authorization header is set automatically. User-supplied
 
 Examples:
   $ assistant oauth request --provider twitter https://api.x.com/2/tweets
-  $ assistant oauth request --provider gmail /gmail/v1/users/me/messages -G
+  $ assistant oauth request --provider google /gmail/v1/users/me/messages -G
   $ assistant oauth request --provider twitter -X POST -d '{"text":"Hello"}' https://api.x.com/2/tweets
   $ assistant oauth request --provider google -d @body.json https://www.googleapis.com/calendar/v3/calendars
   $ assistant oauth request --provider slack -H "Content-Type: application/json" -d '{"channel":"C123"}' /api/chat.postMessage --json`,

--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -27,7 +27,7 @@ Do not offer AgentMail as an option or mention it unless the user specifically a
 
 ### Gmail
 
-1. **Try connecting directly first.** Call `credential_store` with `action: "oauth2_connect"` and `service: "gmail"`. The tool auto-fills Google's OAuth endpoints and looks up any previously stored client credentials - so this single call may be all that's needed.
+1. **Try connecting directly first.** Call `credential_store` with `action: "oauth2_connect"` and `service: "google"`. The tool auto-fills Google's OAuth endpoints and looks up any previously stored client credentials - so this single call may be all that's needed.
 2. **If it fails because no client_id is found:** The user needs to create Google Cloud OAuth credentials first. Load the **google-oauth-applescript** skill:
    - Call `skill_load` with `skill: "google-oauth-applescript"` to load the dependency skill.
    - Tell the user Gmail isn't connected yet and briefly explain what the setup involves, then use `ui_show` with `surface_type: "confirmation"` to ask for permission to start:
@@ -36,13 +36,13 @@ Do not offer AgentMail as an option or mention it unless the user specifically a
      - **confirmLabel:** "Get Started"
      - **cancelLabel:** "Not Now"
    - If the user confirms, briefly acknowledge (e.g., "Setting up Gmail now...") and proceed with the setup guide. If they decline, acknowledge and let them know they can set it up later.
-3. **If the user provides a client_id directly in chat:** Call `credential_store` with `action: "oauth2_connect"`, `service: "gmail"`, and `client_id: "<their value>"`. Include `client_secret` too if they provide one. Everything else is auto-filled.
+3. **If the user provides a client_id directly in chat:** Call `credential_store` with `action: "oauth2_connect"`, `service: "google"`, and `client_id: "<their value>"`. Include `client_secret` too if they provide one. Everything else is auto-filled.
 
 ## Error Recovery
 
 When a Gmail tool fails with a token or authorization error:
 
-1. **Try to reconnect silently.** Call `credential_store` with `action: "oauth2_connect"` and `service: "gmail"`. This often resolves expired tokens automatically.
+1. **Try to reconnect silently.** Call `credential_store` with `action: "oauth2_connect"` and `service: "google"`. This often resolves expired tokens automatically.
 2. **If reconnection fails, go straight to setup.** Don't present options, ask which route the user prefers, or explain what went wrong technically. Just tell the user briefly (e.g., "Gmail needs to be reconnected - let me set that up") and immediately follow the connection setup flow for Gmail (e.g., install and load **google-oauth-applescript**). The user came to you to get something done, not to troubleshoot OAuth - make it seamless.
 3. **Never try alternative approaches.** Don't use bash, curl, browser automation, or any workaround. If the Gmail tools can't do it, the reconnection flow is the answer.
 4. **Never expose error details.** The user doesn't need to see error messages about tokens, OAuth, or API failures. Translate errors into plain language.

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -56,7 +56,7 @@ When the user asks to "connect my email", "set up email", "manage my email", or 
 
 ### Gmail
 
-1. **Try connecting directly first.** Call `credential_store` with `action: "oauth2_connect"` and `service: "gmail"`. The tool auto-fills Google's OAuth endpoints and looks up any previously stored client credentials - so this single call may be all that's needed.
+1. **Try connecting directly first.** Call `credential_store` with `action: "oauth2_connect"` and `service: "google"`. The tool auto-fills Google's OAuth endpoints and looks up any previously stored client credentials - so this single call may be all that's needed.
 2. **If it fails because no client_id is found:** The user needs to create Google Cloud OAuth credentials first. Load the **google-oauth-applescript** skill:
    - Call `skill_load` with `skill: "google-oauth-applescript"` to load the dependency skill.
    - Tell the user Gmail isn't connected yet and briefly explain what the setup involves, then use `ui_show` with `surface_type: "confirmation"` to ask for permission to start:
@@ -65,7 +65,7 @@ When the user asks to "connect my email", "set up email", "manage my email", or 
      - **confirmLabel:** "Get Started"
      - **cancelLabel:** "Not Now"
    - If the user confirms, briefly acknowledge (e.g., "Setting up Gmail now...") and proceed with the setup guide. If they decline, acknowledge and let them know they can set it up later.
-3. **If the user provides a client_id directly in chat:** Call `credential_store` with `action: "oauth2_connect"`, `service: "gmail"`, and `client_id: "<their value>"`. Include `client_secret` too if they provide one. Everything else is auto-filled.
+3. **If the user provides a client_id directly in chat:** Call `credential_store` with `action: "oauth2_connect"`, `service: "google"`, and `client_id: "<their value>"`. Include `client_secret` too if they provide one. Everything else is auto-filled.
 
 ### Slack
 

--- a/skills/google-oauth-applescript/SKILL.md
+++ b/skills/google-oauth-applescript/SKILL.md
@@ -16,7 +16,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 ## Provider Details
 
 - **Provider key:** `google`
-- **Provider search keys:** `gmail`, `google`
+- **Provider search keys:** `google`
 - **Credential type (Path A):** Desktop app
 - **Credential type (Path B):** Web application (callback through public gateway)
 

--- a/skills/oauth-setup/SKILL.md
+++ b/skills/oauth-setup/SKILL.md
@@ -45,7 +45,7 @@ Well-known services with dedicated setup skills (note: not all follow the `<serv
 
 | Service  | Skill ID                 |
 | -------- | ------------------------ |
-| gmail    | google-oauth-applescript |
+| google   | google-oauth-applescript |
 | notion   | notion-oauth-setup       |
 | twitter  | twitter-oauth-setup      |
 | github   | github-oauth-setup       |


### PR DESCRIPTION
## Summary
- Update CLI help text to replace gmail with notion/google in examples
- Update integrations.md to remove alias documentation
- Update oauth-setup and google-oauth-applescript skill files
- Change bundled skill SKILL.md instructions from service: gmail to service: google

Part of plan: remove-oauth-service-aliases.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
