### PR TITLE
fix: focus input placeholder suggestion on last question in message (JARVIS-352)

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1333,7 +1333,7 @@ async function generateLlmSuggestion(
   const truncated =
     assistantText.length > 2000 ? assistantText.slice(-2000) : assistantText;
 
-  const prompt = `Given this assistant message, write a very short tab-complete suggestion the user could send next to keep the conversation going. Be casual, curious, or actionable — like a quick reply, not a formal request. Reply with ONLY the suggestion text.\n\nAssistant's message:\n${truncated}`;
+  const prompt = `Given this assistant message, write a very short tab-complete suggestion the user could send next. Focus on the LAST question or call-to-action in the message — ignore earlier summary content. Be casual, curious, or actionable — like a quick reply, not a formal request. Reply with ONLY the suggestion text.\n\nAssistant's message:\n${truncated}`;
   const response = await provider.sendMessage(
     [{ role: "user", content: [{ type: "text", text: prompt }] }],
     [], // no tools


### PR DESCRIPTION
## Summary
- When an assistant sends a long message ending with a question like "Want to do that now?", the input placeholder suggestion was reflecting the broader topic of the entire message instead of the final question/call-to-action.
- Updated the LLM prompt in `generateLlmSuggestion` to instruct the model to focus on the LAST question or call-to-action in the message and ignore earlier summary content.

## Test plan
- [x] Existing tests pass (`bun test src/__tests__/suggestion-routes.test.ts` — 10/10 passing)
- [ ] Verify in app: send a long assistant message with a summary followed by a question, confirm the placeholder suggestion matches the final question

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
