### PR TITLE
Refresh live conversations after provider credential updates

### DIFF
--- a/assistant/src/__tests__/secret-routes-managed-proxy.test.ts
+++ b/assistant/src/__tests__/secret-routes-managed-proxy.test.ts
@@ -6,6 +6,7 @@ let lastGeminiConstructorOpts: Record<string, unknown> | null = null;
 let secureKeyStore: Record<string, string | undefined> = {};
 const metadataUpserts: Array<{ service: string; field: string }> = [];
 const metadataDeletes: Array<{ service: string; field: string }> = [];
+let providerRefreshCalls = 0;
 
 const PLATFORM_BASE_URL = "https://platform.example.com";
 const ASSISTANT_API_KEY_PATH = credentialKey("vellum", "assistant_api_key");
@@ -137,6 +138,29 @@ function makeDeleteCredentialRequest(name: string): Request {
   });
 }
 
+function makeAddApiKeyRequest(name: string, value: string): Request {
+  return new Request("http://localhost/v1/secrets", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      type: "api_key",
+      name,
+      value,
+    }),
+  });
+}
+
+function makeDeleteApiKeyRequest(name: string): Request {
+  return new Request("http://localhost/v1/secrets", {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      type: "api_key",
+      name,
+    }),
+  });
+}
+
 describe("secret routes managed proxy registry sync", () => {
   beforeEach(async () => {
     secureKeyStore = {};
@@ -144,6 +168,7 @@ describe("secret routes managed proxy registry sync", () => {
     metadataDeletes.length = 0;
     lastGeminiConstructorOpts = null;
     platformBaseUrlOverride = undefined;
+    providerRefreshCalls = 0;
     await initializeProviders(mockConfig);
   });
 
@@ -169,6 +194,33 @@ describe("secret routes managed proxy registry sync", () => {
     expect(lastGeminiConstructorOpts).toBeDefined();
   });
 
+  test("provider API key writes notify live-conversation refresh listeners", async () => {
+    const res = await handleAddSecret(
+      makeAddApiKeyRequest("fireworks", "fw-key"),
+      {
+        onProviderCredentialsChanged: () => {
+          providerRefreshCalls++;
+        },
+      },
+    );
+
+    expect(res.status).toBe(201);
+    expect(secureKeyStore.fireworks).toBe("fw-key");
+    expect(providerRefreshCalls).toBe(1);
+
+    const deleteRes = await handleDeleteSecret(
+      makeDeleteApiKeyRequest("fireworks"),
+      {
+        onProviderCredentialsChanged: () => {
+          providerRefreshCalls++;
+        },
+      },
+    );
+
+    expect(deleteRes.status).toBe(200);
+    expect(providerRefreshCalls).toBe(2);
+  });
+
   test("deleting vellum:assistant_api_key clears managed fallback providers immediately", async () => {
     secureKeyStore[ASSISTANT_API_KEY_PATH] = "ast-managed-key";
     await initializeProviders(mockConfig);
@@ -188,6 +240,32 @@ describe("secret routes managed proxy registry sync", () => {
       { service: "vellum", field: "assistant_api_key" },
     ]);
     expect(listProviders()).toEqual([]);
+  });
+
+  test("managed proxy credential writes notify live-conversation refresh listeners", async () => {
+    const res = await handleAddSecret(
+      makeAddCredentialRequest("vellum:assistant_api_key", "ast-managed-key"),
+      {
+        onProviderCredentialsChanged: () => {
+          providerRefreshCalls++;
+        },
+      },
+    );
+
+    expect(res.status).toBe(201);
+    expect(providerRefreshCalls).toBe(1);
+
+    const deleteRes = await handleDeleteSecret(
+      makeDeleteCredentialRequest("vellum:assistant_api_key"),
+      {
+        onProviderCredentialsChanged: () => {
+          providerRefreshCalls++;
+        },
+      },
+    );
+
+    expect(deleteRes.status).toBe(200);
+    expect(providerRefreshCalls).toBe(2);
   });
 
   test("storing vellum:platform_base_url sets override and triggers initializeProviders", async () => {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -895,6 +895,8 @@ export async function runDaemon(): Promise<void> {
         getHandlerContext: () => server.getHandlerContext(),
       }),
       getCesClient: () => server.getCesClient(),
+      onProviderCredentialsChanged: () =>
+        server.refreshConversationsForProviderChange(),
       getHeartbeatService: () => server.getHeartbeatService(),
     });
 

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -702,6 +702,14 @@ export class DaemonServer {
     return changed;
   }
 
+  /**
+   * Provider instances are captured when conversations are created, so a key
+   * change must evict or mark them stale before the next turn.
+   */
+  refreshConversationsForProviderChange(): void {
+    this.evictConversationsForReload();
+  }
+
   private async getOrCreateConversation(
     conversationId: string,
     options?: ConversationCreateOptions,

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -251,6 +251,7 @@ export class RuntimeHttpServer {
   private getWatchDeps?: RuntimeHttpServerOptions["getWatchDeps"];
   private getRecordingDeps?: RuntimeHttpServerOptions["getRecordingDeps"];
   private getCesClient?: RuntimeHttpServerOptions["getCesClient"];
+  private onProviderCredentialsChanged?: RuntimeHttpServerOptions["onProviderCredentialsChanged"];
   private getHeartbeatService?: RuntimeHttpServerOptions["getHeartbeatService"];
   private router: HttpRouter;
 
@@ -274,6 +275,7 @@ export class RuntimeHttpServer {
     this.getWatchDeps = options.getWatchDeps;
     this.getRecordingDeps = options.getRecordingDeps;
     this.getCesClient = options.getCesClient;
+    this.onProviderCredentialsChanged = options.onProviderCredentialsChanged;
     this.getHeartbeatService = options.getHeartbeatService;
     this.router = new HttpRouter(this.buildRouteTable());
   }
@@ -944,6 +946,7 @@ export class RuntimeHttpServer {
       ...appManagementRouteDefinitions(),
       ...secretRouteDefinitions({
         getCesClient: this.getCesClient,
+        onProviderCredentialsChanged: this.onProviderCredentialsChanged,
       }),
       ...identityRouteDefinitions(),
       ...upgradeBroadcastRouteDefinitions(),

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -228,8 +228,15 @@ export interface RuntimeHttpServerOptions {
   getRecordingDeps?: () => import("./routes/recording-routes.js").RecordingDeps;
   /** Accessor for the CES client, used to push API key updates to CES after hatch. */
   getCesClient?: () => CesClient | undefined;
+  /**
+   * Called after provider-affecting credentials reload so live conversations
+   * can be recreated with fresh provider instances.
+   */
+  onProviderCredentialsChanged?: () => void | Promise<void>;
   /** Accessor for the heartbeat service (for run-now and config routes). */
-  getHeartbeatService?: () => import("../heartbeat/heartbeat-service.js").HeartbeatService | undefined;
+  getHeartbeatService?: () =>
+    | import("../heartbeat/heartbeat-service.js").HeartbeatService
+    | undefined;
 }
 
 export interface RuntimeAttachmentMetadata {

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -106,7 +106,7 @@ async function queueApiKeyPropagation(
 
 export async function handleAddSecret(
   req: Request,
-  getCesClient?: () => CesClient | undefined,
+  deps?: SecretRouteDeps,
 ): Promise<Response> {
   let body: { type?: string; name?: string; value?: string };
   try {
@@ -192,9 +192,7 @@ export async function handleAddSecret(
           500,
         );
       }
-      clearEmbeddingBackendCache();
-      invalidateConfigCache();
-      await initializeProviders(getConfig());
+      await refreshProvidersAfterSecretChange(deps);
       log.info({ provider: name }, "API key updated via HTTP");
       return Response.json({ success: true, type, name }, { status: 201 });
     }
@@ -275,12 +273,12 @@ export async function handleAddSecret(
         }
       }
       if (isManagedProxyCredential(service, field)) {
-        await initializeProviders(getConfig());
+        await refreshProvidersAfterSecretChange(deps);
         if (service === "vellum" && field === "assistant_api_key") {
           // Push the API key to CES so managed credential materialization
           // works even though the handshake ran before the key was available.
           const generation = ++apiKeyGeneration;
-          const cesClient = getCesClient?.();
+          const cesClient = deps?.getCesClient?.();
           if (cesClient) {
             if (cesClient.isReady()) {
               try {
@@ -394,7 +392,10 @@ export async function handleReadSecret(req: Request): Promise<Response> {
   }
 }
 
-export async function handleDeleteSecret(req: Request): Promise<Response> {
+export async function handleDeleteSecret(
+  req: Request,
+  deps?: SecretRouteDeps,
+): Promise<Response> {
   let body: { type?: string; name?: string };
   try {
     body = (await req.json()) as { type?: string; name?: string };
@@ -438,9 +439,7 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
           500,
         );
       }
-      clearEmbeddingBackendCache();
-      invalidateConfigCache();
-      await initializeProviders(getConfig());
+      await refreshProvidersAfterSecretChange(deps);
       log.info({ provider: name }, "API key deleted via HTTP");
       return Response.json({ success: true, type, name });
     }
@@ -488,7 +487,7 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
         setSentryUserId(undefined);
       }
       if (isManagedProxyCredential(service, field)) {
-        await initializeProviders(getConfig());
+        await refreshProvidersAfterSecretChange(deps);
       }
       log.info({ service, field }, "Credential deleted via HTTP");
       return Response.json({ success: true, type, name });
@@ -548,6 +547,30 @@ export async function handleListSecrets(): Promise<Response> {
 export interface SecretRouteDeps {
   /** Accessor for the CES client, used to push API key updates after hatch. */
   getCesClient?: () => CesClient | undefined;
+  /**
+   * Called after provider-affecting credentials change so live conversations
+   * can be reloaded with fresh provider instances.
+   */
+  onProviderCredentialsChanged?: () => void | Promise<void>;
+}
+
+async function refreshProvidersAfterSecretChange(
+  deps?: SecretRouteDeps,
+): Promise<void> {
+  clearEmbeddingBackendCache();
+  invalidateConfigCache();
+  await initializeProviders(getConfig());
+
+  if (!deps?.onProviderCredentialsChanged) return;
+
+  try {
+    await deps.onProviderCredentialsChanged();
+  } catch (err) {
+    log.warn(
+      { error: err instanceof Error ? err.message : String(err) },
+      "Failed to refresh live conversations after provider credential change",
+    );
+  }
 }
 
 export function secretRouteDefinitions(
@@ -557,7 +580,7 @@ export function secretRouteDefinitions(
     {
       endpoint: "secrets",
       method: "POST",
-      handler: async ({ req }) => handleAddSecret(req, deps?.getCesClient),
+      handler: async ({ req }) => handleAddSecret(req, deps),
       summary: "Add a secret",
       description:
         "Store a new secret (API key, OAuth token, etc.) in the credential vault.",
@@ -576,7 +599,7 @@ export function secretRouteDefinitions(
     {
       endpoint: "secrets",
       method: "DELETE",
-      handler: async ({ req }) => handleDeleteSecret(req),
+      handler: async ({ req }) => handleDeleteSecret(req, deps),
       summary: "Delete a secret",
       description: "Remove a secret from the credential vault by name.",
       tags: ["secrets"],


### PR DESCRIPTION
## Summary
- reload live conversations after provider-affecting secret updates so existing conversations do not keep using stale provider clients
- thread a provider-credentials-changed callback through the runtime HTTP secret routes into daemon lifecycle reload handling
- add regression coverage for API key and managed proxy credential updates notifying the live-conversation refresh path

## Original prompt
--safe After entering in a cluade api key I am getting the following error message in the logs unless I make a new conversation at which point it starts working. this feels like its caching something somewhere can you fix it

ProviderError: Anthropic API error (401): invalid x-api-key
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
