### PR TITLE
Retry gateway credential bootstrap after CES startup

### DIFF
--- a/gateway/src/__tests__/credential-watcher-managed-bootstrap.test.ts
+++ b/gateway/src/__tests__/credential-watcher-managed-bootstrap.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const TEST_SERVICE_TOKEN = "test-ces-service-token";
+
+const testDir = join(tmpdir(), `gw-managed-${Date.now()}-${Math.random()}`);
+
+function metadataRecord(
+  credentialId: string,
+  service: string,
+  field: string,
+): Record<string, unknown> {
+  return {
+    credentialId,
+    service,
+    field,
+    allowedTools: [],
+    allowedDomains: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+function writeCredentialMetadata(
+  credentials: Record<string, unknown>[] = [
+    metadataRecord("test-bt", "telegram", "bot_token"),
+    metadataRecord("test-ws", "telegram", "webhook_secret"),
+  ],
+): void {
+  const dir = join(testDir, ".vellum", "workspace", "data", "credentials");
+  mkdirSync(dir, { recursive: true });
+  const metadataPath = join(dir, "metadata.json");
+  const tmpPath = join(dir, `.tmp-${Date.now()}-metadata.json`);
+  writeFileSync(
+    tmpPath,
+    JSON.stringify({
+      version: 2,
+      credentials,
+    }),
+  );
+  renameSync(tmpPath, metadataPath);
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const gatewayRoot = join(__dirname, "..", "..");
+const gatewayEntry = join(gatewayRoot, "src", "index.ts");
+
+let gatewayProc: ChildProcess | null = null;
+let gatewayPort = 0;
+let cesPort = 0;
+let cesServer: ReturnType<typeof Bun.serve> | null = null;
+
+async function startGateway(): Promise<void> {
+  gatewayPort = 49152 + Math.floor(Math.random() * 8_192);
+  cesPort = gatewayPort + 1;
+
+  gatewayProc = spawn("bun", ["run", gatewayEntry], {
+    env: {
+      ...process.env,
+      BASE_DATA_DIR: testDir,
+      GATEWAY_PORT: String(gatewayPort),
+      CES_CREDENTIAL_URL: `http://127.0.0.1:${cesPort}`,
+      CES_SERVICE_TOKEN: TEST_SERVICE_TOKEN,
+      TELEGRAM_BOT_TOKEN: "",
+      TELEGRAM_WEBHOOK_SECRET: "",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://localhost:${gatewayPort}/healthz`);
+      if (res.ok) return;
+    } catch {
+      // Gateway not ready yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error("Gateway failed to start within 5 seconds");
+}
+
+function startFakeCes(credentials: Record<string, string>): void {
+  cesServer = Bun.serve({
+    port: cesPort,
+    fetch(req) {
+      const authHeader = req.headers.get("authorization");
+      if (authHeader !== `Bearer ${TEST_SERVICE_TOKEN}`) {
+        return Response.json(
+          { error: "Invalid service token" },
+          { status: 403 },
+        );
+      }
+
+      const url = new URL(req.url);
+      if (req.method === "GET" && url.pathname === "/v1/credentials") {
+        return Response.json({ accounts: Object.keys(credentials) });
+      }
+
+      if (req.method === "GET" && url.pathname.startsWith("/v1/credentials/")) {
+        const account = decodeURIComponent(
+          url.pathname.slice("/v1/credentials/".length),
+        );
+        const value = credentials[account];
+        if (!value) {
+          return Response.json(
+            { error: "Credential not found", account },
+            { status: 404 },
+          );
+        }
+        return Response.json({ account, value });
+      }
+
+      return new Response("Not Found", { status: 404 });
+    },
+  });
+}
+
+afterEach(() => {
+  cesServer?.stop(true);
+  cesServer = null;
+
+  if (gatewayProc) {
+    gatewayProc.kill();
+    gatewayProc = null;
+  }
+
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe("gateway managed credential bootstrap retry", () => {
+  test("reloads Telegram credentials after CES becomes reachable without a metadata rewrite", async () => {
+    mkdirSync(testDir, { recursive: true });
+    writeCredentialMetadata();
+
+    await startGateway();
+
+    const base = `http://localhost:${gatewayPort}`;
+    const before = await fetch(`${base}/webhooks/telegram`, { method: "POST" });
+    expect(before.status).toBe(503);
+
+    startFakeCes({
+      "credential/telegram/bot_token": "fake-bot-token:ABC123",
+      "credential/telegram/webhook_secret": "fake-webhook-secret",
+    });
+
+    const deadline = Date.now() + 5_000;
+    let status = before.status;
+    while (Date.now() < deadline) {
+      const resp = await fetch(`${base}/webhooks/telegram`, {
+        method: "POST",
+      });
+      status = resp.status;
+      if (status === 401) break;
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+
+    expect(status).toBe(401);
+  }, 15_000);
+});

--- a/gateway/src/__tests__/credential-watcher-managed-bootstrap.test.ts
+++ b/gateway/src/__tests__/credential-watcher-managed-bootstrap.test.ts
@@ -54,9 +54,14 @@ let gatewayPort = 0;
 let cesPort = 0;
 let cesServer: ReturnType<typeof Bun.serve> | null = null;
 
-async function startGateway(): Promise<void> {
+function assignPorts(): void {
+  if (gatewayPort !== 0 && cesPort !== 0) return;
   gatewayPort = 49152 + Math.floor(Math.random() * 8_192);
   cesPort = gatewayPort + 1;
+}
+
+async function startGateway(): Promise<void> {
+  assignPorts();
 
   gatewayProc = spawn("bun", ["run", gatewayEntry], {
     env: {
@@ -84,7 +89,14 @@ async function startGateway(): Promise<void> {
   throw new Error("Gateway failed to start within 5 seconds");
 }
 
-function startFakeCes(credentials: Record<string, string>): void {
+function startFakeCes(opts: {
+  accounts?: string[];
+  credentials?: Record<string, string>;
+  resolveValue?: (account: string) => string | undefined;
+}): void {
+  assignPorts();
+  const accounts = opts.accounts ?? Object.keys(opts.credentials ?? {});
+  const credentials = opts.credentials ?? {};
   cesServer = Bun.serve({
     port: cesPort,
     fetch(req) {
@@ -98,14 +110,14 @@ function startFakeCes(credentials: Record<string, string>): void {
 
       const url = new URL(req.url);
       if (req.method === "GET" && url.pathname === "/v1/credentials") {
-        return Response.json({ accounts: Object.keys(credentials) });
+        return Response.json({ accounts });
       }
 
       if (req.method === "GET" && url.pathname.startsWith("/v1/credentials/")) {
         const account = decodeURIComponent(
           url.pathname.slice("/v1/credentials/".length),
         );
-        const value = credentials[account];
+        const value = opts.resolveValue?.(account) ?? credentials[account];
         if (!value) {
           return Response.json(
             { error: "Credential not found", account },
@@ -123,6 +135,8 @@ function startFakeCes(credentials: Record<string, string>): void {
 afterEach(() => {
   cesServer?.stop(true);
   cesServer = null;
+  gatewayPort = 0;
+  cesPort = 0;
 
   if (gatewayProc) {
     gatewayProc.kill();
@@ -144,9 +158,55 @@ describe("gateway managed credential bootstrap retry", () => {
     expect(before.status).toBe(503);
 
     startFakeCes({
-      "credential/telegram/bot_token": "fake-bot-token:ABC123",
-      "credential/telegram/webhook_secret": "fake-webhook-secret",
+      credentials: {
+        "credential/telegram/bot_token": "fake-bot-token:ABC123",
+        "credential/telegram/webhook_secret": "fake-webhook-secret",
+      },
     });
+
+    const deadline = Date.now() + 5_000;
+    let status = before.status;
+    while (Date.now() < deadline) {
+      const resp = await fetch(`${base}/webhooks/telegram`, {
+        method: "POST",
+      });
+      status = resp.status;
+      if (status === 401) break;
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+
+    expect(status).toBe(401);
+  }, 15_000);
+
+  test("keeps retrying until configured credential reads succeed after CES list is already available", async () => {
+    mkdirSync(testDir, { recursive: true });
+    writeCredentialMetadata();
+
+    let readsReady = false;
+    startFakeCes({
+      accounts: [
+        "credential/telegram/bot_token",
+        "credential/telegram/webhook_secret",
+      ],
+      resolveValue(account) {
+        if (!readsReady) return undefined;
+        if (account === "credential/telegram/bot_token") {
+          return "fake-bot-token:ABC123";
+        }
+        if (account === "credential/telegram/webhook_secret") {
+          return "fake-webhook-secret";
+        }
+        return undefined;
+      },
+    });
+
+    await startGateway();
+
+    const base = `http://localhost:${gatewayPort}`;
+    const before = await fetch(`${base}/webhooks/telegram`, { method: "POST" });
+    expect(before.status).toBe(503);
+
+    readsReady = true;
 
     const deadline = Date.now() + 5_000;
     let status = before.status;

--- a/gateway/src/credential-watcher.ts
+++ b/gateway/src/credential-watcher.ts
@@ -22,6 +22,8 @@ import {
 const log = getLogger("credential-watcher");
 
 const DEBOUNCE_MS = 500;
+const MANAGED_BOOTSTRAP_POLL_MS = 1_000;
+const MANAGED_BOOTSTRAP_TIMEOUT_MS = 1_000;
 
 export type CredentialChangeEvent = {
   /** Map from service name to resolved credentials (null if unavailable) */
@@ -35,6 +37,8 @@ export type CredentialChangeCallback = (event: CredentialChangeEvent) => void;
 export class CredentialWatcher {
   private watchers: FSWatcher[] = [];
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private managedBootstrapTimer: ReturnType<typeof setInterval> | null = null;
+  private managedBootstrapPollInFlight = false;
   private lastSerialized: Map<string, string> = new Map();
   private polling = false;
   private pendingPoll = false;
@@ -70,6 +74,8 @@ export class CredentialWatcher {
     // but the encrypted ciphertext will (new IV). Force a full reload so
     // channel listeners restart even when the plaintext values match.
     this.startWatcher(protectedDir, "keys.enc", { forceChanged: true });
+
+    this.startManagedBootstrapRetry();
   }
 
   private startWatcher(
@@ -101,11 +107,73 @@ export class CredentialWatcher {
       clearTimeout(this.debounceTimer);
       this.debounceTimer = null;
     }
+    if (this.managedBootstrapTimer) {
+      clearInterval(this.managedBootstrapTimer);
+      this.managedBootstrapTimer = null;
+    }
+    this.managedBootstrapPollInFlight = false;
     this.pendingPoll = false;
     for (const watcher of this.watchers) {
       watcher.close();
     }
     this.watchers = [];
+  }
+
+  private startManagedBootstrapRetry(): void {
+    const baseUrl = process.env.CES_CREDENTIAL_URL?.trim();
+    const serviceToken = process.env.CES_SERVICE_TOKEN?.trim();
+    if (!baseUrl || !serviceToken) return;
+
+    const poll = (): void => {
+      void this.pollManagedBootstrap(baseUrl, serviceToken);
+    };
+
+    this.managedBootstrapTimer = setInterval(poll, MANAGED_BOOTSTRAP_POLL_MS);
+    this.managedBootstrapTimer.unref?.();
+    poll();
+  }
+
+  private async pollManagedBootstrap(
+    baseUrl: string,
+    serviceToken: string,
+  ): Promise<void> {
+    if (this.managedBootstrapPollInFlight) return;
+    this.managedBootstrapPollInFlight = true;
+    try {
+      const resp = await fetch(`${baseUrl}/v1/credentials`, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${serviceToken}`,
+          Accept: "application/json",
+        },
+        signal: AbortSignal.timeout(MANAGED_BOOTSTRAP_TIMEOUT_MS),
+      });
+      if (resp.status === 401 || resp.status === 403 || resp.status === 404) {
+        if (this.managedBootstrapTimer) {
+          clearInterval(this.managedBootstrapTimer);
+          this.managedBootstrapTimer = null;
+        }
+        log.warn(
+          { status: resp.status },
+          "Stopping managed credential bootstrap retry due to non-retryable CES response",
+        );
+        return;
+      }
+      if (!resp.ok) {
+        return;
+      }
+
+      await this.pollOnce();
+
+      if (this.managedBootstrapTimer) {
+        clearInterval(this.managedBootstrapTimer);
+        this.managedBootstrapTimer = null;
+      }
+    } catch {
+      // CES isn't reachable yet. Keep retrying until the sidecar is ready.
+    } finally {
+      this.managedBootstrapPollInFlight = false;
+    }
   }
 
   /** Whether the next scheduled poll should treat all services as changed. */

--- a/gateway/src/credential-watcher.ts
+++ b/gateway/src/credential-watcher.ts
@@ -9,7 +9,13 @@
  * causing later credential changes to be missed until restart.
  */
 
-import { mkdirSync, watch, type FSWatcher } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  watch,
+  type FSWatcher,
+} from "node:fs";
 import { dirname, join } from "node:path";
 import { getLogger } from "./logger.js";
 import {
@@ -39,6 +45,8 @@ export class CredentialWatcher {
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private managedBootstrapTimer: ReturnType<typeof setInterval> | null = null;
   private managedBootstrapPollInFlight = false;
+  private lastConfiguredServices = new Set<string>();
+  private lastReadyServices = new Set<string>();
   private lastSerialized: Map<string, string> = new Map();
   private polling = false;
   private pendingPoll = false;
@@ -165,7 +173,7 @@ export class CredentialWatcher {
 
       await this.pollOnce();
 
-      if (this.managedBootstrapTimer) {
+      if (this.allConfiguredServicesReady() && this.managedBootstrapTimer) {
         clearInterval(this.managedBootstrapTimer);
         this.managedBootstrapTimer = null;
       }
@@ -203,9 +211,16 @@ export class CredentialWatcher {
     this.polling = true;
     try {
       const credentials = new Map<string, Record<string, string> | null>();
+      const configuredServices = this.loadConfiguredServices();
       for (const spec of ALL_CREDENTIAL_SPECS) {
         credentials.set(spec.service, await readServiceCredentials(spec));
       }
+      this.lastConfiguredServices = configuredServices;
+      this.lastReadyServices = new Set(
+        [...credentials.entries()]
+          .filter(([, creds]) => creds !== null)
+          .map(([service]) => service),
+      );
 
       const changedServices = new Set<string>();
       for (const [service, creds] of credentials) {
@@ -233,5 +248,43 @@ export class CredentialWatcher {
         void this.pollOnce(force);
       }
     }
+  }
+
+  private loadConfiguredServices(): Set<string> {
+    if (!existsSync(this.metadataPath)) return new Set();
+
+    try {
+      const raw = readFileSync(this.metadataPath, "utf-8");
+      const data = JSON.parse(raw) as {
+        credentials?: Array<{ service?: string; field?: string }>;
+      };
+      if (!Array.isArray(data.credentials)) return new Set();
+
+      const configured = new Set<string>();
+      for (const spec of ALL_CREDENTIAL_SPECS) {
+        const hasAllRequiredFields = spec.requiredFields.every((field) =>
+          data.credentials?.some(
+            (credential) =>
+              credential.service === spec.service && credential.field === field,
+          ),
+        );
+        if (hasAllRequiredFields) {
+          configured.add(spec.service);
+        }
+      }
+
+      return configured;
+    } catch {
+      return new Set();
+    }
+  }
+
+  private allConfiguredServicesReady(): boolean {
+    for (const service of this.lastConfiguredServices) {
+      if (!this.lastReadyServices.has(service)) {
+        return false;
+      }
+    }
+    return true;
   }
 }


### PR DESCRIPTION
## Summary
- retry gateway credential discovery while the managed CES sidecar is still coming up so Telegram and other channel readiness flags recover after restart without a credential rewrite
- stop the bootstrap retry loop once CES is reachable, and add a regression test covering the late-CES startup case

## Original prompt
 --safe restarting app and getting this │ gateway-sidecar [00:25:32.050] WARN (gateway/1): Telegram integration not configured — rejecting request with 503
│ gateway-sidecar     module: "main"
│ gateway-sidecar     integration: "Telegram"

even though it was configured is this a caching issue
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
