### PR TITLE
fix: use streaming for release notes generation to avoid SDK timeout

### DIFF
--- a/scripts/generate-release-notes.ts
+++ b/scripts/generate-release-notes.ts
@@ -109,7 +109,7 @@ async function main(): Promise<void> {
 
   const commitList = commits.map((c, i) => `${i + 1}. ${c}`).join("\n");
 
-  const response = await client.messages.create({
+  const stream = client.messages.stream({
     model: "claude-sonnet-4-6",
     max_tokens: 64000,
     messages: [
@@ -138,6 +138,8 @@ ${commitList}`,
       },
     ],
   });
+
+  const response = await stream.finalMessage();
 
   const content = response.content[0];
   if (content.type !== "text") {


### PR DESCRIPTION
## Problem

The v0.5.11 release page has no highlights/release notes — just basic build info:

![image](https://github.com/user-attachments/assets/placeholder)

## Root Cause

The `generate-release-notes.ts` script uses `client.messages.create()` (blocking). With **195 commits** between v0.5.10 and v0.5.11, the Anthropic SDK threw:

```
Streaming is strongly recommended for operations that may take longer than 10 minutes.
```

The script caught the error and fell back to basic build-info-only notes.

## Fix

Switch from `client.messages.create()` to `client.messages.stream()` + `await stream.finalMessage()`. This keeps the HTTP connection alive with incremental chunks, bypassing the SDK's timeout guard.

## Testing

- 3-line change, isolated to the release notes generation script
- No behavioral change — same prompt, same output format, just streamed instead of blocking
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
