### PR TITLE
feat: replace Slack approval message with follow-up content

### DIFF
--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -552,17 +552,22 @@ export function createSlackDeliverHandler(
     // (not already an update) to a thread with a pending approval replacement,
     // convert it to an update of the approval message so the follow-up content
     // replaces the original approval prompt.
+    let isApprovalReplacement = false;
     if (threadTs && !isUpdate && !isEphemeral && !chatAction && text) {
       const replacementKey = `${chatId}:${threadTs}`;
       const pending = pendingApprovalReplacements?.get(replacementKey);
-      if (pending) {
+      if (pending && pending.expiresAt > Date.now()) {
         messageTs = pending.messageTs;
         isUpdate = true;
+        isApprovalReplacement = true;
         pendingApprovalReplacements!.delete(replacementKey);
         tlog.info(
           { chatId, threadTs, approvalMessageTs: messageTs },
           "Converting delivery to approval message replacement",
         );
+      } else if (pending) {
+        // Expired — clean up stale entry
+        pendingApprovalReplacements!.delete(replacementKey);
       }
     }
 
@@ -826,7 +831,7 @@ export function createSlackDeliverHandler(
             text,
             ts: messageTs,
           };
-          if (blocks.length > 0) {
+          if (blocks.length > 0 || isApprovalReplacement) {
             updateBody.blocks = blocks;
           }
           result = await callSlackApiWithRetries(

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -330,6 +330,10 @@ export function createSlackDeliverHandler(
   config: GatewayConfig,
   onThreadReply?: (threadTs: string) => void,
   caches?: { credentials?: CredentialCache; configFile?: ConfigFileCache },
+  pendingApprovalReplacements?: Map<
+    string,
+    { messageTs: string; expiresAt: number }
+  >,
 ) {
   return async (req: Request): Promise<Response> => {
     const traceId = req.headers.get("x-trace-id") ?? undefined;
@@ -541,8 +545,26 @@ export function createSlackDeliverHandler(
 
     // Support threading via query param
     const threadTs = new URL(req.url).searchParams.get("threadTs") ?? undefined;
-    const messageTs = body.messageTs ?? updateTs;
-    const isUpdate = typeof messageTs === "string" && messageTs.length > 0;
+    let messageTs = body.messageTs ?? updateTs;
+    let isUpdate = typeof messageTs === "string" && messageTs.length > 0;
+
+    // Check for pending approval message replacement: if this is a new message
+    // (not already an update) to a thread with a pending approval replacement,
+    // convert it to an update of the approval message so the follow-up content
+    // replaces the original approval prompt.
+    if (threadTs && !isUpdate && !isEphemeral && !chatAction && text) {
+      const replacementKey = `${chatId}:${threadTs}`;
+      const pending = pendingApprovalReplacements?.get(replacementKey);
+      if (pending) {
+        messageTs = pending.messageTs;
+        isUpdate = true;
+        pendingApprovalReplacements!.delete(replacementKey);
+        tlog.info(
+          { chatId, threadTs, approvalMessageTs: messageTs },
+          "Converting delivery to approval message replacement",
+        );
+      }
+    }
 
     // Resolve Block Kit blocks: use provided blocks, approval prompt, or auto-format text
     const blocks: Block[] =

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -241,12 +241,28 @@ async function main() {
     credentials: credentialCache,
     configFile: configFileCache,
   });
+  // Map: "channel:threadTs" -> { messageTs, expiresAt } for replacing approval
+  // messages with the bot's follow-up content after an approval button click.
+  const pendingApprovalReplacements = new Map<
+    string,
+    { messageTs: string; expiresAt: number }
+  >();
+
+  // Clean up expired entries every 60s
+  setInterval(() => {
+    const now = Date.now();
+    for (const [key, entry] of pendingApprovalReplacements) {
+      if (entry.expiresAt <= now) pendingApprovalReplacements.delete(key);
+    }
+  }, 60_000);
+
   const handleSlackDeliver = createSlackDeliverHandler(
     config,
     (threadTs) => {
       slackSocketClient?.trackThread(threadTs);
     },
     { credentials: credentialCache, configFile: configFileCache },
+    pendingApprovalReplacements,
   );
   const handleOAuthCallback = createOAuthCallbackHandler(config);
   const pairingProxy = createPairingProxyHandler(config);
@@ -1192,6 +1208,18 @@ async function main() {
             .catch(() => forward());
         } else {
           forward();
+        }
+
+        // When an approval button is clicked, store the approval message ts
+        // so the next outbound delivery to this thread replaces the approval
+        // message instead of posting a new one.
+        const callbackData = normalized.event.message.callbackData;
+        if (callbackData?.startsWith("apr:") && messageTs && threadTs) {
+          const key = `${channel}:${threadTs}`;
+          pendingApprovalReplacements.set(key, {
+            messageTs,
+            expiresAt: Date.now() + 60_000, // 60s TTL
+          });
         }
       },
     );


### PR DESCRIPTION
## Summary
- After clicking an approval button in Slack, the original approval message (with action buttons) is now replaced by the bot's next follow-up message
- Previously, buttons remained visible after clicking; now the approval prompt is replaced with the actual tool result/progress message
- Implementation uses a gateway-side in-memory map with 60s TTL to track pending replacements

## How it works
1. When a `block_actions` event with an `apr:` prefix arrives (approval button click), the gateway stores the approval message timestamp keyed by `channel:threadTs`
2. When the next outbound delivery to that thread arrives (the follow-up message), the gateway converts it from `chat.postMessage` to `chat.update`, replacing the approval prompt
3. Guards ensure only text-bearing, non-ephemeral, non-typing deliveries trigger replacement
4. The existing `chat.update` → `chat.postMessage` fallback handles errors gracefully

## Test plan
- [ ] Click an approval button in Slack → verify buttons are removed and follow-up content replaces the prompt
- [ ] Verify ephemeral messages don't accidentally consume the replacement
- [ ] Verify typing indicators don't consume the replacement
- [ ] Test that if no follow-up arrives within 60s, the entry expires and the next message posts normally
- [ ] Test that the existing "✓ Approved" edit still works as an intermediate state

Fixes JARVIS-361

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
