### PR TITLE
M3: Migrate ConversationActionsDrawer to VMenu (#21606)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
@@ -59,35 +59,29 @@ struct ConversationActionsDrawer: View {
     var onOpenInNewWindow: (() -> Void)? = nil
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        VMenu(width: 200) {
             if presentation.canCopy {
-                SidebarPrimaryRow(icon: VIcon.copy.rawValue, label: "Copy full conversation", action: onCopy)
+                VMenuItem(icon: VIcon.copy.rawValue, label: "Copy full conversation", action: onCopy)
             }
 
             if presentation.showsForkConversationAction {
-                SidebarPrimaryRow(icon: VIcon.gitBranch.rawValue, label: "Fork conversation", action: onForkConversation)
+                VMenuItem(icon: VIcon.gitBranch.rawValue, label: "Fork conversation", action: onForkConversation)
             }
 
             if let onOpenInNewWindow {
-                SidebarPrimaryRow(icon: VIcon.externalLink.rawValue, label: "Open in new window", action: onOpenInNewWindow)
+                VMenuItem(icon: VIcon.externalLink.rawValue, label: "Open in new window", action: onOpenInNewWindow)
             }
 
-            SidebarPrimaryRow(
+            VMenuItem(
                 icon: presentation.isPinned ? VIcon.pinOff.rawValue : VIcon.pin.rawValue,
                 label: presentation.isPinned ? "Unpin" : "Pin",
                 action: presentation.isPinned ? onUnpin : onPin
             )
 
-            SidebarPrimaryRow(icon: VIcon.pencil.rawValue, label: "Rename", action: onRename)
+            VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename", action: onRename)
 
-            SidebarPrimaryRow(icon: VIcon.archive.rawValue, label: "Archive", action: onArchive)
+            VMenuItem(icon: VIcon.archive.rawValue, label: "Archive", action: onArchive)
         }
-        .padding(VSpacing.sm)
-        .background(VColor.surfaceLift)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-        .shadow(color: VColor.auxBlack.opacity(0.1), radius: 1.5, x: 0, y: 1)
-        .shadow(color: VColor.auxBlack.opacity(0.1), radius: 6, x: 0, y: 4)
-        .frame(width: 200)
         .transition(.opacity.combined(with: .scale(scale: 0.95, anchor: .top)))
     }
 }


### PR DESCRIPTION
## Summary
- Replaces manual drawer chrome (VStack, padding, background, clipShape, shadows) in `ConversationActionsDrawer` with the new `VMenu` container component
- Replaces all `SidebarPrimaryRow` calls with `VMenuItem` calls
- Preserves all actions, conditional logic, and transition animation

## Test plan
- [ ] Open a conversation and tap the title chevron to open the actions drawer
- [ ] Verify all menu items appear: Copy, Fork, Open in new window, Pin/Unpin, Rename, Archive
- [ ] Verify conditional items (Copy, Fork, Open in new window) show/hide correctly
- [ ] Verify the drawer visually matches the previous version (same background, shadow, corner radius)
- [ ] Verify the transition animation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
