### PR TITLE
Add "Create Skill" button to Skills tab filter bar and wire up sheet

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -15,6 +15,7 @@ struct AgentPanelContent: View {
     @State private var skillToDelete: SkillInfo?
     @State private var selectedCategory: SkillCategory?
     @State private var globalSkillSearchQuery = ""
+    @State private var showCreateSheet = false
 
     init(onInvokeSkill: ((SkillInfo) -> Void)? = nil, onSkillsChanged: (() -> Void)? = nil, connectionManager: GatewayConnectionManager) {
         self.onInvokeSkill = onInvokeSkill
@@ -69,6 +70,12 @@ struct AgentPanelContent: View {
                 selectedInstalledSkillId = nil
             }
         }
+        .sheet(isPresented: $showCreateSheet) {
+            SkillCreateSheet(
+                skillsManager: skillsManager,
+                onDismiss: { showCreateSheet = false }
+            )
+        }
         .sheet(item: $skillToDelete) { skill in
             SkillDeleteConfirmView(
                 skillName: skill.name,
@@ -89,6 +96,13 @@ struct AgentPanelContent: View {
     private var filterBar: some View {
         HStack(spacing: VSpacing.sm) {
             VSearchBar(placeholder: "Search Skills", text: $globalSkillSearchQuery)
+            VButton(
+                label: "Create",
+                leftIcon: VIcon.plus.rawValue,
+                style: .primary,
+                size: .compact,
+                action: { showCreateSheet = true }
+            )
         }
     }
 
@@ -190,7 +204,7 @@ struct AgentPanelContent: View {
             VEmptyState(
                 title: selectedCategory == nil ? "No Skills Installed" : "No \(selectedCategory!.displayName) Skills",
                 subtitle: selectedCategory == nil
-                    ? "Ask your assistant in chat to search for and install new skills."
+                    ? "Create a custom skill or ask your assistant to search for one."
                     : "Try selecting a different category or clearing the filter.",
                 icon: VIcon.zap.rawValue
             )


### PR DESCRIPTION
## Summary
- Add a Create button with plus icon to the Skills tab filter bar next to search
- Wire button to open SkillCreateSheet modal via .sheet modifier
- Update empty state text to mention the new creation path

Part of plan: skills-create-custom.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
