### PR TITLE
Forward skill draft/create state from SkillsStore through SkillsManager

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -18,6 +18,13 @@ final class SkillsManager {
     var isLoadingSkillFiles = false
     var skillFilesError: String?
 
+    // Draft / create state
+    var isDrafting = false
+    var draftResult: SkillsStore.SkillDraftResult?
+    var draftError: String?
+    var isCreating = false
+    var createError: String?
+
     @ObservationIgnored private var cancellables = Set<AnyCancellable>()
 
     // Kept for source compatibility with existing macOS views.
@@ -38,6 +45,11 @@ final class SkillsManager {
         skillsStore.$selectedSkillFiles.sink { [weak self] in self?.selectedSkillFiles = $0 }.store(in: &cancellables)
         skillsStore.$isLoadingSkillFiles.sink { [weak self] in self?.isLoadingSkillFiles = $0 }.store(in: &cancellables)
         skillsStore.$skillFilesError.sink { [weak self] in self?.skillFilesError = $0 }.store(in: &cancellables)
+        skillsStore.$isDrafting.sink { [weak self] in self?.isDrafting = $0 }.store(in: &cancellables)
+        skillsStore.$draftResult.sink { [weak self] in self?.draftResult = $0 }.store(in: &cancellables)
+        skillsStore.$draftError.sink { [weak self] in self?.draftError = $0 }.store(in: &cancellables)
+        skillsStore.$isCreating.sink { [weak self] in self?.isCreating = $0 }.store(in: &cancellables)
+        skillsStore.$createError.sink { [weak self] in self?.createError = $0 }.store(in: &cancellables)
     }
 
     // MARK: - Delegated Operations
@@ -60,5 +72,17 @@ final class SkillsManager {
 
     func clearSkillDetail() {
         skillsStore.clearSkillDetail()
+    }
+
+    func draftSkill(sourceText: String) {
+        skillsStore.draftSkill(sourceText: sourceText)
+    }
+
+    func createSkillFromDraft(skillId: String, name: String, description: String, emoji: String?, bodyMarkdown: String) {
+        skillsStore.createSkillFromDraft(skillId: skillId, name: name, description: description, emoji: emoji, bodyMarkdown: bodyMarkdown)
+    }
+
+    func resetDraftState() {
+        skillsStore.resetDraftState()
     }
 }


### PR DESCRIPTION
## Summary
- Forward isDrafting, draftResult, draftError, isCreating, createError properties from SkillsStore through SkillsManager via Combine sinks
- Add delegated methods: draftSkill, createSkillFromDraft, resetDraftState
- Enables the upcoming SkillCreateSheet to interact with skill drafting/creation through SkillsManager

Part of plan: skills-create-custom.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
