### PR TITLE
M2: Wire pagination into handleListMessages HTTP endpoint

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4210,13 +4210,17 @@ paths:
                     type: array
                     items: {}
                     description: Array of message objects
-                  interfaceFiles:
-                    type: array
-                    items: {}
-                    description: Interface file paths with modification timestamps
+                  hasMore:
+                    description: Whether older messages exist beyond this page
+                    type: boolean
+                  oldestTimestamp:
+                    description: Timestamp of the oldest message in this page (ms since epoch)
+                    type: number
+                  oldestMessageId:
+                    description: ID of the oldest message in this page
+                    type: string
                 required:
                   - messages
-                  - interfaceFiles
                 additionalProperties: false
     post:
       operationId: messages_post

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -549,17 +549,20 @@ export function handleListMessages(
     };
   });
 
-  const oldestTimestamp =
-    rawMessages.length > 0 ? rawMessages[0].createdAt : undefined;
-  const oldestMessageId =
-    rawMessages.length > 0 ? rawMessages[0].id : undefined;
+  if (isPaginated) {
+    const oldestTimestamp =
+      rawMessages.length > 0 ? rawMessages[0].createdAt : undefined;
+    const oldestMessageId =
+      rawMessages.length > 0 ? rawMessages[0].id : undefined;
+    return Response.json({
+      messages,
+      hasMore,
+      ...(oldestTimestamp != null ? { oldestTimestamp } : {}),
+      ...(oldestMessageId != null ? { oldestMessageId } : {}),
+    });
+  }
 
-  return Response.json({
-    messages,
-    ...(isPaginated ? { hasMore } : {}),
-    ...(oldestTimestamp != null ? { oldestTimestamp } : {}),
-    ...(oldestMessageId != null ? { oldestMessageId } : {}),
-  });
+  return Response.json({ messages });
 }
 
 /**

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -48,7 +48,10 @@ import {
 } from "../../memory/canonical-guardian-store.js";
 import {
   addMessage,
+  getLastAssistantTimestampBefore,
   getMessages,
+  getMessagesPaginated,
+  type MessageRow,
   provenanceFromTrustContext,
   setConversationOriginChannelIfUnset,
   setConversationOriginInterfaceIfUnset,
@@ -360,7 +363,49 @@ export function handleListMessages(
   if (!resolvedConversationId) {
     return Response.json({ messages: [] });
   }
-  const rawMessages = getMessages(resolvedConversationId);
+
+  const beforeTimestampRaw = url.searchParams.get("beforeTimestamp");
+  const limitRaw = url.searchParams.get("limit");
+
+  // Validate: reject NaN values with 400
+  if (beforeTimestampRaw !== null && isNaN(Number(beforeTimestampRaw))) {
+    return httpError(
+      "BAD_REQUEST",
+      "beforeTimestamp must be a valid number",
+      400,
+    );
+  }
+  if (limitRaw !== null && isNaN(Number(limitRaw))) {
+    return httpError("BAD_REQUEST", "limit must be a valid number", 400);
+  }
+
+  const beforeTimestamp = beforeTimestampRaw
+    ? Number(beforeTimestampRaw)
+    : undefined;
+  // Clamp limit to 1-500 range
+  const limit = limitRaw
+    ? Math.min(Math.max(Math.floor(Number(limitRaw)), 1), 500)
+    : undefined;
+
+  // Option A: only paginate when beforeTimestamp is present.
+  // Initial load and reconnect send limit but no beforeTimestamp — those must continue
+  // returning all messages for zero regression risk.
+  const isPaginated = beforeTimestamp != null;
+
+  let rawMessages: MessageRow[];
+  let hasMore = false;
+
+  if (isPaginated) {
+    const result = getMessagesPaginated(
+      resolvedConversationId,
+      limit,
+      beforeTimestamp,
+    );
+    rawMessages = result.messages;
+    hasMore = result.hasMore;
+  } else {
+    rawMessages = getMessages(resolvedConversationId);
+  }
 
   // Parse content blocks and extract text + tool calls
   const parsed = rawMessages.map((msg) => {
@@ -429,6 +474,12 @@ export function handleListMessages(
   const interfaceFiles = getInterfaceFilesWithMtimes(interfacesDir);
 
   let prevAssistantTimestamp = 0;
+  if (isPaginated && rawMessages.length > 0) {
+    prevAssistantTimestamp = getLastAssistantTimestampBefore(
+      resolvedConversationId!,
+      rawMessages[0].createdAt,
+    );
+  }
   const messages: RuntimeMessagePayload[] = parsed.map((m) => {
     let msgAttachments: RuntimeAttachmentMetadata[] = [];
     if (m.id) {
@@ -498,7 +549,17 @@ export function handleListMessages(
     };
   });
 
-  return Response.json({ messages });
+  const oldestTimestamp =
+    rawMessages.length > 0 ? rawMessages[0].createdAt : undefined;
+  const oldestMessageId =
+    rawMessages.length > 0 ? rawMessages[0].id : undefined;
+
+  return Response.json({
+    messages,
+    ...(isPaginated ? { hasMore } : {}),
+    ...(oldestTimestamp != null ? { oldestTimestamp } : {}),
+    ...(oldestMessageId != null ? { oldestMessageId } : {}),
+  });
 }
 
 /**
@@ -1502,9 +1563,20 @@ export function conversationRouteDefinitions(deps: {
       tags: ["messages"],
       responseBody: z.object({
         messages: z.array(z.unknown()).describe("Array of message objects"),
-        interfaceFiles: z
-          .array(z.unknown())
-          .describe("Interface file paths with modification timestamps"),
+        hasMore: z
+          .boolean()
+          .optional()
+          .describe("Whether older messages exist beyond this page"),
+        oldestTimestamp: z
+          .number()
+          .optional()
+          .describe(
+            "Timestamp of the oldest message in this page (ms since epoch)",
+          ),
+        oldestMessageId: z
+          .string()
+          .optional()
+          .describe("ID of the oldest message in this page"),
       }),
       handler: ({ url }) => handleListMessages(url, deps.interfacesDir),
     },


### PR DESCRIPTION
Part of #21550. Updates handleListMessages to parse beforeTimestamp/limit query params, call getMessagesPaginated() when beforeTimestamp is present (Option A), seed interface diffs correctly for paginated pages, and return hasMore/oldestTimestamp/oldestMessageId metadata. Updates route schema.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
