### PR TITLE
fix: add missing VellumAssistantShared import to ScrollDiagnosticsRecorder

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ScrollDiagnosticsRecorder.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollDiagnosticsRecorder.swift
@@ -1,5 +1,6 @@
 import Foundation
 import os
+import VellumAssistantShared
 
 /// Owns all scroll-related diagnostic recording — loop detection, transcript
 /// snapshot capture, and non-finite geometry logging — extracted from


### PR DESCRIPTION
## Summary
ScrollDiagnosticsRecorder uses ChatMessage (defined in VellumAssistantShared) but was missing the import. Build error caught during local testing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
