### PR TITLE
Reusable VMenu component + migrate all drawer components

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
@@ -59,35 +59,29 @@ struct ConversationActionsDrawer: View {
     var onOpenInNewWindow: (() -> Void)? = nil
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        VMenu(width: 200) {
             if presentation.canCopy {
-                SidebarPrimaryRow(icon: VIcon.copy.rawValue, label: "Copy full conversation", action: onCopy)
+                VMenuItem(icon: VIcon.copy.rawValue, label: "Copy full conversation", action: onCopy)
             }
 
             if presentation.showsForkConversationAction {
-                SidebarPrimaryRow(icon: VIcon.gitBranch.rawValue, label: "Fork conversation", action: onForkConversation)
+                VMenuItem(icon: VIcon.gitBranch.rawValue, label: "Fork conversation", action: onForkConversation)
             }
 
             if let onOpenInNewWindow {
-                SidebarPrimaryRow(icon: VIcon.externalLink.rawValue, label: "Open in new window", action: onOpenInNewWindow)
+                VMenuItem(icon: VIcon.externalLink.rawValue, label: "Open in new window", action: onOpenInNewWindow)
             }
 
-            SidebarPrimaryRow(
+            VMenuItem(
                 icon: presentation.isPinned ? VIcon.pinOff.rawValue : VIcon.pin.rawValue,
                 label: presentation.isPinned ? "Unpin" : "Pin",
                 action: presentation.isPinned ? onUnpin : onPin
             )
 
-            SidebarPrimaryRow(icon: VIcon.pencil.rawValue, label: "Rename", action: onRename)
+            VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename", action: onRename)
 
-            SidebarPrimaryRow(icon: VIcon.archive.rawValue, label: "Archive", action: onArchive)
+            VMenuItem(icon: VIcon.archive.rawValue, label: "Archive", action: onArchive)
         }
-        .padding(VSpacing.sm)
-        .background(VColor.surfaceLift)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-        .shadow(color: VColor.auxBlack.opacity(0.1), radius: 1.5, x: 0, y: 1)
-        .shadow(color: VColor.auxBlack.opacity(0.1), radius: 6, x: 0, y: 4)
-        .frame(width: 200)
         .transition(.opacity.combined(with: .scale(scale: 0.95, anchor: .top)))
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -24,75 +24,61 @@ struct ConversationSwitcherDrawer: View {
     }
 
     var body: some View {
-        VStack(spacing: SidebarLayoutMetrics.listRowGap) {
-            Text("\(regularConversations.count) conversations")
-                .font(VFont.labelDefault)
-                .foregroundStyle(VColor.contentDisabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, VSpacing.lg)
-                .padding(.top, VSpacing.sm)
-                .padding(.bottom, VSpacing.xs)
-
-            VColor.surfaceBase.frame(height: 1)
-                .padding(.horizontal, VSpacing.xs)
-
-            ForEach(regularConversations) { conversation in
-                SidebarConversationItem(
-                    conversation: conversation,
-                    isSelected: isConversationSelected(conversation),
-                    interactionState: conversationManager.interactionState(for: conversation.id),
-                    isHovered: sidebar.isHoveredConversation == conversation.id,
-                    isPendingDeletion: sidebar.conversationPendingDeletion == conversation.id,
-                    selectConversation: { selectConversation(conversation) },
-                    onSelect: onDismiss,
-                    onTogglePin: {
-                        withAnimation(VAnimation.standard) {
-                            if conversation.isPinned {
-                                conversationManager.unpinConversation(id: conversation.id)
-                            } else {
-                                conversationManager.pinConversation(id: conversation.id)
+        VMenu {
+            VMenuSection(header: "\(regularConversations.count) conversations") {
+                ForEach(regularConversations) { conversation in
+                    SidebarConversationItem(
+                        conversation: conversation,
+                        isSelected: isConversationSelected(conversation),
+                        interactionState: conversationManager.interactionState(for: conversation.id),
+                        isHovered: sidebar.isHoveredConversation == conversation.id,
+                        isPendingDeletion: sidebar.conversationPendingDeletion == conversation.id,
+                        selectConversation: { selectConversation(conversation) },
+                        onSelect: onDismiss,
+                        onTogglePin: {
+                            withAnimation(VAnimation.standard) {
+                                if conversation.isPinned {
+                                    conversationManager.unpinConversation(id: conversation.id)
+                                } else {
+                                    conversationManager.pinConversation(id: conversation.id)
+                                }
                             }
-                        }
-                    },
-                    onArchive: { conversationManager.archiveConversation(id: conversation.id) },
-                    onBeginArchive: { sidebar.conversationPendingDeletion = conversation.id },
-                    onConfirmArchive: {
-                        conversationManager.archiveConversation(id: conversation.id)
-                        sidebar.conversationPendingDeletion = nil
-                    },
-                    onStartRename: {
-                        sidebar.renamingConversationId = conversation.id
-                        sidebar.renameText = conversation.title
-                    },
-                    onMarkUnread: { conversationManager.markConversationUnread(conversationId: conversation.id) },
-                    onHoverChange: { hovering in
-                        withAnimation(VAnimation.fast) {
-                            sidebar.setConversationHover(conversationId: conversation.id, hovering: hovering)
-                        }
-                    },
-                    onDragStart: {
-                        sidebar.draggingConversationId = conversation.id
-                        sidebar.isHoveredConversation = nil
-                    },
-                    onOpenInNewWindow: conversation.conversationId != nil ? {
-                        AppDelegate.shared?.threadWindowManager?.openThread(
-                            conversationLocalId: conversation.id,
-                            conversationManager: conversationManager
-                        )
-                    } : nil,
-                    onShowFeedback: conversation.conversationId != nil && !LogExporter.isManagedAssistant ? {
-                        AppDelegate.shared?.showLogReportWindow(scope: .conversation(conversationId: conversation.conversationId!, conversationTitle: conversation.title))
-                    } : nil
-                )
-                .equatable()
+                        },
+                        onArchive: { conversationManager.archiveConversation(id: conversation.id) },
+                        onBeginArchive: { sidebar.conversationPendingDeletion = conversation.id },
+                        onConfirmArchive: {
+                            conversationManager.archiveConversation(id: conversation.id)
+                            sidebar.conversationPendingDeletion = nil
+                        },
+                        onStartRename: {
+                            sidebar.renamingConversationId = conversation.id
+                            sidebar.renameText = conversation.title
+                        },
+                        onMarkUnread: { conversationManager.markConversationUnread(conversationId: conversation.id) },
+                        onHoverChange: { hovering in
+                            withAnimation(VAnimation.fast) {
+                                sidebar.setConversationHover(conversationId: conversation.id, hovering: hovering)
+                            }
+                        },
+                        onDragStart: {
+                            sidebar.draggingConversationId = conversation.id
+                            sidebar.isHoveredConversation = nil
+                        },
+                        onOpenInNewWindow: conversation.conversationId != nil ? {
+                            AppDelegate.shared?.threadWindowManager?.openThread(
+                                conversationLocalId: conversation.id,
+                                conversationManager: conversationManager
+                            )
+                        } : nil,
+                        onShowFeedback: conversation.conversationId != nil && !LogExporter.isManagedAssistant ? {
+                            AppDelegate.shared?.showLogReportWindow(scope: .conversation(conversationId: conversation.conversationId!, conversationTitle: conversation.title))
+                        } : nil
+                    )
+                    .equatable()
+                }
             }
         }
-        .padding(VSpacing.sm)
         .fixedSize(horizontal: false, vertical: true)
-        .background(VColor.surfaceLift)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-        .shadow(color: VColor.auxBlack.opacity(0.1), radius: 1.5, x: 0, y: 1)
-        .shadow(color: VColor.auxBlack.opacity(0.1), radius: 6, x: 0, y: 4)
         .onDisappear {
             if sidebar.isHoveredConversation != nil {
                 sidebar.isHoveredConversation = nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -24,64 +24,56 @@ struct DrawerMenuView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xs) {
-            DrawerThemeToggle()
-                .padding(.horizontal, VSpacing.sm)
-
-            VColor.surfaceBase.frame(height: 1)
-                .padding(.vertical, VSpacing.xs)
-
-            if let balance = effectiveBalance {
-                HStack {
-                    Text("$\(balance) remaining")
-                        .font(VFont.bodyMediumDefault)
-                        .foregroundStyle(
-                            isZeroBalance ? VColor.systemNegativeStrong :
-                            isLowBalance ? VColor.systemMidStrong :
-                            VColor.contentDefault
-                        )
-                    Spacer()
-                    if isBillingVisible {
-                        Button("Add funds") { onOpenBilling() }
-                            .font(VFont.labelDefault)
-                            .foregroundStyle(VColor.primaryBase)
-                            .buttonStyle(.plain)
-                    }
-                }
-                .padding(.horizontal, VSpacing.sm)
-
-                VColor.surfaceBase.frame(height: 1)
-                    .padding(.vertical, VSpacing.xs)
+        VMenu {
+            VMenuCustomRow {
+                DrawerThemeToggle()
             }
 
-            VStack(alignment: .leading, spacing: 0) {
-                SidebarPrimaryRow(icon: VIcon.settings.rawValue, label: String(localized: "Settings"), action: onSettings)
+            VMenuDivider()
 
+            if let balance = effectiveBalance {
+                VMenuCustomRow {
+                    HStack {
+                        Text("$\(balance) remaining")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(
+                                isZeroBalance ? VColor.systemNegativeStrong :
+                                isLowBalance ? VColor.systemMidStrong :
+                                VColor.contentDefault
+                            )
+                        Spacer()
+                        if isBillingVisible {
+                            Button("Add funds") { onOpenBilling() }
+                                .font(VFont.labelDefault)
+                                .foregroundStyle(VColor.primaryBase)
+                                .buttonStyle(.plain)
+                        }
+                    }
+                }
+
+                VMenuDivider()
+            }
+
+            VMenuItem(icon: VIcon.settings.rawValue, label: String(localized: "Settings"), action: onSettings)
+
+            VMenuCustomRow {
                 Text("Ask the assistant in chat to help you with any settings you wish to alter.")
                     .font(VFont.labelDefault)
                     .foregroundStyle(VColor.contentDisabled)
-                    .padding(.horizontal, VSpacing.sm)
                     .padding(.top, VSpacing.xs)
+            }
 
-                VColor.surfaceBase.frame(height: 1)
-                    .padding(.vertical, VSpacing.sm)
+            VMenuDivider()
 
-                SidebarPrimaryRow(icon: VIcon.barChart.rawValue, label: String(localized: "Usage"), action: onUsage)
+            VMenuItem(icon: VIcon.barChart.rawValue, label: String(localized: "Usage"), action: onUsage)
+            VMenuItem(icon: VIcon.scrollText.rawValue, label: String(localized: "Logs"), action: onDebug)
 
-                SidebarPrimaryRow(icon: VIcon.scrollText.rawValue, label: String(localized: "Logs"), action: onDebug)
-
-                if authManager.isAuthenticated {
-                    SidebarPrimaryRow(icon: VIcon.logOut.rawValue, label: String(localized: "Log Out"), action: onLogOut)
-                } else {
-                    SidebarPrimaryRow(icon: VIcon.logOut.rawValue, label: String(localized: "Log In"), action: onSignIn)
-                }
+            if authManager.isAuthenticated {
+                VMenuItem(icon: VIcon.logOut.rawValue, label: String(localized: "Log Out"), action: onLogOut)
+            } else {
+                VMenuItem(icon: VIcon.logOut.rawValue, label: String(localized: "Log In"), action: onSignIn)
             }
         }
-        .padding(VSpacing.sm)
-        .background(VColor.surfaceLift)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-        .shadow(color: VColor.auxBlack.opacity(0.1), radius: 1.5, x: 0, y: 1)
-        .shadow(color: VColor.auxBlack.opacity(0.1), radius: 6, x: 0, y: 4)
         .onReceive(NotificationCenter.default.publisher(for: .localBootstrapCompleted)) { _ in
             bootstrapGeneration += 1
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -185,7 +185,6 @@ struct SidebarConversationItem: View, Equatable {
             VMenuItem(icon: VIcon.circle.rawValue, label: "Mark as unread") {
                 onMarkUnread()
             }
-            .opacity(canMarkUnread ? 1 : 0.4)
             .disabled(!canMarkUnread)
 
             if let onOpenInNewWindow {
@@ -199,7 +198,6 @@ struct SidebarConversationItem: View, Equatable {
             VMenuItem(icon: VIcon.messageCircle.rawValue, label: "Share Feedback") {
                 onShowFeedback?()
             }
-            .opacity(onShowFeedback != nil ? 1 : 0.4)
             .disabled(onShowFeedback == nil)
         }
         .pointerCursor { hovering in

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -173,7 +173,7 @@ struct SidebarConversationItem: View, Equatable {
         }
         .padding(.horizontal, 0)
         .vContextMenu(width: 200) {
-            VMenuItem(icon: VIcon.pin.rawValue, label: conversation.isPinned ? "Unpin" : "Pin") {
+            VMenuItem(icon: conversation.isPinned ? VIcon.pinOff.rawValue : VIcon.pin.rawValue, label: conversation.isPinned ? "Unpin" : "Pin") {
                 onTogglePin()
             }
             VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -35,6 +35,8 @@ struct SidebarConversationItem: View, Equatable {
         lhs.isPendingDeletion == rhs.isPendingDeletion
     }
 
+    @State private var showContextMenu = false
+
     private var hasTrailingIcon: Bool { isHovered || isPendingDeletion }
     private var canMarkUnread: Bool {
         !conversation.hasUnseenLatestAssistantMessage &&
@@ -172,45 +174,44 @@ struct SidebarConversationItem: View, Equatable {
             }
         }
         .padding(.horizontal, 0)
-        .contextMenu {
-            Button {
-                onTogglePin()
-            } label: {
-                Label { Text(conversation.isPinned ? "Unpin" : "Pin") } icon: { VIconView(conversation.isPinned ? .pinOff : .pin, size: 14) }
-            }
-            Button {
-                onStartRename()
-            } label: {
-                Label { Text("Rename") } icon: { VIconView(.pencil, size: 14) }
-            }
-            Button {
-                onArchive()
-            } label: {
-                Label { Text("Archive") } icon: { VIconView(.archive, size: 14) }
-            }
-            Button {
-                onMarkUnread()
-            } label: {
-                Label { Text("Mark as unread") } icon: { VIconView(.circle, size: 14) }
-            }
-            .disabled(!canMarkUnread)
-
-            if let onOpenInNewWindow {
-                Button {
-                    onOpenInNewWindow()
-                } label: {
-                    Label { Text("Open in New Window") } icon: { VIconView(.externalLink, size: 14) }
+        .onRightClick { showContextMenu = true }
+        .popover(isPresented: $showContextMenu, arrowEdge: .trailing) {
+            VMenu(width: 200) {
+                VMenuItem(icon: VIcon.pin.rawValue, label: conversation.isPinned ? "Unpin" : "Pin") {
+                    showContextMenu = false
+                    onTogglePin()
                 }
-            }
+                VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") {
+                    showContextMenu = false
+                    onStartRename()
+                }
+                VMenuItem(icon: VIcon.archive.rawValue, label: "Archive") {
+                    showContextMenu = false
+                    onArchive()
+                }
+                VMenuItem(icon: VIcon.circle.rawValue, label: "Mark as unread") {
+                    showContextMenu = false
+                    onMarkUnread()
+                }
+                .opacity(canMarkUnread ? 1 : 0.4)
+                .disabled(!canMarkUnread)
 
-            Divider()
+                if let onOpenInNewWindow {
+                    VMenuItem(icon: VIcon.externalLink.rawValue, label: "Open in New Window") {
+                        showContextMenu = false
+                        onOpenInNewWindow()
+                    }
+                }
 
-            Button {
-                onShowFeedback?()
-            } label: {
-                Label { Text("Share Feedback") } icon: { VIconView(.messageCircle, size: 14) }
+                VMenuDivider()
+
+                VMenuItem(icon: VIcon.messageCircle.rawValue, label: "Share Feedback") {
+                    showContextMenu = false
+                    onShowFeedback?()
+                }
+                .opacity(onShowFeedback != nil ? 1 : 0.4)
+                .disabled(onShowFeedback == nil)
             }
-            .disabled(onShowFeedback == nil)
         }
         .pointerCursor { hovering in
             onHoverChange(hovering)
@@ -239,6 +240,67 @@ struct SidebarConversationItem: View, Equatable {
             .frame(width: 220, alignment: .leading)
             .background(VColor.surfaceBase.opacity(0.9))
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        }
+    }
+}
+
+// MARK: - Right-click detection (local prototype only)
+
+private struct RightClickView: NSViewRepresentable {
+    let action: () -> Void
+
+    func makeNSView(context: Context) -> RightClickNSView {
+        RightClickNSView(action: action)
+    }
+
+    func updateNSView(_ nsView: RightClickNSView, context: Context) {
+        nsView.action = action
+    }
+
+    class RightClickNSView: NSView {
+        var action: () -> Void
+        private var monitor: Any?
+
+        init(action: @escaping () -> Void) {
+            self.action = action
+            super.init(frame: .zero)
+        }
+
+        required init?(coder: NSCoder) { fatalError() }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            monitor.flatMap(NSEvent.removeMonitor)
+            monitor = nil
+            guard window != nil else { return }
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .rightMouseDown) { [weak self] event in
+                guard let self, let window = self.window else { return event }
+                let locationInView = self.convert(event.locationInWindow, from: nil)
+                if self.bounds.contains(locationInView) {
+                    self.action()
+                    return nil // consume the right-click
+                }
+                return event // pass through if not in our bounds
+            }
+        }
+
+        override func removeFromSuperview() {
+            monitor.flatMap(NSEvent.removeMonitor)
+            monitor = nil
+            super.removeFromSuperview()
+        }
+
+        // Return nil from hitTest so this view never intercepts left clicks,
+        // hover, drag, or any other mouse events from reaching SwiftUI content.
+        override func hitTest(_ point: NSPoint) -> NSView? { nil }
+    }
+}
+
+private extension View {
+    func onRightClick(perform action: @escaping () -> Void) -> some View {
+        background {
+            RightClickView(action: action)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -35,52 +35,11 @@ struct SidebarConversationItem: View, Equatable {
         lhs.isPendingDeletion == rhs.isPendingDeletion
     }
 
-    @State private var contextMenuPanel: VMenuPanel?
-
     private var hasTrailingIcon: Bool { isHovered || isPendingDeletion }
     private var canMarkUnread: Bool {
         !conversation.hasUnseenLatestAssistantMessage &&
             conversation.conversationId != nil &&
             conversation.latestAssistantMessageAt != nil
-    }
-
-    private var contextMenuContent: some View {
-        VMenu(width: 200) {
-            VMenuItem(icon: VIcon.pin.rawValue, label: conversation.isPinned ? "Unpin" : "Pin") {
-                contextMenuPanel?.close()
-                onTogglePin()
-            }
-            VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") {
-                contextMenuPanel?.close()
-                onStartRename()
-            }
-            VMenuItem(icon: VIcon.archive.rawValue, label: "Archive") {
-                contextMenuPanel?.close()
-                onArchive()
-            }
-            VMenuItem(icon: VIcon.circle.rawValue, label: "Mark as unread") {
-                contextMenuPanel?.close()
-                onMarkUnread()
-            }
-            .opacity(canMarkUnread ? 1 : 0.4)
-            .disabled(!canMarkUnread)
-
-            if let onOpenInNewWindow {
-                VMenuItem(icon: VIcon.externalLink.rawValue, label: "Open in New Window") {
-                    contextMenuPanel?.close()
-                    onOpenInNewWindow()
-                }
-            }
-
-            VMenuDivider()
-
-            VMenuItem(icon: VIcon.messageCircle.rawValue, label: "Share Feedback") {
-                contextMenuPanel?.close()
-                onShowFeedback?()
-            }
-            .opacity(onShowFeedback != nil ? 1 : 0.4)
-            .disabled(onShowFeedback == nil)
-        }
     }
 
     var body: some View {
@@ -213,13 +172,35 @@ struct SidebarConversationItem: View, Equatable {
             }
         }
         .padding(.horizontal, 0)
-        .onRightClick { screenPoint in
-            contextMenuPanel?.close()
-            contextMenuPanel = VMenuPanel.show(at: screenPoint) {
-                contextMenuContent
-            } onDismiss: {
-                contextMenuPanel = nil
+        .vContextMenu(width: 200) {
+            VMenuItem(icon: VIcon.pin.rawValue, label: conversation.isPinned ? "Unpin" : "Pin") {
+                onTogglePin()
             }
+            VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") {
+                onStartRename()
+            }
+            VMenuItem(icon: VIcon.archive.rawValue, label: "Archive") {
+                onArchive()
+            }
+            VMenuItem(icon: VIcon.circle.rawValue, label: "Mark as unread") {
+                onMarkUnread()
+            }
+            .opacity(canMarkUnread ? 1 : 0.4)
+            .disabled(!canMarkUnread)
+
+            if let onOpenInNewWindow {
+                VMenuItem(icon: VIcon.externalLink.rawValue, label: "Open in New Window") {
+                    onOpenInNewWindow()
+                }
+            }
+
+            VMenuDivider()
+
+            VMenuItem(icon: VIcon.messageCircle.rawValue, label: "Share Feedback") {
+                onShowFeedback?()
+            }
+            .opacity(onShowFeedback != nil ? 1 : 0.4)
+            .disabled(onShowFeedback == nil)
         }
         .pointerCursor { hovering in
             onHoverChange(hovering)
@@ -252,183 +233,3 @@ struct SidebarConversationItem: View, Equatable {
     }
 }
 
-// MARK: - Right-click detection (local prototype only)
-
-// MARK: - Right-click detection (local prototype only)
-
-private struct RightClickView: NSViewRepresentable {
-    /// Called with the click location in screen coordinates.
-    let action: (CGPoint) -> Void
-
-    func makeNSView(context: Context) -> RightClickNSView {
-        RightClickNSView(action: action)
-    }
-
-    func updateNSView(_ nsView: RightClickNSView, context: Context) {
-        nsView.action = action
-    }
-
-    class RightClickNSView: NSView {
-        var action: (CGPoint) -> Void
-        private var monitor: Any?
-
-        init(action: @escaping (CGPoint) -> Void) {
-            self.action = action
-            super.init(frame: .zero)
-        }
-
-        required init?(coder: NSCoder) { fatalError() }
-
-        override func viewDidMoveToWindow() {
-            super.viewDidMoveToWindow()
-            monitor.flatMap(NSEvent.removeMonitor)
-            monitor = nil
-            guard window != nil else { return }
-            monitor = NSEvent.addLocalMonitorForEvents(matching: .rightMouseDown) { [weak self] event in
-                guard let self, let window = self.window else { return event }
-                let locationInView = self.convert(event.locationInWindow, from: nil)
-                if self.bounds.contains(locationInView) {
-                    let screenPoint = window.convertPoint(toScreen: event.locationInWindow)
-                    // Tag the screen point with the source window's appearance
-                    VMenuPanel.sourceAppearance = window.effectiveAppearance
-                    self.action(screenPoint)
-                    return nil
-                }
-                return event
-            }
-        }
-
-        override func removeFromSuperview() {
-            monitor.flatMap(NSEvent.removeMonitor)
-            monitor = nil
-            super.removeFromSuperview()
-        }
-
-        override func hitTest(_ point: NSPoint) -> NSView? { nil }
-    }
-}
-
-private extension View {
-    func onRightClick(perform action: @escaping (CGPoint) -> Void) -> some View {
-        background {
-            RightClickView(action: action)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
-    }
-}
-
-// MARK: - VMenuPanel (floating window for context menus)
-
-/// A borderless, floating NSPanel that hosts a VMenu at a given screen position.
-/// Dismisses automatically when the user clicks outside or presses Escape.
-private class VMenuPanel: NSPanel {
-    private var dismissHandler: (() -> Void)?
-    private var clickMonitor: Any?
-
-    /// Set by RightClickNSView before invoking the action so the panel inherits
-    /// the source window's appearance (light/dark) for correct VColor resolution.
-    static var sourceAppearance: NSAppearance?
-
-    /// Show a VMenu at the given screen coordinates. Returns the panel for later dismissal.
-    static func show<Content: View>(
-        at screenPoint: CGPoint,
-        @ViewBuilder content: () -> Content,
-        onDismiss: @escaping () -> Void
-    ) -> VMenuPanel {
-        let panel = VMenuPanel(
-            contentRect: .zero,
-            styleMask: [.borderless, .nonactivatingPanel],
-            backing: .buffered,
-            defer: true
-        )
-        panel.isFloatingPanel = true
-        panel.level = .popUpMenu
-        panel.isOpaque = false
-        panel.backgroundColor = .clear
-        panel.hasShadow = false // VMenu provides its own shadow
-        panel.dismissHandler = onDismiss
-
-        // Inherit the source window's appearance so VColor tokens resolve correctly
-        if let appearance = sourceAppearance {
-            panel.appearance = appearance
-        }
-        sourceAppearance = nil
-
-        let hostingView = NSHostingView(rootView: content())
-        hostingView.sizingOptions = [.intrinsicContentSize]
-
-        // Wrap in a container that accepts first-mouse so clicks work immediately
-        // without needing to activate the panel first.
-        let container = FirstMouseView()
-        container.wantsLayer = true
-        container.layer?.cornerRadius = 12 // VRadius.lg
-        container.layer?.masksToBounds = true
-
-        hostingView.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(hostingView)
-        NSLayoutConstraint.activate([
-            hostingView.topAnchor.constraint(equalTo: container.topAnchor),
-            hostingView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
-            hostingView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            hostingView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-        ])
-        panel.contentView = container
-
-        // Size to fit content
-        let intrinsicSize = hostingView.intrinsicContentSize
-        let menuSize = CGSize(
-            width: max(intrinsicSize.width, 200),
-            height: intrinsicSize.height
-        )
-
-        // Position: top-left of menu at cursor, menu grows downward.
-        // In AppKit screen coords, Y=0 is bottom, so subtract height.
-        let origin = CGPoint(x: screenPoint.x, y: screenPoint.y - menuSize.height)
-        panel.setFrame(CGRect(origin: origin, size: menuSize), display: true)
-        panel.makeKeyAndOrderFront(nil)
-
-        // Install click-outside monitor (one-shot, async to skip the opening right-click)
-        DispatchQueue.main.async {
-            panel.clickMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { event in
-                // If the click is inside the panel, let it through (menu item tap)
-                let locationInPanel = panel.convertPoint(fromScreen: NSEvent.mouseLocation)
-                let panelBounds = panel.contentView?.bounds ?? .zero
-                if panelBounds.contains(locationInPanel) {
-                    return event
-                }
-                // Click outside — dismiss
-                panel.close()
-                return event
-            }
-        }
-
-        return panel
-    }
-
-    override func close() {
-        clickMonitor.flatMap(NSEvent.removeMonitor)
-        clickMonitor = nil
-        dismissHandler?()
-        dismissHandler = nil
-        super.close()
-    }
-
-    override func cancelOperation(_ sender: Any?) {
-        close() // Escape key dismisses
-    }
-
-    override var canBecomeKey: Bool { true }
-    override var canBecomeMain: Bool { false }
-}
-
-/// Container view that accepts first-mouse clicks so taps work immediately
-/// in a non-activating panel without requiring a focus click first.
-private class FirstMouseView: NSView {
-    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
-
-    // Propagate first-mouse to all subviews (including NSHostingView internals)
-    override func hitTest(_ point: NSPoint) -> NSView? {
-        let hit = super.hitTest(point)
-        return hit
-    }
-}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -35,13 +35,52 @@ struct SidebarConversationItem: View, Equatable {
         lhs.isPendingDeletion == rhs.isPendingDeletion
     }
 
-    @State private var showContextMenu = false
+    @State private var contextMenuPanel: VMenuPanel?
 
     private var hasTrailingIcon: Bool { isHovered || isPendingDeletion }
     private var canMarkUnread: Bool {
         !conversation.hasUnseenLatestAssistantMessage &&
             conversation.conversationId != nil &&
             conversation.latestAssistantMessageAt != nil
+    }
+
+    private var contextMenuContent: some View {
+        VMenu(width: 200) {
+            VMenuItem(icon: VIcon.pin.rawValue, label: conversation.isPinned ? "Unpin" : "Pin") {
+                contextMenuPanel?.close()
+                onTogglePin()
+            }
+            VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") {
+                contextMenuPanel?.close()
+                onStartRename()
+            }
+            VMenuItem(icon: VIcon.archive.rawValue, label: "Archive") {
+                contextMenuPanel?.close()
+                onArchive()
+            }
+            VMenuItem(icon: VIcon.circle.rawValue, label: "Mark as unread") {
+                contextMenuPanel?.close()
+                onMarkUnread()
+            }
+            .opacity(canMarkUnread ? 1 : 0.4)
+            .disabled(!canMarkUnread)
+
+            if let onOpenInNewWindow {
+                VMenuItem(icon: VIcon.externalLink.rawValue, label: "Open in New Window") {
+                    contextMenuPanel?.close()
+                    onOpenInNewWindow()
+                }
+            }
+
+            VMenuDivider()
+
+            VMenuItem(icon: VIcon.messageCircle.rawValue, label: "Share Feedback") {
+                contextMenuPanel?.close()
+                onShowFeedback?()
+            }
+            .opacity(onShowFeedback != nil ? 1 : 0.4)
+            .disabled(onShowFeedback == nil)
+        }
     }
 
     var body: some View {
@@ -174,43 +213,12 @@ struct SidebarConversationItem: View, Equatable {
             }
         }
         .padding(.horizontal, 0)
-        .onRightClick { showContextMenu = true }
-        .popover(isPresented: $showContextMenu, arrowEdge: .trailing) {
-            VMenu(width: 200) {
-                VMenuItem(icon: VIcon.pin.rawValue, label: conversation.isPinned ? "Unpin" : "Pin") {
-                    showContextMenu = false
-                    onTogglePin()
-                }
-                VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") {
-                    showContextMenu = false
-                    onStartRename()
-                }
-                VMenuItem(icon: VIcon.archive.rawValue, label: "Archive") {
-                    showContextMenu = false
-                    onArchive()
-                }
-                VMenuItem(icon: VIcon.circle.rawValue, label: "Mark as unread") {
-                    showContextMenu = false
-                    onMarkUnread()
-                }
-                .opacity(canMarkUnread ? 1 : 0.4)
-                .disabled(!canMarkUnread)
-
-                if let onOpenInNewWindow {
-                    VMenuItem(icon: VIcon.externalLink.rawValue, label: "Open in New Window") {
-                        showContextMenu = false
-                        onOpenInNewWindow()
-                    }
-                }
-
-                VMenuDivider()
-
-                VMenuItem(icon: VIcon.messageCircle.rawValue, label: "Share Feedback") {
-                    showContextMenu = false
-                    onShowFeedback?()
-                }
-                .opacity(onShowFeedback != nil ? 1 : 0.4)
-                .disabled(onShowFeedback == nil)
+        .onRightClick { screenPoint in
+            contextMenuPanel?.close()
+            contextMenuPanel = VMenuPanel.show(at: screenPoint) {
+                contextMenuContent
+            } onDismiss: {
+                contextMenuPanel = nil
             }
         }
         .pointerCursor { hovering in
@@ -246,8 +254,11 @@ struct SidebarConversationItem: View, Equatable {
 
 // MARK: - Right-click detection (local prototype only)
 
+// MARK: - Right-click detection (local prototype only)
+
 private struct RightClickView: NSViewRepresentable {
-    let action: () -> Void
+    /// Called with the click location in screen coordinates.
+    let action: (CGPoint) -> Void
 
     func makeNSView(context: Context) -> RightClickNSView {
         RightClickNSView(action: action)
@@ -258,10 +269,10 @@ private struct RightClickView: NSViewRepresentable {
     }
 
     class RightClickNSView: NSView {
-        var action: () -> Void
+        var action: (CGPoint) -> Void
         private var monitor: Any?
 
-        init(action: @escaping () -> Void) {
+        init(action: @escaping (CGPoint) -> Void) {
             self.action = action
             super.init(frame: .zero)
         }
@@ -277,10 +288,13 @@ private struct RightClickView: NSViewRepresentable {
                 guard let self, let window = self.window else { return event }
                 let locationInView = self.convert(event.locationInWindow, from: nil)
                 if self.bounds.contains(locationInView) {
-                    self.action()
-                    return nil // consume the right-click
+                    let screenPoint = window.convertPoint(toScreen: event.locationInWindow)
+                    // Tag the screen point with the source window's appearance
+                    VMenuPanel.sourceAppearance = window.effectiveAppearance
+                    self.action(screenPoint)
+                    return nil
                 }
-                return event // pass through if not in our bounds
+                return event
             }
         }
 
@@ -290,17 +304,131 @@ private struct RightClickView: NSViewRepresentable {
             super.removeFromSuperview()
         }
 
-        // Return nil from hitTest so this view never intercepts left clicks,
-        // hover, drag, or any other mouse events from reaching SwiftUI content.
         override func hitTest(_ point: NSPoint) -> NSView? { nil }
     }
 }
 
 private extension View {
-    func onRightClick(perform action: @escaping () -> Void) -> some View {
+    func onRightClick(perform action: @escaping (CGPoint) -> Void) -> some View {
         background {
             RightClickView(action: action)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+    }
+}
+
+// MARK: - VMenuPanel (floating window for context menus)
+
+/// A borderless, floating NSPanel that hosts a VMenu at a given screen position.
+/// Dismisses automatically when the user clicks outside or presses Escape.
+private class VMenuPanel: NSPanel {
+    private var dismissHandler: (() -> Void)?
+    private var clickMonitor: Any?
+
+    /// Set by RightClickNSView before invoking the action so the panel inherits
+    /// the source window's appearance (light/dark) for correct VColor resolution.
+    static var sourceAppearance: NSAppearance?
+
+    /// Show a VMenu at the given screen coordinates. Returns the panel for later dismissal.
+    static func show<Content: View>(
+        at screenPoint: CGPoint,
+        @ViewBuilder content: () -> Content,
+        onDismiss: @escaping () -> Void
+    ) -> VMenuPanel {
+        let panel = VMenuPanel(
+            contentRect: .zero,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: true
+        )
+        panel.isFloatingPanel = true
+        panel.level = .popUpMenu
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false // VMenu provides its own shadow
+        panel.dismissHandler = onDismiss
+
+        // Inherit the source window's appearance so VColor tokens resolve correctly
+        if let appearance = sourceAppearance {
+            panel.appearance = appearance
+        }
+        sourceAppearance = nil
+
+        let hostingView = NSHostingView(rootView: content())
+        hostingView.sizingOptions = [.intrinsicContentSize]
+
+        // Wrap in a container that accepts first-mouse so clicks work immediately
+        // without needing to activate the panel first.
+        let container = FirstMouseView()
+        container.wantsLayer = true
+        container.layer?.cornerRadius = 12 // VRadius.lg
+        container.layer?.masksToBounds = true
+
+        hostingView.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(hostingView)
+        NSLayoutConstraint.activate([
+            hostingView.topAnchor.constraint(equalTo: container.topAnchor),
+            hostingView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            hostingView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            hostingView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+        ])
+        panel.contentView = container
+
+        // Size to fit content
+        let intrinsicSize = hostingView.intrinsicContentSize
+        let menuSize = CGSize(
+            width: max(intrinsicSize.width, 200),
+            height: intrinsicSize.height
+        )
+
+        // Position: top-left of menu at cursor, menu grows downward.
+        // In AppKit screen coords, Y=0 is bottom, so subtract height.
+        let origin = CGPoint(x: screenPoint.x, y: screenPoint.y - menuSize.height)
+        panel.setFrame(CGRect(origin: origin, size: menuSize), display: true)
+        panel.makeKeyAndOrderFront(nil)
+
+        // Install click-outside monitor (one-shot, async to skip the opening right-click)
+        DispatchQueue.main.async {
+            panel.clickMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { event in
+                // If the click is inside the panel, let it through (menu item tap)
+                let locationInPanel = panel.convertPoint(fromScreen: NSEvent.mouseLocation)
+                let panelBounds = panel.contentView?.bounds ?? .zero
+                if panelBounds.contains(locationInPanel) {
+                    return event
+                }
+                // Click outside — dismiss
+                panel.close()
+                return event
+            }
+        }
+
+        return panel
+    }
+
+    override func close() {
+        clickMonitor.flatMap(NSEvent.removeMonitor)
+        clickMonitor = nil
+        dismissHandler?()
+        dismissHandler = nil
+        super.close()
+    }
+
+    override func cancelOperation(_ sender: Any?) {
+        close() // Escape key dismisses
+    }
+
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+}
+
+/// Container view that accepts first-mouse clicks so taps work immediately
+/// in a non-activating panel without requiring a focus click first.
+private class FirstMouseView: NSView {
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+    // Propagate first-mouse to all subviews (including NSHostingView internals)
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        let hit = super.hitTest(point)
+        return hit
     }
 }

--- a/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
@@ -1,0 +1,181 @@
+import SwiftUI
+
+// MARK: - VMenu
+
+/// A reusable popover container that provides consistent chrome (background, corner radius, shadow)
+/// matching the drawer pattern used throughout the app. Callers are responsible for their own
+/// transitions and presentation logic.
+///
+/// Usage:
+/// ```swift
+/// VMenu(width: 200) {
+///     VMenuItem(icon: VIcon.copy.rawValue, label: "Copy") { handleCopy() }
+///     VMenuDivider()
+///     VMenuItem(label: "Delete") { handleDelete() }
+/// }
+/// ```
+public struct VMenu<Content: View>: View {
+    public let width: CGFloat?
+    public let content: Content
+
+    public init(
+        width: CGFloat? = nil,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.width = width
+        self.content = content()
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            content
+        }
+        .padding(VSpacing.sm)
+        .frame(width: width)
+        .background(VColor.surfaceLift)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .shadow(color: VColor.auxBlack.opacity(0.1), radius: 1.5, x: 0, y: 1)
+        .shadow(color: VColor.auxBlack.opacity(0.1), radius: 6, x: 0, y: 4)
+    }
+}
+
+// MARK: - VMenuItem
+
+/// A tappable menu row that delegates to `VSidebarRow` for consistent styling.
+/// Supports an optional leading icon, active state, and trailing content.
+///
+/// Usage:
+/// ```swift
+/// VMenuItem(icon: VIcon.settings.rawValue, label: "Settings") { openSettings() }
+///
+/// // With trailing content:
+/// VMenuItem(label: "Theme", isActive: true) { toggleTheme() } trailing: {
+///     Text("Dark").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+/// }
+/// ```
+public struct VMenuItem<Trailing: View>: View {
+    public let icon: String?
+    public let label: String
+    public let isActive: Bool
+    public let action: () -> Void
+    public let trailing: Trailing
+
+    public init(
+        icon: String? = nil,
+        label: String,
+        isActive: Bool = false,
+        action: @escaping () -> Void,
+        @ViewBuilder trailing: () -> Trailing
+    ) {
+        self.icon = icon
+        self.label = label
+        self.isActive = isActive
+        self.action = action
+        self.trailing = trailing()
+    }
+
+    public var body: some View {
+        VSidebarRow(
+            icon: icon,
+            label: label,
+            isActive: isActive,
+            isExpanded: true,
+            action: action
+        ) {
+            trailing
+        }
+    }
+}
+
+// MARK: - VMenuItem convenience (no trailing)
+
+public extension VMenuItem where Trailing == EmptyView {
+    /// Menu item with no trailing content.
+    init(
+        icon: String? = nil,
+        label: String,
+        isActive: Bool = false,
+        action: @escaping () -> Void
+    ) {
+        self.init(icon: icon, label: label, isActive: isActive, action: action) {
+            EmptyView()
+        }
+    }
+}
+
+// MARK: - VMenuSection
+
+/// Groups menu items with an optional header label and divider.
+///
+/// Usage:
+/// ```swift
+/// VMenuSection(header: "Navigation") {
+///     VMenuItem(label: "Home") { goHome() }
+///     VMenuItem(label: "Settings") { openSettings() }
+/// }
+/// ```
+public struct VMenuSection<Content: View>: View {
+    public let header: String?
+    public let content: Content
+
+    public init(
+        header: String? = nil,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.header = header
+        self.content = content()
+    }
+
+    public var body: some View {
+        if let header {
+            Text(header)
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentDisabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.top, VSpacing.sm)
+                .padding(.bottom, VSpacing.xs)
+        }
+
+        VColor.surfaceBase.frame(height: 1)
+            .padding(.horizontal, VSpacing.xs)
+
+        content
+    }
+}
+
+// MARK: - VMenuDivider
+
+/// A simple horizontal divider for separating menu items.
+public struct VMenuDivider: View {
+    public init() {}
+
+    public var body: some View {
+        VColor.surfaceBase.frame(height: 1)
+            .padding(.horizontal, VSpacing.xs)
+            .padding(.vertical, VSpacing.xs)
+    }
+}
+
+// MARK: - VMenuCustomRow
+
+/// Escape hatch for embedding arbitrary content in a menu with consistent horizontal alignment.
+///
+/// Usage:
+/// ```swift
+/// VMenuCustomRow {
+///     DrawerThemeToggle()
+/// }
+/// ```
+public struct VMenuCustomRow<Content: View>: View {
+    public let content: Content
+
+    public init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    public var body: some View {
+        content
+            .padding(.horizontal, VSpacing.sm)
+    }
+}

--- a/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
@@ -141,7 +141,7 @@ public struct VMenuItem<Trailing: View>: View {
         } else {
             HStack(spacing: VSpacing.xs) {
                 if let icon {
-                    VIconView(.resolve(icon), size: Self.iconSlotSize)
+                    VIconView(.resolve(icon), size: 13)
                         .foregroundStyle(iconColor)
                         .frame(width: Self.iconSlotSize, height: Self.iconSlotSize)
                 }

--- a/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
@@ -1,5 +1,21 @@
 import SwiftUI
 
+// MARK: - VMenu Dismiss Environment
+
+/// Environment key injected by `.vContextMenu` so that `VMenuItem` can
+/// auto-dismiss the hosting panel when an action is tapped. When `nil`
+/// (the default), VMenuItem does not auto-dismiss — callers manage dismissal.
+private struct VMenuDismissKey: EnvironmentKey {
+    static let defaultValue: (() -> Void)? = nil
+}
+
+public extension EnvironmentValues {
+    var vMenuDismiss: (() -> Void)? {
+        get { self[VMenuDismissKey.self] }
+        set { self[VMenuDismissKey.self] = newValue }
+    }
+}
+
 // MARK: - VMenu
 
 /// A reusable popover container that provides consistent chrome (background, corner radius, shadow)
@@ -81,6 +97,7 @@ public struct VMenuItem<Trailing: View>: View {
     public let action: () -> Void
     public let trailing: Trailing
 
+    @Environment(\.vMenuDismiss) private var dismissMenu
     @State private var isHovered = false
 
     public init(
@@ -114,7 +131,7 @@ public struct VMenuItem<Trailing: View>: View {
                 label: label,
                 isActive: isActive,
                 isExpanded: true,
-                action: action
+                action: { dismissMenu?(); action() }
             ) {
                 trailing
             }
@@ -147,7 +164,7 @@ public struct VMenuItem<Trailing: View>: View {
             .animation(VAnimation.fast, value: isHovered)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())
-            .onTapGesture { action() }
+            .onTapGesture { dismissMenu?(); action() }
             .onHover { isHovered = $0 }
             .pointerCursor()
         }

--- a/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
@@ -98,10 +98,6 @@ public struct VMenuItem<Trailing: View>: View {
     @Environment(\.isEnabled) private var isEnabled
     @State private var isHovered = false
 
-    /// Icon slot size — matches `VSidebarRow.iconSlotSize`.
-    private static var iconSlotSize: CGFloat { 20 }
-    /// Minimum row height — matches `VSidebarRow.rowMinHeight`.
-    private static var rowMinHeight: CGFloat { 32 }
 
     public init(
         icon: String? = nil,
@@ -141,9 +137,9 @@ public struct VMenuItem<Trailing: View>: View {
         } else {
             HStack(spacing: VSpacing.xs) {
                 if let icon {
-                    VIconView(.resolve(icon), size: 13)
+                    VIconView(.resolve(icon), size: VSize.iconDefault)
                         .foregroundStyle(iconColor)
-                        .frame(width: Self.iconSlotSize, height: Self.iconSlotSize)
+                        .frame(width: VSize.iconSlot, height: VSize.iconSlot)
                 }
                 Text(label)
                     .font(size.font)
@@ -157,7 +153,7 @@ public struct VMenuItem<Trailing: View>: View {
             .padding(.leading, VSpacing.xs)
             .padding(.trailing, VSpacing.sm)
             .padding(.vertical, VSpacing.xs)
-            .frame(minHeight: Self.rowMinHeight)
+            .frame(minHeight: VSize.rowMinHeight)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 isActive ? VColor.surfaceActive :

--- a/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
@@ -65,9 +65,6 @@ public enum VMenuItemSize {
     case regular
 
     fileprivate var font: Font { self == .compact ? VFont.menuCompact : VFont.bodyMediumDefault }
-    fileprivate var iconSize: CGFloat { 13 }
-    fileprivate static var iconSlotSize: CGFloat { 20 }
-    fileprivate static var rowMinHeight: CGFloat { 32 }
 }
 
 // MARK: - VMenuItem
@@ -98,7 +95,13 @@ public struct VMenuItem<Trailing: View>: View {
     public let trailing: Trailing
 
     @Environment(\.vMenuDismiss) private var dismissMenu
+    @Environment(\.isEnabled) private var isEnabled
     @State private var isHovered = false
+
+    /// Icon slot size — all leading icons occupy a uniform 20x20 frame.
+    private static let iconSlotSize: CGFloat = 20
+    /// Minimum row height for accessible touch/click targets.
+    private static let rowMinHeight: CGFloat = 32
 
     public init(
         icon: String? = nil,
@@ -138,13 +141,13 @@ public struct VMenuItem<Trailing: View>: View {
         } else {
             HStack(spacing: VSpacing.xs) {
                 if let icon {
-                    VIconView(.resolve(icon), size: size.iconSize)
+                    VIconView(.resolve(icon), size: 13)
                         .foregroundStyle(iconColor)
-                        .frame(width: VMenuItemSize.iconSlotSize, height: VMenuItemSize.iconSlotSize)
+                        .frame(width: Self.iconSlotSize, height: Self.iconSlotSize)
                 }
                 Text(label)
                     .font(size.font)
-                    .foregroundStyle(textColor)
+                    .foregroundStyle(isEnabled ? textColor : VColor.contentDisabled)
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .allowsHitTesting(false)
@@ -154,17 +157,17 @@ public struct VMenuItem<Trailing: View>: View {
             .padding(.leading, VSpacing.xs)
             .padding(.trailing, VSpacing.sm)
             .padding(.vertical, VSpacing.xs)
-            .frame(minHeight: VMenuItemSize.rowMinHeight)
+            .frame(minHeight: Self.rowMinHeight)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 isActive ? VColor.surfaceActive :
-                isHovered ? VColor.surfaceBase :
+                isHovered && isEnabled ? VColor.surfaceBase :
                 Color.clear
             )
             .animation(VAnimation.fast, value: isHovered)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())
-            .onTapGesture { dismissMenu?(); action() }
+            .onTapGesture { guard isEnabled else { return }; dismissMenu?(); action() }
             .onHover { isHovered = $0 }
             .pointerCursor()
         }

--- a/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
@@ -39,14 +39,34 @@ public struct VMenu<Content: View>: View {
     }
 }
 
+// MARK: - VMenuItemSize
+
+/// Size variants for `VMenuItem`.
+public enum VMenuItemSize {
+    /// Compact menu item — 13pt DM Sans, matching sidebar conversation rows.
+    case compact
+    /// Regular menu item — delegates to `VSidebarRow` (14pt `VFont.bodyMediumDefault`).
+    case regular
+
+    fileprivate var font: Font { self == .compact ? VFont.menuCompact : VFont.bodyMediumDefault }
+    fileprivate var iconSize: CGFloat { 13 }
+    fileprivate static var iconSlotSize: CGFloat { 20 }
+    fileprivate static var rowMinHeight: CGFloat { 32 }
+}
+
 // MARK: - VMenuItem
 
-/// A tappable menu row that delegates to `VSidebarRow` for consistent styling.
-/// Supports an optional leading icon, active state, and trailing content.
+/// A tappable menu row with optional leading icon, active state, and trailing content.
+///
+/// Defaults to `.compact` size (13pt) to match sidebar conversation rows. Use `.regular`
+/// for 14pt rows that match `VSidebarRow`.
 ///
 /// Usage:
 /// ```swift
 /// VMenuItem(icon: VIcon.settings.rawValue, label: "Settings") { openSettings() }
+///
+/// // Regular size (14pt, same as VSidebarRow):
+/// VMenuItem(icon: VIcon.settings.rawValue, label: "Settings", size: .regular) { openSettings() }
 ///
 /// // With trailing content:
 /// VMenuItem(label: "Theme", isActive: true) { toggleTheme() } trailing: {
@@ -57,32 +77,79 @@ public struct VMenuItem<Trailing: View>: View {
     public let icon: String?
     public let label: String
     public let isActive: Bool
+    public let size: VMenuItemSize
     public let action: () -> Void
     public let trailing: Trailing
+
+    @State private var isHovered = false
 
     public init(
         icon: String? = nil,
         label: String,
         isActive: Bool = false,
+        size: VMenuItemSize = .compact,
         action: @escaping () -> Void,
         @ViewBuilder trailing: () -> Trailing
     ) {
         self.icon = icon
         self.label = label
         self.isActive = isActive
+        self.size = size
         self.action = action
         self.trailing = trailing()
     }
 
+    private var iconColor: Color {
+        isActive ? VColor.primaryActive : VColor.primaryBase
+    }
+
+    private var textColor: Color {
+        isActive ? VColor.contentEmphasized : VColor.contentSecondary
+    }
+
     public var body: some View {
-        VSidebarRow(
-            icon: icon,
-            label: label,
-            isActive: isActive,
-            isExpanded: true,
-            action: action
-        ) {
-            trailing
+        if size == .regular {
+            VSidebarRow(
+                icon: icon,
+                label: label,
+                isActive: isActive,
+                isExpanded: true,
+                action: action
+            ) {
+                trailing
+            }
+        } else {
+            HStack(spacing: VSpacing.xs) {
+                if let icon {
+                    VIconView(.resolve(icon), size: size.iconSize)
+                        .foregroundStyle(iconColor)
+                        .frame(width: VMenuItemSize.iconSlotSize, height: VMenuItemSize.iconSlotSize)
+                }
+                Text(label)
+                    .font(size.font)
+                    .foregroundStyle(textColor)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .allowsHitTesting(false)
+                Spacer()
+                trailing
+            }
+            .padding(.leading, VSpacing.xs)
+            .padding(.trailing, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
+            .frame(minHeight: VMenuItemSize.rowMinHeight)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                isActive ? VColor.surfaceActive :
+                isHovered ? VColor.surfaceBase :
+                Color.clear
+            )
+            .animation(VAnimation.fast, value: isHovered)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .contentShape(Rectangle())
+            .onTapGesture { action() }
+            .onHover { isHovered = $0 }
+            .pointerCursor()
         }
     }
 }
@@ -95,9 +162,10 @@ public extension VMenuItem where Trailing == EmptyView {
         icon: String? = nil,
         label: String,
         isActive: Bool = false,
+        size: VMenuItemSize = .compact,
         action: @escaping () -> Void
     ) {
-        self.init(icon: icon, label: label, isActive: isActive, action: action) {
+        self.init(icon: icon, label: label, isActive: isActive, size: size, action: action) {
             EmptyView()
         }
     }

--- a/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
@@ -98,10 +98,10 @@ public struct VMenuItem<Trailing: View>: View {
     @Environment(\.isEnabled) private var isEnabled
     @State private var isHovered = false
 
-    /// Icon slot size — all leading icons occupy a uniform 20x20 frame.
-    private static let iconSlotSize: CGFloat = 20
-    /// Minimum row height for accessible touch/click targets.
-    private static let rowMinHeight: CGFloat = 32
+    /// Icon slot size — matches `VSidebarRow.iconSlotSize`.
+    private static var iconSlotSize: CGFloat { 20 }
+    /// Minimum row height — matches `VSidebarRow.rowMinHeight`.
+    private static var rowMinHeight: CGFloat { 32 }
 
     public init(
         icon: String? = nil,
@@ -141,7 +141,7 @@ public struct VMenuItem<Trailing: View>: View {
         } else {
             HStack(spacing: VSpacing.xs) {
                 if let icon {
-                    VIconView(.resolve(icon), size: 13)
+                    VIconView(.resolve(icon), size: Self.iconSlotSize)
                         .foregroundStyle(iconColor)
                         .frame(width: Self.iconSlotSize, height: Self.iconSlotSize)
                 }

--- a/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
@@ -72,11 +72,12 @@ public class VMenuPanel: NSPanel {
         ])
         panel.contentView = container
 
-        // Size and position
-        let intrinsicSize = hostingView.intrinsicContentSize
+        // Size and position — fittingSize is more reliable than intrinsicContentSize
+        // which can return NSView.noIntrinsicMetric (-1) before layout settles.
+        let fittingSize = hostingView.fittingSize
         let menuSize = CGSize(
-            width: max(intrinsicSize.width, 1),
-            height: max(intrinsicSize.height, 1)
+            width: max(fittingSize.width, 1),
+            height: max(fittingSize.height, 1)
         )
 
         // Clamp to screen bounds so the menu doesn't go off-screen
@@ -100,9 +101,11 @@ public class VMenuPanel: NSPanel {
         return panel
     }
 
-    /// Calculate panel origin clamped to visible screen bounds.
+    /// Calculate panel origin clamped to the visible bounds of the screen containing the cursor.
     private func clampedOrigin(for size: CGSize, cursorAt cursor: CGPoint) -> CGPoint {
-        let screen = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? .zero
+        let screen = NSScreen.screens.first(where: { $0.frame.contains(cursor) })?.visibleFrame
+            ?? NSScreen.main?.visibleFrame
+            ?? .zero
 
         // Default: menu top-left at cursor, growing down-right.
         // Offset by shadowInset so the VMenu's visual edge aligns with the cursor.
@@ -181,38 +184,42 @@ private struct VContextMenuModifier<MenuContent: View>: ViewModifier {
     let menuWidth: CGFloat?
     @ViewBuilder let menuContent: () -> MenuContent
 
-    @State private var panel: VMenuPanel?
-    @State private var sourceAppearance: NSAppearance?
+    /// Weak reference avoids retain cycles — the window server keeps the panel
+    /// alive while it's visible; we only need this to close on re-open.
+    @State private var panelRef = WeakPanel()
 
     func body(content: Content) -> some View {
         content
             .onRightClick { screenPoint in
-                panel?.close()
+                // Close any existing panel synchronously before creating a new one.
+                // Nil the ref first so the old panel's onDismiss doesn't race.
+                let oldPanel = panelRef.value
+                panelRef.value = nil
+                oldPanel?.close()
 
-                // Capture appearance from the current window
-                let appearance = sourceAppearance
+                // Capture appearance from the window under the cursor at click time
+                let appearance = NSApp.windows
+                    .first(where: { $0.frame.contains(screenPoint) })?
+                    .effectiveAppearance
 
-                panel = VMenuPanel.show(
+                let newPanel = VMenuPanel.show(
                     at: screenPoint,
                     sourceAppearance: appearance
                 ) {
                     VMenu(width: menuWidth) {
                         menuContent()
                     }
-                } onDismiss: {
-                    panel = nil
+                } onDismiss: { [weak panelRef] in
+                    panelRef?.value = nil
                 }
-            }
-            .background {
-                // Capture the source window's appearance for the panel
-                GeometryReader { _ in
-                    Color.clear
-                        .onAppear {
-                            sourceAppearance = NSApp.keyWindow?.effectiveAppearance
-                        }
-                }
-                .frame(width: 0, height: 0)
+                panelRef.value = newPanel
             }
     }
+}
+
+/// Weak box for VMenuPanel so @State doesn't create a strong retain cycle
+/// with the panel's dismiss handler.
+private class WeakPanel {
+    weak var value: VMenuPanel?
 }
 #endif

--- a/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
@@ -1,0 +1,218 @@
+#if os(macOS)
+import SwiftUI
+import AppKit
+
+// MARK: - VMenuPanel
+
+/// A borderless, floating NSPanel that hosts a SwiftUI `VMenu` at a given
+/// screen position. Dismisses automatically on click-outside or Escape.
+///
+/// Typically you don't create this directly — use the `.vContextMenu` modifier.
+public class VMenuPanel: NSPanel {
+    private var dismissHandler: (() -> Void)?
+    private var clickMonitor: Any?
+
+    /// Extra padding added around the VMenu content so its shadow can render
+    /// without being clipped by the hosting view's bounds.
+    static let shadowInset: CGFloat = 14
+
+    /// Show SwiftUI content in a floating panel at the given screen point.
+    ///
+    /// - Parameters:
+    ///   - screenPoint: Cursor position in screen coordinates.
+    ///   - sourceAppearance: The source window's appearance for correct color resolution.
+    ///   - content: The SwiftUI view to display (typically a `VMenu`).
+    ///   - onDismiss: Called when the panel is dismissed for any reason.
+    /// - Returns: The panel instance (store it to keep the panel alive).
+    @discardableResult
+    public static func show<Content: View>(
+        at screenPoint: CGPoint,
+        sourceAppearance: NSAppearance? = nil,
+        @ViewBuilder content: () -> Content,
+        onDismiss: @escaping () -> Void
+    ) -> VMenuPanel {
+        let panel = VMenuPanel(
+            contentRect: .zero,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: true
+        )
+        panel.isFloatingPanel = true
+        panel.level = .popUpMenu
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.dismissHandler = onDismiss
+
+        if let appearance = sourceAppearance {
+            panel.appearance = appearance
+        }
+
+        // Inject auto-dismiss environment and add shadow padding.
+        // The dismiss closure captures `panel` (a local var) directly —
+        // NOT the caller's @State, which wouldn't be assigned yet.
+        let paddedContent = content()
+            .environment(\.vMenuDismiss, { [weak panel] in panel?.close() })
+            .padding(Self.shadowInset)
+        let hostingView = NSHostingView(rootView: paddedContent)
+        hostingView.sizingOptions = [.intrinsicContentSize]
+
+        // Wrap in FirstMouseView so clicks register immediately
+        let container = FirstMouseView()
+        container.wantsLayer = true
+        container.layer?.backgroundColor = .clear
+
+        hostingView.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(hostingView)
+        NSLayoutConstraint.activate([
+            hostingView.topAnchor.constraint(equalTo: container.topAnchor),
+            hostingView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            hostingView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            hostingView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+        ])
+        panel.contentView = container
+
+        // Size and position
+        let intrinsicSize = hostingView.intrinsicContentSize
+        let menuSize = CGSize(
+            width: max(intrinsicSize.width, 1),
+            height: max(intrinsicSize.height, 1)
+        )
+
+        // Clamp to screen bounds so the menu doesn't go off-screen
+        let origin = panel.clampedOrigin(for: menuSize, cursorAt: screenPoint)
+        panel.setFrame(CGRect(origin: origin, size: menuSize), display: true)
+        panel.makeKeyAndOrderFront(nil)
+
+        // Click-outside dismissal (async to skip the opening right-click)
+        DispatchQueue.main.async {
+            panel.clickMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { event in
+                let locationInPanel = panel.convertPoint(fromScreen: NSEvent.mouseLocation)
+                let panelBounds = panel.contentView?.bounds ?? .zero
+                if panelBounds.contains(locationInPanel) {
+                    return event
+                }
+                panel.close()
+                return event
+            }
+        }
+
+        return panel
+    }
+
+    /// Calculate panel origin clamped to visible screen bounds.
+    private func clampedOrigin(for size: CGSize, cursorAt cursor: CGPoint) -> CGPoint {
+        let screen = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? .zero
+
+        // Default: menu top-left at cursor, growing down-right.
+        // Offset by shadowInset so the VMenu's visual edge aligns with the cursor.
+        var x = cursor.x - Self.shadowInset
+        var y = cursor.y - size.height + Self.shadowInset
+
+        // Clamp right edge
+        if x + size.width > screen.maxX {
+            x = cursor.x - size.width + Self.shadowInset
+        }
+        // Clamp left edge
+        if x < screen.minX {
+            x = screen.minX
+        }
+        // Clamp bottom edge — flip upward if needed
+        if y < screen.minY {
+            y = cursor.y - Self.shadowInset
+        }
+        // Clamp top edge
+        if y + size.height > screen.maxY {
+            y = screen.maxY - size.height
+        }
+
+        return CGPoint(x: x, y: y)
+    }
+
+    public override func close() {
+        clickMonitor.flatMap(NSEvent.removeMonitor)
+        clickMonitor = nil
+        dismissHandler?()
+        dismissHandler = nil
+        super.close()
+    }
+
+    public override func cancelOperation(_ sender: Any?) {
+        close()
+    }
+
+    public override var canBecomeKey: Bool { true }
+    public override var canBecomeMain: Bool { false }
+}
+
+// MARK: - FirstMouseView
+
+/// Container view that accepts first-mouse clicks so taps work immediately
+/// in a floating panel without requiring a focus click first.
+class FirstMouseView: NSView {
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+}
+
+// MARK: - .vContextMenu modifier
+
+public extension View {
+    /// Attaches a custom context menu using `VMenu` that appears on right-click.
+    ///
+    /// Menu items (`VMenuItem`) automatically dismiss the menu when tapped.
+    ///
+    /// Usage:
+    /// ```swift
+    /// Text("Hello")
+    ///     .vContextMenu {
+    ///         VMenuItem(icon: VIcon.copy.rawValue, label: "Copy") { handleCopy() }
+    ///         VMenuDivider()
+    ///         VMenuItem(icon: VIcon.trash.rawValue, label: "Delete") { handleDelete() }
+    ///     }
+    /// ```
+    func vContextMenu<Content: View>(
+        width: CGFloat? = nil,
+        @ViewBuilder content: @escaping () -> Content
+    ) -> some View {
+        modifier(VContextMenuModifier(menuWidth: width, menuContent: content))
+    }
+}
+
+private struct VContextMenuModifier<MenuContent: View>: ViewModifier {
+    let menuWidth: CGFloat?
+    @ViewBuilder let menuContent: () -> MenuContent
+
+    @State private var panel: VMenuPanel?
+    @State private var sourceAppearance: NSAppearance?
+
+    func body(content: Content) -> some View {
+        content
+            .onRightClick { screenPoint in
+                panel?.close()
+
+                // Capture appearance from the current window
+                let appearance = sourceAppearance
+
+                panel = VMenuPanel.show(
+                    at: screenPoint,
+                    sourceAppearance: appearance
+                ) {
+                    VMenu(width: menuWidth) {
+                        menuContent()
+                    }
+                } onDismiss: {
+                    panel = nil
+                }
+            }
+            .background {
+                // Capture the source window's appearance for the panel
+                GeometryReader { _ in
+                    Color.clear
+                        .onAppear {
+                            sourceAppearance = NSApp.keyWindow?.effectiveAppearance
+                        }
+                }
+                .frame(width: 0, height: 0)
+            }
+    }
+}
+#endif

--- a/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
@@ -47,7 +47,7 @@ public struct VSplitButton<MenuContent: View>: View {
             Button(action: action) {
                 HStack(spacing: VSpacing.sm) {
                     if let icon {
-                        VIconView(.resolve(icon), size: 13)
+                        VIconView(.resolve(icon), size: VSize.iconDefault)
                     }
                     Text(label)
                         .font(size == .regular ? VFont.bodyMediumDefault : VFont.labelDefault)

--- a/clients/shared/DesignSystem/Core/Navigation/VSidebarRow.swift
+++ b/clients/shared/DesignSystem/Core/Navigation/VSidebarRow.swift
@@ -26,11 +26,8 @@ public struct VSidebarRow<Trailing: View>: View {
 
     @State private var isHovered = false
 
-    /// Icon slot size — all leading icons occupy a uniform 20x20 frame.
-    private static var iconSlotSize: CGFloat { 20 }
-
-    /// Minimum row height to ensure touch/click targets remain accessible.
-    private static var rowMinHeight: CGFloat { 32 }
+    private static var iconSlotSize: CGFloat { VSize.iconSlot }
+    private static var rowMinHeight: CGFloat { VSize.rowMinHeight }
 
     public init(
         icon: String? = nil,
@@ -59,7 +56,7 @@ public struct VSidebarRow<Trailing: View>: View {
     public var body: some View {
         HStack(spacing: isExpanded ? VSpacing.xs : 0) {
             if let icon {
-                VIconView(.resolve(icon), size: 13)
+                VIconView(.resolve(icon), size: VSize.iconDefault)
                     .foregroundStyle(iconColor)
                     .frame(width: Self.iconSlotSize, height: Self.iconSlotSize)
             }

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -130,6 +130,7 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
                 GalleryComponent("vSidebarRow", "VSidebarRow", keywords: ["sidebar row", "navigation row"], description: "Sidebar navigation row with icon, label, hover/active states, trailing disclosure icon, and collapsed mode."),
                 GalleryComponent("vLink", "VLink", keywords: ["link", "url", "external link", "hyperlink"], description: "Styled external link that opens a URL in the default browser. Applies pointer cursor, single-line truncation, and caption font by default."),
                 GalleryComponent("vThemeToggle", "VThemeToggle", keywords: ["theme toggle", "dark mode", "light mode"], description: "Three-way theme toggle (System / Light / Dark). Reads and writes themePreference in UserDefaults."),
+                GalleryComponent("vMenu", "VMenu", keywords: ["menu", "popover", "dropdown", "drawer", "overflow"], description: "Reusable popover container with section headers, dividers, action items, and custom rows. Use instead of manual drawer chrome."),
             ]
         case .tokens:
             return [

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -123,6 +123,7 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
                 GalleryComponent("ifMod", ".if()", keywords: ["conditional modifier"], description: "Conditionally applies a view transformation. Use sparingly — prefer named modifiers for common patterns."),
                 GalleryComponent("vShimmer", ".vShimmer()", keywords: ["shimmer", "loading animation"], description: "Sweeps a translucent highlight across the view for skeleton loading animations. Respects reduced motion."),
                 GalleryComponent("inlineWidgetCard", ".inlineWidgetCard()", keywords: ["inline widget", "card"], description: "Standard card chrome for inline chat widgets with padding, background, border, and optional hover highlight."),
+                GalleryComponent("onRightClick", ".onRightClick()", keywords: ["right click", "right-click", "secondary click", "context"], description: "Detects right-click (secondary click) and reports screen-coordinate position. Does not interfere with left-click, hover, or drag."),
             ]
         case .navigation:
             return [
@@ -131,6 +132,7 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
                 GalleryComponent("vLink", "VLink", keywords: ["link", "url", "external link", "hyperlink"], description: "Styled external link that opens a URL in the default browser. Applies pointer cursor, single-line truncation, and caption font by default."),
                 GalleryComponent("vThemeToggle", "VThemeToggle", keywords: ["theme toggle", "dark mode", "light mode"], description: "Three-way theme toggle (System / Light / Dark). Reads and writes themePreference in UserDefaults."),
                 GalleryComponent("vMenu", "VMenu", keywords: ["menu", "popover", "dropdown", "drawer", "overflow"], description: "Reusable popover container with section headers, dividers, action items, and custom rows. Use instead of manual drawer chrome."),
+                GalleryComponent("vContextMenu", ".vContextMenu()", keywords: ["context menu", "right click", "right-click", "secondary click"], description: "Custom context menu using VMenu that appears on right-click. Menu items auto-dismiss. Uses a floating NSPanel for correct z-order and positioning."),
             ]
         case .tokens:
             return [

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -124,6 +124,7 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
                 GalleryComponent("vShimmer", ".vShimmer()", keywords: ["shimmer", "loading animation"], description: "Sweeps a translucent highlight across the view for skeleton loading animations. Respects reduced motion."),
                 GalleryComponent("inlineWidgetCard", ".inlineWidgetCard()", keywords: ["inline widget", "card"], description: "Standard card chrome for inline chat widgets with padding, background, border, and optional hover highlight."),
                 GalleryComponent("onRightClick", ".onRightClick()", keywords: ["right click", "right-click", "secondary click", "context"], description: "Detects right-click (secondary click) and reports screen-coordinate position. Does not interfere with left-click, hover, or drag."),
+                GalleryComponent("vContextMenu", ".vContextMenu()", keywords: ["context menu", "right click", "right-click", "secondary click"], description: "Custom context menu using VMenu that appears on right-click. Menu items auto-dismiss. Uses a floating NSPanel for correct z-order and positioning.", useInsteadOf: ".contextMenu { } when you want VMenu styling"),
             ]
         case .navigation:
             return [
@@ -132,7 +133,6 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
                 GalleryComponent("vLink", "VLink", keywords: ["link", "url", "external link", "hyperlink"], description: "Styled external link that opens a URL in the default browser. Applies pointer cursor, single-line truncation, and caption font by default."),
                 GalleryComponent("vThemeToggle", "VThemeToggle", keywords: ["theme toggle", "dark mode", "light mode"], description: "Three-way theme toggle (System / Light / Dark). Reads and writes themePreference in UserDefaults."),
                 GalleryComponent("vMenu", "VMenu", keywords: ["menu", "popover", "dropdown", "drawer", "overflow"], description: "Reusable popover container with section headers, dividers, action items, and custom rows. Use instead of manual drawer chrome."),
-                GalleryComponent("vContextMenu", ".vContextMenu()", keywords: ["context menu", "right click", "right-click", "secondary click"], description: "Custom context menu using VMenu that appears on right-click. Menu items auto-dismiss. Uses a floating NSPanel for correct z-order and positioning."),
             ]
         case .tokens:
             return [

--- a/clients/shared/DesignSystem/Gallery/Sections/ModifiersGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ModifiersGallerySection.swift
@@ -348,9 +348,49 @@ struct ModifiersGallerySection: View {
                 }
             }
 
+            #if os(macOS)
+            if filter == nil || filter == "onRightClick" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+                // MARK: - .onRightClick()
+                GallerySectionHeader(
+                    title: ".onRightClick()",
+                    description: "Detects right-click (secondary click) and reports the screen-coordinate position. Uses an NSEvent local monitor so it does not interfere with left-click, hover, or drag gestures."
+                )
+
+                VCard {
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
+                        Text("Right-click the area below").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
+
+                        RightClickDemo()
+                    }
+                }
+            }
+            #endif
+
         }
     }
 }
+
+#if os(macOS)
+private struct RightClickDemo: View {
+    @State private var lastClick: String = "No right-click yet"
+
+    var body: some View {
+        Text(lastClick)
+            .font(VFont.bodyMediumDefault)
+            .foregroundStyle(VColor.contentDefault)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(VSpacing.lg)
+            .background(VColor.surfaceBase)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .onRightClick { point in
+                lastClick = "Right-clicked at (\(Int(point.x)), \(Int(point.y)))"
+            }
+    }
+}
+#endif
 
 // MARK: - Component Page Router
 
@@ -366,6 +406,7 @@ extension ModifiersGallerySection {
         case "ifMod": ModifiersGallerySection(filter: "ifMod")
         case "vShimmer": ModifiersGallerySection(filter: "vShimmer")
         case "inlineWidgetCard": ModifiersGallerySection(filter: "inlineWidgetCard")
+        case "onRightClick": ModifiersGallerySection(filter: "onRightClick")
         default: EmptyView()
         }
     }

--- a/clients/shared/DesignSystem/Gallery/Sections/ModifiersGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ModifiersGallerySection.swift
@@ -367,6 +367,64 @@ struct ModifiersGallerySection: View {
                     }
                 }
             }
+
+            if filter == nil || filter == "vContextMenu" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+                // MARK: - .vContextMenu()
+                GallerySectionHeader(
+                    title: ".vContextMenu()",
+                    description: "Custom context menu using VMenu that appears on right-click. Menu items auto-dismiss the menu when tapped. Uses a floating NSPanel for correct z-order and screen-edge clamping.",
+                    useInsteadOf: ".contextMenu { } when you want VMenu styling"
+                )
+
+                VCard {
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
+                        Text("Right-click the card below").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
+
+                        Text("Right-click me!")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentDefault)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(VSpacing.lg)
+                            .background(VColor.surfaceBase)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                            .vContextMenu(width: 200) {
+                                VMenuItem(icon: VIcon.copy.rawValue, label: "Copy") {}
+                                VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") {}
+                                VMenuItem(icon: VIcon.archive.rawValue, label: "Archive") {}
+                                VMenuDivider()
+                                VMenuItem(icon: VIcon.externalLink.rawValue, label: "Open in New Window") {}
+                            }
+                    }
+                }
+
+                VCard {
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
+                        Text("With sections and disabled items").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
+
+                        Text("Right-click me too!")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentDefault)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(VSpacing.lg)
+                            .background(VColor.surfaceBase)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                            .vContextMenu(width: 220) {
+                                VMenuSection(header: "Actions") {
+                                    VMenuItem(icon: VIcon.pin.rawValue, label: "Pin") {}
+                                    VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") {}
+                                    VMenuItem(icon: VIcon.archive.rawValue, label: "Archive") {}
+                                    VMenuItem(icon: VIcon.circle.rawValue, label: "Mark as unread") {}
+                                        .disabled(true)
+                                }
+                                VMenuDivider()
+                                VMenuItem(icon: VIcon.messageCircle.rawValue, label: "Share Feedback") {}
+                            }
+                    }
+                }
+            }
             #endif
 
         }
@@ -407,6 +465,7 @@ extension ModifiersGallerySection {
         case "vShimmer": ModifiersGallerySection(filter: "vShimmer")
         case "inlineWidgetCard": ModifiersGallerySection(filter: "inlineWidgetCard")
         case "onRightClick": ModifiersGallerySection(filter: "onRightClick")
+        case "vContextMenu": ModifiersGallerySection(filter: "vContextMenu")
         default: EmptyView()
         }
     }

--- a/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
@@ -252,6 +252,129 @@ struct NavigationGallerySection: View {
                 }
             }
 
+            if filter == nil || filter == "vMenu" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+                // MARK: - VMenu (Simple Action Menu)
+                GallerySectionHeader(
+                    title: "VMenu",
+                    description: "Reusable popover container with section headers, dividers, action items, and custom rows. Use instead of manual drawer chrome."
+                )
+
+                VCard {
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
+                        Text("Simple Action Menu").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
+
+                        VMenu {
+                            VMenuItem(icon: VIcon.copy.rawValue, label: "Copy") {}
+                            VMenuItem(icon: VIcon.gitBranch.rawValue, label: "Fork") {}
+                            VMenuItem(icon: VIcon.archive.rawValue, label: "Archive") {}
+                        }
+                    }
+                }
+
+                Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+
+                // MARK: - VMenu (Sections)
+                GallerySectionHeader(
+                    title: "VMenu with Sections",
+                    description: "VMenuSection groups items with an optional header label and divider."
+                )
+
+                VCard {
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
+                        Text("Menu with Section Headers").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
+
+                        VMenu {
+                            VMenuItem(icon: VIcon.pencil.rawValue, label: "Edit") {}
+                            VMenuItem(icon: VIcon.copy.rawValue, label: "Duplicate") {}
+
+                            VMenuSection(header: "Analytics") {
+                                VMenuItem(icon: VIcon.barChart.rawValue, label: "View Stats") {}
+                                VMenuItem(icon: VIcon.scrollText.rawValue, label: "View Logs") {}
+                            }
+
+                            VMenuSection(header: "Danger Zone") {
+                                VMenuItem(icon: VIcon.archive.rawValue, label: "Archive") {}
+                            }
+                        }
+                    }
+                }
+
+                Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+
+                // MARK: - VMenu (Active Item)
+                GallerySectionHeader(
+                    title: "VMenu with Active Item",
+                    description: "A VMenuItem with isActive: true shows the highlighted/selected state."
+                )
+
+                VCard {
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
+                        Text("Active Item Highlight").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
+
+                        VMenu {
+                            VMenuItem(icon: VIcon.pin.rawValue, label: "Pinned") {}
+                            VMenuItem(icon: VIcon.settings.rawValue, label: "Settings", isActive: true) {}
+                            VMenuItem(icon: VIcon.externalLink.rawValue, label: "Open External") {}
+                        }
+                    }
+                }
+
+                Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+
+                // MARK: - VMenu (Custom Row)
+                GallerySectionHeader(
+                    title: "VMenu with Custom Row",
+                    description: "VMenuCustomRow embeds arbitrary content in a menu with consistent horizontal alignment."
+                )
+
+                VCard {
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
+                        Text("Custom Row Content").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
+
+                        VMenu {
+                            VMenuItem(icon: VIcon.settings.rawValue, label: "Settings") {}
+                            VMenuDivider()
+                            VMenuCustomRow {
+                                HStack {
+                                    Text("Theme")
+                                        .font(VFont.bodySmallDefault)
+                                        .foregroundStyle(VColor.contentDefault)
+                                    Spacer()
+                                    VThemeToggle(showLabel: false)
+                                }
+                                .padding(.vertical, VSpacing.xs)
+                            }
+                            VMenuDivider()
+                            VMenuItem(icon: VIcon.logOut.rawValue, label: "Sign Out") {}
+                        }
+                    }
+                }
+
+                Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+
+                // MARK: - VMenu (Fixed Width)
+                GallerySectionHeader(
+                    title: "VMenu with Fixed Width",
+                    description: "Pass a width parameter to constrain the menu to a fixed size."
+                )
+
+                VCard {
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
+                        Text("Fixed Width (200pt)").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
+
+                        VMenu(width: 200) {
+                            VMenuItem(icon: VIcon.copy.rawValue, label: "Copy") {}
+                            VMenuItem(icon: VIcon.gitBranch.rawValue, label: "Fork") {}
+                            VMenuDivider()
+                            VMenuItem(icon: VIcon.archive.rawValue, label: "Archive") {}
+                        }
+                    }
+                }
+            }
+
         }
     }
 }
@@ -266,6 +389,7 @@ extension NavigationGallerySection {
         case "vSidebarRow": NavigationGallerySection(filter: "vSidebarRow")
         case "vLink": NavigationGallerySection(filter: "vLink")
         case "vThemeToggle": NavigationGallerySection(filter: "vThemeToggle")
+        case "vMenu": NavigationGallerySection(filter: "vMenu")
         default: EmptyView()
         }
     }

--- a/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
@@ -375,6 +375,67 @@ struct NavigationGallerySection: View {
                 }
             }
 
+            #if os(macOS)
+            if filter == nil || filter == "vContextMenu" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+                // MARK: - .vContextMenu
+                GallerySectionHeader(
+                    title: ".vContextMenu()",
+                    description: "Custom context menu using VMenu that appears on right-click. Menu items auto-dismiss the menu when tapped. Uses a floating NSPanel for correct z-order and screen-edge clamping.",
+                    useInsteadOf: ".contextMenu { } when you want VMenu styling"
+                )
+
+                VCard {
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
+                        Text("Right-click the card below").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
+
+                        Text("Right-click me!")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentDefault)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(VSpacing.lg)
+                            .background(VColor.surfaceBase)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                            .vContextMenu(width: 200) {
+                                VMenuItem(icon: VIcon.copy.rawValue, label: "Copy") {}
+                                VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") {}
+                                VMenuItem(icon: VIcon.archive.rawValue, label: "Archive") {}
+                                VMenuDivider()
+                                VMenuItem(icon: VIcon.externalLink.rawValue, label: "Open in New Window") {}
+                            }
+                    }
+                }
+
+                VCard {
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
+                        Text("With sections and disabled items").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
+
+                        Text("Right-click me too!")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentDefault)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(VSpacing.lg)
+                            .background(VColor.surfaceBase)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                            .vContextMenu(width: 220) {
+                                VMenuSection(header: "Actions") {
+                                    VMenuItem(icon: VIcon.pin.rawValue, label: "Pin") {}
+                                    VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") {}
+                                    VMenuItem(icon: VIcon.archive.rawValue, label: "Archive") {}
+                                    VMenuItem(icon: VIcon.circle.rawValue, label: "Mark as unread") {}
+                                        .opacity(0.4)
+                                        .disabled(true)
+                                }
+                                VMenuDivider()
+                                VMenuItem(icon: VIcon.messageCircle.rawValue, label: "Share Feedback") {}
+                            }
+                    }
+                }
+            }
+            #endif
+
         }
     }
 }
@@ -390,6 +451,7 @@ extension NavigationGallerySection {
         case "vLink": NavigationGallerySection(filter: "vLink")
         case "vThemeToggle": NavigationGallerySection(filter: "vThemeToggle")
         case "vMenu": NavigationGallerySection(filter: "vMenu")
+        case "vContextMenu": NavigationGallerySection(filter: "vContextMenu")
         default: EmptyView()
         }
     }

--- a/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
@@ -375,66 +375,6 @@ struct NavigationGallerySection: View {
                 }
             }
 
-            #if os(macOS)
-            if filter == nil || filter == "vContextMenu" {
-                if filter == nil {
-                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
-                }
-                // MARK: - .vContextMenu
-                GallerySectionHeader(
-                    title: ".vContextMenu()",
-                    description: "Custom context menu using VMenu that appears on right-click. Menu items auto-dismiss the menu when tapped. Uses a floating NSPanel for correct z-order and screen-edge clamping.",
-                    useInsteadOf: ".contextMenu { } when you want VMenu styling"
-                )
-
-                VCard {
-                    VStack(alignment: .leading, spacing: VSpacing.lg) {
-                        Text("Right-click the card below").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
-
-                        Text("Right-click me!")
-                            .font(VFont.bodyMediumDefault)
-                            .foregroundStyle(VColor.contentDefault)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(VSpacing.lg)
-                            .background(VColor.surfaceBase)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                            .vContextMenu(width: 200) {
-                                VMenuItem(icon: VIcon.copy.rawValue, label: "Copy") {}
-                                VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") {}
-                                VMenuItem(icon: VIcon.archive.rawValue, label: "Archive") {}
-                                VMenuDivider()
-                                VMenuItem(icon: VIcon.externalLink.rawValue, label: "Open in New Window") {}
-                            }
-                    }
-                }
-
-                VCard {
-                    VStack(alignment: .leading, spacing: VSpacing.lg) {
-                        Text("With sections and disabled items").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
-
-                        Text("Right-click me too!")
-                            .font(VFont.bodyMediumDefault)
-                            .foregroundStyle(VColor.contentDefault)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(VSpacing.lg)
-                            .background(VColor.surfaceBase)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                            .vContextMenu(width: 220) {
-                                VMenuSection(header: "Actions") {
-                                    VMenuItem(icon: VIcon.pin.rawValue, label: "Pin") {}
-                                    VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") {}
-                                    VMenuItem(icon: VIcon.archive.rawValue, label: "Archive") {}
-                                    VMenuItem(icon: VIcon.circle.rawValue, label: "Mark as unread") {}
-                                        .opacity(0.4)
-                                        .disabled(true)
-                                }
-                                VMenuDivider()
-                                VMenuItem(icon: VIcon.messageCircle.rawValue, label: "Share Feedback") {}
-                            }
-                    }
-                }
-            }
-            #endif
 
         }
     }
@@ -451,7 +391,6 @@ extension NavigationGallerySection {
         case "vLink": NavigationGallerySection(filter: "vLink")
         case "vThemeToggle": NavigationGallerySection(filter: "vThemeToggle")
         case "vMenu": NavigationGallerySection(filter: "vMenu")
-        case "vContextMenu": NavigationGallerySection(filter: "vContextMenu")
         default: EmptyView()
         }
     }

--- a/clients/shared/DesignSystem/Modifiers/VRightClickModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/VRightClickModifier.swift
@@ -4,9 +4,12 @@ import AppKit
 
 // MARK: - Right-click detection
 
-/// Detects right-click (secondary click) events on a view and reports the
-/// screen-coordinate position. Uses an NSEvent local monitor so it does not
-/// interfere with left-click, hover, or drag gestures.
+/// Detects right-click and Ctrl-click (secondary click) events on a view and
+/// reports the screen-coordinate position. Uses an NSEvent local monitor so it
+/// does not interfere with left-click, hover, or drag gestures.
+///
+/// The monitor is scoped to this view's window — events from other windows
+/// are ignored and passed through.
 private struct RightClickDetector: NSViewRepresentable {
     let action: (CGPoint) -> Void
 
@@ -20,7 +23,8 @@ private struct RightClickDetector: NSViewRepresentable {
 
     class RightClickNSView: NSView {
         var action: (CGPoint) -> Void
-        private var monitor: Any?
+        private var rightClickMonitor: Any?
+        private var ctrlClickMonitor: Any?
 
         init(action: @escaping (CGPoint) -> Void) {
             self.action = action
@@ -29,26 +33,45 @@ private struct RightClickDetector: NSViewRepresentable {
 
         required init?(coder: NSCoder) { fatalError() }
 
+        private func handleSecondaryClick(_ event: NSEvent) -> NSEvent? {
+            guard let myWindow = self.window else { return event }
+            // Only handle events from this view's window
+            guard event.window === myWindow else { return event }
+            let locationInView = self.convert(event.locationInWindow, from: nil)
+            if self.bounds.contains(locationInView) {
+                let screenPoint = myWindow.convertPoint(toScreen: event.locationInWindow)
+                self.action(screenPoint)
+                return nil
+            }
+            return event
+        }
+
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
-            monitor.flatMap(NSEvent.removeMonitor)
-            monitor = nil
+            removeMonitors()
             guard window != nil else { return }
-            monitor = NSEvent.addLocalMonitorForEvents(matching: .rightMouseDown) { [weak self] event in
-                guard let self, let window = self.window else { return event }
-                let locationInView = self.convert(event.locationInWindow, from: nil)
-                if self.bounds.contains(locationInView) {
-                    let screenPoint = window.convertPoint(toScreen: event.locationInWindow)
-                    self.action(screenPoint)
-                    return nil
-                }
-                return event
+
+            // Monitor right-click
+            rightClickMonitor = NSEvent.addLocalMonitorForEvents(matching: .rightMouseDown) { [weak self] event in
+                self?.handleSecondaryClick(event) ?? event
+            }
+
+            // Monitor Ctrl-click (standard macOS secondary click fallback)
+            ctrlClickMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { [weak self] event in
+                guard event.modifierFlags.contains(.control) else { return event }
+                return self?.handleSecondaryClick(event) ?? event
             }
         }
 
+        private func removeMonitors() {
+            rightClickMonitor.flatMap(NSEvent.removeMonitor)
+            rightClickMonitor = nil
+            ctrlClickMonitor.flatMap(NSEvent.removeMonitor)
+            ctrlClickMonitor = nil
+        }
+
         override func removeFromSuperview() {
-            monitor.flatMap(NSEvent.removeMonitor)
-            monitor = nil
+            removeMonitors()
             super.removeFromSuperview()
         }
 

--- a/clients/shared/DesignSystem/Modifiers/VRightClickModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/VRightClickModifier.swift
@@ -1,0 +1,72 @@
+#if os(macOS)
+import SwiftUI
+import AppKit
+
+// MARK: - Right-click detection
+
+/// Detects right-click (secondary click) events on a view and reports the
+/// screen-coordinate position. Uses an NSEvent local monitor so it does not
+/// interfere with left-click, hover, or drag gestures.
+private struct RightClickDetector: NSViewRepresentable {
+    let action: (CGPoint) -> Void
+
+    func makeNSView(context: Context) -> RightClickNSView {
+        RightClickNSView(action: action)
+    }
+
+    func updateNSView(_ nsView: RightClickNSView, context: Context) {
+        nsView.action = action
+    }
+
+    class RightClickNSView: NSView {
+        var action: (CGPoint) -> Void
+        private var monitor: Any?
+
+        init(action: @escaping (CGPoint) -> Void) {
+            self.action = action
+            super.init(frame: .zero)
+        }
+
+        required init?(coder: NSCoder) { fatalError() }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            monitor.flatMap(NSEvent.removeMonitor)
+            monitor = nil
+            guard window != nil else { return }
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .rightMouseDown) { [weak self] event in
+                guard let self, let window = self.window else { return event }
+                let locationInView = self.convert(event.locationInWindow, from: nil)
+                if self.bounds.contains(locationInView) {
+                    let screenPoint = window.convertPoint(toScreen: event.locationInWindow)
+                    self.action(screenPoint)
+                    return nil
+                }
+                return event
+            }
+        }
+
+        override func removeFromSuperview() {
+            monitor.flatMap(NSEvent.removeMonitor)
+            monitor = nil
+            super.removeFromSuperview()
+        }
+
+        // Never intercept hit testing — left clicks, hover, and drag pass through.
+        override func hitTest(_ point: NSPoint) -> NSView? { nil }
+    }
+}
+
+// MARK: - View extension
+
+public extension View {
+    /// Calls `action` with the screen-coordinate click position when the user
+    /// right-clicks (secondary clicks) anywhere on this view.
+    func onRightClick(perform action: @escaping (_ screenPoint: CGPoint) -> Void) -> some View {
+        background {
+            RightClickDetector(action: action)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+}
+#endif

--- a/clients/shared/DesignSystem/Tokens/SizingTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/SizingTokens.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Component sizing tokens for consistent dimensions across the design system.
+///
+/// Use these instead of hardcoded values for icon sizes, row heights, and slot frames.
+public enum VSize {
+    // MARK: - Icons
+
+    /// Default icon render size used in sidebar rows, menu items, and split buttons (13pt).
+    public static let iconDefault: CGFloat = 13
+
+    /// Frame size for the leading icon slot in rows — all icons occupy a uniform square frame (20pt).
+    public static let iconSlot: CGFloat = 20
+
+    // MARK: - Rows
+
+    /// Minimum row height for interactive list/menu rows to ensure accessible tap targets (32pt).
+    public static let rowMinHeight: CGFloat = 32
+}

--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -88,6 +88,11 @@ public enum VFont {
     public static let labelDefault = dmSans(weight: 400, size: 11)
     public static let labelSmall   = dmSans(weight: 400, size: 10)
 
+    // MARK: - Menu
+
+    /// 13pt DM Sans — compact menu item text matching sidebar conversation rows.
+    public static let menuCompact = dmSans(weight: 400, size: 13)
+
     // MARK: - Chat (Figma — 16pt Medium with 24px line height, applied via .lineSpacing)
 
     public static let chat = dmSans(weight: 400, size: 16)


### PR DESCRIPTION
## Summary
Extracts the duplicated popover/drawer chrome pattern into a reusable `VMenu` design system component and migrates all 3 existing one-off drawer components to use it.

## Changes
- **VMenu component** (`clients/shared/DesignSystem/Components/Navigation/VMenu.swift`): New reusable popover container with `VMenu`, `VMenuItem`, `VMenuSection`, `VMenuDivider`, and `VMenuCustomRow` primitives
- **Component gallery**: Added VMenu examples to NavigationGallerySection with 5 demos (simple menu, sections, active state, custom rows, fixed width)
- **ConversationActionsDrawer**: Migrated from manual VStack + chrome to `VMenu` + `VMenuItem`
- **DrawerMenuView**: Migrated from manual VStack + chrome to `VMenu` + `VMenuItem` + `VMenuCustomRow` + `VMenuDivider`
- **ConversationSwitcherDrawer**: Migrated from manual VStack + chrome to `VMenu` + `VMenuSection`

## Milestone PRs (merged into feature branch)
- #21609: M1: Create VMenu design system component
- #21610: M2: Add VMenu to component gallery
- #21611: M3: Migrate ConversationActionsDrawer to VMenu
- #21614: M4: Migrate DrawerMenuView to VMenu
- #21615: M5: Migrate ConversationSwitcherDrawer to VMenu

## Project issue
Closes #21603

## Test plan
- [ ] Open component gallery → Navigation → VMenu: verify all 5 examples render correctly
- [ ] Click conversation title header → verify actions drawer appears with same items and hover states
- [ ] Click sidebar settings icon → verify drawer menu appears with theme toggle, balance, and all action items
- [ ] Collapse sidebar → click conversation count badge → verify switcher drawer appears with conversation list
- [ ] Verify hover states work on all menu items in all 3 migrated drawers
- [ ] Verify dark mode renders correctly for all menus
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
