### PR TITLE
fix: align CLI --help text with AGENTS.md guidelines

### DIFF
--- a/assistant/src/cli/commands/contacts.ts
+++ b/assistant/src/cli/commands/contacts.ts
@@ -132,7 +132,7 @@ Examples:
       "after",
       `
 Arguments:
-  id   UUID of the contact to retrieve
+  id   UUID of the contact to retrieve. Run 'assistant contacts list' to find IDs.
 
 Returns the full contact record including role, display name, and all
 channel memberships (phone numbers, Telegram IDs, email addresses, etc.).
@@ -174,7 +174,8 @@ Examples:
       "after",
       `
 Arguments:
-  keepId    UUID of the surviving contact that will absorb the other
+  keepId    UUID of the surviving contact that will absorb the other.
+            Run 'assistant contacts list' to find IDs.
   mergeId   UUID of the contact to be merged and deleted
 
 All channel memberships, conversation history, and metadata from mergeId
@@ -331,7 +332,8 @@ Examples:
       "after",
       `
 Arguments:
-  channelId   UUID of the contact channel to update
+  channelId   UUID of the contact channel to update. Run 'assistant contacts get <contactId>'
+              to see a contact's channel IDs.
 
 Updates the access-control fields on an existing channel. At least one of
 --status or --policy must be provided.
@@ -590,7 +592,7 @@ Examples:
       "after",
       `
 Arguments:
-  inviteId   UUID of the invite to revoke
+  inviteId   UUID of the invite to revoke. Run 'assistant contacts invites list' to find IDs.
 
 Revokes an active invite so it can no longer be redeemed. Already-redeemed
 channel memberships are not affected. Returns the updated invite record.

--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -121,7 +121,7 @@ Arguments:
   conversationId   Optional conversation ID (or unique prefix). Defaults to the
                    most recent conversation. Supports prefix matching — e.g.
                    "abc123" matches the first conversation whose ID starts with
-                   "abc123".
+                   "abc123". Run 'assistant conversations list' to find IDs.
 
 Two output formats are available:
   md    Markdown conversation transcript (default). Human-readable rendering
@@ -277,6 +277,7 @@ Examples:
       `
 Arguments:
   conversationId   Conversation ID (or unique prefix). Supports prefix matching.
+                   Run 'assistant conversations list' to find IDs.
 
 Permanently wipes the conversation and reverts all memory changes it caused:
 restores superseded memory items, deletes conversation summaries, and cancels

--- a/assistant/src/cli/commands/credential-execution.ts
+++ b/assistant/src/cli/commands/credential-execution.ts
@@ -129,6 +129,20 @@ export function registerCredentialExecutionCommand(program: Command): void {
     )
     .option("--json", "Machine-readable compact JSON output");
 
+  ce.addHelpText(
+    "after",
+    `
+The Credential Execution Service (CES) mediates all secret-bearing operations.
+Grants authorize specific credential handles for constrained purposes, and
+audit records log each credentialed operation. Neither grants nor audit records
+ever contain raw secret values — only sanitized metadata.
+
+Examples:
+  $ assistant credential-execution grants list
+  $ assistant credential-execution grants revoke <grantId>
+  $ assistant credential-execution audit list`,
+  );
+
   // -------------------------------------------------------------------------
   // grants
   // -------------------------------------------------------------------------
@@ -215,7 +229,8 @@ that grant for credentialed operations. The grant is permanently removed
 from CES state.
 
 Arguments:
-  grantId   The stable grant identifier (UUID)
+  grantId   The stable grant identifier (UUID). Run 'assistant credential-execution
+            grants list' to find grant IDs.
 
 Examples:
   $ assistant credential-execution grants revoke 7a3b1c2d-4e5f-6789-abcd-ef0123456789

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -92,18 +92,10 @@ Arguments:
   provider   Provider name (e.g. google, slack, notion).
              Run 'assistant oauth providers list' to see available providers.
 
-Options:
-  --scopes <scopes...>   Scopes to request for the authorization. In managed
-                         mode, each scope must be in the provider's allowed set
-                         (use full scope URLs where required). In BYO mode,
-                         scopes are appended to the provider's defaults.
-  --open-browser         Open the authorization URL in your browser and wait
-                         for completion. In managed mode, polls for a new
-                         platform connection. In BYO mode, starts a local
-                         callback server and blocks until the OAuth redirect.
-  --client-id <id>       BYO-only: select a specific OAuth app when multiple
-                         apps exist for the same provider. Ignored for
-                         platform-managed providers.
+In managed mode, --scopes must be in the provider's allowed set (use full
+scope URLs). In BYO mode, --scopes are appended to the provider's defaults.
+The --open-browser flag polls for a platform connection (managed) or starts
+a local callback server (BYO).
 
 Examples:
   $ assistant oauth connect google

--- a/assistant/src/cli/commands/oauth/disconnect.ts
+++ b/assistant/src/cli/commands/oauth/disconnect.ts
@@ -39,22 +39,11 @@ Arguments:
   provider   Provider name (e.g. google, slack, notion).
              Run 'assistant oauth providers list' to see available providers.
 
-Options:
-  --account          Recommended way to specify which connection to disconnect.
-                     Works for both managed and BYO modes. Use the account
-                     identifier shown by 'assistant oauth status <provider>'
-                     (e.g. an email address for Google).
-  --connection-id    Exact match on the connection ID shown by
-                     'assistant oauth status <provider>'. Useful when account
-                     labels are ambiguous or absent.
+At most one of --account or --connection-id may be specified. Use the values
+shown by 'assistant oauth status <provider>' to find the right identifier.
 
-  At most one of --account or --connection-id may be specified.
-
-Disambiguation:
-  When a provider has multiple active connections and neither --account nor
-  --connection-id is given, the command errors with a list of connections
-  (id + account label) and a hint to use --account or --connection-id.
-  Run 'assistant oauth status <provider>' to discover available values.
+When a provider has multiple active connections and neither flag is given,
+the command errors with a list of connections and a hint to disambiguate.
 
 Examples:
   $ assistant oauth disconnect google
@@ -115,11 +104,7 @@ Examples:
             const client = await requirePlatformClient(cmd);
             if (!client) return;
 
-            const entries = await fetchActiveConnections(
-              client,
-              provider,
-              cmd,
-            );
+            const entries = await fetchActiveConnections(client, provider, cmd);
             if (!entries) return;
 
             let connectionId: string | undefined;
@@ -203,9 +188,7 @@ Examples:
             writeOutput(cmd, result);
 
             if (!jsonMode) {
-              log.info(
-                `Disconnected ${provider} connection ${connectionId}`,
-              );
+              log.info(`Disconnected ${provider} connection ${connectionId}`);
             }
           } else {
             // -----------------------------------------------------------------
@@ -290,9 +273,7 @@ Examples:
             writeOutput(cmd, result);
 
             if (!jsonMode) {
-              log.info(
-                `Disconnected ${provider} connection ${connectionId}`,
-              );
+              log.info(`Disconnected ${provider} connection ${connectionId}`);
             }
           }
         } catch (err) {

--- a/assistant/src/cli/commands/oauth/mode.ts
+++ b/assistant/src/cli/commands/oauth/mode.ts
@@ -64,11 +64,6 @@ Arguments:
   provider   Provider name (e.g. google, slack).
              Run "assistant oauth providers list" to see available providers.
 
-Options:
-  --set <mode>   Set the mode to "managed" (platform-handled credentials) or
-                 "your-own" (bring-your-own client ID and secret). Omit to
-                 show the current mode.
-
 Modes:
   managed    OAuth credentials are managed by the Vellum platform. The
              assistant connects via a platform-hosted authorization flow.
@@ -217,12 +212,10 @@ Examples:
           // Old mode was managed — check platform connections
           oldModeConnections = await countManagedConnections(provider, cmd);
           // New mode is your-own — check local connections
-          newModeConnections =
-            listActiveConnectionsByProvider(provider).length;
+          newModeConnections = listActiveConnectionsByProvider(provider).length;
         } else {
           // Old mode was your-own — check local connections
-          oldModeConnections =
-            listActiveConnectionsByProvider(provider).length;
+          oldModeConnections = listActiveConnectionsByProvider(provider).length;
           // New mode is managed — check platform connections
           newModeConnections = await countManagedConnections(provider, cmd);
         }

--- a/assistant/src/cli/commands/oauth/ping.ts
+++ b/assistant/src/cli/commands/oauth/ping.ts
@@ -29,12 +29,9 @@ Arguments:
   provider   Provider name (e.g. google, slack).
              Run 'assistant oauth providers list' to see available providers.
 
-Options:
-  --account <account>   Account identifier (e.g. email) to disambiguate when
-                        multiple accounts are connected for the same provider.
-  --client-id <id>      BYO-only: select a specific OAuth app when multiple
-                        apps exist for the same provider. Ignored for
-                        platform-managed providers.
+Hits the provider's configured ping URL with the stored OAuth token and
+reports whether the token is valid. Use 'assistant oauth status <provider>'
+to find account identifiers for --account.
 
 Examples:
   $ assistant oauth ping google
@@ -106,10 +103,7 @@ Examples:
 
           let connection;
           try {
-            connection = await resolveOAuthConnection(
-              provider,
-              resolveOptions,
-            );
+            connection = await resolveOAuthConnection(provider, resolveOptions);
           } catch (resolveErr) {
             const resolveMessage =
               resolveErr instanceof Error

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -204,66 +204,72 @@ Examples:
       "--provider-key <key>",
       "Unique provider key (e.g. \"custom-service\"). Must not collide with an existing key from 'assistant oauth providers list'.",
     )
-    .requiredOption("--auth-url <url>", "Authorization endpoint URL")
-    .requiredOption("--token-url <url>", "Token endpoint URL")
-    .option("--base-url <url>", "API base URL")
-    .option("--userinfo-url <url>", "Userinfo endpoint URL")
-    .option("--scopes <scopes>", "Comma-separated default scopes")
-    .option("--token-auth-method <method>", "Token endpoint auth method")
-    .option("--callback-transport <transport>", "Callback transport")
+    .requiredOption(
+      "--auth-url <url>",
+      "OAuth authorization endpoint URL (e.g. https://accounts.example.com/o/oauth2/auth)",
+    )
+    .requiredOption(
+      "--token-url <url>",
+      "OAuth token endpoint URL (e.g. https://oauth2.example.com/token)",
+    )
+    .option("--base-url <url>", "API base URL for the service")
+    .option("--userinfo-url <url>", "OpenID Connect userinfo endpoint URL")
+    .option(
+      "--scopes <scopes>",
+      'Comma-separated default scopes (e.g. "read,write,profile")',
+    )
+    .option(
+      "--token-auth-method <method>",
+      'How the client authenticates at the token endpoint: "client_secret_post" or "client_secret_basic"',
+    )
+    .option(
+      "--callback-transport <transport>",
+      'OAuth callback transport: "loopback" (local HTTP server, default) or "gateway" (public ingress)',
+    )
     .option(
       "--ping-url <url>",
-      "Health-check endpoint URL for token validation",
+      'Health-check endpoint URL for token validation (e.g. "https://api.example.com/user"). Used by "assistant oauth ping" to verify a stored token.',
     )
     .option(
       "--ping-method <method>",
-      "HTTP method for the ping endpoint (default: GET)",
+      "HTTP method for the ping endpoint: GET (default) or POST",
     )
     .option(
       "--ping-headers <json>",
-      "JSON object of extra headers for the ping request",
+      'JSON object of extra headers for the ping request (e.g. \'{"Notion-Version":"2022-06-28"}\')',
     )
-    .option("--ping-body <json>", "JSON body to send with the ping request")
-    .option("--display-name <name>", "Display name for the provider")
-    .option("--description <text>", "Short description")
-    .option("--dashboard-url <url>", "Developer console URL")
-    .option("--client-id-placeholder <text>", "Placeholder for client ID field")
+    .option(
+      "--ping-body <json>",
+      'JSON body to send with the ping request (e.g. \'{"query":"{ viewer { id } }"}\')',
+    )
+    .option(
+      "--display-name <name>",
+      "Human-readable display name for the provider",
+    )
+    .option("--description <text>", "Short description of the provider")
+    .option(
+      "--dashboard-url <url>",
+      "URL to the provider's developer console / dashboard",
+    )
+    .option(
+      "--client-id-placeholder <text>",
+      "Placeholder text shown in the client ID input field",
+    )
     .option(
       "--no-client-secret",
-      "Set requires_client_secret to false (default is true)",
+      "Mark this provider as not requiring a client secret (default: required)",
     )
     .addHelpText(
       "after",
       `
-Arguments (via options):
-  --provider-key        Unique identifier for this provider (e.g. "custom-service").
-                        Must not collide with an existing provider key.
-  --auth-url            The OAuth authorization endpoint URL.
-  --token-url           The OAuth token endpoint URL.
-  --base-url            Optional API base URL for the service.
-  --userinfo-url        Optional OpenID Connect userinfo endpoint.
-  --scopes              Comma-separated list of default scopes (e.g. "read,write,profile").
-  --token-auth-method   How the client authenticates at the token endpoint
-                        (e.g. "client_secret_post", "client_secret_basic").
-  --callback-transport  Transport method for the OAuth callback.
-  --ping-url            Optional URL for a lightweight health-check endpoint.
-                        Used by "assistant oauth ping" to validate that a stored token
-                        is still functional (e.g. "https://api.example.com/user").
-  --ping-method         HTTP method for the ping health-check (GET, POST). Defaults to GET.
-  --ping-headers        JSON object of extra HTTP headers for the ping request
-                        (e.g. '{"Notion-Version":"2022-06-28"}').
-  --ping-body           JSON body to send with the ping request
-                        (e.g. '{"query":"{ viewer { id } }"}').
-  --display-name        Optional human-readable display name for the provider.
-  --description         Optional short description of the provider.
-  --dashboard-url       Optional URL to the provider's developer console / dashboard.
-  --client-id-placeholder  Optional placeholder text for the client ID input field.
-  --no-client-secret    If set, marks the provider as not requiring a client secret
-                        (sets requires_client_secret to 0). Default is true (1).
+Registers a new OAuth provider configuration in the local store for custom
+integrations not covered by the built-in provider seeds. The provider key
+must be unique — if it collides with an existing key, the command fails.
+Run 'assistant oauth providers list' to see existing keys.
 
-Registers a new OAuth provider configuration in the local store. This is
-used for custom integrations not covered by the built-in provider seeds.
 On success, returns the full provider row including generated timestamps.
+After registering, create an OAuth app with 'assistant oauth apps create'
+and then connect with 'assistant oauth connect <provider-key>'.
 
 Examples:
   $ assistant oauth providers register \\
@@ -276,10 +282,12 @@ Examples:
       --token-url https://my-service.com/token \\
       --scopes read,write --json
   $ assistant oauth providers register \\
-      --provider-key custom-api \\
+      --provider-key my-graphql-api \\
       --auth-url https://example.com/auth \\
       --token-url https://example.com/token \\
-      --ping-url https://example.com/user`,
+      --ping-url https://example.com/graphql \\
+      --ping-method POST \\
+      --ping-body '{"query":"{ viewer { id } }"}'`,
     )
     .action(
       (
@@ -330,7 +338,10 @@ Examples:
 
           writeOutput(cmd, parseProviderRow(row));
         } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
+          let message = err instanceof Error ? err.message : String(err);
+          if (message.includes("already exists")) {
+            message += ` Run 'assistant oauth providers list' to see existing providers, or choose a different --provider-key.`;
+          }
           writeOutput(cmd, { ok: false, error: message });
           process.exitCode = 1;
         }

--- a/assistant/src/cli/commands/oauth/token.ts
+++ b/assistant/src/cli/commands/oauth/token.ts
@@ -49,18 +49,9 @@ Arguments:
              Run 'assistant oauth providers list' to see all available
              providers.
 
-Options:
-  --account <account>   Select a specific account when multiple connections
-                        exist for the same provider. Uses the account label
-                        shown in 'assistant oauth status <provider>'.
-  --client-id <id>      Select a specific OAuth app when multiple apps exist
-                        for the same provider.
-
-
-This command is discouraged from use and should be used sparingly. Only use
-if you need direct access to the token (i.e. \`assistant oauth request\` is
-insufficient for your use case) and you are comfortable with the potential
-security implications of exposing this token.
+This command is discouraged and should be used sparingly. Only use if you
+need direct access to the token (i.e. \`assistant oauth request\` is
+insufficient) and you are comfortable with the security implications.
 
 Token retrieval is only supported for providers with mode set to "your-own".
 Platform-managed providers handle tokens internally — use
@@ -68,8 +59,8 @@ Platform-managed providers handle tokens internally — use
 'assistant oauth request --provider <provider> <url>' to make
 authenticated requests.
 
-Shell lockdown: This command is blocked when running in an untrusted
-shell (VELLUM_UNTRUSTED_SHELL=1) to prevent token exfiltration.
+Use 'assistant oauth status <provider>' to find account identifiers for
+--account. Shell lockdown: blocked when VELLUM_UNTRUSTED_SHELL=1.
 
 Examples:
   $ assistant oauth token google

--- a/assistant/src/cli/commands/sequence.ts
+++ b/assistant/src/cli/commands/sequence.ts
@@ -142,7 +142,7 @@ Examples:
       "after",
       `
 Arguments:
-  id   The sequence ID (e.g. seq_abc123)
+  id   The sequence ID (e.g. seq_abc123). Run 'assistant sequence list' to find IDs.
 
 Returns full sequence details: name, status, channel, description, exit-on-reply
 setting, all steps with delay and approval configuration, and enrollment
@@ -215,7 +215,7 @@ Examples:
       "after",
       `
 Arguments:
-  id   The sequence ID to pause (e.g. seq_abc123)
+  id   The sequence ID to pause (e.g. seq_abc123). Run 'assistant sequence list' to find IDs.
 
 Pauses a sequence, halting all scheduled step deliveries. Existing active
 enrollments remain in their current state but no new steps will be sent
@@ -246,7 +246,7 @@ Examples:
       "after",
       `
 Arguments:
-  id   The sequence ID to resume (e.g. seq_abc123)
+  id   The sequence ID to resume (e.g. seq_abc123). Run 'assistant sequence list' to find IDs.
 
 Resumes a paused sequence, re-enabling scheduled step deliveries for all
 active enrollments. No-op if the sequence is already active.
@@ -276,7 +276,8 @@ Examples:
       "after",
       `
 Arguments:
-  enrollmentId   The enrollment ID to cancel (e.g. enr_xyz789)
+  enrollmentId   The enrollment ID to cancel (e.g. enr_xyz789). Run 'assistant sequence get <id>'
+                 to see enrollment IDs for a sequence.
 
 Immediately cancels a specific enrollment, stopping all future step
 deliveries for that contact in this sequence. The enrollment status

--- a/assistant/src/cli/commands/shotgun.ts
+++ b/assistant/src/cli/commands/shotgun.ts
@@ -101,6 +101,19 @@ export function registerShotgunCommand(program: Command): void {
     .command("shotgun")
     .description("Start and monitor screen-watch (shotgun) sessions via IPC");
 
+  shotgun.addHelpText(
+    "after",
+    `
+Screen-watch sessions capture periodic screenshots and feed them to the
+assistant for observation. The CLI communicates with the running assistant
+via IPC signal files — the assistant must be running for these commands
+to work.
+
+Examples:
+  $ assistant shotgun start --duration 600 --focus "browsing workflow"
+  $ assistant shotgun status <watchId>`,
+  );
+
   shotgun
     .command("start")
     .description("Start a new screen-watch session")
@@ -206,6 +219,9 @@ Examples:
     .addHelpText(
       "after",
       `
+Arguments:
+  watchId   The watch session ID returned by 'assistant shotgun start'.
+
 Queries the status of an existing screen-watch session by watchId.
 
 Output (JSON): { ok, watchId, conversationId, status }

--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -56,6 +56,16 @@ Examples:
     .command("list")
     .description("List available catalog skills")
     .option("--json", "Machine-readable JSON output")
+    .addHelpText(
+      "after",
+      `
+Lists all skills available in the Vellum catalog with their ID, name,
+description, and dependency information.
+
+Examples:
+  $ assistant skills list
+  $ assistant skills list --json`,
+    )
     .action(async (opts: { json?: boolean }) => {
       try {
         // In dev mode, use the local catalog as the source of truth
@@ -287,6 +297,21 @@ Examples:
     .description("Install a skill from the catalog")
     .option("--overwrite", "Replace an already installed skill")
     .option("--json", "Machine-readable JSON output")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  skill-id   Skill identifier from the Vellum catalog. Run 'assistant skills list'
+             to see available IDs. For community skills, use 'assistant skills add'.
+
+Downloads and installs the skill into the workspace skills directory. If the
+skill is already installed, use --overwrite to replace it.
+
+Examples:
+  $ assistant skills install weather
+  $ assistant skills install weather --overwrite
+  $ assistant skills install weather --json`,
+    )
     .action(
       async (
         skillId: string,
@@ -339,6 +364,19 @@ Examples:
     .command("uninstall <skill-id>")
     .description("Uninstall a previously installed skill")
     .option("--json", "Machine-readable JSON output")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  skill-id   Skill identifier to remove. Run 'assistant skills list' to see
+             installed skills.
+
+Removes the skill directory from the workspace. This action cannot be undone.
+
+Examples:
+  $ assistant skills uninstall weather
+  $ assistant skills uninstall weather --json`,
+    )
     .action(async (skillId: string, opts: { json?: boolean }) => {
       const json = opts.json ?? false;
 

--- a/assistant/src/cli/commands/usage.ts
+++ b/assistant/src/cli/commands/usage.ts
@@ -280,12 +280,11 @@ Examples:
     .addHelpText(
       "after",
       `
-Arguments:
-  --group-by <dimension>   One of: actor, provider, model (default: model)
-    actor     Groups by the subsystem that made the call (main_agent,
-              title_generator, etc.)
-    provider  Groups by LLM provider (anthropic, openai, etc.)
-    model     Groups by model name (claude-sonnet-4-20250514, etc.)
+Grouping dimensions:
+  actor     Groups by the subsystem that made the call (main_agent,
+            title_generator, etc.)
+  provider  Groups by LLM provider (anthropic, openai, etc.)
+  model     Groups by model name (claude-sonnet-4-20250514, etc.)
 
 Shows one row per group with input/output tokens, estimated cost, and
 call count. Rows are sorted by cost descending.

--- a/assistant/src/hooks/cli.ts
+++ b/assistant/src/hooks/cli.ts
@@ -14,9 +14,33 @@ const log = getCliLogger("hooks");
 export function registerHooksCommand(program: Command): void {
   const hooks = program.command("hooks").description("Manage hooks");
 
+  hooks.addHelpText(
+    "after",
+    `
+Hooks are user-installed scripts that run in response to assistant lifecycle
+events (e.g. tool invocations, message sends). Each hook is a directory
+containing a hook.json manifest and a script file. Hooks are stored in
+~/.vellum/hooks/ and must be explicitly enabled after installation.
+
+Examples:
+  $ assistant hooks list
+  $ assistant hooks install ./my-hook
+  $ assistant hooks enable my-hook
+  $ assistant hooks disable my-hook`,
+  );
+
   hooks
     .command("list")
     .description("List all installed hooks")
+    .addHelpText(
+      "after",
+      `
+Displays a table of all installed hooks with their name, subscribed events,
+enabled status, and version.
+
+Examples:
+  $ assistant hooks list`,
+    )
     .action(() => {
       const discovered = discoverHooks();
       if (discovered.length === 0) {
@@ -53,6 +77,17 @@ export function registerHooksCommand(program: Command): void {
   hooks
     .command("enable <name>")
     .description("Enable a hook")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  name   Hook name as shown by 'assistant hooks list'
+
+Enables a previously installed hook so it runs on matching events.
+
+Examples:
+  $ assistant hooks enable my-hook`,
+    )
     .action((name: string) => {
       const discovered = discoverHooks();
       const hook = discovered.find((h) => h.name === name);
@@ -67,6 +102,18 @@ export function registerHooksCommand(program: Command): void {
   hooks
     .command("disable <name>")
     .description("Disable a hook")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  name   Hook name as shown by 'assistant hooks list'
+
+Disables a hook so it no longer runs on events. The hook remains installed
+and can be re-enabled later.
+
+Examples:
+  $ assistant hooks disable my-hook`,
+    )
     .action((name: string) => {
       const discovered = discoverHooks();
       const hook = discovered.find((h) => h.name === name);
@@ -81,6 +128,21 @@ export function registerHooksCommand(program: Command): void {
   hooks
     .command("install <path>")
     .description("Install a hook from a directory")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  path   Path to a directory containing a hook.json manifest and a script file.
+         The manifest must have name, script, description, version, and at
+         least one valid event.
+
+Copies the hook directory into ~/.vellum/hooks/<name>/ and registers it as
+disabled by default. Run 'assistant hooks enable <name>' to activate.
+
+Examples:
+  $ assistant hooks install ./my-hook
+  $ assistant hooks install /path/to/custom-hook`,
+    )
     .action((hookPath: string) => {
       const srcDir = resolve(hookPath);
       if (!pathExists(srcDir)) {
@@ -146,6 +208,18 @@ export function registerHooksCommand(program: Command): void {
   hooks
     .command("remove <name>")
     .description("Remove an installed hook")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  name   Hook name as shown by 'assistant hooks list'
+
+Permanently deletes the hook directory and removes it from configuration.
+Prompts for confirmation before proceeding.
+
+Examples:
+  $ assistant hooks remove my-hook`,
+    )
     .action(async (name: string) => {
       const discovered = discoverHooks();
       const hook = discovered.find((h) => h.name === name);


### PR DESCRIPTION
## Summary
- Add missing `addHelpText` to 3 namespaces (credential-execution, hooks, shotgun) and 8 subcommands (hooks list/enable/disable/install/remove, skills list/install/uninstall) that had no domain explanation, examples, or argument descriptions
- Remove redundant option descriptions from `addHelpText` in 6 OAuth commands and usage breakdown that duplicated what Commander already renders in the Options section
- Add ID/key discovery hints (e.g. "Run 'assistant contacts list' to find IDs") to 12 arguments across contacts, conversations, sequence, credential-execution, and shotgun commands
- Improve oauth providers register: precise option descriptions with valid values, fix misleading duplicate provider-key in examples, actionable error on collision
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
