### PR TITLE
fix: update feedback upload route to /v1/upload/feedback/

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -41,7 +41,7 @@ enum LogExporter {
     }
 
     /// Collects logs, archives them, and uploads the archive to the platform API
-    /// (`POST /v1/feedback/`) for storage.
+    /// (`POST /v1/upload/feedback/`) for storage.
     /// Includes report metadata (reason, message) from the log report form.
     ///
     /// Throws if the archive build or platform upload fails. The caller is
@@ -93,7 +93,7 @@ enum LogExporter {
         connectedAssistantId: String?
     ) async throws {
         let baseURL = AuthService.shared.baseURL
-        guard let url = URL(string: "\(baseURL)/v1/feedback/") else {
+        guard let url = URL(string: "\(baseURL)/v1/upload/feedback/") else {
             log.warning("Failed to construct platform feedback URL")
             throw URLError(.badURL)
         }


### PR DESCRIPTION
## Summary

- Update the macOS LogExporter to POST feedback submissions to `/v1/upload/feedback/` instead of `/v1/feedback/`, routing them through the dedicated upload service for better resource isolation

## Original prompt

Can you update the vellum-assistant repo to use the new /v1/upload/feedback/ route? I believe it is currently /v1/feedback/. That repo is at the same folder level as this one

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
