### PR TITLE
feat: auto-initiate A2A pairing from contact_message when target is unknown

### DIFF
--- a/assistant/src/__tests__/a2a-lifecycle-e2e.test.ts
+++ b/assistant/src/__tests__/a2a-lifecycle-e2e.test.ts
@@ -71,7 +71,6 @@ import type {
 } from "../runtime/a2a/index.js";
 import {
   completePairingApproval,
-  completePairingVerification,
   handleInboundPairingRequest,
   handlePairingAccepted,
   handlePairingFinalize,

--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -443,19 +443,28 @@ Replace `<invite_id>` with the invite's `id` from the list response. The same re
 
 ## Assistant-to-Assistant Messaging
 
-Send messages to other paired assistants using the `contact_message` tool. This requires:
+Send messages to other assistants using the `contact_message` tool. The `assistant-a2a` feature flag must be enabled.
 
-1. The target contact must be of type `assistant` (set via `--contact-type assistant` during creation or A2A pairing).
-2. The target contact must have valid Vellum assistant metadata (set during A2A pairing).
-3. The `assistant-a2a` feature flag must be enabled.
-
-### Send a message to an assistant contact
+### Send a message to a known assistant contact
 
 Use the `contact_message` tool to send a message to a known assistant contact. You can identify the target by either `contact_id` or `contact_name`.
 
 When `contact_name` is used, the tool searches for assistant contacts matching the name. If multiple matches are found, the tool returns the list for disambiguation -- the user must then specify the `contact_id`.
 
 The tool sends the message through the gateway's A2A delivery endpoint. The daemon sends a standard channel reply payload -- all A2A envelope construction and credential resolution is handled by the gateway.
+
+### Auto-pairing: messaging an unknown assistant
+
+When the user wants to message an assistant that isn't a contact yet, provide `gateway_url` and `assistant_id` along with the `message` in the `contact_message` tool call. The tool will automatically initiate A2A pairing:
+
+1. User says something like "message the assistant at http://localhost:8002 with ID bob-123 and ask about coffee"
+2. Call `contact_message` with `message`, `gateway_url`, and `assistant_id` (and optionally `contact_name`)
+3. The tool detects the target isn't a contact, sends a pairing request, and returns a message asking for the verification code
+4. Tell the user: the target assistant's guardian needs to approve and share a 6-digit verification code
+5. When the user provides the code, call `contact_pair_verify` with the `code`
+6. Once pairing completes, call `contact_message` again with the original message -- the target is now a contact
+
+This mirrors how Telegram/Slack contact flows work: pairing is a natural side effect of trying to communicate, not a separate manual step.
 
 ### Reply routing
 

--- a/assistant/src/config/bundled-skills/contacts/TOOLS.json
+++ b/assistant/src/config/bundled-skills/contacts/TOOLS.json
@@ -163,7 +163,7 @@
     },
     {
       "name": "contact_message",
-      "description": "Send a message to a known assistant contact via assistant-to-assistant (A2A) messaging. Requires the target contact to be of type 'assistant' with valid Vellum assistant metadata from a completed A2A pairing.",
+      "description": "Send a message to an assistant contact via assistant-to-assistant (A2A) messaging. If the target isn't a contact yet, provide gateway_url and assistant_id to automatically initiate pairing — the user then submits the verification code via contact_pair_verify before the message can be sent.",
       "category": "contacts",
       "risk": "medium",
       "input_schema": {
@@ -181,6 +181,14 @@
             "type": "string",
             "description": "The message content to send to the target assistant"
           },
+          "gateway_url": {
+            "type": "string",
+            "description": "The gateway URL of the target assistant (e.g. https://gateway.example.com). Used to auto-initiate pairing when the target is not yet a contact."
+          },
+          "assistant_id": {
+            "type": "string",
+            "description": "The assistant ID of the target assistant. Used together with gateway_url to auto-initiate pairing when the target is not yet a contact."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -189,6 +197,54 @@
         "required": ["message"]
       },
       "executor": "tools/contact-message.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "contact_pair",
+      "description": "Initiate A2A pairing with a remote assistant. Sends a pairing request to the target assistant's gateway. The target's guardian must approve and share a 6-digit verification code.",
+      "category": "contacts",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "gateway_url": {
+            "type": "string",
+            "description": "The gateway URL of the target assistant (e.g. https://gateway.example.com)"
+          },
+          "assistant_id": {
+            "type": "string",
+            "description": "The assistant ID of the target assistant to pair with"
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["gateway_url", "assistant_id"]
+      },
+      "executor": "tools/contact-pair.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "contact_pair_verify",
+      "description": "Complete A2A pairing by sending the 6-digit verification code received from the target assistant's guardian. Must have an active outbound pairing request (initiated via contact_pair or automatically by contact_message when the target wasn't a contact yet).",
+      "category": "contacts",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "The 6-digit verification code shared by the target assistant's guardian"
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["code"]
+      },
+      "executor": "tools/contact-pair-verify.ts",
       "execution_target": "host"
     }
   ]

--- a/assistant/src/config/bundled-skills/contacts/tools/contact-message.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-message.ts
@@ -2,6 +2,11 @@
  * Bundled tool: contact-message
  *
  * Sends a message to a known assistant contact via the A2A outbound sender.
+ * When the target isn't a contact yet but gateway_url and assistant_id are
+ * provided, automatically initiates A2A pairing — the user then submits the
+ * 6-digit verification code via contact_pair_verify to complete pairing
+ * before the message can be sent.
+ *
  * Gated behind the `feature_flags.assistant-a2a.enabled` feature flag.
  */
 
@@ -10,6 +15,7 @@ import {
   searchContacts,
 } from "../../../../contacts/contact-store.js";
 import { sendA2AMessage } from "../../../../runtime/a2a/outbound-client.js";
+import { initiatePairing } from "../../../../runtime/a2a/pairing.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -39,6 +45,8 @@ export async function executeContactMessage(
   const contactId = input.contact_id as string | undefined;
   const contactName = input.contact_name as string | undefined;
   const message = input.message as string | undefined;
+  const gatewayUrl = input.gateway_url as string | undefined;
+  const assistantId = input.assistant_id as string | undefined;
 
   if (!message || typeof message !== "string" || message.trim().length === 0) {
     return {
@@ -69,8 +77,16 @@ export async function executeContactMessage(
     });
 
     if (results.length === 0) {
+      // No contact found — attempt auto-pairing if gateway info is provided
+      if (gatewayUrl && assistantId) {
+        return await attemptAutoPairing(
+          gatewayUrl.trim(),
+          assistantId.trim(),
+          contactName,
+        );
+      }
       return {
-        content: `Error: No assistant contact found matching "${contactName}"`,
+        content: `No assistant contact found matching "${contactName}". To message an unknown assistant, provide gateway_url and assistant_id so pairing can be initiated automatically.`,
         isError: true,
       };
     }
@@ -87,10 +103,32 @@ export async function executeContactMessage(
 
     resolvedContactId = results[0].id;
     displayName = results[0].displayName;
+  } else if (gatewayUrl && assistantId) {
+    // No contact_id or contact_name, but gateway info provided — try to find
+    // an existing contact by assistant_id, or initiate pairing
+    const results = searchContacts({
+      query: assistantId,
+      contactType: "assistant",
+      limit: 5,
+    });
+
+    const exactMatch = results.find((c) => {
+      // Check if any channel address matches the assistant ID
+      return c.channels?.some(
+        (ch) => ch.address === assistantId || ch.externalUserId === assistantId,
+      );
+    });
+
+    if (exactMatch) {
+      resolvedContactId = exactMatch.id;
+      displayName = exactMatch.displayName;
+    } else {
+      return await attemptAutoPairing(gatewayUrl.trim(), assistantId.trim());
+    }
   } else {
     return {
       content:
-        "Error: Either contact_id or contact_name is required to identify the target assistant",
+        "Error: Either contact_id, contact_name, or both gateway_url and assistant_id are required to identify the target assistant",
       isError: true,
     };
   }
@@ -108,6 +146,40 @@ export async function executeContactMessage(
     content: `Failed to send message to ${displayName ?? resolvedContactId}: ${result.error}`,
     isError: true,
   };
+}
+
+/**
+ * Attempt to auto-initiate A2A pairing when the target assistant is not
+ * a known contact. Returns a tool result asking the user for the
+ * verification code.
+ */
+async function attemptAutoPairing(
+  gatewayUrl: string,
+  assistantId: string,
+  contactName?: string,
+): Promise<ToolExecutionResult> {
+  try {
+    await initiatePairing(assistantId, gatewayUrl);
+
+    const target = contactName
+      ? `"${contactName}" (${assistantId})`
+      : assistantId;
+
+    return {
+      content:
+        `I've sent a pairing request to ${target} at ${gatewayUrl}. ` +
+        `Their guardian needs to approve it and share a 6-digit verification code with you. ` +
+        `Once you have the code, provide it using the contact_pair_verify tool, ` +
+        `and then I'll send the message.`,
+      isError: false,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      content: `Failed to initiate pairing with assistant at ${gatewayUrl}: ${message}`,
+      isError: true,
+    };
+  }
 }
 
 export { executeContactMessage as run };

--- a/assistant/src/config/bundled-skills/contacts/tools/contact-pair-verify.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-pair-verify.ts
@@ -1,0 +1,60 @@
+/**
+ * Bundled tool: contact-pair-verify
+ *
+ * Sends a 6-digit verification code to complete an A2A pairing handshake.
+ * Gated behind the `feature_flags.assistant-a2a.enabled` feature flag.
+ */
+
+import { sendPairingVerify } from "../../../../runtime/a2a/pairing.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { isAssistantFeatureFlagEnabled } from "../../../assistant-feature-flags.js";
+import { getConfig } from "../../../loader.js";
+
+export async function executeContactPairVerify(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  // Feature flag gate
+  const config = getConfig();
+  if (
+    !isAssistantFeatureFlagEnabled(
+      "feature_flags.assistant-a2a.enabled",
+      config,
+    )
+  ) {
+    return {
+      content:
+        "Error: Assistant-to-assistant messaging is not enabled. Enable the assistant-a2a feature flag to use this tool.",
+      isError: true,
+    };
+  }
+
+  const code = input.code as string | undefined;
+
+  if (!code || typeof code !== "string" || code.trim().length === 0) {
+    return {
+      content: "Error: code is required and must be a non-empty string",
+      isError: true,
+    };
+  }
+
+  const result = await sendPairingVerify(code.trim());
+
+  if (result.ok) {
+    return {
+      content:
+        "Verification code sent successfully. Pairing will complete once the remote assistant validates the code.",
+      isError: false,
+    };
+  }
+
+  return {
+    content: `Failed to verify pairing: ${result.error ?? "Unknown error"}`,
+    isError: true,
+  };
+}
+
+export { executeContactPairVerify as run };

--- a/assistant/src/config/bundled-skills/contacts/tools/contact-pair.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-pair.ts
@@ -1,0 +1,77 @@
+/**
+ * Bundled tool: contact-pair
+ *
+ * Initiates A2A pairing with a remote assistant by gateway URL and assistant ID.
+ * Gated behind the `feature_flags.assistant-a2a.enabled` feature flag.
+ */
+
+import { initiatePairing } from "../../../../runtime/a2a/pairing.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { isAssistantFeatureFlagEnabled } from "../../../assistant-feature-flags.js";
+import { getConfig } from "../../../loader.js";
+
+export async function executeContactPair(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  // Feature flag gate
+  const config = getConfig();
+  if (
+    !isAssistantFeatureFlagEnabled(
+      "feature_flags.assistant-a2a.enabled",
+      config,
+    )
+  ) {
+    return {
+      content:
+        "Error: Assistant-to-assistant messaging is not enabled. Enable the assistant-a2a feature flag to use this tool.",
+      isError: true,
+    };
+  }
+
+  const gatewayUrl = input.gateway_url as string | undefined;
+  const assistantId = input.assistant_id as string | undefined;
+
+  if (
+    !gatewayUrl ||
+    typeof gatewayUrl !== "string" ||
+    gatewayUrl.trim().length === 0
+  ) {
+    return {
+      content: "Error: gateway_url is required and must be a non-empty string",
+      isError: true,
+    };
+  }
+
+  if (
+    !assistantId ||
+    typeof assistantId !== "string" ||
+    assistantId.trim().length === 0
+  ) {
+    return {
+      content: "Error: assistant_id is required and must be a non-empty string",
+      isError: true,
+    };
+  }
+
+  try {
+    await initiatePairing(assistantId.trim(), gatewayUrl.trim());
+
+    return {
+      content:
+        "Pairing request sent. The other assistant's guardian will need to approve and share a 6-digit verification code with you.",
+      isError: false,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      content: `Failed to initiate pairing: ${message}`,
+      isError: true,
+    };
+  }
+}
+
+export { executeContactPair as run };


### PR DESCRIPTION
## Summary
- Update `contact_message` tool to accept optional `gateway_url` and `assistant_id` params
- When target contact doesn't exist and gateway info is provided, automatically initiate pairing via `initiatePairing()`
- Update `contact_pair_verify` tool description to mention it also handles auto-pairing flow
- Update SKILL.md with auto-pairing workflow documentation
- Fix pre-existing unused import lint error in lifecycle test
- Mirrors Telegram/Slack flow: pairing is a natural side effect of trying to communicate, not a separate step

Part of JARVIS-342
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
