### PR TITLE
feat: add rename_conversation skill (JARVIS-92)

### DIFF
--- a/assistant/src/config/bundled-skills/conversations/SKILL.md
+++ b/assistant/src/config/bundled-skills/conversations/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: conversations
+description: Manage conversation threads (rename)
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "\U0001F4AC"
+  vellum:
+    display-name: "Conversations"
+---
+
+Tools for managing conversation threads.
+
+## Renaming
+
+Use the `rename_conversation` tool to rename the current conversation thread when:
+- The topic has shifted significantly from the original title
+- The auto-generated title is generic or unhelpful
+- The user explicitly asks to rename the thread
+
+Keep titles concise (under 60 characters) and descriptive of the current topic.

--- a/assistant/src/config/bundled-skills/conversations/TOOLS.json
+++ b/assistant/src/config/bundled-skills/conversations/TOOLS.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "rename_conversation",
+      "description": "Rename the current conversation thread. Use this when the conversation topic has shifted significantly from the original title, or when you notice the title is generic/unhelpful and you can provide a better one based on what has been discussed.",
+      "category": "conversation",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "The new title for the conversation. Should be concise (under 60 characters) and descriptive of the current topic."
+          }
+        },
+        "required": ["title"]
+      },
+      "executor": "tools/rename-conversation.ts",
+      "execution_target": "sandbox"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/conversations/TOOLS.json
+++ b/assistant/src/config/bundled-skills/conversations/TOOLS.json
@@ -17,7 +17,7 @@
         "required": ["title"]
       },
       "executor": "tools/rename-conversation.ts",
-      "execution_target": "sandbox"
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/conversations/tools/rename-conversation.ts
+++ b/assistant/src/config/bundled-skills/conversations/tools/rename-conversation.ts
@@ -1,0 +1,66 @@
+import {
+  getConversation,
+  updateConversationTitle,
+} from "../../../../memory/conversation-crud.js";
+import { buildAssistantEvent } from "../../../../runtime/assistant-event.js";
+import { assistantEventHub } from "../../../../runtime/assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../../../runtime/assistant-scope.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { getLogger } from "../../../../util/logger.js";
+
+const log = getLogger("rename-conversation");
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const title = input.title;
+  if (typeof title !== "string" || title.trim() === "") {
+    return {
+      content: "Error: title must be a non-empty string.",
+      isError: true,
+    };
+  }
+
+  const trimmedTitle = title.trim();
+  const conversationId = context.conversationId;
+
+  const conversation = getConversation(conversationId);
+  if (!conversation) {
+    return {
+      content: `Error: conversation ${conversationId} not found.`,
+      isError: true,
+    };
+  }
+
+  // Persist with isAutoTitle = 0 so auto-generation won't overwrite it
+  updateConversationTitle(conversationId, trimmedTitle, 0);
+
+  // Notify connected clients so the UI updates immediately
+  const assistantId = context.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
+  assistantEventHub
+    .publish(
+      buildAssistantEvent(
+        assistantId,
+        {
+          type: "conversation_title_updated",
+          conversationId,
+          title: trimmedTitle,
+        },
+        conversationId,
+      ),
+    )
+    .catch((err) => {
+      log.warn({ err }, "Failed to publish conversation_title_updated event");
+    });
+
+  log.info({ conversationId, title: trimmedTitle }, "Conversation renamed");
+
+  return {
+    content: `Conversation renamed to "${trimmedTitle}".`,
+    isError: false,
+  };
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -56,6 +56,8 @@ import * as contactMerge from "./bundled-skills/contacts/tools/contact-merge.js"
 import * as contactSearch from "./bundled-skills/contacts/tools/contact-search.js";
 import * as contactUpsert from "./bundled-skills/contacts/tools/contact-upsert.js";
 import * as googleContacts from "./bundled-skills/contacts/tools/google-contacts.js";
+// ── conversations ─────────────────────────────────────────────────────────────
+import * as renameConversation from "./bundled-skills/conversations/tools/rename-conversation.js";
 // ── document ───────────────────────────────────────────────────────────────────
 import * as documentCreate from "./bundled-skills/document/tools/document-create.js";
 import * as documentUpdate from "./bundled-skills/document/tools/document-update.js";
@@ -221,6 +223,9 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["contacts:tools/contact-search.ts", contactSearch],
   ["contacts:tools/contact-merge.ts", contactMerge],
   ["contacts:tools/google-contacts.ts", googleContacts],
+
+  // conversations
+  ["conversations:tools/rename-conversation.ts", renameConversation],
 
   // document
   ["document:tools/document-create.ts", documentCreate],


### PR DESCRIPTION
## Summary
- Adds a `rename_conversation` bundled skill that gives the assistant a tool to rename conversation threads at any point in a conversation
- Persists with `isAutoTitle = 0` so auto-generation won't overwrite assistant-set titles
- Publishes `conversation_title_updated` event so connected clients update immediately

## Test plan
- [ ] Start a new conversation, send a message, then ask the assistant to rename the thread
- [ ] Verify the title updates in the sidebar immediately
- [ ] Verify auto-title generation does not overwrite the renamed title on subsequent messages

Closes JARVIS-92

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
