### PR TITLE
Remove resolveService mocks and gmail alias test cases

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -213,7 +213,6 @@ mock.module("../oauth/connect-orchestrator.js", () => ({
 // ---------------------------------------------------------------------------
 
 mock.module("../oauth/provider-behaviors.js", () => ({
-  resolveService: (service: string) => service,
   getProviderBehavior: (providerKey: string) =>
     mockGetProviderBehavior(providerKey),
 }));

--- a/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
@@ -81,12 +81,6 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
 }));
 
 mock.module("../../../../oauth/provider-behaviors.js", () => ({
-  resolveService: (service: string) => {
-    const aliases: Record<string, string> = {
-      gmail: "google",
-    };
-    return aliases[service] ?? service;
-  },
   getProviderBehavior: (key: string) => mockGetProviderBehavior(key),
 }));
 
@@ -130,12 +124,6 @@ mock.module("../../../lib/daemon-credential-client.js", () => ({
 
 // Mock shared.js helpers to control managed vs BYO mode routing
 mock.module("../shared.js", () => ({
-  resolveService: (service: string) => {
-    const aliases: Record<string, string> = {
-      gmail: "google",
-    };
-    return aliases[service] ?? service;
-  },
   isManagedMode: (key: string) => mockIsManagedMode(key),
   requirePlatformClient: async (_cmd: Command) => {
     if (
@@ -277,43 +265,6 @@ describe("assistant oauth connect", () => {
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("Unknown provider");
     expect(parsed.error).toContain("providers list");
-  });
-
-  // -------------------------------------------------------------------------
-  // Provider alias resolution
-  // -------------------------------------------------------------------------
-
-  test("provider alias 'gmail' resolves to google", async () => {
-    let capturedProviderKey: string | undefined;
-
-    mockGetProvider = (key: string) => {
-      capturedProviderKey = key;
-      return {
-        providerKey: key,
-        authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-        tokenUrl: "https://oauth2.googleapis.com/token",
-        managedServiceConfigKey: null,
-      };
-    };
-
-    mockGetMostRecentAppByProvider = () => ({
-      id: "app-1",
-      clientId: "test-id",
-      clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "google",
-      createdAt: 0,
-      updatedAt: 0,
-    });
-
-    mockOrchestrateOAuthConnect = async () => ({
-      success: true,
-      deferred: false,
-      grantedScopes: ["read"],
-      accountInfo: "user@example.com",
-    });
-
-    await runCommand(["connect", "gmail", "--json"]);
-    expect(capturedProviderKey).toBe("google");
   });
 
   // -------------------------------------------------------------------------

--- a/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
@@ -98,12 +98,6 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
 }));
 
 mock.module("../../../../oauth/provider-behaviors.js", () => ({
-  resolveService: (service: string) => {
-    const aliases: Record<string, string> = {
-      gmail: "google",
-    };
-    return aliases[service] ?? service;
-  },
   getProviderBehavior: () => undefined,
 }));
 
@@ -161,12 +155,6 @@ mock.module("../../../lib/daemon-credential-client.js", () => ({
 
 // Mock shared.js helpers to control managed vs BYO mode routing
 mock.module("../shared.js", () => ({
-  resolveService: (service: string) => {
-    const aliases: Record<string, string> = {
-      gmail: "google",
-    };
-    return aliases[service] ?? service;
-  },
   isManagedMode: (key: string) => mockIsManagedMode(key),
   requirePlatformClient: async (_cmd: Command) => {
     if (

--- a/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
@@ -90,12 +90,6 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
 }));
 
 mock.module("../../../../oauth/provider-behaviors.js", () => ({
-  resolveService: (service: string) => {
-    const aliases: Record<string, string> = {
-      gmail: "google",
-    };
-    return aliases[service] ?? service;
-  },
   getProviderBehavior: () => undefined,
 }));
 
@@ -127,12 +121,6 @@ mock.module("../../../lib/daemon-credential-client.js", () => ({
 
 // Mock shared.js helpers
 mock.module("../shared.js", () => ({
-  resolveService: (service: string) => {
-    const aliases: Record<string, string> = {
-      gmail: "google",
-    };
-    return aliases[service] ?? service;
-  },
   isManagedMode: () => false,
   getManagedServiceConfigKey: (key: string) =>
     mockGetManagedServiceConfigKey(key),
@@ -281,25 +269,6 @@ describe("assistant oauth mode", () => {
       expect(parsed.ok).toBe(false);
       expect(parsed.error).toContain("Unknown provider");
       expect(parsed.error).toContain("providers list");
-    });
-
-    test("provider alias resolution: gmail resolves to google", async () => {
-      let capturedProviderKey: string | undefined;
-
-      mockGetProvider = (key: string) => {
-        capturedProviderKey = key;
-        return {
-          providerKey: key,
-          managedServiceConfigKey: "google-oauth",
-        };
-      };
-      mockGetManagedServiceConfigKey = () => "google-oauth";
-      mockConfigServices = {
-        "google-oauth": { mode: "managed" },
-      };
-
-      await runCommand(["mode", "gmail", "--json"]);
-      expect(capturedProviderKey).toBe("google");
     });
 
     test("provider without managedServiceConfigKey returns your-own with managedModeSupported: false", async () => {

--- a/assistant/src/cli/commands/oauth/__tests__/ping.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/ping.test.ts
@@ -52,12 +52,6 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
 }));
 
 mock.module("../../../../oauth/provider-behaviors.js", () => ({
-  resolveService: (service: string) => {
-    const aliases: Record<string, string> = {
-      gmail: "google",
-    };
-    return aliases[service] ?? service;
-  },
   getProviderBehavior: () => undefined,
 }));
 
@@ -97,12 +91,6 @@ mock.module("../../../../util/logger.js", () => ({
 
 // Mock shared.js helpers
 mock.module("../shared.js", () => ({
-  resolveService: (service: string) => {
-    const aliases: Record<string, string> = {
-      gmail: "google",
-    };
-    return aliases[service] ?? service;
-  },
   isManagedMode: () => false,
   requirePlatformClient: async () => null,
   fetchActiveConnections: async () => [],
@@ -212,35 +200,6 @@ describe("assistant oauth ping", () => {
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("No ping URL configured");
     expect(parsed.error).toContain("providers register --ping-url");
-  });
-
-  // -------------------------------------------------------------------------
-  // Provider alias resolution
-  // -------------------------------------------------------------------------
-
-  test("resolves provider alias (gmail -> google)", async () => {
-    mockGetProvider = () => ({
-      providerKey: "google",
-      pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
-    });
-
-    mockResolveOAuthConnectionResult = {
-      request: async () => ({
-        status: 200,
-        headers: {},
-        body: { ok: true },
-      }),
-    };
-
-    const { exitCode, stdout } = await runCommand(["ping", "gmail", "--json"]);
-    expect(exitCode).toBe(0);
-    const parsed = JSON.parse(stdout);
-    expect(parsed.ok).toBe(true);
-    expect(parsed.provider).toBe("google");
-
-    // Verify resolveOAuthConnection was called with resolved key
-    expect(mockResolveOAuthConnectionCalls).toHaveLength(1);
-    expect(mockResolveOAuthConnectionCalls[0].providerKey).toBe("google");
   });
 
   // =========================================================================

--- a/assistant/src/cli/commands/oauth/__tests__/status.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/status.test.ts
@@ -57,12 +57,6 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
 }));
 
 mock.module("../../../../oauth/provider-behaviors.js", () => ({
-  resolveService: (service: string) => {
-    const aliases: Record<string, string> = {
-      gmail: "google",
-    };
-    return aliases[service] ?? service;
-  },
   getProviderBehavior: () => undefined,
 }));
 
@@ -106,12 +100,6 @@ mock.module("../../../lib/daemon-credential-client.js", () => ({
 
 // Mock shared.js helpers to control managed vs BYO mode routing
 mock.module("../shared.js", () => ({
-  resolveService: (service: string) => {
-    const aliases: Record<string, string> = {
-      gmail: "google",
-    };
-    return aliases[service] ?? service;
-  },
   isManagedMode: (key: string) => mockIsManagedMode(key),
   requirePlatformClient: async (_cmd: Command) => {
     if (

--- a/assistant/src/cli/commands/oauth/__tests__/token.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/token.test.ts
@@ -55,12 +55,6 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
 }));
 
 mock.module("../../../../oauth/provider-behaviors.js", () => ({
-  resolveService: (service: string) => {
-    const aliases: Record<string, string> = {
-      gmail: "google",
-    };
-    return aliases[service] ?? service;
-  },
   getProviderBehavior: () => undefined,
 }));
 
@@ -94,12 +88,6 @@ mock.module("../../../lib/daemon-credential-client.js", () => ({
 
 // Mock shared.js helpers to control managed vs BYO mode routing
 mock.module("../shared.js", () => ({
-  resolveService: (service: string) => {
-    const aliases: Record<string, string> = {
-      gmail: "google",
-    };
-    return aliases[service] ?? service;
-  },
   isManagedMode: (key: string) => mockIsManagedMode(key),
 }));
 
@@ -221,25 +209,6 @@ describe("assistant oauth token", () => {
       expect(parsed.ok).toBe(false);
       expect(parsed.error).toContain("No access token found");
     });
-  });
-
-  // =========================================================================
-  // Provider alias resolution
-  // =========================================================================
-
-  test("resolves provider alias (gmail -> google)", async () => {
-    let calledWithService = "";
-    mockWithValidToken = async (service, callback) => {
-      calledWithService = service;
-      return callback("alias-token");
-    };
-
-    const { exitCode, stdout } = await runCommand(["token", "gmail", "--json"]);
-    expect(exitCode).toBe(0);
-    expect(calledWithService).toBe("google");
-    const parsed = JSON.parse(stdout);
-    expect(parsed.ok).toBe(true);
-    expect(parsed.token).toBe("alias-token");
   });
 
   // =========================================================================


### PR DESCRIPTION
## Summary
- Remove resolveService from mock.module() blocks in 6 CLI command test files
- Delete gmail alias resolution test cases from connect, ping, token, and mode tests
- Remove identity resolveService mock from oauth-cli.test.ts
- Verify oauth-provider-profiles.test.ts already updated by PR 1

Part of plan: remove-oauth-service-aliases.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
