### PR TITLE
fix: restore oauth providers delete command and address review gaps

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -163,12 +163,6 @@ mock.module("../oauth/oauth-store.js", () => ({
   updateConnection: () => ({}),
 }));
 
-mock.module("../oauth/seed-providers.js", () => ({
-  SEEDED_PROVIDER_KEYS: new Set(["google", "slack", "github"]),
-  PROVIDER_SEED_DATA: {},
-  seedAllProviders: () => {},
-}));
-
 // Stub out transitive dependencies that token-manager would normally pull in
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (account: string) => mockGetSecureKey(account),

--- a/assistant/src/cli/commands/oauth/__tests__/providers-delete.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/providers-delete.test.ts
@@ -19,8 +19,13 @@ let mockListConnectionsResult: Array<Record<string, unknown>> = [];
 let mockDeleteAppCalls: string[] = [];
 let mockDeleteAppResult = true;
 
-let mockDeleteConnectionCalls: string[] = [];
-let mockDeleteConnectionResult = true;
+let mockDisconnectCalls: Array<{
+  providerKey: string;
+  clientId: string | undefined;
+  connectionId: string | undefined;
+}> = [];
+let mockDisconnectResult: "disconnected" | "not-found" | "error" =
+  "disconnected";
 
 let mockSeededProviderKeys = new Set<string>(["google", "slack", "github"]);
 
@@ -52,9 +57,13 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
     mockDeleteAppCalls.push(id);
     return mockDeleteAppResult;
   },
-  deleteConnection: (id: string) => {
-    mockDeleteConnectionCalls.push(id);
-    return mockDeleteConnectionResult;
+  disconnectOAuthProvider: async (
+    providerKey: string,
+    clientId?: string,
+    connectionId?: string,
+  ) => {
+    mockDisconnectCalls.push({ providerKey, clientId, connectionId });
+    return mockDisconnectResult;
   },
   listProviders: () => [],
   registerProvider: () => ({}),
@@ -70,7 +79,7 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
   getConnectionByProvider: () => undefined,
   listActiveConnectionsByProvider: () => [],
   isProviderConnected: () => false,
-  disconnectOAuthProvider: async () => "not-found",
+  deleteConnection: () => false,
 }));
 
 mock.module("../../../../oauth/seed-providers.js", () => ({
@@ -164,8 +173,8 @@ describe("assistant oauth providers delete", () => {
     mockListConnectionsResult = [];
     mockDeleteAppCalls = [];
     mockDeleteAppResult = true;
-    mockDeleteConnectionCalls = [];
-    mockDeleteConnectionResult = true;
+    mockDisconnectCalls = [];
+    mockDisconnectResult = "disconnected";
     mockSeededProviderKeys = new Set(["google", "slack", "github"]);
     mockLogInfoCalls = [];
     process.exitCode = 0;
@@ -312,8 +321,19 @@ describe("assistant oauth providers delete", () => {
     expect(parsed.deleted.apps).toBe(1); // Only custom-api apps, not other-provider
     expect(parsed.deleted.connections).toBe(2);
 
-    // Verify connections were deleted
-    expect(mockDeleteConnectionCalls).toEqual(["conn-1", "conn-2"]);
+    // Verify disconnectOAuthProvider was called for each connection
+    expect(mockDisconnectCalls).toEqual([
+      {
+        providerKey: "custom-api",
+        clientId: undefined,
+        connectionId: "conn-1",
+      },
+      {
+        providerKey: "custom-api",
+        clientId: undefined,
+        connectionId: "conn-2",
+      },
+    ]);
 
     // Verify only matching apps were deleted (not app-other)
     expect(mockDeleteAppCalls).toEqual(["app-1"]);
@@ -346,7 +366,7 @@ describe("assistant oauth providers delete", () => {
     expect(parsed.deleted.connections).toBe(0);
 
     // No cascade deletes should have happened
-    expect(mockDeleteConnectionCalls).toHaveLength(0);
+    expect(mockDisconnectCalls).toHaveLength(0);
     expect(mockDeleteAppCalls).toHaveLength(0);
   });
 
@@ -428,6 +448,60 @@ describe("assistant oauth providers delete", () => {
     // Should have logged a warning about re-creation
     const warningLogged = mockLogInfoCalls.some(
       (msg) => msg.includes("built-in") && msg.includes("re-created"),
+    );
+    expect(warningLogged).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Token cleanup error is logged but does not abort cascade
+  // -------------------------------------------------------------------------
+
+  test("token cleanup error logs warning but continues cascade delete", async () => {
+    mockGetProvider = (key) =>
+      key === "custom-api"
+        ? { providerKey: "custom-api", authUrl: "https://example.com/auth" }
+        : undefined;
+
+    mockListAppsResult = [
+      {
+        id: "app-1",
+        providerKey: "custom-api",
+        clientId: "c1",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    ];
+
+    mockListConnectionsResult = [
+      {
+        id: "conn-1",
+        providerKey: "custom-api",
+        oauthAppId: "app-1",
+        status: "active",
+      },
+    ];
+
+    // Simulate token cleanup failure
+    mockDisconnectResult = "error";
+
+    const { exitCode, stdout } = await runCommand([
+      "providers",
+      "delete",
+      "custom-api",
+      "--force",
+      "--json",
+    ]);
+    // Should still succeed despite token cleanup error
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.deleted.provider).toBe(1);
+    expect(parsed.deleted.connections).toBe(1);
+
+    // Should have logged a warning about the token cleanup failure
+    const warningLogged = mockLogInfoCalls.some(
+      (msg) =>
+        msg.includes("failed to clean up tokens") && msg.includes("conn-1"),
     );
     expect(warningLogged).toBe(true);
   });

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -4,8 +4,8 @@ import { loadConfig } from "../../../config/loader.js";
 import { getOAuthCallbackUrl } from "../../../inbound/public-ingress-urls.js";
 import {
   deleteApp,
-  deleteConnection,
   deleteProvider,
+  disconnectOAuthProvider,
   getProvider,
   listApps,
   listConnections,
@@ -360,33 +360,60 @@ Examples:
   providers
     .command("update <provider-key>")
     .description("Update an existing custom OAuth provider configuration")
-    .option("--auth-url <url>", "Authorization endpoint URL")
-    .option("--token-url <url>", "Token endpoint URL")
-    .option("--base-url <url>", "API base URL")
-    .option("--userinfo-url <url>", "Userinfo endpoint URL")
-    .option("--scopes <scopes>", "Comma-separated default scopes")
-    .option("--token-auth-method <method>", "Token endpoint auth method")
-    .option("--callback-transport <transport>", "Callback transport")
+    .option(
+      "--auth-url <url>",
+      "OAuth authorization endpoint URL (e.g. https://accounts.example.com/o/oauth2/auth)",
+    )
+    .option(
+      "--token-url <url>",
+      "OAuth token endpoint URL (e.g. https://oauth2.example.com/token)",
+    )
+    .option("--base-url <url>", "API base URL for the service")
+    .option("--userinfo-url <url>", "OpenID Connect userinfo endpoint URL")
+    .option(
+      "--scopes <scopes>",
+      'Comma-separated default scopes (e.g. "read,write,profile")',
+    )
+    .option(
+      "--token-auth-method <method>",
+      'How the client authenticates at the token endpoint: "client_secret_post" or "client_secret_basic"',
+    )
+    .option(
+      "--callback-transport <transport>",
+      'OAuth callback transport: "loopback" (local HTTP server, default) or "gateway" (public ingress)',
+    )
     .option(
       "--ping-url <url>",
-      "Health-check endpoint URL for token validation",
+      'Health-check endpoint URL for token validation (e.g. "https://api.example.com/user"). Used by "assistant oauth ping" to verify a stored token.',
     )
     .option(
       "--ping-method <method>",
-      "HTTP method for the ping endpoint (default: GET)",
+      "HTTP method for the ping endpoint: GET (default) or POST",
     )
     .option(
       "--ping-headers <json>",
-      "JSON object of extra headers for the ping request",
+      'JSON object of extra headers for the ping request (e.g. \'{"Notion-Version":"2022-06-28"}\')',
     )
-    .option("--ping-body <json>", "JSON body to send with the ping request")
-    .option("--display-name <name>", "Display name for the provider")
-    .option("--description <text>", "Short description")
-    .option("--dashboard-url <url>", "Developer console URL")
-    .option("--client-id-placeholder <text>", "Placeholder for client ID field")
+    .option(
+      "--ping-body <json>",
+      'JSON body to send with the ping request (e.g. \'{"query":"{ viewer { id } }"}\')',
+    )
+    .option(
+      "--display-name <name>",
+      "Human-readable display name for the provider",
+    )
+    .option("--description <text>", "Short description of the provider")
+    .option(
+      "--dashboard-url <url>",
+      "URL to the provider's developer console / dashboard",
+    )
+    .option(
+      "--client-id-placeholder <text>",
+      "Placeholder text shown in the client ID input field",
+    )
     .option(
       "--no-client-secret",
-      "Set requires_client_secret to false (default is true)",
+      "Mark this provider as not requiring a client secret (default: required)",
     )
     .addHelpText(
       "after",
@@ -479,6 +506,13 @@ Examples:
             params.dashboardUrl = opts.dashboardUrl;
           if (opts.clientIdPlaceholder !== undefined)
             params.clientIdPlaceholder = opts.clientIdPlaceholder;
+
+          // Handle the negated --no-client-* flag: Commander defaults
+          // opts.clientSecret to true; the negated form sets it to false.
+          // Use getOptionValueSource to detect explicit user intent.
+          if (cmd.getOptionValueSource("clientSecret") === "cli") {
+            params.requiresClientSecret = opts.clientSecret ? 1 : 0;
+          }
 
           // Check if any fields were actually provided
           if (Object.keys(params).length === 0) {
@@ -579,8 +613,19 @@ Examples:
           }
 
           // Cascade-delete connections first, then apps, then the provider.
+          // Use disconnectOAuthProvider to clean up OAuth tokens from secure
+          // storage in addition to deleting the connection DB row.
           for (const conn of dependentConnections) {
-            deleteConnection(conn.id);
+            const result = await disconnectOAuthProvider(
+              providerKey,
+              undefined,
+              conn.id as string,
+            );
+            if (result === "error") {
+              log.info(
+                `Warning: failed to clean up tokens for connection ${conn.id} — continuing cascade delete.`,
+              );
+            }
           }
           for (const app of dependentApps) {
             await deleteApp(app.id);


### PR DESCRIPTION
## Summary
- Fix token leak: use `disconnectOAuthProvider` instead of `deleteConnection` for proper secure-storage cleanup during cascade delete
- Wire up `--no-client-secret` in update handler to actually update `requiresClientSecret`
- Remove duplicate seed-providers mock in oauth-cli.test.ts
- Align update command option descriptions with register command
- Add test coverage for token cleanup error handling during cascade delete

Part of plan: oauth-provider-update-delete.md (review fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
