### PR TITLE
refactor: simplify restoreScrollToBottom from 3-stage retry to 2-stage with initial scrollToEdge

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator+PinAndScroll.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator+PinAndScroll.swift
@@ -138,12 +138,13 @@ extension MessageListScrollCoordinator {
         }
     }
 
-    /// Staged scroll-to-bottom that retries after increasing delays to handle
-    /// cases where SwiftUI hasn't committed the new content's layout yet.
+    /// Delayed scroll-to-bottom fallback that catches cases where the preceding
+    /// `scrollToEdge(.bottom)` fires before SwiftUI has fully laid out the content.
     ///
-    /// The initial `scrollToEdge(.bottom)` in `conversationSwitched` handles
-    /// most cases. This method catches slow LazyVStack materialization where
-    /// the edge scroll fires before content is fully laid out.
+    /// All callers now perform `scrollToEdge(.bottom)` before invoking this method
+    /// (both `conversationSwitched` and `onAppear`). This single 100ms delayed
+    /// fallback uses the ID-based `requestBottomPin` as a belt-and-suspenders check
+    /// for cases where the edge scroll fires before content layout is complete.
     func restoreScrollToBottom(
         conversationId: UUID?,
         anchorMessageId: Binding<UUID?>
@@ -151,35 +152,16 @@ extension MessageListScrollCoordinator {
         scrollRestoreTask?.cancel()
 
         scrollRestoreTask = Task { @MainActor [weak self] in
-            guard let self, !Task.isCancelled else { return }
-            os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=0")
-            scrollCoordinatorLog.debug("Scroll restore: stage 0 (immediate)")
-
-            // Stage 1: ~3 frames — handles most conversation switches.
-            try? await Task.sleep(nanoseconds: 50_000_000)
-            guard !Task.isCancelled else { return }
-            os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=1")
-            if anchorMessageId.wrappedValue == nil {
-                requestBottomPin(reason: .initialRestore, conversationId: conversationId)
-            }
-            scrollCoordinatorLog.debug("Scroll restore: stage 1 (50ms)")
-
-            // Stage 2: ~12 frames — catches slower layout/materialization.
-            try? await Task.sleep(nanoseconds: 150_000_000)
-            guard !Task.isCancelled else { return }
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            guard !Task.isCancelled, let self else { return }
             if anchorMessageId.wrappedValue == nil
-                && !hasReceivedScrollEvent
+                && !self.hasReceivedScrollEvent
                 && !self.isAtBottom
             {
-                os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=2 action=retry")
-                requestBottomPin(reason: .initialRestore, conversationId: conversationId)
-                scrollCoordinatorLog.debug("Scroll restore: stage 2 (200ms) — retrying")
-            } else {
-                os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=2 action=skipped")
-                scrollCoordinatorLog.debug("Scroll restore: stage 2 skipped (anchor=\(String(describing: anchorMessageId.wrappedValue)) scrollEvent=\(self.hasReceivedScrollEvent) atBottom=\(self.isAtBottom))")
+                os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=fallback")
+                self.requestBottomPin(reason: .initialRestore, conversationId: conversationId)
             }
-
-            if !Task.isCancelled { scrollRestoreTask = nil }
+            self.scrollRestoreTask = nil
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -965,6 +965,7 @@ struct MessageListView: View {
                         }
                     }
                 } else {
+                    scrollCoordinator.scrollToEdge?(.bottom)
                     restoreScrollToBottom()
                 }
             }

--- a/clients/macos/vellum-assistantTests/MessageListScrollCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollCoordinatorTests.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import XCTest
 @testable import VellumAssistantLib
 
@@ -76,5 +77,85 @@ final class MessageListScrollCoordinatorTests: XCTestCase {
         // At the moment scrollTo was called, suppression must have been cleared.
         XCTAssertEqual(wasSuppressedDuringScroll, false,
                        "Suppression must be cleared before the pin request, not after")
+    }
+
+    // MARK: - restoreScrollToBottom: Delayed Fallback
+
+    /// Regression test: when the coordinator is not at bottom, has no anchor,
+    /// and has not received a scroll event, the delayed restore fallback should
+    /// fire `requestBottomPin` after 100ms.
+    func testRestoreScrollToBottomFallbackFiresWhenNotAtBottom() async throws {
+        let convId = UUID()
+
+        // Wire the bottom pin coordinator so pin requests flow through to scrollTo.
+        coordinator.configureBottomPinCoordinator(
+            scrollViewportHeight: 600,
+            conversationId: convId,
+            isNearBottom: .constant(true)
+        )
+        coordinator.bottomPinCoordinator.reattach()
+
+        // Preconditions: not at bottom, no anchor, no scroll events.
+        coordinator.isAtBottom = false
+        coordinator.hasReceivedScrollEvent = false
+
+        var anchorMessageId: UUID? = nil
+        let anchorBinding = Binding<UUID?>(
+            get: { anchorMessageId },
+            set: { anchorMessageId = $0 }
+        )
+
+        coordinator.restoreScrollToBottom(
+            conversationId: convId,
+            anchorMessageId: anchorBinding
+        )
+
+        // Wait for the 100ms delay plus a small margin.
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        // The fallback should have fired requestBottomPin, resulting in a scrollTo call.
+        XCTAssertFalse(scrollToCalls.isEmpty,
+                       "restoreScrollToBottom fallback should fire requestBottomPin when not at bottom")
+        XCTAssertEqual(scrollToCalls.first?.id, "scroll-bottom-anchor" as AnyHashable,
+                       "fallback should scroll to the bottom anchor")
+    }
+
+    // MARK: - restoreScrollToBottom: Deep-Link Anchor Prevents Fallback
+
+    /// Regression test: when `anchorMessageId` is non-nil (deep-link in progress),
+    /// `restoreScrollToBottom` must NOT fire `requestBottomPin` — the anchor guard
+    /// prevents fighting between the deep-link scroll and the restore fallback.
+    func testRestoreScrollToBottomRespectsDeepLinkAnchor() async throws {
+        let convId = UUID()
+
+        // Wire the bottom pin coordinator so pin requests flow through to scrollTo.
+        coordinator.configureBottomPinCoordinator(
+            scrollViewportHeight: 600,
+            conversationId: convId,
+            isNearBottom: .constant(true)
+        )
+        coordinator.bottomPinCoordinator.reattach()
+
+        // Preconditions: not at bottom, no scroll events, but anchor IS set.
+        coordinator.isAtBottom = false
+        coordinator.hasReceivedScrollEvent = false
+
+        var anchorMessageId: UUID? = UUID() // non-nil deep-link anchor
+        let anchorBinding = Binding<UUID?>(
+            get: { anchorMessageId },
+            set: { anchorMessageId = $0 }
+        )
+
+        coordinator.restoreScrollToBottom(
+            conversationId: convId,
+            anchorMessageId: anchorBinding
+        )
+
+        // Wait for the 100ms delay plus a small margin.
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        // The fallback should NOT have fired because anchorMessageId is non-nil.
+        XCTAssertTrue(scrollToCalls.isEmpty,
+                      "restoreScrollToBottom must not fire requestBottomPin when a deep-link anchor is set")
     }
 }


### PR DESCRIPTION
## Summary
- Add scrollToEdge(.bottom) at onAppear site, matching conversationSwitched pattern
- Simplify restoreScrollToBottom from 3-stage retry to single 100ms delayed fallback
- Add regression tests for delayed restore fallback and deep-link anchor handoff

Part of plan: scroll-coordinator-simplify.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
