### PR TITLE
feat: add configurable pop-out conversation shortcut to settings

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -78,7 +78,6 @@ struct VellumAssistantApp: App {
                 Button("Pop Out Conversation") {
                     appDelegate.popOutActiveConversation()
                 }
-                .keyboardShortcut("p", modifiers: .command)
             }
             // View menu: zoom shortcuts for discoverability.
             // The actual handling is done by event monitors (registerZoomMonitor)

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -72,6 +72,12 @@ extension UserDefaults {
         }
         return string(forKey: "currentConversationShortcut") ?? ""
     }
+    @objc dynamic var popOutShortcut: String {
+        if UserDefaults.standard.object(forKey: "popOutShortcut") == nil {
+            return "cmd+p"
+        }
+        return string(forKey: "popOutShortcut") ?? ""
+    }
 }
 
 // MARK: - Input Monitors
@@ -88,6 +94,7 @@ extension AppDelegate {
         registerCmdKMonitor()
         registerNewChatMonitor()
         registerCurrentConversationMonitor()
+        registerPopOutMonitor()
 
         globalHotkeyObserver = Publishers.Merge4(
             UserDefaults.standard.publisher(for: \.globalHotkeyShortcut).map { _ in () },
@@ -97,6 +104,7 @@ extension AppDelegate {
         )
         .merge(with: UserDefaults.standard.publisher(for: \.newChatShortcut).map { _ in () })
         .merge(with: UserDefaults.standard.publisher(for: \.currentConversationShortcut).map { _ in () })
+        .merge(with: UserDefaults.standard.publisher(for: \.popOutShortcut).map { _ in () })
         .debounce(for: .milliseconds(100), scheduler: RunLoop.main)
         .sink { [weak self] _ in
             self?.registerGlobalHotkeyMonitor()
@@ -104,6 +112,7 @@ extension AppDelegate {
             self?.registerSidebarToggleMonitor()
             self?.registerNewChatMonitor()
             self?.registerCurrentConversationMonitor()
+            self?.registerPopOutMonitor()
             self?.updateNewChatMenuItemShortcut()
             self?.updateCurrentConversationMenuItemShortcut()
         }
@@ -206,6 +215,10 @@ extension AppDelegate {
         if let monitor = sidebarToggleLocalMonitor {
             NSEvent.removeMonitor(monitor)
             sidebarToggleLocalMonitor = nil
+        }
+        if let monitor = popOutLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            popOutLocalMonitor = nil
         }
     }
 
@@ -372,6 +385,37 @@ extension AppDelegate {
             return nil
         }
         sidebarToggleLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+    }
+
+    /// Registers a local event monitor to pop out the active conversation into
+    /// a new window when the configured shortcut (default: Cmd+P) is pressed.
+    /// The shortcut is read dynamically from UserDefaults so it can be
+    /// reconfigured without restarting.
+    func registerPopOutMonitor() {
+        if let existing = popOutLocalMonitor {
+            NSEvent.removeMonitor(existing)
+            popOutLocalMonitor = nil
+        }
+
+        let shortcut = UserDefaults.standard.string(forKey: "popOutShortcut") ?? "cmd+p"
+        guard !shortcut.isEmpty else { return }
+
+        let (targetModifiers, targetKey) = ShortcutHelper.parseShortcut(shortcut)
+
+        let handler: (NSEvent) -> NSEvent? = { [weak self] event in
+            guard self?.isBootstrapping != true,
+                  self?.mainWindow?.isVisible == true else { return event }
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask).subtracting(.numericPad)
+            guard mods == targetModifiers,
+                  event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else {
+                return event
+            }
+            Task { @MainActor in
+                self?.popOutActiveConversation()
+            }
+            return nil
+        }
+        popOutLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
     }
 
     /// Registers Cmd+=/Cmd+-/Cmd+0 as local shortcuts for window zoom.

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -60,6 +60,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var navLocalMonitor: Any?
     var zoomLocalMonitor: Any?
     var sidebarToggleLocalMonitor: Any?
+    var popOutLocalMonitor: Any?
     public let services = AppServices()
     let vellumCli = VellumCli()
     public let updateManager = UpdateManager()

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -13,6 +13,7 @@ struct SettingsAppearanceTab: View {
     @State private var isRecordingSidebarToggle = false
     @State private var isRecordingNewChat = false
     @State private var isRecordingCurrentConversation = false
+    @State private var isRecordingPopOut = false
     @State private var isRecordingVoiceInput = false
     @State private var shortcutMonitor: Any?
     @State private var flagsMonitor: Any?
@@ -386,6 +387,39 @@ struct SettingsAppearanceTab: View {
 
                 SettingsDivider()
 
+                // Pop out conversation (configurable)
+                HStack {
+                    Text("Pop out conversation")
+                        .font(VFont.bodyMediumLighter)
+                        .foregroundStyle(VColor.contentSecondary)
+                    Spacer()
+                    if isRecordingPopOut, let display = recordingDisplayString, !display.isEmpty {
+                        VShortcutTag(display)
+                    } else {
+                        VShortcutTag(ShortcutHelper.displayString(for: store.popOutShortcut))
+                    }
+
+                    if isRecordingPopOut {
+                        VButton(label: "Press shortcut...", style: .outlined) {
+                            stopRecording()
+                        }
+                    } else {
+                        HStack(spacing: VSpacing.sm) {
+                            VButton(label: "Record", style: .outlined) {
+                                startRecordingPopOut()
+                            }
+                            if !store.popOutShortcut.isEmpty {
+                                VButton(label: "Unbind", style: .outlined) {
+                                    store.popOutShortcut = ""
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical, VSpacing.md)
+
+                SettingsDivider()
+
                 VToggle(
                     isOn: Binding(
                         get: { store.cmdEnterToSend },
@@ -602,6 +636,13 @@ struct SettingsAppearanceTab: View {
         isRecordingCurrentConversation = true
     }
 
+    private func startRecordingPopOut() {
+        startRecordingShortcut { shortcut, _ in
+            store.popOutShortcut = shortcut
+        }
+        isRecordingPopOut = true
+    }
+
     /// Shared recording logic. The callback receives the shortcut string and the raw NSEvent key code.
     private func startRecordingShortcut(onRecord: @escaping (String, UInt16) -> Void) {
         stopRecording()
@@ -648,6 +689,7 @@ struct SettingsAppearanceTab: View {
         isRecordingSidebarToggle = false
         isRecordingNewChat = false
         isRecordingCurrentConversation = false
+        isRecordingPopOut = false
         recordingDisplayString = nil
         if let monitor = shortcutMonitor {
             NSEvent.removeMonitor(monitor)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -82,6 +82,7 @@ public final class SettingsStore: ObservableObject {
     @Published var sidebarToggleShortcut: String
     @Published var newChatShortcut: String
     @Published var currentConversationShortcut: String
+    @Published var popOutShortcut: String
     @Published var cmdEnterToSend: Bool
 
     // MARK: - Media Embed Settings
@@ -431,6 +432,11 @@ public final class SettingsStore: ObservableObject {
         } else {
             self.currentConversationShortcut = UserDefaults.standard.string(forKey: "currentConversationShortcut") ?? ""
         }
+        if UserDefaults.standard.object(forKey: "popOutShortcut") == nil {
+            self.popOutShortcut = "cmd+p"
+        } else {
+            self.popOutShortcut = UserDefaults.standard.string(forKey: "popOutShortcut") ?? ""
+        }
 
         // Use defaults for config-dependent properties; the daemon will
         // provide authoritative values once reachable via loadConfigFromDaemon().
@@ -519,6 +525,11 @@ public final class SettingsStore: ObservableObject {
         $currentConversationShortcut
             .dropFirst()
             .sink { value in UserDefaults.standard.set(value, forKey: "currentConversationShortcut") }
+            .store(in: &cancellables)
+
+        $popOutShortcut
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "popOutShortcut") }
             .store(in: &cancellables)
 
         // Mirror GatewayConnectionManager's trust-rules-open flag so views can disable their buttons


### PR DESCRIPTION
## Summary
- Adds "Pop out conversation" (default ⌘P) to the Keyboard Shortcuts settings section with Record/Unbind support
- Replaces the hardcoded SwiftUI menu shortcut with a dynamic event monitor so the shortcut can be reconfigured or disabled
- Follows the same pattern as existing configurable shortcuts (sidebar toggle, new chat, etc.)

## Test plan
- [ ] Open Settings → Appearance → Keyboard Shortcuts and verify "Pop out conversation" row appears with ⌘ P
- [ ] Press ⌘P with a conversation open to verify it pops out into a new window
- [ ] Use "Record" to rebind the shortcut, confirm the new binding works
- [ ] Use "Unbind" to disable the shortcut, confirm ⌘P no longer triggers popout
- [ ] Verify the "Pop Out Conversation" menu item still appears in the File menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
