### PR TITLE
fix: expand InlineTableWidget cells to show full text (LUM-427)

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -55,6 +55,16 @@ public struct InlineSurfaceRouter: View {
         return false
     }
 
+    private var isTableSurface: Bool {
+        if case .table = surface.data { return true }
+        return false
+    }
+
+    private var standardWidgetMaxWidth: CGFloat {
+        // Tables should use the full chat bubble width before falling back to horizontal scroll.
+        isTableSurface ? VSpacing.chatBubbleMaxWidth : 540
+    }
+
     /// Whether the surface renders as a lightweight chip without card chrome.
     private var isChipOnlySurface: Bool {
         return false
@@ -92,7 +102,7 @@ public struct InlineSurfaceRouter: View {
                 actionButtons
             }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: isTableSurface ? nil : .infinity, alignment: .leading)
         .inlineWidgetCard(interactive: isDynamicPreview || isDocumentPreview)
         .overlay(alignment: .topTrailing) {
             if isDynamicPreview && !isAppCreated {
@@ -137,8 +147,8 @@ public struct InlineSurfaceRouter: View {
                 }
             }
         }
-        // Consistent width for all widget cards; dynamic page previews and document previews are more compact.
-        .frame(maxWidth: isAppCreated ? 400 : (isDynamicPreview || isDocumentPreview ? 350 : 540), alignment: .leading)
+        // Dynamic page/document previews stay compact; tables can grow to the chat bubble max width.
+        .frame(maxWidth: isAppCreated ? 400 : (isDynamicPreview || isDocumentPreview ? 350 : standardWidgetMaxWidth), alignment: .leading)
         }
         }
         .onChange(of: surface) { oldSurface, newSurface in

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -1,89 +1,18 @@
 import SwiftUI
 
-// MARK: - TableRowLayout
-
-/// Custom `Layout` that distributes available width among table columns
-/// in a single layout pass — no measurement state, no re-renders.
-///
-/// Fixed-width columns receive their specified size (clamped to available
-/// space). Flexible columns share the remaining width equally. Each child
-/// view corresponds to one column cell (plus an optional leading selection
-/// cell when `selectionWidth > 0`).
-private struct TableRowLayout: Layout {
-    let columnWidths: [Int?]
-    let selectionWidth: CGFloat
-
-    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
-        let width = proposal.width ?? 0
-        let resolvedWidths = resolveColumnWidths(for: width)
-        let heights = subviewHeights(subviews: subviews, columnWidths: resolvedWidths)
-        return CGSize(width: width, height: heights.max() ?? 0)
-    }
-
-    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
-        let resolvedWidths = resolveColumnWidths(for: bounds.width)
-        var x = bounds.minX
-
-        for (index, subview) in subviews.enumerated() {
-            let colWidth = resolvedWidths[index]
-            let cellProposal = ProposedViewSize(width: colWidth, height: nil)
-            subview.place(at: CGPoint(x: x, y: bounds.minY), anchor: .topLeading, proposal: cellProposal)
-            x += colWidth
-        }
-    }
-
-    // MARK: - Column Width Resolution
-
-    /// Distribute `totalWidth` among the selection column (if any) and data columns.
-    /// Returns one width per subview (selection + columns).
-    private func resolveColumnWidths(for totalWidth: CGFloat) -> [CGFloat] {
-        var widths: [CGFloat] = []
-        var remaining = totalWidth
-
-        // Selection column
-        if selectionWidth > 0 {
-            let sel = min(selectionWidth, remaining)
-            widths.append(sel)
-            remaining -= sel
-        }
-
-        // Data columns
-        let fixedTotal = CGFloat(columnWidths.compactMap { $0 }.reduce(0, +))
-        let flexCount = columnWidths.filter { $0 == nil }.count
-        let flexWidth = flexCount > 0 ? max(0, (remaining - fixedTotal) / CGFloat(flexCount)) : 0
-
-        for colWidth in columnWidths {
-            if let fixed = colWidth {
-                let clamped = min(CGFloat(fixed), remaining)
-                widths.append(clamped)
-            } else {
-                widths.append(flexWidth)
-            }
-        }
-
-        return widths
-    }
-
-    /// Measure each subview's height given its resolved column width.
-    private func subviewHeights(subviews: Subviews, columnWidths: [CGFloat]) -> [CGFloat] {
-        zip(subviews, columnWidths).map { subview, width in
-            subview.sizeThatFits(ProposedViewSize(width: width, height: nil)).height
-        }
-    }
-}
-
-// MARK: - InlineTableWidget
-
 /// Inline table widget with selectable rows and action support.
 ///
-/// Uses a custom `TableRowLayout` (the `Layout` protocol) to distribute
-/// the parent's proposed width among columns in a single layout pass —
-/// no GeometryReader, no measurement state, no re-render cycle.
+/// Follows the same layout pattern as `MarkdownTableView`: measures the
+/// available container width, applies it as a hard `.frame(width:)`
+/// constraint on the table VStack, and lets cells share that constrained
+/// space via `.frame(maxWidth: .infinity)`. This guarantees text wraps
+/// within columns and the table never overflows its container.
 public struct InlineTableWidget: View {
     public let data: TableSurfaceData
     public let onAction: (String, [String: AnyCodable]?) -> Void
 
     @State private var selectedIds: Set<String> = []
+    @State private var tableWidth: CGFloat = 0
 
     public init(data: TableSurfaceData, onAction: @escaping (String, [String: AnyCodable]?) -> Void) {
         self.data = data
@@ -99,38 +28,55 @@ public struct InlineTableWidget: View {
         return !ids.isEmpty && ids.isSubset(of: selectedIds)
     }
 
-    /// The `TableRowLayout` configuration shared by headers and all data rows.
-    private var rowLayout: TableRowLayout {
-        TableRowLayout(
-            columnWidths: data.columns.map(\.width),
-            selectionWidth: data.selectionMode != .none ? 28 : 0
-        )
-    }
-
     // MARK: - Body
 
     public var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            // Column headers
-            rowLayout {
-                if data.selectionMode == .multiple {
-                    Button {
-                        toggleSelectAll()
-                    } label: {
-                        VIconView(allSelected ? .circleCheck : .circle, size: 14)
-                            .foregroundStyle(allSelected ? VColor.primaryBase : VColor.contentTertiary)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(allSelected ? "Deselect all" : "Select all")
-                } else if data.selectionMode != .none {
-                    Color.clear
+        // Outer wrapper: invisible spacer measures available width,
+        // then the table renders at that exact width.
+        VStack(spacing: 0) {
+            // Measure available width from a contentless view that can't
+            // overflow — it always reports the parent's proposed width.
+            Color.clear
+                .frame(height: 0)
+                .frame(maxWidth: .infinity)
+                .onGeometryChange(for: CGFloat.self) { $0.size.width } action: {
+                    tableWidth = $0
                 }
 
+            if tableWidth > 0 {
+                tableBody
+                    // Hard width constraint — the key to preventing overflow.
+                    // Identical to MarkdownTableView's .frame(maxWidth: maxWidth).
+                    // Forces the VStack and all children to lay out within this
+                    // exact width. Cells with .frame(maxWidth: .infinity) then
+                    // share this constrained space equally.
+                    .frame(width: tableWidth, alignment: .leading)
+            }
+        }
+        .onAppear {
+            selectedIds = Set(data.rows.filter(\.selected).map(\.id))
+            if data.selectionMode != .none {
+                onAction("selection_changed", ["selectedIds": AnyCodable(Array(selectedIds))])
+            }
+        }
+    }
+
+    // MARK: - Table Content
+
+    /// The actual table layout. Identical pattern to `MarkdownTableView`:
+    /// each cell uses `.frame(maxWidth: .infinity)` to share the parent's
+    /// constrained width equally.
+    private var tableBody: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            // Column headers
+            HStack(spacing: 0) {
+                selectionCell(isHeader: true)
                 ForEach(data.columns) { column in
                     Text(column.label)
                         .font(VFont.labelDefault)
                         .foregroundStyle(VColor.contentTertiary)
                         .textSelection(.enabled)
+                        .cellFrame(column.width)
                 }
             }
             .padding(.bottom, VSpacing.xxs)
@@ -154,19 +100,31 @@ public struct InlineTableWidget: View {
                     .padding(.top, VSpacing.xs)
             }
         }
-        .onAppear {
-            selectedIds = Set(data.rows.filter(\.selected).map(\.id))
-            if data.selectionMode != .none {
-                onAction("selection_changed", ["selectedIds": AnyCodable(Array(selectedIds))])
-            }
-        }
     }
 
     // MARK: - Row & Cell Views
 
+    @ViewBuilder
+    private func selectionCell(isHeader: Bool = false) -> some View {
+        if data.selectionMode == .multiple && isHeader {
+            Button {
+                toggleSelectAll()
+            } label: {
+                VIconView(allSelected ? .circleCheck : .circle, size: 14)
+                    .foregroundStyle(allSelected ? VColor.primaryBase : VColor.contentTertiary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(allSelected ? "Deselect all" : "Select all")
+            .frame(width: 28)
+        } else if data.selectionMode != .none {
+            Color.clear
+                .frame(width: 28)
+        }
+    }
+
     private func rowView(_ row: TableRow) -> some View {
         let isSelected = selectedIds.contains(row.id)
-        return rowLayout {
+        return HStack(spacing: 0) {
             if data.selectionMode != .none && row.selectable {
                 Button {
                     toggleSelection(row.id)
@@ -175,12 +133,14 @@ public struct InlineTableWidget: View {
                         .foregroundStyle(isSelected ? VColor.primaryBase : VColor.contentTertiary)
                 }
                 .buttonStyle(.plain)
+                .frame(width: 28)
             } else if data.selectionMode != .none {
                 Color.clear
+                    .frame(width: 28)
             }
 
             ForEach(data.columns) { column in
-                cellView(row.cells[column.id])
+                cellView(row.cells[column.id], columnWidth: column.width)
             }
         }
         .padding(.vertical, VSpacing.xs)
@@ -197,7 +157,7 @@ public struct InlineTableWidget: View {
     }
 
     @ViewBuilder
-    private func cellView(_ value: TableCellValue?) -> some View {
+    private func cellView(_ value: TableCellValue?, columnWidth: Int?) -> some View {
         HStack(spacing: VSpacing.xs) {
             if let icon = value?.icon,
                let vIcon = SFSymbolMapping.icon(forSFSymbol: icon) {
@@ -210,6 +170,7 @@ public struct InlineTableWidget: View {
                 .lineLimit(nil)
                 .textSelection(.enabled)
         }
+        .cellFrame(columnWidth)
     }
 
     // MARK: - Helpers
@@ -248,5 +209,21 @@ public struct InlineTableWidget: View {
             }
         }
         onAction("selection_changed", ["selectedIds": AnyCodable(Array(selectedIds))])
+    }
+}
+
+// MARK: - Cell Sizing
+
+private extension View {
+    /// Fixed-width columns get their specified size.
+    /// Flexible columns use `.frame(maxWidth: .infinity)` to share the
+    /// parent's constrained width equally — the same pattern MarkdownTableView uses.
+    @ViewBuilder
+    func cellFrame(_ width: Int?) -> some View {
+        if let w = width {
+            self.frame(width: CGFloat(w), alignment: .leading)
+        } else {
+            self.frame(maxWidth: .infinity, alignment: .leading)
+        }
     }
 }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -1,21 +1,102 @@
 import SwiftUI
 
-/// Inline table widget with selectable rows and action support.
+// MARK: - TableColumnLayout
+
+/// Custom `Layout` that distributes the parent's proposed width among
+/// table columns in a single layout pass. Fixed-width columns receive
+/// their specified size (clamped to available space). Flexible columns
+/// share the remaining width equally. Each subview = one column cell.
 ///
-/// Measures the available container width using a zero-height spacer
-/// and distributes it among columns explicitly, so text wraps within
-/// each column instead of overflowing the viewport.
+/// This participates directly in SwiftUI's layout system — no
+/// GeometryReader, no measurement state, no re-render cycle.
+private struct TableColumnLayout: Layout {
+    /// Per-column spec: `nil` = flexible, `CGFloat` = fixed.
+    let specs: [CGFloat?]
+    /// Minimum width for flexible columns.
+    let minFlexWidth: CGFloat
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout [CGFloat]) -> CGSize {
+        let widths = resolvedWidths(for: proposal.width ?? 0, count: subviews.count)
+        cache = widths
+        let height = zip(subviews, widths).map { sub, w in
+            sub.sizeThatFits(ProposedViewSize(width: w, height: nil)).height
+        }.max() ?? 0
+        return CGSize(width: widths.reduce(0, +), height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout [CGFloat]) {
+        let widths = cache.isEmpty
+            ? resolvedWidths(for: bounds.width, count: subviews.count)
+            : cache
+        var x = bounds.minX
+        for (i, subview) in subviews.enumerated() {
+            let w = i < widths.count ? widths[i] : 0
+            subview.place(
+                at: CGPoint(x: x, y: bounds.minY),
+                anchor: .topLeading,
+                proposal: ProposedViewSize(width: w, height: bounds.height)
+            )
+            x += w
+        }
+    }
+
+    func makeCache(subviews: Subviews) -> [CGFloat] { [] }
+
+    /// Distribute `available` width among `count` subviews based on `specs`.
+    private func resolvedWidths(for available: CGFloat, count: Int) -> [CGFloat] {
+        guard count > 0 else { return [] }
+        let padded = specs + Array(repeating: nil as CGFloat?, count: max(0, count - specs.count))
+        let effective = Array(padded.prefix(count))
+
+        let fixedTotal = effective.compactMap { $0 }.reduce(0, +)
+        let flexCount = effective.filter { $0 == nil }.count
+        let flexWidth = flexCount > 0
+            ? max(minFlexWidth, (available - fixedTotal) / CGFloat(flexCount))
+            : 0
+
+        return effective.map { spec in
+            if let fixed = spec {
+                return min(fixed, available)
+            }
+            return flexWidth
+        }
+    }
+}
+
+// MARK: - Constants
+
+private let minColumnWidth: CGFloat = 60
+private let selectionColumnWidth: CGFloat = 28
+private let resizeHandleWidth: CGFloat = 8
+
+// MARK: - InlineTableWidget
+
+/// Inline table widget with selectable rows, resizable columns, and
+/// optional horizontal scrolling.
+///
+/// Layout approach:
+/// - A custom `TableColumnLayout` (the `Layout` protocol) distributes
+///   the parent's proposed width among columns in a single layout pass.
+/// - The selection checkbox column sits outside the Layout in an HStack,
+///   so SwiftUI subtracts its 28pt before proposing width to the Layout.
+/// - When total minimum widths exceed the available space, a horizontal
+///   `ScrollView` activates as a fallback.
+/// - Users can resize columns by dragging dividers in the header row.
 public struct InlineTableWidget: View {
     public let data: TableSurfaceData
     public let onAction: (String, [String: AnyCodable]?) -> Void
 
     @State private var selectedIds: Set<String> = []
-    @State private var availableWidth: CGFloat = 0
+    /// User-resized column widths. Keyed by column ID.
+    /// When absent, the column uses its default (fixed or flex) width.
+    @State private var columnOverrides: [String: CGFloat] = [:]
 
     public init(data: TableSurfaceData, onAction: @escaping (String, [String: AnyCodable]?) -> Void) {
         self.data = data
         self.onAction = onAction
     }
+
+    // MARK: - Computed Properties
 
     private var selectableIds: Set<String> {
         Set(data.rows.filter(\.selectable).map(\.id))
@@ -26,53 +107,65 @@ public struct InlineTableWidget: View {
         return !ids.isEmpty && ids.isSubset(of: selectedIds)
     }
 
-    /// Whether the available width has been measured yet.
-    private var isMeasured: Bool { availableWidth > 0 }
-
-    // MARK: - Column Width Calculation
-
-    /// Width reserved for the selection checkbox / spacer column.
-    private var selectionColumnWidth: CGFloat {
-        data.selectionMode != .none ? 28 : 0
+    private var hasSelection: Bool {
+        data.selectionMode != .none
     }
 
-    /// Resolved width for a single column. Fixed-width columns use their
-    /// specified value (clamped to available space); flexible columns share
-    /// the remaining space equally.
-    private func columnWidth(for column: TableColumn) -> CGFloat {
-        guard isMeasured else { return 0 }
-        let distributable = availableWidth - selectionColumnWidth
-        if let w = column.width {
-            return min(CGFloat(w), distributable)
+    /// Column specs for the Layout: user overrides take precedence,
+    /// then backend fixed widths, then nil (flexible).
+    private var columnSpecs: [CGFloat?] {
+        data.columns.map { col in
+            if let override = columnOverrides[col.id] {
+                return override
+            }
+            if let fixed = col.width {
+                return CGFloat(fixed)
+            }
+            return nil
         }
-        let fixedTotal = CGFloat(data.columns.compactMap(\.width).reduce(0, +))
-        let flexCount = data.columns.filter({ $0.width == nil }).count
-        guard flexCount > 0 else { return 0 }
-        return max(0, (distributable - fixedTotal) / CGFloat(flexCount))
+    }
+
+    /// The Layout instance shared by header and all data rows.
+    private var columnLayout: TableColumnLayout {
+        TableColumnLayout(specs: columnSpecs, minFlexWidth: minColumnWidth)
+    }
+
+    /// Whether horizontal scrolling is needed (total minimums exceed container).
+    /// The container width is 508pt (540pt card - 32pt padding).
+    /// We use a conservative estimate since the actual proposed width
+    /// comes from the parent at layout time.
+    private var needsHorizontalScroll: Bool {
+        let checkboxWidth: CGFloat = hasSelection ? selectionColumnWidth : 0
+        let fixedTotal = columnSpecs.compactMap { $0 }.reduce(0, +)
+        let flexCount = columnSpecs.filter { $0 == nil }.count
+        let totalMin = checkboxWidth + fixedTotal + CGFloat(flexCount) * minColumnWidth
+        return totalMin > 508
     }
 
     // MARK: - Body
 
     public var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            // Zero-height spacer to measure the parent's proposed width.
-            // Unlike the table content, this can't overflow because it has
-            // no intrinsic content width — it always reports exactly the
-            // proposed width from the parent.
-            Color.clear
-                .frame(maxWidth: .infinity)
-                .frame(height: 0)
-                .onGeometryChange(for: CGFloat.self) { $0.size.width } action: {
-                    availableWidth = $0
+            if needsHorizontalScroll {
+                ScrollView(.horizontal, showsIndicators: true) {
+                    tableContent
                 }
-
-            if isMeasured {
+                .scrollClipDisabled(false)
+            } else {
                 tableContent
             }
+
+            if let caption = data.caption {
+                Text(caption)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .padding(.top, VSpacing.xs)
+            }
         }
+        .clipped()
         .onAppear {
             selectedIds = Set(data.rows.filter(\.selected).map(\.id))
-            if data.selectionMode != .none {
+            if hasSelection {
                 onAction("selection_changed", ["selectedIds": AnyCodable(Array(selectedIds))])
             }
         }
@@ -80,82 +173,87 @@ public struct InlineTableWidget: View {
 
     // MARK: - Table Content
 
-    @ViewBuilder
     private var tableContent: some View {
-        // Column headers
-        HStack(spacing: 0) {
-            selectionSpacer(isHeader: true)
-            ForEach(data.columns) { column in
-                Text(column.label)
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentTertiary)
-                    .textSelection(.enabled)
-                    .frame(width: columnWidth(for: column), alignment: .leading)
-            }
-        }
-        .padding(.bottom, VSpacing.xxs)
+        VStack(alignment: .leading, spacing: 0) {
+            headerRow
+                .padding(.bottom, VSpacing.xxs)
 
-        Divider()
-            .background(VColor.borderBase.opacity(0.3))
+            Divider()
+                .background(VColor.borderBase.opacity(0.3))
 
-        // Rows
-        ForEach(Array(data.rows.enumerated()), id: \.element.id) { index, row in
-            rowView(row)
-            if index < data.rows.count - 1 {
-                Divider()
-                    .background(VColor.borderBase.opacity(0.15))
-            }
-        }
-
-        if let caption = data.caption {
-            Text(caption)
-                .font(VFont.labelDefault)
-                .foregroundStyle(VColor.contentTertiary)
-                .padding(.top, VSpacing.xs)
-        }
-    }
-
-    // MARK: - Row & Cell Views
-
-    @ViewBuilder
-    private func selectionSpacer(isHeader: Bool = false) -> some View {
-        if data.selectionMode != .none {
-            if isHeader && data.selectionMode == .multiple {
-                Button {
-                    toggleSelectAll()
-                } label: {
-                    VIconView(allSelected ? .circleCheck : .circle, size: 14)
-                        .foregroundStyle(allSelected ? VColor.primaryBase : VColor.contentTertiary)
+            ForEach(Array(data.rows.enumerated()), id: \.element.id) { index, row in
+                dataRow(row)
+                if index < data.rows.count - 1 {
+                    Divider()
+                        .background(VColor.borderBase.opacity(0.15))
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel(allSelected ? "Deselect all" : "Select all")
-                .frame(width: 28)
-            } else {
-                Color.clear
-                    .frame(width: 28)
             }
         }
     }
 
-    private func rowView(_ row: TableRow) -> some View {
+    // MARK: - Header Row
+
+    private var headerRow: some View {
+        HStack(spacing: 0) {
+            if hasSelection {
+                if data.selectionMode == .multiple {
+                    Button {
+                        toggleSelectAll()
+                    } label: {
+                        VIconView(allSelected ? .circleCheck : .circle, size: 14)
+                            .foregroundStyle(allSelected ? VColor.primaryBase : VColor.contentTertiary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(allSelected ? "Deselect all" : "Select all")
+                    .frame(width: selectionColumnWidth)
+                } else {
+                    Color.clear.frame(width: selectionColumnWidth)
+                }
+            }
+
+            columnLayout {
+                ForEach(Array(data.columns.enumerated()), id: \.element.id) { index, column in
+                    HStack(spacing: 0) {
+                        Text(column.label)
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+
+                        // Resize handle (between columns, not after the last one)
+                        if index < data.columns.count - 1 {
+                            resizeHandle(for: index)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Data Row
+
+    private func dataRow(_ row: TableRow) -> some View {
         let isSelected = selectedIds.contains(row.id)
         return HStack(spacing: 0) {
-            if data.selectionMode != .none && row.selectable {
-                Button {
-                    toggleSelection(row.id)
-                } label: {
-                    VIconView(isSelected ? .circleCheck : .circle, size: 14)
-                        .foregroundStyle(isSelected ? VColor.primaryBase : VColor.contentTertiary)
+            if hasSelection {
+                if row.selectable {
+                    Button {
+                        toggleSelection(row.id)
+                    } label: {
+                        VIconView(isSelected ? .circleCheck : .circle, size: 14)
+                            .foregroundStyle(isSelected ? VColor.primaryBase : VColor.contentTertiary)
+                    }
+                    .buttonStyle(.plain)
+                    .frame(width: selectionColumnWidth)
+                } else {
+                    Color.clear.frame(width: selectionColumnWidth)
                 }
-                .buttonStyle(.plain)
-                .frame(width: 28)
-            } else if data.selectionMode != .none {
-                Color.clear
-                    .frame(width: 28)
             }
 
-            ForEach(data.columns) { column in
-                cellView(row.cells[column.id], width: columnWidth(for: column))
+            columnLayout {
+                ForEach(data.columns) { column in
+                    cellView(row.cells[column.id])
+                }
             }
         }
         .padding(.vertical, VSpacing.xs)
@@ -165,14 +263,16 @@ public struct InlineTableWidget: View {
         )
         .contentShape(Rectangle())
         .onTapGesture {
-            if row.selectable && data.selectionMode != .none {
+            if row.selectable && hasSelection {
                 toggleSelection(row.id)
             }
         }
     }
 
+    // MARK: - Cell View
+
     @ViewBuilder
-    private func cellView(_ value: TableCellValue?, width: CGFloat) -> some View {
+    private func cellView(_ value: TableCellValue?) -> some View {
         HStack(spacing: VSpacing.xs) {
             if let icon = value?.icon,
                let vIcon = SFSymbolMapping.icon(forSFSymbol: icon) {
@@ -185,7 +285,51 @@ public struct InlineTableWidget: View {
                 .lineLimit(nil)
                 .textSelection(.enabled)
         }
-        .frame(width: width, alignment: .leading)
+        .padding(.trailing, VSpacing.xs)
+    }
+
+    // MARK: - Resize Handle
+
+    private func resizeHandle(for columnIndex: Int) -> some View {
+        Rectangle()
+            .fill(Color.clear)
+            .frame(width: resizeHandleWidth)
+            .overlay(
+                Rectangle()
+                    .fill(VColor.borderBase.opacity(0.2))
+                    .frame(width: 1)
+            )
+            .contentShape(Rectangle())
+            #if os(macOS)
+            .onHover { hovering in
+                if hovering {
+                    NSCursor.resizeLeftRight.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
+            #endif
+            .gesture(
+                DragGesture(minimumDistance: 1)
+                    .onChanged { value in
+                        let column = data.columns[columnIndex]
+                        let currentWidth = columnOverrides[column.id]
+                            ?? column.width.map { CGFloat($0) }
+                            ?? estimatedFlexWidth()
+                        let newWidth = max(minColumnWidth, currentWidth + value.translation.width)
+                        columnOverrides[column.id] = newWidth
+                    }
+            )
+    }
+
+    /// Estimate the default flexible column width for drag baseline.
+    /// Uses 508pt (card content area) as a reasonable default.
+    private func estimatedFlexWidth() -> CGFloat {
+        let checkboxWidth: CGFloat = hasSelection ? selectionColumnWidth : 0
+        let fixedTotal = data.columns.compactMap(\.width).map { CGFloat($0) }.reduce(0, +)
+        let flexCount = data.columns.filter({ $0.width == nil }).count
+        guard flexCount > 0 else { return minColumnWidth }
+        return max(minColumnWidth, (508 - checkboxWidth - fixedTotal) / CGFloat(flexCount))
     }
 
     // MARK: - Helpers

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -86,6 +86,7 @@ private struct TableColumnLayout: Layout {
 private let minColumnWidth: CGFloat = 60
 private let selectionColumnWidth: CGFloat = 28
 private let resizeHandleWidth: CGFloat = 8
+private let resizeGestureCoordinateSpaceName = "InlineTableWidgetResize"
 
 // MARK: - InlineTableWidget
 
@@ -110,6 +111,11 @@ public struct InlineTableWidget: View {
     @State private var columnOverrides: [String: CGFloat] = [:]
     /// Baseline width captured at drag start for each column.
     @State private var resizeDragStartWidths: [String: CGFloat] = [:]
+    @State private var hoveredResizeHandleIndex: Int?
+    @State private var activeResizeHandleIndex: Int?
+    #if os(macOS)
+    @State private var didPushResizeCursor = false
+    #endif
 
     public init(data: TableSurfaceData, onAction: @escaping (String, [String: AnyCodable]?) -> Void) {
         self.data = data
@@ -172,6 +178,10 @@ public struct InlineTableWidget: View {
         needsHorizontalScroll
     }
 
+    private var isResizingColumn: Bool {
+        activeResizeHandleIndex != nil
+    }
+
     // MARK: - Body
 
     public var body: some View {
@@ -190,6 +200,17 @@ public struct InlineTableWidget: View {
             if hasSelection {
                 onAction("selection_changed", ["selectedIds": AnyCodable(Array(selectedIds))])
             }
+        }
+        .coordinateSpace(name: resizeGestureCoordinateSpaceName)
+        .onDisappear {
+            hoveredResizeHandleIndex = nil
+            activeResizeHandleIndex = nil
+            #if os(macOS)
+            if didPushResizeCursor {
+                NSCursor.pop()
+                didPushResizeCursor = false
+            }
+            #endif
         }
     }
 
@@ -210,6 +231,7 @@ public struct InlineTableWidget: View {
             tableContent
                 .frame(width: minimumTableWidth, alignment: .leading)
         }
+        .scrollDisabled(isResizingColumn)
         .frame(maxWidth: maxTableViewportWidth, alignment: .leading)
         .overlay(alignment: .trailing) {
             if shouldShowHorizontalHint {
@@ -354,28 +376,42 @@ public struct InlineTableWidget: View {
     // MARK: - Resize Handle
 
     private func resizeHandle(for columnIndex: Int) -> some View {
-        Rectangle()
+        let isHighlighted = isResizeHandleHighlighted(columnIndex)
+        return Rectangle()
             .fill(Color.clear)
             .frame(width: resizeHandleWidth)
             .overlay(
                 Rectangle()
-                    .fill(VColor.borderBase.opacity(0.2))
+                    .fill(VColor.borderBase.opacity(0.45))
                     .frame(width: 1)
+                    .opacity(resizeHandleIndicatorOpacity(isHighlighted: isHighlighted))
+                    .animation(VAnimation.fast, value: isHighlighted)
             )
             .contentShape(Rectangle())
             #if os(macOS)
             .onHover { hovering in
                 if hovering {
-                    NSCursor.resizeLeftRight.push()
-                } else {
-                    NSCursor.pop()
+                    hoveredResizeHandleIndex = columnIndex
+                    if !didPushResizeCursor {
+                        NSCursor.resizeLeftRight.push()
+                        didPushResizeCursor = true
+                    }
+                } else if hoveredResizeHandleIndex == columnIndex {
+                    hoveredResizeHandleIndex = nil
+                    if didPushResizeCursor && !isResizingColumn {
+                        NSCursor.pop()
+                        didPushResizeCursor = false
+                    }
                 }
             }
             #endif
             .gesture(
-                DragGesture(minimumDistance: 1)
+                DragGesture(minimumDistance: 0, coordinateSpace: .named(resizeGestureCoordinateSpaceName))
                     .onChanged { value in
                         let column = data.columns[columnIndex]
+                        if activeResizeHandleIndex == nil {
+                            activeResizeHandleIndex = columnIndex
+                        }
                         let startWidth: CGFloat
                         if let existing = resizeDragStartWidths[column.id] {
                             startWidth = existing
@@ -384,14 +420,41 @@ public struct InlineTableWidget: View {
                             resizeDragStartWidths[column.id] = captured
                             startWidth = captured
                         }
-                        let newWidth = max(minColumnWidth, startWidth + value.translation.width)
-                        columnOverrides[column.id] = newWidth
+                        let delta = value.location.x - value.startLocation.x
+                        let newWidth = max(minColumnWidth, startWidth + delta)
+                        let snappedWidth = (newWidth * 2).rounded() / 2
+                        if columnOverrides[column.id] != snappedWidth {
+                            var transaction = Transaction()
+                            transaction.disablesAnimations = true
+                            withTransaction(transaction) {
+                                columnOverrides[column.id] = snappedWidth
+                            }
+                        }
                     }
                     .onEnded { _ in
                         let column = data.columns[columnIndex]
                         resizeDragStartWidths[column.id] = nil
+                        activeResizeHandleIndex = nil
+                        #if os(macOS)
+                        if didPushResizeCursor && hoveredResizeHandleIndex == nil {
+                            NSCursor.pop()
+                            didPushResizeCursor = false
+                        }
+                        #endif
                     }
             )
+    }
+
+    private func isResizeHandleHighlighted(_ columnIndex: Int) -> Bool {
+        hoveredResizeHandleIndex == columnIndex || activeResizeHandleIndex == columnIndex
+    }
+
+    private func resizeHandleIndicatorOpacity(isHighlighted: Bool) -> Double {
+        #if os(macOS)
+        isHighlighted ? 1 : 0
+        #else
+        isHighlighted ? 1 : 0.2
+        #endif
     }
 
     private func currentColumnWidth(_ column: TableColumn) -> CGFloat {

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -1,72 +1,9 @@
 import SwiftUI
 
-// MARK: - TableColumnLayout
-
-/// Custom `Layout` that distributes the parent's proposed width among
-/// table columns in a single layout pass. Fixed-width columns receive
-/// their specified size (clamped to available space). Flexible columns
-/// share the remaining width equally. Each subview = one column cell.
-///
-/// This participates directly in SwiftUI's layout system — no
-/// GeometryReader, no measurement state, no re-render cycle.
-private struct TableColumnLayout: Layout {
-    /// Per-column spec: `nil` = flexible, `CGFloat` = fixed.
-    let specs: [CGFloat?]
-    /// Minimum width for flexible columns.
-    let minFlexWidth: CGFloat
-
-    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout [CGFloat]) -> CGSize {
-        let widths = resolvedWidths(for: proposal.width ?? 0, count: subviews.count)
-        cache = widths
-        let height = zip(subviews, widths).map { sub, w in
-            sub.sizeThatFits(ProposedViewSize(width: w, height: nil)).height
-        }.max() ?? 0
-        return CGSize(width: widths.reduce(0, +), height: height)
-    }
-
-    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout [CGFloat]) {
-        let widths = cache.isEmpty
-            ? resolvedWidths(for: bounds.width, count: subviews.count)
-            : cache
-        var x = bounds.minX
-        for (i, subview) in subviews.enumerated() {
-            let w = i < widths.count ? widths[i] : 0
-            subview.place(
-                at: CGPoint(x: x, y: bounds.minY),
-                anchor: .topLeading,
-                proposal: ProposedViewSize(width: w, height: bounds.height)
-            )
-            x += w
-        }
-    }
-
-    func makeCache(subviews: Subviews) -> [CGFloat] { [] }
-
-    /// Distribute `available` width among `count` subviews based on `specs`.
-    private func resolvedWidths(for available: CGFloat, count: Int) -> [CGFloat] {
-        guard count > 0 else { return [] }
-        let padded = specs + Array(repeating: nil as CGFloat?, count: max(0, count - specs.count))
-        let effective = Array(padded.prefix(count))
-
-        let fixedTotal = effective.compactMap { $0 }.reduce(0, +)
-        let flexCount = effective.filter { $0 == nil }.count
-        let flexWidth = flexCount > 0
-            ? max(minFlexWidth, (available - fixedTotal) / CGFloat(flexCount))
-            : 0
-
-        return effective.map { spec in
-            if let fixed = spec {
-                return min(fixed, available)
-            }
-            return flexWidth
-        }
-    }
-}
-
 // MARK: - Constants
 
 private let minColumnWidth: CGFloat = 60
-private let selectionColumnWidth: CGFloat = 28
+private let checkboxColumnWidth: CGFloat = 28
 private let resizeHandleWidth: CGFloat = 8
 
 // MARK: - InlineTableWidget
@@ -74,21 +11,17 @@ private let resizeHandleWidth: CGFloat = 8
 /// Inline table widget with selectable rows, resizable columns, and
 /// optional horizontal scrolling.
 ///
-/// Layout approach:
-/// - A custom `TableColumnLayout` (the `Layout` protocol) distributes
-///   the parent's proposed width among columns in a single layout pass.
-/// - The selection checkbox column sits outside the Layout in an HStack,
-///   so SwiftUI subtracts its 28pt before proposing width to the Layout.
-/// - When total minimum widths exceed the available space, a horizontal
-///   `ScrollView` activates as a fallback.
-/// - Users can resize columns by dragging dividers in the header row.
+/// Uses `onGeometryChange` (macOS 15) to measure the available container
+/// width from a zero-height spacer, then distributes explicit
+/// `frame(width:)` constraints across columns. Cells wrap text within
+/// their allocated width via `.lineLimit(nil)`.
 public struct InlineTableWidget: View {
     public let data: TableSurfaceData
     public let onAction: (String, [String: AnyCodable]?) -> Void
 
     @State private var selectedIds: Set<String> = []
-    /// User-resized column widths. Keyed by column ID.
-    /// When absent, the column uses its default (fixed or flex) width.
+    @State private var availableWidth: CGFloat = 0
+    /// User-resized column widths keyed by column ID.
     @State private var columnOverrides: [String: CGFloat] = [:]
 
     public init(data: TableSurfaceData, onAction: @escaping (String, [String: AnyCodable]?) -> Void) {
@@ -107,52 +40,72 @@ public struct InlineTableWidget: View {
         return !ids.isEmpty && ids.isSubset(of: selectedIds)
     }
 
-    private var hasSelection: Bool {
-        data.selectionMode != .none
+    private var hasSelection: Bool { data.selectionMode != .none }
+    private var isMeasured: Bool { availableWidth > 0 }
+
+    /// Width available for data columns (after subtracting checkbox if present).
+    private var columnBudget: CGFloat {
+        availableWidth - (hasSelection ? checkboxColumnWidth : 0)
     }
 
-    /// Column specs for the Layout: user overrides take precedence,
-    /// then backend fixed widths, then nil (flexible).
-    private var columnSpecs: [CGFloat?] {
-        data.columns.map { col in
-            if let override = columnOverrides[col.id] {
-                return override
-            }
-            if let fixed = col.width {
-                return CGFloat(fixed)
-            }
-            return nil
-        }
-    }
-
-    /// The Layout instance shared by header and all data rows.
-    private var columnLayout: TableColumnLayout {
-        TableColumnLayout(specs: columnSpecs, minFlexWidth: minColumnWidth)
-    }
-
-    /// Whether horizontal scrolling is needed (total minimums exceed container).
-    /// The container width is 508pt (540pt card - 32pt padding).
-    /// We use a conservative estimate since the actual proposed width
-    /// comes from the parent at layout time.
+    /// Whether the table needs horizontal scrolling (column minimums exceed budget).
     private var needsHorizontalScroll: Bool {
-        let checkboxWidth: CGFloat = hasSelection ? selectionColumnWidth : 0
-        let fixedTotal = columnSpecs.compactMap { $0 }.reduce(0, +)
-        let flexCount = columnSpecs.filter { $0 == nil }.count
-        let totalMin = checkboxWidth + fixedTotal + CGFloat(flexCount) * minColumnWidth
-        return totalMin > 508
+        guard isMeasured else { return false }
+        let fixedTotal = data.columns.compactMap(\.width).map { CGFloat($0) }.reduce(0, +)
+        let flexCount = data.columns.filter({ $0.width == nil }).count
+        return fixedTotal + CGFloat(flexCount) * minColumnWidth > columnBudget
+    }
+
+    /// Total content width when horizontal scrolling is active.
+    private var scrollContentWidth: CGFloat {
+        let fixedTotal = data.columns.compactMap(\.width).map { CGFloat($0) }.reduce(0, +)
+        let flexCount = data.columns.filter({ $0.width == nil }).count
+        return fixedTotal + CGFloat(flexCount) * minColumnWidth
+    }
+
+    // MARK: - Column Width Calculation
+
+    /// Resolved width for a column. User overrides take precedence, then
+    /// backend fixed widths, then equal flex distribution.
+    private func columnWidth(for column: TableColumn) -> CGFloat {
+        if let override = columnOverrides[column.id] {
+            return override
+        }
+        if let fixed = column.width {
+            return min(CGFloat(fixed), columnBudget)
+        }
+        let fixedTotal = data.columns.compactMap(\.width).map { CGFloat($0) }.reduce(0, +)
+        let overrideTotal = columnOverrides.values.reduce(0, +)
+        let flexCount = data.columns.filter({ $0.width == nil && columnOverrides[$0.id] == nil }).count
+        guard flexCount > 0 else { return minColumnWidth }
+
+        let budget = needsHorizontalScroll ? scrollContentWidth : columnBudget
+        return max(minColumnWidth, (budget - fixedTotal - overrideTotal) / CGFloat(flexCount))
     }
 
     // MARK: - Body
 
     public var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            if needsHorizontalScroll {
-                ScrollView(.horizontal, showsIndicators: true) {
+            // Zero-height spacer measures the parent's proposed width.
+            // It has no intrinsic content so it always reports exactly
+            // the proposed width — no overflow, no feedback loop.
+            Color.clear
+                .frame(height: 0)
+                .frame(maxWidth: .infinity)
+                .onGeometryChange(for: CGFloat.self) { $0.size.width } action: {
+                    availableWidth = $0
+                }
+
+            if isMeasured {
+                if needsHorizontalScroll {
+                    ScrollView(.horizontal, showsIndicators: true) {
+                        tableContent
+                            .frame(width: scrollContentWidth + (hasSelection ? checkboxColumnWidth : 0))
+                    }
+                } else {
                     tableContent
                 }
-                .scrollClipDisabled(false)
-            } else {
-                tableContent
             }
 
             if let caption = data.caption {
@@ -205,27 +158,27 @@ public struct InlineTableWidget: View {
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel(allSelected ? "Deselect all" : "Select all")
-                    .frame(width: selectionColumnWidth)
+                    .frame(width: checkboxColumnWidth)
                 } else {
-                    Color.clear.frame(width: selectionColumnWidth)
+                    Color.clear.frame(width: checkboxColumnWidth)
                 }
             }
 
-            columnLayout {
-                ForEach(Array(data.columns.enumerated()), id: \.element.id) { index, column in
-                    HStack(spacing: 0) {
-                        Text(column.label)
-                            .font(VFont.labelDefault)
-                            .foregroundStyle(VColor.contentTertiary)
-                            .textSelection(.enabled)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+            ForEach(Array(data.columns.enumerated()), id: \.element.id) { index, column in
+                HStack(spacing: 0) {
+                    Text(column.label)
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                        .textSelection(.enabled)
+                        .lineLimit(1)
 
-                        // Resize handle (between columns, not after the last one)
-                        if index < data.columns.count - 1 {
-                            resizeHandle(for: index)
-                        }
+                    Spacer(minLength: 0)
+
+                    if index < data.columns.count - 1 {
+                        resizeHandle(for: index)
                     }
                 }
+                .frame(width: columnWidth(for: column), alignment: .leading)
             }
         }
     }
@@ -244,16 +197,15 @@ public struct InlineTableWidget: View {
                             .foregroundStyle(isSelected ? VColor.primaryBase : VColor.contentTertiary)
                     }
                     .buttonStyle(.plain)
-                    .frame(width: selectionColumnWidth)
+                    .frame(width: checkboxColumnWidth)
                 } else {
-                    Color.clear.frame(width: selectionColumnWidth)
+                    Color.clear.frame(width: checkboxColumnWidth)
                 }
             }
 
-            columnLayout {
-                ForEach(data.columns) { column in
-                    cellView(row.cells[column.id])
-                }
+            ForEach(data.columns) { column in
+                cellView(row.cells[column.id])
+                    .frame(width: columnWidth(for: column), alignment: .leading)
             }
         }
         .padding(.vertical, VSpacing.xs)
@@ -285,7 +237,6 @@ public struct InlineTableWidget: View {
                 .lineLimit(nil)
                 .textSelection(.enabled)
         }
-        .padding(.trailing, VSpacing.xs)
     }
 
     // MARK: - Resize Handle
@@ -313,23 +264,12 @@ public struct InlineTableWidget: View {
                 DragGesture(minimumDistance: 1)
                     .onChanged { value in
                         let column = data.columns[columnIndex]
-                        let currentWidth = columnOverrides[column.id]
+                        let current = columnOverrides[column.id]
                             ?? column.width.map { CGFloat($0) }
-                            ?? estimatedFlexWidth()
-                        let newWidth = max(minColumnWidth, currentWidth + value.translation.width)
-                        columnOverrides[column.id] = newWidth
+                            ?? columnWidth(for: column)
+                        columnOverrides[column.id] = max(minColumnWidth, current + value.translation.width)
                     }
             )
-    }
-
-    /// Estimate the default flexible column width for drag baseline.
-    /// Uses 508pt (card content area) as a reasonable default.
-    private func estimatedFlexWidth() -> CGFloat {
-        let checkboxWidth: CGFloat = hasSelection ? selectionColumnWidth : 0
-        let fixedTotal = data.columns.compactMap(\.width).map { CGFloat($0) }.reduce(0, +)
-        let flexCount = data.columns.filter({ $0.width == nil }).count
-        guard flexCount > 0 else { return minColumnWidth }
-        return max(minColumnWidth, (508 - checkboxWidth - fixedTotal) / CGFloat(flexCount))
     }
 
     // MARK: - Helpers

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -6,7 +6,7 @@ private extension View {
         if let w = width {
             self.frame(width: CGFloat(w), alignment: .leading)
         } else {
-            self.frame(maxWidth: .infinity, alignment: .leading)
+            self.frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
         }
     }
 }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -131,7 +131,7 @@ public struct InlineTableWidget: View {
             Text(value?.text ?? "")
                 .font(VFont.bodyMediumLighter)
                 .foregroundStyle(VColor.contentDefault)
-                .lineLimit(2)
+                .lineLimit(nil)
                 .textSelection(.enabled)
         }
         .columnFrame(width)

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
 
 // MARK: - TableColumnLayout
 
@@ -85,7 +88,7 @@ private struct TableColumnLayout: Layout {
 
 private let minColumnWidth: CGFloat = 60
 private let selectionColumnWidth: CGFloat = 28
-private let resizeHandleWidth: CGFloat = 8
+private let resizeHandleWidth: CGFloat = 18
 private let resizeGestureCoordinateSpaceName = "InlineTableWidgetResize"
 
 // MARK: - InlineTableWidget
@@ -113,9 +116,6 @@ public struct InlineTableWidget: View {
     @State private var resizeDragStartWidths: [String: CGFloat] = [:]
     @State private var hoveredResizeHandleIndex: Int?
     @State private var activeResizeHandleIndex: Int?
-    #if os(macOS)
-    @State private var didPushResizeCursor = false
-    #endif
 
     public init(data: TableSurfaceData, onAction: @escaping (String, [String: AnyCodable]?) -> Void) {
         self.data = data
@@ -205,12 +205,6 @@ public struct InlineTableWidget: View {
         .onDisappear {
             hoveredResizeHandleIndex = nil
             activeResizeHandleIndex = nil
-            #if os(macOS)
-            if didPushResizeCursor {
-                NSCursor.pop()
-                didPushResizeCursor = false
-            }
-            #endif
         }
     }
 
@@ -382,67 +376,27 @@ public struct InlineTableWidget: View {
             .frame(width: resizeHandleWidth)
             .overlay(
                 Rectangle()
-                    .fill(VColor.borderBase.opacity(0.45))
-                    .frame(width: 1)
+                    .fill(resizeHandleIndicatorColor(isHighlighted: isHighlighted))
+                    .frame(width: resizeHandleIndicatorWidth(isHighlighted: isHighlighted))
                     .opacity(resizeHandleIndicatorOpacity(isHighlighted: isHighlighted))
-                    .animation(VAnimation.fast, value: isHighlighted)
             )
-            .contentShape(Rectangle())
             #if os(macOS)
-            .onHover { hovering in
-                if hovering {
-                    hoveredResizeHandleIndex = columnIndex
-                    if !didPushResizeCursor {
-                        NSCursor.resizeLeftRight.push()
-                        didPushResizeCursor = true
+            .overlay {
+                HorizontalResizeHandleTrackingView(
+                    isDragging: activeResizeHandleIndex == columnIndex,
+                    onHoverChanged: { hovering in
+                        if hovering {
+                            hoveredResizeHandleIndex = columnIndex
+                        } else if hoveredResizeHandleIndex == columnIndex {
+                            hoveredResizeHandleIndex = nil
+                        }
                     }
-                } else if hoveredResizeHandleIndex == columnIndex {
-                    hoveredResizeHandleIndex = nil
-                    if didPushResizeCursor && !isResizingColumn {
-                        NSCursor.pop()
-                        didPushResizeCursor = false
-                    }
-                }
+                )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
             #endif
-            .gesture(
-                DragGesture(minimumDistance: 0, coordinateSpace: .named(resizeGestureCoordinateSpaceName))
-                    .onChanged { value in
-                        let column = data.columns[columnIndex]
-                        if activeResizeHandleIndex == nil {
-                            activeResizeHandleIndex = columnIndex
-                        }
-                        let startWidth: CGFloat
-                        if let existing = resizeDragStartWidths[column.id] {
-                            startWidth = existing
-                        } else {
-                            let captured = currentColumnWidth(column)
-                            resizeDragStartWidths[column.id] = captured
-                            startWidth = captured
-                        }
-                        let delta = value.location.x - value.startLocation.x
-                        let newWidth = max(minColumnWidth, startWidth + delta)
-                        let snappedWidth = (newWidth * 2).rounded() / 2
-                        if columnOverrides[column.id] != snappedWidth {
-                            var transaction = Transaction()
-                            transaction.disablesAnimations = true
-                            withTransaction(transaction) {
-                                columnOverrides[column.id] = snappedWidth
-                            }
-                        }
-                    }
-                    .onEnded { _ in
-                        let column = data.columns[columnIndex]
-                        resizeDragStartWidths[column.id] = nil
-                        activeResizeHandleIndex = nil
-                        #if os(macOS)
-                        if didPushResizeCursor && hoveredResizeHandleIndex == nil {
-                            NSCursor.pop()
-                            didPushResizeCursor = false
-                        }
-                        #endif
-                    }
-            )
+            .contentShape(Rectangle())
+            .gesture(resizeHandleDragGesture(for: columnIndex))
     }
 
     private func isResizeHandleHighlighted(_ columnIndex: Int) -> Bool {
@@ -455,6 +409,55 @@ public struct InlineTableWidget: View {
         #else
         isHighlighted ? 1 : 0.2
         #endif
+    }
+
+    private func resizeHandleDragGesture(for columnIndex: Int) -> some Gesture {
+        DragGesture(minimumDistance: 0, coordinateSpace: .named(resizeGestureCoordinateSpaceName))
+            .onChanged { value in
+                let column = data.columns[columnIndex]
+                if activeResizeHandleIndex == nil {
+                    activeResizeHandleIndex = columnIndex
+                }
+                #if os(macOS)
+                NSCursor.resizeLeftRight.set()
+                #endif
+                let startWidth: CGFloat
+                if let existing = resizeDragStartWidths[column.id] {
+                    startWidth = existing
+                } else {
+                    let captured = currentColumnWidth(column)
+                    resizeDragStartWidths[column.id] = captured
+                    startWidth = captured
+                }
+                let delta = value.location.x - value.startLocation.x
+                let newWidth = max(minColumnWidth, startWidth + delta)
+                let snappedWidth = (newWidth * 2).rounded() / 2
+                if columnOverrides[column.id] != snappedWidth {
+                    var transaction = Transaction()
+                    transaction.disablesAnimations = true
+                    withTransaction(transaction) {
+                        columnOverrides[column.id] = snappedWidth
+                    }
+                }
+            }
+            .onEnded { _ in
+                let column = data.columns[columnIndex]
+                resizeDragStartWidths[column.id] = nil
+                activeResizeHandleIndex = nil
+                #if os(macOS)
+                if hoveredResizeHandleIndex == nil {
+                    NSCursor.arrow.set()
+                }
+                #endif
+            }
+    }
+
+    private func resizeHandleIndicatorWidth(isHighlighted: Bool) -> CGFloat {
+        isHighlighted ? 2 : 1
+    }
+
+    private func resizeHandleIndicatorColor(isHighlighted: Bool) -> Color {
+        isHighlighted ? VColor.primaryBase : VColor.borderBase.opacity(0.45)
     }
 
     private func currentColumnWidth(_ column: TableColumn) -> CGFloat {
@@ -511,3 +514,94 @@ public struct InlineTableWidget: View {
         onAction("selection_changed", ["selectedIds": AnyCodable(Array(selectedIds))])
     }
 }
+
+#if os(macOS)
+private struct HorizontalResizeHandleTrackingView: NSViewRepresentable {
+    let isDragging: Bool
+    let onHoverChanged: (Bool) -> Void
+
+    final class Coordinator {
+        var onHoverChanged: (Bool) -> Void
+
+        init(onHoverChanged: @escaping (Bool) -> Void) {
+            self.onHoverChanged = onHoverChanged
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onHoverChanged: onHoverChanged)
+    }
+
+    func makeNSView(context: Context) -> HorizontalResizeHandleTrackingNSView {
+        let view = HorizontalResizeHandleTrackingNSView()
+        view.onHoverChanged = { hovering in
+            context.coordinator.onHoverChanged(hovering)
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: HorizontalResizeHandleTrackingNSView, context: Context) {
+        context.coordinator.onHoverChanged = onHoverChanged
+        nsView.onHoverChanged = { hovering in
+            context.coordinator.onHoverChanged(hovering)
+        }
+        nsView.isDragging = isDragging
+        nsView.window?.invalidateCursorRects(for: nsView)
+        if isDragging {
+            NSCursor.resizeLeftRight.set()
+        }
+    }
+}
+
+private final class HorizontalResizeHandleTrackingNSView: NSView {
+    var onHoverChanged: ((Bool) -> Void)?
+    var isDragging: Bool = false
+    private var trackingAreaRef: NSTrackingArea?
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        window?.invalidateCursorRects(for: self)
+    }
+
+    override func updateTrackingAreas() {
+        if let trackingAreaRef {
+            removeTrackingArea(trackingAreaRef)
+        }
+        let options: NSTrackingArea.Options = [
+            .mouseEnteredAndExited,
+            .activeInKeyWindow,
+            .enabledDuringMouseDrag,
+            .inVisibleRect,
+            .cursorUpdate
+        ]
+        let area = NSTrackingArea(rect: .zero, options: options, owner: self, userInfo: nil)
+        addTrackingArea(area)
+        trackingAreaRef = area
+        super.updateTrackingAreas()
+    }
+
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: .resizeLeftRight)
+    }
+
+    override func cursorUpdate(with event: NSEvent) {
+        NSCursor.resizeLeftRight.set()
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        onHoverChanged?(true)
+        NSCursor.resizeLeftRight.set()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        onHoverChanged?(false)
+        if !isDragging {
+            NSCursor.arrow.set()
+        }
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+}
+#endif

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -1,18 +1,89 @@
 import SwiftUI
 
+// MARK: - TableRowLayout
+
+/// Custom `Layout` that distributes available width among table columns
+/// in a single layout pass — no measurement state, no re-renders.
+///
+/// Fixed-width columns receive their specified size (clamped to available
+/// space). Flexible columns share the remaining width equally. Each child
+/// view corresponds to one column cell (plus an optional leading selection
+/// cell when `selectionWidth > 0`).
+private struct TableRowLayout: Layout {
+    let columnWidths: [Int?]
+    let selectionWidth: CGFloat
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let width = proposal.width ?? 0
+        let resolvedWidths = resolveColumnWidths(for: width)
+        let heights = subviewHeights(subviews: subviews, columnWidths: resolvedWidths)
+        return CGSize(width: width, height: heights.max() ?? 0)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let resolvedWidths = resolveColumnWidths(for: bounds.width)
+        var x = bounds.minX
+
+        for (index, subview) in subviews.enumerated() {
+            let colWidth = resolvedWidths[index]
+            let cellProposal = ProposedViewSize(width: colWidth, height: nil)
+            subview.place(at: CGPoint(x: x, y: bounds.minY), anchor: .topLeading, proposal: cellProposal)
+            x += colWidth
+        }
+    }
+
+    // MARK: - Column Width Resolution
+
+    /// Distribute `totalWidth` among the selection column (if any) and data columns.
+    /// Returns one width per subview (selection + columns).
+    private func resolveColumnWidths(for totalWidth: CGFloat) -> [CGFloat] {
+        var widths: [CGFloat] = []
+        var remaining = totalWidth
+
+        // Selection column
+        if selectionWidth > 0 {
+            let sel = min(selectionWidth, remaining)
+            widths.append(sel)
+            remaining -= sel
+        }
+
+        // Data columns
+        let fixedTotal = CGFloat(columnWidths.compactMap { $0 }.reduce(0, +))
+        let flexCount = columnWidths.filter { $0 == nil }.count
+        let flexWidth = flexCount > 0 ? max(0, (remaining - fixedTotal) / CGFloat(flexCount)) : 0
+
+        for colWidth in columnWidths {
+            if let fixed = colWidth {
+                let clamped = min(CGFloat(fixed), remaining)
+                widths.append(clamped)
+            } else {
+                widths.append(flexWidth)
+            }
+        }
+
+        return widths
+    }
+
+    /// Measure each subview's height given its resolved column width.
+    private func subviewHeights(subviews: Subviews, columnWidths: [CGFloat]) -> [CGFloat] {
+        zip(subviews, columnWidths).map { subview, width in
+            subview.sizeThatFits(ProposedViewSize(width: width, height: nil)).height
+        }
+    }
+}
+
+// MARK: - InlineTableWidget
+
 /// Inline table widget with selectable rows and action support.
 ///
-/// Follows the same layout pattern as `MarkdownTableView`: measures the
-/// available container width, applies it as a hard `.frame(width:)`
-/// constraint on the table VStack, and lets cells share that constrained
-/// space via `.frame(maxWidth: .infinity)`. This guarantees text wraps
-/// within columns and the table never overflows its container.
+/// Uses a custom `TableRowLayout` (the `Layout` protocol) to distribute
+/// the parent's proposed width among columns in a single layout pass —
+/// no GeometryReader, no measurement state, no re-render cycle.
 public struct InlineTableWidget: View {
     public let data: TableSurfaceData
     public let onAction: (String, [String: AnyCodable]?) -> Void
 
     @State private var selectedIds: Set<String> = []
-    @State private var tableWidth: CGFloat = 0
 
     public init(data: TableSurfaceData, onAction: @escaping (String, [String: AnyCodable]?) -> Void) {
         self.data = data
@@ -28,55 +99,38 @@ public struct InlineTableWidget: View {
         return !ids.isEmpty && ids.isSubset(of: selectedIds)
     }
 
+    /// The `TableRowLayout` configuration shared by headers and all data rows.
+    private var rowLayout: TableRowLayout {
+        TableRowLayout(
+            columnWidths: data.columns.map(\.width),
+            selectionWidth: data.selectionMode != .none ? 28 : 0
+        )
+    }
+
     // MARK: - Body
 
     public var body: some View {
-        // Outer wrapper: invisible spacer measures available width,
-        // then the table renders at that exact width.
-        VStack(spacing: 0) {
-            // Measure available width from a contentless view that can't
-            // overflow — it always reports the parent's proposed width.
-            Color.clear
-                .frame(height: 0)
-                .frame(maxWidth: .infinity)
-                .onGeometryChange(for: CGFloat.self) { $0.size.width } action: {
-                    tableWidth = $0
-                }
-
-            if tableWidth > 0 {
-                tableBody
-                    // Hard width constraint — the key to preventing overflow.
-                    // Identical to MarkdownTableView's .frame(maxWidth: maxWidth).
-                    // Forces the VStack and all children to lay out within this
-                    // exact width. Cells with .frame(maxWidth: .infinity) then
-                    // share this constrained space equally.
-                    .frame(width: tableWidth, alignment: .leading)
-            }
-        }
-        .onAppear {
-            selectedIds = Set(data.rows.filter(\.selected).map(\.id))
-            if data.selectionMode != .none {
-                onAction("selection_changed", ["selectedIds": AnyCodable(Array(selectedIds))])
-            }
-        }
-    }
-
-    // MARK: - Table Content
-
-    /// The actual table layout. Identical pattern to `MarkdownTableView`:
-    /// each cell uses `.frame(maxWidth: .infinity)` to share the parent's
-    /// constrained width equally.
-    private var tableBody: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             // Column headers
-            HStack(spacing: 0) {
-                selectionCell(isHeader: true)
+            rowLayout {
+                if data.selectionMode == .multiple {
+                    Button {
+                        toggleSelectAll()
+                    } label: {
+                        VIconView(allSelected ? .circleCheck : .circle, size: 14)
+                            .foregroundStyle(allSelected ? VColor.primaryBase : VColor.contentTertiary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(allSelected ? "Deselect all" : "Select all")
+                } else if data.selectionMode != .none {
+                    Color.clear
+                }
+
                 ForEach(data.columns) { column in
                     Text(column.label)
                         .font(VFont.labelDefault)
                         .foregroundStyle(VColor.contentTertiary)
                         .textSelection(.enabled)
-                        .cellFrame(column.width)
                 }
             }
             .padding(.bottom, VSpacing.xxs)
@@ -100,31 +154,19 @@ public struct InlineTableWidget: View {
                     .padding(.top, VSpacing.xs)
             }
         }
+        .onAppear {
+            selectedIds = Set(data.rows.filter(\.selected).map(\.id))
+            if data.selectionMode != .none {
+                onAction("selection_changed", ["selectedIds": AnyCodable(Array(selectedIds))])
+            }
+        }
     }
 
     // MARK: - Row & Cell Views
 
-    @ViewBuilder
-    private func selectionCell(isHeader: Bool = false) -> some View {
-        if data.selectionMode == .multiple && isHeader {
-            Button {
-                toggleSelectAll()
-            } label: {
-                VIconView(allSelected ? .circleCheck : .circle, size: 14)
-                    .foregroundStyle(allSelected ? VColor.primaryBase : VColor.contentTertiary)
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel(allSelected ? "Deselect all" : "Select all")
-            .frame(width: 28)
-        } else if data.selectionMode != .none {
-            Color.clear
-                .frame(width: 28)
-        }
-    }
-
     private func rowView(_ row: TableRow) -> some View {
         let isSelected = selectedIds.contains(row.id)
-        return HStack(spacing: 0) {
+        return rowLayout {
             if data.selectionMode != .none && row.selectable {
                 Button {
                     toggleSelection(row.id)
@@ -133,14 +175,12 @@ public struct InlineTableWidget: View {
                         .foregroundStyle(isSelected ? VColor.primaryBase : VColor.contentTertiary)
                 }
                 .buttonStyle(.plain)
-                .frame(width: 28)
             } else if data.selectionMode != .none {
                 Color.clear
-                    .frame(width: 28)
             }
 
             ForEach(data.columns) { column in
-                cellView(row.cells[column.id], columnWidth: column.width)
+                cellView(row.cells[column.id])
             }
         }
         .padding(.vertical, VSpacing.xs)
@@ -157,7 +197,7 @@ public struct InlineTableWidget: View {
     }
 
     @ViewBuilder
-    private func cellView(_ value: TableCellValue?, columnWidth: Int?) -> some View {
+    private func cellView(_ value: TableCellValue?) -> some View {
         HStack(spacing: VSpacing.xs) {
             if let icon = value?.icon,
                let vIcon = SFSymbolMapping.icon(forSFSymbol: icon) {
@@ -170,7 +210,6 @@ public struct InlineTableWidget: View {
                 .lineLimit(nil)
                 .textSelection(.enabled)
         }
-        .cellFrame(columnWidth)
     }
 
     // MARK: - Helpers
@@ -209,21 +248,5 @@ public struct InlineTableWidget: View {
             }
         }
         onAction("selection_changed", ["selectedIds": AnyCodable(Array(selectedIds))])
-    }
-}
-
-// MARK: - Cell Sizing
-
-private extension View {
-    /// Fixed-width columns get their specified size.
-    /// Flexible columns use `.frame(maxWidth: .infinity)` to share the
-    /// parent's constrained width equally — the same pattern MarkdownTableView uses.
-    @ViewBuilder
-    func cellFrame(_ width: Int?) -> some View {
-        if let w = width {
-            self.frame(width: CGFloat(w), alignment: .leading)
-        } else {
-            self.frame(maxWidth: .infinity, alignment: .leading)
-        }
     }
 }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -1,9 +1,90 @@
 import SwiftUI
 
+// MARK: - TableColumnLayout
+
+/// Custom `Layout` that distributes the parent's proposed width among
+/// table columns in a single layout pass. Fixed-width columns retain
+/// their configured width. Flexible columns share any extra width, but
+/// never shrink below a minimum. Each subview = one column cell.
+///
+/// This participates directly in SwiftUI's layout system — no
+/// GeometryReader, no measurement state, no re-render cycle.
+private struct TableColumnLayout: Layout {
+    /// Per-column spec: `nil` = flexible, `CGFloat` = fixed.
+    let specs: [CGFloat?]
+    /// Minimum width for flexible columns.
+    let minFlexWidth: CGFloat
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout [CGFloat]) -> CGSize {
+        let widths = resolvedWidths(for: proposal.width, count: subviews.count)
+        cache = widths
+        let height = zip(subviews, widths).map { sub, w in
+            sub.sizeThatFits(ProposedViewSize(width: w, height: nil)).height
+        }.max() ?? 0
+        return CGSize(width: widths.reduce(0, +), height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout [CGFloat]) {
+        let widths = cache.isEmpty
+            ? resolvedWidths(for: proposal.width ?? bounds.width, count: subviews.count)
+            : cache
+        var x = bounds.minX
+        for (i, subview) in subviews.enumerated() {
+            let w = i < widths.count ? widths[i] : 0
+            subview.place(
+                at: CGPoint(x: x, y: bounds.minY),
+                anchor: .topLeading,
+                proposal: ProposedViewSize(width: w, height: bounds.height)
+            )
+            x += w
+        }
+    }
+
+    func makeCache(subviews: Subviews) -> [CGFloat] { [] }
+
+    /// Distribute `available` width among `count` subviews based on `specs`.
+    private func resolvedWidths(for available: CGFloat?, count: Int) -> [CGFloat] {
+        guard count > 0 else { return [] }
+        let padded = specs + Array(repeating: nil as CGFloat?, count: max(0, count - specs.count))
+        let effective = Array(padded.prefix(count))
+
+        let normalizedFixed = effective.map { spec in
+            spec.map { max(0, $0) }
+        }
+        let fixedTotal = normalizedFixed.compactMap { $0 }.reduce(0, +)
+        let flexCount = normalizedFixed.filter { $0 == nil }.count
+        let minimumTotal = fixedTotal + CGFloat(flexCount) * minFlexWidth
+
+        let constrainedWidth: CGFloat?
+        if let available, available.isFinite, available > 0 {
+            constrainedWidth = available
+        } else {
+            constrainedWidth = nil
+        }
+
+        let flexWidth: CGFloat
+        if flexCount == 0 {
+            flexWidth = 0
+        } else if let constrainedWidth, constrainedWidth > minimumTotal {
+            let extraPerColumn = (constrainedWidth - minimumTotal) / CGFloat(flexCount)
+            flexWidth = minFlexWidth + extraPerColumn
+        } else {
+            flexWidth = minFlexWidth
+        }
+
+        return normalizedFixed.map { spec in
+            if let fixed = spec {
+                return fixed
+            }
+            return flexWidth
+        }
+    }
+}
+
 // MARK: - Constants
 
 private let minColumnWidth: CGFloat = 60
-private let checkboxColumnWidth: CGFloat = 28
+private let selectionColumnWidth: CGFloat = 28
 private let resizeHandleWidth: CGFloat = 8
 
 // MARK: - InlineTableWidget
@@ -11,18 +92,24 @@ private let resizeHandleWidth: CGFloat = 8
 /// Inline table widget with selectable rows, resizable columns, and
 /// optional horizontal scrolling.
 ///
-/// Uses `onGeometryChange` (macOS 15) to measure the available container
-/// width from a zero-height spacer, then distributes explicit
-/// `frame(width:)` constraints across columns. Cells wrap text within
-/// their allocated width via `.lineLimit(nil)`.
+/// Layout approach:
+/// - A custom `TableColumnLayout` (the `Layout` protocol) distributes
+///   the parent's proposed width among columns in a single layout pass.
+/// - The selection checkbox column sits outside the Layout in an HStack,
+///   so SwiftUI subtracts its 28pt before proposing width to the Layout.
+/// - When total minimum widths exceed the available space, a horizontal
+///   `ScrollView` activates as a fallback.
+/// - Users can resize columns by dragging dividers in the header row.
 public struct InlineTableWidget: View {
     public let data: TableSurfaceData
     public let onAction: (String, [String: AnyCodable]?) -> Void
 
     @State private var selectedIds: Set<String> = []
-    @State private var availableWidth: CGFloat = 0
-    /// User-resized column widths keyed by column ID.
+    /// User-resized column widths. Keyed by column ID.
+    /// When absent, the column uses its default (fixed or flex) width.
     @State private var columnOverrides: [String: CGFloat] = [:]
+    /// Baseline width captured at drag start for each column.
+    @State private var resizeDragStartWidths: [String: CGFloat] = [:]
 
     public init(data: TableSurfaceData, onAction: @escaping (String, [String: AnyCodable]?) -> Void) {
         self.data = data
@@ -40,73 +127,56 @@ public struct InlineTableWidget: View {
         return !ids.isEmpty && ids.isSubset(of: selectedIds)
     }
 
-    private var hasSelection: Bool { data.selectionMode != .none }
-    private var isMeasured: Bool { availableWidth > 0 }
-
-    /// Width available for data columns (after subtracting checkbox if present).
-    private var columnBudget: CGFloat {
-        availableWidth - (hasSelection ? checkboxColumnWidth : 0)
+    private var hasSelection: Bool {
+        data.selectionMode != .none
     }
 
-    /// Whether the table needs horizontal scrolling (column minimums exceed budget).
+    /// Column specs for the Layout: user overrides take precedence,
+    /// then backend fixed widths, then nil (flexible).
+    private var columnSpecs: [CGFloat?] {
+        data.columns.map { col in
+            if let override = columnOverrides[col.id] {
+                return override
+            }
+            if let fixed = col.width {
+                return CGFloat(fixed)
+            }
+            return nil
+        }
+    }
+
+    /// The Layout instance shared by header and all data rows.
+    private var columnLayout: TableColumnLayout {
+        TableColumnLayout(specs: columnSpecs, minFlexWidth: minColumnWidth)
+    }
+
+    /// Minimum content width before the table overflows horizontally.
+    private var minimumTableWidth: CGFloat {
+        let checkboxWidth: CGFloat = hasSelection ? selectionColumnWidth : 0
+        let handleTotal = CGFloat(max(0, data.columns.count - 1)) * resizeHandleWidth
+        let fixedTotal = columnSpecs.compactMap { $0 }.reduce(0, +)
+        let flexCount = columnSpecs.filter { $0 == nil }.count
+        return checkboxWidth + handleTotal + fixedTotal + CGFloat(flexCount) * minColumnWidth
+    }
+
+    /// Table content viewport width inside the card chrome when fully expanded.
+    private var maxTableViewportWidth: CGFloat {
+        max(minColumnWidth, VSpacing.chatBubbleMaxWidth - 2 * VSpacing.lg)
+    }
+
     private var needsHorizontalScroll: Bool {
-        guard isMeasured else { return false }
-        let fixedTotal = data.columns.compactMap(\.width).map { CGFloat($0) }.reduce(0, +)
-        let flexCount = data.columns.filter({ $0.width == nil }).count
-        return fixedTotal + CGFloat(flexCount) * minColumnWidth > columnBudget
+        minimumTableWidth > maxTableViewportWidth + 1
     }
 
-    /// Total content width when horizontal scrolling is active.
-    private var scrollContentWidth: CGFloat {
-        let fixedTotal = data.columns.compactMap(\.width).map { CGFloat($0) }.reduce(0, +)
-        let flexCount = data.columns.filter({ $0.width == nil }).count
-        return fixedTotal + CGFloat(flexCount) * minColumnWidth
-    }
-
-    // MARK: - Column Width Calculation
-
-    /// Resolved width for a column. User overrides take precedence, then
-    /// backend fixed widths, then equal flex distribution.
-    private func columnWidth(for column: TableColumn) -> CGFloat {
-        if let override = columnOverrides[column.id] {
-            return override
-        }
-        if let fixed = column.width {
-            return min(CGFloat(fixed), columnBudget)
-        }
-        let fixedTotal = data.columns.compactMap(\.width).map { CGFloat($0) }.reduce(0, +)
-        let overrideTotal = columnOverrides.values.reduce(0, +)
-        let flexCount = data.columns.filter({ $0.width == nil && columnOverrides[$0.id] == nil }).count
-        guard flexCount > 0 else { return minColumnWidth }
-
-        let budget = needsHorizontalScroll ? scrollContentWidth : columnBudget
-        return max(minColumnWidth, (budget - fixedTotal - overrideTotal) / CGFloat(flexCount))
+    private var shouldShowHorizontalHint: Bool {
+        needsHorizontalScroll
     }
 
     // MARK: - Body
 
     public var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            // Zero-height spacer measures the parent's proposed width.
-            // It has no intrinsic content so it always reports exactly
-            // the proposed width — no overflow, no feedback loop.
-            Color.clear
-                .frame(height: 0)
-                .frame(maxWidth: .infinity)
-                .onGeometryChange(for: CGFloat.self) { $0.size.width } action: {
-                    availableWidth = $0
-                }
-
-            if isMeasured {
-                if needsHorizontalScroll {
-                    ScrollView(.horizontal, showsIndicators: true) {
-                        tableContent
-                            .frame(width: scrollContentWidth + (hasSelection ? checkboxColumnWidth : 0))
-                    }
-                } else {
-                    tableContent
-                }
-            }
+            tableContainer
 
             if let caption = data.caption {
                 Text(caption)
@@ -115,7 +185,6 @@ public struct InlineTableWidget: View {
                     .padding(.top, VSpacing.xs)
             }
         }
-        .clipped()
         .onAppear {
             selectedIds = Set(data.rows.filter(\.selected).map(\.id))
             if hasSelection {
@@ -125,6 +194,41 @@ public struct InlineTableWidget: View {
     }
 
     // MARK: - Table Content
+
+    @ViewBuilder
+    private var tableContainer: some View {
+        if needsHorizontalScroll {
+            horizontalScrollableTable
+        } else {
+            tableContent
+                .frame(width: minimumTableWidth, alignment: .leading)
+        }
+    }
+
+    private var horizontalScrollableTable: some View {
+        ScrollView(.horizontal, showsIndicators: true) {
+            tableContent
+                .frame(width: minimumTableWidth, alignment: .leading)
+        }
+        .frame(maxWidth: maxTableViewportWidth, alignment: .leading)
+        .overlay(alignment: .trailing) {
+            if shouldShowHorizontalHint {
+                overflowHint
+            }
+        }
+    }
+
+    private var overflowHint: some View {
+        LinearGradient(
+            colors: [Color.clear, VColor.surfaceOverlay],
+            startPoint: .leading,
+            endPoint: .trailing
+        )
+        .frame(width: 28)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
 
     private var tableContent: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -158,27 +262,29 @@ public struct InlineTableWidget: View {
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel(allSelected ? "Deselect all" : "Select all")
-                    .frame(width: checkboxColumnWidth)
+                    .frame(width: selectionColumnWidth)
                 } else {
-                    Color.clear.frame(width: checkboxColumnWidth)
+                    Color.clear.frame(width: selectionColumnWidth)
                 }
             }
 
-            ForEach(Array(data.columns.enumerated()), id: \.element.id) { index, column in
-                HStack(spacing: 0) {
-                    Text(column.label)
-                        .font(VFont.labelDefault)
-                        .foregroundStyle(VColor.contentTertiary)
-                        .textSelection(.enabled)
-                        .lineLimit(1)
+            columnLayout {
+                ForEach(Array(data.columns.enumerated()), id: \.element.id) { index, column in
+                    HStack(spacing: 0) {
+                        Text(column.label)
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                            .textSelection(.enabled)
+                            .lineLimit(nil)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(maxWidth: .infinity, alignment: .leading)
 
-                    Spacer(minLength: 0)
-
-                    if index < data.columns.count - 1 {
-                        resizeHandle(for: index)
+                        // Resize handle (between columns, not after the last one)
+                        if index < data.columns.count - 1 {
+                            resizeHandle(for: index)
+                        }
                     }
                 }
-                .frame(width: columnWidth(for: column), alignment: .leading)
             }
         }
     }
@@ -197,15 +303,16 @@ public struct InlineTableWidget: View {
                             .foregroundStyle(isSelected ? VColor.primaryBase : VColor.contentTertiary)
                     }
                     .buttonStyle(.plain)
-                    .frame(width: checkboxColumnWidth)
+                    .frame(width: selectionColumnWidth)
                 } else {
-                    Color.clear.frame(width: checkboxColumnWidth)
+                    Color.clear.frame(width: selectionColumnWidth)
                 }
             }
 
-            ForEach(data.columns) { column in
-                cellView(row.cells[column.id])
-                    .frame(width: columnWidth(for: column), alignment: .leading)
+            columnLayout {
+                ForEach(data.columns) { column in
+                    cellView(row.cells[column.id])
+                }
             }
         }
         .padding(.vertical, VSpacing.xs)
@@ -225,7 +332,7 @@ public struct InlineTableWidget: View {
 
     @ViewBuilder
     private func cellView(_ value: TableCellValue?) -> some View {
-        HStack(spacing: VSpacing.xs) {
+        HStack(alignment: .top, spacing: VSpacing.xs) {
             if let icon = value?.icon,
                let vIcon = SFSymbolMapping.icon(forSFSymbol: icon) {
                 VIconView(vIcon, size: 12)
@@ -235,8 +342,13 @@ public struct InlineTableWidget: View {
                 .font(VFont.bodyMediumLighter)
                 .foregroundStyle(VColor.contentDefault)
                 .lineLimit(nil)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
                 .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .padding(.trailing, VSpacing.xs)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Resize Handle
@@ -264,12 +376,38 @@ public struct InlineTableWidget: View {
                 DragGesture(minimumDistance: 1)
                     .onChanged { value in
                         let column = data.columns[columnIndex]
-                        let current = columnOverrides[column.id]
-                            ?? column.width.map { CGFloat($0) }
-                            ?? columnWidth(for: column)
-                        columnOverrides[column.id] = max(minColumnWidth, current + value.translation.width)
+                        let startWidth: CGFloat
+                        if let existing = resizeDragStartWidths[column.id] {
+                            startWidth = existing
+                        } else {
+                            let captured = currentColumnWidth(column)
+                            resizeDragStartWidths[column.id] = captured
+                            startWidth = captured
+                        }
+                        let newWidth = max(minColumnWidth, startWidth + value.translation.width)
+                        columnOverrides[column.id] = newWidth
+                    }
+                    .onEnded { _ in
+                        let column = data.columns[columnIndex]
+                        resizeDragStartWidths[column.id] = nil
                     }
             )
+    }
+
+    private func currentColumnWidth(_ column: TableColumn) -> CGFloat {
+        columnOverrides[column.id]
+            ?? column.width.map { CGFloat($0) }
+            ?? estimatedFlexWidth()
+    }
+
+    /// Estimate a flexible column's baseline width for drag start.
+    /// This uses the non-scroll card content width (540 - 2*16 = 508pt).
+    private func estimatedFlexWidth() -> CGFloat {
+        let checkboxWidth: CGFloat = hasSelection ? selectionColumnWidth : 0
+        let fixedTotal = columnSpecs.compactMap { $0 }.reduce(0, +)
+        let flexCount = columnSpecs.filter { $0 == nil }.count
+        guard flexCount > 0 else { return minColumnWidth }
+        return max(minColumnWidth, (508 - checkboxWidth - fixedTotal) / CGFloat(flexCount))
     }
 
     // MARK: - Helpers

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -1,89 +1,16 @@
 import SwiftUI
 
-// MARK: - TableRowLayout
-
-/// Custom `Layout` that distributes available width among table columns
-/// in a single layout pass — no measurement state, no re-renders.
-///
-/// Fixed-width columns receive their specified size (clamped to available
-/// space). Flexible columns share the remaining width equally. Each child
-/// view corresponds to one column cell (plus an optional leading selection
-/// cell when `selectionWidth > 0`).
-private struct TableRowLayout: Layout {
-    let columnWidths: [Int?]
-    let selectionWidth: CGFloat
-
-    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
-        let width = proposal.width ?? 0
-        let resolvedWidths = resolveColumnWidths(for: width)
-        let heights = subviewHeights(subviews: subviews, columnWidths: resolvedWidths)
-        return CGSize(width: width, height: heights.max() ?? 0)
-    }
-
-    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
-        let resolvedWidths = resolveColumnWidths(for: bounds.width)
-        var x = bounds.minX
-
-        for (index, subview) in subviews.enumerated() {
-            let colWidth = resolvedWidths[index]
-            let cellProposal = ProposedViewSize(width: colWidth, height: nil)
-            subview.place(at: CGPoint(x: x, y: bounds.minY), anchor: .topLeading, proposal: cellProposal)
-            x += colWidth
-        }
-    }
-
-    // MARK: - Column Width Resolution
-
-    /// Distribute `totalWidth` among the selection column (if any) and data columns.
-    /// Returns one width per subview (selection + columns).
-    private func resolveColumnWidths(for totalWidth: CGFloat) -> [CGFloat] {
-        var widths: [CGFloat] = []
-        var remaining = totalWidth
-
-        // Selection column
-        if selectionWidth > 0 {
-            let sel = min(selectionWidth, remaining)
-            widths.append(sel)
-            remaining -= sel
-        }
-
-        // Data columns
-        let fixedTotal = CGFloat(columnWidths.compactMap { $0 }.reduce(0, +))
-        let flexCount = columnWidths.filter { $0 == nil }.count
-        let flexWidth = flexCount > 0 ? max(0, (remaining - fixedTotal) / CGFloat(flexCount)) : 0
-
-        for colWidth in columnWidths {
-            if let fixed = colWidth {
-                let clamped = min(CGFloat(fixed), remaining)
-                widths.append(clamped)
-            } else {
-                widths.append(flexWidth)
-            }
-        }
-
-        return widths
-    }
-
-    /// Measure each subview's height given its resolved column width.
-    private func subviewHeights(subviews: Subviews, columnWidths: [CGFloat]) -> [CGFloat] {
-        zip(subviews, columnWidths).map { subview, width in
-            subview.sizeThatFits(ProposedViewSize(width: width, height: nil)).height
-        }
-    }
-}
-
-// MARK: - InlineTableWidget
-
 /// Inline table widget with selectable rows and action support.
 ///
-/// Uses a custom `TableRowLayout` (the `Layout` protocol) to distribute
-/// the parent's proposed width among columns in a single layout pass —
-/// no GeometryReader, no measurement state, no re-render cycle.
+/// Measures the available container width using a zero-height spacer
+/// and distributes it among columns explicitly, so text wraps within
+/// each column instead of overflowing the viewport.
 public struct InlineTableWidget: View {
     public let data: TableSurfaceData
     public let onAction: (String, [String: AnyCodable]?) -> Void
 
     @State private var selectedIds: Set<String> = []
+    @State private var availableWidth: CGFloat = 0
 
     public init(data: TableSurfaceData, onAction: @escaping (String, [String: AnyCodable]?) -> Void) {
         self.data = data
@@ -99,59 +26,48 @@ public struct InlineTableWidget: View {
         return !ids.isEmpty && ids.isSubset(of: selectedIds)
     }
 
-    /// The `TableRowLayout` configuration shared by headers and all data rows.
-    private var rowLayout: TableRowLayout {
-        TableRowLayout(
-            columnWidths: data.columns.map(\.width),
-            selectionWidth: data.selectionMode != .none ? 28 : 0
-        )
+    /// Whether the available width has been measured yet.
+    private var isMeasured: Bool { availableWidth > 0 }
+
+    // MARK: - Column Width Calculation
+
+    /// Width reserved for the selection checkbox / spacer column.
+    private var selectionColumnWidth: CGFloat {
+        data.selectionMode != .none ? 28 : 0
+    }
+
+    /// Resolved width for a single column. Fixed-width columns use their
+    /// specified value (clamped to available space); flexible columns share
+    /// the remaining space equally.
+    private func columnWidth(for column: TableColumn) -> CGFloat {
+        guard isMeasured else { return 0 }
+        let distributable = availableWidth - selectionColumnWidth
+        if let w = column.width {
+            return min(CGFloat(w), distributable)
+        }
+        let fixedTotal = CGFloat(data.columns.compactMap(\.width).reduce(0, +))
+        let flexCount = data.columns.filter({ $0.width == nil }).count
+        guard flexCount > 0 else { return 0 }
+        return max(0, (distributable - fixedTotal) / CGFloat(flexCount))
     }
 
     // MARK: - Body
 
     public var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            // Column headers
-            rowLayout {
-                if data.selectionMode == .multiple {
-                    Button {
-                        toggleSelectAll()
-                    } label: {
-                        VIconView(allSelected ? .circleCheck : .circle, size: 14)
-                            .foregroundStyle(allSelected ? VColor.primaryBase : VColor.contentTertiary)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(allSelected ? "Deselect all" : "Select all")
-                } else if data.selectionMode != .none {
-                    Color.clear
+            // Zero-height spacer to measure the parent's proposed width.
+            // Unlike the table content, this can't overflow because it has
+            // no intrinsic content width — it always reports exactly the
+            // proposed width from the parent.
+            Color.clear
+                .frame(maxWidth: .infinity)
+                .frame(height: 0)
+                .onGeometryChange(for: CGFloat.self) { $0.size.width } action: {
+                    availableWidth = $0
                 }
 
-                ForEach(data.columns) { column in
-                    Text(column.label)
-                        .font(VFont.labelDefault)
-                        .foregroundStyle(VColor.contentTertiary)
-                        .textSelection(.enabled)
-                }
-            }
-            .padding(.bottom, VSpacing.xxs)
-
-            Divider()
-                .background(VColor.borderBase.opacity(0.3))
-
-            // Rows
-            ForEach(Array(data.rows.enumerated()), id: \.element.id) { index, row in
-                rowView(row)
-                if index < data.rows.count - 1 {
-                    Divider()
-                        .background(VColor.borderBase.opacity(0.15))
-                }
-            }
-
-            if let caption = data.caption {
-                Text(caption)
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentTertiary)
-                    .padding(.top, VSpacing.xs)
+            if isMeasured {
+                tableContent
             }
         }
         .onAppear {
@@ -162,11 +78,68 @@ public struct InlineTableWidget: View {
         }
     }
 
+    // MARK: - Table Content
+
+    @ViewBuilder
+    private var tableContent: some View {
+        // Column headers
+        HStack(spacing: 0) {
+            selectionSpacer(isHeader: true)
+            ForEach(data.columns) { column in
+                Text(column.label)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .textSelection(.enabled)
+                    .frame(width: columnWidth(for: column), alignment: .leading)
+            }
+        }
+        .padding(.bottom, VSpacing.xxs)
+
+        Divider()
+            .background(VColor.borderBase.opacity(0.3))
+
+        // Rows
+        ForEach(Array(data.rows.enumerated()), id: \.element.id) { index, row in
+            rowView(row)
+            if index < data.rows.count - 1 {
+                Divider()
+                    .background(VColor.borderBase.opacity(0.15))
+            }
+        }
+
+        if let caption = data.caption {
+            Text(caption)
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+                .padding(.top, VSpacing.xs)
+        }
+    }
+
     // MARK: - Row & Cell Views
+
+    @ViewBuilder
+    private func selectionSpacer(isHeader: Bool = false) -> some View {
+        if data.selectionMode != .none {
+            if isHeader && data.selectionMode == .multiple {
+                Button {
+                    toggleSelectAll()
+                } label: {
+                    VIconView(allSelected ? .circleCheck : .circle, size: 14)
+                        .foregroundStyle(allSelected ? VColor.primaryBase : VColor.contentTertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(allSelected ? "Deselect all" : "Select all")
+                .frame(width: 28)
+            } else {
+                Color.clear
+                    .frame(width: 28)
+            }
+        }
+    }
 
     private func rowView(_ row: TableRow) -> some View {
         let isSelected = selectedIds.contains(row.id)
-        return rowLayout {
+        return HStack(spacing: 0) {
             if data.selectionMode != .none && row.selectable {
                 Button {
                     toggleSelection(row.id)
@@ -175,12 +148,14 @@ public struct InlineTableWidget: View {
                         .foregroundStyle(isSelected ? VColor.primaryBase : VColor.contentTertiary)
                 }
                 .buttonStyle(.plain)
+                .frame(width: 28)
             } else if data.selectionMode != .none {
                 Color.clear
+                    .frame(width: 28)
             }
 
             ForEach(data.columns) { column in
-                cellView(row.cells[column.id])
+                cellView(row.cells[column.id], width: columnWidth(for: column))
             }
         }
         .padding(.vertical, VSpacing.xs)
@@ -197,7 +172,7 @@ public struct InlineTableWidget: View {
     }
 
     @ViewBuilder
-    private func cellView(_ value: TableCellValue?) -> some View {
+    private func cellView(_ value: TableCellValue?, width: CGFloat) -> some View {
         HStack(spacing: VSpacing.xs) {
             if let icon = value?.icon,
                let vIcon = SFSymbolMapping.icon(forSFSymbol: icon) {
@@ -210,6 +185,7 @@ public struct InlineTableWidget: View {
                 .lineLimit(nil)
                 .textSelection(.enabled)
         }
+        .frame(width: width, alignment: .leading)
     }
 
     // MARK: - Helpers

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -1,29 +1,16 @@
 import SwiftUI
 
-/// Applies an explicit width when measured, or `maxWidth: .infinity` as
-/// a fallback before the container width is known.
-private extension View {
-    @ViewBuilder
-    func columnFrame(_ width: CGFloat) -> some View {
-        if width.isFinite {
-            self.frame(width: width, alignment: .leading)
-        } else {
-            self.frame(maxWidth: .infinity, alignment: .leading)
-        }
-    }
-}
-
 /// Inline table widget with selectable rows and action support.
 ///
-/// Measures the available container width via `onGeometryChange` and
-/// distributes it among columns explicitly, so text wraps within
+/// Measures the available container width using a zero-height spacer
+/// and distributes it among columns explicitly, so text wraps within
 /// each column instead of overflowing the viewport.
 public struct InlineTableWidget: View {
     public let data: TableSurfaceData
     public let onAction: (String, [String: AnyCodable]?) -> Void
 
     @State private var selectedIds: Set<String> = []
-    @State private var tableWidth: CGFloat = 0
+    @State private var availableWidth: CGFloat = 0
 
     public init(data: TableSurfaceData, onAction: @escaping (String, [String: AnyCodable]?) -> Void) {
         self.data = data
@@ -39,6 +26,9 @@ public struct InlineTableWidget: View {
         return !ids.isEmpty && ids.isSubset(of: selectedIds)
     }
 
+    /// Whether the available width has been measured yet.
+    private var isMeasured: Bool { availableWidth > 0 }
+
     // MARK: - Column Width Calculation
 
     /// Width reserved for the selection checkbox / spacer column.
@@ -47,77 +37,40 @@ public struct InlineTableWidget: View {
     }
 
     /// Resolved width for a single column. Fixed-width columns use their
-    /// specified value; flexible columns share the remaining space equally.
+    /// specified value (clamped to available space); flexible columns share
+    /// the remaining space equally.
     private func columnWidth(for column: TableColumn) -> CGFloat {
+        guard isMeasured else { return 0 }
+        let distributable = availableWidth - selectionColumnWidth
         if let w = column.width {
-            return CGFloat(w)
+            return min(CGFloat(w), distributable)
         }
-        guard tableWidth > 0 else { return .infinity }
         let fixedTotal = CGFloat(data.columns.compactMap(\.width).reduce(0, +))
         let flexCount = data.columns.filter({ $0.width == nil }).count
         guard flexCount > 0 else { return 0 }
-        return max(0, (tableWidth - fixedTotal - selectionColumnWidth) / CGFloat(flexCount))
+        return max(0, (distributable - fixedTotal) / CGFloat(flexCount))
     }
 
     // MARK: - Body
 
     public var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            // Column headers
-            HStack(spacing: 0) {
-                if data.selectionMode == .multiple {
-                    Button {
-                        toggleSelectAll()
-                    } label: {
-                        VIconView(allSelected ? .circleCheck : .circle, size: 14)
-                            .foregroundStyle(allSelected ? VColor.primaryBase : VColor.contentTertiary)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(allSelected ? "Deselect all" : "Select all")
-                    .frame(width: 28)
-                } else if data.selectionMode != .none {
-                    Color.clear
-                        .frame(width: 28)
+            // Zero-height spacer to measure the parent's proposed width.
+            // Unlike the table content, this can't overflow because it has
+            // no intrinsic content width — it always reports exactly the
+            // proposed width from the parent.
+            Color.clear
+                .frame(maxWidth: .infinity)
+                .frame(height: 0)
+                .onGeometryChange(for: CGFloat.self) { $0.size.width } action: {
+                    availableWidth = $0
                 }
-                ForEach(data.columns) { column in
-                    Text(column.label)
-                        .font(VFont.labelDefault)
-                        .foregroundStyle(VColor.contentTertiary)
-                        .columnFrame(columnWidth(for: column))
-                        .textSelection(.enabled)
-                }
-            }
-            .padding(.bottom, VSpacing.xxs)
 
-            Divider()
-                .background(VColor.borderBase.opacity(0.3))
-
-            // Rows
-            ForEach(Array(data.rows.enumerated()), id: \.element.id) { index, row in
-                rowView(row)
-                if index < data.rows.count - 1 {
-                    Divider()
-                        .background(VColor.borderBase.opacity(0.15))
-                }
+            if isMeasured {
+                tableContent
             }
-
-            if let caption = data.caption {
-                Text(caption)
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentTertiary)
-                    .padding(.top, VSpacing.xs)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .onGeometryChange(for: CGFloat.self) { proxy in
-            proxy.size.width
-        } action: { newWidth in
-            tableWidth = newWidth
         }
         .onAppear {
-            // Initialize selection from data and notify the parent so action
-            // buttons always carry the current selection — even if the user
-            // never toggles a checkbox.
             selectedIds = Set(data.rows.filter(\.selected).map(\.id))
             if data.selectionMode != .none {
                 onAction("selection_changed", ["selectedIds": AnyCodable(Array(selectedIds))])
@@ -125,7 +78,64 @@ public struct InlineTableWidget: View {
         }
     }
 
+    // MARK: - Table Content
+
+    @ViewBuilder
+    private var tableContent: some View {
+        // Column headers
+        HStack(spacing: 0) {
+            selectionSpacer(isHeader: true)
+            ForEach(data.columns) { column in
+                Text(column.label)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .textSelection(.enabled)
+                    .frame(width: columnWidth(for: column), alignment: .leading)
+            }
+        }
+        .padding(.bottom, VSpacing.xxs)
+
+        Divider()
+            .background(VColor.borderBase.opacity(0.3))
+
+        // Rows
+        ForEach(Array(data.rows.enumerated()), id: \.element.id) { index, row in
+            rowView(row)
+            if index < data.rows.count - 1 {
+                Divider()
+                    .background(VColor.borderBase.opacity(0.15))
+            }
+        }
+
+        if let caption = data.caption {
+            Text(caption)
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+                .padding(.top, VSpacing.xs)
+        }
+    }
+
     // MARK: - Row & Cell Views
+
+    @ViewBuilder
+    private func selectionSpacer(isHeader: Bool = false) -> some View {
+        if data.selectionMode != .none {
+            if isHeader && data.selectionMode == .multiple {
+                Button {
+                    toggleSelectAll()
+                } label: {
+                    VIconView(allSelected ? .circleCheck : .circle, size: 14)
+                        .foregroundStyle(allSelected ? VColor.primaryBase : VColor.contentTertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(allSelected ? "Deselect all" : "Select all")
+                .frame(width: 28)
+            } else {
+                Color.clear
+                    .frame(width: 28)
+            }
+        }
+    }
 
     private func rowView(_ row: TableRow) -> some View {
         let isSelected = selectedIds.contains(row.id)
@@ -175,7 +185,7 @@ public struct InlineTableWidget: View {
                 .lineLimit(nil)
                 .textSelection(.enabled)
         }
-        .columnFrame(width)
+        .frame(width: width, alignment: .leading)
     }
 
     // MARK: - Helpers

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -2,14 +2,15 @@ import SwiftUI
 
 /// Inline table widget with selectable rows and action support.
 ///
-/// Uses `Grid` for proper column-aligned layout that respects the
-/// container width — text wraps within each column instead of
-/// overflowing horizontally.
+/// Measures the available container width via `onGeometryChange` and
+/// distributes it among columns explicitly, so text wraps within
+/// each column instead of overflowing the viewport.
 public struct InlineTableWidget: View {
     public let data: TableSurfaceData
     public let onAction: (String, [String: AnyCodable]?) -> Void
 
     @State private var selectedIds: Set<String> = []
+    @State private var tableWidth: CGFloat = 0
 
     public init(data: TableSurfaceData, onAction: @escaping (String, [String: AnyCodable]?) -> Void) {
         self.data = data
@@ -25,10 +26,32 @@ public struct InlineTableWidget: View {
         return !ids.isEmpty && ids.isSubset(of: selectedIds)
     }
 
+    // MARK: - Column Width Calculation
+
+    /// Width reserved for the selection checkbox / spacer column.
+    private var selectionColumnWidth: CGFloat {
+        data.selectionMode != .none ? 28 : 0
+    }
+
+    /// Resolved width for a single column. Fixed-width columns use their
+    /// specified value; flexible columns share the remaining space equally.
+    private func columnWidth(for column: TableColumn) -> CGFloat {
+        if let w = column.width {
+            return CGFloat(w)
+        }
+        guard tableWidth > 0 else { return 0 }
+        let fixedTotal = CGFloat(data.columns.compactMap(\.width).reduce(0, +))
+        let flexCount = data.columns.filter({ $0.width == nil }).count
+        guard flexCount > 0 else { return 0 }
+        return max(0, (tableWidth - fixedTotal - selectionColumnWidth) / CGFloat(flexCount))
+    }
+
+    // MARK: - Body
+
     public var body: some View {
-        Grid(alignment: .topLeading, horizontalSpacing: 0, verticalSpacing: 0) {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
             // Column headers
-            GridRow {
+            HStack(spacing: 0) {
                 if data.selectionMode == .multiple {
                     Button {
                         toggleSelectAll()
@@ -47,19 +70,22 @@ public struct InlineTableWidget: View {
                     Text(column.label)
                         .font(VFont.labelDefault)
                         .foregroundStyle(VColor.contentTertiary)
+                        .frame(width: columnWidth(for: column), alignment: .leading)
                         .textSelection(.enabled)
-                        .columnFrame(column.width)
                 }
             }
             .padding(.bottom, VSpacing.xxs)
 
             Divider()
                 .background(VColor.borderBase.opacity(0.3))
-                .gridCellUnsizedAxes(.horizontal)
 
             // Rows
-            ForEach(data.rows) { row in
+            ForEach(Array(data.rows.enumerated()), id: \.element.id) { index, row in
                 rowView(row)
+                if index < data.rows.count - 1 {
+                    Divider()
+                        .background(VColor.borderBase.opacity(0.15))
+                }
             }
 
             if let caption = data.caption {
@@ -67,8 +93,12 @@ public struct InlineTableWidget: View {
                     .font(VFont.labelDefault)
                     .foregroundStyle(VColor.contentTertiary)
                     .padding(.top, VSpacing.xs)
-                    .gridCellColumns(data.columns.count + (data.selectionMode != .none ? 1 : 0))
             }
+        }
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.width
+        } action: { newWidth in
+            tableWidth = newWidth
         }
         .onAppear {
             // Initialize selection from data and notify the parent so action
@@ -81,9 +111,11 @@ public struct InlineTableWidget: View {
         }
     }
 
+    // MARK: - Row & Cell Views
+
     private func rowView(_ row: TableRow) -> some View {
         let isSelected = selectedIds.contains(row.id)
-        return GridRow {
+        return HStack(spacing: 0) {
             if data.selectionMode != .none && row.selectable {
                 Button {
                     toggleSelection(row.id)
@@ -99,7 +131,7 @@ public struct InlineTableWidget: View {
             }
 
             ForEach(data.columns) { column in
-                cellView(row.cells[column.id], width: column.width)
+                cellView(row.cells[column.id], width: columnWidth(for: column))
             }
         }
         .padding(.vertical, VSpacing.xs)
@@ -116,7 +148,7 @@ public struct InlineTableWidget: View {
     }
 
     @ViewBuilder
-    private func cellView(_ value: TableCellValue?, width: Int?) -> some View {
+    private func cellView(_ value: TableCellValue?, width: CGFloat) -> some View {
         HStack(spacing: VSpacing.xs) {
             if let icon = value?.icon,
                let vIcon = SFSymbolMapping.icon(forSFSymbol: icon) {
@@ -129,8 +161,10 @@ public struct InlineTableWidget: View {
                 .lineLimit(nil)
                 .textSelection(.enabled)
         }
-        .columnFrame(width)
+        .frame(width: width, alignment: .leading)
     }
+
+    // MARK: - Helpers
 
     private func resolveIconColor(_ token: String?) -> Color {
         switch token {
@@ -166,18 +200,5 @@ public struct InlineTableWidget: View {
             }
         }
         onAction("selection_changed", ["selectedIds": AnyCodable(Array(selectedIds))])
-    }
-}
-
-// MARK: - Column Sizing
-
-private extension View {
-    @ViewBuilder
-    func columnFrame(_ width: Int?) -> some View {
-        if let w = width {
-            self.frame(width: CGFloat(w), alignment: .leading)
-        } else {
-            self.frame(maxWidth: .infinity, alignment: .leading)
-        }
     }
 }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -1,13 +1,10 @@
 import SwiftUI
 
-private extension View {
-    @ViewBuilder
-    func columnFrame(_ width: Int?) -> some View {
-        if let w = width {
-            self.frame(width: CGFloat(w), alignment: .leading)
-        } else {
-            self.frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
-        }
+/// Preference key for measuring the available table width.
+private struct TableWidthKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
     }
 }
 
@@ -17,6 +14,7 @@ public struct InlineTableWidget: View {
     public let onAction: (String, [String: AnyCodable]?) -> Void
 
     @State private var selectedIds: Set<String> = []
+    @State private var tableWidth: CGFloat = 0
 
     public init(data: TableSurfaceData, onAction: @escaping (String, [String: AnyCodable]?) -> Void) {
         self.data = data
@@ -30,6 +28,25 @@ public struct InlineTableWidget: View {
     private var allSelected: Bool {
         let ids = selectableIds
         return !ids.isEmpty && ids.isSubset(of: selectedIds)
+    }
+
+    /// Width reserved for the selection checkbox / spacer column.
+    private var selectionColumnWidth: CGFloat {
+        data.selectionMode != .none ? 28 : 0
+    }
+
+    /// Calculate the explicit width for a column based on the measured table width.
+    /// Fixed-width columns get their specified size; flexible columns share the remainder equally.
+    private func resolvedColumnWidth(for column: TableColumn) -> CGFloat {
+        if let w = column.width {
+            return CGFloat(w)
+        }
+        guard tableWidth > 0 else { return 100 }
+        let fixedTotal = CGFloat(data.columns.compactMap(\.width).reduce(0, +))
+        let flexCount = data.columns.filter({ $0.width == nil }).count
+        guard flexCount > 0 else { return 100 }
+        let remaining = tableWidth - fixedTotal - selectionColumnWidth
+        return max(40, remaining / CGFloat(flexCount))
     }
 
     public var body: some View {
@@ -54,7 +71,7 @@ public struct InlineTableWidget: View {
                     Text(column.label)
                         .font(VFont.labelDefault)
                         .foregroundStyle(VColor.contentTertiary)
-                        .columnFrame(column.width)
+                        .frame(width: resolvedColumnWidth(for: column), alignment: .leading)
                         .textSelection(.enabled)
                 }
             }
@@ -74,6 +91,14 @@ public struct InlineTableWidget: View {
                     .foregroundStyle(VColor.contentTertiary)
                     .padding(.top, VSpacing.xs)
             }
+        }
+        .background(
+            GeometryReader { geometry in
+                Color.clear.preference(key: TableWidthKey.self, value: geometry.size.width)
+            }
+        )
+        .onPreferenceChange(TableWidthKey.self) { width in
+            tableWidth = width
         }
         .onAppear {
             // Initialize selection from data and notify the parent so action
@@ -104,7 +129,7 @@ public struct InlineTableWidget: View {
             }
 
             ForEach(data.columns) { column in
-                cellView(row.cells[column.id], width: column.width)
+                cellView(row.cells[column.id], width: resolvedColumnWidth(for: column))
             }
         }
         .padding(.vertical, VSpacing.xs)
@@ -121,7 +146,7 @@ public struct InlineTableWidget: View {
     }
 
     @ViewBuilder
-    private func cellView(_ value: TableCellValue?, width: Int?) -> some View {
+    private func cellView(_ value: TableCellValue?, width: CGFloat) -> some View {
         HStack(spacing: VSpacing.xs) {
             if let icon = value?.icon,
                let vIcon = SFSymbolMapping.icon(forSFSymbol: icon) {
@@ -134,7 +159,7 @@ public struct InlineTableWidget: View {
                 .lineLimit(nil)
                 .textSelection(.enabled)
         }
-        .columnFrame(width)
+        .frame(width: width, alignment: .leading)
     }
 
     private func resolveIconColor(_ token: String?) -> Color {

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -1,20 +1,15 @@
 import SwiftUI
 
-/// Preference key for measuring the available table width.
-private struct TableWidthKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
-    }
-}
-
 /// Inline table widget with selectable rows and action support.
+///
+/// Uses `Grid` for proper column-aligned layout that respects the
+/// container width — text wraps within each column instead of
+/// overflowing horizontally.
 public struct InlineTableWidget: View {
     public let data: TableSurfaceData
     public let onAction: (String, [String: AnyCodable]?) -> Void
 
     @State private var selectedIds: Set<String> = []
-    @State private var tableWidth: CGFloat = 0
 
     public init(data: TableSurfaceData, onAction: @escaping (String, [String: AnyCodable]?) -> Void) {
         self.data = data
@@ -30,29 +25,10 @@ public struct InlineTableWidget: View {
         return !ids.isEmpty && ids.isSubset(of: selectedIds)
     }
 
-    /// Width reserved for the selection checkbox / spacer column.
-    private var selectionColumnWidth: CGFloat {
-        data.selectionMode != .none ? 28 : 0
-    }
-
-    /// Calculate the explicit width for a column based on the measured table width.
-    /// Fixed-width columns get their specified size; flexible columns share the remainder equally.
-    private func resolvedColumnWidth(for column: TableColumn) -> CGFloat {
-        if let w = column.width {
-            return CGFloat(w)
-        }
-        guard tableWidth > 0 else { return 100 }
-        let fixedTotal = CGFloat(data.columns.compactMap(\.width).reduce(0, +))
-        let flexCount = data.columns.filter({ $0.width == nil }).count
-        guard flexCount > 0 else { return 100 }
-        let remaining = tableWidth - fixedTotal - selectionColumnWidth
-        return max(40, remaining / CGFloat(flexCount))
-    }
-
     public var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
+        Grid(alignment: .topLeading, horizontalSpacing: 0, verticalSpacing: 0) {
             // Column headers
-            HStack(spacing: 0) {
+            GridRow {
                 if data.selectionMode == .multiple {
                     Button {
                         toggleSelectAll()
@@ -71,14 +47,15 @@ public struct InlineTableWidget: View {
                     Text(column.label)
                         .font(VFont.labelDefault)
                         .foregroundStyle(VColor.contentTertiary)
-                        .frame(width: resolvedColumnWidth(for: column), alignment: .leading)
                         .textSelection(.enabled)
+                        .columnFrame(column.width)
                 }
             }
             .padding(.bottom, VSpacing.xxs)
 
             Divider()
                 .background(VColor.borderBase.opacity(0.3))
+                .gridCellUnsizedAxes(.horizontal)
 
             // Rows
             ForEach(data.rows) { row in
@@ -90,15 +67,8 @@ public struct InlineTableWidget: View {
                     .font(VFont.labelDefault)
                     .foregroundStyle(VColor.contentTertiary)
                     .padding(.top, VSpacing.xs)
+                    .gridCellColumns(data.columns.count + (data.selectionMode != .none ? 1 : 0))
             }
-        }
-        .background(
-            GeometryReader { geometry in
-                Color.clear.preference(key: TableWidthKey.self, value: geometry.size.width)
-            }
-        )
-        .onPreferenceChange(TableWidthKey.self) { width in
-            tableWidth = width
         }
         .onAppear {
             // Initialize selection from data and notify the parent so action
@@ -113,7 +83,7 @@ public struct InlineTableWidget: View {
 
     private func rowView(_ row: TableRow) -> some View {
         let isSelected = selectedIds.contains(row.id)
-        return HStack(spacing: 0) {
+        return GridRow {
             if data.selectionMode != .none && row.selectable {
                 Button {
                     toggleSelection(row.id)
@@ -129,7 +99,7 @@ public struct InlineTableWidget: View {
             }
 
             ForEach(data.columns) { column in
-                cellView(row.cells[column.id], width: resolvedColumnWidth(for: column))
+                cellView(row.cells[column.id], width: column.width)
             }
         }
         .padding(.vertical, VSpacing.xs)
@@ -146,7 +116,7 @@ public struct InlineTableWidget: View {
     }
 
     @ViewBuilder
-    private func cellView(_ value: TableCellValue?, width: CGFloat) -> some View {
+    private func cellView(_ value: TableCellValue?, width: Int?) -> some View {
         HStack(spacing: VSpacing.xs) {
             if let icon = value?.icon,
                let vIcon = SFSymbolMapping.icon(forSFSymbol: icon) {
@@ -159,7 +129,7 @@ public struct InlineTableWidget: View {
                 .lineLimit(nil)
                 .textSelection(.enabled)
         }
-        .frame(width: width, alignment: .leading)
+        .columnFrame(width)
     }
 
     private func resolveIconColor(_ token: String?) -> Color {
@@ -196,5 +166,18 @@ public struct InlineTableWidget: View {
             }
         }
         onAction("selection_changed", ["selectedIds": AnyCodable(Array(selectedIds))])
+    }
+}
+
+// MARK: - Column Sizing
+
+private extension View {
+    @ViewBuilder
+    func columnFrame(_ width: Int?) -> some View {
+        if let w = width {
+            self.frame(width: CGFloat(w), alignment: .leading)
+        } else {
+            self.frame(maxWidth: .infinity, alignment: .leading)
+        }
     }
 }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -277,6 +277,7 @@ public struct InlineTableWidget: View {
                             .foregroundStyle(allSelected ? VColor.primaryBase : VColor.contentTertiary)
                     }
                     .buttonStyle(.plain)
+                    .pointerCursor()
                     .accessibilityLabel(allSelected ? "Deselect all" : "Select all")
                     .frame(width: selectionColumnWidth)
                 } else {
@@ -319,6 +320,7 @@ public struct InlineTableWidget: View {
                             .foregroundStyle(isSelected ? VColor.primaryBase : VColor.contentTertiary)
                     }
                     .buttonStyle(.plain)
+                    .pointerCursor()
                     .frame(width: selectionColumnWidth)
                 } else {
                     Color.clear.frame(width: selectionColumnWidth)
@@ -332,6 +334,7 @@ public struct InlineTableWidget: View {
             }
         }
         .padding(.vertical, VSpacing.xs)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: VRadius.sm)
                 .fill(isSelected ? VColor.primaryBase.opacity(0.1) : Color.clear)
@@ -371,6 +374,7 @@ public struct InlineTableWidget: View {
 
     private func resizeHandle(for columnIndex: Int) -> some View {
         let isHighlighted = isResizeHandleHighlighted(columnIndex)
+        #if os(macOS)
         return Rectangle()
             .fill(Color.clear)
             .frame(width: resizeHandleWidth)
@@ -380,7 +384,6 @@ public struct InlineTableWidget: View {
                     .frame(width: resizeHandleIndicatorWidth(isHighlighted: isHighlighted))
                     .opacity(resizeHandleIndicatorOpacity(isHighlighted: isHighlighted))
             )
-            #if os(macOS)
             .overlay {
                 HorizontalResizeHandleTrackingView(
                     isDragging: activeResizeHandleIndex == columnIndex,
@@ -390,13 +393,33 @@ public struct InlineTableWidget: View {
                         } else if hoveredResizeHandleIndex == columnIndex {
                             hoveredResizeHandleIndex = nil
                         }
+                    },
+                    onDragBegan: {
+                        beginResize(for: columnIndex)
+                    },
+                    onDragChanged: { delta in
+                        applyResizeDelta(delta, for: columnIndex)
+                    },
+                    onDragEnded: {
+                        endResize(for: columnIndex)
                     }
                 )
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
-            #endif
+            .contentShape(Rectangle())
+        #else
+        return Rectangle()
+            .fill(Color.clear)
+            .frame(width: resizeHandleWidth)
+            .overlay(
+                Rectangle()
+                    .fill(resizeHandleIndicatorColor(isHighlighted: isHighlighted))
+                    .frame(width: resizeHandleIndicatorWidth(isHighlighted: isHighlighted))
+                    .opacity(resizeHandleIndicatorOpacity(isHighlighted: isHighlighted))
+            )
             .contentShape(Rectangle())
             .gesture(resizeHandleDragGesture(for: columnIndex))
+        #endif
     }
 
     private func isResizeHandleHighlighted(_ columnIndex: Int) -> Bool {
@@ -414,42 +437,51 @@ public struct InlineTableWidget: View {
     private func resizeHandleDragGesture(for columnIndex: Int) -> some Gesture {
         DragGesture(minimumDistance: 0, coordinateSpace: .named(resizeGestureCoordinateSpaceName))
             .onChanged { value in
-                let column = data.columns[columnIndex]
-                if activeResizeHandleIndex == nil {
-                    activeResizeHandleIndex = columnIndex
-                }
+                beginResize(for: columnIndex)
                 #if os(macOS)
                 NSCursor.resizeLeftRight.set()
                 #endif
-                let startWidth: CGFloat
-                if let existing = resizeDragStartWidths[column.id] {
-                    startWidth = existing
-                } else {
-                    let captured = currentColumnWidth(column)
-                    resizeDragStartWidths[column.id] = captured
-                    startWidth = captured
-                }
                 let delta = value.location.x - value.startLocation.x
-                let newWidth = max(minColumnWidth, startWidth + delta)
-                let snappedWidth = (newWidth * 2).rounded() / 2
-                if columnOverrides[column.id] != snappedWidth {
-                    var transaction = Transaction()
-                    transaction.disablesAnimations = true
-                    withTransaction(transaction) {
-                        columnOverrides[column.id] = snappedWidth
-                    }
-                }
+                applyResizeDelta(delta, for: columnIndex)
             }
             .onEnded { _ in
-                let column = data.columns[columnIndex]
-                resizeDragStartWidths[column.id] = nil
-                activeResizeHandleIndex = nil
-                #if os(macOS)
-                if hoveredResizeHandleIndex == nil {
-                    NSCursor.arrow.set()
-                }
-                #endif
+                endResize(for: columnIndex)
             }
+    }
+
+    private func beginResize(for columnIndex: Int) {
+        let column = data.columns[columnIndex]
+        if activeResizeHandleIndex == nil {
+            activeResizeHandleIndex = columnIndex
+        }
+        if resizeDragStartWidths[column.id] == nil {
+            resizeDragStartWidths[column.id] = currentColumnWidth(column)
+        }
+    }
+
+    private func applyResizeDelta(_ delta: CGFloat, for columnIndex: Int) {
+        let column = data.columns[columnIndex]
+        guard let startWidth = resizeDragStartWidths[column.id] else { return }
+        let newWidth = max(minColumnWidth, startWidth + delta)
+        let snappedWidth = (newWidth * 2).rounded() / 2
+        if columnOverrides[column.id] != snappedWidth {
+            var transaction = Transaction()
+            transaction.disablesAnimations = true
+            withTransaction(transaction) {
+                columnOverrides[column.id] = snappedWidth
+            }
+        }
+    }
+
+    private func endResize(for columnIndex: Int) {
+        let column = data.columns[columnIndex]
+        resizeDragStartWidths[column.id] = nil
+        activeResizeHandleIndex = nil
+        #if os(macOS)
+        if hoveredResizeHandleIndex == nil {
+            NSCursor.arrow.set()
+        }
+        #endif
     }
 
     private func resizeHandleIndicatorWidth(isHighlighted: Bool) -> CGFloat {
@@ -519,17 +551,36 @@ public struct InlineTableWidget: View {
 private struct HorizontalResizeHandleTrackingView: NSViewRepresentable {
     let isDragging: Bool
     let onHoverChanged: (Bool) -> Void
+    let onDragBegan: () -> Void
+    let onDragChanged: (CGFloat) -> Void
+    let onDragEnded: () -> Void
 
     final class Coordinator {
         var onHoverChanged: (Bool) -> Void
+        var onDragBegan: () -> Void
+        var onDragChanged: (CGFloat) -> Void
+        var onDragEnded: () -> Void
 
-        init(onHoverChanged: @escaping (Bool) -> Void) {
+        init(
+            onHoverChanged: @escaping (Bool) -> Void,
+            onDragBegan: @escaping () -> Void,
+            onDragChanged: @escaping (CGFloat) -> Void,
+            onDragEnded: @escaping () -> Void
+        ) {
             self.onHoverChanged = onHoverChanged
+            self.onDragBegan = onDragBegan
+            self.onDragChanged = onDragChanged
+            self.onDragEnded = onDragEnded
         }
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onHoverChanged: onHoverChanged)
+        Coordinator(
+            onHoverChanged: onHoverChanged,
+            onDragBegan: onDragBegan,
+            onDragChanged: onDragChanged,
+            onDragEnded: onDragEnded
+        )
     }
 
     func makeNSView(context: Context) -> HorizontalResizeHandleTrackingNSView {
@@ -537,13 +588,34 @@ private struct HorizontalResizeHandleTrackingView: NSViewRepresentable {
         view.onHoverChanged = { hovering in
             context.coordinator.onHoverChanged(hovering)
         }
+        view.onDragBegan = {
+            context.coordinator.onDragBegan()
+        }
+        view.onDragChanged = { delta in
+            context.coordinator.onDragChanged(delta)
+        }
+        view.onDragEnded = {
+            context.coordinator.onDragEnded()
+        }
         return view
     }
 
     func updateNSView(_ nsView: HorizontalResizeHandleTrackingNSView, context: Context) {
         context.coordinator.onHoverChanged = onHoverChanged
+        context.coordinator.onDragBegan = onDragBegan
+        context.coordinator.onDragChanged = onDragChanged
+        context.coordinator.onDragEnded = onDragEnded
         nsView.onHoverChanged = { hovering in
             context.coordinator.onHoverChanged(hovering)
+        }
+        nsView.onDragBegan = {
+            context.coordinator.onDragBegan()
+        }
+        nsView.onDragChanged = { delta in
+            context.coordinator.onDragChanged(delta)
+        }
+        nsView.onDragEnded = {
+            context.coordinator.onDragEnded()
         }
         nsView.isDragging = isDragging
         nsView.window?.invalidateCursorRects(for: nsView)
@@ -555,8 +627,12 @@ private struct HorizontalResizeHandleTrackingView: NSViewRepresentable {
 
 private final class HorizontalResizeHandleTrackingNSView: NSView {
     var onHoverChanged: ((Bool) -> Void)?
+    var onDragBegan: (() -> Void)?
+    var onDragChanged: ((CGFloat) -> Void)?
+    var onDragEnded: (() -> Void)?
     var isDragging: Bool = false
     private var trackingAreaRef: NSTrackingArea?
+    private var dragStartXInWindow: CGFloat?
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
@@ -601,7 +677,29 @@ private final class HorizontalResizeHandleTrackingNSView: NSView {
     }
 
     override func hitTest(_ point: NSPoint) -> NSView? {
-        nil
+        self
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        dragStartXInWindow = event.locationInWindow.x
+        onDragBegan?()
+        NSCursor.resizeLeftRight.set()
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let dragStartXInWindow else { return }
+        let delta = event.locationInWindow.x - dragStartXInWindow
+        onDragChanged?(delta)
+        NSCursor.resizeLeftRight.set()
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        if let dragStartXInWindow {
+            let delta = event.locationInWindow.x - dragStartXInWindow
+            onDragChanged?(delta)
+        }
+        dragStartXInWindow = nil
+        onDragEnded?()
     }
 }
 #endif

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -1,16 +1,89 @@
 import SwiftUI
 
+// MARK: - TableRowLayout
+
+/// Custom `Layout` that distributes available width among table columns
+/// in a single layout pass — no measurement state, no re-renders.
+///
+/// Fixed-width columns receive their specified size (clamped to available
+/// space). Flexible columns share the remaining width equally. Each child
+/// view corresponds to one column cell (plus an optional leading selection
+/// cell when `selectionWidth > 0`).
+private struct TableRowLayout: Layout {
+    let columnWidths: [Int?]
+    let selectionWidth: CGFloat
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let width = proposal.width ?? 0
+        let resolvedWidths = resolveColumnWidths(for: width)
+        let heights = subviewHeights(subviews: subviews, columnWidths: resolvedWidths)
+        return CGSize(width: width, height: heights.max() ?? 0)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let resolvedWidths = resolveColumnWidths(for: bounds.width)
+        var x = bounds.minX
+
+        for (index, subview) in subviews.enumerated() {
+            let colWidth = resolvedWidths[index]
+            let cellProposal = ProposedViewSize(width: colWidth, height: nil)
+            subview.place(at: CGPoint(x: x, y: bounds.minY), anchor: .topLeading, proposal: cellProposal)
+            x += colWidth
+        }
+    }
+
+    // MARK: - Column Width Resolution
+
+    /// Distribute `totalWidth` among the selection column (if any) and data columns.
+    /// Returns one width per subview (selection + columns).
+    private func resolveColumnWidths(for totalWidth: CGFloat) -> [CGFloat] {
+        var widths: [CGFloat] = []
+        var remaining = totalWidth
+
+        // Selection column
+        if selectionWidth > 0 {
+            let sel = min(selectionWidth, remaining)
+            widths.append(sel)
+            remaining -= sel
+        }
+
+        // Data columns
+        let fixedTotal = CGFloat(columnWidths.compactMap { $0 }.reduce(0, +))
+        let flexCount = columnWidths.filter { $0 == nil }.count
+        let flexWidth = flexCount > 0 ? max(0, (remaining - fixedTotal) / CGFloat(flexCount)) : 0
+
+        for colWidth in columnWidths {
+            if let fixed = colWidth {
+                let clamped = min(CGFloat(fixed), remaining)
+                widths.append(clamped)
+            } else {
+                widths.append(flexWidth)
+            }
+        }
+
+        return widths
+    }
+
+    /// Measure each subview's height given its resolved column width.
+    private func subviewHeights(subviews: Subviews, columnWidths: [CGFloat]) -> [CGFloat] {
+        zip(subviews, columnWidths).map { subview, width in
+            subview.sizeThatFits(ProposedViewSize(width: width, height: nil)).height
+        }
+    }
+}
+
+// MARK: - InlineTableWidget
+
 /// Inline table widget with selectable rows and action support.
 ///
-/// Measures the available container width using a zero-height spacer
-/// and distributes it among columns explicitly, so text wraps within
-/// each column instead of overflowing the viewport.
+/// Uses a custom `TableRowLayout` (the `Layout` protocol) to distribute
+/// the parent's proposed width among columns in a single layout pass —
+/// no GeometryReader, no measurement state, no re-render cycle.
 public struct InlineTableWidget: View {
     public let data: TableSurfaceData
     public let onAction: (String, [String: AnyCodable]?) -> Void
 
     @State private var selectedIds: Set<String> = []
-    @State private var availableWidth: CGFloat = 0
 
     public init(data: TableSurfaceData, onAction: @escaping (String, [String: AnyCodable]?) -> Void) {
         self.data = data
@@ -26,48 +99,59 @@ public struct InlineTableWidget: View {
         return !ids.isEmpty && ids.isSubset(of: selectedIds)
     }
 
-    /// Whether the available width has been measured yet.
-    private var isMeasured: Bool { availableWidth > 0 }
-
-    // MARK: - Column Width Calculation
-
-    /// Width reserved for the selection checkbox / spacer column.
-    private var selectionColumnWidth: CGFloat {
-        data.selectionMode != .none ? 28 : 0
-    }
-
-    /// Resolved width for a single column. Fixed-width columns use their
-    /// specified value (clamped to available space); flexible columns share
-    /// the remaining space equally.
-    private func columnWidth(for column: TableColumn) -> CGFloat {
-        guard isMeasured else { return 0 }
-        let distributable = availableWidth - selectionColumnWidth
-        if let w = column.width {
-            return min(CGFloat(w), distributable)
-        }
-        let fixedTotal = CGFloat(data.columns.compactMap(\.width).reduce(0, +))
-        let flexCount = data.columns.filter({ $0.width == nil }).count
-        guard flexCount > 0 else { return 0 }
-        return max(0, (distributable - fixedTotal) / CGFloat(flexCount))
+    /// The `TableRowLayout` configuration shared by headers and all data rows.
+    private var rowLayout: TableRowLayout {
+        TableRowLayout(
+            columnWidths: data.columns.map(\.width),
+            selectionWidth: data.selectionMode != .none ? 28 : 0
+        )
     }
 
     // MARK: - Body
 
     public var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            // Zero-height spacer to measure the parent's proposed width.
-            // Unlike the table content, this can't overflow because it has
-            // no intrinsic content width — it always reports exactly the
-            // proposed width from the parent.
-            Color.clear
-                .frame(maxWidth: .infinity)
-                .frame(height: 0)
-                .onGeometryChange(for: CGFloat.self) { $0.size.width } action: {
-                    availableWidth = $0
+            // Column headers
+            rowLayout {
+                if data.selectionMode == .multiple {
+                    Button {
+                        toggleSelectAll()
+                    } label: {
+                        VIconView(allSelected ? .circleCheck : .circle, size: 14)
+                            .foregroundStyle(allSelected ? VColor.primaryBase : VColor.contentTertiary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(allSelected ? "Deselect all" : "Select all")
+                } else if data.selectionMode != .none {
+                    Color.clear
                 }
 
-            if isMeasured {
-                tableContent
+                ForEach(data.columns) { column in
+                    Text(column.label)
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                        .textSelection(.enabled)
+                }
+            }
+            .padding(.bottom, VSpacing.xxs)
+
+            Divider()
+                .background(VColor.borderBase.opacity(0.3))
+
+            // Rows
+            ForEach(Array(data.rows.enumerated()), id: \.element.id) { index, row in
+                rowView(row)
+                if index < data.rows.count - 1 {
+                    Divider()
+                        .background(VColor.borderBase.opacity(0.15))
+                }
+            }
+
+            if let caption = data.caption {
+                Text(caption)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .padding(.top, VSpacing.xs)
             }
         }
         .onAppear {
@@ -78,68 +162,11 @@ public struct InlineTableWidget: View {
         }
     }
 
-    // MARK: - Table Content
-
-    @ViewBuilder
-    private var tableContent: some View {
-        // Column headers
-        HStack(spacing: 0) {
-            selectionSpacer(isHeader: true)
-            ForEach(data.columns) { column in
-                Text(column.label)
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentTertiary)
-                    .textSelection(.enabled)
-                    .frame(width: columnWidth(for: column), alignment: .leading)
-            }
-        }
-        .padding(.bottom, VSpacing.xxs)
-
-        Divider()
-            .background(VColor.borderBase.opacity(0.3))
-
-        // Rows
-        ForEach(Array(data.rows.enumerated()), id: \.element.id) { index, row in
-            rowView(row)
-            if index < data.rows.count - 1 {
-                Divider()
-                    .background(VColor.borderBase.opacity(0.15))
-            }
-        }
-
-        if let caption = data.caption {
-            Text(caption)
-                .font(VFont.labelDefault)
-                .foregroundStyle(VColor.contentTertiary)
-                .padding(.top, VSpacing.xs)
-        }
-    }
-
     // MARK: - Row & Cell Views
-
-    @ViewBuilder
-    private func selectionSpacer(isHeader: Bool = false) -> some View {
-        if data.selectionMode != .none {
-            if isHeader && data.selectionMode == .multiple {
-                Button {
-                    toggleSelectAll()
-                } label: {
-                    VIconView(allSelected ? .circleCheck : .circle, size: 14)
-                        .foregroundStyle(allSelected ? VColor.primaryBase : VColor.contentTertiary)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(allSelected ? "Deselect all" : "Select all")
-                .frame(width: 28)
-            } else {
-                Color.clear
-                    .frame(width: 28)
-            }
-        }
-    }
 
     private func rowView(_ row: TableRow) -> some View {
         let isSelected = selectedIds.contains(row.id)
-        return HStack(spacing: 0) {
+        return rowLayout {
             if data.selectionMode != .none && row.selectable {
                 Button {
                     toggleSelection(row.id)
@@ -148,14 +175,12 @@ public struct InlineTableWidget: View {
                         .foregroundStyle(isSelected ? VColor.primaryBase : VColor.contentTertiary)
                 }
                 .buttonStyle(.plain)
-                .frame(width: 28)
             } else if data.selectionMode != .none {
                 Color.clear
-                    .frame(width: 28)
             }
 
             ForEach(data.columns) { column in
-                cellView(row.cells[column.id], width: columnWidth(for: column))
+                cellView(row.cells[column.id])
             }
         }
         .padding(.vertical, VSpacing.xs)
@@ -172,7 +197,7 @@ public struct InlineTableWidget: View {
     }
 
     @ViewBuilder
-    private func cellView(_ value: TableCellValue?, width: CGFloat) -> some View {
+    private func cellView(_ value: TableCellValue?) -> some View {
         HStack(spacing: VSpacing.xs) {
             if let icon = value?.icon,
                let vIcon = SFSymbolMapping.icon(forSFSymbol: icon) {
@@ -185,7 +210,6 @@ public struct InlineTableWidget: View {
                 .lineLimit(nil)
                 .textSelection(.enabled)
         }
-        .frame(width: width, alignment: .leading)
     }
 
     // MARK: - Helpers

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -1,5 +1,18 @@
 import SwiftUI
 
+/// Applies an explicit width when measured, or `maxWidth: .infinity` as
+/// a fallback before the container width is known.
+private extension View {
+    @ViewBuilder
+    func columnFrame(_ width: CGFloat) -> some View {
+        if width.isFinite {
+            self.frame(width: width, alignment: .leading)
+        } else {
+            self.frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
 /// Inline table widget with selectable rows and action support.
 ///
 /// Measures the available container width via `onGeometryChange` and
@@ -39,7 +52,7 @@ public struct InlineTableWidget: View {
         if let w = column.width {
             return CGFloat(w)
         }
-        guard tableWidth > 0 else { return 0 }
+        guard tableWidth > 0 else { return .infinity }
         let fixedTotal = CGFloat(data.columns.compactMap(\.width).reduce(0, +))
         let flexCount = data.columns.filter({ $0.width == nil }).count
         guard flexCount > 0 else { return 0 }
@@ -70,7 +83,7 @@ public struct InlineTableWidget: View {
                     Text(column.label)
                         .font(VFont.labelDefault)
                         .foregroundStyle(VColor.contentTertiary)
-                        .frame(width: columnWidth(for: column), alignment: .leading)
+                        .columnFrame(columnWidth(for: column))
                         .textSelection(.enabled)
                 }
             }
@@ -95,6 +108,7 @@ public struct InlineTableWidget: View {
                     .padding(.top, VSpacing.xs)
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .onGeometryChange(for: CGFloat.self) { proxy in
             proxy.size.width
         } action: { newWidth in
@@ -161,7 +175,7 @@ public struct InlineTableWidget: View {
                 .lineLimit(nil)
                 .textSelection(.enabled)
         }
-        .frame(width: width, alignment: .leading)
+        .columnFrame(width)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary
- Removed the 2-line limit (`.lineLimit(2)` → `.lineLimit(nil)`) on InlineTableWidget cell text so cells expand to display all content instead of truncating with ellipsis or wrapping awkwardly

## Changes
- `clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift`: Changed `.lineLimit(2)` to `.lineLimit(nil)` in `cellView`

## Milestone PRs (merged into feature branch)
- #21567: fix: expand InlineTableWidget cells to show full text (LUM-427)

## Project issue
Closes #21563

## Test plan
- [ ] Open a conversation with an InlineTableWidget containing long cell text
- [ ] Verify cells expand to show full text instead of truncating with "..."
- [ ] Verify table layout remains clean with row dividers separating rows

Closes LUM-427
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
