### PR TITLE
fix: contact support (not ngrok) when managed callback registration fails

### DIFF
--- a/assistant/src/inbound/platform-callback-registration.ts
+++ b/assistant/src/inbound/platform-callback-registration.ts
@@ -204,18 +204,13 @@ export async function resolveCallbackUrl(
     }
     return url;
   } catch (err) {
-    log.warn(
-      { err, callbackPath, type },
-      "Failed to register platform callback route, falling back to direct URL",
+    // In managed/containerized mode there is no local-ingress fallback and
+    // ngrok is not applicable. Surface a clear error so callers (and the
+    // user) understand this is a platform-side issue, not a tunnel problem.
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Managed callback route registration failed: ${detail}. ` +
+        `Please contact support if this problem persists.`,
     );
-    try {
-      return directUrl();
-    } catch (fallbackErr) {
-      log.error(
-        { fallbackErr, callbackPath, type },
-        "Direct URL fallback also failed after platform registration failure",
-      );
-      throw err;
-    }
   }
 }

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -238,7 +238,10 @@ export async function maybeStartNgrokTunnel(
   // Managed/containerized deployments route webhooks through the platform's
   // callback proxy. ngrok is not needed and would not be reachable from the
   // platform anyway — skip it entirely.
-  if (process.env.IS_CONTAINERIZED) return null;
+  const isContainerized =
+    process.env.IS_CONTAINERIZED === "true" ||
+    process.env.IS_CONTAINERIZED === "1";
+  if (isContainerized) return null;
   if (!hasWebhookIntegrationsConfigured()) return null;
   if (hasNonNgrokIngressUrl()) return null;
 

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -235,6 +235,10 @@ function hasNonNgrokIngressUrl(): boolean {
 export async function maybeStartNgrokTunnel(
   targetPort: number,
 ): Promise<ChildProcess | null> {
+  // Managed/containerized deployments route webhooks through the platform's
+  // callback proxy. ngrok is not needed and would not be reachable from the
+  // platform anyway — skip it entirely.
+  if (process.env.IS_CONTAINERIZED) return null;
   if (!hasWebhookIntegrationsConfigured()) return null;
   if (hasNonNgrokIngressUrl()) return null;
 

--- a/gateway/src/telegram/webhook-manager.ts
+++ b/gateway/src/telegram/webhook-manager.ts
@@ -148,7 +148,21 @@ export async function reconcileTelegramWebhook(
     return;
   }
 
-  const expectedUrl = await resolveExpectedTelegramWebhookUrl(caches);
+  let expectedUrl: string | undefined;
+  try {
+    expectedUrl = await resolveExpectedTelegramWebhookUrl(caches);
+  } catch (err) {
+    // Managed callback route registration failed — this is a platform-side
+    // issue. Do not suggest ngrok or other tunnel options; they are not
+    // usable in containerized deployments.
+    const detail = err instanceof Error ? err.message : String(err);
+    log.error(
+      { err },
+      `Telegram webhook registration failed: managed platform callback route could not be registered. ` +
+        `Please contact support. (${detail})`,
+    );
+    return;
+  }
   if (!expectedUrl) {
     log.debug(
       "Skipping webhook reconciliation: no public ingress or managed callback route available",


### PR DESCRIPTION
## Summary
- In managed/containerized mode, webhook callbacks route through the platform proxy — ngrok is never applicable, but a failure in platform callback registration could previously lead to ngrok being suggested or auto-started
- `maybeStartNgrokTunnel` now exits early when `IS_CONTAINERIZED` is set — no ngrok auto-start in managed deployments
- `resolveCallbackUrl` no longer falls back to a direct/ngrok URL in managed mode; it now throws a clear error telling the user to contact support
- `reconcileTelegramWebhook` now catches managed registration errors and logs a "contact support" message instead of propagating a generic exception (which the assistant might interpret as a tunnel problem)

## Original prompt
do not suggest ngrok for telegram or other webhooks when in managed/containerized mode if the managed callback registration fails. If the managed callback registration fails instead suggest contacting support

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
