### PR TITLE
fix: clarify draft-only email policy during Gmail setup

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -32,7 +32,7 @@ Do not offer AgentMail as an option or mention it unless the user specifically a
    - Call `skill_load` with `skill: "google-oauth-applescript"` to load the dependency skill.
    - Tell the user Gmail isn't connected yet and briefly explain what the setup involves, then use `ui_show` with `surface_type: "confirmation"` to ask for permission to start:
      - **message:** "Ready to set up Gmail?"
-     - **detail:** "I'll open a few pages in your browser and walk you through setting up Google Cloud credentials - creating a project, enabling APIs, and connecting your account. Takes about 5 minutes."
+     - **detail:** "I'll open a few pages in your browser and walk you through setting up Google Cloud credentials - creating a project, enabling APIs, and connecting your account. Takes about 5 minutes.\n\n**Your emails stay under your control** — I only ever create drafts. Nothing gets sent without your explicit say-so."
      - **confirmLabel:** "Get Started"
      - **cancelLabel:** "Not Now"
    - If the user confirms, briefly acknowledge (e.g., "Setting up Gmail now...") and proceed with the setup guide. If they decline, acknowledge and let them know they can set it up later.

--- a/skills/google-oauth-applescript/SKILL.md
+++ b/skills/google-oauth-applescript/SKILL.md
@@ -28,6 +28,8 @@ The flow has 9 steps total, takes about 3–5 minutes.
 
 > Before we start - fair warning: this setup involves Google's developer console, which can feel pretty technical. Don't worry about that - you don't need to understand any of it. I'll open every page for you and tell you exactly what to click. If anything looks confusing or different from what I describe, just tell me and I'll figure it out.
 >
+> One thing worth knowing upfront: even after setup, I'll only ever create email drafts — I won't send anything without your explicit say-so.
+>
 > Do you have a Google account you'd like to use for this?
 
 If no Google account → guide them to create one or defer.
@@ -147,7 +149,7 @@ host_bash:
 >
 > **Note:** GCP may categorize these scopes differently than you'd expect — that's fine, as long as all 7 are present.
 >
-> **Quick note:** The `gmail.modify` and `gmail.send` scopes are what allow me to draft and send emails on your behalf. If you'd rather I only have read access to your email for now, you can uncheck those two - everything else will still work fine, and you can always come back and add them later.
+> **Quick note on email safety:** The `gmail.modify` and `gmail.send` scopes let me create drafts and, when you explicitly ask, send them. By default I only create drafts — nothing leaves your outbox without your approval. If you'd rather I only have read access to your email for now, you can uncheck those two - everything else will still work fine, and you can always come back and add them later.
 
 **Milestone (5 of 9):** "Over halfway - the fiddliest part is behind us."
 

--- a/skills/google-oauth-applescript/references/path-b-manual-setup.md
+++ b/skills/google-oauth-applescript/references/path-b-manual-setup.md
@@ -10,6 +10,8 @@ Tell the user:
 >
 > Fair warning - this involves Google's developer console, which can feel pretty technical. Don't worry about that - you don't need to understand any of it. I'll give you a direct link for every step and tell you exactly what to do. If anything looks confusing, just let me know and I'll help you through it.
 >
+> One thing worth knowing upfront: even after setup, I'll only ever create email drafts — I won't send anything without your explicit say-so.
+>
 > Since I can't open pages in your browser from here, you'll need:
 >
 > 1. A Google account with access to Google Cloud Console
@@ -87,7 +89,7 @@ Tell the user:
 >   - Click **Update** at the bottom of the panel
 >   - Back on the main page, scroll down and click **Save**
 >
-> **Quick note:** The `gmail.modify` and `gmail.send` scopes are what allow me to draft and send emails on your behalf. If you'd rather I only have read access to your email for now, you can remove those two from the list before pasting - everything else will still work fine, and you can always add them later.
+> **Quick note on email safety:** The `gmail.modify` and `gmail.send` scopes let me create drafts and, when you explicitly ask, send them. By default I only create drafts — nothing leaves your outbox without your approval. If you'd rather I only have read access to your email for now, you can remove those two from the list before pasting - everything else will still work fine, and you can always add them later.
 >
 > Let me know when all parts are done.
 


### PR DESCRIPTION
## Summary
- Adds clear "I only create drafts — nothing gets sent without your approval" messaging at three key points in the Gmail onboarding flow: the setup confirmation dialog, the prerequisite intro (both Path A and Path B), and the scopes step
- Rewords the scope explanation from vague ("draft and send on your behalf") to explicit about the draft-first workflow

Closes JARVIS-337

## Test plan
- [ ] Trigger Gmail setup on macOS (no existing Google credentials) — verify the confirmation dialog includes the draft-only note
- [ ] Walk through Path A OAuth flow — verify Step 0 intro and Step 5c scopes mention the policy
- [ ] Walk through Path B manual setup — verify Step 1 intro and Step 4 scopes mention the policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
