### PR TITLE
feat: forward error-level logs to Sentry (daemon + macOS)

### DIFF
--- a/assistant/src/util/logger.ts
+++ b/assistant/src/util/logger.ts
@@ -18,6 +18,7 @@ import {
 } from "../config/env-registry.js";
 import { logSerializers } from "./log-redact.js";
 import { getLogPath } from "./platform.js";
+import { createSentryLogStream } from "./sentry-log-stream.js";
 
 /** Common pino-pretty options that inline [module] into the message prefix. */
 function prettyOpts(extra?: PrettyOptions): PrettyOptions {
@@ -133,6 +134,11 @@ function buildRotatingLogger(config: LogFileConfig): pino.Logger {
   activeLogDate = today;
   activeLogFileConfig = { ...config, dir };
 
+  const sentryStream = {
+    stream: createSentryLogStream(),
+    level: "error" as const,
+  };
+
   // When stdout is not a TTY (e.g. desktop app redirects to a hatch log file),
   // write to the rotating file only — the hatch log already captured early
   // startup output and echoing pino output there is unnecessary duplication.
@@ -141,7 +147,10 @@ function buildRotatingLogger(config: LogFileConfig): pino.Logger {
   if (!process.stdout.isTTY && !getIsContainerized()) {
     return pino(
       { name: "assistant", level: "info", serializers: logSerializers },
-      fileStream,
+      pino.multistream([
+        { stream: fileStream, level: "info" as const },
+        sentryStream,
+      ]),
     );
   }
 
@@ -153,6 +162,7 @@ function buildRotatingLogger(config: LogFileConfig): pino.Logger {
         stream: pinoPretty(prettyOpts({ destination: 1 })),
         level: "info" as const,
       },
+      sentryStream,
     ]),
   );
 }

--- a/assistant/src/util/sentry-log-stream.ts
+++ b/assistant/src/util/sentry-log-stream.ts
@@ -1,0 +1,51 @@
+import { Writable } from "node:stream";
+
+import * as Sentry from "@sentry/node";
+
+/**
+ * Pino-compatible writable stream that forwards error/fatal log messages
+ * to Sentry as captured events. Add this stream to a pino multistream at
+ * the "error" level so that every `log.error(…)` and `log.fatal(…)` call
+ * automatically creates a Sentry issue.
+ *
+ * If the log entry contains an `err` field (serialised error object), the
+ * error is captured via `Sentry.captureException`; otherwise the message
+ * text is captured via `Sentry.captureMessage`.
+ */
+export function createSentryLogStream(): Writable {
+  return new Writable({
+    write(chunk, _encoding, callback) {
+      try {
+        const entry = JSON.parse(chunk.toString());
+        const module: string = entry.module ?? "unknown";
+        const msg: string = entry.msg ?? "";
+
+        if (entry.err && typeof entry.err === "object") {
+          // Reconstruct an Error so Sentry gets a proper stack trace.
+          const errObj = entry.err;
+          const error = new Error(errObj.message ?? msg);
+          error.name = errObj.type ?? errObj.name ?? "Error";
+          if (errObj.stack) error.stack = errObj.stack;
+
+          Sentry.withScope((scope) => {
+            scope.setTag("source", "error_log");
+            scope.setTag("log_module", module);
+            scope.setLevel(entry.level >= 60 ? "fatal" : "error");
+            if (msg) scope.setExtra("log_message", msg);
+            Sentry.captureException(error);
+          });
+        } else {
+          Sentry.withScope((scope) => {
+            scope.setTag("source", "error_log");
+            scope.setTag("log_module", module);
+            scope.setLevel(entry.level >= 60 ? "fatal" : "error");
+            Sentry.captureMessage(`[${module}] ${msg}`);
+          });
+        }
+      } catch {
+        // Never block logging if Sentry capture fails.
+      }
+      callback();
+    },
+  });
+}

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -373,6 +373,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 options.maxAttachmentSize = MetricKitManager.sentryMaxAttachmentSize
             }
             SentryDeviceInfo.configureSentryScope()
+            SentryLogReporter.start()
         }
 
         // Surface any crash log from the previous session so the user can send

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -195,6 +195,7 @@ import os
     /// `nonisolated` so AppDelegate and Settings code can call it without
     /// crossing the @MainActor boundary.
     nonisolated static func closeSentry() {
+        SentryLogReporter.stop()
         sentrySerialQueue.async {
             SentrySDK.close()
         }
@@ -209,6 +210,7 @@ import os
         sentrySerialQueue.async {
             restartSentryInline()
         }
+        SentryLogReporter.start()
     }
 
     /// Synchronous Sentry restart — must be called from `sentrySerialQueue`.

--- a/clients/macos/vellum-assistant/Telemetry/SentryLogReporter.swift
+++ b/clients/macos/vellum-assistant/Telemetry/SentryLogReporter.swift
@@ -10,8 +10,8 @@ import VellumAssistantShared
 /// do not need any changes. The forwarder uses `OSLogStore` with
 /// `.currentProcessIdentifier` scope, which requires no special entitlements.
 ///
-/// Additionally installs the `VLogger.errorReporter` callback so that any
-/// code using the new `VLogger` type also flows into Sentry immediately.
+/// Additionally installs the `ReportableLogger.errorReporter` callback so
+/// that any code using `ReportableLogger` also flows into Sentry immediately.
 ///
 /// Call `SentryLogReporter.start()` once at app startup (after `SentrySDK.start`).
 final class SentryLogReporter: @unchecked Sendable {
@@ -30,6 +30,12 @@ final class SentryLogReporter: @unchecked Sendable {
     private var recentFingerprints = Set<String>()
     private let maxFingerprintCacheSize = 500
 
+    /// Categories that already have explicit Sentry integration and should
+    /// be skipped by the OSLogStore poller to avoid duplicate events.
+    private let excludedCategories: Set<String> = [
+        "MetricKit",       // MetricKitManager sends hang diagnostics directly
+    ]
+
     private init() {}
 
     // MARK: - Public API
@@ -37,22 +43,22 @@ final class SentryLogReporter: @unchecked Sendable {
     /// Start the log forwarder. Safe to call multiple times (subsequent
     /// calls are no-ops).
     static func start() {
-        shared.installVLoggerHook()
+        shared.installReportableLoggerHook()
         shared.startPolling()
     }
 
     /// Stop the log forwarder. Called when the user disables diagnostics.
     static func stop() {
-        VLogger.errorReporter = nil
+        ReportableLogger.errorReporter = nil
         shared.stopPolling()
     }
 
-    // MARK: - VLogger hook
+    // MARK: - ReportableLogger hook
 
-    /// Wire up `VLogger.errorReporter` so that new code using `VLogger`
-    /// captures to Sentry immediately (no polling delay).
-    private func installVLoggerHook() {
-        VLogger.errorReporter = { message, category in
+    /// Wire up `ReportableLogger.errorReporter` so that new code using
+    /// `ReportableLogger` captures to Sentry immediately (no polling delay).
+    private func installReportableLoggerHook() {
+        ReportableLogger.errorReporter = { message, category in
             // Record the fingerprint so pollForErrors() skips this entry
             // when it later reads the same message from OSLogStore.
             let fingerprint = "\(category):\(message)"
@@ -108,6 +114,9 @@ final class SentryLogReporter: @unchecked Sendable {
             for case let entry as OSLogEntryLog in entries {
                 // Skip entries from before our window (position is inclusive).
                 guard entry.date > cutoff else { continue }
+
+                // Skip categories that already send explicit Sentry events.
+                guard !excludedCategories.contains(entry.category) else { continue }
 
                 let message = entry.composedMessage
                 guard !message.isEmpty else { continue }

--- a/clients/macos/vellum-assistant/Telemetry/SentryLogReporter.swift
+++ b/clients/macos/vellum-assistant/Telemetry/SentryLogReporter.swift
@@ -1,0 +1,171 @@
+import Foundation
+import OSLog
+@preconcurrency import Sentry
+import VellumAssistantShared
+
+/// Periodically reads error- and fault-level entries from the unified log
+/// for the current process and forwards them to Sentry as captured events.
+///
+/// This approach is completely non-invasive: existing `os.Logger` call sites
+/// do not need any changes. The forwarder uses `OSLogStore` with
+/// `.currentProcessIdentifier` scope, which requires no special entitlements.
+///
+/// Additionally installs the `VLogger.errorReporter` callback so that any
+/// code using the new `VLogger` type also flows into Sentry immediately.
+///
+/// Call `SentryLogReporter.start()` once at app startup (after `SentrySDK.start`).
+final class SentryLogReporter: @unchecked Sendable {
+
+    static let shared = SentryLogReporter()
+
+    private let queue = DispatchQueue(label: "com.vellum.sentry-log-reporter", qos: .utility)
+    private var timer: DispatchSourceTimer?
+    private var lastCheckDate = Date()
+
+    /// How often to poll OSLogStore for new error entries (seconds).
+    private let pollInterval: TimeInterval = 10
+
+    /// Seen message fingerprints within the current poll window to avoid
+    /// sending the same error twice (e.g. rapid repeated failures).
+    private var recentFingerprints = Set<String>()
+    private let maxFingerprintCacheSize = 500
+
+    private init() {}
+
+    // MARK: - Public API
+
+    /// Start the log forwarder. Safe to call multiple times (subsequent
+    /// calls are no-ops).
+    static func start() {
+        shared.installVLoggerHook()
+        shared.startPolling()
+    }
+
+    /// Stop the log forwarder. Called when the user disables diagnostics.
+    static func stop() {
+        shared.stopPolling()
+    }
+
+    // MARK: - VLogger hook
+
+    /// Wire up `VLogger.errorReporter` so that new code using `VLogger`
+    /// captures to Sentry immediately (no polling delay).
+    private func installVLoggerHook() {
+        // Intentionally import-free: VLogger is in VellumAssistantShared
+        // which is a dependency of VellumAssistantLib.
+        VLogger.errorReporter = { message, category in
+            SentryLogReporter.captureToSentry(message: message, category: category)
+        }
+    }
+
+    // MARK: - OSLogStore polling
+
+    private func startPolling() {
+        queue.async { [weak self] in
+            guard let self, self.timer == nil else { return }
+            self.lastCheckDate = Date()
+
+            let timer = DispatchSource.makeTimerSource(queue: self.queue)
+            timer.schedule(
+                deadline: .now() + self.pollInterval,
+                repeating: self.pollInterval
+            )
+            timer.setEventHandler { [weak self] in
+                self?.pollForErrors()
+            }
+            timer.resume()
+            self.timer = timer
+        }
+    }
+
+    private func stopPolling() {
+        queue.async { [weak self] in
+            self?.timer?.cancel()
+            self?.timer = nil
+        }
+    }
+
+    private func pollForErrors() {
+        guard SentrySDK.isEnabled else { return }
+
+        do {
+            let store = try OSLogStore(scope: .currentProcessIdentifier)
+            let position = store.position(date: lastCheckDate)
+            let cutoff = lastCheckDate
+            lastCheckDate = Date()
+
+            let predicate = NSPredicate(format: "messageType == %d OR messageType == %d",
+                                        OSLogEntryLog.Level.error.rawValue,
+                                        OSLogEntryLog.Level.fault.rawValue)
+
+            let entries = try store.getEntries(at: position, matching: predicate)
+
+            for case let entry as OSLogEntryLog in entries {
+                // Skip entries from before our window (position is inclusive).
+                guard entry.date > cutoff else { continue }
+
+                let message = entry.composedMessage
+                guard !message.isEmpty else { continue }
+
+                // Deduplicate within the poll window.
+                let fingerprint = "\(entry.category):\(message)"
+                guard !recentFingerprints.contains(fingerprint) else { continue }
+                recentFingerprints.insert(fingerprint)
+
+                Self.captureToSentry(
+                    message: message,
+                    category: entry.category,
+                    level: entry.level == .fault ? .fatal : .error
+                )
+            }
+
+            // Prevent unbounded fingerprint cache growth.
+            if recentFingerprints.count > maxFingerprintCacheSize {
+                recentFingerprints.removeAll()
+            }
+        } catch {
+            // OSLogStore can throw on first access or when the log daemon is
+            // busy. Silently retry on the next poll cycle.
+        }
+    }
+
+    // MARK: - Sentry capture
+
+    private static func captureToSentry(
+        message: String,
+        category: String,
+        level: SentryLevel = .error
+    ) {
+        let event = Event(level: level)
+        event.message = SentryMessage(formatted: "[\(category)] \(message)")
+        event.tags = [
+            "source": "error_log",
+            "log_category": category,
+        ]
+        // Group by category + message prefix so repeated errors don't flood
+        // Sentry with unique issues. Sentry uses the fingerprint array for
+        // issue grouping.
+        event.fingerprint = ["error_log", category, Self.messagePrefix(message)]
+        MetricKitManager.captureSentryEvent(event)
+    }
+
+    /// Extract a stable prefix from the message for fingerprinting.
+    /// Strips trailing dynamic content (UUIDs, numbers, paths) so that
+    /// "Failed to load /path/a" and "Failed to load /path/b" group together.
+    private static func messagePrefix(_ message: String) -> String {
+        let maxLen = 80
+        let truncated = message.count <= maxLen ? message : String(message.prefix(maxLen))
+        // Replace common dynamic suffixes with a placeholder.
+        return truncated
+            .replacingOccurrences(
+                of: #"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"#,
+                with: "<uuid>",
+                options: .regularExpression
+            )
+            .replacingOccurrences(
+                of: #"\d{4,}"#,
+                with: "<n>",
+                options: .regularExpression
+            )
+    }
+}

--- a/clients/macos/vellum-assistant/Telemetry/SentryLogReporter.swift
+++ b/clients/macos/vellum-assistant/Telemetry/SentryLogReporter.swift
@@ -43,6 +43,7 @@ final class SentryLogReporter: @unchecked Sendable {
 
     /// Stop the log forwarder. Called when the user disables diagnostics.
     static func stop() {
+        VLogger.errorReporter = nil
         shared.stopPolling()
     }
 
@@ -51,9 +52,13 @@ final class SentryLogReporter: @unchecked Sendable {
     /// Wire up `VLogger.errorReporter` so that new code using `VLogger`
     /// captures to Sentry immediately (no polling delay).
     private func installVLoggerHook() {
-        // Intentionally import-free: VLogger is in VellumAssistantShared
-        // which is a dependency of VellumAssistantLib.
         VLogger.errorReporter = { message, category in
+            // Record the fingerprint so pollForErrors() skips this entry
+            // when it later reads the same message from OSLogStore.
+            let fingerprint = "\(category):\(message)"
+            SentryLogReporter.shared.queue.async {
+                SentryLogReporter.shared.recentFingerprints.insert(fingerprint)
+            }
             SentryLogReporter.captureToSentry(message: message, category: category)
         }
     }

--- a/clients/shared/Utilities/ReportableLogger.swift
+++ b/clients/shared/Utilities/ReportableLogger.swift
@@ -1,22 +1,22 @@
 import Foundation
 import os
 
-/// Drop-in replacement for `os.Logger` that forwards error- and fault-level
-/// messages to a configurable reporter (e.g. Sentry) in addition to the
-/// unified logging system.
+/// Drop-in replacement for `os.Logger` that forwards error-, fault-, and
+/// critical-level messages to a configurable reporter (e.g. Sentry) in
+/// addition to the unified logging system.
 ///
 /// Usage:
 /// ```swift
-/// private let log = VLogger(subsystem: "com.vellum.vellum-assistant", category: "MyFeature")
+/// private let log = ReportableLogger(subsystem: "com.vellum.vellum-assistant", category: "MyFeature")
 /// log.info("loaded")           // → os.Logger only
 /// log.error("something broke") // → os.Logger + error reporter (if configured)
 /// ```
 ///
 /// Configure the reporter at app startup:
 /// ```swift
-/// VLogger.errorReporter = { message, category in /* Sentry, analytics, etc. */ }
+/// ReportableLogger.errorReporter = { message, category in /* Sentry, analytics, etc. */ }
 /// ```
-public struct VLogger: Sendable {
+public struct ReportableLogger: Sendable {
 
     // MARK: - Error reporter hook
 
@@ -26,9 +26,9 @@ public struct VLogger: Sendable {
     private static let _lock = NSLock()
     private static var _errorReporter: (@Sendable (String, String) -> Void)?
 
-    /// Called for every `error()` and `fault()` log. Set once at app startup
-    /// to bridge error logs into Sentry or another crash reporter.
-    /// Parameters: (message: String, category: String).
+    /// Called for every `error()`, `fault()`, and `critical()` log. Set once
+    /// at app startup to bridge error logs into Sentry or another crash
+    /// reporter. Parameters: (message: String, category: String).
     public static var errorReporter: (@Sendable (String, String) -> Void)? {
         get { _lock.lock(); defer { _lock.unlock() }; return _errorReporter }
         set { _lock.lock(); defer { _lock.unlock() }; _errorReporter = newValue }
@@ -51,9 +51,8 @@ public struct VLogger: Sendable {
     public func info(_ message: String) { osLogger.info("\(message)") }
     public func notice(_ message: String) { osLogger.notice("\(message)") }
     public func warning(_ message: String) { osLogger.warning("\(message)") }
-    public func critical(_ message: String) { osLogger.critical("\(message)") }
 
-    // MARK: - Error / Fault — captured to reporter
+    // MARK: - Error / Fault / Critical — captured to reporter
 
     /// Log an error and forward to the error reporter (e.g. Sentry).
     public func error(_ message: String) {
@@ -64,6 +63,14 @@ public struct VLogger: Sendable {
     /// Log a fault and forward to the error reporter (e.g. Sentry).
     public func fault(_ message: String) {
         osLogger.fault("\(message, privacy: .public)")
+        Self.errorReporter?(message, category)
+    }
+
+    /// Log a critical message and forward to the error reporter.
+    /// Apple maps `Logger.critical()` to `OSLogType.fault`, so this
+    /// receives the same Sentry treatment as `fault()`.
+    public func critical(_ message: String) {
+        osLogger.critical("\(message, privacy: .public)")
         Self.errorReporter?(message, category)
     }
 }

--- a/clients/shared/Utilities/VLogger.swift
+++ b/clients/shared/Utilities/VLogger.swift
@@ -1,3 +1,4 @@
+import Foundation
 import os
 
 /// Drop-in replacement for `os.Logger` that forwards error- and fault-level
@@ -19,10 +20,19 @@ public struct VLogger: Sendable {
 
     // MARK: - Error reporter hook
 
+    /// Lock protecting `_errorReporter` so concurrent reads (from log call
+    /// sites on arbitrary threads) and writes (from start/stop on the main
+    /// thread) don't race.
+    private static let _lock = NSLock()
+    private static var _errorReporter: (@Sendable (String, String) -> Void)?
+
     /// Called for every `error()` and `fault()` log. Set once at app startup
     /// to bridge error logs into Sentry or another crash reporter.
     /// Parameters: (message: String, category: String).
-    public nonisolated(unsafe) static var errorReporter: (@Sendable (String, String) -> Void)?
+    public static var errorReporter: (@Sendable (String, String) -> Void)? {
+        get { _lock.lock(); defer { _lock.unlock() }; return _errorReporter }
+        set { _lock.lock(); defer { _lock.unlock() }; _errorReporter = newValue }
+    }
 
     // MARK: - Initialisation
 

--- a/clients/shared/Utilities/VLogger.swift
+++ b/clients/shared/Utilities/VLogger.swift
@@ -1,0 +1,59 @@
+import os
+
+/// Drop-in replacement for `os.Logger` that forwards error- and fault-level
+/// messages to a configurable reporter (e.g. Sentry) in addition to the
+/// unified logging system.
+///
+/// Usage:
+/// ```swift
+/// private let log = VLogger(subsystem: "com.vellum.vellum-assistant", category: "MyFeature")
+/// log.info("loaded")           // → os.Logger only
+/// log.error("something broke") // → os.Logger + error reporter (if configured)
+/// ```
+///
+/// Configure the reporter at app startup:
+/// ```swift
+/// VLogger.errorReporter = { message, category in /* Sentry, analytics, etc. */ }
+/// ```
+public struct VLogger: Sendable {
+
+    // MARK: - Error reporter hook
+
+    /// Called for every `error()` and `fault()` log. Set once at app startup
+    /// to bridge error logs into Sentry or another crash reporter.
+    /// Parameters: (message: String, category: String).
+    public nonisolated(unsafe) static var errorReporter: (@Sendable (String, String) -> Void)?
+
+    // MARK: - Initialisation
+
+    private let osLogger: Logger
+    public let category: String
+
+    public init(subsystem: String, category: String) {
+        self.osLogger = Logger(subsystem: subsystem, category: category)
+        self.category = category
+    }
+
+    // MARK: - Pass-through levels
+
+    public func trace(_ message: String) { osLogger.trace("\(message)") }
+    public func debug(_ message: String) { osLogger.debug("\(message)") }
+    public func info(_ message: String) { osLogger.info("\(message)") }
+    public func notice(_ message: String) { osLogger.notice("\(message)") }
+    public func warning(_ message: String) { osLogger.warning("\(message)") }
+    public func critical(_ message: String) { osLogger.critical("\(message)") }
+
+    // MARK: - Error / Fault — captured to reporter
+
+    /// Log an error and forward to the error reporter (e.g. Sentry).
+    public func error(_ message: String) {
+        osLogger.error("\(message, privacy: .public)")
+        Self.errorReporter?(message, category)
+    }
+
+    /// Log a fault and forward to the error reporter (e.g. Sentry).
+    public func fault(_ message: String) {
+        osLogger.fault("\(message, privacy: .public)")
+        Self.errorReporter?(message, category)
+    }
+}


### PR DESCRIPTION
## Summary
- **Daemon**: new `sentry-log-stream.ts` pino writable stream added to the multistream at the `error` level — every `log.error()` and `log.fatal()` call now auto-creates a Sentry issue, using `captureException` when an `err` object is present and `captureMessage` otherwise
- **macOS app**: new `SentryLogReporter` polls `OSLogStore` every 10 seconds for error/fault entries and forwards them to Sentry — completely non-invasive, zero changes to existing `os.Logger` call sites
- **Infrastructure**: new `VLogger` struct (shared module) provides a drop-in logger with a configurable error reporter callback, wired to Sentry in the macOS target for immediate capture in new code

## Original prompt
make a sentry integration to log unhandled exceptions (error logs) both for daemon and macos app, using respective dsns

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
