### PR TITLE
fix: expand InlineTableWidget cells to show full text (LUM-427)

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -131,7 +131,7 @@ public struct InlineTableWidget: View {
             Text(value?.text ?? "")
                 .font(VFont.bodyMediumLighter)
                 .foregroundStyle(VColor.contentDefault)
-                .lineLimit(2)
+                .lineLimit(nil)
                 .textSelection(.enabled)
         }
         .columnFrame(width)


### PR DESCRIPTION
## Summary
- Changed `.lineLimit(2)` to `.lineLimit(nil)` in InlineTableWidget cellView
- Cells now expand to show full text content instead of truncating at 2 lines

Part of #21563
Fixes LUM-427
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
