### PR TITLE
fix: remove references to non-existent "Settings > Integrations" tab

### DIFF
--- a/assistant/src/__tests__/navigate-settings-tab.test.ts
+++ b/assistant/src/__tests__/navigate-settings-tab.test.ts
@@ -9,11 +9,13 @@ function makeContext(sendToClient?: (msg: unknown) => void): ToolContext {
 
 const CANONICAL_TABS = [
   "General",
-  "Channels",
   "Models & Services",
   "Voice",
+  "Sounds",
   "Permissions & Privacy",
-  "Contacts",
+  "Billing",
+  "Archived Conversations",
+  "Schedules",
   "Developer",
 ];
 
@@ -28,6 +30,8 @@ const LEGACY_TABS = [
   "Privacy",
   "Sentry Testing",
   "Automation",
+  "Channels",
+  "Contacts",
 ];
 
 describe("navigate-settings-tab", () => {

--- a/assistant/src/__tests__/token-estimator-accuracy.benchmark.test.ts
+++ b/assistant/src/__tests__/token-estimator-accuracy.benchmark.test.ts
@@ -205,7 +205,7 @@ function makeSystemPrompt(size: "small" | "production" = "small"): string {
     "### OAuth Setup",
     "Most integrations use OAuth for authentication.",
     "Guide the user through the OAuth flow when setting up a new integration:",
-    "1. Navigate to Settings > Integrations",
+    "1. Navigate to Settings > Models & Services",
     "2. Click 'Connect' for the desired service",
     "3. Authorize in the browser popup",
     "4. Confirm the connection is active",

--- a/assistant/src/config/bundled-skills/settings/TOOLS.json
+++ b/assistant/src/config/bundled-skills/settings/TOOLS.json
@@ -67,11 +67,13 @@
             "type": "string",
             "enum": [
               "General",
-              "Channels",
               "Models & Services",
               "Voice",
+              "Sounds",
               "Permissions & Privacy",
-              "Contacts",
+              "Billing",
+              "Archived Conversations",
+              "Schedules",
               "Developer"
             ],
             "description": "The settings tab to navigate to"

--- a/assistant/src/config/bundled-skills/settings/TOOLS.json
+++ b/assistant/src/config/bundled-skills/settings/TOOLS.json
@@ -57,7 +57,7 @@
     },
     {
       "name": "navigate_settings_tab",
-      "description": "Open the Vellum settings panel to a specific tab (e.g. General, Channels, Voice). Use this when the user needs to review or adjust settings visually.",
+      "description": "Open the Vellum settings panel to a specific tab (e.g. General, Models & Services, Voice). Use this when the user needs to review or adjust settings visually.",
       "category": "system",
       "risk": "low",
       "input_schema": {

--- a/assistant/src/config/bundled-skills/settings/tools/navigate-settings-tab.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/navigate-settings-tab.ts
@@ -5,11 +5,13 @@ import type {
 
 const SETTINGS_TABS = [
   "General",
-  "Channels",
   "Models & Services",
   "Voice",
+  "Sounds",
   "Permissions & Privacy",
-  "Contacts",
+  "Billing",
+  "Archived Conversations",
+  "Schedules",
   "Developer",
 ] as const;
 

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -275,6 +275,8 @@ function buildInChatConfigurationSection(): string {
     "## In-Chat Configuration",
     "",
     "When the user needs to configure a value, collect it conversationally in the chat. Never direct the user to the Settings page for initial setup - Settings is for reviewing and updating existing configuration.",
+    "",
+    'The Settings tabs are: General, Models & Services, Voice, Sounds, Permissions & Privacy, Billing, Archived Conversations, Schedules, Developer. There is NO "Integrations" tab — never refer to "Settings > Integrations". For API keys and provider configuration, the correct tab is "Models & Services".',
   ].join("\n");
 }
 
@@ -435,9 +437,9 @@ function readPromptFile(path: string): string | null {
  * This is useful for injecting identity context into subsystems (e.g. memory
  * extraction) that run outside the main system prompt pipeline.
  */
-export function buildCoreIdentityContext(
-  opts?: { userPersona?: string | null },
-): string | null {
+export function buildCoreIdentityContext(opts?: {
+  userPersona?: string | null;
+}): string | null {
   const parts: string[] = [];
   for (const file of PROMPT_FILES) {
     const content = readPromptFile(getWorkspacePromptPath(file));

--- a/assistant/src/runtime/migrations/rebind-secrets-screen.ts
+++ b/assistant/src/runtime/migrations/rebind-secrets-screen.ts
@@ -106,7 +106,7 @@ const TASK_DEFINITIONS: readonly TaskDefinition[] = [
       "Secrets are redacted in export bundles for security. Re-enter all API keys, tokens, and credentials in the destination instance.",
     required: true,
     helpText:
-      "Navigate to Settings > Integrations to re-enter provider API keys (e.g., Anthropic, OpenAI). Check Settings > Secrets for any custom secrets used by skills.",
+      "Navigate to Settings > Models & Services to re-enter provider API keys (e.g., Anthropic, OpenAI). Check Settings > Models & Services for any custom secrets used by skills.",
   },
   {
     id: "rebind-channels",
@@ -133,7 +133,7 @@ const TASK_DEFINITIONS: readonly TaskDefinition[] = [
       "Ensure all webhook URLs registered with external services point to the new instance's public ingress URL.",
     required: false,
     helpText:
-      "Review the public ingress URL in Settings > Gateway. Update any external services (GitHub, calendar providers, etc.) that send webhooks to this assistant.",
+      "Review the public ingress URL in Settings > General. Update any external services (GitHub, calendar providers, etc.) that send webhooks to this assistant.",
   },
 ] as const;
 

--- a/assistant/src/runtime/migrations/rebind-secrets-screen.ts
+++ b/assistant/src/runtime/migrations/rebind-secrets-screen.ts
@@ -133,7 +133,7 @@ const TASK_DEFINITIONS: readonly TaskDefinition[] = [
       "Ensure all webhook URLs registered with external services point to the new instance's public ingress URL.",
     required: false,
     helpText:
-      "Review the public ingress URL in Settings > General. Update any external services (GitHub, calendar providers, etc.) that send webhooks to this assistant.",
+      "Review the public ingress URL in Settings > Developer. Update any external services (GitHub, calendar providers, etc.) that send webhooks to this assistant.",
   },
 ] as const;
 


### PR DESCRIPTION
## Summary
- Remove all references to "Settings > Integrations" which no longer exists in the app
- Update migration wizard help text to point to "Settings > Models & Services" and "Settings > General"
- Sync the `navigate_settings_tab` tool enum with actual Swift `SettingsTab` values (removed "Channels"/"Contacts", added "Sounds"/"Billing"/"Archived Conversations"/"Schedules")
- Add valid tab list to system prompt so the LLM stops hallucinating "Settings > Integrations"

Closes JARVIS-353

## Test plan
- [ ] Verify assistant no longer mentions "Settings > Integrations" in chat
- [ ] Test `navigate_settings_tab` tool with each enum value opens the correct tab
- [ ] Confirm migration wizard help text shows correct tab names

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
