### PR TITLE
feat: ACP permission UX improvements

### DIFF
--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -55,6 +55,8 @@ export class VellumAcpClientHandler implements Client {
   private accumulatedText = "";
   /** Tracks pending ACP permission requestIds for cleanup on session close. */
   readonly pendingRequestIds = new Set<string>();
+  /** When true, auto-approve all subsequent permission requests for this session. */
+  private autoApproveAll = false;
 
   /** Returns the full agent response text accumulated from agent_message_chunk events. */
   get responseText(): string {
@@ -164,6 +166,7 @@ export class VellumAcpClientHandler implements Client {
         toolTitle,
         toolKind,
         optionCount: options.length,
+        autoApproveAll: this.autoApproveAll,
       },
       "ACP permission requested",
     );
@@ -178,6 +181,26 @@ export class VellumAcpClientHandler implements Client {
         : { command: rawInput };
 
     const toolName = `ACP Agent: ${toolTitle}`;
+
+    // If the user previously chose "Allow all for this session", auto-approve
+    // and show the decided indicator directly (no pending flash).
+    if (this.autoApproveAll) {
+      this.sendToVellum({
+        type: "confirmation_request",
+        requestId,
+        toolName,
+        input,
+        riskLevel: "medium",
+        allowlistOptions: [],
+        scopeOptions: [],
+        persistentDecisionsAllowed: false,
+        acpToolKind: toolKind,
+        acpOptions: [],
+        conversationId: this.parentConversationId,
+      });
+      const optionId = mapDecisionToOptionId("allow", options);
+      return { outcome: { outcome: "selected", optionId } };
+    }
     const acpOptions = options.map((opt) => ({
       optionId: opt.optionId,
       name: opt.name,
@@ -195,6 +218,7 @@ export class VellumAcpClientHandler implements Client {
       allowlistOptions: [],
       scopeOptions: [],
       persistentDecisionsAllowed: false,
+      temporaryOptionsAvailable: ["allow_conversation"],
       acpToolKind: toolKind,
       acpOptions,
       conversationId: this.parentConversationId,
@@ -208,6 +232,13 @@ export class VellumAcpClientHandler implements Client {
       const timer = setTimeout(() => {
         const pending = pendingInteractions.resolve(requestId);
         if (pending?.directResolve) {
+          this.sendToVellum({
+            type: "confirmation_state_changed",
+            conversationId: this.parentConversationId,
+            requestId,
+            state: "timed_out",
+            source: "timeout",
+          });
           pending.directResolve("deny");
         }
       }, timeoutMs);
@@ -224,12 +255,26 @@ export class VellumAcpClientHandler implements Client {
           allowlistOptions: [],
           scopeOptions: [],
           persistentDecisionsAllowed: false,
+          temporaryOptionsAvailable: ["allow_conversation"],
           acpToolKind: toolKind,
           acpOptions,
         },
         directResolve: (decision: UserDecision) => {
           clearTimeout(timer);
           this.pendingRequestIds.delete(requestId);
+          // "Allow for this conversation" => auto-approve all future
+          // requests in this ACP session.
+          if (decision === "allow_conversation") {
+            this.autoApproveAll = true;
+          }
+          const isApproved = decision !== "deny" && decision !== "always_deny";
+          this.sendToVellum({
+            type: "confirmation_state_changed",
+            conversationId: this.parentConversationId,
+            requestId,
+            state: isApproved ? "approved" : "denied",
+            source: "button",
+          });
           const optionId = mapDecisionToOptionId(decision, options);
           resolve(optionId);
         },

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -352,9 +352,13 @@ struct MessageListView: View {
 
         var nextDecidedConfirmationByIndex: [Int: ToolConfirmationData] = [:]
         for i in liveMessages.indices {
+            // Only absorb decided confirmations that have a toolUseId — these
+            // can be rendered as chips on the preceding assistant's tool call.
+            // ACP confirmations have no toolUseId and must stay standalone.
             if i + 1 < liveMessages.count,
                let conf = liveMessages[i + 1].confirmation,
-               conf.state != .pending {
+               conf.state != .pending,
+               conf.toolUseId != nil, !conf.toolUseId!.isEmpty {
                 nextDecidedConfirmationByIndex[i] = conf
             }
         }
@@ -1202,7 +1206,12 @@ private struct MessageCellView: View, Equatable {
                     .id(message.id)
                 }
             } else {
-                if !hasPrecedingAssistant {
+                // Show standalone decided card when there's no preceding
+                // assistant to absorb it, OR when the confirmation has no
+                // toolUseId (e.g. ACP permissions that can't be rendered
+                // as chips on a tool call).
+                let hasToolUseId = confirmation.toolUseId != nil && !confirmation.toolUseId!.isEmpty
+                if !hasPrecedingAssistant || !hasToolUseId {
                     ToolConfirmationBubble(
                         confirmation: confirmation,
                         onAllow: { onConfirmationAllow(confirmation.requestId) },


### PR DESCRIPTION
## Summary
- Add "Allow for this conversation" option to ACP permission prompts — auto-approves all subsequent requests in that ACP session without re-prompting
- Emit `confirmation_state_changed` events for ACP approvals/denials/timeouts so the client shows decided state
- Keep ACP decided confirmation cards visible as standalone chips (they have no `toolUseId` so can't be absorbed into tool call bubbles)

## Test plan
- [x] Manual: "Allow once" shows decided indicator after approval
- [x] Manual: "Allow for this conversation" auto-approves subsequent requests
- [x] Manual: Auto-approve only affects the current ACP session, not parent conversation or future sessions
- [x] TypeScript typecheck passes
- [x] All ACP tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
