### PR TITLE
fix: add snapshot-level suppressionReason format assertion

### DIFF
--- a/clients/macos/vellum-assistantTests/MessageListScrollCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollCoordinatorTests.swift
@@ -424,4 +424,41 @@ final class MessageListScrollCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.activeSuppressionReasons, [],
                        "Empty after clearAll")
     }
+
+    // MARK: - Suppression: Snapshot String Format
+
+    /// Verifies the comma-joined suppressionReason string that gets passed to
+    /// ChatTranscriptSnapshot matches the expected format (e.g. "resize,expansion").
+    /// This catches formatting bugs like wrong separator, trailing commas, or
+    /// unexpected ordering that the array-level test above would not surface.
+    func testSuppressionReasonJoinedStringFormat() {
+        // No reasons → empty string (snapshot passes nil in this case).
+        XCTAssertEqual(coordinator.activeSuppressionReasons.joined(separator: ","), "",
+                       "No reasons should produce empty string")
+
+        // Single reason.
+        coordinator.beginResizeSuppression()
+        XCTAssertEqual(coordinator.activeSuppressionReasons.joined(separator: ","), "resize",
+                       "Single reason should produce plain string without separators")
+
+        // Two reasons — mirrors the snapshot construction expression exactly.
+        coordinator.beginExpansionSuppression()
+        XCTAssertEqual(coordinator.activeSuppressionReasons.joined(separator: ","), "resize,expansion",
+                       "Two reasons should be comma-separated with no spaces")
+
+        // All three reasons.
+        coordinator.beginPaginationSuppression()
+        XCTAssertEqual(coordinator.activeSuppressionReasons.joined(separator: ","), "resize,pagination,expansion",
+                       "Three reasons should be comma-separated in stable order")
+
+        // After clearing one, the joined string updates correctly.
+        coordinator.endResizeSuppression()
+        XCTAssertEqual(coordinator.activeSuppressionReasons.joined(separator: ","), "pagination,expansion",
+                       "Joined string should reflect remaining reasons after partial clear")
+
+        // After clearing all, back to empty.
+        coordinator.clearAllSuppression()
+        XCTAssertEqual(coordinator.activeSuppressionReasons.joined(separator: ","), "",
+                       "Joined string should be empty after clearAll")
+    }
 }


### PR DESCRIPTION
## Summary
Fixes gap from plan review for scroll-coord-phase2.md.

Adds test verifying the comma-joined suppressionReason string matches expected format for ChatTranscriptSnapshot.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
