### PR TITLE
M1: Add composite DB index and getMessagesPaginated()

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -10,6 +10,7 @@ import {
   gte,
   inArray,
   isNull,
+  lt,
   lte,
   sql,
 } from "drizzle-orm";
@@ -1110,6 +1111,77 @@ export function getMessages(conversationId: string): MessageRow[] {
     .orderBy(asc(messages.createdAt))
     .all()
     .map(parseMessage);
+}
+
+export interface PaginatedMessagesResult {
+  messages: MessageRow[];
+  hasMore: boolean;
+}
+
+export function getMessagesPaginated(
+  conversationId: string,
+  limit: number | undefined,
+  beforeTimestamp?: number,
+): PaginatedMessagesResult {
+  const db = getDb();
+
+  if (limit === undefined) {
+    const conditions = [eq(messages.conversationId, conversationId)];
+    if (beforeTimestamp !== undefined) {
+      conditions.push(lt(messages.createdAt, beforeTimestamp));
+    }
+    const rows = db
+      .select()
+      .from(messages)
+      .where(and(...conditions))
+      .orderBy(asc(messages.createdAt))
+      .all()
+      .map(parseMessage);
+    return { messages: rows, hasMore: false };
+  }
+
+  const conditions = [eq(messages.conversationId, conversationId)];
+  if (beforeTimestamp !== undefined) {
+    conditions.push(lt(messages.createdAt, beforeTimestamp));
+  }
+
+  const rows = db
+    .select()
+    .from(messages)
+    .where(and(...conditions))
+    .orderBy(desc(messages.createdAt))
+    .limit(limit + 1)
+    .all()
+    .map(parseMessage);
+
+  const hasMore = rows.length > limit;
+  if (hasMore) {
+    rows.splice(limit);
+  }
+  rows.reverse();
+
+  return { messages: rows, hasMore };
+}
+
+export function getLastAssistantTimestampBefore(
+  conversationId: string,
+  beforeTimestamp: number,
+): number {
+  const db = getDb();
+  const row = db
+    .select({ createdAt: messages.createdAt })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, conversationId),
+        eq(messages.role, "assistant"),
+        lt(messages.createdAt, beforeTimestamp),
+      ),
+    )
+    .orderBy(desc(messages.createdAt))
+    .limit(1)
+    .get();
+  return row?.createdAt ?? 0;
 }
 
 /** Fetch a single message by ID, optionally scoped to a specific conversation. */

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -89,6 +89,7 @@ import {
   migrateLlmRequestLogMessageId,
   migrateLlmRequestLogProvider,
   migrateMemoryItemSupersession,
+  migrateMessagesConversationCreatedAtIndex,
   migrateMessagesFtsBackfill,
   migrateNormalizePhoneIdentities,
   migrateNotificationDeliveryThreadDecision,
@@ -519,6 +520,9 @@ export function initializeDb(): void {
 
   // 93. Strip `integration:` prefix from provider_key across OAuth tables
   migrateStripIntegrationPrefixFromProviderKeys(database);
+
+  // 94. Composite index on messages(conversation_id, created_at) for paginated history queries
+  migrateMessagesConversationCreatedAtIndex(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/196-messages-conversation-created-at-index.ts
+++ b/assistant/src/memory/migrations/196-messages-conversation-created-at-index.ts
@@ -1,0 +1,9 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+export function migrateMessagesConversationCreatedAtIndex(
+  database: DrizzleDb,
+): void {
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_messages_conversation_created_at ON messages(conversation_id, created_at)`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -134,6 +134,7 @@ export { migrateContactsUserFileColumn } from "./192-contacts-user-file-column.j
 export { migrateAddSourceTypeColumns } from "./193-add-source-type-columns.js";
 export { migrateCreateMemoryRecallLogs } from "./194-memory-recall-logs.js";
 export { migrateOAuthProvidersPingConfig } from "./195-oauth-providers-ping-config.js";
+export { migrateMessagesConversationCreatedAtIndex } from "./196-messages-conversation-created-at-index.js";
 export { migrateStripIntegrationPrefixFromProviderKeys } from "./196-strip-integration-prefix-from-provider-keys.js";
 export {
   MIGRATION_REGISTRY,


### PR DESCRIPTION
## Summary
- Adds composite DB index `idx_messages_conversation_created_at` on `messages(conversation_id, created_at)` for efficient paginated history queries
- Adds `getMessagesPaginated()` with limit+1 sentinel pattern for server-side cursor pagination
- Adds `getLastAssistantTimestampBefore()` for interface diff seeding

Part of #21550.

## Test plan
- [ ] Verify migration creates index without error on fresh DB
- [ ] Verify `getMessagesPaginated()` with `limit=undefined` returns all messages in ASC order with `hasMore: false`
- [ ] Verify `getMessagesPaginated()` with a limit returns correct slice with sentinel-based `hasMore`
- [ ] Verify `getMessagesPaginated()` with `beforeTimestamp` filters correctly
- [ ] Verify `getLastAssistantTimestampBefore()` returns correct timestamp or 0

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
