### PR TITLE
M5: Migrate ConversationSwitcherDrawer to VMenu (#21608)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -24,75 +24,61 @@ struct ConversationSwitcherDrawer: View {
     }
 
     var body: some View {
-        VStack(spacing: SidebarLayoutMetrics.listRowGap) {
-            Text("\(regularConversations.count) conversations")
-                .font(VFont.labelDefault)
-                .foregroundStyle(VColor.contentDisabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, VSpacing.lg)
-                .padding(.top, VSpacing.sm)
-                .padding(.bottom, VSpacing.xs)
-
-            VColor.surfaceBase.frame(height: 1)
-                .padding(.horizontal, VSpacing.xs)
-
-            ForEach(regularConversations) { conversation in
-                SidebarConversationItem(
-                    conversation: conversation,
-                    isSelected: isConversationSelected(conversation),
-                    interactionState: conversationManager.interactionState(for: conversation.id),
-                    isHovered: sidebar.isHoveredConversation == conversation.id,
-                    isPendingDeletion: sidebar.conversationPendingDeletion == conversation.id,
-                    selectConversation: { selectConversation(conversation) },
-                    onSelect: onDismiss,
-                    onTogglePin: {
-                        withAnimation(VAnimation.standard) {
-                            if conversation.isPinned {
-                                conversationManager.unpinConversation(id: conversation.id)
-                            } else {
-                                conversationManager.pinConversation(id: conversation.id)
+        VMenu {
+            VMenuSection(header: "\(regularConversations.count) conversations") {
+                ForEach(regularConversations) { conversation in
+                    SidebarConversationItem(
+                        conversation: conversation,
+                        isSelected: isConversationSelected(conversation),
+                        interactionState: conversationManager.interactionState(for: conversation.id),
+                        isHovered: sidebar.isHoveredConversation == conversation.id,
+                        isPendingDeletion: sidebar.conversationPendingDeletion == conversation.id,
+                        selectConversation: { selectConversation(conversation) },
+                        onSelect: onDismiss,
+                        onTogglePin: {
+                            withAnimation(VAnimation.standard) {
+                                if conversation.isPinned {
+                                    conversationManager.unpinConversation(id: conversation.id)
+                                } else {
+                                    conversationManager.pinConversation(id: conversation.id)
+                                }
                             }
-                        }
-                    },
-                    onArchive: { conversationManager.archiveConversation(id: conversation.id) },
-                    onBeginArchive: { sidebar.conversationPendingDeletion = conversation.id },
-                    onConfirmArchive: {
-                        conversationManager.archiveConversation(id: conversation.id)
-                        sidebar.conversationPendingDeletion = nil
-                    },
-                    onStartRename: {
-                        sidebar.renamingConversationId = conversation.id
-                        sidebar.renameText = conversation.title
-                    },
-                    onMarkUnread: { conversationManager.markConversationUnread(conversationId: conversation.id) },
-                    onHoverChange: { hovering in
-                        withAnimation(VAnimation.fast) {
-                            sidebar.setConversationHover(conversationId: conversation.id, hovering: hovering)
-                        }
-                    },
-                    onDragStart: {
-                        sidebar.draggingConversationId = conversation.id
-                        sidebar.isHoveredConversation = nil
-                    },
-                    onOpenInNewWindow: conversation.conversationId != nil ? {
-                        AppDelegate.shared?.threadWindowManager?.openThread(
-                            conversationLocalId: conversation.id,
-                            conversationManager: conversationManager
-                        )
-                    } : nil,
-                    onShowFeedback: conversation.conversationId != nil && !LogExporter.isManagedAssistant ? {
-                        AppDelegate.shared?.showLogReportWindow(scope: .conversation(conversationId: conversation.conversationId!, conversationTitle: conversation.title))
-                    } : nil
-                )
-                .equatable()
+                        },
+                        onArchive: { conversationManager.archiveConversation(id: conversation.id) },
+                        onBeginArchive: { sidebar.conversationPendingDeletion = conversation.id },
+                        onConfirmArchive: {
+                            conversationManager.archiveConversation(id: conversation.id)
+                            sidebar.conversationPendingDeletion = nil
+                        },
+                        onStartRename: {
+                            sidebar.renamingConversationId = conversation.id
+                            sidebar.renameText = conversation.title
+                        },
+                        onMarkUnread: { conversationManager.markConversationUnread(conversationId: conversation.id) },
+                        onHoverChange: { hovering in
+                            withAnimation(VAnimation.fast) {
+                                sidebar.setConversationHover(conversationId: conversation.id, hovering: hovering)
+                            }
+                        },
+                        onDragStart: {
+                            sidebar.draggingConversationId = conversation.id
+                            sidebar.isHoveredConversation = nil
+                        },
+                        onOpenInNewWindow: conversation.conversationId != nil ? {
+                            AppDelegate.shared?.threadWindowManager?.openThread(
+                                conversationLocalId: conversation.id,
+                                conversationManager: conversationManager
+                            )
+                        } : nil,
+                        onShowFeedback: conversation.conversationId != nil && !LogExporter.isManagedAssistant ? {
+                            AppDelegate.shared?.showLogReportWindow(scope: .conversation(conversationId: conversation.conversationId!, conversationTitle: conversation.title))
+                        } : nil
+                    )
+                    .equatable()
+                }
             }
         }
-        .padding(VSpacing.sm)
         .fixedSize(horizontal: false, vertical: true)
-        .background(VColor.surfaceLift)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-        .shadow(color: VColor.auxBlack.opacity(0.1), radius: 1.5, x: 0, y: 1)
-        .shadow(color: VColor.auxBlack.opacity(0.1), radius: 6, x: 0, y: 4)
         .onDisappear {
             if sidebar.isHoveredConversation != nil {
                 sidebar.isHoveredConversation = nil


### PR DESCRIPTION
## Summary
- Replaces manual drawer chrome (VStack + padding + background + clipShape + shadow) in `ConversationSwitcherDrawer` with `VMenu` container
- Maps the "N conversations" header + divider to `VMenuSection(header:)` which provides identical styling
- Preserves all `SidebarConversationItem` usage and existing behavior (context menus, drag, hover, etc.)

## Test plan
- [ ] Open the conversation switcher drawer and verify it renders correctly
- [ ] Verify the header text ("N conversations") and divider appear as before
- [ ] Verify conversation items are clickable, hoverable, and context menus work
- [ ] Verify drag-and-drop still functions
- [ ] Verify the drawer dismisses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
