### PR TITLE
feat: add --provider-key filter to oauth apps list

### DIFF
--- a/assistant/src/cli/commands/oauth/apps.ts
+++ b/assistant/src/cli/commands/oauth/apps.ts
@@ -45,6 +45,7 @@ a provider with a mode of "your-own" set.
 
 Examples:
   $ assistant oauth apps list
+  $ assistant oauth apps list --provider-key google
   $ assistant oauth apps get --id <uuid>
   $ assistant oauth apps get --provider google
   $ assistant oauth apps upsert --provider google --client-id abc123
@@ -58,22 +59,34 @@ Examples:
   apps
     .command("list")
     .description("List all OAuth app registrations")
+    .option(
+      "--provider-key <key>",
+      "Filter by provider key (exact match). Only apps associated with this provider are returned. Run 'assistant oauth providers list' to see available keys.",
+    )
     .addHelpText(
       "after",
       `
-Returns all registered OAuth apps with their provider key, client ID, and
+Returns registered OAuth apps with their provider key, client ID, and
 timestamps. Output is an array of app objects.
+
+When --provider-key is specified, only apps whose providerKey exactly matches
+the given value are returned. Without the flag, all apps are listed.
 
 In JSON mode (--json), returns the array directly. In human mode, logs a
 summary count and prints the formatted list.
 
 Examples:
   $ assistant oauth apps list
-  $ assistant oauth apps list --json`,
+  $ assistant oauth apps list --provider-key google
+  $ assistant oauth apps list --provider-key slack --json`,
     )
-    .action((_opts: unknown, cmd: Command) => {
+    .action((opts: { providerKey?: string }, cmd: Command) => {
       try {
-        const rows = listApps().map(formatAppRow);
+        let rows = listApps().map(formatAppRow);
+
+        if (opts.providerKey) {
+          rows = rows.filter((r) => r.providerKey === opts.providerKey);
+        }
 
         if (!shouldOutputJson(cmd)) {
           log.info(`Found ${rows.length} app(s)`);


### PR DESCRIPTION
## Summary
- Adds a `--provider-key` option to `assistant oauth apps list` that filters results to only apps associated with the specified provider (exact match)
- Includes updated help text with examples and discovery hint pointing to `assistant oauth providers list`
- Updated top-level `apps` namespace examples to show the new filtering option

## Original prompt
add a --provider-key option to assistant oauth apps list that supports filtering the list down to only those oauth apps associated with the specified provider
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
