### PR TITLE
M4: Add pagination test suite for handleListMessages

### DIFF
--- a/assistant/src/__tests__/list-messages-attachments.test.ts
+++ b/assistant/src/__tests__/list-messages-attachments.test.ts
@@ -286,3 +286,174 @@ describe("handleListMessages no_response filtering", () => {
     expect(body.messages[0].content).toBe("What does <no_response/> do?");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Pagination
+// ---------------------------------------------------------------------------
+
+interface PaginatedResponse {
+  messages: { id: string; content: string; timestamp: string }[];
+  hasMore?: boolean;
+  oldestTimestamp?: number;
+  oldestMessageId?: string;
+}
+
+function createPaginatedUrl(
+  conversationId: string,
+  params?: { limit?: string; beforeTimestamp?: string },
+): URL {
+  const url = new URL(
+    `http://localhost/v1/messages?conversationId=${conversationId}`,
+  );
+  if (params?.limit !== undefined) url.searchParams.set("limit", params.limit);
+  if (params?.beforeTimestamp !== undefined)
+    url.searchParams.set("beforeTimestamp", params.beforeTimestamp);
+  return url;
+}
+
+/** Helper: insert N messages with distinct, increasing timestamps and return them in insertion order. */
+async function insertMessages(
+  conversationId: string,
+  count: number,
+): Promise<{ id: string; createdAt: number }[]> {
+  const msgs: { id: string; createdAt: number }[] = [];
+  for (let i = 0; i < count; i++) {
+    const msg = await addMessage(
+      conversationId,
+      i % 2 === 0 ? "user" : "assistant",
+      JSON.stringify([{ type: "text", text: `msg-${i}` }]),
+    );
+    msgs.push({ id: msg.id, createdAt: msg.createdAt });
+  }
+  return msgs;
+}
+
+describe("handleListMessages pagination", () => {
+  beforeEach(resetTables);
+
+  test("no params → all messages, no hasMore field", async () => {
+    const conv = createConversation();
+    await insertMessages(conv.id, 5);
+
+    const response = handleListMessages(createTestUrl(conv.id), null);
+    const body = (await response.json()) as PaginatedResponse;
+
+    expect(body.messages).toHaveLength(5);
+    expect(body.hasMore).toBeUndefined();
+    expect(body.oldestTimestamp).toBeUndefined();
+    expect(body.oldestMessageId).toBeUndefined();
+  });
+
+  test("limit only (no beforeTimestamp) → all messages, no hasMore", async () => {
+    const conv = createConversation();
+    await insertMessages(conv.id, 5);
+
+    const url = createPaginatedUrl(conv.id, { limit: "3" });
+    const response = handleListMessages(url, null);
+    const body = (await response.json()) as PaginatedResponse;
+
+    // Option A: without beforeTimestamp, all messages are returned regardless of limit
+    expect(body.messages).toHaveLength(5);
+    expect(body.hasMore).toBeUndefined();
+  });
+
+  test("beforeTimestamp + limit → correct page with hasMore: true", async () => {
+    const conv = createConversation();
+    const msgs = await insertMessages(conv.id, 10);
+
+    // Cursor is message[7]'s timestamp; limit=3 → should return messages [4,5,6]
+    const url = createPaginatedUrl(conv.id, {
+      beforeTimestamp: String(msgs[7].createdAt),
+      limit: "3",
+    });
+    const response = handleListMessages(url, null);
+    const body = (await response.json()) as PaginatedResponse;
+
+    expect(body.messages).toHaveLength(3);
+    expect(body.messages.map((m) => m.id)).toEqual([
+      msgs[4].id,
+      msgs[5].id,
+      msgs[6].id,
+    ]);
+    expect(body.hasMore).toBe(true);
+  });
+
+  test("beforeTimestamp is strictly exclusive", async () => {
+    const conv = createConversation();
+    const msgs = await insertMessages(conv.id, 3);
+
+    // Use message[1]'s exact timestamp as cursor — message[1] should NOT appear
+    const url = createPaginatedUrl(conv.id, {
+      beforeTimestamp: String(msgs[1].createdAt),
+      limit: "10",
+    });
+    const response = handleListMessages(url, null);
+    const body = (await response.json()) as PaginatedResponse;
+
+    const ids = body.messages.map((m) => m.id);
+    expect(ids).toContain(msgs[0].id);
+    expect(ids).not.toContain(msgs[1].id);
+    expect(ids).not.toContain(msgs[2].id);
+  });
+
+  test("hasMore: false when all older messages fit", async () => {
+    const conv = createConversation();
+    const msgs = await insertMessages(conv.id, 5);
+
+    // beforeTimestamp beyond the last message, limit larger than total count
+    const url = createPaginatedUrl(conv.id, {
+      beforeTimestamp: String(msgs[4].createdAt + 1),
+      limit: "10",
+    });
+    const response = handleListMessages(url, null);
+    const body = (await response.json()) as PaginatedResponse;
+
+    expect(body.messages).toHaveLength(5);
+    expect(body.hasMore).toBe(false);
+  });
+
+  test("oldestTimestamp and oldestMessageId match oldest returned message", async () => {
+    const conv = createConversation();
+    const msgs = await insertMessages(conv.id, 5);
+
+    // Fetch last 3 messages before a cursor past the end
+    const url = createPaginatedUrl(conv.id, {
+      beforeTimestamp: String(msgs[4].createdAt + 1),
+      limit: "3",
+    });
+    const response = handleListMessages(url, null);
+    const body = (await response.json()) as PaginatedResponse;
+
+    expect(body.messages).toHaveLength(3);
+    // Oldest returned message is msgs[2] (messages [2,3,4])
+    expect(body.oldestTimestamp).toBe(msgs[2].createdAt);
+    expect(body.oldestMessageId).toBe(msgs[2].id);
+  });
+
+  test("empty / nonexistent conversation → empty messages, no pagination metadata", async () => {
+    const url = createPaginatedUrl("nonexistent-conv-id");
+    const response = handleListMessages(url, null);
+    const body = (await response.json()) as PaginatedResponse;
+
+    expect(body.messages).toEqual([]);
+    expect(body.hasMore).toBeUndefined();
+    expect(body.oldestTimestamp).toBeUndefined();
+    expect(body.oldestMessageId).toBeUndefined();
+  });
+
+  test("invalid limit (NaN) → 400", async () => {
+    const conv = createConversation();
+    const url = createPaginatedUrl(conv.id, { limit: "abc" });
+    const response = handleListMessages(url, null);
+
+    expect(response.status).toBe(400);
+  });
+
+  test("invalid beforeTimestamp (NaN) → 400", async () => {
+    const conv = createConversation();
+    const url = createPaginatedUrl(conv.id, { beforeTimestamp: "abc" });
+    const response = handleListMessages(url, null);
+
+    expect(response.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 9 pagination test cases to `list-messages-attachments.test.ts` covering backward compatibility (no params, limit-only), cursor pagination with `beforeTimestamp + limit`, strict exclusivity of `beforeTimestamp`, `hasMore` logic, `oldestTimestamp`/`oldestMessageId` metadata correctness, empty conversations, and input validation (NaN limit/beforeTimestamp → 400).

## Test plan
- [x] All 17 tests pass (4 attachment + 4 no_response + 9 pagination)
- [x] `bun test src/__tests__/list-messages-attachments.test.ts` green

Part of #21550.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
