### PR TITLE
feat: add `assistant oauth providers delete` CLI command

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -153,6 +153,7 @@ mock.module("../oauth/oauth-store.js", () => ({
   getProvider: (providerKey: string) => mockGetProvider(providerKey),
   listProviders: () => mockListProviders(),
   registerProvider: () => ({}),
+  deleteProvider: () => false,
   seedProviders: () => {},
   getActiveConnection: () => undefined,
   listActiveConnectionsByProvider: () => [],
@@ -215,6 +216,18 @@ mock.module("../oauth/connect-orchestrator.js", () => ({
 mock.module("../oauth/provider-behaviors.js", () => ({
   getProviderBehavior: (providerKey: string) =>
     mockGetProviderBehavior(providerKey),
+}));
+
+mock.module("../oauth/seed-providers.js", () => ({
+  SEEDED_PROVIDER_KEYS: new Set([
+    "google",
+    "slack",
+    "github",
+    "notion",
+    "twitter",
+    "linear",
+  ]),
+  seedOAuthProviders: () => {},
 }));
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/cli/commands/oauth/__tests__/providers-delete.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/providers-delete.test.ts
@@ -1,0 +1,434 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockGetProvider: (
+  key: string,
+) => Record<string, unknown> | undefined = () => undefined;
+
+let mockDeleteProviderResult = false;
+
+let mockListAppsResult: Array<Record<string, unknown>> = [];
+
+let mockListConnectionsResult: Array<Record<string, unknown>> = [];
+
+let mockDeleteAppCalls: string[] = [];
+let mockDeleteAppResult = true;
+
+let mockDeleteConnectionCalls: string[] = [];
+let mockDeleteConnectionResult = true;
+
+let mockSeededProviderKeys = new Set<string>(["google", "slack", "github"]);
+
+let mockLogInfoCalls: string[] = [];
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+mock.module("../../../../config/loader.js", () => ({
+  getConfig: () => ({ services: {} }),
+  loadConfig: () => ({ services: {} }),
+  API_KEY_PROVIDERS: [],
+}));
+
+mock.module("../../../../oauth/oauth-store.js", () => ({
+  getProvider: (key: string) => mockGetProvider(key),
+  deleteProvider: () => mockDeleteProviderResult,
+  listApps: () => mockListAppsResult,
+  listConnections: (providerKey?: string) => {
+    if (providerKey) {
+      return mockListConnectionsResult.filter(
+        (c) => c.providerKey === providerKey,
+      );
+    }
+    return mockListConnectionsResult;
+  },
+  deleteApp: async (id: string) => {
+    mockDeleteAppCalls.push(id);
+    return mockDeleteAppResult;
+  },
+  deleteConnection: (id: string) => {
+    mockDeleteConnectionCalls.push(id);
+    return mockDeleteConnectionResult;
+  },
+  listProviders: () => [],
+  registerProvider: () => ({}),
+  seedProviders: () => {},
+  upsertApp: async () => ({}),
+  getApp: () => undefined,
+  getAppByProviderAndClientId: () => undefined,
+  getMostRecentAppByProvider: () => undefined,
+  createConnection: () => ({}),
+  updateConnection: () => ({}),
+  getConnection: () => undefined,
+  getActiveConnection: () => undefined,
+  getConnectionByProvider: () => undefined,
+  listActiveConnectionsByProvider: () => [],
+  isProviderConnected: () => false,
+  disconnectOAuthProvider: async () => "not-found",
+}));
+
+mock.module("../../../../oauth/seed-providers.js", () => ({
+  SEEDED_PROVIDER_KEYS: mockSeededProviderKeys,
+  seedOAuthProviders: () => {},
+}));
+
+mock.module("../../../../oauth/provider-behaviors.js", () => ({
+  getProviderBehavior: () => undefined,
+}));
+
+mock.module("../../../../inbound/public-ingress-urls.js", () => ({
+  getOAuthCallbackUrl: () => null,
+}));
+
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: (msg: string) => {
+      mockLogInfoCalls.push(msg);
+    },
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+const { registerProviderCommands } = await import("../providers.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCommand(
+  args: string[],
+): Promise<{ stdout: string; exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = (() => true) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.option("--json", "JSON output");
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerProviderCommands(program);
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return { exitCode, stdout: stdoutChunks.join("") };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth providers delete", () => {
+  beforeEach(() => {
+    mockGetProvider = () => undefined;
+    mockDeleteProviderResult = true;
+    mockListAppsResult = [];
+    mockListConnectionsResult = [];
+    mockDeleteAppCalls = [];
+    mockDeleteAppResult = true;
+    mockDeleteConnectionCalls = [];
+    mockDeleteConnectionResult = true;
+    mockSeededProviderKeys = new Set(["google", "slack", "github"]);
+    mockLogInfoCalls = [];
+    process.exitCode = 0;
+  });
+
+  // -------------------------------------------------------------------------
+  // Provider not found
+  // -------------------------------------------------------------------------
+
+  test("provider not found returns exit code 1 with actionable error", async () => {
+    mockGetProvider = () => undefined;
+
+    const { exitCode, stdout } = await runCommand([
+      "providers",
+      "delete",
+      "nonexistent",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("not found");
+    expect(parsed.error).toContain("nonexistent");
+    expect(parsed.error).toContain("providers list");
+  });
+
+  // -------------------------------------------------------------------------
+  // Provider with dependents, no --force
+  // -------------------------------------------------------------------------
+
+  test("provider with dependents and no --force returns exit code 1 with counts", async () => {
+    mockGetProvider = (key) =>
+      key === "custom-api"
+        ? { providerKey: "custom-api", authUrl: "https://example.com/auth" }
+        : undefined;
+
+    mockListAppsResult = [
+      {
+        id: "app-1",
+        providerKey: "custom-api",
+        clientId: "c1",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+      {
+        id: "app-2",
+        providerKey: "custom-api",
+        clientId: "c2",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    ];
+
+    mockListConnectionsResult = [
+      {
+        id: "conn-1",
+        providerKey: "custom-api",
+        oauthAppId: "app-1",
+        status: "active",
+      },
+      {
+        id: "conn-2",
+        providerKey: "custom-api",
+        oauthAppId: "app-1",
+        status: "active",
+      },
+      {
+        id: "conn-3",
+        providerKey: "custom-api",
+        oauthAppId: "app-2",
+        status: "active",
+      },
+    ];
+
+    const { exitCode, stdout } = await runCommand([
+      "providers",
+      "delete",
+      "custom-api",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("2 app(s)");
+    expect(parsed.error).toContain("3 connection(s)");
+    expect(parsed.error).toContain("--force");
+  });
+
+  // -------------------------------------------------------------------------
+  // Provider with dependents, --force
+  // -------------------------------------------------------------------------
+
+  test("provider with dependents and --force cascades deletion and returns summary", async () => {
+    mockGetProvider = (key) =>
+      key === "custom-api"
+        ? { providerKey: "custom-api", authUrl: "https://example.com/auth" }
+        : undefined;
+
+    mockListAppsResult = [
+      {
+        id: "app-1",
+        providerKey: "custom-api",
+        clientId: "c1",
+        clientSecretCredentialPath: "cred/app-1",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+      {
+        id: "app-other",
+        providerKey: "other-provider",
+        clientId: "c3",
+        clientSecretCredentialPath: "cred/app-other",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    ];
+
+    mockListConnectionsResult = [
+      {
+        id: "conn-1",
+        providerKey: "custom-api",
+        oauthAppId: "app-1",
+        status: "active",
+      },
+      {
+        id: "conn-2",
+        providerKey: "custom-api",
+        oauthAppId: "app-1",
+        status: "active",
+      },
+    ];
+
+    const { exitCode, stdout } = await runCommand([
+      "providers",
+      "delete",
+      "custom-api",
+      "--force",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.deleted.provider).toBe(1);
+    expect(parsed.deleted.apps).toBe(1); // Only custom-api apps, not other-provider
+    expect(parsed.deleted.connections).toBe(2);
+
+    // Verify connections were deleted
+    expect(mockDeleteConnectionCalls).toEqual(["conn-1", "conn-2"]);
+
+    // Verify only matching apps were deleted (not app-other)
+    expect(mockDeleteAppCalls).toEqual(["app-1"]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Provider with no dependents, no --force
+  // -------------------------------------------------------------------------
+
+  test("provider with no dependents and no --force deletes cleanly", async () => {
+    mockGetProvider = (key) =>
+      key === "custom-api"
+        ? { providerKey: "custom-api", authUrl: "https://example.com/auth" }
+        : undefined;
+
+    mockListAppsResult = [];
+    mockListConnectionsResult = [];
+
+    const { exitCode, stdout } = await runCommand([
+      "providers",
+      "delete",
+      "custom-api",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.deleted.provider).toBe(1);
+    expect(parsed.deleted.apps).toBe(0);
+    expect(parsed.deleted.connections).toBe(0);
+
+    // No cascade deletes should have happened
+    expect(mockDeleteConnectionCalls).toHaveLength(0);
+    expect(mockDeleteAppCalls).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Built-in provider with --force logs warning
+  // -------------------------------------------------------------------------
+
+  test("built-in provider with --force succeeds and logs warning about re-creation", async () => {
+    mockGetProvider = (key) =>
+      key === "google"
+        ? { providerKey: "google", authUrl: "https://accounts.google.com" }
+        : undefined;
+
+    mockListAppsResult = [
+      {
+        id: "app-g",
+        providerKey: "google",
+        clientId: "goog-client",
+        clientSecretCredentialPath: "cred/app-g",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    ];
+
+    mockListConnectionsResult = [
+      {
+        id: "conn-g",
+        providerKey: "google",
+        oauthAppId: "app-g",
+        status: "active",
+      },
+    ];
+
+    const { exitCode, stdout } = await runCommand([
+      "providers",
+      "delete",
+      "google",
+      "--force",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.deleted.provider).toBe(1);
+    expect(parsed.deleted.apps).toBe(1);
+    expect(parsed.deleted.connections).toBe(1);
+
+    // Should have logged a warning about re-creation
+    const warningLogged = mockLogInfoCalls.some(
+      (msg) => msg.includes("built-in") && msg.includes("re-created"),
+    );
+    expect(warningLogged).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Built-in provider without --force and no dependents logs warning
+  // -------------------------------------------------------------------------
+
+  test("built-in provider without --force and no dependents logs warning and deletes", async () => {
+    mockGetProvider = (key) =>
+      key === "google"
+        ? { providerKey: "google", authUrl: "https://accounts.google.com" }
+        : undefined;
+
+    mockListAppsResult = [];
+    mockListConnectionsResult = [];
+
+    const { exitCode, stdout } = await runCommand([
+      "providers",
+      "delete",
+      "google",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.deleted.provider).toBe(1);
+
+    // Should have logged a warning about re-creation
+    const warningLogged = mockLogInfoCalls.some(
+      (msg) => msg.includes("built-in") && msg.includes("re-created"),
+    );
+    expect(warningLogged).toBe(true);
+  });
+});

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -3,11 +3,17 @@ import { type Command } from "commander";
 import { loadConfig } from "../../../config/loader.js";
 import { getOAuthCallbackUrl } from "../../../inbound/public-ingress-urls.js";
 import {
+  deleteApp,
+  deleteConnection,
+  deleteProvider,
   getProvider,
+  listApps,
+  listConnections,
   listProviders,
   registerProvider,
 } from "../../../oauth/oauth-store.js";
 import { getProviderBehavior } from "../../../oauth/provider-behaviors.js";
+import { SEEDED_PROVIDER_KEYS } from "../../../oauth/seed-providers.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 
@@ -327,6 +333,107 @@ Examples:
           });
 
           writeOutput(cmd, parseProviderRow(row));
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          writeOutput(cmd, { ok: false, error: message });
+          process.exitCode = 1;
+        }
+      },
+    );
+
+  // ---------------------------------------------------------------------------
+  // providers delete <provider-key>
+  // ---------------------------------------------------------------------------
+
+  providers
+    .command("delete <provider-key>")
+    .description(
+      "Delete a custom OAuth provider and optionally its associated apps and connections",
+    )
+    .option(
+      "--force",
+      "Cascade-delete all associated apps and connections before removing the provider",
+    )
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  provider-key   Provider key to delete (e.g. "custom-api").
+                 Run 'assistant oauth providers list' to see registered providers.
+
+When --force is specified, all OAuth connections and apps that depend on
+this provider are deleted before the provider itself is removed. Without
+--force, the command refuses to delete a provider that has dependents and
+exits with an error listing the counts.
+
+Built-in providers (e.g. "google", "slack") can be deleted, but a warning
+is emitted because they will be re-created automatically on the next
+assistant startup.
+
+Examples:
+  $ assistant oauth providers delete custom-api
+  $ assistant oauth providers delete custom-api --force
+  $ assistant oauth providers delete custom-api --force --json`,
+    )
+    .action(
+      async (providerKey: string, opts: { force?: boolean }, cmd: Command) => {
+        try {
+          const provider = getProvider(providerKey);
+          if (!provider) {
+            writeOutput(cmd, {
+              ok: false,
+              error: `Provider not found: "${providerKey}". Run 'assistant oauth providers list' to see all registered providers.`,
+            });
+            process.exitCode = 1;
+            return;
+          }
+
+          if (SEEDED_PROVIDER_KEYS.has(providerKey) && !opts.force) {
+            log.info(
+              `Note: "${providerKey}" is a built-in provider and will be re-created on next startup.`,
+            );
+          }
+
+          const dependentApps = listApps().filter(
+            (a) => a.providerKey === providerKey,
+          );
+          const dependentConnections = listConnections(providerKey);
+          const appCount = dependentApps.length;
+          const connCount = dependentConnections.length;
+
+          if ((appCount > 0 || connCount > 0) && !opts.force) {
+            writeOutput(cmd, {
+              ok: false,
+              error: `Cannot delete provider "${providerKey}": ${appCount} app(s) and ${connCount} connection(s) depend on it. Use --force to cascade-delete all dependent apps and connections, or remove them manually first with 'assistant oauth apps delete' and 'assistant oauth disconnect'.`,
+            });
+            process.exitCode = 1;
+            return;
+          }
+
+          // Warn about built-in providers when --force is used
+          if (SEEDED_PROVIDER_KEYS.has(providerKey) && opts.force) {
+            log.info(
+              `Note: "${providerKey}" is a built-in provider and will be re-created on next startup.`,
+            );
+          }
+
+          // Cascade-delete connections first, then apps, then the provider.
+          for (const conn of dependentConnections) {
+            deleteConnection(conn.id);
+          }
+          for (const app of dependentApps) {
+            await deleteApp(app.id);
+          }
+          deleteProvider(providerKey);
+
+          if (!shouldOutputJson(cmd)) {
+            log.info(`Deleted provider: ${providerKey}`);
+          }
+
+          writeOutput(cmd, {
+            ok: true,
+            deleted: { provider: 1, apps: appCount, connections: connCount },
+          });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           writeOutput(cmd, { ok: false, error: message });


### PR DESCRIPTION
## Summary
- Add `providers delete <provider-key>` subcommand for removing custom providers
- Support `--force` flag for cascade-deleting dependent apps and connections
- Warn (but allow) deletion of built-in providers that will be re-created on startup
- Include comprehensive tests covering 404, dependents blocking, force cascade, and built-in warning

Part of plan: oauth-provider-update-delete.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
