### PR TITLE
refactor: remove retry session machinery from ChatBottomPinCoordinator

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBottomPinCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBottomPinCoordinator.swift
@@ -27,62 +27,6 @@ enum BottomPinUserAction: Sendable {
     case jumpToLatest
 }
 
-// MARK: - Pin Session
-
-/// Represents a single bounded scroll-to-bottom retry session.
-/// Sessions coalesce duplicate requests and cap total retry attempts.
-struct BottomPinSession: Sendable {
-    /// Stable identifier for tracing this session across log entries.
-    let sessionId: UUID
-    /// The conversation this session targets.
-    let conversationId: UUID
-    /// The reason that initiated this session.
-    let reason: BottomPinRequestReason
-    /// Number of retry attempts executed so far.
-    private(set) var attemptCount: Int = 0
-    /// Wall-clock time the session was created.
-    let startTime: CFAbsoluteTime
-
-    /// Maximum retries before the session self-terminates.
-    /// Prevents an unbounded series of pin attempts from a single trigger.
-    static let maxRetries: Int = 5
-
-    /// Whether the session has exhausted its retry budget.
-    var isExhausted: Bool { attemptCount >= Self.maxRetries }
-
-    /// Records a retry attempt. Returns false if the budget is exhausted.
-    @discardableResult
-    mutating func recordAttempt() -> Bool {
-        guard !isExhausted else { return false }
-        attemptCount += 1
-        return true
-    }
-
-    /// Elapsed milliseconds since the session was created.
-    var elapsedMs: Int {
-        Int((CFAbsoluteTimeGetCurrent() - startTime) * 1000)
-    }
-
-    /// Whether this session can coalesce a new request with the given reason
-    /// and conversation. Coalescing merges duplicates into the existing session
-    /// instead of creating a new retry loop.
-    func canCoalesce(reason: BottomPinRequestReason, conversationId: UUID) -> Bool {
-        guard self.conversationId == conversationId else { return false }
-        guard !isExhausted else { return false }
-        // Requests coalesce freely when they share the same reason within the same conversation.
-        // Different reasons (e.g. resize vs expansion) start a fresh session.
-        switch (self.reason, reason) {
-        case (.initialRestore, .initialRestore),
-             (.expansion, .expansion),
-             (.messageCount, .messageCount),
-             (.resize, .resize):
-            return true
-        default:
-            return false
-        }
-    }
-}
-
 // MARK: - Cancellation Triggers
 
 /// Events that cancel the active pin session.
@@ -99,17 +43,13 @@ enum BottomPinCancellationTrigger: String, Sendable {
 
 // MARK: - Coordinator
 
-/// Centralizes the transcript follow-vs-detached state and coordinates bounded
-/// scroll-to-bottom retry sessions.
+/// Centralizes the transcript follow-vs-detached state and coordinates
+/// scroll-to-bottom pin requests.
 ///
 /// The coordinator is decision-complete: while the user is detached from the
 /// bottom, background requests from streaming, message growth, and progress
 /// expansion are suppressed. Once the user explicitly returns to the bottom,
-/// requests may schedule a bounded retry sequence again.
-///
-/// Only one pin session is active at a time. Duplicate requests for the same
-/// conversation inside the active window merge into the existing session
-/// instead of creating a fresh loop.
+/// requests proceed immediately.
 @MainActor
 final class ChatBottomPinCoordinator {
 
@@ -119,43 +59,15 @@ final class ChatBottomPinCoordinator {
     /// When false (detached), background pin requests are suppressed.
     private(set) var isFollowingBottom: Bool = true
 
-    /// The currently active pin session, if any.
-    private(set) var activeSession: BottomPinSession?
-
-    /// The in-flight async task driving the active session's retry loop.
-    private var sessionTask: Task<Void, Never>?
-
-    /// Monotonically increasing generation counter. Incremented each time a new
-    /// session task is started so that stale tasks don't clobber newer sessions.
-    private var sessionGeneration: Int = 0
-
-    /// Timestamp of the last conversation switch (set by `reset()`).
-    /// During the grace period after a switch, all pin reasons coalesce
-    /// to prevent competing sessions from initialRestore + messageCount + expansion.
-    private var lastResetTime: CFAbsoluteTime?
-
-    /// Duration after a conversation switch during which all pin reasons
-    /// coalesce into the active session regardless of reason type.
-    static let initialLoadGracePeriod: TimeInterval = 0.5
-
     /// Callback invoked when the coordinator decides a scroll-to-bottom should
     /// be executed. The caller (typically MessageListView) performs the actual
     /// `proxy.scrollTo` call. The Bool return indicates whether the pin was
-    /// successful (anchor is within viewport).
+    /// accepted (false when `isSuppressed` is true inside the callback).
     var onPinRequested: ((_ reason: BottomPinRequestReason, _ animated: Bool) -> Bool)?
 
     /// Callback invoked when the follow/detach state changes, allowing the
     /// view to update `isNearBottom` and related reactive state.
     var onFollowStateChanged: ((_ isFollowing: Bool) -> Void)?
-
-    // MARK: - Configuration
-
-    /// Delay between retry attempts in a pin session.
-    static let retryInterval: UInt64 = 50_000_000 // 50ms
-
-    /// Maximum elapsed time for a single pin session before it self-terminates,
-    /// even if retries remain. Prevents stale sessions from lingering.
-    static let sessionTimeout: TimeInterval = 0.5
 
     // MARK: - Follow/Detach State Machine
 
@@ -200,8 +112,8 @@ final class ChatBottomPinCoordinator {
     /// Requests a scroll-to-bottom pin for the given reason.
     ///
     /// When the user is detached, the request is silently suppressed (decision-
-    /// complete suppression). When following, the request either coalesces into
-    /// the active session or starts a new bounded session.
+    /// complete suppression). When following, the request calls `onPinRequested`
+    /// directly and returns immediately.
     ///
     /// - Parameters:
     ///   - reason: Why the pin is being requested.
@@ -218,144 +130,19 @@ final class ChatBottomPinCoordinator {
             return
         }
 
-        // Coalesce into active session if possible.
-        // During the initial-load grace period after a conversation switch,
-        // all pin reasons coalesce (regardless of reason type) to prevent
-        // competing sessions from initialRestore + messageCount + expansion.
-        let inGracePeriod = lastResetTime.map { CFAbsoluteTimeGetCurrent() - $0 < Self.initialLoadGracePeriod } ?? false
-        let canCoalesce = if let session = activeSession {
-            inGracePeriod
-                ? (session.conversationId == conversationId && !session.isExhausted)
-                : session.canCoalesce(reason: reason, conversationId: conversationId)
-        } else {
-            false
-        }
-        if canCoalesce {
-            let session = activeSession!
-            log.debug("[BottomPin] coalesce sid=\(session.sessionId) reason=\(reason.rawValue) attempt=\(session.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(session.elapsedMs) gracePeriod=\(inGracePeriod) isFollowingBottom=\(self.isFollowingBottom)")
-            // The existing session task continues; no new task needed.
-            // Just record that a new request arrived (the retry loop will
-            // pick it up on its next iteration).
-            return
-        }
-
-        // Cancel any stale session before starting a new one.
-        cancelActiveSession(reason: .conversationSwitch)
-
-        // Start a new bounded session.
-        let session = BottomPinSession(
-            sessionId: UUID(),
-            conversationId: conversationId,
-            reason: reason,
-            startTime: CFAbsoluteTimeGetCurrent()
-        )
-        activeSession = session
-        log.debug("[BottomPin] start sid=\(session.sessionId) reason=\(reason.rawValue) animated=\(animated) isFollowingBottom=\(self.isFollowingBottom)")
-        startSessionTask(animated: animated)
+        log.debug("[BottomPin] pin reason=\(reason.rawValue) animated=\(animated) isFollowingBottom=\(self.isFollowingBottom)")
+        onPinRequested?(reason, animated)
     }
 
-    /// Cancels the active pin session and its associated task.
+    /// No-op — retained for call-site compatibility during the inline transition
+    /// (PR 4 removes this method along with the coordinator itself).
     func cancelActiveSession(reason: BottomPinCancellationTrigger) {
-        guard let session = activeSession else { return }
-        log.debug("[BottomPin] cancel sid=\(session.sessionId) trigger=\(reason.rawValue) attempt=\(session.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(session.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
-        sessionTask?.cancel()
-        sessionTask = nil
-        activeSession = nil
+        log.debug("[BottomPin] cancelActiveSession trigger=\(reason.rawValue) (no-op)")
     }
 
-    /// Resets all state, typically called on conversation switch.
+    /// Resets follow state, typically called on conversation switch.
     func reset(newConversationId: UUID? = nil) {
-        cancelActiveSession(reason: .conversationSwitch)
         isFollowingBottom = true
-        lastResetTime = CFAbsoluteTimeGetCurrent()
         onFollowStateChanged?(true)
-    }
-
-    // MARK: - Session Task
-
-    private func startSessionTask(animated: Bool) {
-        sessionTask?.cancel()
-        sessionGeneration += 1
-        let generation = sessionGeneration
-
-        // Immediate first attempt — synchronous so callers see the result
-        // before yielding (important for tests and single-frame UI updates).
-        guard var session = activeSession else { return }
-        session.recordAttempt()
-        activeSession = session
-        log.debug("[BottomPin] immediateAttempt sid=\(session.sessionId) reason=\(session.reason.rawValue) animated=\(animated) attempt=\(session.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(session.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
-        let pinned = onPinRequested?(session.reason, animated) ?? false
-
-        if pinned {
-            log.debug("[BottomPin] success sid=\(session.sessionId) attempt=\(session.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(session.elapsedMs)")
-            completeSession(generation: generation)
-            return
-        }
-
-        // Async bounded retry loop for subsequent attempts.
-        sessionTask = Task { @MainActor [weak self] in
-            while !Task.isCancelled {
-                guard let self else { break }
-                guard self.sessionGeneration == generation else {
-                    if let s = self.activeSession {
-                        log.debug("[BottomPin] generationMismatch sid=\(s.sessionId) staleGen=\(generation) currentGen=\(self.sessionGeneration)")
-                    }
-                    break
-                }
-                guard var currentSession = self.activeSession else { break }
-                guard !currentSession.isExhausted else {
-                    log.debug("[BottomPin] exhausted sid=\(currentSession.sessionId) attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(currentSession.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
-                    break
-                }
-
-                // Check session timeout.
-                let elapsed = CFAbsoluteTimeGetCurrent() - currentSession.startTime
-                if elapsed > Self.sessionTimeout {
-                    let elapsedMs = Int(elapsed * 1000)
-                    log.debug("[BottomPin] timeout sid=\(currentSession.sessionId) attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
-                    break
-                }
-
-                do {
-                    try await Task.sleep(nanoseconds: Self.retryInterval)
-                } catch {
-                    break
-                }
-                guard !Task.isCancelled else { break }
-
-                // Re-check follow state after sleep — user may have scrolled up.
-                guard self.isFollowingBottom else {
-                    log.debug("[BottomPin] retryAborted sid=\(currentSession.sessionId) reason=detachedDuringSleep attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(currentSession.elapsedMs) isFollowingBottom=false")
-                    break
-                }
-
-                currentSession.recordAttempt()
-                self.activeSession = currentSession
-                log.debug("[BottomPin] retryAttempt sid=\(currentSession.sessionId) reason=\(currentSession.reason.rawValue) animated=\(animated) attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(currentSession.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
-                let succeeded = self.onPinRequested?(currentSession.reason, animated) ?? false
-
-                if succeeded {
-                    log.debug("[BottomPin] success sid=\(currentSession.sessionId) attempt=\(currentSession.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(currentSession.elapsedMs)")
-                    self.completeSession(generation: generation)
-                    return
-                }
-            }
-
-            // Clean up if we fell through without completing.
-            if let self, let s = self.activeSession, self.sessionGeneration == generation {
-                log.debug("[BottomPin] sessionEnd sid=\(s.sessionId) attempt=\(s.attemptCount)/\(BottomPinSession.maxRetries) elapsedMs=\(s.elapsedMs) isFollowingBottom=\(self.isFollowingBottom)")
-            }
-            self?.completeSession(generation: generation)
-        }
-    }
-
-    private func completeSession(generation: Int) {
-        guard sessionGeneration == generation else { return }
-        sessionTask = nil
-        activeSession = nil
-    }
-
-    deinit {
-        sessionTask?.cancel()
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator+PinAndScroll.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator+PinAndScroll.swift
@@ -248,14 +248,15 @@ extension MessageListScrollCoordinator {
             self.suppressionTimeoutTasks[ScrollSuppression.resize.rawValue]?.cancel()
             self.suppressionTimeoutTasks[ScrollSuppression.resize.rawValue] = nil
             defer {
-                if !Task.isCancelled {
-                    self.removeSuppression(.resize)
-                    onComplete()
-                }
+                if !Task.isCancelled { onComplete() }
             }
             try? await Task.sleep(nanoseconds: 100_000_000)
-            guard !Task.isCancelled else { return }
-
+            guard !Task.isCancelled else {
+                self.removeSuppression(.resize)
+                return
+            }
+            // Remove suppression BEFORE the pin request so it isn't rejected.
+            self.removeSuppression(.resize)
             if isNearBottom && anchorMessageId == nil && !self.isAtBottom {
                 self.requestBottomPin(reason: .resize, conversationId: conversationId)
             }

--- a/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatBottomPinCoordinatorTests.swift
@@ -39,7 +39,6 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
 
     func testInitialStateIsFollowingBottom() {
         XCTAssertTrue(coordinator.isFollowingBottom)
-        XCTAssertNil(coordinator.activeSession)
     }
 
     // MARK: - Detach on Upward Scroll
@@ -49,18 +48,6 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
 
         XCTAssertFalse(coordinator.isFollowingBottom)
         XCTAssertEqual(followStateChanges, [false])
-    }
-
-    func testScrollUpCancelsActiveSession() {
-        let convId = UUID()
-        pinShouldSucceed = false
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-        XCTAssertNotNil(coordinator.activeSession)
-
-        coordinator.handleUserAction(.scrollUp)
-
-        XCTAssertFalse(coordinator.isFollowingBottom)
-        XCTAssertNil(coordinator.activeSession)
     }
 
     func testRepeatedScrollUpDoesNotDuplicateStateChange() {
@@ -108,7 +95,6 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
         coordinator.requestPin(reason: .resize, conversationId: convId)
 
         XCTAssertEqual(pinRequestCount, 0)
-        XCTAssertNil(coordinator.activeSession)
     }
 
     func testPinRequestSuppressedForMessageCountWhileDetached() {
@@ -141,600 +127,57 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
         XCTAssertEqual(pinRequestCount, 1)
     }
 
-    // MARK: - Coalescing Duplicate Requests
+    // MARK: - Immediate Pin Execution
 
-    func testDuplicateExpansionRequestsCoalesce() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.requestPin(reason: .expansion, conversationId: convId)
-        let firstSessionStartTime = coordinator.activeSession?.startTime
-
-        // Second expansion request should coalesce.
-        coordinator.requestPin(reason: .expansion, conversationId: convId)
-
-        // Should still be the same session (same start time).
-        XCTAssertEqual(coordinator.activeSession?.startTime, firstSessionStartTime)
-        // Only one pin call from the initial session start.
-        XCTAssertEqual(pinRequestCount, 1)
-    }
-
-    func testDuplicateMessageCountRequestsCoalesce() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-        let firstStartTime = coordinator.activeSession?.startTime
-
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-
-        XCTAssertEqual(coordinator.activeSession?.startTime, firstStartTime)
-        XCTAssertEqual(pinRequestCount, 1)
-    }
-
-    func testDifferentReasonsDoNotCoalesce() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.requestPin(reason: .expansion, conversationId: convId)
-        let firstStartTime = coordinator.activeSession?.startTime
-
-        coordinator.requestPin(reason: .resize, conversationId: convId)
-
-        // Should be a new session with a new start time.
-        XCTAssertNotEqual(coordinator.activeSession?.startTime, firstStartTime)
-    }
-
-    func testDifferentConversationsDoNotCoalesce() {
-        let conv1 = UUID()
-        let conv2 = UUID()
-        pinShouldSucceed = false
-
-        coordinator.requestPin(reason: .expansion, conversationId: conv1)
-        let firstConvSession = coordinator.activeSession
-
-        coordinator.requestPin(reason: .expansion, conversationId: conv2)
-
-        // New session for the different conversation.
-        XCTAssertNotEqual(coordinator.activeSession?.conversationId, firstConvSession?.conversationId)
-        XCTAssertEqual(coordinator.activeSession?.conversationId, conv2)
-    }
-
-    // MARK: - Bounded Retry Sessions
-
-    func testSessionCapsRetries() {
-        var session = BottomPinSession(
-            sessionId: UUID(),
-            conversationId: UUID(),
-            reason: .expansion,
-            startTime: CFAbsoluteTimeGetCurrent()
-        )
-
-        for _ in 0..<BottomPinSession.maxRetries {
-            XCTAssertFalse(session.isExhausted)
-            let recorded = session.recordAttempt()
-            XCTAssertTrue(recorded)
-        }
-
-        XCTAssertTrue(session.isExhausted)
-        let overBudget = session.recordAttempt()
-        XCTAssertFalse(overBudget)
-        XCTAssertEqual(session.attemptCount, BottomPinSession.maxRetries)
-    }
-
-    func testExhaustedSessionDoesNotCoalesce() {
-        var session = BottomPinSession(
-            sessionId: UUID(),
-            conversationId: UUID(),
-            reason: .expansion,
-            startTime: CFAbsoluteTimeGetCurrent()
-        )
-
-        for _ in 0..<BottomPinSession.maxRetries {
-            session.recordAttempt()
-        }
-
-        XCTAssertFalse(session.canCoalesce(reason: .expansion, conversationId: session.conversationId))
-    }
-
-    func testSuccessfulPinCompletesSession() {
+    func testSuccessfulPinExecutesImmediately() {
         let convId = UUID()
         pinShouldSucceed = true
 
         coordinator.requestPin(reason: .initialRestore, conversationId: convId)
 
-        // Successful pin on first attempt should clear the session.
         XCTAssertEqual(pinRequestCount, 1)
-        XCTAssertNil(coordinator.activeSession)
     }
 
-    // MARK: - Cancellation Triggers
-
-    func testDeepLinkAnchorCancelsSession() {
+    func testRequestPinCallsOnPinRequestedExactlyOnce() {
         let convId = UUID()
-        pinShouldSucceed = false
 
         coordinator.requestPin(reason: .messageCount, conversationId: convId)
-        XCTAssertNotNil(coordinator.activeSession)
+        XCTAssertEqual(pinRequestCount, 1)
 
-        coordinator.cancelActiveSession(reason: .deepLinkAnchorHandoff)
+        coordinator.requestPin(reason: .expansion, conversationId: convId)
+        XCTAssertEqual(pinRequestCount, 2)
 
-        XCTAssertNil(coordinator.activeSession)
+        coordinator.requestPin(reason: .resize, conversationId: convId)
+        XCTAssertEqual(pinRequestCount, 3)
     }
 
-    func testPaginationRestoreCancelsSession() {
+    // MARK: - User Action Handling
+
+    func testDetachCancelsAndSuppressesFutureRequests() {
         let convId = UUID()
-        pinShouldSucceed = false
 
+        coordinator.detach(trigger: .userScrollUp)
+
+        XCTAssertFalse(coordinator.isFollowingBottom)
+
+        // Subsequent requests should be suppressed.
         coordinator.requestPin(reason: .messageCount, conversationId: convId)
-        XCTAssertNotNil(coordinator.activeSession)
-
-        coordinator.cancelActiveSession(reason: .paginationRestore)
-
-        XCTAssertNil(coordinator.activeSession)
-    }
-
-    func testConversationSwitchCancelsSession() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-        XCTAssertNotNil(coordinator.activeSession)
-
-        coordinator.cancelActiveSession(reason: .conversationSwitch)
-
-        XCTAssertNil(coordinator.activeSession)
+        XCTAssertEqual(pinRequestCount, 0,
+                       "Pin requests should be suppressed while detached")
     }
 
     // MARK: - Reset
 
     func testResetClearsAllStateAndReattaches() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
         coordinator.handleUserAction(.scrollUp)
-        coordinator.requestPin(reason: .expansion, conversationId: convId)
         XCTAssertFalse(coordinator.isFollowingBottom)
 
         let newConvId = UUID()
         coordinator.reset(newConversationId: newConvId)
 
         XCTAssertTrue(coordinator.isFollowingBottom)
-        XCTAssertNil(coordinator.activeSession)
     }
 
-    // MARK: - Pin Session Struct
-
-    func testSessionCoalesceRequiresSameConversation() {
-        let convA = UUID()
-        let convB = UUID()
-        let session = BottomPinSession(
-            sessionId: UUID(),
-            conversationId: convA,
-            reason: .expansion,
-            startTime: CFAbsoluteTimeGetCurrent()
-        )
-
-        XCTAssertTrue(session.canCoalesce(reason: .expansion, conversationId: convA))
-        XCTAssertFalse(session.canCoalesce(reason: .expansion, conversationId: convB))
-    }
-
-    func testSessionCoalesceRequiresSameReason() {
-        let convId = UUID()
-        let session = BottomPinSession(
-            sessionId: UUID(),
-            conversationId: convId,
-            reason: .messageCount,
-            startTime: CFAbsoluteTimeGetCurrent()
-        )
-
-        XCTAssertTrue(session.canCoalesce(reason: .messageCount, conversationId: convId))
-        XCTAssertFalse(session.canCoalesce(reason: .expansion, conversationId: convId))
-        XCTAssertFalse(session.canCoalesce(reason: .resize, conversationId: convId))
-        XCTAssertFalse(session.canCoalesce(reason: .initialRestore, conversationId: convId))
-    }
-
-    // MARK: - Async Retry Behavior
-
-    func testRetryLoopStopsOnSuccess() async throws {
-        let convId = UUID()
-        var callCount = 0
-        pinShouldSucceed = false
-
-        coordinator.onPinRequested = { [weak self] reason, animated in
-            callCount += 1
-            self?.pinRequestCount = callCount
-            // Succeed on the third attempt.
-            if callCount >= 3 {
-                return true
-            }
-            return false
-        }
-
-        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
-
-        // Poll until the session completes (robust against slow CI scheduling).
-        let deadline = CFAbsoluteTimeGetCurrent() + 1.0
-        while coordinator.activeSession != nil, CFAbsoluteTimeGetCurrent() < deadline {
-            try await Task.sleep(nanoseconds: 10_000_000) // 10ms
-        }
-
-        // Should have stopped after success (3 attempts), not continued to maxRetries.
-        XCTAssertGreaterThanOrEqual(callCount, 3)
-        XCTAssertLessThanOrEqual(callCount, BottomPinSession.maxRetries)
-        XCTAssertNil(coordinator.activeSession)
-    }
-
-    func testRetryLoopAbortsOnDetach() async throws {
-        let convId = UUID()
-        var callCount = 0
-        pinShouldSucceed = false
-
-        coordinator.onPinRequested = { reason, animated in
-            callCount += 1
-            return false
-        }
-
-        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
-
-        // Let one retry fire.
-        try await Task.sleep(nanoseconds: 80_000_000)
-
-        // User scrolls up mid-session.
-        coordinator.handleUserAction(.scrollUp)
-
-        let countAfterDetach = callCount
-        try await Task.sleep(nanoseconds: 200_000_000)
-
-        // No more attempts after detach.
-        XCTAssertEqual(callCount, countAfterDetach)
-        XCTAssertNil(coordinator.activeSession)
-    }
-
-    // MARK: - Session ID Stability
-
-    func testSessionHasStableSessionId() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-
-        let sessionId = coordinator.activeSession?.sessionId
-        XCTAssertNotNil(sessionId, "Active session should have a stable sessionId")
-    }
-
-    func testCoalescingPreservesSessionId() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.requestPin(reason: .expansion, conversationId: convId)
-        let originalSessionId = coordinator.activeSession?.sessionId
-
-        // Second request with same reason coalesces.
-        coordinator.requestPin(reason: .expansion, conversationId: convId)
-
-        XCTAssertEqual(coordinator.activeSession?.sessionId, originalSessionId,
-                       "Coalesced request should preserve the original sessionId")
-    }
-
-    func testNewSessionGetsDistinctSessionId() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.requestPin(reason: .expansion, conversationId: convId)
-        let firstSessionId = coordinator.activeSession?.sessionId
-
-        // Different reason triggers a new session.
-        coordinator.requestPin(reason: .resize, conversationId: convId)
-        let secondSessionId = coordinator.activeSession?.sessionId
-
-        XCTAssertNotNil(firstSessionId)
-        XCTAssertNotNil(secondSessionId)
-        XCTAssertNotEqual(firstSessionId, secondSessionId,
-                          "A new session should get a distinct sessionId")
-    }
-
-    // MARK: - Timeout
-
-    func testSessionTimesOutAfterDeadline() async throws {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
-        XCTAssertNotNil(coordinator.activeSession)
-
-        // Wait longer than sessionTimeout (0.5s) + retry interval headroom.
-        try await Task.sleep(nanoseconds: 700_000_000)
-
-        // Session should have self-terminated via timeout.
-        XCTAssertNil(coordinator.activeSession,
-                     "Session should be nil after timeout expires")
-    }
-
-    // MARK: - Cancel on Detach
-
-    func testDetachCancelsActiveSessionAndSuppressesFutureRequests() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-        XCTAssertNotNil(coordinator.activeSession)
-
-        coordinator.detach(trigger: .userScrollUp)
-
-        XCTAssertNil(coordinator.activeSession,
-                     "Detach should cancel the active session")
-        XCTAssertFalse(coordinator.isFollowingBottom)
-
-        // Subsequent requests should be suppressed.
-        let countBefore = pinRequestCount
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-        XCTAssertEqual(pinRequestCount, countBefore,
-                       "Pin requests should be suppressed while detached")
-    }
-
-    func testCancelOnDetachDuringRetryLoop() async throws {
-        let convId = UUID()
-        var callCount = 0
-        pinShouldSucceed = false
-
-        coordinator.onPinRequested = { reason, animated in
-            callCount += 1
-            return false
-        }
-
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-        XCTAssertNotNil(coordinator.activeSession)
-
-        // Let a retry or two fire.
-        try await Task.sleep(nanoseconds: 120_000_000)
-        let countBeforeDetach = callCount
-
-        // Detach mid-retry loop.
-        coordinator.detach(trigger: .userScrollUp)
-
-        // Wait for the task to observe cancellation.
-        try await Task.sleep(nanoseconds: 200_000_000)
-
-        XCTAssertNil(coordinator.activeSession)
-        // No additional pin attempts should have been made after detach.
-        XCTAssertEqual(callCount, countBeforeDetach,
-                       "No retries should fire after detach")
-    }
-
-    // MARK: - Stale Task Cleanup (Generation Mismatch)
-
-    func testStaleTaskDoesNotClobberNewerSession() async throws {
-        let conv1 = UUID()
-        let conv2 = UUID()
-        pinShouldSucceed = false
-
-        // Start a session that will enter the retry loop.
-        coordinator.requestPin(reason: .messageCount, conversationId: conv1)
-        let firstSessionId = coordinator.activeSession?.sessionId
-        XCTAssertNotNil(firstSessionId)
-
-        // Immediately start a new session for a different conversation,
-        // which bumps the generation counter and invalidates the first task.
-        coordinator.requestPin(reason: .expansion, conversationId: conv2)
-        let secondSessionId = coordinator.activeSession?.sessionId
-        XCTAssertNotNil(secondSessionId)
-        XCTAssertNotEqual(firstSessionId, secondSessionId)
-
-        // Let async tasks run to completion.
-        try await Task.sleep(nanoseconds: 300_000_000)
-
-        // The stale first task should not have cleared the second session.
-        // The second session either completed normally or timed out on its own.
-        // Either way, no leftover state from the first session should remain.
-        if let remaining = coordinator.activeSession {
-            XCTAssertEqual(remaining.sessionId, secondSessionId,
-                           "If a session remains, it must be the newer one")
-        }
-    }
-
-    func testRapidRequestsOnlyKeepLatestSession() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        // Fire multiple requests with different reasons in rapid succession.
-        coordinator.requestPin(reason: .expansion, conversationId: convId)
-        coordinator.requestPin(reason: .resize, conversationId: convId)
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-
-        // Only the last session should be active.
-        XCTAssertEqual(coordinator.activeSession?.reason, .messageCount,
-                       "Only the most recent session should remain active")
-    }
-
-    // MARK: - Completion Path
-
-    func testSuccessfulRetryCompletesSession() async throws {
-        let convId = UUID()
-        var callCount = 0
-
-        coordinator.onPinRequested = { reason, animated in
-            callCount += 1
-            // Succeed on the second attempt (first retry).
-            return callCount >= 2
-        }
-
-        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
-
-        // First attempt fails synchronously; retry loop should succeed.
-        try await Task.sleep(nanoseconds: 200_000_000)
-
-        XCTAssertGreaterThanOrEqual(callCount, 2)
-        XCTAssertNil(coordinator.activeSession,
-                     "Session should be cleared after successful retry")
-        XCTAssertTrue(coordinator.isFollowingBottom,
-                      "Coordinator should still be following bottom after success")
-    }
-
-    func testSessionElapsedMsIsNonNegative() {
-        let session = BottomPinSession(
-            sessionId: UUID(),
-            conversationId: UUID(),
-            reason: .messageCount,
-            startTime: CFAbsoluteTimeGetCurrent()
-        )
-
-        XCTAssertGreaterThanOrEqual(session.elapsedMs, 0,
-                                    "elapsedMs should be non-negative for a freshly created session")
-    }
-
-    // MARK: - Geometry Unavailable Regression
-
-    /// Regression: transient missing geometry must not trigger endless retry churn.
-    ///
-    /// Before the fix, `geometryUnavailable` was collapsed into `needsRepin = true`,
-    /// so the coordinator's `onPinRequested` callback would always return `false`
-    /// when geometry was missing, causing the session to exhaust its retry budget
-    /// and then potentially trigger new sessions from other call sites that also
-    /// treated missing geometry as "needs repin". With the fix, call sites only
-    /// request new pins for `.needsRepin` (genuine drift), and the coordinator
-    /// callback returns `outcome == .anchored` (only true for finite, in-bounds
-    /// geometry). This test verifies the session terminates within its retry budget
-    /// when geometry is persistently unavailable, and that follow state is preserved.
-    func testTransientMissingGeometryDoesNotCauseEndlessRetries() async throws {
-        let convId = UUID()
-        var callCount = 0
-
-        // Simulate geometry unavailable: onPinRequested always returns false
-        // (the verify() call would return .geometryUnavailable, so
-        // outcome == .anchored is false).
-        coordinator.onPinRequested = { reason, animated in
-            callCount += 1
-            return false // geometry unavailable — not anchored
-        }
-
-        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
-
-        // Wait long enough for the session to exhaust or timeout.
-        // Use a generous timeout because @MainActor Task scheduling on CI
-        // runners can be much slower than the 50ms retry interval would suggest.
-        try await Task.sleep(nanoseconds: 2_000_000_000)
-
-        // The session must have terminated on its own (bounded retries or timeout).
-        XCTAssertNil(coordinator.activeSession,
-                     "Session should terminate after bounded retries, not run indefinitely")
-
-        // Total attempts must not exceed the session budget.
-        XCTAssertLessThanOrEqual(callCount, BottomPinSession.maxRetries,
-                                  "Retry count should be bounded by maxRetries")
-
-        // The coordinator should still be logically following bottom —
-        // transient geometry issues must not detach the follow state.
-        XCTAssertTrue(coordinator.isFollowingBottom,
-                      "Transient geometry unavailability should not detach follow state")
-
-        // Issuing the same pin reason again must NOT coalesce with the
-        // now-terminated session — it starts a fresh one, proving the old
-        // session was fully cleaned up.
-        let countBefore = callCount
-        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
-        XCTAssertGreaterThan(callCount, countBefore,
-                             "A new pin request after session cleanup should fire immediately")
-    }
-
-    /// Regression: when geometry transitions from unavailable to available
-    /// mid-session, the session should complete successfully without churning
-    /// through all retries.
-    func testGeometryBecomingAvailableMidSessionCompletesPin() async throws {
-        let convId = UUID()
-        var callCount = 0
-
-        // First few attempts simulate geometry unavailable (returns false),
-        // then geometry becomes available (returns true).
-        coordinator.onPinRequested = { reason, animated in
-            callCount += 1
-            return callCount >= 3 // anchored after attempt 3
-        }
-
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-
-        // Wait for retries to process. Use a generous timeout because
-        // @MainActor Task scheduling on CI runners can be much slower than
-        // the 50ms retry interval would suggest.
-        try await Task.sleep(nanoseconds: 1_000_000_000)
-
-        // Session should have completed successfully once geometry appeared.
-        XCTAssertNil(coordinator.activeSession,
-                     "Session should complete once geometry becomes available")
-        XCTAssertGreaterThanOrEqual(callCount, 3,
-                                    "Should have retried until geometry was available")
-        XCTAssertLessThanOrEqual(callCount, BottomPinSession.maxRetries,
-                                  "Should not have retried beyond the success point")
-        XCTAssertTrue(coordinator.isFollowingBottom,
-                      "Should still be following bottom after successful pin")
-    }
-
-    // MARK: - Initial-Load Grace Period
-
-    /// Within 500ms of `reset()`, `.initialRestore` and `.messageCount` coalesce
-    /// into one session even though they have different reasons.
-    func testGracePeriodCoalescesInitialRestoreAndMessageCount() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.reset(newConversationId: convId)
-        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
-        let firstSessionId = coordinator.activeSession?.sessionId
-        let firstStartTime = coordinator.activeSession?.startTime
-        XCTAssertNotNil(firstSessionId)
-
-        // During grace period, a different reason should coalesce.
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-
-        XCTAssertEqual(coordinator.activeSession?.sessionId, firstSessionId,
-                       "messageCount should coalesce with initialRestore during grace period")
-        XCTAssertEqual(coordinator.activeSession?.startTime, firstStartTime,
-                       "Coalesced request should preserve the original session start time")
-        // Only one pin call from the initial session start.
-        XCTAssertEqual(pinRequestCount, 1)
-    }
-
-    /// Within 500ms of `reset()`, `.expansion` also coalesces with the active session.
-    func testGracePeriodCoalescesExpansionWithActiveSession() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.reset(newConversationId: convId)
-        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
-        let firstSessionId = coordinator.activeSession?.sessionId
-        XCTAssertNotNil(firstSessionId)
-
-        // Expansion should also coalesce during grace period.
-        coordinator.requestPin(reason: .expansion, conversationId: convId)
-
-        XCTAssertEqual(coordinator.activeSession?.sessionId, firstSessionId,
-                       "expansion should coalesce with initialRestore during grace period")
-        XCTAssertEqual(pinRequestCount, 1)
-    }
-
-    /// After the grace period expires, normal reason-based coalescing rules apply
-    /// (different reasons do NOT coalesce).
-    func testAfterGracePeriodNormalCoalescingRulesApply() async throws {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.reset(newConversationId: convId)
-        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
-        let firstSessionId = coordinator.activeSession?.sessionId
-        XCTAssertNotNil(firstSessionId)
-
-        // Wait for grace period to expire.
-        try await Task.sleep(nanoseconds: 600_000_000) // 600ms > 500ms grace period
-
-        // After grace period, a different reason should NOT coalesce.
-        coordinator.requestPin(reason: .messageCount, conversationId: convId)
-
-        XCTAssertNotEqual(coordinator.activeSession?.sessionId, firstSessionId,
-                          "After grace period, different reasons should start a new session")
-    }
-
-    /// `reset()` without subsequent pin requests should have no side effects
-    /// beyond resetting follow state.
     func testResetWithoutSubsequentRequestsHasNoSideEffects() {
         coordinator.handleUserAction(.scrollUp)
         XCTAssertFalse(coordinator.isFollowingBottom)
@@ -742,63 +185,8 @@ final class ChatBottomPinCoordinatorTests: XCTestCase {
         coordinator.reset()
 
         XCTAssertTrue(coordinator.isFollowingBottom)
-        XCTAssertNil(coordinator.activeSession)
         // No pin calls should have been triggered.
         XCTAssertEqual(pinRequestCount, 0)
-    }
-
-    /// Grace period coalescing still requires the same conversation ID.
-    func testGracePeriodDoesNotCoalesceDifferentConversations() {
-        let conv1 = UUID()
-        let conv2 = UUID()
-        pinShouldSucceed = false
-
-        coordinator.reset(newConversationId: conv1)
-        coordinator.requestPin(reason: .initialRestore, conversationId: conv1)
-        let firstSessionId = coordinator.activeSession?.sessionId
-
-        // Different conversation should NOT coalesce even during grace period.
-        coordinator.requestPin(reason: .messageCount, conversationId: conv2)
-
-        XCTAssertNotEqual(coordinator.activeSession?.sessionId, firstSessionId,
-                          "Grace period should not coalesce requests for different conversations")
-        XCTAssertEqual(coordinator.activeSession?.conversationId, conv2)
-    }
-
-    /// Grace period coalescing does not apply to exhausted sessions.
-    func testGracePeriodDoesNotCoalesceExhaustedSession() {
-        let convId = UUID()
-        pinShouldSucceed = false
-
-        coordinator.reset(newConversationId: convId)
-        coordinator.requestPin(reason: .initialRestore, conversationId: convId)
-
-        // Exhaust the session by recording max attempts.
-        // We need to manipulate the session directly since it's a struct.
-        if var session = coordinator.activeSession {
-            for _ in 0..<BottomPinSession.maxRetries {
-                session.recordAttempt()
-            }
-            // The coordinator won't see our local mutations since BottomPinSession is a struct.
-            // Instead, start a fresh session and exhaust it through rapid requests.
-        }
-
-        // Exhaust the session by sending maxRetries worth of different-conversation requests
-        // that force new sessions. Instead, let's test through the coordinator by
-        // verifying that canCoalesce returns false for exhausted sessions.
-        var session = BottomPinSession(
-            sessionId: UUID(),
-            conversationId: convId,
-            reason: .initialRestore,
-            startTime: CFAbsoluteTimeGetCurrent()
-        )
-        for _ in 0..<BottomPinSession.maxRetries {
-            session.recordAttempt()
-        }
-        XCTAssertTrue(session.isExhausted)
-        // An exhausted session should not coalesce, even during grace period.
-        // This is enforced by the `!session.isExhausted` guard in the grace-period path.
-        XCTAssertFalse(session.canCoalesce(reason: .messageCount, conversationId: convId))
     }
 
 }

--- a/clients/macos/vellum-assistantTests/MessageListScrollCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollCoordinatorTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class MessageListScrollCoordinatorTests: XCTestCase {
+    private var coordinator: MessageListScrollCoordinator!
+    private var scrollToCalls: [(id: AnyHashable, anchor: UnitPoint?)] = []
+
+    override func setUp() {
+        super.setUp()
+        coordinator = MessageListScrollCoordinator()
+        scrollToCalls = []
+
+        coordinator.scrollTo = { [weak self] id, anchor in
+            self?.scrollToCalls.append((id: id as! AnyHashable, anchor: anchor))
+        }
+    }
+
+    override func tearDown() {
+        coordinator.cancelAllTasks()
+        coordinator = nil
+        super.tearDown()
+    }
+
+    // MARK: - makeResizeTask: Suppression Cleared Before Pin
+
+    /// Regression test: `makeResizeTask` must clear suppression BEFORE requesting
+    /// a bottom pin. If suppression is still active when the pin fires, the
+    /// `onPinRequested` callback returns false (suppressed) and the scroll-to-
+    /// bottom never happens.
+    func testMakeResizeTaskPinsAfterSuppressionCleared() async throws {
+        let convId = UUID()
+
+        // Wire the bottom pin coordinator so pin requests flow through to scrollTo.
+        coordinator.configureBottomPinCoordinator(
+            scrollViewportHeight: 600,
+            conversationId: convId,
+            isNearBottom: .constant(true)
+        )
+
+        // Preconditions: near bottom but not at bottom, no anchor.
+        coordinator.isAtBottom = false
+        coordinator.bottomPinCoordinator.reattach()
+
+        var wasSuppressedDuringScroll: Bool?
+        let originalScrollTo = coordinator.scrollTo
+        coordinator.scrollTo = { [weak self] id, anchor in
+            // Record whether suppression was active at the moment scrollTo fires.
+            wasSuppressedDuringScroll = self?.coordinator.isSuppressed ?? true
+            originalScrollTo?(id, anchor)
+        }
+
+        // Re-configure after swapping scrollTo so the pin coordinator callback
+        // uses the new closure.
+        coordinator.configureBottomPinCoordinator(
+            scrollViewportHeight: 600,
+            conversationId: convId,
+            isNearBottom: .constant(true)
+        )
+
+        let completionExpectation = expectation(description: "resize task completed")
+        let task = coordinator.makeResizeTask(
+            conversationId: convId,
+            isNearBottom: true,
+            anchorMessageId: nil,
+            onComplete: { completionExpectation.fulfill() }
+        )
+
+        await fulfillment(of: [completionExpectation], timeout: 2.0)
+        _ = task // keep task alive
+
+        // The pin should have fired (scrollTo was called).
+        XCTAssertFalse(scrollToCalls.isEmpty,
+                       "scrollTo should have been called — the bottom pin should fire after resize")
+
+        // At the moment scrollTo was called, suppression must have been cleared.
+        XCTAssertEqual(wasSuppressedDuringScroll, false,
+                       "Suppression must be cleared before the pin request, not after")
+    }
+}

--- a/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
@@ -135,36 +135,27 @@ final class MessageListScrollPerformanceTests: XCTestCase {
         }
     }
 
-    // MARK: - Test 3: ChatBottomPinCoordinator Session Lifecycle
+    // MARK: - Test 3: ChatBottomPinCoordinator Pin Request
 
-    /// Measures a complete ChatBottomPinCoordinator session lifecycle:
-    /// create coordinator, start a session, record 5 retry attempts, then
-    /// let the session exhaust. This benchmarks the synchronous hot path
-    /// (no async retry loop) to keep the test deterministic.
+    /// Measures the synchronous hot path of ChatBottomPinCoordinator:
+    /// create coordinator, request a pin, reset — repeated 100 times.
+    /// With sessions removed, each requestPin is a single-attempt call.
     @MainActor
-    func testChatBottomPinCoordinatorSessionLifecycle() {
+    func testChatBottomPinCoordinatorPinRequest() {
         measure(metrics: [XCTClockMetric()]) {
             let coordinator = ChatBottomPinCoordinator()
             var pinCallCount = 0
 
             coordinator.onPinRequested = { _, _ in
                 pinCallCount += 1
-                return false // Simulate geometry unavailable
+                return true
             }
 
             let convId = UUID()
 
-            // Run 100 session lifecycles to get a stable measurement.
+            // Run 100 pin request cycles to get a stable measurement.
             for _ in 0..<100 {
-                pinCallCount = 0
-
-                // Start a session (triggers immediate first attempt).
                 coordinator.requestPin(reason: .initialRestore, conversationId: convId)
-
-                // The session is active with 1 attempt recorded.
-                // Manually exhaust it by sending requests that coalesce,
-                // then cancel and reset for the next iteration.
-                coordinator.cancelActiveSession(reason: .conversationSwitch)
                 coordinator.reset(newConversationId: convId)
             }
 


### PR DESCRIPTION
## Summary
- Strip BottomPinSession struct, retry loop, session coalescing, and generation counter from ChatBottomPinCoordinator
- Restructure makeResizeTask to clear suppression before pin request (fixes deferred-repin ordering)
- Create MessageListScrollCoordinatorTests.swift with resize regression test

Part of plan: scroll-coordinator-simplify.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
