### PR TITLE
M3: Fix typography (VFont tokens), progress bar color, and field width on resize

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -190,12 +190,11 @@ struct APIKeyEntryStepView: View {
                         guard !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
                         saveAndHatch()
                     },
-                    maxWidth: 400,
                     isFocused: $keyFieldFocused
                 )
             }
         }
-        .frame(maxWidth: 400)
+        .frame(maxWidth: .infinity)
     }
 
     // MARK: - Helpers

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -145,7 +145,7 @@ struct APIKeyStepView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     HStack(spacing: VSpacing.sm) {
                         Text(title)
-                            .font(.system(size: 15, weight: .medium))
+                            .font(VFont.bodyLargeEmphasised)
                             .foregroundStyle(isDisabled ? VColor.contentTertiary : VColor.contentDefault)
 
                         Spacer()
@@ -161,7 +161,7 @@ struct APIKeyStepView: View {
                         }
                     }
                     Text(subtitle)
-                        .font(.system(size: 12))
+                        .font(VFont.bodySmallDefault)
                         .foregroundStyle(isDisabled ? VColor.contentTertiary : VColor.contentSecondary)
                 }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -156,7 +156,7 @@ struct HatchingStepView: View {
                         .font(.system(size: 24, weight: .regular, design: .serif))
                         .foregroundStyle(VColor.contentDefault)
                     Text("You have an assistant on the hosted platform")
-                        .font(.system(size: 14))
+                        .font(VFont.bodyMediumDefault)
                         .foregroundStyle(VColor.contentSecondary)
                 } else {
                     Text("Something went wrong")
@@ -164,7 +164,7 @@ struct HatchingStepView: View {
                         .foregroundStyle(VColor.contentDefault)
                     if let reason = failureReason {
                         Text(reason)
-                            .font(.system(size: 14))
+                            .font(VFont.bodyMediumDefault)
                             .foregroundStyle(VColor.contentSecondary)
                             .textSelection(.enabled)
                     }
@@ -182,7 +182,7 @@ struct HatchingStepView: View {
                     .font(.system(size: 24, weight: .regular, design: .serif))
                     .foregroundStyle(VColor.contentDefault)
                 Text("Hang tight \u{2014} your assistant will have a few\nquestions for you once it\u{2019}s up.")
-                    .font(.system(size: 13))
+                    .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentTertiary)
                     .multilineTextAlignment(.center)
             }
@@ -203,6 +203,7 @@ struct HatchingStepView: View {
             TimelineView(.animation) { context in
                 ProgressView(value: progressValue(at: context.date))
                     .progressViewStyle(.linear)
+                    .tint(VColor.primaryBase)
                     .frame(maxWidth: 240)
             }
             if let label = state.hatchStepLabel {


### PR DESCRIPTION
Part of LUM-432 — replace raw .system() fonts with VFont design tokens in hosting cards and hatching status text, tint progress bar with VColor.primaryBase, and remove maxWidth constraints so fields stay 100% width when resizing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
