### PR TITLE
Remove resolveService() and SERVICE_ALIASES from OAuth subsystem

### DIFF
--- a/assistant/src/__tests__/oauth-provider-profiles.test.ts
+++ b/assistant/src/__tests__/oauth-provider-profiles.test.ts
@@ -1,16 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import {
-  getProviderBehavior,
-  resolveService,
-} from "../oauth/provider-behaviors.js";
+import { getProviderBehavior } from "../oauth/provider-behaviors.js";
 
 describe("oauth provider behaviors", () => {
-  test("gmail behavior defines bearer injection templates for Google API hosts", () => {
-    const service = resolveService("gmail");
-    const behavior = getProviderBehavior(service);
+  test("google behavior defines bearer injection templates for Google API hosts", () => {
+    const behavior = getProviderBehavior("google");
 
-    expect(service).toBe("google");
     expect(behavior).toBeDefined();
     expect(behavior?.injectionTemplates).toBeDefined();
     expect(behavior?.injectionTemplates).toHaveLength(3);

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -15,7 +15,6 @@ import {
   fetchActiveConnections,
   isManagedMode,
   requirePlatformClient,
-  resolveService,
 } from "./shared.js";
 
 const log = getCliLogger("cli");
@@ -82,17 +81,12 @@ Examples:
 
         try {
           // ---------------------------------------------------------------
-          // 1. Resolve provider key
+          // 1. Validate provider exists
           // ---------------------------------------------------------------
-          const providerKey = resolveService(provider);
-
-          // ---------------------------------------------------------------
-          // 2. Validate provider exists
-          // ---------------------------------------------------------------
-          const providerRow = getProvider(providerKey);
+          const providerRow = getProvider(provider);
           if (!providerRow) {
             writeError(
-              `Unknown provider "${providerKey}". ` +
+              `Unknown provider "${provider}". ` +
                 `Run 'assistant oauth providers list' to see available providers.`,
             );
             return;
@@ -101,7 +95,7 @@ Examples:
           // ---------------------------------------------------------------
           // 3. Detect mode
           // ---------------------------------------------------------------
-          const managed = isManagedMode(providerKey);
+          const managed = isManagedMode(provider);
 
           if (managed) {
             // =============================================================
@@ -111,7 +105,7 @@ Examples:
             // Warn about --client-id being ignored in managed mode
             if (opts.clientId) {
               log.info(
-                `Warning: --client-id is ignored for platform-managed providers. The platform manages OAuth apps for "${providerKey}".`,
+                `Warning: --client-id is ignored for platform-managed providers. The platform manages OAuth apps for "${provider}".`,
               );
             }
 
@@ -119,7 +113,7 @@ Examples:
             if (!client) return;
 
             // Call the platform's OAuth start endpoint
-            const startPath = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/${encodeURIComponent(providerKey)}/start/`;
+            const startPath = `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/oauth/${encodeURIComponent(provider)}/start/`;
 
             const body: Record<string, unknown> = {};
             if (opts.scopes && opts.scopes.length > 0) {
@@ -155,7 +149,7 @@ Examples:
               // Snapshot existing connection IDs before opening browser
               const snapshotEntries = await fetchActiveConnections(
                 client,
-                providerKey,
+                provider,
                 cmd,
               );
               if (!snapshotEntries) {
@@ -168,7 +162,7 @@ Examples:
 
               if (!jsonMode) {
                 log.info(
-                  `Opening browser to connect ${providerKey}. Waiting for authorization...`,
+                  `Opening browser to connect ${provider}. Waiting for authorization...`,
                 );
               }
 
@@ -187,7 +181,7 @@ Examples:
 
                 const currentEntries = await fetchActiveConnections(
                   client,
-                  providerKey,
+                  provider,
                   cmd,
                   { silent: true },
                 );
@@ -207,7 +201,7 @@ Examples:
                 if (jsonMode) {
                   writeOutput(cmd, {
                     ok: true,
-                    provider: providerKey,
+                    provider: provider,
                     connectionId: newConnection.id,
                     accountLabel: newConnection.account_label ?? null,
                     scopesGranted: newConnection.scopes_granted ?? [],
@@ -216,7 +210,7 @@ Examples:
                   const label = newConnection.account_label
                     ? ` as ${newConnection.account_label}`
                     : "";
-                  process.stdout.write(`Connected to ${providerKey}${label}\n`);
+                  process.stdout.write(`Connected to ${provider}${label}\n`);
                 }
               } else {
                 // Timeout — authorization may still be in progress
@@ -224,7 +218,7 @@ Examples:
                   writeOutput(cmd, {
                     ok: true,
                     deferred: true,
-                    provider: providerKey,
+                    provider: provider,
                     connectUrl: result.connect_url,
                     message:
                       "Authorization may still be in progress. Check with 'assistant oauth status <provider>'.",
@@ -232,7 +226,7 @@ Examples:
                 } else {
                   process.stdout.write(
                     `Timed out waiting for authorization. It may still be in progress.\n` +
-                      `Check with: assistant oauth status ${providerKey}\n`,
+                      `Check with: assistant oauth status ${provider}\n`,
                   );
                 }
               }
@@ -243,7 +237,7 @@ Examples:
                   ok: true,
                   deferred: true,
                   connectUrl: result.connect_url,
-                  provider: providerKey,
+                  provider: provider,
                 });
               } else {
                 process.stdout.write(result.connect_url + "\n");
@@ -254,13 +248,10 @@ Examples:
             // BYO PATH
             // =============================================================
 
-            // a. Resolve service alias (already done above via resolveService)
-            const resolvedServiceKey = providerKey;
-
-            // b. Resolve client credentials from the DB
+            // a. Resolve client credentials from the DB
             const dbApp = opts.clientId
-              ? getAppByProviderAndClientId(resolvedServiceKey, opts.clientId)
-              : getMostRecentAppByProvider(resolvedServiceKey);
+              ? getAppByProviderAndClientId(provider, opts.clientId)
+              : getMostRecentAppByProvider(provider);
 
             let clientId = opts.clientId;
             let clientSecret: string | undefined;
@@ -274,7 +265,7 @@ Examples:
             } else if (opts.clientId) {
               // --client-id was explicitly provided but no matching app exists
               writeError(
-                `No registered app found for "${resolvedServiceKey}" with client ID "${opts.clientId}". ` +
+                `No registered app found for "${provider}" with client ID "${opts.clientId}". ` +
                   `Register one with 'assistant oauth apps upsert'.`,
               );
               return;
@@ -283,7 +274,7 @@ Examples:
             // c. Validate client_id exists
             if (!clientId) {
               writeError(
-                `No client_id found for "${resolvedServiceKey}". ` +
+                `No client_id found for "${provider}". ` +
                   `Register one with 'assistant oauth apps upsert'.`,
               );
               return;
@@ -291,7 +282,7 @@ Examples:
 
             // d. Check if client_secret is required but missing
             if (clientSecret === undefined) {
-              const behavior = getProviderBehavior(resolvedServiceKey);
+              const behavior = getProviderBehavior(provider);
 
               const requiresSecret =
                 behavior?.setup?.requiresClientSecret ??
@@ -302,7 +293,7 @@ Examples:
 
               if (requiresSecret) {
                 writeError(
-                  `client_secret is required for ${resolvedServiceKey} but not found. ` +
+                  `client_secret is required for ${provider} but not found. ` +
                     `Store it with 'assistant oauth apps upsert --client-secret'.`,
                 );
                 return;
@@ -335,7 +326,7 @@ Examples:
                 });
               } else {
                 process.stdout.write(
-                  `\nAuthorize with ${resolvedServiceKey}:\n\n${result.authUrl}\n\nThe connection will complete automatically once you authorize.\n`,
+                  `\nAuthorize with ${provider}:\n\n${result.authUrl}\n\nThe connection will complete automatically once you authorize.\n`,
                 );
               }
               return;
@@ -349,7 +340,7 @@ Examples:
                 accountInfo: result.accountInfo,
               });
             } else {
-              const msg = `Connected to ${resolvedServiceKey}${result.accountInfo ? ` as ${result.accountInfo}` : ""}`;
+              const msg = `Connected to ${provider}${result.accountInfo ? ` as ${result.accountInfo}` : ""}`;
               process.stdout.write(msg + "\n");
             }
           }

--- a/assistant/src/cli/commands/oauth/disconnect.ts
+++ b/assistant/src/cli/commands/oauth/disconnect.ts
@@ -229,7 +229,7 @@ Examples:
               accountLabel = conn.accountInfo ?? undefined;
             } else if (opts.connectionId) {
               const conn = getConnection(opts.connectionId);
-              if (!conn || conn.provider !== provider) {
+              if (!conn || conn.providerKey !== provider) {
                 writeError(
                   `Connection "${opts.connectionId}" is not an active ${provider} connection.\n\n` +
                     `Run 'assistant oauth status ${provider}' to see active connections.`,

--- a/assistant/src/cli/commands/oauth/disconnect.ts
+++ b/assistant/src/cli/commands/oauth/disconnect.ts
@@ -13,7 +13,6 @@ import {
   fetchActiveConnections,
   isManagedMode,
   requirePlatformClient,
-  resolveService,
 } from "./shared.js";
 
 const log = getCliLogger("cli");
@@ -81,11 +80,9 @@ Examples:
 
         try {
           // -------------------------------------------------------------------
-          // 1. Resolve + validate provider
+          // 1. Validate provider
           // -------------------------------------------------------------------
-          const providerKey = resolveService(provider);
-
-          const providerRow = getProvider(providerKey);
+          const providerRow = getProvider(provider);
           if (!providerRow) {
             writeError(
               `Unknown provider "${provider}".\n\n` +
@@ -109,7 +106,7 @@ Examples:
           // -------------------------------------------------------------------
           // 3. Detect mode
           // -------------------------------------------------------------------
-          const managed = isManagedMode(providerKey);
+          const managed = isManagedMode(provider);
 
           if (managed) {
             // -----------------------------------------------------------------
@@ -120,7 +117,7 @@ Examples:
 
             const entries = await fetchActiveConnections(
               client,
-              providerKey,
+              provider,
               cmd,
             );
             if (!entries) return;
@@ -135,7 +132,7 @@ Examples:
               );
               if (matching.length === 0) {
                 writeError(
-                  `No active connection found for "${providerKey}" with account "${opts.account}".\n\n` +
+                  `No active connection found for "${provider}" with account "${opts.account}".\n\n` +
                     `Run 'assistant oauth status ${provider}' to see connected accounts.`,
                 );
                 return;
@@ -147,7 +144,7 @@ Examples:
               const match = entries.find((c) => c.id === opts.connectionId);
               if (!match) {
                 writeError(
-                  `Connection "${opts.connectionId}" is not an active ${providerKey} connection.\n\n` +
+                  `Connection "${opts.connectionId}" is not an active ${provider} connection.\n\n` +
                     `Run 'assistant oauth status ${provider}' to see active connections.`,
                 );
                 return;
@@ -158,7 +155,7 @@ Examples:
               // Neither specified — auto-resolve
               if (entries.length === 0) {
                 writeError(
-                  `No active connections found for "${providerKey}".\n\n` +
+                  `No active connections found for "${provider}".\n\n` +
                     `Run 'assistant oauth status ${provider}' to check connection status.`,
                 );
                 return;
@@ -170,7 +167,7 @@ Examples:
                   account: c.account_label ?? null,
                 }));
                 writeError(
-                  `Multiple active connections for "${providerKey}". ` +
+                  `Multiple active connections for "${provider}". ` +
                     `Specify which one to disconnect with --account or --connection-id.\n\n` +
                     `Run 'assistant oauth status ${provider}' to see connected accounts and IDs.`,
                   { connections: connectionList },
@@ -199,7 +196,7 @@ Examples:
 
             const result: Record<string, unknown> = {
               ok: true,
-              provider: providerKey,
+              provider: provider,
               connectionId,
             };
             if (accountLabel) result.account = accountLabel;
@@ -207,7 +204,7 @@ Examples:
 
             if (!jsonMode) {
               log.info(
-                `Disconnected ${providerKey} connection ${connectionId}`,
+                `Disconnected ${provider} connection ${connectionId}`,
               );
             }
           } else {
@@ -218,12 +215,12 @@ Examples:
             let accountLabel: string | undefined;
 
             if (opts.account) {
-              const conn = getActiveConnection(providerKey, {
+              const conn = getActiveConnection(provider, {
                 account: opts.account,
               });
               if (!conn) {
                 writeError(
-                  `No active connection found for "${providerKey}" with account "${opts.account}".\n\n` +
+                  `No active connection found for "${provider}" with account "${opts.account}".\n\n` +
                     `Run 'assistant oauth status ${provider}' to see connected accounts.`,
                 );
                 return;
@@ -232,9 +229,9 @@ Examples:
               accountLabel = conn.accountInfo ?? undefined;
             } else if (opts.connectionId) {
               const conn = getConnection(opts.connectionId);
-              if (!conn || conn.providerKey !== providerKey) {
+              if (!conn || conn.provider !== provider) {
                 writeError(
-                  `Connection "${opts.connectionId}" is not an active ${providerKey} connection.\n\n` +
+                  `Connection "${opts.connectionId}" is not an active ${provider} connection.\n\n` +
                     `Run 'assistant oauth status ${provider}' to see active connections.`,
                 );
                 return;
@@ -243,11 +240,11 @@ Examples:
               accountLabel = conn.accountInfo ?? undefined;
             } else {
               // Neither specified — auto-resolve
-              const active = listActiveConnectionsByProvider(providerKey);
+              const active = listActiveConnectionsByProvider(provider);
 
               if (active.length === 0) {
                 writeError(
-                  `No active connections found for "${providerKey}".\n\n` +
+                  `No active connections found for "${provider}".\n\n` +
                     `Run 'assistant oauth status ${provider}' to check connection status.`,
                 );
                 return;
@@ -259,7 +256,7 @@ Examples:
                   account: c.accountInfo ?? null,
                 }));
                 writeError(
-                  `Multiple active connections for "${providerKey}". ` +
+                  `Multiple active connections for "${provider}". ` +
                     `Specify which one to disconnect with --account or --connection-id.\n\n` +
                     `Run 'assistant oauth status ${provider}' to see connected accounts and IDs.`,
                   { connections: connectionList },
@@ -273,20 +270,20 @@ Examples:
 
             // Disconnect the OAuth connection (tokens + connection row)
             const oauthResult = await disconnectOAuthProvider(
-              providerKey,
+              provider,
               undefined,
               connectionId,
             );
             if (oauthResult === "error") {
               writeError(
-                `Failed to disconnect OAuth provider "${providerKey}" — please try again.`,
+                `Failed to disconnect OAuth provider "${provider}" — please try again.`,
               );
               return;
             }
 
             const result: Record<string, unknown> = {
               ok: true,
-              provider: providerKey,
+              provider: provider,
               connectionId,
             };
             if (accountLabel) result.account = accountLabel;
@@ -294,7 +291,7 @@ Examples:
 
             if (!jsonMode) {
               log.info(
-                `Disconnected ${providerKey} connection ${connectionId}`,
+                `Disconnected ${provider} connection ${connectionId}`,
               );
             }
           }

--- a/assistant/src/cli/commands/oauth/mode.ts
+++ b/assistant/src/cli/commands/oauth/mode.ts
@@ -17,7 +17,6 @@ import { shouldOutputJson, writeOutput } from "../../output.js";
 import {
   fetchActiveConnections,
   getManagedServiceConfigKey,
-  resolveService,
 } from "./shared.js";
 
 /**
@@ -29,13 +28,13 @@ import {
  * command output or set a non-zero exit code.
  */
 async function countManagedConnections(
-  providerKey: string,
+  provider: string,
   cmd: Command,
 ): Promise<number> {
   try {
     const client = await VellumPlatformClient.create();
     if (!client || !client.platformAssistantId) return 0;
-    const entries = await fetchActiveConnections(client, providerKey, cmd, {
+    const entries = await fetchActiveConnections(client, provider, cmd, {
       silent: true,
     });
     return entries?.length ?? 0;
@@ -85,10 +84,9 @@ Examples:
     .action(async (provider: string, opts: { set?: string }, cmd: Command) => {
       try {
         // -----------------------------------------------------------------
-        // Resolve + validate provider
+        // Validate provider
         // -----------------------------------------------------------------
-        const providerKey = resolveService(provider);
-        const providerRow = getProvider(providerKey);
+        const providerRow = getProvider(provider);
 
         if (!providerRow) {
           writeOutput(cmd, {
@@ -101,7 +99,7 @@ Examples:
           return;
         }
 
-        const managedKey = getManagedServiceConfigKey(providerKey);
+        const managedKey = getManagedServiceConfigKey(provider);
 
         // -----------------------------------------------------------------
         // GET mode (no --set flag)
@@ -112,13 +110,13 @@ Examples:
             if (shouldOutputJson(cmd)) {
               writeOutput(cmd, {
                 ok: true,
-                provider: providerKey,
+                provider: provider,
                 mode: "your-own",
                 managedModeSupported: false,
               });
             } else {
               log.info(
-                `${providerKey} mode: your-own (managed mode not available for this provider)`,
+                `${provider} mode: your-own (managed mode not available for this provider)`,
               );
             }
             return;
@@ -131,12 +129,12 @@ Examples:
           if (shouldOutputJson(cmd)) {
             writeOutput(cmd, {
               ok: true,
-              provider: providerKey,
+              provider: provider,
               mode: currentMode,
               managedModeSupported: true,
             });
           } else {
-            log.info(`${providerKey} mode: ${currentMode}`);
+            log.info(`${provider} mode: ${currentMode}`);
           }
           return;
         }
@@ -163,14 +161,14 @@ Examples:
             if (shouldOutputJson(cmd)) {
               writeOutput(cmd, {
                 ok: true,
-                provider: providerKey,
+                provider: provider,
                 mode: "your-own",
                 changed: false,
                 managedModeSupported: false,
               });
             } else {
               log.info(
-                `${providerKey} is already set to your-own (managed mode not available for this provider)`,
+                `${provider} is already set to your-own (managed mode not available for this provider)`,
               );
             }
             return;
@@ -180,7 +178,7 @@ Examples:
           writeOutput(cmd, {
             ok: false,
             error:
-              `Managed mode is not available for ${providerKey}. ` +
+              `Managed mode is not available for ${provider}. ` +
               `Only providers with platform-managed OAuth support can be switched to managed mode.`,
           });
           process.exitCode = 1;
@@ -196,13 +194,13 @@ Examples:
           if (shouldOutputJson(cmd)) {
             writeOutput(cmd, {
               ok: true,
-              provider: providerKey,
+              provider: provider,
               mode: newMode,
               changed: false,
               managedModeSupported: true,
             });
           } else {
-            log.info(`${providerKey} is already set to ${newMode}`);
+            log.info(`${provider} is already set to ${newMode}`);
           }
           return;
         }
@@ -217,28 +215,28 @@ Examples:
         let newModeConnections = 0;
         if (currentMode === "managed") {
           // Old mode was managed — check platform connections
-          oldModeConnections = await countManagedConnections(providerKey, cmd);
+          oldModeConnections = await countManagedConnections(provider, cmd);
           // New mode is your-own — check local connections
           newModeConnections =
-            listActiveConnectionsByProvider(providerKey).length;
+            listActiveConnectionsByProvider(provider).length;
         } else {
           // Old mode was your-own — check local connections
           oldModeConnections =
-            listActiveConnectionsByProvider(providerKey).length;
+            listActiveConnectionsByProvider(provider).length;
           // New mode is managed — check platform connections
-          newModeConnections = await countManagedConnections(providerKey, cmd);
+          newModeConnections = await countManagedConnections(provider, cmd);
         }
 
         // Build hint if there are connections on the old mode but none on the new
         let hint: string | undefined;
         if (oldModeConnections > 0 && newModeConnections === 0) {
-          hint = `No active connections in ${newMode} mode. Run 'assistant oauth connect ${providerKey}' to connect.`;
+          hint = `No active connections in ${newMode} mode. Run 'assistant oauth connect ${provider}' to connect.`;
         }
 
         if (shouldOutputJson(cmd)) {
           const result: Record<string, unknown> = {
             ok: true,
-            provider: providerKey,
+            provider: provider,
             mode: newMode,
             changed: true,
             managedModeSupported: true,
@@ -246,7 +244,7 @@ Examples:
           if (hint) result.hint = hint;
           writeOutput(cmd, result);
         } else {
-          log.info(`${providerKey} mode changed to ${newMode}`);
+          log.info(`${provider} mode changed to ${newMode}`);
           if (hint) {
             process.stderr.write(hint + "\n");
           }

--- a/assistant/src/cli/commands/oauth/ping.ts
+++ b/assistant/src/cli/commands/oauth/ping.ts
@@ -7,7 +7,6 @@ import {
 import { getProvider } from "../../../oauth/oauth-store.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
-import { resolveService } from "./shared.js";
 
 const log = getCliLogger("cli");
 
@@ -55,19 +54,14 @@ Examples:
 
         try {
           // -----------------------------------------------------------------
-          // 1. Resolve provider key
+          // 1. Validate provider exists
           // -----------------------------------------------------------------
-          const providerKey = resolveService(provider);
-
-          // -----------------------------------------------------------------
-          // 2. Validate provider exists
-          // -----------------------------------------------------------------
-          const providerRow = getProvider(providerKey);
+          const providerRow = getProvider(provider);
           if (!providerRow) {
             writeOutput(cmd, {
               ok: false,
               error:
-                `Unknown provider "${providerKey}". ` +
+                `Unknown provider "${provider}". ` +
                 `Run 'assistant oauth providers list' to see available providers.`,
             });
             process.exitCode = 1;
@@ -81,7 +75,7 @@ Examples:
             writeOutput(cmd, {
               ok: false,
               error:
-                `No ping URL configured for "${providerKey}". ` +
+                `No ping URL configured for "${provider}". ` +
                 `Register one with 'assistant oauth providers register --ping-url <url>'.`,
             });
             process.exitCode = 1;
@@ -113,7 +107,7 @@ Examples:
           let connection;
           try {
             connection = await resolveOAuthConnection(
-              providerKey,
+              provider,
               resolveOptions,
             );
           } catch (resolveErr) {
@@ -126,7 +120,7 @@ Examples:
               ok: false,
               error: resolveMessage,
               hint:
-                `Run 'assistant oauth status ${providerKey}' to check connection health. ` +
+                `Run 'assistant oauth status ${provider}' to check connection health. ` +
                 `To reconnect, run 'assistant oauth connect --help'.`,
             });
             process.exitCode = 1;
@@ -165,25 +159,25 @@ Examples:
           if (response.status >= 200 && response.status < 300) {
             // Success
             if (!jsonMode) {
-              log.info(`${providerKey}: OK (HTTP ${response.status})`);
+              log.info(`${provider}: OK (HTTP ${response.status})`);
             }
             writeOutput(cmd, {
               ok: true,
-              provider: providerKey,
+              provider: provider,
               status: response.status,
             });
           } else {
             // Non-2xx failure
             const payload: Record<string, unknown> = {
               ok: false,
-              provider: providerKey,
+              provider: provider,
               status: response.status,
               error: `Ping failed with HTTP ${response.status}`,
             };
 
             if (response.status === 401 || response.status === 403) {
               payload.hint =
-                `Run 'assistant oauth status ${providerKey}' to check connection health. ` +
+                `Run 'assistant oauth status ${provider}' to check connection health. ` +
                 `To reconnect, run 'assistant oauth connect --help'.`;
             }
 
@@ -194,19 +188,11 @@ Examples:
           // Network failure or other unexpected error
           const message = err instanceof Error ? err.message : String(err);
 
-          // Try to extract providerKey for recovery hints
-          let providerKey: string;
-          try {
-            providerKey = resolveService(provider);
-          } catch {
-            providerKey = provider;
-          }
-
           writeOutput(cmd, {
             ok: false,
             error: message,
             hint:
-              `Run 'assistant oauth status ${providerKey}' to check connection health. ` +
+              `Run 'assistant oauth status ${provider}' to check connection health. ` +
               `To reconnect, run 'assistant oauth connect --help'.`,
           });
           process.exitCode = 1;

--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -14,7 +14,7 @@ import {
 } from "../../../oauth/oauth-store.js";
 import { VellumPlatformClient } from "../../../platform/client.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
-import { isManagedMode, resolveService } from "./shared.js";
+import { isManagedMode } from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -175,17 +175,12 @@ Examples:
 
         try {
           // -----------------------------------------------------------------
-          // 1. Resolve provider key
-          // -----------------------------------------------------------------
-          const providerKey = resolveService(opts.provider);
-
-          // -----------------------------------------------------------------
           // Pre-flight check 1: Provider not found
           // -----------------------------------------------------------------
-          const providerRow = getProvider(providerKey);
+          const providerRow = getProvider(opts.provider);
           if (!providerRow) {
             writeError(
-              `Error: Unknown provider "${providerKey}".\n\n` +
+              `Error: Unknown provider "${opts.provider}".\n\n` +
                 `Run 'assistant oauth providers list' to see available providers.\n` +
                 `If this is a custom provider, register it first with 'assistant oauth providers register --help'.`,
             );
@@ -195,7 +190,7 @@ Examples:
           // -----------------------------------------------------------------
           // Pre-flight check 2: Determine managed vs BYO mode
           // -----------------------------------------------------------------
-          const managed = isManagedMode(providerKey);
+          const managed = isManagedMode(opts.provider);
 
           // -----------------------------------------------------------------
           // Pre-flight check 3: Client ID not found (BYO only)
@@ -203,16 +198,16 @@ Examples:
           if (opts.clientId) {
             if (managed) {
               writeInfo(
-                `Warning: --client-id is ignored for platform-managed providers. The platform manages OAuth apps for "${providerKey}".`,
+                `Warning: --client-id is ignored for platform-managed providers. The platform manages OAuth apps for "${opts.provider}".`,
               );
             } else {
               const app = getAppByProviderAndClientId(
-                providerKey,
+                opts.provider,
                 opts.clientId,
               );
               if (!app) {
                 writeError(
-                  `Error: No registered OAuth app found for "${providerKey}" with client ID "${opts.clientId}".\n\n` +
+                  `Error: No registered OAuth app found for "${opts.provider}" with client ID "${opts.clientId}".\n\n` +
                     `Run 'assistant oauth apps list' to see registered apps for this provider.\n` +
                     `To register a new app, run 'assistant oauth apps upsert --help'.`,
                 );
@@ -230,7 +225,7 @@ Examples:
               const client = await VellumPlatformClient.create();
               if (client && client.platformAssistantId) {
                 const params = new URLSearchParams();
-                params.set("provider", providerKey);
+                params.set("provider", opts.provider);
                 params.set("status", "ACTIVE");
                 params.set("account_identifier", opts.account);
 
@@ -247,8 +242,8 @@ Examples:
 
                   if (connections.length === 0) {
                     writeError(
-                      `Error: No active platform connection found for "${providerKey}" with account "${opts.account}".\n\n` +
-                        `Run 'assistant oauth status ${providerKey}' to see connected accounts for this provider.\n` +
+                      `Error: No active platform connection found for "${opts.provider}" with account "${opts.account}".\n\n` +
+                        `Run 'assistant oauth status ${opts.provider}' to see connected accounts for this provider.\n` +
                         `To connect a new account, run 'assistant oauth connect --help'.`,
                     );
                     return;
@@ -260,14 +255,14 @@ Examples:
                 );
               }
             } else {
-              const conn = getActiveConnection(providerKey, {
+              const conn = getActiveConnection(opts.provider, {
                 clientId: opts.clientId,
                 account: opts.account,
               });
               if (!conn) {
                 writeError(
-                  `Error: No active OAuth connection found for "${providerKey}" with account "${opts.account}"${opts.clientId ? ` and client ID "${opts.clientId}"` : ""}.\n\n` +
-                    `Run 'assistant oauth status ${providerKey}' to see active connections.\n` +
+                  `Error: No active OAuth connection found for "${opts.provider}" with account "${opts.account}"${opts.clientId ? ` and client ID "${opts.clientId}"` : ""}.\n\n` +
+                    `Run 'assistant oauth status ${opts.provider}' to see active connections.\n` +
                     `To connect a new account, run 'assistant oauth connect --help'.`,
                 );
                 return;
@@ -419,7 +414,7 @@ Examples:
           let connection;
           try {
             connection = await resolveOAuthConnection(
-              providerKey,
+              opts.provider,
               resolveOptions,
             );
           } catch (resolveErr) {
@@ -435,13 +430,13 @@ Examples:
             if (managed) {
               writeError(
                 `Error: ${resolveMessage}\n\n` +
-                  `Run 'assistant oauth status ${providerKey}' to check connection status.\n` +
+                  `Run 'assistant oauth status ${opts.provider}' to check connection status.\n` +
                   `To connect, run 'assistant oauth connect --help'.`,
               );
             } else {
               writeError(
                 `Error: ${resolveMessage}\n\n` +
-                  `Run 'assistant oauth status ${providerKey}' to see active connections.\n` +
+                  `Run 'assistant oauth status ${opts.provider}' to see active connections.\n` +
                   `To connect, run 'assistant oauth connect --help'.`,
               );
             }
@@ -474,12 +469,12 @@ Examples:
             if (managed) {
               authHint =
                 `Hint: Request returned HTTP ${response.status}. The OAuth token may be expired or revoked.\n\n` +
-                `Run 'assistant oauth status ${providerKey}' to check connection health.\n` +
+                `Run 'assistant oauth status ${opts.provider}' to check connection health.\n` +
                 `To reconnect, run 'assistant oauth connect --help'.`;
             } else {
               authHint =
                 `Hint: Request returned HTTP ${response.status}. The OAuth token may be expired or revoked.\n\n` +
-                `Run 'assistant oauth status ${providerKey}' to check connection status.\n` +
+                `Run 'assistant oauth status ${opts.provider}' to check connection status.\n` +
                 `To reconnect, run 'assistant oauth connect --help'.`;
             }
             writeInfo(authHint);
@@ -536,14 +531,6 @@ Examples:
           // Error case 7: Generic/unexpected errors
           const message = err instanceof Error ? err.message : String(err);
 
-          // Try to extract providerKey for the generic hint
-          let providerKey: string;
-          try {
-            providerKey = resolveService(opts.provider);
-          } catch {
-            providerKey = opts.provider;
-          }
-
           // BYO connections throw on persistent 401 (after refresh retry
           // exhaustion) with a `status` property. Detect this and show the
           // same auth hint that the response-level 401/403 check would give.
@@ -553,13 +540,13 @@ Examples:
               : undefined;
 
           if (errStatus === 401 || errStatus === 403) {
-            const managed = isManagedMode(providerKey);
+            const managed = isManagedMode(opts.provider);
             const authHint = managed
               ? `Hint: Request returned HTTP ${errStatus}. The OAuth token may be expired or revoked.\n\n` +
-                `Run 'assistant oauth status ${providerKey}' to check connection health.\n` +
+                `Run 'assistant oauth status ${opts.provider}' to check connection health.\n` +
                 `To reconnect, run 'assistant oauth connect --help'.`
               : `Hint: Request returned HTTP ${errStatus}. The OAuth token may be expired or revoked.\n\n` +
-                `Run 'assistant oauth status ${providerKey}' to check connection status.\n` +
+                `Run 'assistant oauth status ${opts.provider}' to check connection status.\n` +
                 `To reconnect, run 'assistant oauth connect --help'.`;
 
             writeError(`Error: ${message}`, authHint);
@@ -569,7 +556,7 @@ Examples:
 
           writeError(
             `Error: ${message}\n\n` +
-              `For provider diagnostics, run 'assistant oauth providers get ${providerKey}'.`,
+              `For provider diagnostics, run 'assistant oauth providers get ${opts.provider}'.`,
           );
         }
       },

--- a/assistant/src/cli/commands/oauth/shared.ts
+++ b/assistant/src/cli/commands/oauth/shared.ts
@@ -6,15 +6,8 @@ import {
   ServicesSchema,
 } from "../../../config/schemas/services.js";
 import { getProvider } from "../../../oauth/oauth-store.js";
-import { resolveService } from "../../../oauth/provider-behaviors.js";
 import { VellumPlatformClient } from "../../../platform/client.js";
 import { writeOutput } from "../../output.js";
-
-// ---------------------------------------------------------------------------
-// Re-exports
-// ---------------------------------------------------------------------------
-
-export { resolveService };
 
 // ---------------------------------------------------------------------------
 // Shared types

--- a/assistant/src/cli/commands/oauth/status.ts
+++ b/assistant/src/cli/commands/oauth/status.ts
@@ -7,7 +7,6 @@ import {
   fetchActiveConnections,
   isManagedMode,
   requirePlatformClient,
-  resolveService,
 } from "./shared.js";
 
 const log = getCliLogger("cli");
@@ -45,10 +44,9 @@ Examples:
       ) => {
         try {
           // -----------------------------------------------------------------
-          // Resolve + validate provider
+          // Validate provider
           // -----------------------------------------------------------------
-          const providerKey = resolveService(provider);
-          const providerRow = getProvider(providerKey);
+          const providerRow = getProvider(provider);
 
           if (!providerRow) {
             writeOutput(cmd, {
@@ -64,7 +62,7 @@ Examples:
           // -----------------------------------------------------------------
           // Detect mode
           // -----------------------------------------------------------------
-          const managed = isManagedMode(providerKey);
+          const managed = isManagedMode(provider);
 
           if (managed) {
             // ---------------------------------------------------------------
@@ -75,7 +73,7 @@ Examples:
 
             const rawEntries = await fetchActiveConnections(
               client,
-              providerKey,
+              provider,
               cmd,
             );
             if (!rawEntries) return;
@@ -90,7 +88,7 @@ Examples:
             if (shouldOutputJson(cmd)) {
               writeOutput(cmd, {
                 ok: true,
-                provider: providerKey,
+                provider: provider,
                 mode: "managed",
                 connections,
               });
@@ -100,12 +98,12 @@ Examples:
             // Human output
             if (connections.length === 0) {
               log.info(
-                `No active connections for ${providerKey}. Connect with 'assistant oauth connect ${providerKey}'.`,
+                `No active connections for ${provider}. Connect with 'assistant oauth connect ${provider}'.`,
               );
               return;
             }
 
-            log.info(`Provider: ${providerKey} (managed)`);
+            log.info(`Provider: ${provider} (managed)`);
             log.info(`${connections.length} active connection(s):`);
             for (const c of connections) {
               const scopes =
@@ -120,7 +118,7 @@ Examples:
             // ---------------------------------------------------------------
             // BYO path
             // ---------------------------------------------------------------
-            const allConnections = listConnections(providerKey);
+            const allConnections = listConnections(provider);
             const activeRows = allConnections.filter(
               (r) => r.status === "active",
             );
@@ -150,7 +148,7 @@ Examples:
             if (shouldOutputJson(cmd)) {
               writeOutput(cmd, {
                 ok: true,
-                provider: providerKey,
+                provider: provider,
                 mode: "byo",
                 connections,
               });
@@ -160,12 +158,12 @@ Examples:
             // Human output
             if (connections.length === 0) {
               log.info(
-                `No active connections for ${providerKey}. Connect with 'assistant oauth connect ${providerKey}'.`,
+                `No active connections for ${provider}. Connect with 'assistant oauth connect ${provider}'.`,
               );
               return;
             }
 
-            log.info(`Provider: ${providerKey} (byo)`);
+            log.info(`Provider: ${provider} (byo)`);
             log.info(`${connections.length} active connection(s):`);
             for (const c of connections) {
               const scopes =

--- a/assistant/src/cli/commands/oauth/token.ts
+++ b/assistant/src/cli/commands/oauth/token.ts
@@ -3,7 +3,7 @@ import type { Command } from "commander";
 import { getActiveConnection } from "../../../oauth/oauth-store.js";
 import { withValidToken } from "../../../security/token-manager.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
-import { isManagedMode, resolveService } from "./shared.js";
+import { isManagedMode } from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // CES shell lockdown guard
@@ -85,20 +85,15 @@ Examples:
       ) => {
         try {
           // ---------------------------------------------------------------
-          // 1. Resolve provider key
+          // 1. Check managed mode
           // ---------------------------------------------------------------
-          const providerKey = resolveService(provider);
-
-          // ---------------------------------------------------------------
-          // 2. Check managed mode
-          // ---------------------------------------------------------------
-          if (isManagedMode(providerKey)) {
+          if (isManagedMode(provider)) {
             const message =
               "Token retrieval is not supported for platform-managed providers. " +
               "When a provider is in managed mode, Vellum handles OAuth tokens on your behalf — " +
               "they are not exposed directly.\n\n" +
-              `To verify your connection is working, run 'assistant oauth ping ${providerKey}'.\n` +
-              `To make authenticated requests, use 'assistant oauth request --provider ${providerKey} <url>'.`;
+              `To verify your connection is working, run 'assistant oauth ping ${provider}'.\n` +
+              `To make authenticated requests, use 'assistant oauth request --provider ${provider} <url>'.`;
             writeOutput(cmd, { ok: false, error: message });
             process.exitCode = 1;
             return;
@@ -123,7 +118,7 @@ Examples:
           let tokenOpts: string | { connectionId: string } | undefined;
 
           if (opts.account || opts.clientId) {
-            const conn = getActiveConnection(providerKey, {
+            const conn = getActiveConnection(provider, {
               clientId: opts.clientId,
               account: opts.account,
             });
@@ -134,8 +129,8 @@ Examples:
                   ? ` with client ID "${opts.clientId}"`
                   : "";
               const message =
-                `No active connection found for "${providerKey}"${hint}. ` +
-                `Connect first with 'assistant oauth connect ${providerKey}'.`;
+                `No active connection found for "${provider}"${hint}. ` +
+                `Connect first with 'assistant oauth connect ${provider}'.`;
               writeOutput(cmd, { ok: false, error: message });
               process.exitCode = 1;
               return;
@@ -144,7 +139,7 @@ Examples:
           }
 
           const token = await withValidToken(
-            providerKey,
+            provider,
             async (t) => t,
             tokenOpts,
           );

--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -29,7 +29,7 @@ import type {
   OAuthScopePolicy,
 } from "./connect-types.js";
 import { getProvider } from "./oauth-store.js";
-import { getProviderBehavior, resolveService } from "./provider-behaviors.js";
+import { getProviderBehavior } from "./provider-behaviors.js";
 import { resolveScopes } from "./scope-policy.js";
 import { storeOAuth2Tokens } from "./token-persistence.js";
 
@@ -76,7 +76,7 @@ function safeJsonParse<T>(value: string | null | undefined, fallback: T): T {
 // ---------------------------------------------------------------------------
 
 export interface OAuthConnectOptions {
-  /** Raw service name (may be an alias like "gmail"). */
+  /** Canonical service name (e.g. "google", "slack"). */
   service: string;
   /** Scopes to request beyond the provider's defaults. */
   requestedScopes?: string[];
@@ -119,11 +119,9 @@ export interface OAuthConnectOptions {
 export async function orchestrateOAuthConnect(
   options: OAuthConnectOptions,
 ): Promise<OAuthConnectResult> {
-  const resolvedService = resolveService(options.service);
   log.info(
     {
-      rawService: options.service,
-      resolvedService,
+      service: options.service,
       isInteractive: options.isInteractive,
       hasOpenUrl: !!options.openUrl,
       hasSendToClient: !!options.sendToClient,
@@ -132,17 +130,17 @@ export async function orchestrateOAuthConnect(
   );
 
   // Read provider config from the DB
-  const providerRow = getProvider(resolvedService);
+  const providerRow = getProvider(options.service);
   if (!providerRow) {
     return {
       success: false,
-      error: `No OAuth provider registered for "${resolvedService}". Ensure the provider is seeded in the database.`,
+      error: `No OAuth provider registered for "${options.service}". Ensure the provider is seeded in the database.`,
       safeError: true,
     };
   }
 
   // Behavioral/code-side fields come from the behavior registry
-  const behavior = resolveBehavior(resolvedService);
+  const behavior = resolveBehavior(options.service);
 
   // Deserialize JSON fields from the DB row
   const dbDefaultScopes = safeJsonParse<string[]>(
@@ -177,7 +175,7 @@ export async function orchestrateOAuthConnect(
 
   // Resolve scopes via the scope policy engine
   const scopeProfile = {
-    service: resolvedService,
+    service: options.service,
     defaultScopes: dbDefaultScopes,
     scopePolicy: dbScopePolicy,
   };
@@ -211,7 +209,7 @@ export async function orchestrateOAuthConnect(
 
   log.info(
     {
-      service: resolvedService,
+      service: options.service,
       authUrl,
       tokenUrl,
       scopeCount: finalScopes.length,
@@ -235,7 +233,7 @@ export async function orchestrateOAuthConnect(
   };
 
   const storageParams = {
-    service: resolvedService,
+    service: options.service,
     clientId: options.clientId,
     clientSecret: options.clientSecret,
     userinfoUrl,
@@ -299,36 +297,36 @@ export async function orchestrateOAuthConnect(
             });
             log.info(
               {
-                service: resolvedService,
+                service: options.service,
                 accountInfo: stored.accountInfo ?? parsedAccountIdentifier,
               },
               "Deferred OAuth2 flow completed — tokens stored",
             );
             options.onDeferredComplete?.({
               success: true,
-              service: resolvedService,
+              service: options.service,
               accountInfo: stored.accountInfo ?? parsedAccountIdentifier,
             });
           } catch (err) {
             log.error(
-              { err, service: resolvedService },
+              { err, service: options.service },
               "Failed to store tokens from deferred OAuth2 flow",
             );
             options.onDeferredComplete?.({
               success: false,
-              service: resolvedService,
+              service: options.service,
               error: err instanceof Error ? err.message : "Unknown error",
             });
           }
         })
         .catch((err) => {
           log.error(
-            { err, service: resolvedService },
+            { err, service: options.service },
             "Deferred OAuth2 flow failed",
           );
           options.onDeferredComplete?.({
             success: false,
-            service: resolvedService,
+            service: options.service,
             error: err instanceof Error ? err.message : "Unknown error",
           });
         });
@@ -338,7 +336,7 @@ export async function orchestrateOAuthConnect(
         deferred: true,
         authUrl: prepared.authUrl,
         state: prepared.state,
-        service: resolvedService,
+        service: options.service,
       };
     } catch (err: unknown) {
       const message =
@@ -347,7 +345,7 @@ export async function orchestrateOAuthConnect(
           : "Unknown error preparing OAuth flow";
       return {
         success: false,
-        error: `Error connecting "${resolvedService}": ${message}`,
+        error: `Error connecting "${options.service}": ${message}`,
       };
     }
   }
@@ -356,7 +354,7 @@ export async function orchestrateOAuthConnect(
   // Interactive path — open browser, block until completion
   // -----------------------------------------------------------------------
   log.info(
-    { service: resolvedService, callbackTransport, loopbackPort },
+    { service: options.service, callbackTransport, loopbackPort },
     "orchestrateOAuthConnect: entering interactive path",
   );
   try {
@@ -365,7 +363,7 @@ export async function orchestrateOAuthConnect(
       {
         openUrl: (url) => {
           log.info(
-            { service: resolvedService, urlLength: url.length },
+            { service: options.service, urlLength: url.length },
             "orchestrateOAuthConnect: openUrl callback fired, delivering auth URL to client",
           );
           if (options.openUrl) {
@@ -376,7 +374,7 @@ export async function orchestrateOAuthConnect(
             options.sendToClient({
               type: "open_url",
               url,
-              title: `Connect ${resolvedService}`,
+              title: `Connect ${options.service}`,
             });
           } else {
             log.warn("orchestrateOAuthConnect: no openUrl or sendToClient available — auth URL will not reach the user");
@@ -391,7 +389,7 @@ export async function orchestrateOAuthConnect(
     );
 
     log.info(
-      { service: resolvedService, grantedScopeCount: grantedScopes.length },
+      { service: options.service, grantedScopeCount: grantedScopes.length },
       "orchestrateOAuthConnect: interactive flow completed, exchanged code for tokens",
     );
 
@@ -404,7 +402,7 @@ export async function orchestrateOAuthConnect(
           tokens.accessToken,
         );
         log.info(
-          { service: resolvedService, parsedAccountIdentifier },
+          { service: options.service, parsedAccountIdentifier },
           "orchestrateOAuthConnect: identity verified",
         );
       } catch {
@@ -421,7 +419,7 @@ export async function orchestrateOAuthConnect(
     });
 
     log.info(
-      { service: resolvedService, accountInfo },
+      { service: options.service, accountInfo },
       "orchestrateOAuthConnect: tokens stored, connect complete",
     );
 
@@ -435,12 +433,12 @@ export async function orchestrateOAuthConnect(
     const message =
       err instanceof Error ? err.message : "Unknown error during OAuth flow";
     log.error(
-      { service: resolvedService, err },
+      { service: options.service, err },
       "orchestrateOAuthConnect: interactive flow failed",
     );
     return {
       success: false,
-      error: `Error connecting "${resolvedService}": ${message}`,
+      error: `Error connecting "${options.service}": ${message}`,
     };
   }
 }

--- a/assistant/src/oauth/provider-behaviors.ts
+++ b/assistant/src/oauth/provider-behaviors.ts
@@ -591,20 +591,6 @@ export const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
   },
 };
 
-// ---------------------------------------------------------------------------
-// Aliases & resolution
-// ---------------------------------------------------------------------------
-
-/** Map shorthand aliases to canonical service names. */
-export const SERVICE_ALIASES: Record<string, string> = {
-  gmail: "google",
-};
-
-/** Resolve a service name through aliases. */
-export function resolveService(service: string): string {
-  return SERVICE_ALIASES[service] ?? service;
-}
-
 /** Look up a provider behavior by canonical service name. */
 export function getProviderBehavior(
   service: string,

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -167,12 +167,14 @@ async function handleOAuthConnectStart(body: {
     return httpError("BAD_REQUEST", "Missing required field: service", 400);
   }
 
+  const service = body.service;
+
   // Resolve client_id and client_secret from oauth-store.
   let clientId: string | undefined;
   let clientSecret: string | undefined;
 
   // Try existing connection first (re-auth flow)
-  const conn = getConnectionByProvider(body.service);
+  const conn = getConnectionByProvider(service);
   if (conn) {
     const app = getApp(conn.oauthAppId);
     if (app) {
@@ -183,7 +185,7 @@ async function handleOAuthConnectStart(body: {
 
   // Fall back to most recent app for this provider (first-time connect with stored app)
   if (!clientId) {
-    const dbApp = getMostRecentAppByProvider(body.service);
+    const dbApp = getMostRecentAppByProvider(service);
     if (dbApp) {
       clientId = dbApp.clientId;
       if (!clientSecret) {
@@ -197,20 +199,20 @@ async function handleOAuthConnectStart(body: {
   if (!clientId) {
     return httpError(
       "BAD_REQUEST",
-      `No client_id found for "${body.service}". Store it first via the credential vault.`,
+      `No client_id found for "${service}". Store it first via the credential vault.`,
       400,
     );
   }
 
-  const behavior = getProviderBehavior(body.service);
-  const providerRow = getProvider(body.service);
+  const behavior = getProviderBehavior(service);
+  const providerRow = getProvider(service);
   const requiresSecret =
     behavior?.setup?.requiresClientSecret ??
     !!(providerRow?.tokenEndpointAuthMethod || providerRow?.extraParams);
   if (requiresSecret && !clientSecret) {
     return httpError(
       "BAD_REQUEST",
-      `client_secret is required for "${body.service}" but not found in the credential store. Store it first via the credential vault.`,
+      `client_secret is required for "${service}" but not found in the credential store. Store it first via the credential vault.`,
       400,
     );
   }
@@ -221,7 +223,7 @@ async function handleOAuthConnectStart(body: {
     let authUrl: string | undefined;
 
     const result = await orchestrateOAuthConnect({
-      service: body.service,
+      service,
       requestedScopes: body.requestedScopes,
       clientId,
       clientSecret,
@@ -233,7 +235,7 @@ async function handleOAuthConnectStart(body: {
         // Prefer accountInfo from oauth-store when available.
         let accountInfo = deferredResult.accountInfo;
         try {
-          const conn = getConnectionByProvider(body.service);
+          const conn = getConnectionByProvider(service);
           if (conn?.accountInfo) accountInfo = conn.accountInfo;
         } catch {
           // DB not ready — use orchestrator value
@@ -272,7 +274,7 @@ async function handleOAuthConnectStart(body: {
 
     if (!result.success) {
       log.error(
-        { err: result.error, service: body.service },
+        { err: result.error, service },
         "OAuth connect orchestrator returned error",
       );
       return httpError(
@@ -293,7 +295,7 @@ async function handleOAuthConnectStart(body: {
     // Prefer accountInfo from oauth-store when available.
     let responseAccountInfo = result.accountInfo;
     try {
-      const conn = getConnectionByProvider(body.service);
+      const conn = getConnectionByProvider(service);
       if (conn?.accountInfo) responseAccountInfo = conn.accountInfo;
     } catch {
       // DB not ready — use orchestrator value
@@ -307,7 +309,7 @@ async function handleOAuthConnectStart(body: {
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    log.error({ err, service: body.service }, "OAuth connect flow failed");
+    log.error({ err, service }, "OAuth connect flow failed");
     return httpError("INTERNAL_ERROR", sanitizeOAuthError(message), 500);
   }
 }

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -30,10 +30,7 @@ import {
   getMostRecentAppByProvider,
   getProvider,
 } from "../../oauth/oauth-store.js";
-import {
-  getProviderBehavior,
-  resolveService,
-} from "../../oauth/provider-behaviors.js";
+import { getProviderBehavior } from "../../oauth/provider-behaviors.js";
 import {
   check,
   classifyRisk,
@@ -170,14 +167,12 @@ async function handleOAuthConnectStart(body: {
     return httpError("BAD_REQUEST", "Missing required field: service", 400);
   }
 
-  const resolvedService = resolveService(body.service);
-
   // Resolve client_id and client_secret from oauth-store.
   let clientId: string | undefined;
   let clientSecret: string | undefined;
 
   // Try existing connection first (re-auth flow)
-  const conn = getConnectionByProvider(resolvedService);
+  const conn = getConnectionByProvider(body.service);
   if (conn) {
     const app = getApp(conn.oauthAppId);
     if (app) {
@@ -188,7 +183,7 @@ async function handleOAuthConnectStart(body: {
 
   // Fall back to most recent app for this provider (first-time connect with stored app)
   if (!clientId) {
-    const dbApp = getMostRecentAppByProvider(resolvedService);
+    const dbApp = getMostRecentAppByProvider(body.service);
     if (dbApp) {
       clientId = dbApp.clientId;
       if (!clientSecret) {
@@ -207,8 +202,8 @@ async function handleOAuthConnectStart(body: {
     );
   }
 
-  const behavior = getProviderBehavior(resolvedService);
-  const providerRow = getProvider(resolvedService);
+  const behavior = getProviderBehavior(body.service);
+  const providerRow = getProvider(body.service);
   const requiresSecret =
     behavior?.setup?.requiresClientSecret ??
     !!(providerRow?.tokenEndpointAuthMethod || providerRow?.extraParams);
@@ -238,7 +233,7 @@ async function handleOAuthConnectStart(body: {
         // Prefer accountInfo from oauth-store when available.
         let accountInfo = deferredResult.accountInfo;
         try {
-          const conn = getConnectionByProvider(resolvedService);
+          const conn = getConnectionByProvider(body.service);
           if (conn?.accountInfo) accountInfo = conn.accountInfo;
         } catch {
           // DB not ready — use orchestrator value
@@ -298,7 +293,7 @@ async function handleOAuthConnectStart(body: {
     // Prefer accountInfo from oauth-store when available.
     let responseAccountInfo = result.accountInfo;
     try {
-      const conn = getConnectionByProvider(resolvedService);
+      const conn = getConnectionByProvider(body.service);
       if (conn?.accountInfo) responseAccountInfo = conn.accountInfo;
     } catch {
       // DB not ready — use orchestrator value

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -15,7 +15,6 @@ import {
 import {
   getProviderBehavior,
   PROVIDER_BEHAVIORS,
-  resolveService,
 } from "../../oauth/provider-behaviors.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
@@ -822,15 +821,12 @@ class CredentialStoreTool implements Tool {
       }
 
       case "oauth2_connect": {
-        const rawService = input.service as string | undefined;
-        if (!rawService)
+        const service = input.service as string | undefined;
+        if (!service)
           return {
             content: "Error: service is required for oauth2_connect action",
             isError: true,
           };
-
-        // Resolve aliases (e.g. "gmail" → "google")
-        const service = resolveService(rawService);
 
         // Code-side behavioral fields (identityVerifier, setup, etc.)
         const behavior = getProviderBehavior(service);
@@ -889,7 +885,7 @@ class CredentialStoreTool implements Tool {
             ? `\n\nLoad the "${skillId}" skill for provider-specific instructions on obtaining the client secret.`
             : '\n\nUse credential_store with action "prompt" to securely collect the client_secret from the user before calling oauth2_connect again.';
           return {
-            content: `Error: client_secret is required for ${rawService} but not found in the vault.${skillHint}`,
+            content: `Error: client_secret is required for ${service} but not found in the vault.${skillHint}`,
             isError: true,
           };
         }
@@ -897,7 +893,7 @@ class CredentialStoreTool implements Tool {
         // Delegate to the shared orchestrator - it resolves authUrl, tokenUrl,
         // extraParams, userinfoUrl, and tokenEndpointAuthMethod from the DB.
         const result = await orchestrateOAuthConnect({
-          service: rawService,
+          service,
           clientId,
           clientSecret,
           isInteractive: !!context.isInteractive,
@@ -949,7 +945,7 @@ class CredentialStoreTool implements Tool {
 
         if (result.deferred) {
           return {
-            content: `To connect ${rawService}, open this link and authorize access:\n\n${result.authUrl}\n\nOnce you authorize, the connection will be set up automatically. You can verify by asking me to check your inbox.`,
+            content: `To connect ${service}, open this link and authorize access:\n\n${result.authUrl}\n\nOnce you authorize, the connection will be set up automatically. You can verify by asking me to check your inbox.`,
             isError: false,
           };
         }
@@ -963,25 +959,24 @@ class CredentialStoreTool implements Tool {
       }
 
       case "describe": {
-        const rawService = (input.service as string | undefined) ?? "";
-        if (!rawService) {
+        const descService = (input.service as string | undefined) ?? "";
+        if (!descService) {
           return {
             content: "Error: service is required for describe action",
             isError: true,
           };
         }
-        const resolvedService = resolveService(rawService);
-        const descProviderRow = getProvider(resolvedService);
+        const descProviderRow = getProvider(descService);
         if (!descProviderRow) {
           return {
-            content: `No well-known OAuth config found for "${rawService}". Available services: ${Object.keys(
+            content: `No well-known OAuth config found for "${descService}". Available services: ${Object.keys(
               PROVIDER_BEHAVIORS,
             ).join(", ")}`,
             isError: false,
           };
         }
 
-        const descBehavior = getProviderBehavior(resolvedService);
+        const descBehavior = getProviderBehavior(descService);
 
         // Compute the redirect URI based on callback transport
         let redirectUri: string;
@@ -1023,7 +1018,7 @@ class CredentialStoreTool implements Tool {
           : [];
 
         const info: Record<string, unknown> = {
-          service: resolvedService,
+          service: descService,
           authUrl: descProviderRow.authUrl,
           tokenUrl: descProviderRow.tokenUrl,
           scopes: descDefaultScopes,


### PR DESCRIPTION
## Summary
- Delete SERVICE_ALIASES and resolveService() from provider-behaviors.ts
- Remove re-export from shared.ts and all imports across 12 files
- Simplify all CLI commands, connect-orchestrator, settings-routes, and vault to use provider names directly
- Clean up dead resolvedServiceKey alias and double-resolution patterns

Part of plan: remove-oauth-service-aliases.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
