### PR TITLE
M4: Migrate DrawerMenuView to VMenu (#21607)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -24,64 +24,56 @@ struct DrawerMenuView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xs) {
-            DrawerThemeToggle()
-                .padding(.horizontal, VSpacing.sm)
-
-            VColor.surfaceBase.frame(height: 1)
-                .padding(.vertical, VSpacing.xs)
-
-            if let balance = effectiveBalance {
-                HStack {
-                    Text("$\(balance) remaining")
-                        .font(VFont.bodyMediumDefault)
-                        .foregroundStyle(
-                            isZeroBalance ? VColor.systemNegativeStrong :
-                            isLowBalance ? VColor.systemMidStrong :
-                            VColor.contentDefault
-                        )
-                    Spacer()
-                    if isBillingVisible {
-                        Button("Add funds") { onOpenBilling() }
-                            .font(VFont.labelDefault)
-                            .foregroundStyle(VColor.primaryBase)
-                            .buttonStyle(.plain)
-                    }
-                }
-                .padding(.horizontal, VSpacing.sm)
-
-                VColor.surfaceBase.frame(height: 1)
-                    .padding(.vertical, VSpacing.xs)
+        VMenu {
+            VMenuCustomRow {
+                DrawerThemeToggle()
             }
 
-            VStack(alignment: .leading, spacing: 0) {
-                SidebarPrimaryRow(icon: VIcon.settings.rawValue, label: String(localized: "Settings"), action: onSettings)
+            VMenuDivider()
 
+            if let balance = effectiveBalance {
+                VMenuCustomRow {
+                    HStack {
+                        Text("$\(balance) remaining")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(
+                                isZeroBalance ? VColor.systemNegativeStrong :
+                                isLowBalance ? VColor.systemMidStrong :
+                                VColor.contentDefault
+                            )
+                        Spacer()
+                        if isBillingVisible {
+                            Button("Add funds") { onOpenBilling() }
+                                .font(VFont.labelDefault)
+                                .foregroundStyle(VColor.primaryBase)
+                                .buttonStyle(.plain)
+                        }
+                    }
+                }
+
+                VMenuDivider()
+            }
+
+            VMenuItem(icon: VIcon.settings.rawValue, label: String(localized: "Settings"), action: onSettings)
+
+            VMenuCustomRow {
                 Text("Ask the assistant in chat to help you with any settings you wish to alter.")
                     .font(VFont.labelDefault)
                     .foregroundStyle(VColor.contentDisabled)
-                    .padding(.horizontal, VSpacing.sm)
                     .padding(.top, VSpacing.xs)
+            }
 
-                VColor.surfaceBase.frame(height: 1)
-                    .padding(.vertical, VSpacing.sm)
+            VMenuDivider()
 
-                SidebarPrimaryRow(icon: VIcon.barChart.rawValue, label: String(localized: "Usage"), action: onUsage)
+            VMenuItem(icon: VIcon.barChart.rawValue, label: String(localized: "Usage"), action: onUsage)
+            VMenuItem(icon: VIcon.scrollText.rawValue, label: String(localized: "Logs"), action: onDebug)
 
-                SidebarPrimaryRow(icon: VIcon.scrollText.rawValue, label: String(localized: "Logs"), action: onDebug)
-
-                if authManager.isAuthenticated {
-                    SidebarPrimaryRow(icon: VIcon.logOut.rawValue, label: String(localized: "Log Out"), action: onLogOut)
-                } else {
-                    SidebarPrimaryRow(icon: VIcon.logOut.rawValue, label: String(localized: "Log In"), action: onSignIn)
-                }
+            if authManager.isAuthenticated {
+                VMenuItem(icon: VIcon.logOut.rawValue, label: String(localized: "Log Out"), action: onLogOut)
+            } else {
+                VMenuItem(icon: VIcon.logOut.rawValue, label: String(localized: "Log In"), action: onSignIn)
             }
         }
-        .padding(VSpacing.sm)
-        .background(VColor.surfaceLift)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-        .shadow(color: VColor.auxBlack.opacity(0.1), radius: 1.5, x: 0, y: 1)
-        .shadow(color: VColor.auxBlack.opacity(0.1), radius: 6, x: 0, y: 4)
         .onReceive(NotificationCenter.default.publisher(for: .localBootstrapCompleted)) { _ in
             bootstrapGeneration += 1
         }


### PR DESCRIPTION
## Summary
- Replaces manual drawer chrome (`.padding`, `.background`, `.clipShape`, `.shadow`) in `DrawerMenuView` with the `VMenu` container component
- Converts `SidebarPrimaryRow` calls to `VMenuItem` for Settings, Usage, Logs, and Log Out/Log In rows
- Wraps theme toggle and balance row in `VMenuCustomRow` (removing inner horizontal padding to avoid double-padding since `VMenuCustomRow` provides its own)
- Replaces manual `VColor.surfaceBase.frame(height: 1)` dividers with `VMenuDivider()`
- Preserves all functionality: balance loading, billing link, auth-dependent actions, `.onReceive`, `.task`

## Test plan
- [ ] Open the drawer menu and verify visual parity with the previous implementation
- [ ] Confirm theme toggle row renders correctly without double horizontal padding
- [ ] Confirm balance row appears when authenticated with balance data
- [ ] Confirm "Add funds" button appears when billing feature flag is enabled
- [ ] Confirm dividers render between sections
- [ ] Confirm Settings, Usage, Logs, and Log Out/Log In actions all work
- [ ] Confirm the menu has correct background, corner radius, and shadow (provided by VMenu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
