### PR TITLE
fix: handle missing admin permissions in Notion onboarding (JARVIS-338)

### DIFF
--- a/skills/notion-oauth-setup/SKILL.md
+++ b/skills/notion-oauth-setup/SKILL.md
@@ -64,6 +64,7 @@ There is no Type selector on the creation form - integrations are created as **I
 **Known issues:**
 
 - If they already have an integration named "Vellum Assistant", ask if they'd like to reuse it - skip ahead to Step 3
+- **Missing admin permissions:** Only workspace **admins** can create integrations. If the user can't find the "New integration" button, sees a disabled/grayed-out option, gets a permissions error, or tells you they aren't an admin — see [references/non-admin-alternatives.md](references/non-admin-alternatives.md).
 
 **Milestone (2 of 4):** "Integration created - now let's grab the secret and grant page access."
 

--- a/skills/notion-oauth-setup/references/non-admin-alternatives.md
+++ b/skills/notion-oauth-setup/references/non-admin-alternatives.md
@@ -1,0 +1,25 @@
+# Non-Admin Alternatives for Notion Integration Setup
+
+The user doesn't have admin permissions on their Notion workspace. Only workspace admins can create Internal integrations, so the standard Step 2 won't work for them.
+
+Present these options:
+
+1. **Ask a workspace admin to create the integration** — The admin creates an Internal integration named "Vellum Assistant", copies the secret token (`ntn_...`), and shares it with the user. The user can then grant it access to their own pages. This is the easiest path.
+2. **Use a different workspace** — If the user has a personal Notion workspace (or any workspace where they're admin), they can set up the integration there instead.
+3. **Request admin permissions** — The user can ask their workspace admin to grant them admin access, then retry Step 2.
+
+Suggested message:
+
+> No worries — you don't need to be an admin yourself. The easiest path is to ask a workspace admin to create the integration and send you the secret token. You can then grant it access to your own pages.
+>
+> Here are your options:
+>
+> 1. **Ask your admin** to create an Internal integration named "Vellum Assistant" and share the secret token with you
+> 2. **Use a different workspace** where you're an admin (e.g., a personal workspace)
+> 3. **Request admin access** from your workspace admin, then come back to this step
+
+After the user picks an option, adapt the flow:
+
+- **Option 1 (admin shares token):** When the user has the secret, skip directly to Step 3a (collect the secret via `credential_store prompt`) and then 3b (grant page access on their own pages).
+- **Option 2 (different workspace):** Restart from Step 1 targeting the new workspace.
+- **Option 3 (request admin access):** Pause the flow. Tell them to come back when they have admin access and you'll pick up where you left off.

--- a/skills/notion-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/notion-oauth-setup/references/path-b-manual-setup.md
@@ -37,7 +37,9 @@ Tell the user:
 >
 > The integration will be created as Internal by default - that's exactly what we want.
 >
-> Let me know when the integration is created.
+> Let me know when the integration is created, or if you run into any issues.
+
+If the user reports they can't create the integration due to missing admin permissions, see [non-admin-alternatives.md](non-admin-alternatives.md). If they receive a secret from their admin, skip directly to Path B Step 3.
 
 ## Path B Step 3: Copy the Internal Integration Secret
 


### PR DESCRIPTION
## Summary
- When non-admin users try to create a Notion integration, they now get clear alternatives instead of a hard block
- Alternatives (ask admin for token, use different workspace, request admin access) are progressively disclosed — only surfaced when the user indicates they lack permissions
- Covers both Path A (collaborative browser) and Path B (manual/chat) flows

## Test plan
- [ ] Run Notion setup as a non-admin user and verify alternatives are presented
- [ ] Run Notion setup as an admin user and verify the flow is unchanged

Closes JARVIS-338

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
