### PR TITLE
M1: Replace bordered containers with VCard and fix border widths to 2pt

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -197,7 +197,7 @@ struct APIKeyStepView: View {
                             .stroke(
                                 isSelected ? VColor.primaryBase.opacity(0.5)
                                     : (isDisabled ? VColor.borderDisabled : VColor.borderBase),
-                                lineWidth: 1
+                                lineWidth: 2
                             )
                     )
             )

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -190,10 +190,10 @@ struct APIKeyStepView: View {
             .frame(minHeight: 64)
             .contentShape(Rectangle())
             .background(
-                RoundedRectangle(cornerRadius: VRadius.lg)
+                RoundedRectangle(cornerRadius: VRadius.xl)
                     .fill(isSelected ? VColor.primaryBase.opacity(0.1) : Color.clear)
                     .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.lg)
+                        RoundedRectangle(cornerRadius: VRadius.xl)
                             .stroke(
                                 isSelected ? VColor.primaryBase.opacity(0.5)
                                     : (isDisabled ? VColor.borderDisabled : VColor.borderBase),

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -36,42 +36,35 @@ struct ImproveExperienceStepView: View {
         VStack(spacing: VSpacing.md) {
             VStack(spacing: VSpacing.md) {
                 // Privacy toggles card
-                VStack(spacing: VSpacing.lg) {
-                    // Usage analytics toggle
-                    VToggle(
-                        isOn: $collectUsageData,
-                        label: "Share Analytics",
-                        helperText: "Send anonymous product usage data. Your conversations and personal data are never included."
-                    )
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                VCard(padding: VSpacing.lg) {
+                    VStack(spacing: VSpacing.lg) {
+                        // Usage analytics toggle
+                        VToggle(
+                            isOn: $collectUsageData,
+                            label: "Share Analytics",
+                            helperText: "Send anonymous product usage data. Your conversations and personal data are never included."
+                        )
 
-                    SettingsDivider()
+                        SettingsDivider()
 
-                    // Diagnostics toggle
-                    VToggle(
-                        isOn: $sendDiagnostics,
-                        label: "Share Diagnostics",
-                        helperText: "Send crash reports and performance metrics. Your conversations and personal data are never included."
-                    )
+                        // Diagnostics toggle
+                        VToggle(
+                            isOn: $sendDiagnostics,
+                            label: "Share Diagnostics",
+                            helperText: "Send crash reports and performance metrics. Your conversations and personal data are never included."
+                        )
+                    }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .padding(VSpacing.lg)
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.lg)
-                        .stroke(VColor.borderBase, lineWidth: 1)
-                )
 
                 // ToS consent checkbox
-                HStack(spacing: VSpacing.md) {
-                    VCheckbox(isOn: $tosAccepted)
-                    tosConsentText
+                VCard(padding: VSpacing.lg) {
+                    HStack(spacing: VSpacing.md) {
+                        VCheckbox(isOn: $tosAccepted)
+                        tosConsentText
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(VSpacing.lg)
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.lg)
-                        .stroke(VColor.borderBase, lineWidth: 1)
-                )
 
                 OnboardingButton(
                     title: "Accept and Start",

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -44,6 +44,7 @@ struct ImproveExperienceStepView: View {
                             label: "Share Analytics",
                             helperText: "Send anonymous product usage data. Your conversations and personal data are never included."
                         )
+                        .frame(maxWidth: .infinity, alignment: .leading)
 
                         SettingsDivider()
 
@@ -53,8 +54,8 @@ struct ImproveExperienceStepView: View {
                             label: "Share Diagnostics",
                             helperText: "Send crash reports and performance metrics. Your conversations and personal data are never included."
                         )
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     }
-                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
                 // ToS consent checkbox


### PR DESCRIPTION
Part of LUM-432 — replace custom overlay borders with VCard component in onboarding views and update hosting card border width from 1pt to 2pt for design consistency.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
