### PR TITLE
feat: add `assistant oauth providers update` CLI command

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -153,12 +153,20 @@ mock.module("../oauth/oauth-store.js", () => ({
   getProvider: (providerKey: string) => mockGetProvider(providerKey),
   listProviders: () => mockListProviders(),
   registerProvider: () => ({}),
+  updateProvider: () => undefined,
+  deleteProvider: () => false,
   seedProviders: () => {},
   getActiveConnection: () => undefined,
   listActiveConnectionsByProvider: () => [],
   createConnection: () => ({}),
   isProviderConnected: () => false,
   updateConnection: () => ({}),
+}));
+
+mock.module("../oauth/seed-providers.js", () => ({
+  SEEDED_PROVIDER_KEYS: new Set(["google", "slack", "github"]),
+  PROVIDER_SEED_DATA: {},
+  seedAllProviders: () => {},
 }));
 
 // Stub out transitive dependencies that token-manager would normally pull in

--- a/assistant/src/cli/commands/oauth/__tests__/providers-update.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/providers-update.test.ts
@@ -1,0 +1,313 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockGetProvider: (
+  key: string,
+) => Record<string, unknown> | undefined = () => undefined;
+
+let mockUpdateProvider: (
+  key: string,
+  params: Record<string, unknown>,
+) => Record<string, unknown> | undefined = () => undefined;
+
+let mockUpdateProviderCalls: Array<{
+  key: string;
+  params: Record<string, unknown>;
+}> = [];
+
+let mockSeededProviderKeys = new Set<string>(["google", "slack", "github"]);
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../../config/loader.js", () => ({
+  getConfig: () => ({ services: {} }),
+  loadConfig: () => ({ services: {} }),
+  API_KEY_PROVIDERS: [],
+}));
+
+mock.module("../../../../oauth/oauth-store.js", () => ({
+  getProvider: (key: string) => mockGetProvider(key),
+  updateProvider: (key: string, params: Record<string, unknown>) => {
+    mockUpdateProviderCalls.push({ key, params });
+    return mockUpdateProvider(key, params);
+  },
+  listProviders: () => [],
+  registerProvider: () => ({}),
+  seedProviders: () => {},
+  getConnection: () => undefined,
+  getConnectionByProvider: () => undefined,
+  getActiveConnection: () => undefined,
+  listActiveConnectionsByProvider: () => [],
+  isProviderConnected: () => false,
+  createConnection: () => ({}),
+  updateConnection: () => ({}),
+  deleteConnection: () => false,
+  upsertApp: async () => ({}),
+  getApp: () => undefined,
+  getAppByProviderAndClientId: () => undefined,
+  getMostRecentAppByProvider: () => undefined,
+  listApps: () => [],
+  deleteApp: async () => false,
+  listConnections: () => [],
+}));
+
+mock.module("../../../../oauth/seed-providers.js", () => ({
+  SEEDED_PROVIDER_KEYS: mockSeededProviderKeys,
+  PROVIDER_SEED_DATA: {},
+  seedAllProviders: () => {},
+}));
+
+mock.module("../../../../oauth/provider-behaviors.js", () => ({
+  getProviderBehavior: () => undefined,
+}));
+
+mock.module("../../../../inbound/public-ingress-urls.js", () => ({
+  getOAuthCallbackUrl: () => null,
+}));
+
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+const { registerProviderCommands } = await import("../providers.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = (() => true) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.option("--json", "JSON output");
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerProviderCommands(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return { exitCode, stdout: stdoutChunks.join("") };
+}
+
+// ---------------------------------------------------------------------------
+// Sample provider row
+// ---------------------------------------------------------------------------
+
+const sampleProviderRow = {
+  providerKey: "custom-api",
+  authUrl: "https://custom-api.example.com/oauth/authorize",
+  tokenUrl: "https://custom-api.example.com/oauth/token",
+  tokenEndpointAuthMethod: null,
+  userinfoUrl: null,
+  baseUrl: null,
+  defaultScopes: "[]",
+  scopePolicy: "{}",
+  extraParams: null,
+  callbackTransport: null,
+  managedServiceConfigKey: null,
+  pingUrl: null,
+  pingMethod: null,
+  pingHeaders: null,
+  pingBody: null,
+  displayName: null,
+  description: null,
+  dashboardUrl: null,
+  clientIdPlaceholder: null,
+  requiresClientSecret: 1,
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth providers update", () => {
+  beforeEach(() => {
+    mockGetProvider = () => undefined;
+    mockUpdateProvider = () => undefined;
+    mockUpdateProviderCalls = [];
+    mockSeededProviderKeys = new Set(["google", "slack", "github"]);
+    process.exitCode = 0;
+  });
+
+  // -------------------------------------------------------------------------
+  // Provider not found
+  // -------------------------------------------------------------------------
+
+  test("provider not found returns error with hint", async () => {
+    mockGetProvider = () => undefined;
+
+    const { exitCode, stdout } = await runCommand([
+      "providers",
+      "update",
+      "nonexistent",
+      "--display-name",
+      "Foo",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("not found");
+    expect(parsed.error).toContain("providers list");
+  });
+
+  // -------------------------------------------------------------------------
+  // Built-in provider
+  // -------------------------------------------------------------------------
+
+  test("built-in provider returns error suggesting register", async () => {
+    mockGetProvider = () => ({
+      providerKey: "google",
+      ...sampleProviderRow,
+      providerKey: "google",
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "providers",
+      "update",
+      "google",
+      "--display-name",
+      "Foo",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Cannot update built-in");
+    expect(parsed.error).toContain("providers register");
+  });
+
+  // -------------------------------------------------------------------------
+  // No options provided
+  // -------------------------------------------------------------------------
+
+  test("no options provided returns error", async () => {
+    mockGetProvider = () => ({ ...sampleProviderRow });
+
+    const { exitCode, stdout } = await runCommand([
+      "providers",
+      "update",
+      "custom-api",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Nothing to update");
+  });
+
+  // -------------------------------------------------------------------------
+  // Successful update with --display-name
+  // -------------------------------------------------------------------------
+
+  test("successful update with --display-name returns updated provider row", async () => {
+    mockGetProvider = () => ({ ...sampleProviderRow });
+    mockUpdateProvider = (_key, _params) => ({
+      ...sampleProviderRow,
+      displayName: "New Name",
+      updatedAt: Date.now(),
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "providers",
+      "update",
+      "custom-api",
+      "--display-name",
+      "New Name",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.providerKey).toBe("custom-api");
+    expect(parsed.displayName).toBe("New Name");
+  });
+
+  // -------------------------------------------------------------------------
+  // Successful update with multiple options
+  // -------------------------------------------------------------------------
+
+  test("successful update with multiple options passes all fields to updateProvider", async () => {
+    mockGetProvider = () => ({ ...sampleProviderRow });
+    mockUpdateProvider = (_key, _params) => ({
+      ...sampleProviderRow,
+      displayName: "My API",
+      defaultScopes: '["read","write"]',
+      authUrl: "https://new.example.com/auth",
+      updatedAt: Date.now(),
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "providers",
+      "update",
+      "custom-api",
+      "--display-name",
+      "My API",
+      "--scopes",
+      "read,write",
+      "--auth-url",
+      "https://new.example.com/auth",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.providerKey).toBe("custom-api");
+
+    // Verify updateProvider was called with the correct params
+    expect(mockUpdateProviderCalls).toHaveLength(1);
+    expect(mockUpdateProviderCalls[0].key).toBe("custom-api");
+    expect(mockUpdateProviderCalls[0].params).toEqual({
+      displayName: "My API",
+      defaultScopes: ["read", "write"],
+      authUrl: "https://new.example.com/auth",
+    });
+  });
+});

--- a/assistant/src/cli/commands/oauth/__tests__/providers-update.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/providers-update.test.ts
@@ -206,7 +206,6 @@ describe("assistant oauth providers update", () => {
 
   test("built-in provider returns error suggesting register", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
       ...sampleProviderRow,
       providerKey: "google",
     });

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -6,8 +6,10 @@ import {
   getProvider,
   listProviders,
   registerProvider,
+  updateProvider,
 } from "../../../oauth/oauth-store.js";
 import { getProviderBehavior } from "../../../oauth/provider-behaviors.js";
+import { SEEDED_PROVIDER_KEYS } from "../../../oauth/seed-providers.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 
@@ -325,6 +327,155 @@ Examples:
             clientIdPlaceholder: opts.clientIdPlaceholder,
             requiresClientSecret: opts.clientSecret ? 1 : 0,
           });
+
+          writeOutput(cmd, parseProviderRow(row));
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          writeOutput(cmd, { ok: false, error: message });
+          process.exitCode = 1;
+        }
+      },
+    );
+
+  // ---------------------------------------------------------------------------
+  // providers update <provider-key>
+  // ---------------------------------------------------------------------------
+
+  providers
+    .command("update <provider-key>")
+    .description("Update an existing custom OAuth provider configuration")
+    .option("--auth-url <url>", "Authorization endpoint URL")
+    .option("--token-url <url>", "Token endpoint URL")
+    .option("--base-url <url>", "API base URL")
+    .option("--userinfo-url <url>", "Userinfo endpoint URL")
+    .option("--scopes <scopes>", "Comma-separated default scopes")
+    .option("--token-auth-method <method>", "Token endpoint auth method")
+    .option("--callback-transport <transport>", "Callback transport")
+    .option(
+      "--ping-url <url>",
+      "Health-check endpoint URL for token validation",
+    )
+    .option(
+      "--ping-method <method>",
+      "HTTP method for the ping endpoint (default: GET)",
+    )
+    .option(
+      "--ping-headers <json>",
+      "JSON object of extra headers for the ping request",
+    )
+    .option("--ping-body <json>", "JSON body to send with the ping request")
+    .option("--display-name <name>", "Display name for the provider")
+    .option("--description <text>", "Short description")
+    .option("--dashboard-url <url>", "Developer console URL")
+    .option("--client-id-placeholder <text>", "Placeholder for client ID field")
+    .option(
+      "--no-client-secret",
+      "Set requires_client_secret to false (default is true)",
+    )
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  provider-key   Provider key to update (e.g. "custom-api").
+                 Run 'assistant oauth providers list' to see all registered providers.
+
+Only the fields you specify are updated — all other fields remain unchanged.
+Built-in providers (e.g. "google", "slack") cannot be updated; they are
+managed by the system and reset on startup. To create a custom provider with
+different settings, use 'assistant oauth providers register'.
+
+Examples:
+  $ assistant oauth providers update custom-api --display-name "My Custom API"
+  $ assistant oauth providers update custom-api --scopes read,write --auth-url https://new.example.com/auth
+  $ assistant oauth providers update custom-api --ping-url https://api.example.com/me --json`,
+    )
+    .action(
+      (
+        providerKey: string,
+        opts: {
+          authUrl?: string;
+          tokenUrl?: string;
+          baseUrl?: string;
+          userinfoUrl?: string;
+          scopes?: string;
+          tokenAuthMethod?: string;
+          callbackTransport?: string;
+          pingUrl?: string;
+          pingMethod?: string;
+          pingHeaders?: string;
+          pingBody?: string;
+          displayName?: string;
+          description?: string;
+          dashboardUrl?: string;
+          clientIdPlaceholder?: string;
+          clientSecret: boolean;
+        },
+        cmd: Command,
+      ) => {
+        try {
+          // Verify provider exists
+          const existing = getProvider(providerKey);
+          if (!existing) {
+            writeOutput(cmd, {
+              ok: false,
+              error: `Provider "${providerKey}" not found. Run 'assistant oauth providers list' to see all registered providers.`,
+            });
+            process.exitCode = 1;
+            return;
+          }
+
+          // Block updates to built-in providers
+          if (SEEDED_PROVIDER_KEYS.has(providerKey)) {
+            writeOutput(cmd, {
+              ok: false,
+              error: `Cannot update built-in provider "${providerKey}". Built-in providers are managed by the system and reset on startup. To create a custom provider with different settings, use 'assistant oauth providers register --provider-key <your-custom-key> ...'`,
+            });
+            process.exitCode = 1;
+            return;
+          }
+
+          // Build params object from provided options, omitting undefined values
+          const params: Record<string, unknown> = {};
+
+          if (opts.authUrl !== undefined) params.authUrl = opts.authUrl;
+          if (opts.tokenUrl !== undefined) params.tokenUrl = opts.tokenUrl;
+          if (opts.baseUrl !== undefined) params.baseUrl = opts.baseUrl;
+          if (opts.userinfoUrl !== undefined)
+            params.userinfoUrl = opts.userinfoUrl;
+          if (opts.scopes !== undefined)
+            params.defaultScopes = opts.scopes.split(",");
+          if (opts.tokenAuthMethod !== undefined)
+            params.tokenEndpointAuthMethod = opts.tokenAuthMethod;
+          if (opts.callbackTransport !== undefined)
+            params.callbackTransport = opts.callbackTransport;
+          if (opts.pingUrl !== undefined) params.pingUrl = opts.pingUrl;
+          if (opts.pingMethod !== undefined)
+            params.pingMethod = opts.pingMethod;
+          if (opts.pingHeaders !== undefined)
+            params.pingHeaders = JSON.parse(opts.pingHeaders);
+          if (opts.pingBody !== undefined)
+            params.pingBody = JSON.parse(opts.pingBody);
+          if (opts.displayName !== undefined)
+            params.displayName = opts.displayName;
+          if (opts.description !== undefined)
+            params.description = opts.description;
+          if (opts.dashboardUrl !== undefined)
+            params.dashboardUrl = opts.dashboardUrl;
+          if (opts.clientIdPlaceholder !== undefined)
+            params.clientIdPlaceholder = opts.clientIdPlaceholder;
+
+          // Check if any fields were actually provided
+          if (Object.keys(params).length === 0) {
+            writeOutput(cmd, {
+              ok: false,
+              error:
+                "Nothing to update. Provide at least one option to change (e.g. --auth-url, --scopes, --display-name). Run 'assistant oauth providers update --help' for all options.",
+            });
+            process.exitCode = 1;
+            return;
+          }
+
+          const row = updateProvider(providerKey, params);
 
           writeOutput(cmd, parseProviderRow(row));
         } catch (err) {


### PR DESCRIPTION
## Summary
- Add `providers update <provider-key>` subcommand with all mutable provider fields as options
- Block updates to built-in (seeded) providers with actionable error suggesting `register`
- Require at least one option to be specified, with clear error if none provided
- Include comprehensive tests covering 404, built-in blocking, empty update, and success cases

Part of plan: oauth-provider-update-delete.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
