### PR TITLE
fix: add missing Slack app manifest scopes and events

### DIFF
--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -65,11 +65,15 @@ Generate the manifest JSON:
         "app_mentions:read",
         "assistant:write",
         "channels:history",
+        "channels:read",
         "chat:write",
         "files:write",
+        "groups:history",
+        "groups:read",
         "im:history",
         "im:read",
         "im:write",
+        "reactions:read",
         "reactions:write",
         "users:read"
       ]
@@ -77,7 +81,7 @@ Generate the manifest JSON:
   },
   "settings": {
     "event_subscriptions": {
-      "bot_events": ["app_mention", "message.channels", "message.im"]
+      "bot_events": ["app_mention", "message.channels", "message.groups", "message.im", "message.mpim", "reaction_added"]
     },
     "interactivity": { "is_enabled": true },
     "org_deploy_enabled": false,

--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -73,6 +73,8 @@ Generate the manifest JSON:
         "im:history",
         "im:read",
         "im:write",
+        "mpim:history",
+        "mpim:read",
         "reactions:read",
         "reactions:write",
         "users:read"
@@ -81,7 +83,14 @@ Generate the manifest JSON:
   },
   "settings": {
     "event_subscriptions": {
-      "bot_events": ["app_mention", "message.channels", "message.groups", "message.im", "message.mpim", "reaction_added"]
+      "bot_events": [
+        "app_mention",
+        "message.channels",
+        "message.groups",
+        "message.im",
+        "message.mpim",
+        "reaction_added"
+      ]
     },
     "interactivity": { "is_enabled": true },
     "org_deploy_enabled": false,


### PR DESCRIPTION
## Summary
- Added missing bot scopes: `channels:read`, `groups:history`, `groups:read`, `reactions:read`
- Added missing event subscriptions: `message.groups`, `message.mpim`, `reaction_added`
- These gaps caused new Slack app setups to lack permissions for private channels, channel listing, and emoji-based approvals

## Context
Rok reported that after going through the Slack setup wizard, the bot app was missing `im:write` and other scopes, and the bot couldn't receive DM replies. The manifest was missing several scopes and event subscriptions that the bot code relies on.

## Test plan
- [ ] Create a new Slack app using the updated manifest link from the setup wizard
- [ ] Verify the app has all required scopes (channels:read, groups:history, etc.)
- [ ] Verify the app subscribes to all required events (reaction_added, message.groups, etc.)
- [ ] Test DM replies are received by the bot
- [ ] Test emoji reactions on approval prompts work

Fixes JARVIS-360

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
