### PR TITLE
fix: Remove resolveService mocks and gmail alias tests from test files

### DIFF
--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -779,7 +779,7 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     _setStorePath(STORE_PATH);
     _resetBackend();
     _setMetadataPath(join(TEST_DIR, "metadata.json"));
-    // Return well-known provider rows so vault.ts knows gmail/slack are
+    // Return well-known provider rows so vault.ts knows google/slack are
     // registered, and custom providers return undefined.
     mockGetProvider.mockImplementation(
       (key: string) => wellKnownProviders[key] ?? undefined,
@@ -933,16 +933,16 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     const result = await credentialStoreTool.execute(
       {
         action: "oauth2_connect",
-        service: "gmail",
+        service: "google",
       },
       { ..._ctx, isInteractive: false },
     );
 
     // Should pass client_id and client_secret checks — the flow proceeds
-    // through the channel path (gmail uses loopback transport so no
+    // through the channel path (google uses loopback transport so no
     // public ingress URL is needed) and returns the authorization URL.
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("To connect gmail, open this link");
+    expect(result.content).toContain("To connect google, open this link");
     expect(result.content).not.toContain("client_id is required");
     expect(result.content).not.toContain("client_secret is required");
 
@@ -987,7 +987,7 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     const result = await credentialStoreTool.execute(
       {
         action: "oauth2_connect",
-        service: "gmail",
+        service: "google",
         client_id: "caller-supplied-client-id",
       },
       { ..._ctx, isInteractive: false },
@@ -995,7 +995,7 @@ describe("credential_store tool — oauth2_connect error paths", () => {
 
     // Should succeed — client_secret resolved from the matched app
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("To connect gmail, open this link");
+    expect(result.content).toContain("To connect google, open this link");
     // getMostRecentAppByProvider should NOT have been called since client_id was known
     expect(mockGetMostRecentAppByProvider).not.toHaveBeenCalled();
 
@@ -1031,13 +1031,13 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     const result = await credentialStoreTool.execute(
       {
         action: "oauth2_connect",
-        service: "gmail",
+        service: "google",
       },
       { ..._ctx, isInteractive: false },
     );
 
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("To connect gmail, open this link");
+    expect(result.content).toContain("To connect google, open this link");
     // getAppByProviderAndClientId should NOT have been called since client_id was unknown
     expect(mockGetAppByProviderAndClientId).not.toHaveBeenCalled();
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for remove-oauth-service-aliases.md.

**Gap:** Test cleanup from PR 3 not applied to feature branch
**What was expected:** resolveService mocks removed from 7 test files, gmail alias tests deleted
**What was found:** All test files still had old resolveService mocks and gmail alias test cases

Changes:
- Remove resolveService from mock.module blocks in 6 CLI command test files (12 mock entries total)
- Delete 4 gmail alias resolution test cases
- Remove identity resolveService mock from oauth-cli.test.ts
- Update 3 credential-vault-unit tests from service: gmail to service: google
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
