### PR TITLE
M3: Client-side safety fixes for pagination edge cases

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -777,9 +777,12 @@ public final class ChatViewModel: ObservableObject {
     /// True while a previous-page load is in progress (brief async delay for UX).
     @Published public var isLoadingMoreMessages: Bool = false
 
-    /// Timeout task that logs a warning if the daemon takes too long to respond
-    /// to a pagination request. The flag is intentionally NOT cleared here —
-    /// see the comment in `loadPreviousMessagePage()` for rationale.
+    /// Timeout task that logs a warning at 30s if the daemon is slow, then
+    /// clears `isLoadingMoreMessages` at 60s to unblock the user. The 30s
+    /// warning preserves the flag to avoid misclassifying late-but-valid
+    /// responses (see loadPreviousMessagePage); the 60s hard clear accepts
+    /// the risk of a narrow misclassification window to prevent a permanently
+    /// stuck loading spinner.
     private var loadMoreTimeoutTask: Task<Void, Never>?
 
     /// The subset of messages that are actually displayed (excludes subagent notifications
@@ -891,6 +894,9 @@ public final class ChatViewModel: ObservableObject {
         // of prepending. The flag is properly cleared by populateFromHistory
         // when the response arrives, or by reconnect/conversation-switch logic if
         // the daemon disconnects.
+        // At 60s a hard clear of isLoadingMoreMessages fires to prevent a permanent
+        // stuck spinner. This accepts a narrow misclassification window for late
+        // responses arriving between 60-65s.
         loadMoreTimeoutTask?.cancel()
         loadMoreTimeoutTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 30_000_000_000) // 30 seconds
@@ -899,7 +905,8 @@ public final class ChatViewModel: ObservableObject {
             try? await Task.sleep(nanoseconds: 30_000_000_000) // +30s = 60s total
             guard let self, !Task.isCancelled, self.isLoadingMoreMessages else { return }
             log.error("Pagination request timed out after 60s — resetting pagination state")
-            self.resetMessagePagination()
+            self.isLoadingMoreMessages = false
+            self.loadMoreTimeoutTask = nil
         }
         onLoadMoreHistory?(conversationId, cursor)
         // The loading indicator is cleared by populateFromHistory when the response arrives.

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -896,6 +896,10 @@ public final class ChatViewModel: ObservableObject {
             try? await Task.sleep(nanoseconds: 30_000_000_000) // 30 seconds
             guard let self, !Task.isCancelled, self.isLoadingMoreMessages else { return }
             log.warning("Pagination request still pending after 30s — daemon may be unresponsive")
+            try? await Task.sleep(nanoseconds: 30_000_000_000) // +30s = 60s total
+            guard let self, !Task.isCancelled, self.isLoadingMoreMessages else { return }
+            log.error("Pagination request timed out after 60s — resetting pagination state")
+            self.resetMessagePagination()
         }
         onLoadMoreHistory?(conversationId, cursor)
         // The loading indicator is cleared by populateFromHistory when the response arrives.
@@ -2889,7 +2893,7 @@ public final class ChatViewModel: ObservableObject {
             self.loadMoreTimeoutTask?.cancel()
             self.loadMoreTimeoutTask = nil
             self.isLoadingMoreMessages = false
-            trimOldMessagesIfNeeded()
+            // TODO: Add pagination-aware trim that doesn't regress historyCursor (follow-up)
             refreshModelMetadataIfNeeded(hasModelCommand)
             os_signpost(.end, log: Self.poiLog, name: "populateFromHistory", signpostID: spid, "path=pagination")
             return


### PR DESCRIPTION
## Summary
- Removed `trimOldMessagesIfNeeded()` from the pagination prepend branch in `populateFromHistory()` to prevent an infinite fetch-trim loop (trim removes just-fetched messages, resetting cursor, causing re-fetch)
- Added a second-stage 60s hard timeout in `loadPreviousMessagePage()` that calls `resetMessagePagination()` to prevent permanently stuck loading spinners when the daemon is unresponsive

## Test plan
- [ ] Verify pagination loading still works normally (loads older messages on scroll up)
- [ ] Verify that if daemon is unresponsive for 60s, the loading state resets cleanly
- [ ] Verify that loading many pages of history (exceeding 150 message trim threshold) no longer causes an infinite fetch loop

Part of #21550.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
