### PR TITLE
Skills tab: add clear path to create a new custom skill (LUM-426)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -15,6 +15,7 @@ struct AgentPanelContent: View {
     @State private var skillToDelete: SkillInfo?
     @State private var selectedCategory: SkillCategory?
     @State private var globalSkillSearchQuery = ""
+    @State private var showCreateSheet = false
 
     init(onInvokeSkill: ((SkillInfo) -> Void)? = nil, onSkillsChanged: (() -> Void)? = nil, connectionManager: GatewayConnectionManager) {
         self.onInvokeSkill = onInvokeSkill
@@ -69,6 +70,12 @@ struct AgentPanelContent: View {
                 selectedInstalledSkillId = nil
             }
         }
+        .sheet(isPresented: $showCreateSheet) {
+            SkillCreateSheet(
+                skillsManager: skillsManager,
+                onDismiss: { showCreateSheet = false }
+            )
+        }
         .sheet(item: $skillToDelete) { skill in
             SkillDeleteConfirmView(
                 skillName: skill.name,
@@ -89,6 +96,13 @@ struct AgentPanelContent: View {
     private var filterBar: some View {
         HStack(spacing: VSpacing.sm) {
             VSearchBar(placeholder: "Search Skills", text: $globalSkillSearchQuery)
+            VButton(
+                label: "Create",
+                leftIcon: VIcon.plus.rawValue,
+                style: .primary,
+                size: .compact,
+                action: { showCreateSheet = true }
+            )
         }
     }
 
@@ -190,7 +204,7 @@ struct AgentPanelContent: View {
             VEmptyState(
                 title: selectedCategory == nil ? "No Skills Installed" : "No \(selectedCategory!.displayName) Skills",
                 subtitle: selectedCategory == nil
-                    ? "Ask your assistant in chat to search for and install new skills."
+                    ? "Create a custom skill or ask your assistant to search for one."
                     : "Try selecting a different category or clearing the filter.",
                 icon: VIcon.zap.rawValue
             )

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -70,7 +70,7 @@ struct AgentPanelContent: View {
                 selectedInstalledSkillId = nil
             }
         }
-        .sheet(isPresented: $showCreateSheet) {
+        .sheet(isPresented: $showCreateSheet, onDismiss: { skillsManager.resetDraftState() }) {
             SkillCreateSheet(
                 skillsManager: skillsManager,
                 onDismiss: { showCreateSheet = false }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillCreateSheet.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillCreateSheet.swift
@@ -1,0 +1,284 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct SkillCreateSheet: View {
+    let skillsManager: SkillsManager
+    let onDismiss: () -> Void
+
+    @State private var name: String = ""
+    @State private var skillId: String = ""
+    @State private var description: String = ""
+    @State private var emoji: String = ""
+    @State private var bodyMarkdown: String = ""
+    @State private var sourceText: String = ""
+    @State private var showAdvanced: Bool = false
+    @State private var hasDrafted: Bool = false
+    @State private var userEditedSkillId: Bool = false
+    @State private var lastAppliedDraftName: String?
+
+    var body: some View {
+        VModal(title: "New Skill") {
+            VStack(alignment: .leading, spacing: VSpacing.lg) {
+                if showAdvanced || hasDrafted {
+                    formView
+                } else {
+                    draftView
+                }
+
+                // Draft error
+                if let draftError = skillsManager.draftError {
+                    errorRow(draftError)
+                }
+
+                // Create error
+                if let createError = skillsManager.createError {
+                    errorRow(createError)
+                }
+
+                // Draft warnings
+                if let warnings = skillsManager.draftResult?.warnings, !warnings.isEmpty {
+                    ForEach(warnings, id: \.self) { warning in
+                        HStack(spacing: VSpacing.xs) {
+                            VIconView(.triangleAlert, size: 11)
+                                .foregroundStyle(VColor.systemMidStrong)
+                            Text(warning)
+                                .font(VFont.labelDefault)
+                                .foregroundStyle(VColor.systemMidStrong)
+                        }
+                    }
+                }
+            }
+        } footer: {
+            HStack {
+                Spacer()
+                VButton(label: "Cancel", style: .outlined) {
+                    dismiss()
+                }
+                VButton(
+                    label: skillsManager.isCreating ? "Creating..." : "Create",
+                    leftIcon: skillsManager.isCreating ? nil : VIcon.plus.rawValue,
+                    style: .primary,
+                    isDisabled: !isFormValid || skillsManager.isCreating
+                ) {
+                    create()
+                }
+            }
+        }
+        .frame(width: 520, height: 560)
+        .onChange(of: name) { _, newValue in
+            if !userEditedSkillId {
+                skillId = deriveSkillId(from: newValue)
+            }
+        }
+        .onChange(of: skillsManager.isDrafting) { wasDrafting, isDrafting in
+            if wasDrafting && !isDrafting, let result = skillsManager.draftResult, result.name != lastAppliedDraftName {
+                name = result.name
+                skillId = result.skillId
+                description = result.description
+                emoji = result.emoji ?? ""
+                bodyMarkdown = result.bodyMarkdown
+                userEditedSkillId = true // Don't overwrite drafted skillId
+                lastAppliedDraftName = result.name
+                hasDrafted = true
+            }
+        }
+        .onChange(of: skillsManager.isCreating) { wasCreating, isCreating in
+            if wasCreating && !isCreating && skillsManager.createError == nil {
+                dismiss()
+            }
+        }
+    }
+
+    // MARK: - Draft Mode View
+
+    @ViewBuilder
+    private var draftView: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("Source Text")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+            TextEditor(text: $sourceText)
+                .font(VFont.bodyMediumLighter)
+                .foregroundStyle(VColor.contentDefault)
+                .scrollContentBackground(.hidden)
+                .padding(VSpacing.sm)
+                .background(VColor.surfaceActive)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(VColor.borderBase, lineWidth: 1)
+                )
+                .frame(minHeight: 200)
+                .overlay(alignment: .topLeading) {
+                    if sourceText.isEmpty {
+                        Text("Paste a skill prompt, instructions, or description...")
+                            .font(VFont.bodyMediumLighter)
+                            .foregroundStyle(VColor.contentTertiary)
+                            .padding(VSpacing.sm)
+                            .padding(.top, 1)
+                            .allowsHitTesting(false)
+                    }
+                }
+        }
+
+        HStack {
+            VButton(
+                label: skillsManager.isDrafting ? "Generating..." : "Generate",
+                leftIcon: skillsManager.isDrafting ? nil : VIcon.sparkles.rawValue,
+                style: .primary,
+                isDisabled: sourceText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || skillsManager.isDrafting
+            ) {
+                skillsManager.draftSkill(sourceText: sourceText.trimmingCharacters(in: .whitespacesAndNewlines))
+            }
+
+            if skillsManager.isDrafting {
+                VLoadingIndicator(size: 14)
+            }
+
+            Spacer()
+
+            Button {
+                showAdvanced = true
+            } label: {
+                Text("Write manually")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
+            .buttonStyle(.plain)
+            .pointerCursor()
+        }
+    }
+
+    // MARK: - Manual Form View
+
+    @ViewBuilder
+    private var formView: some View {
+        // Name
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("Name")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+            VTextField(placeholder: "Skill name", text: $name)
+        }
+
+        // Skill ID
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("Skill ID")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+            VTextField(placeholder: "my-skill-id", text: Binding(
+                get: { skillId },
+                set: { newValue in
+                    skillId = newValue
+                    userEditedSkillId = true
+                }
+            ))
+        }
+
+        // Description
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("Description")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+            VTextField(placeholder: "What does this skill do?", text: $description)
+        }
+
+        // Emoji
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("Emoji (optional)")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+            VTextField(placeholder: "🛠️", text: Binding(
+                get: { emoji },
+                set: { newValue in
+                    // Limit to 1 grapheme cluster
+                    if newValue.isEmpty {
+                        emoji = ""
+                    } else {
+                        emoji = String(newValue.prefix(1))
+                    }
+                }
+            ))
+        }
+
+        // Body / Instructions
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("Instructions")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+            TextEditor(text: $bodyMarkdown)
+                .font(VFont.bodyMediumLighter)
+                .foregroundStyle(VColor.contentDefault)
+                .scrollContentBackground(.hidden)
+                .padding(VSpacing.sm)
+                .background(VColor.surfaceActive)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(VColor.borderBase, lineWidth: 1)
+                )
+                .frame(minHeight: 100)
+                .overlay(alignment: .topLeading) {
+                    if bodyMarkdown.isEmpty {
+                        Text("Skill instructions in Markdown...")
+                            .font(VFont.bodyMediumLighter)
+                            .foregroundStyle(VColor.contentTertiary)
+                            .padding(VSpacing.sm)
+                            .padding(.top, 1)
+                            .allowsHitTesting(false)
+                    }
+                }
+        }
+    }
+
+    // MARK: - Error Row
+
+    @ViewBuilder
+    private func errorRow(_ message: String) -> some View {
+        HStack(spacing: VSpacing.xs) {
+            VIconView(.circleAlert, size: 11)
+                .foregroundStyle(VColor.systemNegativeStrong)
+            Text(message)
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.systemNegativeStrong)
+        }
+    }
+
+    // MARK: - Validation
+
+    private var isFormValid: Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !skillId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !bodyMarkdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    // MARK: - Actions
+
+    private func create() {
+        skillsManager.createSkillFromDraft(
+            skillId: skillId.trimmingCharacters(in: .whitespacesAndNewlines),
+            name: name.trimmingCharacters(in: .whitespacesAndNewlines),
+            description: description.trimmingCharacters(in: .whitespacesAndNewlines),
+            emoji: emoji.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : emoji.trimmingCharacters(in: .whitespacesAndNewlines),
+            bodyMarkdown: bodyMarkdown.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+
+    private func dismiss() {
+        skillsManager.resetDraftState()
+        onDismiss()
+    }
+
+    // MARK: - Helpers
+
+    private func deriveSkillId(from name: String) -> String {
+        let lowercased = name.lowercased()
+        // Replace non-alphanumeric characters with hyphens
+        let replaced = lowercased.map { $0.isLetter || $0.isNumber ? String($0) : "-" }.joined()
+        // Collapse consecutive hyphens
+        let collapsed = replaced.replacingOccurrences(of: "-{2,}", with: "-", options: .regularExpression)
+        // Trim leading/trailing hyphens
+        return collapsed.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -18,6 +18,13 @@ final class SkillsManager {
     var isLoadingSkillFiles = false
     var skillFilesError: String?
 
+    // Draft / create state
+    var isDrafting = false
+    var draftResult: SkillsStore.SkillDraftResult?
+    var draftError: String?
+    var isCreating = false
+    var createError: String?
+
     @ObservationIgnored private var cancellables = Set<AnyCancellable>()
 
     // Kept for source compatibility with existing macOS views.
@@ -38,6 +45,11 @@ final class SkillsManager {
         skillsStore.$selectedSkillFiles.sink { [weak self] in self?.selectedSkillFiles = $0 }.store(in: &cancellables)
         skillsStore.$isLoadingSkillFiles.sink { [weak self] in self?.isLoadingSkillFiles = $0 }.store(in: &cancellables)
         skillsStore.$skillFilesError.sink { [weak self] in self?.skillFilesError = $0 }.store(in: &cancellables)
+        skillsStore.$isDrafting.sink { [weak self] in self?.isDrafting = $0 }.store(in: &cancellables)
+        skillsStore.$draftResult.sink { [weak self] in self?.draftResult = $0 }.store(in: &cancellables)
+        skillsStore.$draftError.sink { [weak self] in self?.draftError = $0 }.store(in: &cancellables)
+        skillsStore.$isCreating.sink { [weak self] in self?.isCreating = $0 }.store(in: &cancellables)
+        skillsStore.$createError.sink { [weak self] in self?.createError = $0 }.store(in: &cancellables)
     }
 
     // MARK: - Delegated Operations
@@ -60,5 +72,17 @@ final class SkillsManager {
 
     func clearSkillDetail() {
         skillsStore.clearSkillDetail()
+    }
+
+    func draftSkill(sourceText: String) {
+        skillsStore.draftSkill(sourceText: sourceText)
+    }
+
+    func createSkillFromDraft(skillId: String, name: String, description: String, emoji: String?, bodyMarkdown: String) {
+        skillsStore.createSkillFromDraft(skillId: skillId, name: name, description: description, emoji: emoji, bodyMarkdown: bodyMarkdown)
+    }
+
+    func resetDraftState() {
+        skillsStore.resetDraftState()
     }
 }


### PR DESCRIPTION
## Summary
Add a "Create Skill" button and modal sheet to the macOS Skills tab so users can create custom skills directly from the UI, without needing to ask the assistant in chat. Supports both AI-assisted drafting (paste source text) and manual entry.

## PRs merged into feature branch
- #21595: Forward skill draft/create state from SkillsStore through SkillsManager
- #21596: Add SkillCreateSheet modal for creating custom skills on macOS
- #21597: Add "Create Skill" button to Skills tab filter bar and wire up sheet

Closes LUM-426
Part of plan: skills-create-custom.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
